### PR TITLE
rbac: visibility server requires configmaps (get,list,watch)

### DIFF
--- a/charts/kueue/templates/rbac/role.yaml
+++ b/charts/kueue/templates/rbac/role.yaml
@@ -10,21 +10,22 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - events
-    verbs:
-      - create
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ""
-    resources:
+      - configmaps
       - limitranges
       - namespaces
       - nodes
     verbs:
       - get
       - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
       - watch
   - apiGroups:
       - ""

--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -7,21 +7,22 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
+  - configmaps
   - limitranges
   - namespaces
   - nodes
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""

--- a/pkg/visibility/server.go
+++ b/pkg/visibility/server.go
@@ -53,6 +53,7 @@ var (
 	certDir = "/visibility"
 )
 
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 // +kubebuilder:rbac:groups=flowcontrol.apiserver.k8s.io,resources=prioritylevelconfigurations,verbs=list;watch
 // +kubebuilder:rbac:groups=flowcontrol.apiserver.k8s.io,resources=flowschemas,verbs=list;watch
 // +kubebuilder:rbac:groups=flowcontrol.apiserver.k8s.io,resources=flowschemas/status,verbs=patch


### PR DESCRIPTION
#### What this PR does / why we need it:
The visibility server requires configmaps (get,list,watch) rbac

/bug

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
The following generated the RBAC updates.

```
make update-helm
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Visibility Server: Add configmaps (get,list,watch) rbac
```