### PR TITLE
[Cleanup] Add scheduler test with WorkloadRequestUseMergePatch enabled

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -8086,133 +8086,140 @@ func TestLastSchedulingContext(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx, log := utiltesting.ContextWithLog(t)
-			scheme := runtime.NewScheme()
+		for _, enabled := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", tc.name, enabled), func(t *testing.T) {
+				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, enabled)
+				ctx, log := utiltesting.ContextWithLog(t)
+				scheme := runtime.NewScheme()
 
-			clientBuilder := utiltesting.NewClientBuilder().
-				WithLists(
-					&kueue.WorkloadList{Items: tc.workloads},
-					&kueue.ClusterQueueList{Items: tc.cqs},
-					&kueue.LocalQueueList{Items: queues},
-				).
-				WithObjects(
-					utiltesting.MakeNamespace("default"),
-				).
-				WithStatusSubresource(&kueue.Workload{}).
-				WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
-
-			cl := clientBuilder.Build()
-			broadcaster := record.NewBroadcaster()
-			recorder := broadcaster.NewRecorder(scheme,
-				corev1.EventSource{Component: constants.AdmissionName})
-			cqCache := schdcache.New(cl)
-			qManager := qcache.NewManager(cl, cqCache)
-			// Workloads are loaded into queues or clusterQueues as we add them.
-			for _, q := range queues {
-				if err := qManager.AddLocalQueue(ctx, &q); err != nil {
-					t.Fatalf("Inserting queue %s/%s in manager: %v", q.Namespace, q.Name, err)
+				testWls := make([]kueue.Workload, 0, len(tc.workloads))
+				for _, wl := range tc.workloads {
+					testWls = append(testWls, *wl.DeepCopy())
 				}
-			}
-			for i := range resourceFlavors {
-				cqCache.AddOrUpdateResourceFlavor(log, resourceFlavors[i])
-			}
-			for _, cq := range tc.cqs {
-				if err := cqCache.AddClusterQueue(ctx, &cq); err != nil {
-					t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
-				}
-				if err := qManager.AddClusterQueue(ctx, &cq); err != nil {
-					t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
-				}
-			}
-			scheduler := New(qManager, cqCache, cl, recorder, WithClock(t, fakeClock))
+				clientBuilder := utiltesting.NewClientBuilder().
+					WithLists(
+						&kueue.WorkloadList{Items: testWls},
+						&kueue.ClusterQueueList{Items: tc.cqs},
+						&kueue.LocalQueueList{Items: queues},
+					).
+					WithObjects(
+						utiltesting.MakeNamespace("default"),
+					).
+					WithStatusSubresource(&kueue.Workload{}).
+					WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 
-			wg := sync.WaitGroup{}
-			scheduler.setAdmissionRoutineWrapper(routine.NewWrapper(
-				func() { wg.Add(1) },
-				func() { wg.Done() },
-			))
-
-			var mu sync.Mutex
-			gotPreempted := sets.New[workload.Reference]()
-			scheduler.preemptor.OverrideApply(func(_ context.Context, w *kueue.Workload, _, _ string) error {
-				mu.Lock()
-				gotPreempted.Insert(workload.Key(w))
-				mu.Unlock()
-				return nil
-			})
-
-			ctx, cancel := context.WithTimeout(ctx, queueingTimeout)
-			go qManager.CleanUpOnContext(ctx)
-			defer cancel()
-
-			scheduler.schedule(ctx)
-			wg.Wait()
-
-			if diff := cmp.Diff(tc.wantPreempted, gotPreempted); diff != "" {
-				t.Errorf("Unexpected preemptions (-want,+got):\n%s", diff)
-			}
-
-			gotWorkloads := &kueue.WorkloadList{}
-			err := cl.List(ctx, gotWorkloads)
-			if err != nil {
-				t.Fatalf("Unexpected list workloads error: %v", err)
-			}
-
-			defaultWorkloadCmpOpts := cmp.Options{
-				cmpopts.EquateEmpty(),
-				cmpopts.IgnoreFields(kueue.Workload{}, "ObjectMeta.ResourceVersion"),
-			}
-
-			if diff := cmp.Diff(tc.wantWorkloads, gotWorkloads.Items, defaultWorkloadCmpOpts); diff != "" {
-				t.Errorf("Unexpected scheduled workloads (-want,+got):\n%s", diff)
-			}
-
-			for _, workloadReference := range tc.deleteWorkloads {
-				var workload kueue.Workload
-				err := cl.Get(ctx, workloadReference, &workload)
-				if err != nil {
-					t.Errorf("Unable to get workload: %v", err)
-				}
-				err = cl.Delete(ctx, &workload)
-				if err != nil {
-					t.Errorf("Delete workload failed: %v", err)
-				}
-				err = cqCache.DeleteWorkload(log, &workload)
-				if err != nil {
-					t.Errorf("Delete workload failed: %v", err)
-				}
-				qManager.QueueAssociatedInadmissibleWorkloadsAfter(ctx, &workload, nil)
-			}
-
-			scheduler.schedule(ctx)
-			wg.Wait()
-
-			if diff := cmp.Diff(tc.wantPreempted, gotPreempted); diff != "" {
-				t.Errorf("Unexpected preemptions (-want,+got):\n%s", diff)
-			}
-			// Verify assignments in cache.
-			gotAssignments := make(map[workload.Reference]kueue.Admission)
-			snapshot, err := cqCache.Snapshot(ctx)
-			if err != nil {
-				t.Fatalf("unexpected error while building snapshot: %v", err)
-			}
-			for cqName, c := range snapshot.ClusterQueues() {
-				for name, w := range c.Workloads {
-					switch {
-					case !workload.IsAdmitted(w.Obj):
-						t.Errorf("Workload %s is not admitted by a clusterQueue, but it is found as member of clusterQueue %s in the cache", name, cqName)
-					case w.Obj.Status.Admission.ClusterQueue != cqName:
-						t.Errorf("Workload %s is admitted by clusterQueue %s, but it is found as member of clusterQueue %s in the cache", name, w.Obj.Status.Admission.ClusterQueue, cqName)
-					default:
-						gotAssignments[name] = *w.Obj.Status.Admission
+				cl := clientBuilder.Build()
+				broadcaster := record.NewBroadcaster()
+				recorder := broadcaster.NewRecorder(scheme,
+					corev1.EventSource{Component: constants.AdmissionName})
+				cqCache := schdcache.New(cl)
+				qManager := qcache.NewManager(cl, cqCache)
+				// Workloads are loaded into queues or clusterQueues as we add them.
+				for _, q := range queues {
+					if err := qManager.AddLocalQueue(ctx, &q); err != nil {
+						t.Fatalf("Inserting queue %s/%s in manager: %v", q.Namespace, q.Name, err)
 					}
 				}
-			}
-			if diff := cmp.Diff(tc.wantAdmissionsOnSecondSchedule, gotAssignments); diff != "" {
-				t.Errorf("Unexpected assigned clusterQueues in cache (-want,+got):\n%s", diff)
-			}
-		})
+				for i := range resourceFlavors {
+					cqCache.AddOrUpdateResourceFlavor(log, resourceFlavors[i])
+				}
+				for _, cq := range tc.cqs {
+					if err := cqCache.AddClusterQueue(ctx, &cq); err != nil {
+						t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
+					}
+					if err := qManager.AddClusterQueue(ctx, &cq); err != nil {
+						t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
+					}
+				}
+				scheduler := New(qManager, cqCache, cl, recorder, WithClock(t, fakeClock))
+
+				wg := sync.WaitGroup{}
+				scheduler.setAdmissionRoutineWrapper(routine.NewWrapper(
+					func() { wg.Add(1) },
+					func() { wg.Done() },
+				))
+
+				var mu sync.Mutex
+				gotPreempted := sets.New[workload.Reference]()
+				scheduler.preemptor.OverrideApply(func(_ context.Context, w *kueue.Workload, _, _ string) error {
+					mu.Lock()
+					gotPreempted.Insert(workload.Key(w))
+					mu.Unlock()
+					return nil
+				})
+
+				ctx, cancel := context.WithTimeout(ctx, queueingTimeout)
+				go qManager.CleanUpOnContext(ctx)
+				defer cancel()
+
+				scheduler.schedule(ctx)
+				wg.Wait()
+
+				if diff := cmp.Diff(tc.wantPreempted, gotPreempted); diff != "" {
+					t.Errorf("Unexpected preemptions (-want,+got):\n%s", diff)
+				}
+
+				gotWorkloads := &kueue.WorkloadList{}
+				err := cl.List(ctx, gotWorkloads)
+				if err != nil {
+					t.Fatalf("Unexpected list workloads error: %v", err)
+				}
+
+				defaultWorkloadCmpOpts := cmp.Options{
+					cmpopts.EquateEmpty(),
+					cmpopts.IgnoreFields(kueue.Workload{}, "ObjectMeta.ResourceVersion"),
+				}
+
+				if diff := cmp.Diff(tc.wantWorkloads, gotWorkloads.Items, defaultWorkloadCmpOpts); diff != "" {
+					t.Errorf("Unexpected scheduled workloads (-want,+got):\n%s", diff)
+				}
+
+				for _, workloadReference := range tc.deleteWorkloads {
+					var workload kueue.Workload
+					err := cl.Get(ctx, workloadReference, &workload)
+					if err != nil {
+						t.Errorf("Unable to get workload: %v", err)
+					}
+					err = cl.Delete(ctx, &workload)
+					if err != nil {
+						t.Errorf("Delete workload failed: %v", err)
+					}
+					err = cqCache.DeleteWorkload(log, &workload)
+					if err != nil {
+						t.Errorf("Delete workload failed: %v", err)
+					}
+					qManager.QueueAssociatedInadmissibleWorkloadsAfter(ctx, &workload, nil)
+				}
+
+				scheduler.schedule(ctx)
+				wg.Wait()
+
+				if diff := cmp.Diff(tc.wantPreempted, gotPreempted); diff != "" {
+					t.Errorf("Unexpected preemptions (-want,+got):\n%s", diff)
+				}
+				// Verify assignments in cache.
+				gotAssignments := make(map[workload.Reference]kueue.Admission)
+				snapshot, err := cqCache.Snapshot(ctx)
+				if err != nil {
+					t.Fatalf("unexpected error while building snapshot: %v", err)
+				}
+				for cqName, c := range snapshot.ClusterQueues() {
+					for name, w := range c.Workloads {
+						switch {
+						case !workload.IsAdmitted(w.Obj):
+							t.Errorf("Workload %s is not admitted by a clusterQueue, but it is found as member of clusterQueue %s in the cache", name, cqName)
+						case w.Obj.Status.Admission.ClusterQueue != cqName:
+							t.Errorf("Workload %s is admitted by clusterQueue %s, but it is found as member of clusterQueue %s in the cache", name, w.Obj.Status.Admission.ClusterQueue, cqName)
+						default:
+							gotAssignments[name] = *w.Obj.Status.Admission
+						}
+					}
+				}
+				if diff := cmp.Diff(tc.wantAdmissionsOnSecondSchedule, gotAssignments); diff != "" {
+					t.Errorf("Unexpected assigned clusterQueues in cache (-want,+got):\n%s", diff)
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
A preparatory PR for https://github.com/kubernetes-sigs/kueue/pull/7246
This change adds an extra run of scheduler tests with the WorkloadRequestUseMergePatch feature enabled.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to https://github.com/kubernetes-sigs/kueue/issues/7035

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```