### PR TITLE
Add ExpectAdmissionCheckState test util function and use it across e2e/integration tests

### DIFF
--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -218,11 +218,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			ginkgo.By("Waiting to be admitted in worker2", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, createdLeaderWorkload)).To(gomega.Succeed())
-					g.Expect(admissioncheck.FindAdmissionCheck(createdLeaderWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAc.Name))).To(gomega.BeComparableTo(&kueue.AdmissionCheckState{
-						Name:    kueue.AdmissionCheckReference(multiKueueAc.Name),
-						State:   kueue.CheckStatePending,
-						Message: `The workload got reservation on "worker2"`,
-					}, cmpopts.IgnoreFields(kueue.AdmissionCheckState{}, "LastTransitionTime")))
+					util.ExpectAdmissionCheckState(g, createdLeaderWorkload, multiKueueAc.Name, kueue.CheckStatePending, `The workload got reservation on "worker2"`)
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -415,11 +411,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			ginkgo.By("Waiting to be admitted in worker2", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, createdLeaderWorkload)).To(gomega.Succeed())
-					g.Expect(admissioncheck.FindAdmissionCheck(createdLeaderWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAc.Name))).To(gomega.BeComparableTo(&kueue.AdmissionCheckState{
-						Name:    kueue.AdmissionCheckReference(multiKueueAc.Name),
-						State:   kueue.CheckStatePending,
-						Message: `The workload got reservation on "worker2"`,
-					}, cmpopts.IgnoreFields(kueue.AdmissionCheckState{}, "LastTransitionTime")))
+					util.ExpectAdmissionCheckState(g, createdLeaderWorkload, multiKueueAc.Name, kueue.CheckStatePending, `The workload got reservation on "worker2"`)
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 
 				ginkgo.By("ensure all pods are created", func() {
@@ -469,11 +461,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			ginkgo.By("Waiting to be admitted in worker2, and the manager's job unsuspended", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, createdLeaderWorkload)).To(gomega.Succeed())
-					g.Expect(admissioncheck.FindAdmissionCheck(createdLeaderWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAc.Name))).To(gomega.BeComparableTo(&kueue.AdmissionCheckState{
-						Name:    kueue.AdmissionCheckReference(multiKueueAc.Name),
-						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker2"`,
-					}, cmpopts.IgnoreFields(kueue.AdmissionCheckState{}, "LastTransitionTime")))
+					util.ExpectAdmissionCheckState(g, createdLeaderWorkload, multiKueueAc.Name, kueue.CheckStateReady, `The workload got reservation on "worker2"`)
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -1057,11 +1045,7 @@ func waitForJobAdmitted(wlLookupKey types.NamespacedName, acName, workerName str
 			Reason:  "Admitted",
 			Message: "The workload is admitted",
 		}, util.IgnoreConditionTimestampsAndObservedGeneration))
-		g.Expect(admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(acName))).To(gomega.BeComparableTo(&kueue.AdmissionCheckState{
-			Name:    kueue.AdmissionCheckReference(acName),
-			State:   kueue.CheckStateReady,
-			Message: fmt.Sprintf(`The workload got reservation on "%s"`, workerName),
-		}, cmpopts.IgnoreFields(kueue.AdmissionCheckState{}, "LastTransitionTime")))
+		util.ExpectAdmissionCheckState(g, createdWorkload, acName, kueue.CheckStateReady, fmt.Sprintf(`The workload got reservation on "%s"`, workerName))
 	}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 }
 

--- a/test/integration/multikueue/dispatcher_test.go
+++ b/test/integration/multikueue/dispatcher_test.go
@@ -34,7 +34,6 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/features"
-	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
@@ -660,9 +659,7 @@ var _ = ginkgo.Describe("MultiKueueDispatcherAllAtOnce", ginkgo.Ordered, ginkgo.
 						Message: "The workload is admitted",
 					}, util.IgnoreConditionTimestampsAndObservedGeneration),
 				))
-				state := admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
-				g.Expect(state).NotTo(gomega.BeNil())
-				g.Expect(state.State).To(gomega.Equal(kueue.CheckStateReady))
+				util.ExpectAdmissionCheckState(g, createdWorkload, multiKueueAC.Name, kueue.CheckStateReady, "")
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
@@ -709,9 +706,7 @@ var _ = ginkgo.Describe("MultiKueueDispatcherAllAtOnce", ginkgo.Ordered, ginkgo.
 						Message: "The workload is admitted",
 					}, util.IgnoreConditionTimestampsAndObservedGeneration),
 				))
-				state := admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
-				g.Expect(state).NotTo(gomega.BeNil())
-				g.Expect(state.State).To(gomega.Equal(kueue.CheckStateReady))
+				util.ExpectAdmissionCheckState(g, createdWorkload, multiKueueAC.Name, kueue.CheckStateReady, "")
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -1439,12 +1439,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 				createdWorkload := &kueue.Workload{}
 				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 				acs := admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
-				g.Expect(acs).To(gomega.BeComparableTo(&kueue.AdmissionCheckState{
-					Name:       kueue.AdmissionCheckReference(multiKueueAC.Name),
-					State:      kueue.CheckStatePending,
-					RetryCount: ptr.To(int32(1)),
-				}, cmpopts.IgnoreFields(kueue.AdmissionCheckState{}, "LastTransitionTime", "Message")))
-
+				util.ExpectAdmissionCheckState(g, createdWorkload, multiKueueAC.Name, kueue.CheckStatePending, "")
 				// The transition interval should be close to testingKeepReadyTimeout (taking into account the resolution of the LastTransitionTime field)
 				g.Expect(acs.LastTransitionTime.Time).To(gomega.BeComparableTo(disconnectedTime.Add(testingWorkerLostTimeout), cmpopts.EquateApproxTime(2*time.Second)))
 

--- a/test/integration/multikueue/no_gc_test.go
+++ b/test/integration/multikueue/no_gc_test.go
@@ -32,7 +32,6 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/features"
-	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
@@ -249,9 +248,7 @@ var _ = ginkgo.Describe("MultiKueue no GC", ginkgo.Ordered, ginkgo.ContinueOnFai
 		ginkgo.By("setting workload reservation in worker1, AC state is updated in manager and worker2 wl is removed", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
-				acs := admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
-				g.Expect(acs).NotTo(gomega.BeNil())
-				g.Expect(acs.State).To(gomega.Equal(kueue.CheckStatePending))
+				util.ExpectAdmissionCheckState(g, createdWorkload, multiKueueAC.Name, kueue.CheckStatePending, "")
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 

--- a/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
@@ -642,9 +642,7 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			ginkgo.By("Checking the admission check state indicates an inactive check", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, wlKey, &updatedWl)).To(gomega.Succeed())
-					state := admissioncheck.FindAdmissionCheck(updatedWl.Status.AdmissionChecks, kueue.AdmissionCheckReference(ac.Name))
-					g.Expect(state).NotTo(gomega.BeNil())
-					g.Expect(state.Message).To(gomega.Equal(provisioning.CheckInactiveMessage))
+					util.ExpectAdmissionCheckState(g, &updatedWl, ac.Name, kueue.CheckStatePending, provisioning.CheckInactiveMessage)
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -38,7 +38,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/admissionchecks/provisioning"
 	"sigs.k8s.io/kueue/pkg/controller/tas"
 	"sigs.k8s.io/kueue/pkg/features"
-	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -2649,9 +2648,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				ginkgo.By("await for the check to be ready", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, wlKey, wl1)).To(gomega.Succeed())
-						state := admissioncheck.FindAdmissionCheck(wl1.Status.AdmissionChecks, kueue.AdmissionCheckReference(ac.Name))
-						g.Expect(state).NotTo(gomega.BeNil())
-						g.Expect(state.State).To(gomega.Equal(kueue.CheckStateReady))
+						util.ExpectAdmissionCheckState(g, wl1, ac.Name, kueue.CheckStateReady, "")
 					}, util.Timeout, time.Millisecond).Should(gomega.Succeed())
 				})
 

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -2648,7 +2648,15 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				ginkgo.By("await for the check to be ready", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, wlKey, wl1)).To(gomega.Succeed())
-						util.ExpectAdmissionCheckState(g, wl1, ac.Name, kueue.CheckStateReady, "")
+						util.ExpectAdmissionCheckState(g, wl1, ac.Name, kueue.CheckStateReady, "", []kueue.PodSetUpdate{
+							{
+								Name: "main",
+								Annotations: map[string]string{
+									autoscaling.ProvisioningRequestPodAnnotationKey: provReqKey.Name,
+									autoscaling.ProvisioningClassPodAnnotationKey:   prc.Spec.ProvisioningClassName,
+								},
+							},
+						}...)
 					}, util.Timeout, time.Millisecond).Should(gomega.Succeed())
 				})
 

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -76,6 +76,40 @@ import (
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
+var DefaultTestPodSetUpdates1 = []kueue.PodSetUpdate{
+	{
+		Name: "ps1",
+		Annotations: map[string]string{
+			"autoscaling.x-k8s.io/consume-provisioning-request": "wl-ac-prov-1",
+			"autoscaling.x-k8s.io/provisioning-class-name":      "provisioning-class",
+		},
+	},
+	{
+		Name: "ps2",
+		Annotations: map[string]string{
+			"autoscaling.x-k8s.io/consume-provisioning-request": "wl-ac-prov-1",
+			"autoscaling.x-k8s.io/provisioning-class-name":      "provisioning-class",
+		},
+	},
+}
+
+var DefaultTestPodSetUpdates2 = []kueue.PodSetUpdate{
+	{
+		Name: "ps1",
+		Annotations: map[string]string{
+			"autoscaling.x-k8s.io/consume-provisioning-request": "wl-ac-prov-2",
+			"autoscaling.x-k8s.io/provisioning-class-name":      "provisioning-class",
+		},
+	},
+	{
+		Name: "ps2",
+		Annotations: map[string]string{
+			"autoscaling.x-k8s.io/consume-provisioning-request": "wl-ac-prov-2",
+			"autoscaling.x-k8s.io/provisioning-class-name":      "provisioning-class",
+		},
+	},
+}
+
 var SetupLogger = sync.OnceFunc(func() {
 	ctrl.SetLogger(NewTestingLogger(ginkgo.GinkgoWriter))
 })
@@ -633,9 +667,7 @@ func ExpectAdmissionCheckState(g gomega.Gomega, updatedWl *kueue.Workload, admis
 	if expectedMessage != "" {
 		g.ExpectWithOffset(1, check.Message).To(gomega.Equal(expectedMessage))
 	}
-	if len(podSetUpdates) > 0 {
-		g.ExpectWithOffset(1, check.PodSetUpdates).To(gomega.Equal(podSetUpdates))
-	}
+	g.ExpectWithOffset(1, check.PodSetUpdates).To(gomega.Equal(podSetUpdates))
 }
 
 func ExpectLQAdmissionChecksWaitTimeMetric(lq *kueue.LocalQueue, priorityClass string, count int) {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -626,6 +626,18 @@ func ExpectAdmissionChecksWaitTimeMetric(cq *kueue.ClusterQueue, priorityClass s
 	}, Timeout, Interval).Should(gomega.Succeed())
 }
 
+func ExpectAdmissionCheckState(g gomega.Gomega, updatedWl *kueue.Workload, admissionCheckName string, expectedState kueue.CheckState, expectedMessage string, podSetUpdates ...kueue.PodSetUpdate) {
+	check := admissioncheck.FindAdmissionCheck(updatedWl.Status.AdmissionChecks, kueue.AdmissionCheckReference(admissionCheckName))
+	g.ExpectWithOffset(1, check).NotTo(gomega.BeNil())
+	g.ExpectWithOffset(1, check.State).To(gomega.Equal(expectedState))
+	if expectedMessage != "" {
+		g.ExpectWithOffset(1, check.Message).To(gomega.Equal(expectedMessage))
+	}
+	if len(podSetUpdates) > 0 {
+		g.ExpectWithOffset(1, check.PodSetUpdates).To(gomega.Equal(podSetUpdates))
+	}
+}
+
 func ExpectLQAdmissionChecksWaitTimeMetric(lq *kueue.LocalQueue, priorityClass string, count int) {
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
 		metric := metrics.LocalQueueAdmissionChecksWaitTime.WithLabelValues(lq.Name, lq.Namespace, priorityClass)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Add a test utils function ExpectAdmissionCheckState and refactor tests which check for the admissionCheck state to use it 
To make test more readable and robust and have a common pattern when checking the AdmissionCheck state

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7021 

#### Special notes for your reviewer:

1- For the `ExpectAdmissionCheckState` initially i wanted made it as wrapper for `gomega.Eventually` block but this to make this work in the test file i either need to call inside another gomega.Eventually block which is not recommended to have nested `gomega.Eventually` blocks because it makes the tests harder to debug and slower
and the other option is to separate  the AdmissionCheckState check logic outside of any gomega.Eventually and call the util function directly which i didn't like since it might have different behaviour and the function is not flexible to use 
so i opted to pass the `gomega.Eventually` `g reference` to the util function and use it like `g.ExpectWithOffset(1` inside the util function which is okay and error handling is working and firing to the parent  gomega.Eventually correctly and i can use it exactly as the current tests implementation 

2- few of the test files have a one liner which they call `FindAdmissionCheck` to just check if the workload has an AdmissionCheck. for those cases i didn't replace this with the util function since it does not add a value or reduce test code

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

NONE

```