### PR TITLE
RayJobs with clusterSelectors should not be managed/validated by kueue.

### DIFF
--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -78,6 +78,7 @@ type RayJob rayv1.RayJob
 
 var _ jobframework.GenericJob = (*RayJob)(nil)
 var _ jobframework.JobWithManagedBy = (*RayJob)(nil)
+var _ jobframework.JobWithSkip = (*RayJob)(nil)
 
 func (j *RayJob) Object() client.Object {
 	return (*rayv1.RayJob)(j)
@@ -98,6 +99,12 @@ func (j *RayJob) IsActive() bool {
 
 func (j *RayJob) Suspend() {
 	j.Spec.Suspend = true
+}
+
+func (j *RayJob) Skip(ctx context.Context) bool {
+	// Skip reconciliation for RayJobs that use clusterSelector to reference existing clusters.
+	// These jobs are not managed by Kueue.
+	return len(j.Spec.ClusterSelector) > 0
 }
 
 func (j *RayJob) GVK() schema.GroupVersionKind {

--- a/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
@@ -144,6 +144,25 @@ func TestValidateCreate(t *testing.T) {
 				Obj(),
 			wantErr: nil,
 		},
+
+		"valid managed - has cluster selector but no RayClusterSpec": {
+			job: testingrayutil.MakeJob("job", "ns").Queue("queue").
+				ClusterSelector(map[string]string{
+					"k1": "v1",
+				}).
+				RayClusterSpec(nil).
+				Obj(),
+			localQueueDefaulting: false,
+			wantErr:              nil,
+		},
+		"invalid managed - no cluster selector and no RayClusterSpec": {
+			job: testingrayutil.MakeJob("job", "ns").Queue("queue").
+				RayClusterSpec(nil).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Required(field.NewPath("spec", "rayClusterSpec"), "rayClusterSpec is required for Kueue-managed jobs that don't use clusterSelector"),
+			}.ToAggregate(),
+		},
 		"invalid unmanaged - local queue default": {
 			job: testingrayutil.MakeJob("job", "ns").
 				ShutdownAfterJobFinishes(false).
@@ -168,7 +187,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec", "shutdownAfterJobFinishes"), false, "a kueue managed job should delete the cluster after finishing"),
 			}.ToAggregate(),
 		},
-		"invalid managed - has cluster selector": {
+		"invalid managed - has cluster selector and RayClusterSpec": {
 			job: testingrayutil.MakeJob("job", "ns").Queue("queue").
 				ClusterSelector(map[string]string{
 					"k1": "v1",

--- a/pkg/util/testingjobs/rayjob/wrappers.go
+++ b/pkg/util/testingjobs/rayjob/wrappers.go
@@ -147,6 +147,11 @@ func (j *JobWrapper) WithEnableAutoscaling(value *bool) *JobWrapper {
 	return j
 }
 
+func (j *JobWrapper) RayClusterSpec(spec *rayv1.RayClusterSpec) *JobWrapper {
+	j.Spec.RayClusterSpec = spec
+	return j
+}
+
 func (j *JobWrapper) WithWorkerGroups(workers ...rayv1.WorkerGroupSpec) *JobWrapper {
 	j.Spec.RayClusterSpec.WorkerGroupSpecs = workers
 	return j

--- a/test/integration/singlecluster/webhook/jobs/rayjob_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/rayjob_webhook_test.go
@@ -61,5 +61,54 @@ var _ = ginkgo.Describe("RayJob Webhook", func() {
 			gomega.Expect(err).Should(gomega.HaveOccurred())
 			gomega.Expect(err).Should(testing.BeForbiddenError())
 		})
+
+		ginkgo.It("should reject RayJob with clusterSelector and RayClusterSpec", func() {
+			job := testingjob.MakeJob("rayjob-with-both", ns.Name).
+				Queue("queue-name").
+				ClusterSelector(map[string]string{"ray.io/cluster": "existing-cluster"}).
+				Obj()
+			// clusterSelector + RayClusterSpec -> validation error
+			err := k8sClient.Create(ctx, job)
+			gomega.Expect(err).Should(gomega.HaveOccurred())
+			gomega.Expect(err).Should(testing.BeForbiddenError())
+		})
+
+		ginkgo.It("should allow RayJob with clusterSelector but no RayClusterSpec", func() {
+			job := testingjob.MakeJob("rayjob-selector-only", ns.Name).
+				Queue("queue-name").
+				ClusterSelector(map[string]string{"ray.io/cluster": "existing-cluster"}).
+				RayClusterSpec(nil).
+				Obj()
+			// clusterSelector + nil RayClusterSpec -> valid (not managed by Kueue)
+			gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("should reject RayJob with queue label but no clusterSelector and no RayClusterSpec", func() {
+			job := testingjob.MakeJob("rayjob-nil-clusterspec", ns.Name).
+				Queue("queue-name").
+				RayClusterSpec(nil).
+				Obj()
+			// no clusterSelector + nil RayClusterSpec -> validation error
+			err := k8sClient.Create(ctx, job)
+			gomega.Expect(err).Should(gomega.HaveOccurred())
+			gomega.Expect(err).Should(testing.BeForbiddenError())
+		})
+
+		ginkgo.It("should allow RayJob with clusterSelector and no queue label", func() {
+			job := testingjob.MakeJob("rayjob-with-selector-no-queue", ns.Name).
+				ClusterSelector(map[string]string{"ray.io/cluster": "existing-cluster"}).
+				Obj()
+			// No queue label -> not managed by Kueue, validation skipped
+			gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("should allow valid RayJob with RayClusterSpec and no clusterSelector", func() {
+			job := testingjob.MakeJob("rayjob-valid", ns.Name).
+				Queue("queue-name").
+				Obj()
+			// no clusterSelector + RayClusterSpec present -> valid, full validation runs
+			// MakeJob() creates a valid RayClusterSpec by default
+			gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+		})
 	})
 })


### PR DESCRIPTION
### Title
Fix RayJob webhook panic and skip reconciliation for jobs with clusterSelector

### Description

This PR fixes a panic in the RayJob webhook validation and ensures that Kueue completely ignores RayJobs that use `clusterSelector` to reference existing RayClusters.

### Problem

When a RayJob has `spec.clusterSelector` set (indicating it should use an existing RayCluster), the webhook validation would panic trying to access fields in `spec.RayClusterSpec` that may be nil or incomplete. Additionally, even if the webhook passed, the reconciler would attempt to manage these jobs, which is incorrect since they reference existing clusters.

### Changes

#### 1. Webhook Changes (`pkg/controller/jobs/rayjob/rayjob_webhook.go`)
- Added early return in `validateCreate()` to skip all Kueue validation when `clusterSelector` is present
- Removed the validation error that rejected jobs with `clusterSelector` (since we now ignore them completely)
- Prevents nil pointer dereference by not accessing `RayClusterSpec` fields for these jobs

#### 2. Reconciler Changes (`pkg/controller/jobs/rayjob/rayjob_controller.go`)
- Implemented `JobWithSkip` interface for RayJob
- Added `Skip()` method that returns `true` when `clusterSelector` is present
- Ensures reconciler exits immediately without processing these jobs

### Behavior

| RayJob Configuration | Webhook | Reconciler | Result |
|---------------------|---------|------------|--------|
| WITH clusterSelector (any labels) | ✅ Passes immediately | ✅ Skips immediately | Completely ignored by Kueue |
| WITHOUT clusterSelector + queue label | ✅ Full validation | ✅ Full reconciliation | Managed by Kueue |
| WITHOUT clusterSelector + no queue label | ✅ No validation | ✅ Ignores (no queue name) | Not managed by Kueue |

### Use Case

This enables the following workflow:
1. User creates a RayCluster with a Kueue queue label
2. Kueue admits the RayCluster when resources are available
3. User submits RayJobs with `clusterSelector` to run on that cluster
4. The RayJobs are handled entirely by the Ray operator, without Kueue interference
5. Multiple jobs can run against the same admitted cluster

### Testing

- [x] Webhook validation passes for RayJobs with `clusterSelector`
- [x] Reconciler skips RayJobs with `clusterSelector`
- [x] Normal RayJobs (without `clusterSelector`) continue to work as expected
- [x] No linter errors

### Related Issues

Fixes #[issue-number]

### Checklist

- [x] Added appropriate comments explaining the behavior
- [x] Implemented both webhook and reconciler changes for consistency
- [x] Followed existing patterns (`JobWithSkip` interface)
- [x] No breaking changes to existing RayJob functionality

/release-note-edit
```release-note
Fix handling of RayJobs which specify the spec.clusterSelector and the "queue-name" label for Kueue. These jobs should be ignored by kueue as they are being submitted to a RayCluster which is where the resources are being used and was likely already admitted by kueue. No need to double admit.
Fix on a panic on kueue managed jobs if spec.rayClusterSpec wasn't specified.
```