### PR TITLE
Add validation for unsupported DRA features

### DIFF
--- a/pkg/dra/claims.go
+++ b/pkg/dra/claims.go
@@ -33,38 +33,69 @@ import (
 )
 
 var (
-	ErrDeviceClassNotMapped = errors.New("DeviceClass is not mapped in DRA configuration")
-	ErrResourceClaimInUse   = errors.New("ResourceClaim is in use")
-	ErrClaimSpecNotFound    = errors.New("failed to get claim spec")
+	errDeviceClassNotMapped  = errors.New("DeviceClass is not mapped in DRA configuration")
+	errClaimSpecNotFound     = errors.New("failed to get claim spec")
+	errUnsupportedDRAFeature = errors.New("unsupported DRA feature")
+
+	// Specific unsupported DRA feature errors
+	errUnsupportedDRADeviceConstraints = errors.New("device constraints (MatchAttribute) are not supported")
+	errUnsupportedDRADeviceConfig      = errors.New("device config is not supported")
+	errUnsupportedDRAFirstAvailable    = errors.New("FirstAvailable device selection is not supported")
+	errUnsupportedDRACELSelectors      = errors.New("CEL selectors are not supported")
+	errUnsupportedDRAAdminAccess       = errors.New("AdminAccess is not supported")
+	errUnsupportedDRAAllocationModeAll = errors.New("AllocationMode 'All' is not supported")
 )
 
 // countDevicesPerClass returns a resources.Requests representing the
 // total number of devices requested for each DeviceClass inside the provided
-// ResourceClaimSpec.
-func countDevicesPerClass(claimSpec *resourcev1.ResourceClaimSpec) resources.Requests {
+// ResourceClaimSpec. It validates that only supported DRA features are used
+// and returns an error if unsupported features are detected.
+func countDevicesPerClass(claimSpec *resourcev1.ResourceClaimSpec) (resources.Requests, error) {
 	out := resources.Requests{}
 	if claimSpec == nil {
-		return out
+		return out, nil
 	}
+
+	// Check for unsupported device constraints
+	if len(claimSpec.Devices.Constraints) > 0 {
+		return nil, errUnsupportedDRADeviceConstraints
+	}
+
+	// Check for unsupported device config
+	if len(claimSpec.Devices.Config) > 0 {
+		return nil, errUnsupportedDRADeviceConfig
+	}
+
 	for _, req := range claimSpec.Devices.Requests {
-		// v1beta2 DeviceRequest has Exactly or FirstAvailable. For Step 1, we
+		// v1 DeviceRequest has Exactly or FirstAvailable. For Step 1, we
 		// preserve existing semantics by only supporting Exactly with Count.
 		var dcName string
 		var q int64
-		if req.Exactly != nil {
-			dcName = req.Exactly.DeviceClassName
-			if req.Exactly.AllocationMode == resourcev1.DeviceAllocationModeExactCount {
-				q = req.Exactly.Count
-			}
+		if req.FirstAvailable != nil {
+			return nil, errUnsupportedDRAFirstAvailable
 		}
+
+		switch {
+		case len(req.Exactly.Selectors) > 0:
+			return nil, errUnsupportedDRACELSelectors
+		case req.Exactly.AdminAccess != nil && *req.Exactly.AdminAccess:
+			return nil, errUnsupportedDRAAdminAccess
+		case req.Exactly.AllocationMode == resourcev1.DeviceAllocationModeAll:
+			return nil, errUnsupportedDRAAllocationModeAll
+		case req.Exactly.AllocationMode == resourcev1.DeviceAllocationModeExactCount:
+			dcName = req.Exactly.DeviceClassName
+			q = req.Exactly.Count
+		default:
+			return nil, fmt.Errorf("%w: unsupported allocation mode: %s", errUnsupportedDRAFeature, req.Exactly.AllocationMode)
+		}
+
 		dc := corev1.ResourceName(dcName)
 		if dc == "" {
 			continue
 		}
-		// TODO: handle other Allocation modes
 		out[dc] += q
 	}
-	return out
+	return out, nil
 }
 
 // getClaimSpec resolves the ResourceClaim(Template) referenced by the PodResourceClaim
@@ -93,8 +124,8 @@ func getClaimSpec(ctx context.Context, cl client.Client, namespace string, prc c
 // converts DeviceClass counts into logical resources using the provided lookup function and
 // returns the aggregated quantities per PodSet.
 //
-// If at least one DeviceClass is not present in the DRA configuration the function
-// returns an error.
+// If at least one DeviceClass is not present in the DRA configuration or if unsupported DRA
+// features are detected, the function returns an error.
 func GetResourceRequestsForResourceClaimTemplates(
 	ctx context.Context,
 	cl client.Client,
@@ -110,16 +141,21 @@ func GetResourceRequestsForResourceClaimTemplates(
 			}
 			spec, err := getClaimSpec(ctx, cl, wl.Namespace, prc)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get claim spec for ResourceClaimTemplate %s in workload %s podset %s: %w", *prc.ResourceClaimTemplateName, wl.Name, ps.Name, fmt.Errorf("%w: %v", ErrClaimSpecNotFound, err))
+				return nil, fmt.Errorf("failed to get claim spec for ResourceClaimTemplate %s in workload %s podset %s: %w", *prc.ResourceClaimTemplateName, wl.Name, ps.Name, fmt.Errorf("%w: %v", errClaimSpecNotFound, err))
 			}
 			if spec == nil {
 				continue
 			}
 
-			for dc, qty := range countDevicesPerClass(spec) {
+			deviceCounts, err := countDevicesPerClass(spec)
+			if err != nil {
+				return nil, fmt.Errorf("unsupported DRA feature in ResourceClaimTemplate %s in workload %s podset %s: %w", *prc.ResourceClaimTemplateName, wl.Name, ps.Name, err)
+			}
+
+			for dc, qty := range deviceCounts {
 				logical, found := Mapper().lookup(dc)
 				if !found {
-					return nil, fmt.Errorf("DeviceClass %s is not mapped in DRA configuration for workload %s podset %s: %w", dc, wl.Name, ps.Name, ErrDeviceClassNotMapped)
+					return nil, fmt.Errorf("DeviceClass %s is not mapped in DRA configuration for workload %s podset %s: %w", dc, wl.Name, ps.Name, errDeviceClassNotMapped)
 				}
 				aggregated = utilresource.MergeResourceListKeepSum(aggregated, corev1.ResourceList{logical: resource.MustParse(strconv.FormatInt(qty, 10))})
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
 This PR adds validation to reject DRA (Dynamic Resource Allocation) v1 API features that are enabled
   by default in Kubernetes 1.34 but explicitly excluded from Kueue's DRA support scope per [KEP-2941](https://github.com/kubernetes-sigs/kueue/blob/main/keps/2941-DRA/README.md).


  Without validation, Kueue silently ignores unsupported DRA features, leading to:
  1. Silent admission failures - FirstAvailable workloads are admitted with 0 DRA resources, causing
  runtime failures
  2. Misleading errors - 5 out of 6 unsupported features produce confusing "DeviceClass not mapped"
  errors instead of clear feature-not-supported messages
  3. Poor UX - Users waste time debugging DeviceClass mappings when the actual issue is using
  unsupported features


Solution is to add early validation in pkg/dra/claims.go to explicitly reject all 6 enabled-by-default DRA features
   that Kueue doesn't support:

  GA Features:
  - AllocationMode 'All'
  - CEL Selectors
  - Device Constraints
  - Device Config

  Beta Features (enabled by default in K8s 1.34):
  - FirstAvailable (DRAPrioritizedList)
  - AdminAccess (DRAAdminAccess)

  Each feature now returns a clear, actionable error message like "FirstAvailable device selection is
  not supported" instead of misleading DeviceClass mapping errors.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Kueue now properly validates and rejects unsupported DRA (Dynamic Resource Allocation) features with clear error messages instead of silently failing or producing misleading "DeviceClass not mapped" errors. Unsupported features include: AllocationMode 'All', CEL Selectors, Device Constraints, Device Config, FirstAvailable device selection, and AdminAccess.
```