### PR TITLE
Automated cherry pick of #7223: Visibility API: propagate manager kubeConfig to visibility API server

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -263,7 +263,7 @@ func main() {
 
 	if features.Enabled(features.VisibilityOnDemand) {
 		go func() {
-			if err := visibility.CreateAndStartVisibilityServer(ctx, queues); err != nil {
+			if err := visibility.CreateAndStartVisibilityServer(ctx, queues, kubeConfig); err != nil {
 				setupLog.Error(err, "Unable to create and start visibility server")
 				os.Exit(1)
 			}


### PR DESCRIPTION
Cherry pick of #7223 on release-0.13.

#7223: Visibility API: propagate manager kubeConfig to visibility API server

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Visibility API: Fix a bug that the Config clientConnection is not respected in the visibility server.
```