### PR TITLE
WIP: Integration test for preemption from AC flavors - a test case demonstrating issue [EXPERIMENT]

### DIFF
--- a/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
@@ -1725,7 +1725,7 @@ var _ = ginkgo.Describe("Provisioning with scheduling", ginkgo.Ordered, ginkgo.C
 			})
 		})
 
-		ginkgo.FIt("Should be successfully re-admitted on another flavor also with a round-kilobyte memory request", func() {
+		ginkgo.It("Should be successfully re-admitted on another flavor also with a round-kilobyte memory request", func() {
 			ginkgo.By("Set up ClusterQueue and LocalQueue", func() {
 				cq = testing.MakeClusterQueue("cluster-queue").
 					Preemption(kueue.ClusterQueuePreemption{
@@ -1827,12 +1827,6 @@ var _ = ginkgo.Describe("Provisioning with scheduling", ginkgo.Ordered, ginkgo.C
 					util.ExpectObjectToBeDeleted(ctx, k8sClient, job2, true)
 				})
 				wl2Key = types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job2.Name, job2.UID), Namespace: ns.Name}
-			})
-
-			ginkgo.By("await for wl2 to be created", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, wl2Key, &wlObj)).Should(gomega.Succeed())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("await for wl1 to be Admitted on flavor-2", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

It expands #7010 with another test case which demonstrates an occurrence of issue #6966.

By merging this, we will:
- make it evident that that issue exists
- enhance reproducing it and further experimentation (which seems needed for taking next steps).

#### Which issue(s) this PR fixes:

None - but should help in fixing #6966.

#### Special notes for your reviewer:

It's unclear how to best handle an integration test for an _undesired_ behavior.

- For now, I'm asserting the _undesired_ behavior, so that this test doesn't fail and prevent subsequent PRs. \
  This brings a risk of mental confusion (e.g. a fix to the issue is going to break this test). \
  I did my best to address this by leaving [a comment](https://github.com/olekzabl/kueue/blob/ab3caa521ea9f351c542e1243ac0699247cde66b/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go#L1839-L1851) next to the problematic expectation.

- Alternatively, we may decide not to have this PR merged at all. \
  This will mean that the "reproduction scenario" for the issue will not be available _readily_ - one will instead need to patch this PR onto their branch. \
  Still, reproducing will be enhanced by having this PR just _proposed_ in our repo history. Maybe that's enough.

- Yet another option is to merge this test asserting the _desired_ behavior but "disabled" in some way. \
  (E.g. with Ginkgo's `X()`, or just commented out).
  I don't like it. It'd be merging code which gets _dead_ from the very start. Feels unhealthy.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```