### PR TITLE
Automated cherry pick of #7267: Use alias for kueue and visibility consistently

### DIFF
--- a/cmd/kueuectl/app/completion/completion.go
+++ b/cmd/kueuectl/app/completion/completion.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/util"
 )
 
@@ -117,7 +117,7 @@ func WorkloadNameFunc(clientGetter util.ClientGetter, activeStatus *bool) func(*
 		}
 
 		if activeStatus != nil {
-			filteredItems := make([]v1beta1.Workload, 0, len(list.Items))
+			filteredItems := make([]kueue.Workload, 0, len(list.Items))
 			for _, wl := range list.Items {
 				if ptr.Deref(wl.Spec.Active, true) == *activeStatus {
 					filteredItems = append(filteredItems, wl)
@@ -154,12 +154,12 @@ func ClusterQueueNameFunc(clientGetter util.ClientGetter, activeStatus *bool) fu
 		}
 
 		if activeStatus != nil {
-			filteredItems := make([]v1beta1.ClusterQueue, 0, len(list.Items))
+			filteredItems := make([]kueue.ClusterQueue, 0, len(list.Items))
 			for _, cq := range list.Items {
-				stopPolicy := ptr.Deref(cq.Spec.StopPolicy, v1beta1.None)
-				if *activeStatus && stopPolicy == v1beta1.None {
+				stopPolicy := ptr.Deref(cq.Spec.StopPolicy, kueue.None)
+				if *activeStatus && stopPolicy == kueue.None {
 					filteredItems = append(filteredItems, cq)
-				} else if !*activeStatus && stopPolicy != v1beta1.None {
+				} else if !*activeStatus && stopPolicy != kueue.None {
 					filteredItems = append(filteredItems, cq)
 				}
 			}
@@ -197,12 +197,12 @@ func LocalQueueNameFunc(clientGetter util.ClientGetter, activeStatus *bool) func
 		}
 
 		if activeStatus != nil {
-			filteredItems := make([]v1beta1.LocalQueue, 0, len(list.Items))
+			filteredItems := make([]kueue.LocalQueue, 0, len(list.Items))
 			for _, lq := range list.Items {
-				stopPolicy := ptr.Deref(lq.Spec.StopPolicy, v1beta1.None)
-				if *activeStatus && stopPolicy == v1beta1.None {
+				stopPolicy := ptr.Deref(lq.Spec.StopPolicy, kueue.None)
+				if *activeStatus && stopPolicy == kueue.None {
 					filteredItems = append(filteredItems, lq)
-				} else if !*activeStatus && stopPolicy != v1beta1.None {
+				} else if !*activeStatus && stopPolicy != kueue.None {
 					filteredItems = append(filteredItems, lq)
 				}
 			}

--- a/cmd/kueuectl/app/completion/completion_test.go
+++ b/cmd/kueuectl/app/completion/completion_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/fake"
 	cmdtesting "sigs.k8s.io/kueue/cmd/kueuectl/app/testing"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -109,9 +109,9 @@ func TestClusterQueueNameCompletionFunc(t *testing.T) {
 	}{
 		"should return active cluster queue names": {
 			objs: []runtime.Object{
-				utiltesting.MakeClusterQueue("cq1").StopPolicy(v1beta1.None).Obj(),
-				utiltesting.MakeClusterQueue("cq2").StopPolicy(v1beta1.Hold).Obj(),
-				utiltesting.MakeClusterQueue("cq3").StopPolicy(v1beta1.HoldAndDrain).Obj(),
+				utiltesting.MakeClusterQueue("cq1").StopPolicy(kueue.None).Obj(),
+				utiltesting.MakeClusterQueue("cq2").StopPolicy(kueue.Hold).Obj(),
+				utiltesting.MakeClusterQueue("cq3").StopPolicy(kueue.HoldAndDrain).Obj(),
 			},
 			wantNames:     []string{"cq1", "cq2", "cq3"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
@@ -119,9 +119,9 @@ func TestClusterQueueNameCompletionFunc(t *testing.T) {
 		"should return cluster queue names": {
 			status: ptr.To(true),
 			objs: []runtime.Object{
-				utiltesting.MakeClusterQueue("cq1").StopPolicy(v1beta1.None).Obj(),
-				utiltesting.MakeClusterQueue("cq2").StopPolicy(v1beta1.Hold).Obj(),
-				utiltesting.MakeClusterQueue("cq3").StopPolicy(v1beta1.HoldAndDrain).Obj(),
+				utiltesting.MakeClusterQueue("cq1").StopPolicy(kueue.None).Obj(),
+				utiltesting.MakeClusterQueue("cq2").StopPolicy(kueue.Hold).Obj(),
+				utiltesting.MakeClusterQueue("cq3").StopPolicy(kueue.HoldAndDrain).Obj(),
 			},
 			wantNames:     []string{"cq1"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
@@ -129,18 +129,18 @@ func TestClusterQueueNameCompletionFunc(t *testing.T) {
 		"should return inactive cluster queue names": {
 			status: ptr.To(false),
 			objs: []runtime.Object{
-				utiltesting.MakeClusterQueue("cq1").StopPolicy(v1beta1.None).Obj(),
-				utiltesting.MakeClusterQueue("cq2").StopPolicy(v1beta1.Hold).Obj(),
-				utiltesting.MakeClusterQueue("cq3").StopPolicy(v1beta1.HoldAndDrain).Obj(),
+				utiltesting.MakeClusterQueue("cq1").StopPolicy(kueue.None).Obj(),
+				utiltesting.MakeClusterQueue("cq2").StopPolicy(kueue.Hold).Obj(),
+				utiltesting.MakeClusterQueue("cq3").StopPolicy(kueue.HoldAndDrain).Obj(),
 			},
 			wantNames:     []string{"cq2", "cq3"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
 		"shouldn't return cluster queue names because only one argument can be passed": {
 			objs: []runtime.Object{
-				utiltesting.MakeClusterQueue("cq1").StopPolicy(v1beta1.None).Obj(),
-				utiltesting.MakeClusterQueue("cq2").StopPolicy(v1beta1.Hold).Obj(),
-				utiltesting.MakeClusterQueue("cq3").StopPolicy(v1beta1.HoldAndDrain).Obj(),
+				utiltesting.MakeClusterQueue("cq1").StopPolicy(kueue.None).Obj(),
+				utiltesting.MakeClusterQueue("cq2").StopPolicy(kueue.Hold).Obj(),
+				utiltesting.MakeClusterQueue("cq3").StopPolicy(kueue.HoldAndDrain).Obj(),
 			},
 			args:          []string{"cq2"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
@@ -178,9 +178,9 @@ func TestLocalQueueNameCompletionFunc(t *testing.T) {
 	}{
 		"should return local queue names": {
 			objs: []runtime.Object{
-				utiltesting.MakeLocalQueue("lq1", metav1.NamespaceDefault).StopPolicy(v1beta1.None).Obj(),
-				utiltesting.MakeLocalQueue("lq2", metav1.NamespaceDefault).StopPolicy(v1beta1.Hold).Obj(),
-				utiltesting.MakeLocalQueue("lq3", metav1.NamespaceDefault).StopPolicy(v1beta1.HoldAndDrain).Obj(),
+				utiltesting.MakeLocalQueue("lq1", metav1.NamespaceDefault).StopPolicy(kueue.None).Obj(),
+				utiltesting.MakeLocalQueue("lq2", metav1.NamespaceDefault).StopPolicy(kueue.Hold).Obj(),
+				utiltesting.MakeLocalQueue("lq3", metav1.NamespaceDefault).StopPolicy(kueue.HoldAndDrain).Obj(),
 			},
 			wantNames:     []string{"lq1", "lq2", "lq3"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
@@ -188,9 +188,9 @@ func TestLocalQueueNameCompletionFunc(t *testing.T) {
 		"should return active local queue names": {
 			status: ptr.To(true),
 			objs: []runtime.Object{
-				utiltesting.MakeLocalQueue("lq1", metav1.NamespaceDefault).StopPolicy(v1beta1.None).Obj(),
-				utiltesting.MakeLocalQueue("lq2", metav1.NamespaceDefault).StopPolicy(v1beta1.Hold).Obj(),
-				utiltesting.MakeLocalQueue("lq3", metav1.NamespaceDefault).StopPolicy(v1beta1.HoldAndDrain).Obj(),
+				utiltesting.MakeLocalQueue("lq1", metav1.NamespaceDefault).StopPolicy(kueue.None).Obj(),
+				utiltesting.MakeLocalQueue("lq2", metav1.NamespaceDefault).StopPolicy(kueue.Hold).Obj(),
+				utiltesting.MakeLocalQueue("lq3", metav1.NamespaceDefault).StopPolicy(kueue.HoldAndDrain).Obj(),
 			},
 			wantNames:     []string{"lq1"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
@@ -198,9 +198,9 @@ func TestLocalQueueNameCompletionFunc(t *testing.T) {
 		"should return inactive local queue names": {
 			status: ptr.To(false),
 			objs: []runtime.Object{
-				utiltesting.MakeLocalQueue("lq1", metav1.NamespaceDefault).StopPolicy(v1beta1.None).Obj(),
-				utiltesting.MakeLocalQueue("lq2", metav1.NamespaceDefault).StopPolicy(v1beta1.Hold).Obj(),
-				utiltesting.MakeLocalQueue("lq3", metav1.NamespaceDefault).StopPolicy(v1beta1.HoldAndDrain).Obj(),
+				utiltesting.MakeLocalQueue("lq1", metav1.NamespaceDefault).StopPolicy(kueue.None).Obj(),
+				utiltesting.MakeLocalQueue("lq2", metav1.NamespaceDefault).StopPolicy(kueue.Hold).Obj(),
+				utiltesting.MakeLocalQueue("lq3", metav1.NamespaceDefault).StopPolicy(kueue.HoldAndDrain).Obj(),
 			},
 			wantNames:     []string{"lq2", "lq3"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,

--- a/cmd/kueuectl/app/create/create_clusterqueue.go
+++ b/cmd/kueuectl/app/create/create_clusterqueue.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 	"k8s.io/utils/ptr"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/scheme"
 	kueuev1beta1 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/kueue/v1beta1"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/util"
@@ -91,11 +91,11 @@ type ClusterQueueOptions struct {
 	DryRunStrategy               util.DryRunStrategy
 	Name                         string
 	Cohort                       string
-	QueueingStrategy             v1beta1.QueueingStrategy
+	QueueingStrategy             kueue.QueueingStrategy
 	NamespaceSelector            metav1.LabelSelector
-	ReclaimWithinCohort          v1beta1.PreemptionPolicy
-	PreemptionWithinClusterQueue v1beta1.PreemptionPolicy
-	ResourceGroups               []v1beta1.ResourceGroup
+	ReclaimWithinCohort          kueue.PreemptionPolicy
+	PreemptionWithinClusterQueue kueue.PreemptionPolicy
+	ResourceGroups               []kueue.ResourceGroup
 
 	UserSpecifiedQueueingStrategy             string
 	UserSpecifiedNamespaceSelector            map[string]string
@@ -116,9 +116,9 @@ func NewClusterQueueOptions(streams genericiooptions.IOStreams) *ClusterQueueOpt
 	return &ClusterQueueOptions{
 		PrintFlags:                   genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		IOStreams:                    streams,
-		QueueingStrategy:             v1beta1.BestEffortFIFO,
-		ReclaimWithinCohort:          v1beta1.PreemptionPolicyNever,
-		PreemptionWithinClusterQueue: v1beta1.PreemptionPolicyNever,
+		QueueingStrategy:             kueue.BestEffortFIFO,
+		ReclaimWithinCohort:          kueue.PreemptionPolicyNever,
+		PreemptionWithinClusterQueue: kueue.PreemptionPolicyNever,
 	}
 }
 
@@ -184,7 +184,7 @@ func (o *ClusterQueueOptions) Complete(clientGetter util.ClientGetter, cmd *cobr
 	o.Name = args[0]
 
 	if cmd.Flags().Changed(queuingStrategy) {
-		o.QueueingStrategy = v1beta1.QueueingStrategy(o.UserSpecifiedQueueingStrategy)
+		o.QueueingStrategy = kueue.QueueingStrategy(o.UserSpecifiedQueueingStrategy)
 	}
 
 	if cmd.Flags().Changed(namespaceSelector) {
@@ -194,11 +194,11 @@ func (o *ClusterQueueOptions) Complete(clientGetter util.ClientGetter, cmd *cobr
 	}
 
 	if cmd.Flags().Changed(reclaimWithinCohort) {
-		o.ReclaimWithinCohort = v1beta1.PreemptionPolicy(o.UserSpecifiedReclaimWithinCohort)
+		o.ReclaimWithinCohort = kueue.PreemptionPolicy(o.UserSpecifiedReclaimWithinCohort)
 	}
 
 	if cmd.Flags().Changed(preemptionWithinClusterQueue) {
-		o.PreemptionWithinClusterQueue = v1beta1.PreemptionPolicy(o.UserSpecifiedPreemptionWithinClusterQueue)
+		o.PreemptionWithinClusterQueue = kueue.PreemptionPolicy(o.UserSpecifiedPreemptionWithinClusterQueue)
 	}
 
 	var err error
@@ -264,15 +264,15 @@ func (o *ClusterQueueOptions) Run(ctx context.Context) error {
 	return o.PrintObj(cq, o.Out)
 }
 
-func (o *ClusterQueueOptions) createClusterQueue() *v1beta1.ClusterQueue {
-	return &v1beta1.ClusterQueue{
-		TypeMeta:   metav1.TypeMeta{APIVersion: v1beta1.SchemeGroupVersion.String(), Kind: "ClusterQueue"},
+func (o *ClusterQueueOptions) createClusterQueue() *kueue.ClusterQueue {
+	return &kueue.ClusterQueue{
+		TypeMeta:   metav1.TypeMeta{APIVersion: kueue.SchemeGroupVersion.String(), Kind: "ClusterQueue"},
 		ObjectMeta: metav1.ObjectMeta{Name: o.Name},
-		Spec: v1beta1.ClusterQueueSpec{
-			Cohort:            v1beta1.CohortReference(o.Cohort),
+		Spec: kueue.ClusterQueueSpec{
+			Cohort:            kueue.CohortReference(o.Cohort),
 			QueueingStrategy:  o.QueueingStrategy,
 			NamespaceSelector: &o.NamespaceSelector,
-			Preemption: &v1beta1.ClusterQueuePreemption{
+			Preemption: &kueue.ClusterQueuePreemption{
 				ReclaimWithinCohort: o.ReclaimWithinCohort,
 				WithinClusterQueue:  o.PreemptionWithinClusterQueue,
 			},
@@ -312,8 +312,8 @@ func (o *ClusterQueueOptions) parseResourceGroups() error {
 	return nil
 }
 
-func parseUserSpecifiedResourceQuotas(resources []string, quotaType string) ([]v1beta1.ResourceGroup, error) {
-	var resourceGroups []v1beta1.ResourceGroup
+func parseUserSpecifiedResourceQuotas(resources []string, quotaType string) ([]kueue.ResourceGroup, error) {
+	var resourceGroups []kueue.ResourceGroup
 
 	regex := regexp.MustCompile(`^([a-z0-9][a-z0-9\-\.]{0,252}):((\w+[\.-]?)*\/?\w+=\w+;)*(\w+[\.-]?)*\/?\w+=\w+;?$`)
 	for _, r := range resources {
@@ -332,17 +332,17 @@ func parseUserSpecifiedResourceQuotas(resources []string, quotaType string) ([]v
 	return resourceGroups, nil
 }
 
-func toResourceGroup(spec, quotaType string) (v1beta1.ResourceGroup, error) {
+func toResourceGroup(spec, quotaType string) (kueue.ResourceGroup, error) {
 	flavorName, userSpecifiedResources := parseKeyValue(spec, ":")
 	resourceSpecs := strings.Split(userSpecifiedResources, ";")
 	flavorQuotas, err := toFlavorQuotas(flavorName, resourceSpecs, quotaType)
 	if err != nil {
-		return v1beta1.ResourceGroup{}, err
+		return kueue.ResourceGroup{}, err
 	}
 
-	return v1beta1.ResourceGroup{
+	return kueue.ResourceGroup{
 		CoveredResources: getCoveredResources(resourceSpecs),
-		Flavors: []v1beta1.FlavorQuotas{
+		Flavors: []kueue.FlavorQuotas{
 			flavorQuotas,
 		},
 	}, nil
@@ -358,32 +358,32 @@ func getCoveredResources(resourceSpecs []string) []corev1.ResourceName {
 	return coveredResources
 }
 
-func toFlavorQuotas(name string, resourceSpecs []string, quotaType string) (v1beta1.FlavorQuotas, error) {
-	resourceQuotas := make([]v1beta1.ResourceQuota, 0, len(resourceSpecs))
+func toFlavorQuotas(name string, resourceSpecs []string, quotaType string) (kueue.FlavorQuotas, error) {
+	resourceQuotas := make([]kueue.ResourceQuota, 0, len(resourceSpecs))
 	for _, spec := range resourceSpecs {
 		rq, err := toResourceQuota(spec, quotaType)
 		if err != nil {
-			return v1beta1.FlavorQuotas{}, err
+			return kueue.FlavorQuotas{}, err
 		}
 
 		resourceQuotas = append(resourceQuotas, rq)
 	}
 
-	return v1beta1.FlavorQuotas{
-		Name:      v1beta1.ResourceFlavorReference(name),
+	return kueue.FlavorQuotas{
+		Name:      kueue.ResourceFlavorReference(name),
 		Resources: resourceQuotas,
 	}, nil
 }
 
-func toResourceQuota(spec, quotaType string) (v1beta1.ResourceQuota, error) {
+func toResourceQuota(spec, quotaType string) (kueue.ResourceQuota, error) {
 	name, quota := parseKeyValue(spec, "=")
-	rq := v1beta1.ResourceQuota{
+	rq := kueue.ResourceQuota{
 		Name: corev1.ResourceName(name),
 	}
 
 	quantity, err := resource.ParseQuantity(quota)
 	if err != nil {
-		return v1beta1.ResourceQuota{}, errInvalidResourceQuota
+		return kueue.ResourceQuota{}, errInvalidResourceQuota
 	}
 
 	switch quotaType {
@@ -406,10 +406,10 @@ func parseKeyValue(str, sep string) (string, string) {
 	return strings.TrimSpace(pair[0]), strings.TrimSpace(pair[1])
 }
 
-func mergeResourcesByFlavor(resourceGroups []v1beta1.ResourceGroup) ([]v1beta1.ResourceGroup, error) {
-	var mergedResources []v1beta1.ResourceGroup
+func mergeResourcesByFlavor(resourceGroups []kueue.ResourceGroup) ([]kueue.ResourceGroup, error) {
+	var mergedResources []kueue.ResourceGroup
 
-	indexByFlavor := make(map[v1beta1.ResourceFlavorReference]int)
+	indexByFlavor := make(map[kueue.ResourceFlavorReference]int)
 	var index int
 	for _, rg := range resourceGroups {
 		flavorName := rg.Flavors[0].Name
@@ -432,11 +432,11 @@ func mergeResourcesByFlavor(resourceGroups []v1beta1.ResourceGroup) ([]v1beta1.R
 	return mergedResources, nil
 }
 
-func mergeResourceQuotas(rQuotas1, rQuotas2 []v1beta1.ResourceQuota) ([]v1beta1.ResourceQuota, error) {
-	var mergedResourceQuotas []v1beta1.ResourceQuota
+func mergeResourceQuotas(rQuotas1, rQuotas2 []kueue.ResourceQuota) ([]kueue.ResourceQuota, error) {
+	var mergedResourceQuotas []kueue.ResourceQuota
 
 	for _, rq1 := range rQuotas1 {
-		idx := slices.IndexFunc(rQuotas2, func(rq v1beta1.ResourceQuota) bool { return rq.Name == rq1.Name })
+		idx := slices.IndexFunc(rQuotas2, func(rq kueue.ResourceQuota) bool { return rq.Name == rq1.Name })
 		if idx == -1 {
 			// both ResourceQuota lists should contain exactly the same resource names
 			return mergedResourceQuotas, errResourceQuotaNotFound
@@ -459,8 +459,8 @@ func mergeResourceQuotas(rQuotas1, rQuotas2 []v1beta1.ResourceQuota) ([]v1beta1.
 	return mergedResourceQuotas, nil
 }
 
-func mergeFlavorsByCoveredResources(resourceGroups []v1beta1.ResourceGroup) ([]v1beta1.ResourceGroup, error) {
-	var mergedResources []v1beta1.ResourceGroup
+func mergeFlavorsByCoveredResources(resourceGroups []kueue.ResourceGroup) ([]kueue.ResourceGroup, error) {
+	var mergedResources []kueue.ResourceGroup
 
 	indexByResourceGroupID := make(map[string]int)
 	var index int

--- a/cmd/kueuectl/app/create/create_clusterqueue_test.go
+++ b/cmd/kueuectl/app/create/create_clusterqueue_test.go
@@ -24,14 +24,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
 
 func TestCreateClusterQueue(t *testing.T) {
 	testCases := map[string]struct {
 		options  *ClusterQueueOptions
-		expected *v1beta1.ClusterQueue
+		expected *kueue.ClusterQueue
 	}{
 		"success_create": {
 			options: &ClusterQueueOptions{
@@ -43,10 +43,10 @@ func TestCreateClusterQueue(t *testing.T) {
 				},
 				ReclaimWithinCohort:          "Any",
 				PreemptionWithinClusterQueue: "LowerPriority",
-				ResourceGroups: []v1beta1.ResourceGroup{
+				ResourceGroups: []kueue.ResourceGroup{
 					{
 						CoveredResources: []corev1.ResourceName{},
-						Flavors: []v1beta1.FlavorQuotas{
+						Flavors: []kueue.FlavorQuotas{
 							*utiltesting.MakeFlavorQuotas("alpha").
 								Resource("cpu", "0", "0", "0").
 								Resource("memory", "0", "0", "0").
@@ -55,23 +55,23 @@ func TestCreateClusterQueue(t *testing.T) {
 					},
 				},
 			},
-			expected: &v1beta1.ClusterQueue{
+			expected: &kueue.ClusterQueue{
 				TypeMeta:   metav1.TypeMeta{APIVersion: "kueue.x-k8s.io/v1beta1", Kind: "ClusterQueue"},
 				ObjectMeta: metav1.ObjectMeta{Name: "cq1"},
-				Spec: v1beta1.ClusterQueueSpec{
+				Spec: kueue.ClusterQueueSpec{
 					Cohort:           "cohort",
-					QueueingStrategy: v1beta1.StrictFIFO,
+					QueueingStrategy: kueue.StrictFIFO,
 					NamespaceSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"foo": "bar"},
 					},
-					Preemption: &v1beta1.ClusterQueuePreemption{
-						ReclaimWithinCohort: v1beta1.PreemptionPolicyAny,
-						WithinClusterQueue:  v1beta1.PreemptionPolicyLowerPriority,
+					Preemption: &kueue.ClusterQueuePreemption{
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
 					},
-					ResourceGroups: []v1beta1.ResourceGroup{
+					ResourceGroups: []kueue.ResourceGroup{
 						{
 							CoveredResources: []corev1.ResourceName{},
-							Flavors: []v1beta1.FlavorQuotas{
+							Flavors: []kueue.FlavorQuotas{
 								*utiltesting.MakeFlavorQuotas("alpha").
 									Resource("cpu", "0", "0", "0").
 									Resource("memory", "0", "0", "0").
@@ -99,14 +99,14 @@ func TestParseResourceQuotas(t *testing.T) {
 		borrowingArgs      []string
 		lendingArgs        []string
 		wantErr            error
-		wantResourceGroups []v1beta1.ResourceGroup
+		wantResourceGroups []kueue.ResourceGroup
 	}{
 		"should create one resource group with one flavor and nominalQuota set": {
 			quotaArgs: []string{"alpha-2.0:cpu=1;memory=1;example-1.org/memory=5Gi"},
-			wantResourceGroups: []v1beta1.ResourceGroup{
+			wantResourceGroups: []kueue.ResourceGroup{
 				{
 					CoveredResources: []corev1.ResourceName{"cpu", "memory", "example-1.org/memory"},
-					Flavors: []v1beta1.FlavorQuotas{
+					Flavors: []kueue.FlavorQuotas{
 						*utiltesting.MakeFlavorQuotas("alpha-2.0").
 							Resource("cpu", "1").
 							Resource("memory", "1").
@@ -118,10 +118,10 @@ func TestParseResourceQuotas(t *testing.T) {
 		},
 		"should create one resource group with one flavor and borrowingLimit set": {
 			borrowingArgs: []string{"alpha:cpu=1;memory=1"},
-			wantResourceGroups: []v1beta1.ResourceGroup{
+			wantResourceGroups: []kueue.ResourceGroup{
 				{
 					CoveredResources: []corev1.ResourceName{"cpu", "memory"},
-					Flavors: []v1beta1.FlavorQuotas{
+					Flavors: []kueue.FlavorQuotas{
 						*utiltesting.MakeFlavorQuotas("alpha").
 							Resource("cpu", "0", "1").
 							Resource("memory", "0", "1").
@@ -132,10 +132,10 @@ func TestParseResourceQuotas(t *testing.T) {
 		},
 		"should create one resource group with one flavor and lendingLimit set": {
 			lendingArgs: []string{"alpha:cpu=1;memory=1"},
-			wantResourceGroups: []v1beta1.ResourceGroup{
+			wantResourceGroups: []kueue.ResourceGroup{
 				{
 					CoveredResources: []corev1.ResourceName{"cpu", "memory"},
-					Flavors: []v1beta1.FlavorQuotas{
+					Flavors: []kueue.FlavorQuotas{
 						*utiltesting.MakeFlavorQuotas("alpha").
 							Resource("cpu", "0", "", "1").
 							Resource("memory", "0", "", "1").
@@ -146,10 +146,10 @@ func TestParseResourceQuotas(t *testing.T) {
 		},
 		"should create one resource group with two flavors and nominalQuota set": {
 			quotaArgs: []string{"alpha:example.com/gpu=1", "beta:example.com/gpu=2"},
-			wantResourceGroups: []v1beta1.ResourceGroup{
+			wantResourceGroups: []kueue.ResourceGroup{
 				{
 					CoveredResources: []corev1.ResourceName{"example.com/gpu"},
-					Flavors: []v1beta1.FlavorQuotas{
+					Flavors: []kueue.FlavorQuotas{
 						*utiltesting.MakeFlavorQuotas("alpha").
 							Resource("example.com/gpu", "1").
 							Obj(),
@@ -162,10 +162,10 @@ func TestParseResourceQuotas(t *testing.T) {
 		},
 		"should create one resource group when flavors listing resources in different order": {
 			quotaArgs: []string{"alpha:cpu=1;memory=1", "beta:memory=2;cpu=2"},
-			wantResourceGroups: []v1beta1.ResourceGroup{
+			wantResourceGroups: []kueue.ResourceGroup{
 				{
 					CoveredResources: []corev1.ResourceName{"cpu", "memory"},
-					Flavors: []v1beta1.FlavorQuotas{
+					Flavors: []kueue.FlavorQuotas{
 						*utiltesting.MakeFlavorQuotas("alpha").
 							Resource("cpu", "1").
 							Resource("memory", "1").
@@ -180,10 +180,10 @@ func TestParseResourceQuotas(t *testing.T) {
 		},
 		"should create two resource groups with one flavor each and nominalQuota set": {
 			quotaArgs: []string{"alpha:cpu=1;memory=1", "beta:example.com/gpu=2"},
-			wantResourceGroups: []v1beta1.ResourceGroup{
+			wantResourceGroups: []kueue.ResourceGroup{
 				{
 					CoveredResources: []corev1.ResourceName{"cpu", "memory"},
-					Flavors: []v1beta1.FlavorQuotas{
+					Flavors: []kueue.FlavorQuotas{
 						*utiltesting.MakeFlavorQuotas("alpha").
 							Resource("cpu", "1").
 							Resource("memory", "1").
@@ -192,7 +192,7 @@ func TestParseResourceQuotas(t *testing.T) {
 				},
 				{
 					CoveredResources: []corev1.ResourceName{"example.com/gpu"},
-					Flavors: []v1beta1.FlavorQuotas{
+					Flavors: []kueue.FlavorQuotas{
 						*utiltesting.MakeFlavorQuotas("beta").
 							Resource("example.com/gpu", "2").
 							Obj(),
@@ -202,10 +202,10 @@ func TestParseResourceQuotas(t *testing.T) {
 		},
 		"should create two resource groups with multiple flavors and nominalQuota set": {
 			quotaArgs: []string{"alpha:cpu=1;memory=1", "beta:example.com/gpu=2", "gamma:cpu=2;memory=2"},
-			wantResourceGroups: []v1beta1.ResourceGroup{
+			wantResourceGroups: []kueue.ResourceGroup{
 				{
 					CoveredResources: []corev1.ResourceName{"cpu", "memory"},
-					Flavors: []v1beta1.FlavorQuotas{
+					Flavors: []kueue.FlavorQuotas{
 						*utiltesting.MakeFlavorQuotas("alpha").
 							Resource("cpu", "1").
 							Resource("memory", "1").
@@ -218,7 +218,7 @@ func TestParseResourceQuotas(t *testing.T) {
 				},
 				{
 					CoveredResources: []corev1.ResourceName{"example.com/gpu"},
-					Flavors: []v1beta1.FlavorQuotas{
+					Flavors: []kueue.FlavorQuotas{
 						*utiltesting.MakeFlavorQuotas("beta").
 							Resource("example.com/gpu", "2").
 							Obj(),
@@ -230,10 +230,10 @@ func TestParseResourceQuotas(t *testing.T) {
 			quotaArgs:     []string{"alpha:cpu=1;memory=2"},
 			borrowingArgs: []string{"alpha:cpu=1;memory=2"},
 			lendingArgs:   []string{"alpha:cpu=1;memory=2"},
-			wantResourceGroups: []v1beta1.ResourceGroup{
+			wantResourceGroups: []kueue.ResourceGroup{
 				{
 					CoveredResources: []corev1.ResourceName{"cpu", "memory"},
-					Flavors: []v1beta1.FlavorQuotas{
+					Flavors: []kueue.FlavorQuotas{
 						*utiltesting.MakeFlavorQuotas("alpha").
 							Resource("cpu", "1", "1", "1").
 							Resource("memory", "2", "2", "2").
@@ -246,10 +246,10 @@ func TestParseResourceQuotas(t *testing.T) {
 			quotaArgs:     []string{"alpha:example.com/gpu=1", "beta:example.com/gpu=2"},
 			borrowingArgs: []string{"alpha:example.com/gpu=1", "beta:example.com/gpu=2"},
 			lendingArgs:   []string{"alpha:example.com/gpu=1", "beta:example.com/gpu=2"},
-			wantResourceGroups: []v1beta1.ResourceGroup{
+			wantResourceGroups: []kueue.ResourceGroup{
 				{
 					CoveredResources: []corev1.ResourceName{"example.com/gpu"},
-					Flavors: []v1beta1.FlavorQuotas{
+					Flavors: []kueue.FlavorQuotas{
 						*utiltesting.MakeFlavorQuotas("alpha").
 							Resource("example.com/gpu", "1", "1", "1").
 							Obj(),
@@ -264,10 +264,10 @@ func TestParseResourceQuotas(t *testing.T) {
 			quotaArgs:     []string{"alpha:cpu=1;memory=1", "beta:example.com/gpu=2"},
 			borrowingArgs: []string{"alpha:cpu=1;memory=1", "beta:example.com/gpu=2"},
 			lendingArgs:   []string{"alpha:cpu=1;memory=1", "beta:example.com/gpu=2"},
-			wantResourceGroups: []v1beta1.ResourceGroup{
+			wantResourceGroups: []kueue.ResourceGroup{
 				{
 					CoveredResources: []corev1.ResourceName{"cpu", "memory"},
-					Flavors: []v1beta1.FlavorQuotas{
+					Flavors: []kueue.FlavorQuotas{
 						*utiltesting.MakeFlavorQuotas("alpha").
 							Resource("cpu", "1", "1", "1").
 							Resource("memory", "1", "1", "1").
@@ -276,7 +276,7 @@ func TestParseResourceQuotas(t *testing.T) {
 				},
 				{
 					CoveredResources: []corev1.ResourceName{"example.com/gpu"},
-					Flavors: []v1beta1.FlavorQuotas{
+					Flavors: []kueue.FlavorQuotas{
 						*utiltesting.MakeFlavorQuotas("beta").
 							Resource("example.com/gpu", "2", "2", "2").
 							Obj(),
@@ -288,10 +288,10 @@ func TestParseResourceQuotas(t *testing.T) {
 			quotaArgs:     []string{"alpha:cpu=1;memory=1", "beta:example.com/gpu=2", "gamma:cpu=2;memory=2"},
 			borrowingArgs: []string{"alpha:cpu=1;memory=1", "beta:example.com/gpu=2", "gamma:cpu=2;memory=2"},
 			lendingArgs:   []string{"alpha:cpu=1;memory=1", "beta:example.com/gpu=2", "gamma:cpu=2;memory=2"},
-			wantResourceGroups: []v1beta1.ResourceGroup{
+			wantResourceGroups: []kueue.ResourceGroup{
 				{
 					CoveredResources: []corev1.ResourceName{"cpu", "memory"},
-					Flavors: []v1beta1.FlavorQuotas{
+					Flavors: []kueue.FlavorQuotas{
 						*utiltesting.MakeFlavorQuotas("alpha").
 							Resource("cpu", "1", "1", "1").
 							Resource("memory", "1", "1", "1").
@@ -304,7 +304,7 @@ func TestParseResourceQuotas(t *testing.T) {
 				},
 				{
 					CoveredResources: []corev1.ResourceName{"example.com/gpu"},
-					Flavors: []v1beta1.FlavorQuotas{
+					Flavors: []kueue.FlavorQuotas{
 						*utiltesting.MakeFlavorQuotas("beta").
 							Resource("example.com/gpu", "2", "2", "2").
 							Obj(),

--- a/cmd/kueuectl/app/create/create_localqueue.go
+++ b/cmd/kueuectl/app/create/create_localqueue.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/kubectl/pkg/util/templates"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/scheme"
 	kueuev1beta1 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/kueue/v1beta1"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/completion"
@@ -52,7 +52,7 @@ type LocalQueueOptions struct {
 	Name             string
 	Namespace        string
 	EnforceNamespace bool
-	ClusterQueue     v1beta1.ClusterQueueReference
+	ClusterQueue     kueue.ClusterQueueReference
 	IgnoreUnknownCq  bool
 
 	UserSpecifiedClusterQueue string
@@ -122,7 +122,7 @@ func (o *LocalQueueOptions) Complete(clientGetter util.ClientGetter, cmd *cobra.
 		return err
 	}
 
-	o.ClusterQueue = v1beta1.ClusterQueueReference(o.UserSpecifiedClusterQueue)
+	o.ClusterQueue = kueue.ClusterQueueReference(o.UserSpecifiedClusterQueue)
 
 	clientset, err := clientGetter.KueueClientSet()
 	if err != nil {
@@ -190,10 +190,10 @@ func (o *LocalQueueOptions) Run(ctx context.Context) error {
 	return o.PrintObj(lq, o.Out)
 }
 
-func (o *LocalQueueOptions) createLocalQueue() *v1beta1.LocalQueue {
-	return &v1beta1.LocalQueue{
-		TypeMeta:   metav1.TypeMeta{APIVersion: v1beta1.SchemeGroupVersion.String(), Kind: "LocalQueue"},
+func (o *LocalQueueOptions) createLocalQueue() *kueue.LocalQueue {
+	return &kueue.LocalQueue{
+		TypeMeta:   metav1.TypeMeta{APIVersion: kueue.SchemeGroupVersion.String(), Kind: "LocalQueue"},
 		ObjectMeta: metav1.ObjectMeta{Name: o.Name, Namespace: o.Namespace},
-		Spec:       v1beta1.LocalQueueSpec{ClusterQueue: o.ClusterQueue},
+		Spec:       kueue.LocalQueueSpec{ClusterQueue: o.ClusterQueue},
 	}
 }

--- a/cmd/kueuectl/app/create/create_localqueue_test.go
+++ b/cmd/kueuectl/app/create/create_localqueue_test.go
@@ -22,13 +22,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
 
 func TestCreateLocalQueue(t *testing.T) {
 	testCases := map[string]struct {
 		options  *LocalQueueOptions
-		expected *v1beta1.LocalQueue
+		expected *kueue.LocalQueue
 	}{
 		"success_create": {
 			options: &LocalQueueOptions{
@@ -36,10 +36,10 @@ func TestCreateLocalQueue(t *testing.T) {
 				Namespace:    "ns1",
 				ClusterQueue: "cq1",
 			},
-			expected: &v1beta1.LocalQueue{
+			expected: &kueue.LocalQueue{
 				TypeMeta:   metav1.TypeMeta{APIVersion: "kueue.x-k8s.io/v1beta1", Kind: "LocalQueue"},
 				ObjectMeta: metav1.ObjectMeta{Name: "lq1", Namespace: "ns1"},
-				Spec:       v1beta1.LocalQueueSpec{ClusterQueue: "cq1"},
+				Spec:       kueue.LocalQueueSpec{ClusterQueue: "cq1"},
 			},
 		},
 	}

--- a/cmd/kueuectl/app/create/create_resourceflavor.go
+++ b/cmd/kueuectl/app/create/create_resourceflavor.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/kubectl/pkg/util/templates"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/scheme"
 	kueuev1beta1 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/kueue/v1beta1"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/util"
@@ -186,11 +186,11 @@ func (o *ResourceFlavorOptions) Run(ctx context.Context) error {
 	return o.PrintObj(rf, o.Out)
 }
 
-func (o *ResourceFlavorOptions) createResourceFlavor() *v1beta1.ResourceFlavor {
-	return &v1beta1.ResourceFlavor{
-		TypeMeta:   metav1.TypeMeta{APIVersion: v1beta1.SchemeGroupVersion.String(), Kind: "ResourceFlavor"},
+func (o *ResourceFlavorOptions) createResourceFlavor() *kueue.ResourceFlavor {
+	return &kueue.ResourceFlavor{
+		TypeMeta:   metav1.TypeMeta{APIVersion: kueue.SchemeGroupVersion.String(), Kind: "ResourceFlavor"},
 		ObjectMeta: metav1.ObjectMeta{Name: o.Name},
-		Spec: v1beta1.ResourceFlavorSpec{
+		Spec: kueue.ResourceFlavorSpec{
 			NodeLabels:  o.NodeLabels,
 			NodeTaints:  o.NodeTaints,
 			Tolerations: o.Tolerations,

--- a/cmd/kueuectl/app/create/create_resourceflavor_test.go
+++ b/cmd/kueuectl/app/create/create_resourceflavor_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/fake"
 	cmdtesting "sigs.k8s.io/kueue/cmd/kueuectl/app/testing"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -205,7 +205,7 @@ func TestResourceFlavorOptions_parseTolerations(t *testing.T) {
 func TestResourceFlavorOptions_createResourceFlavor(t *testing.T) {
 	testCases := map[string]struct {
 		options  *ResourceFlavorOptions
-		expected *v1beta1.ResourceFlavor
+		expected *kueue.ResourceFlavor
 	}{
 		"success create": {
 			options: &ResourceFlavorOptions{
@@ -213,10 +213,10 @@ func TestResourceFlavorOptions_createResourceFlavor(t *testing.T) {
 				NodeLabels: map[string]string{"key1": "value"},
 				NodeTaints: []corev1.Taint{{Key: "key1", Value: "value", Effect: corev1.TaintEffectNoSchedule}},
 			},
-			expected: &v1beta1.ResourceFlavor{
+			expected: &kueue.ResourceFlavor{
 				TypeMeta:   metav1.TypeMeta{APIVersion: "kueue.x-k8s.io/v1beta1", Kind: "ResourceFlavor"},
 				ObjectMeta: metav1.ObjectMeta{Name: "rf"},
-				Spec: v1beta1.ResourceFlavorSpec{
+				Spec: kueue.ResourceFlavorSpec{
 					NodeLabels: map[string]string{"key1": "value"},
 					NodeTaints: []corev1.Taint{{Key: "key1", Value: "value", Effect: corev1.TaintEffectNoSchedule}},
 				},
@@ -237,7 +237,7 @@ func TestResourceFlavorCmd(t *testing.T) {
 	testCases := map[string]struct {
 		rfName     string
 		args       []string
-		wantRf     *v1beta1.ResourceFlavor
+		wantRf     *kueue.ResourceFlavor
 		wantOut    string
 		wantOutErr string
 		wantErr    string
@@ -250,25 +250,25 @@ func TestResourceFlavorCmd(t *testing.T) {
 		"shouldn't create resource flavor with dry-run client": {
 			rfName:  "rf",
 			args:    []string{"--dry-run", "client"},
-			wantRf:  &v1beta1.ResourceFlavor{},
+			wantRf:  &kueue.ResourceFlavor{},
 			wantOut: "resourceflavor.kueue.x-k8s.io/rf created (client dry run)\n",
 		},
 		"should create resource flavor": {
 			rfName: "rf",
-			wantRf: &v1beta1.ResourceFlavor{
-				TypeMeta:   metav1.TypeMeta{APIVersion: v1beta1.SchemeGroupVersion.String(), Kind: "ResourceFlavor"},
+			wantRf: &kueue.ResourceFlavor{
+				TypeMeta:   metav1.TypeMeta{APIVersion: kueue.SchemeGroupVersion.String(), Kind: "ResourceFlavor"},
 				ObjectMeta: metav1.ObjectMeta{Name: "rf"},
-				Spec:       v1beta1.ResourceFlavorSpec{},
+				Spec:       kueue.ResourceFlavorSpec{},
 			},
 			wantOut: "resourceflavor.kueue.x-k8s.io/rf created\n",
 		},
 		"should create resource flavor with node labels": {
 			rfName: "rf",
 			args:   []string{"--node-labels", "kubernetes.io/arch=arm64,kubernetes.io/os=linux"},
-			wantRf: &v1beta1.ResourceFlavor{
-				TypeMeta:   metav1.TypeMeta{APIVersion: v1beta1.SchemeGroupVersion.String(), Kind: "ResourceFlavor"},
+			wantRf: &kueue.ResourceFlavor{
+				TypeMeta:   metav1.TypeMeta{APIVersion: kueue.SchemeGroupVersion.String(), Kind: "ResourceFlavor"},
 				ObjectMeta: metav1.ObjectMeta{Name: "rf"},
-				Spec: v1beta1.ResourceFlavorSpec{
+				Spec: kueue.ResourceFlavorSpec{
 					NodeLabels: map[string]string{
 						corev1.LabelArchStable: "arm64",
 						corev1.LabelOSStable:   "linux",
@@ -280,10 +280,10 @@ func TestResourceFlavorCmd(t *testing.T) {
 		"should create resource flavor with node taints": {
 			rfName: "rf",
 			args:   []string{"--node-taints", "key1=value:NoSchedule,key1=value:PreferNoSchedule,key2=value:NoSchedule,key3=value:NoSchedule"},
-			wantRf: &v1beta1.ResourceFlavor{
-				TypeMeta:   metav1.TypeMeta{APIVersion: v1beta1.SchemeGroupVersion.String(), Kind: "ResourceFlavor"},
+			wantRf: &kueue.ResourceFlavor{
+				TypeMeta:   metav1.TypeMeta{APIVersion: kueue.SchemeGroupVersion.String(), Kind: "ResourceFlavor"},
 				ObjectMeta: metav1.ObjectMeta{Name: "rf"},
-				Spec: v1beta1.ResourceFlavorSpec{
+				Spec: kueue.ResourceFlavorSpec{
 					NodeTaints: []corev1.Taint{
 						{Key: "key1", Value: "value", Effect: corev1.TaintEffectNoSchedule},
 						{Key: "key1", Value: "value", Effect: corev1.TaintEffectPreferNoSchedule},
@@ -302,10 +302,10 @@ func TestResourceFlavorCmd(t *testing.T) {
 		"should create resource flavor with toleration": {
 			rfName: "rf",
 			args:   []string{"--tolerations", "key1=value:NoSchedule,key2:NoSchedule"},
-			wantRf: &v1beta1.ResourceFlavor{
-				TypeMeta:   metav1.TypeMeta{APIVersion: v1beta1.SchemeGroupVersion.String(), Kind: "ResourceFlavor"},
+			wantRf: &kueue.ResourceFlavor{
+				TypeMeta:   metav1.TypeMeta{APIVersion: kueue.SchemeGroupVersion.String(), Kind: "ResourceFlavor"},
 				ObjectMeta: metav1.ObjectMeta{Name: "rf"},
-				Spec: v1beta1.ResourceFlavorSpec{
+				Spec: kueue.ResourceFlavorSpec{
 					Tolerations: []corev1.Toleration{
 						{Key: "key1", Value: "value", Effect: corev1.TaintEffectNoSchedule, Operator: corev1.TolerationOpEqual},
 						{Key: "key2", Effect: corev1.TaintEffectNoSchedule, Operator: corev1.TolerationOpExists},

--- a/cmd/kueuectl/app/delete/delete_workload.go
+++ b/cmd/kueuectl/app/delete/delete_workload.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/scheme"
 	kueuev1beta1 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/kueue/v1beta1"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/completion"
@@ -189,7 +189,7 @@ func GroupVersionResourceWithName(gvr schema.GroupVersionResource, name string) 
 // Run delete a resource
 func (o *WorkloadOptions) Run(ctx context.Context) error {
 	var (
-		workloads               []*v1beta1.Workload
+		workloads               []*kueue.Workload
 		haveAssociatedResources bool
 		err                     error
 	)
@@ -233,7 +233,7 @@ func (o *WorkloadOptions) Run(ctx context.Context) error {
 	return nil
 }
 
-func (o *WorkloadOptions) getAllWorkloads(ctx context.Context) ([]*v1beta1.Workload, bool, error) {
+func (o *WorkloadOptions) getAllWorkloads(ctx context.Context) ([]*kueue.Workload, bool, error) {
 	var namespace string
 	if !o.AllNamespaces {
 		namespace = o.Namespace
@@ -246,7 +246,7 @@ func (o *WorkloadOptions) getAllWorkloads(ctx context.Context) ([]*v1beta1.Workl
 
 	var haveAssociatedWorkloads bool
 
-	workloads := make([]*v1beta1.Workload, 0, len(list.Items))
+	workloads := make([]*kueue.Workload, 0, len(list.Items))
 	for index := range list.Items {
 		wl := &list.Items[index]
 		workloads = append(workloads, wl)
@@ -258,10 +258,10 @@ func (o *WorkloadOptions) getAllWorkloads(ctx context.Context) ([]*v1beta1.Workl
 	return workloads, haveAssociatedWorkloads, nil
 }
 
-func (o *WorkloadOptions) getWorkloads(ctx context.Context) ([]*v1beta1.Workload, bool, error) {
+func (o *WorkloadOptions) getWorkloads(ctx context.Context) ([]*kueue.Workload, bool, error) {
 	var haveAssociatedWorkloads bool
 
-	workloads := make([]*v1beta1.Workload, 0, len(o.Names))
+	workloads := make([]*kueue.Workload, 0, len(o.Names))
 
 	for _, name := range o.Names {
 		wl, err := o.Client.Workloads(o.Namespace).Get(ctx, name, metav1.GetOptions{})
@@ -282,8 +282,8 @@ func (o *WorkloadOptions) getWorkloads(ctx context.Context) ([]*v1beta1.Workload
 	return workloads, haveAssociatedWorkloads, nil
 }
 
-func (o *WorkloadOptions) getWorkloadResources(workloads []*v1beta1.Workload) (map[*v1beta1.Workload][]GroupVersionResourceName, error) {
-	workloadResources := make(map[*v1beta1.Workload][]GroupVersionResourceName, len(workloads))
+func (o *WorkloadOptions) getWorkloadResources(workloads []*kueue.Workload) (map[*kueue.Workload][]GroupVersionResourceName, error) {
+	workloadResources := make(map[*kueue.Workload][]GroupVersionResourceName, len(workloads))
 
 	for _, wl := range workloads {
 		workloadResources[wl] = make([]GroupVersionResourceName, 0, len(wl.OwnerReferences))
@@ -306,7 +306,7 @@ func (o *WorkloadOptions) getWorkloadResources(workloads []*v1beta1.Workload) (m
 	return workloadResources, nil
 }
 
-func (o *WorkloadOptions) generateConfirmationMessage(workloadResources map[*v1beta1.Workload][]GroupVersionResourceName) string {
+func (o *WorkloadOptions) generateConfirmationMessage(workloadResources map[*kueue.Workload][]GroupVersionResourceName) string {
 	associatedResources := make([]string, 0, len(workloadResources))
 
 	for wl, resources := range workloadResources {
@@ -341,7 +341,7 @@ func (o *WorkloadOptions) confirmation(message string) bool {
 	return strings.EqualFold(input, "y")
 }
 
-func (o *WorkloadOptions) deleteWorkloads(ctx context.Context, workloadNameResources map[*v1beta1.Workload][]GroupVersionResourceName) error {
+func (o *WorkloadOptions) deleteWorkloads(ctx context.Context, workloadNameResources map[*kueue.Workload][]GroupVersionResourceName) error {
 	for wl, nrs := range workloadNameResources {
 		deleteOptions := metav1.DeleteOptions{}
 

--- a/cmd/kueuectl/app/delete/delete_workload_test.go
+++ b/cmd/kueuectl/app/delete/delete_workload_test.go
@@ -31,7 +31,7 @@ import (
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	kubetesting "k8s.io/client-go/testing"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/fake"
 	cmdtesting "sigs.k8s.io/kueue/cmd/kueuectl/app/testing"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -47,7 +47,7 @@ func TestWorkloadCmd(t *testing.T) {
 		workloads     []runtime.Object
 		jobs          []runtime.Object
 		gvk           schema.GroupVersionKind
-		wantWorkloads []v1beta1.Workload
+		wantWorkloads []kueue.Workload
 		wantJobList   runtime.Object
 		ignoreOut     bool
 		wantOut       string
@@ -67,7 +67,7 @@ func TestWorkloadCmd(t *testing.T) {
 				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault}},
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
-			wantWorkloads: []v1beta1.Workload{
+			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
 			},
 			wantJobList: &bactchv1.JobList{
@@ -95,7 +95,7 @@ Do you want to proceed (y/n)? Deletion is canceled
 				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j2", Namespace: metav1.NamespaceDefault}},
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
-			wantWorkloads: []v1beta1.Workload{
+			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
 			},
 			wantJobList: &bactchv1.JobList{
@@ -129,7 +129,7 @@ Do you want to proceed (y/n)? Deletion is canceled
 				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j2", Namespace: metav1.NamespaceDefault}},
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
-			wantWorkloads: []v1beta1.Workload{
+			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
 				*utiltesting.MakeWorkload("wl2", metav1.NamespaceDefault).Obj(),
 			},
@@ -158,7 +158,7 @@ Do you want to proceed (y/n)? jobs.batch/j1 deleted
 				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j2", Namespace: metav1.NamespaceDefault}},
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
-			wantWorkloads: []v1beta1.Workload{
+			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
 				*utiltesting.MakeWorkload("wl2", metav1.NamespaceDefault).Obj(),
 			},
@@ -185,7 +185,7 @@ Do you want to proceed (y/n)? jobs.batch/j1 deleted
 				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j2", Namespace: metav1.NamespaceDefault}},
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
-			wantWorkloads: []v1beta1.Workload{
+			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
 				*utiltesting.MakeWorkload("wl3", "test").Obj(),
 			},
@@ -213,7 +213,7 @@ Do you want to proceed (y/n)? jobs.batch/j1 deleted
 				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j2", Namespace: metav1.NamespaceDefault}},
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
-			wantWorkloads: []v1beta1.Workload{
+			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
 			},
 			wantJobList: &bactchv1.JobList{
@@ -237,7 +237,7 @@ Do you want to proceed (y/n)? jobs.batch/j1 deleted
 				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault}},
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
-			wantWorkloads: []v1beta1.Workload{
+			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
 			},
 			wantJobList: &bactchv1.JobList{
@@ -260,7 +260,7 @@ Do you want to proceed (y/n)? jobs.batch/j1 deleted
 				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault}},
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
-			wantWorkloads: []v1beta1.Workload{
+			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
 			},
 			wantJobList: &bactchv1.JobList{

--- a/cmd/kueuectl/app/list/list_clusterqueue.go
+++ b/cmd/kueuectl/app/list/list_clusterqueue.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 	"k8s.io/utils/clock"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/scheme"
 	kueuev1beta1 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/kueue/v1beta1"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/util"
@@ -207,12 +207,12 @@ func (o *ClusterQueueOptions) Run(ctx context.Context) error {
 	}
 }
 
-func (o *ClusterQueueOptions) filterList(cql *v1beta1.ClusterQueueList) {
+func (o *ClusterQueueOptions) filterList(cql *kueue.ClusterQueueList) {
 	if len(o.Active) == 0 {
 		return
 	}
 
-	filtered := make([]v1beta1.ClusterQueue, 0, len(cql.Items))
+	filtered := make([]kueue.ClusterQueue, 0, len(cql.Items))
 	for _, cq := range cql.Items {
 		if o.Active[0] && isActiveStatus(&cq) {
 			filtered = append(filtered, cq)
@@ -224,6 +224,6 @@ func (o *ClusterQueueOptions) filterList(cql *v1beta1.ClusterQueueList) {
 	cql.Items = filtered
 }
 
-func isActiveStatus(cq *v1beta1.ClusterQueue) bool {
-	return meta.IsStatusConditionTrue(cq.Status.Conditions, v1beta1.ClusterQueueActive)
+func isActiveStatus(cq *kueue.ClusterQueue) bool {
+	return meta.IsStatusConditionTrue(cq.Status.Conditions, kueue.ClusterQueueActive)
 }

--- a/cmd/kueuectl/app/list/list_clusterqueue_printer.go
+++ b/cmd/kueuectl/app/list/list_clusterqueue_printer.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/utils/clock"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
 
 type listClusterQueuePrinter struct {
@@ -39,7 +39,7 @@ var _ printers.ResourcePrinter = (*listClusterQueuePrinter)(nil)
 func (p *listClusterQueuePrinter) PrintObj(obj runtime.Object, out io.Writer) error {
 	printer := printers.NewTablePrinter(p.printOptions)
 
-	list, ok := obj.(*v1beta1.ClusterQueueList)
+	list, ok := obj.(*kueue.ClusterQueueList)
 	if !ok {
 		return errors.New("invalid object type")
 	}
@@ -75,7 +75,7 @@ func newClusterQueueTablePrinter() *listClusterQueuePrinter {
 	}
 }
 
-func (p *listClusterQueuePrinter) printClusterQueueList(list *v1beta1.ClusterQueueList) []metav1.TableRow {
+func (p *listClusterQueuePrinter) printClusterQueueList(list *kueue.ClusterQueueList) []metav1.TableRow {
 	rows := make([]metav1.TableRow, len(list.Items))
 	for index := range list.Items {
 		rows[index] = p.printClusterQueue(&list.Items[index])
@@ -83,7 +83,7 @@ func (p *listClusterQueuePrinter) printClusterQueueList(list *v1beta1.ClusterQue
 	return rows
 }
 
-func (p *listClusterQueuePrinter) printClusterQueue(clusterQueue *v1beta1.ClusterQueue) metav1.TableRow {
+func (p *listClusterQueuePrinter) printClusterQueue(clusterQueue *kueue.ClusterQueue) metav1.TableRow {
 	row := metav1.TableRow{
 		Object: runtime.RawExtension{Object: clusterQueue},
 	}

--- a/cmd/kueuectl/app/list/list_clusterqueue_test.go
+++ b/cmd/kueuectl/app/list/list_clusterqueue_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	testingclock "k8s.io/utils/clock/testing"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/fake"
 	cmdtesting "sigs.k8s.io/kueue/cmd/kueuectl/app/testing"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -52,14 +52,14 @@ func TestClusterQueueRun(t *testing.T) {
 					Cohort("cohort1").
 					PendingWorkloads(1).
 					AdmittedWorkloads(2).
-					Condition(v1beta1.ClusterQueueActive, metav1.ConditionTrue, "", "").
+					Condition(kueue.ClusterQueueActive, metav1.ConditionTrue, "", "").
 					Obj(),
 				utiltesting.MakeClusterQueue("cq2").
 					Creation(testStartTime.Add(-2*time.Hour).Truncate(time.Second)).
 					Cohort("cohort2").
 					PendingWorkloads(3).
 					AdmittedWorkloads(4).
-					Condition(v1beta1.ClusterQueueActive, metav1.ConditionFalse, "", "").
+					Condition(kueue.ClusterQueueActive, metav1.ConditionFalse, "", "").
 					Obj(),
 			},
 			wantOut: `NAME   COHORT    PENDING WORKLOADS   ADMITTED WORKLOADS   ACTIVE   AGE
@@ -74,14 +74,14 @@ cq1    cohort1   1                   2                    true     60m
 					Cohort("cohort1").
 					PendingWorkloads(1).
 					AdmittedWorkloads(2).
-					Condition(v1beta1.ClusterQueueActive, metav1.ConditionTrue, "", "").
+					Condition(kueue.ClusterQueueActive, metav1.ConditionTrue, "", "").
 					Obj(),
 				utiltesting.MakeClusterQueue("cq2").
 					Creation(testStartTime.Add(-2*time.Hour).Truncate(time.Second)).
 					Cohort("cohort2").
 					PendingWorkloads(3).
 					AdmittedWorkloads(4).
-					Condition(v1beta1.ClusterQueueActive, metav1.ConditionFalse, "", "").
+					Condition(kueue.ClusterQueueActive, metav1.ConditionFalse, "", "").
 					Obj(),
 			},
 			wantOut: `NAME   COHORT    PENDING WORKLOADS   ADMITTED WORKLOADS   ACTIVE   AGE
@@ -96,7 +96,7 @@ cq2    cohort2   3                   4                    false    120m
 					Cohort("cohort1").
 					PendingWorkloads(1).
 					AdmittedWorkloads(2).
-					Condition(v1beta1.ClusterQueueActive, metav1.ConditionTrue, "", "").
+					Condition(kueue.ClusterQueueActive, metav1.ConditionTrue, "", "").
 					Label("key", "value1").
 					Obj(),
 				utiltesting.MakeClusterQueue("cq2").
@@ -104,7 +104,7 @@ cq2    cohort2   3                   4                    false    120m
 					Cohort("cohort2").
 					PendingWorkloads(3).
 					AdmittedWorkloads(4).
-					Condition(v1beta1.ClusterQueueActive, metav1.ConditionFalse, "", "").
+					Condition(kueue.ClusterQueueActive, metav1.ConditionFalse, "", "").
 					Label("key", "value2").
 					Obj(),
 			},
@@ -120,7 +120,7 @@ cq1    cohort1   1                   2                    true     60m
 					Cohort("cohort1").
 					PendingWorkloads(1).
 					AdmittedWorkloads(2).
-					Condition(v1beta1.ClusterQueueActive, metav1.ConditionTrue, "", "").
+					Condition(kueue.ClusterQueueActive, metav1.ConditionTrue, "", "").
 					Label("key", "value1").
 					Obj(),
 				utiltesting.MakeClusterQueue("cq2").
@@ -128,7 +128,7 @@ cq1    cohort1   1                   2                    true     60m
 					Cohort("cohort2").
 					PendingWorkloads(3).
 					AdmittedWorkloads(4).
-					Condition(v1beta1.ClusterQueueActive, metav1.ConditionFalse, "", "").
+					Condition(kueue.ClusterQueueActive, metav1.ConditionFalse, "", "").
 					Label("key", "value2").
 					Obj(),
 			},

--- a/cmd/kueuectl/app/list/list_localqueue.go
+++ b/cmd/kueuectl/app/list/list_localqueue.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 	"k8s.io/utils/clock"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/scheme"
 	kueuev1beta1 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/kueue/v1beta1"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/completion"
@@ -205,11 +205,11 @@ func (o *LocalQueueOptions) Run(ctx context.Context) error {
 	}
 }
 
-func (o *LocalQueueOptions) filterList(list *v1beta1.LocalQueueList) {
+func (o *LocalQueueOptions) filterList(list *kueue.LocalQueueList) {
 	if len(o.ClusterQueueFilter) > 0 {
-		filteredItems := make([]v1beta1.LocalQueue, 0, len(o.ClusterQueueFilter))
+		filteredItems := make([]kueue.LocalQueue, 0, len(o.ClusterQueueFilter))
 		for _, lq := range list.Items {
-			if lq.Spec.ClusterQueue == v1beta1.ClusterQueueReference(o.ClusterQueueFilter) {
+			if lq.Spec.ClusterQueue == kueue.ClusterQueueReference(o.ClusterQueueFilter) {
 				filteredItems = append(filteredItems, lq)
 			}
 		}

--- a/cmd/kueuectl/app/list/list_localqueue_printer.go
+++ b/cmd/kueuectl/app/list/list_localqueue_printer.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/utils/clock"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
 
 type listLocalQueuePrinter struct {
@@ -39,7 +39,7 @@ var _ printers.ResourcePrinter = (*listLocalQueuePrinter)(nil)
 func (p *listLocalQueuePrinter) PrintObj(obj runtime.Object, out io.Writer) error {
 	printer := printers.NewTablePrinter(p.printOptions)
 
-	list, ok := obj.(*v1beta1.LocalQueueList)
+	list, ok := obj.(*kueue.LocalQueueList)
 	if !ok {
 		return errors.New("invalid object type")
 	}
@@ -79,7 +79,7 @@ func newLocalQueueTablePrinter() *listLocalQueuePrinter {
 	}
 }
 
-func (p *listLocalQueuePrinter) printLocalQueueList(list *v1beta1.LocalQueueList) []metav1.TableRow {
+func (p *listLocalQueuePrinter) printLocalQueueList(list *kueue.LocalQueueList) []metav1.TableRow {
 	rows := make([]metav1.TableRow, len(list.Items))
 	for index := range list.Items {
 		rows[index] = p.printLocalQueue(&list.Items[index])
@@ -87,7 +87,7 @@ func (p *listLocalQueuePrinter) printLocalQueueList(list *v1beta1.LocalQueueList
 	return rows
 }
 
-func (p *listLocalQueuePrinter) printLocalQueue(localQueue *v1beta1.LocalQueue) metav1.TableRow {
+func (p *listLocalQueuePrinter) printLocalQueue(localQueue *kueue.LocalQueue) metav1.TableRow {
 	row := metav1.TableRow{
 		Object: runtime.RawExtension{Object: localQueue},
 	}

--- a/cmd/kueuectl/app/list/list_localqueue_printer_test.go
+++ b/cmd/kueuectl/app/list/list_localqueue_printer_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	testingclock "k8s.io/utils/clock/testing"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
 
 func TestLocalQueuePrint(t *testing.T) {
@@ -33,21 +33,21 @@ func TestLocalQueuePrint(t *testing.T) {
 
 	testCases := map[string]struct {
 		options *LocalQueueOptions
-		in      *v1beta1.LocalQueueList
+		in      *kueue.LocalQueueList
 		out     []metav1.TableRow
 	}{
 		"should print local queue list": {
 			options: &LocalQueueOptions{},
-			in: &v1beta1.LocalQueueList{
-				Items: []v1beta1.LocalQueue{
+			in: &kueue.LocalQueueList{
+				Items: []kueue.LocalQueue{
 					{
 						TypeMeta: metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{
 							Name:              "lq",
 							CreationTimestamp: metav1.NewTime(testStartTime.Add(-time.Hour).Truncate(time.Second)),
 						},
-						Spec: v1beta1.LocalQueueSpec{ClusterQueue: "cq1"},
-						Status: v1beta1.LocalQueueStatus{
+						Spec: kueue.LocalQueueSpec{ClusterQueue: "cq1"},
+						Status: kueue.LocalQueueStatus{
 							PendingWorkloads:  1,
 							AdmittedWorkloads: 2,
 						},
@@ -56,16 +56,16 @@ func TestLocalQueuePrint(t *testing.T) {
 			},
 			out: []metav1.TableRow{
 				{
-					Cells: []any{"lq", v1beta1.ClusterQueueReference("cq1"), int32(1), int32(2), "60m"},
+					Cells: []any{"lq", kueue.ClusterQueueReference("cq1"), int32(1), int32(2), "60m"},
 					Object: runtime.RawExtension{
-						Object: &v1beta1.LocalQueue{
+						Object: &kueue.LocalQueue{
 							TypeMeta: metav1.TypeMeta{},
 							ObjectMeta: metav1.ObjectMeta{
 								Name:              "lq",
 								CreationTimestamp: metav1.NewTime(testStartTime.Add(-time.Hour).Truncate(time.Second)),
 							},
-							Spec: v1beta1.LocalQueueSpec{ClusterQueue: "cq1"},
-							Status: v1beta1.LocalQueueStatus{
+							Spec: kueue.LocalQueueSpec{ClusterQueue: "cq1"},
+							Status: kueue.LocalQueueStatus{
 								PendingWorkloads:  1,
 								AdmittedWorkloads: 2,
 							},

--- a/cmd/kueuectl/app/list/list_localqueue_test.go
+++ b/cmd/kueuectl/app/list/list_localqueue_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	testingclock "k8s.io/utils/clock/testing"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/fake"
 	cmdtesting "sigs.k8s.io/kueue/cmd/kueuectl/app/testing"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -37,28 +37,28 @@ import (
 func TestLocalQueueFilter(t *testing.T) {
 	testCases := map[string]struct {
 		options *LocalQueueOptions
-		in      *v1beta1.LocalQueueList
-		out     *v1beta1.LocalQueueList
+		in      *kueue.LocalQueueList
+		out     *kueue.LocalQueueList
 	}{
 		"shouldn't filter": {
 			options: &LocalQueueOptions{},
-			in: &v1beta1.LocalQueueList{
-				Items: []v1beta1.LocalQueue{
+			in: &kueue.LocalQueueList{
+				Items: []kueue.LocalQueue{
 					{
-						Spec: v1beta1.LocalQueueSpec{ClusterQueue: "cq1"},
+						Spec: kueue.LocalQueueSpec{ClusterQueue: "cq1"},
 					},
 					{
-						Spec: v1beta1.LocalQueueSpec{ClusterQueue: "cq2"},
+						Spec: kueue.LocalQueueSpec{ClusterQueue: "cq2"},
 					},
 				},
 			},
-			out: &v1beta1.LocalQueueList{
-				Items: []v1beta1.LocalQueue{
+			out: &kueue.LocalQueueList{
+				Items: []kueue.LocalQueue{
 					{
-						Spec: v1beta1.LocalQueueSpec{ClusterQueue: "cq1"},
+						Spec: kueue.LocalQueueSpec{ClusterQueue: "cq1"},
 					},
 					{
-						Spec: v1beta1.LocalQueueSpec{ClusterQueue: "cq2"},
+						Spec: kueue.LocalQueueSpec{ClusterQueue: "cq2"},
 					},
 				},
 			},
@@ -67,20 +67,20 @@ func TestLocalQueueFilter(t *testing.T) {
 			options: &LocalQueueOptions{
 				ClusterQueueFilter: "cq1",
 			},
-			in: &v1beta1.LocalQueueList{
-				Items: []v1beta1.LocalQueue{
+			in: &kueue.LocalQueueList{
+				Items: []kueue.LocalQueue{
 					{
-						Spec: v1beta1.LocalQueueSpec{ClusterQueue: "cq1"},
+						Spec: kueue.LocalQueueSpec{ClusterQueue: "cq1"},
 					},
 					{
-						Spec: v1beta1.LocalQueueSpec{ClusterQueue: "cq2"},
+						Spec: kueue.LocalQueueSpec{ClusterQueue: "cq2"},
 					},
 				},
 			},
-			out: &v1beta1.LocalQueueList{
-				Items: []v1beta1.LocalQueue{
+			out: &kueue.LocalQueueList{
+				Items: []kueue.LocalQueue{
 					{
-						Spec: v1beta1.LocalQueueSpec{ClusterQueue: "cq1"},
+						Spec: kueue.LocalQueueSpec{ClusterQueue: "cq1"},
 					},
 				},
 			},

--- a/cmd/kueuectl/app/list/list_resourceflavor_printer.go
+++ b/cmd/kueuectl/app/list/list_resourceflavor_printer.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/utils/clock"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
 
 type listResourceFlavorPrinter struct {
@@ -42,7 +42,7 @@ var _ printers.ResourcePrinter = (*listResourceFlavorPrinter)(nil)
 func (p *listResourceFlavorPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
 	printer := printers.NewTablePrinter(p.printOptions)
 
-	list, ok := obj.(*v1beta1.ResourceFlavorList)
+	list, ok := obj.(*kueue.ResourceFlavorList)
 	if !ok {
 		return errors.New("invalid object type")
 	}
@@ -75,7 +75,7 @@ func newResourceFlavorTablePrinter() *listResourceFlavorPrinter {
 	}
 }
 
-func (p *listResourceFlavorPrinter) printResourceFlavorList(list *v1beta1.ResourceFlavorList) []metav1.TableRow {
+func (p *listResourceFlavorPrinter) printResourceFlavorList(list *kueue.ResourceFlavorList) []metav1.TableRow {
 	rows := make([]metav1.TableRow, len(list.Items))
 	for index := range list.Items {
 		rows[index] = p.printResourceFlavor(&list.Items[index])
@@ -83,7 +83,7 @@ func (p *listResourceFlavorPrinter) printResourceFlavorList(list *v1beta1.Resour
 	return rows
 }
 
-func (p *listResourceFlavorPrinter) printResourceFlavor(resourceFlavor *v1beta1.ResourceFlavor) metav1.TableRow {
+func (p *listResourceFlavorPrinter) printResourceFlavor(resourceFlavor *kueue.ResourceFlavor) metav1.TableRow {
 	row := metav1.TableRow{Object: runtime.RawExtension{Object: resourceFlavor}}
 	nodeLabels := make([]string, 0, len(resourceFlavor.Spec.NodeLabels))
 	for key, value := range resourceFlavor.Spec.NodeLabels {

--- a/cmd/kueuectl/app/list/list_resourceflavor_printer_test.go
+++ b/cmd/kueuectl/app/list/list_resourceflavor_printer_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	testingclock "k8s.io/utils/clock/testing"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
 
@@ -34,13 +34,13 @@ func TestResourceFlavorPrint(t *testing.T) {
 
 	testCases := map[string]struct {
 		options *ResourceFlavorOptions
-		in      *v1beta1.ResourceFlavorList
+		in      *kueue.ResourceFlavorList
 		out     []metav1.TableRow
 	}{
 		"should print resource flavor list": {
 			options: &ResourceFlavorOptions{},
-			in: &v1beta1.ResourceFlavorList{
-				Items: []v1beta1.ResourceFlavor{
+			in: &kueue.ResourceFlavorList{
+				Items: []kueue.ResourceFlavor{
 					*utiltesting.MakeResourceFlavor("rf").
 						Creation(testStartTime.Add(-time.Hour).Truncate(time.Second)).
 						NodeLabel("key1", "value").

--- a/cmd/kueuectl/app/list/list_test.go
+++ b/cmd/kueuectl/app/list/list_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	testingclock "k8s.io/utils/clock/testing"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/fake"
 	cmdtesting "sigs.k8s.io/kueue/cmd/kueuectl/app/testing"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -92,12 +92,12 @@ ns2         lq2    cq2            2                   2                    120m
 			args: []string{"clusterqueue"},
 			objs: []runtime.Object{
 				utiltesting.MakeClusterQueue("cq1").
-					Condition(v1beta1.ClusterQueueActive, metav1.ConditionTrue, "", "").
+					Condition(kueue.ClusterQueueActive, metav1.ConditionTrue, "", "").
 					Cohort("cohort1").
 					Creation(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
 					Obj(),
 				utiltesting.MakeClusterQueue("cq2").
-					Condition(v1beta1.ClusterQueueActive, metav1.ConditionFalse, "", "").
+					Condition(kueue.ClusterQueueActive, metav1.ConditionFalse, "", "").
 					Cohort("cohort2").
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Obj(),

--- a/cmd/kueuectl/app/list/list_workload.go
+++ b/cmd/kueuectl/app/list/list_workload.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	visibility "sigs.k8s.io/kueue/apis/visibility/v1beta1"
 	clientset "sigs.k8s.io/kueue/client-go/clientset/versioned"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/scheme"
@@ -346,11 +346,11 @@ func (o *WorkloadOptions) Run(ctx context.Context) error {
 	}
 }
 
-func (o *WorkloadOptions) filterList(list *v1beta1.WorkloadList, enableOwnerReferenceFilter bool, uid types.UID) {
+func (o *WorkloadOptions) filterList(list *kueue.WorkloadList, enableOwnerReferenceFilter bool, uid types.UID) {
 	if len(list.Items) == 0 {
 		return
 	}
-	filteredItems := make([]v1beta1.Workload, 0, len(o.LocalQueueFilter))
+	filteredItems := make([]kueue.Workload, 0, len(o.LocalQueueFilter))
 	for _, wl := range list.Items {
 		if o.filterByLocalQueue(&wl) && o.filterByClusterQueue(&wl) && o.filterByStatuses(&wl) &&
 			o.filterByOwnerReference(&wl, enableOwnerReferenceFilter, uid) {
@@ -360,16 +360,16 @@ func (o *WorkloadOptions) filterList(list *v1beta1.WorkloadList, enableOwnerRefe
 	list.Items = filteredItems
 }
 
-func (o *WorkloadOptions) filterByLocalQueue(wl *v1beta1.Workload) bool {
+func (o *WorkloadOptions) filterByLocalQueue(wl *kueue.Workload) bool {
 	return len(o.LocalQueueFilter) == 0 || string(wl.Spec.QueueName) == o.LocalQueueFilter
 }
 
-func (o *WorkloadOptions) filterByClusterQueue(wl *v1beta1.Workload) bool {
+func (o *WorkloadOptions) filterByClusterQueue(wl *kueue.Workload) bool {
 	return len(o.ClusterQueueFilter) == 0 || wl.Status.Admission != nil &&
-		wl.Status.Admission.ClusterQueue == v1beta1.ClusterQueueReference(o.ClusterQueueFilter)
+		wl.Status.Admission.ClusterQueue == kueue.ClusterQueueReference(o.ClusterQueueFilter)
 }
 
-func (o *WorkloadOptions) filterByStatuses(wl *v1beta1.Workload) bool {
+func (o *WorkloadOptions) filterByStatuses(wl *kueue.Workload) bool {
 	if o.StatusesFilter.Len() == 0 || o.StatusesFilter.Has(workloadStatusAll) {
 		return true
 	}
@@ -395,7 +395,7 @@ func (o *WorkloadOptions) filterByStatuses(wl *v1beta1.Workload) bool {
 	return false
 }
 
-func (o *WorkloadOptions) filterByOwnerReference(wl *v1beta1.Workload, isEnabled bool, uid types.UID) bool {
+func (o *WorkloadOptions) filterByOwnerReference(wl *kueue.Workload, isEnabled bool, uid types.UID) bool {
 	if !isEnabled {
 		return true
 	}
@@ -409,8 +409,8 @@ func (o *WorkloadOptions) filterByOwnerReference(wl *v1beta1.Workload, isEnabled
 	return false
 }
 
-func (o *WorkloadOptions) localQueues(ctx context.Context, list *v1beta1.WorkloadList) (map[string]*v1beta1.LocalQueue, error) {
-	localQueues := make(map[string]*v1beta1.LocalQueue)
+func (o *WorkloadOptions) localQueues(ctx context.Context, list *kueue.WorkloadList) (map[string]*kueue.LocalQueue, error) {
+	localQueues := make(map[string]*kueue.LocalQueue)
 	for _, wl := range list.Items {
 		// It's not necessary to get localqueue if we have clusterqueue name on Admission status.
 		if wl.Status.Admission != nil && len(wl.Status.Admission.ClusterQueue) > 0 {
@@ -430,17 +430,17 @@ func (o *WorkloadOptions) localQueues(ctx context.Context, list *v1beta1.Workloa
 	return localQueues, nil
 }
 
-func (o *WorkloadOptions) pendingWorkloads(ctx context.Context, list *v1beta1.WorkloadList, localQueues map[string]*v1beta1.LocalQueue) (map[workload.Reference]*visibility.PendingWorkload, error) {
+func (o *WorkloadOptions) pendingWorkloads(ctx context.Context, list *kueue.WorkloadList, localQueues map[string]*kueue.LocalQueue) (map[workload.Reference]*visibility.PendingWorkload, error) {
 	var err error
 
 	pendingWorkloads := make(map[workload.Reference]*visibility.PendingWorkload)
-	pendingWorkloadsSummaries := make(map[v1beta1.ClusterQueueReference]*visibility.PendingWorkloadsSummary)
+	pendingWorkloadsSummaries := make(map[kueue.ClusterQueueReference]*visibility.PendingWorkloadsSummary)
 
 	for _, wl := range list.Items {
 		if !workloadPending(&wl) {
 			continue
 		}
-		var clusterQueueName v1beta1.ClusterQueueReference
+		var clusterQueueName kueue.ClusterQueueReference
 		if wl.Status.Admission != nil && len(wl.Status.Admission.ClusterQueue) > 0 {
 			clusterQueueName = wl.Status.Admission.ClusterQueue
 		} else if lq := localQueues[localQueueKeyForWorkload(&wl)]; lq != nil {
@@ -474,7 +474,7 @@ func (o *WorkloadOptions) pendingWorkloads(ctx context.Context, list *v1beta1.Wo
 	return pendingWorkloads, nil
 }
 
-func (o *WorkloadOptions) apiResources(list *v1beta1.WorkloadList) (map[string]*metav1.APIResourceList, error) {
+func (o *WorkloadOptions) apiResources(list *kueue.WorkloadList) (map[string]*metav1.APIResourceList, error) {
 	apiResourceLists := make(map[string]*metav1.APIResourceList)
 	for _, wl := range list.Items {
 		for _, ref := range wl.OwnerReferences {
@@ -493,10 +493,10 @@ func (o *WorkloadOptions) apiResources(list *v1beta1.WorkloadList) (map[string]*
 	return apiResourceLists, nil
 }
 
-func workloadPending(wl *v1beta1.Workload) bool {
+func workloadPending(wl *kueue.Workload) bool {
 	return workload.Status(wl) == workload.StatusPending
 }
 
-func localQueueKeyForWorkload(wl *v1beta1.Workload) string {
+func localQueueKeyForWorkload(wl *kueue.Workload) string {
 	return fmt.Sprintf("%s/%s", wl.Namespace, wl.Spec.QueueName)
 }

--- a/cmd/kueuectl/app/list/list_workload_printer.go
+++ b/cmd/kueuectl/app/list/list_workload_printer.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/utils/clock"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	visibility "sigs.k8s.io/kueue/apis/visibility/v1beta1"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -38,14 +38,14 @@ import (
 const crdTypeMaxLength = 20
 
 type listWorkloadResources struct {
-	localQueues      map[string]*v1beta1.LocalQueue
+	localQueues      map[string]*kueue.LocalQueue
 	pendingWorkloads map[workload.Reference]*visibility.PendingWorkload
 	apiResourceLists map[string]*metav1.APIResourceList
 }
 
 func newListWorkloadResources() *listWorkloadResources {
 	return &listWorkloadResources{
-		localQueues:      make(map[string]*v1beta1.LocalQueue),
+		localQueues:      make(map[string]*kueue.LocalQueue),
 		pendingWorkloads: make(map[workload.Reference]*visibility.PendingWorkload),
 		apiResourceLists: make(map[string]*metav1.APIResourceList),
 	}
@@ -62,7 +62,7 @@ var _ printers.ResourcePrinter = (*listWorkloadPrinter)(nil)
 func (p *listWorkloadPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
 	printer := printers.NewTablePrinter(p.printOptions)
 
-	list, ok := obj.(*v1beta1.WorkloadList)
+	list, ok := obj.(*kueue.WorkloadList)
 	if !ok {
 		return errors.New("invalid object type")
 	}
@@ -115,7 +115,7 @@ func newWorkloadTablePrinter() *listWorkloadPrinter {
 	}
 }
 
-func (p *listWorkloadPrinter) printWorkloadList(list *v1beta1.WorkloadList) []metav1.TableRow {
+func (p *listWorkloadPrinter) printWorkloadList(list *kueue.WorkloadList) []metav1.TableRow {
 	rows := make([]metav1.TableRow, len(list.Items))
 	for index := range list.Items {
 		rows[index] = p.printWorkload(&list.Items[index])
@@ -123,7 +123,7 @@ func (p *listWorkloadPrinter) printWorkloadList(list *v1beta1.WorkloadList) []me
 	return rows
 }
 
-func (p *listWorkloadPrinter) printWorkload(wl *v1beta1.Workload) metav1.TableRow {
+func (p *listWorkloadPrinter) printWorkload(wl *kueue.Workload) metav1.TableRow {
 	row := metav1.TableRow{
 		Object: runtime.RawExtension{Object: wl},
 	}
@@ -141,11 +141,11 @@ func (p *listWorkloadPrinter) printWorkload(wl *v1beta1.Workload) metav1.TableRo
 	}
 
 	var execTime string
-	if admittedCond := apimeta.FindStatusCondition(wl.Status.Conditions, v1beta1.WorkloadAdmitted); admittedCond != nil &&
+	if admittedCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadAdmitted); admittedCond != nil &&
 		admittedCond.Status == metav1.ConditionTrue {
 		finishedTime := p.clock.Now()
 
-		if finishedCond := apimeta.FindStatusCondition(wl.Status.Conditions, v1beta1.WorkloadFinished); finishedCond != nil &&
+		if finishedCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadFinished); finishedCond != nil &&
 			finishedCond.Status == metav1.ConditionTrue {
 			finishedTime = finishedCond.LastTransitionTime.Time
 		}
@@ -168,7 +168,7 @@ func (p *listWorkloadPrinter) printWorkload(wl *v1beta1.Workload) metav1.TableRo
 	return row
 }
 
-func (p *listWorkloadPrinter) crdTypes(wl *v1beta1.Workload) []string {
+func (p *listWorkloadPrinter) crdTypes(wl *kueue.Workload) []string {
 	crdTypes := sets.New[string]()
 
 	for _, ref := range wl.OwnerReferences {
@@ -191,7 +191,7 @@ func (p *listWorkloadPrinter) crdTypes(wl *v1beta1.Workload) []string {
 	return crdTypes.UnsortedList()
 }
 
-func (p *listWorkloadPrinter) crdNames(wl *v1beta1.Workload) []string {
+func (p *listWorkloadPrinter) crdNames(wl *kueue.Workload) []string {
 	crdNames := sets.New[string]()
 
 	for _, ref := range wl.OwnerReferences {

--- a/cmd/kueuectl/app/resume/resume_clusterqueue.go
+++ b/cmd/kueuectl/app/resume/resume_clusterqueue.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/scheme"
 	kueuev1beta1 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/kueue/v1beta1"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/completion"
@@ -115,7 +115,7 @@ func (o *ClusterQueueOptions) Run(ctx context.Context) error {
 	}
 
 	cqOriginal := cq.DeepCopy()
-	cq.Spec.StopPolicy = ptr.To(v1beta1.None)
+	cq.Spec.StopPolicy = ptr.To(kueue.None)
 
 	opts := metav1.PatchOptions{}
 	patch := client.MergeFrom(cqOriginal)

--- a/cmd/kueuectl/app/resume/resume_localqueue.go
+++ b/cmd/kueuectl/app/resume/resume_localqueue.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/scheme"
 	kueuev1beta1 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/kueue/v1beta1"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/completion"
@@ -126,7 +126,7 @@ func (o *LocalQueueOptions) Run(ctx context.Context) error {
 	}
 
 	lqOriginal := lq.DeepCopy()
-	lq.Spec.StopPolicy = ptr.To(v1beta1.None)
+	lq.Spec.StopPolicy = ptr.To(kueue.None)
 
 	opts := metav1.PatchOptions{}
 	patch := client.MergeFrom(lqOriginal)

--- a/cmd/kueuectl/app/stop/stop_clusterqueue.go
+++ b/cmd/kueuectl/app/stop/stop_clusterqueue.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/scheme"
 	kueuev1beta1 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/kueue/v1beta1"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/completion"
@@ -139,10 +139,10 @@ func (o *ClusterQueueOptions) Run(ctx context.Context) error {
 	return o.PrintObj(cq, o.Out)
 }
 
-func (o *ClusterQueueOptions) stopClusterQueue(cq *v1beta1.ClusterQueue) {
+func (o *ClusterQueueOptions) stopClusterQueue(cq *kueue.ClusterQueue) {
 	if o.KeepAlreadyRunning {
-		cq.Spec.StopPolicy = ptr.To(v1beta1.Hold)
+		cq.Spec.StopPolicy = ptr.To(kueue.Hold)
 	} else {
-		cq.Spec.StopPolicy = ptr.To(v1beta1.HoldAndDrain)
+		cq.Spec.StopPolicy = ptr.To(kueue.HoldAndDrain)
 	}
 }

--- a/cmd/kueuectl/app/stop/stop_localqueue.go
+++ b/cmd/kueuectl/app/stop/stop_localqueue.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/scheme"
 	kueuev1beta1 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/kueue/v1beta1"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/completion"
@@ -150,10 +150,10 @@ func (o *LocalQueueOptions) Run(ctx context.Context) error {
 	return o.PrintObj(lq, o.Out)
 }
 
-func (o *LocalQueueOptions) stopLocalQueue(lq *v1beta1.LocalQueue) {
+func (o *LocalQueueOptions) stopLocalQueue(lq *kueue.LocalQueue) {
 	if o.KeepAlreadyRunning {
-		lq.Spec.StopPolicy = ptr.To(v1beta1.Hold)
+		lq.Spec.StopPolicy = ptr.To(kueue.Hold)
 	} else {
-		lq.Spec.StopPolicy = ptr.To(v1beta1.HoldAndDrain)
+		lq.Spec.StopPolicy = ptr.To(kueue.HoldAndDrain)
 	}
 }

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
-	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
@@ -181,14 +181,14 @@ func TestValidateCreate(t *testing.T) {
 				LeaderTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
 				WorkerTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
@@ -202,16 +202,16 @@ func TestValidateCreate(t *testing.T) {
 				LeaderTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetRequiredTopologyAnnotation:  "cloud.com/block",
-							kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetRequiredTopologyAnnotation:  "cloud.com/block",
+							kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
 				WorkerTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetRequiredTopologyAnnotation:  "cloud.com/block",
-							kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetRequiredTopologyAnnotation:  "cloud.com/block",
+							kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
@@ -234,9 +234,9 @@ func TestValidateCreate(t *testing.T) {
 				LeaderTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetRequiredTopologyAnnotation:      "cloud.com/block",
-							kueuealpha.PodSetSliceRequiredTopologyAnnotation: "cloud.com/block",
-							kueuealpha.PodSetSliceSizeAnnotation:             "2",
+							kueue.PodSetRequiredTopologyAnnotation:      "cloud.com/block",
+							kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetSliceSizeAnnotation:             "2",
 						},
 					},
 				}).
@@ -244,9 +244,9 @@ func TestValidateCreate(t *testing.T) {
 				WorkerTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetRequiredTopologyAnnotation:      "cloud.com/block",
-							kueuealpha.PodSetSliceRequiredTopologyAnnotation: "cloud.com/block",
-							kueuealpha.PodSetSliceSizeAnnotation:             "20",
+							kueue.PodSetRequiredTopologyAnnotation:      "cloud.com/block",
+							kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetSliceSizeAnnotation:             "20",
 						},
 					},
 				}).
@@ -265,7 +265,7 @@ func TestValidateCreate(t *testing.T) {
 				LeaderTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetSliceSizeAnnotation: "1",
+							kueue.PodSetSliceSizeAnnotation: "1",
 						},
 					},
 				}).
@@ -273,7 +273,7 @@ func TestValidateCreate(t *testing.T) {
 				WorkerTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetSliceSizeAnnotation: "1",
+							kueue.PodSetSliceSizeAnnotation: "1",
 						},
 					},
 				}).
@@ -292,7 +292,7 @@ func TestValidateCreate(t *testing.T) {
 				LeaderTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetSliceRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
@@ -300,7 +300,7 @@ func TestValidateCreate(t *testing.T) {
 				WorkerTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetSliceRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
@@ -319,10 +319,10 @@ func TestValidateCreate(t *testing.T) {
 				LeaderTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetGroupName:                       "groupname",
-							kueuealpha.PodSetRequiredTopologyAnnotation:      "cloud.com/block",
-							kueuealpha.PodSetSliceRequiredTopologyAnnotation: "cloud.com/block",
-							kueuealpha.PodSetSliceSizeAnnotation:             "1",
+							kueue.PodSetGroupName:                       "groupname",
+							kueue.PodSetRequiredTopologyAnnotation:      "cloud.com/block",
+							kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetSliceSizeAnnotation:             "1",
 						},
 					},
 				}).
@@ -330,10 +330,10 @@ func TestValidateCreate(t *testing.T) {
 				WorkerTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetGroupName:                       "groupname",
-							kueuealpha.PodSetRequiredTopologyAnnotation:      "cloud.com/block",
-							kueuealpha.PodSetSliceRequiredTopologyAnnotation: "cloud.com/block",
-							kueuealpha.PodSetSliceSizeAnnotation:             "1",
+							kueue.PodSetGroupName:                       "groupname",
+							kueue.PodSetRequiredTopologyAnnotation:      "cloud.com/block",
+							kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetSliceSizeAnnotation:             "1",
 						},
 					},
 				}).
@@ -356,16 +356,16 @@ func TestValidateCreate(t *testing.T) {
 				LeaderTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetGroupName:                  "groupname",
-							kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                  "groupname",
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
 				WorkerTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetGroupName:                  "groupname",
-							kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                  "groupname",
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
@@ -379,16 +379,16 @@ func TestValidateCreate(t *testing.T) {
 				LeaderTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetGroupName:                  "1234",
-							kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                  "1234",
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
 				WorkerTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetGroupName:                  "1234",
-							kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                  "1234",
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
@@ -407,8 +407,8 @@ func TestValidateCreate(t *testing.T) {
 				LeaderTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetGroupName:                  "groupname",
-							kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                  "groupname",
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
@@ -426,8 +426,8 @@ func TestValidateCreate(t *testing.T) {
 				WorkerTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetGroupName:                  "groupname",
-							kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                  "groupname",
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
@@ -443,16 +443,16 @@ func TestValidateCreate(t *testing.T) {
 				LeaderTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetGroupName:                  "groupname1",
-							kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                  "groupname1",
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
 				WorkerTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetGroupName:                  "groupname2",
-							kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                  "groupname2",
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
@@ -469,16 +469,16 @@ func TestValidateCreate(t *testing.T) {
 				LeaderTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetGroupName:                  "groupname",
-							kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                  "groupname",
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
 				WorkerTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetGroupName:                  "groupname",
-							kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/rack",
+							kueue.PodSetGroupName:                  "groupname",
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/rack",
 						},
 					},
 				}).
@@ -495,16 +495,16 @@ func TestValidateCreate(t *testing.T) {
 				LeaderTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetGroupName:                   "groupname",
-							kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                   "groupname",
+							kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
 				WorkerTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetGroupName:                   "groupname",
-							kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/rack",
+							kueue.PodSetGroupName:                   "groupname",
+							kueue.PodSetPreferredTopologyAnnotation: "cloud.com/rack",
 						},
 					},
 				}).
@@ -521,16 +521,16 @@ func TestValidateCreate(t *testing.T) {
 				LeaderTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetGroupName:                  "groupname",
-							kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                  "groupname",
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
 				WorkerTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetGroupName:                   "groupname",
-							kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                   "groupname",
+							kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
@@ -547,14 +547,14 @@ func TestValidateCreate(t *testing.T) {
 				LeaderTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetGroupName: "groupname",
+							kueue.PodSetGroupName: "groupname",
 						},
 					},
 				}).
 				WorkerTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetGroupName: "groupname",
+							kueue.PodSetGroupName: "groupname",
 						},
 					},
 				}).
@@ -573,8 +573,8 @@ func TestValidateCreate(t *testing.T) {
 				WorkerTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetGroupName:                   "groupname",
-							kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                   "groupname",
+							kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
@@ -991,14 +991,14 @@ func TestValidateUpdate(t *testing.T) {
 				LeaderTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
 				WorkerTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
@@ -1016,16 +1016,16 @@ func TestValidateUpdate(t *testing.T) {
 				LeaderTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetRequiredTopologyAnnotation:  "cloud.com/block",
-							kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetRequiredTopologyAnnotation:  "cloud.com/block",
+							kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).
 				WorkerTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							kueuealpha.PodSetRequiredTopologyAnnotation:  "cloud.com/block",
-							kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetRequiredTopologyAnnotation:  "cloud.com/block",
+							kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block",
 						},
 					},
 				}).

--- a/pkg/controller/jobs/mpijob/mpijob_webhook.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
@@ -43,9 +43,9 @@ var (
 	mpiReplicaSpecsPath         = field.NewPath("spec", "mpiReplicaSpecs")
 	launcherAnnotationsPath     = mpiReplicaSpecsPath.Key(string(v2beta1.MPIReplicaTypeLauncher)).Child("template", "metadata", "annotations")
 	workerAnnotationsPath       = mpiReplicaSpecsPath.Key(string(v2beta1.MPIReplicaTypeWorker)).Child("template", "metadata", "annotations")
-	podSetAnnotationsPathByName = map[v1beta1.PodSetReference]*field.Path{
-		v1beta1.NewPodSetReference(string(v2beta1.MPIReplicaTypeLauncher)): launcherAnnotationsPath,
-		v1beta1.NewPodSetReference(string(v2beta1.MPIReplicaTypeWorker)):   workerAnnotationsPath,
+	podSetAnnotationsPathByName = map[kueue.PodSetReference]*field.Path{
+		kueue.NewPodSetReference(string(v2beta1.MPIReplicaTypeLauncher)): launcherAnnotationsPath,
+		kueue.NewPodSetReference(string(v2beta1.MPIReplicaTypeWorker)):   workerAnnotationsPath,
 	}
 )
 
@@ -169,7 +169,7 @@ func (w *MpiJobWebhook) validateTopologyRequest(mpiJob *MPIJob) (field.ErrorList
 			continue
 		}
 
-		podSet := podset.FindPodSetByName(podSets, v1beta1.NewPodSetReference(string(replicaType)))
+		podSet := podset.FindPodSetByName(podSets, kueue.NewPodSetReference(string(replicaType)))
 		allErrs = append(allErrs, jobframework.ValidateSliceSizeAnnotationUpperBound(replicaMetaPath, &replicaSpec.Template.ObjectMeta, podSet)...)
 	}
 

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
-	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	"sigs.k8s.io/kueue/pkg/constants"
 	ctrlconstants "sigs.k8s.io/kueue/pkg/controller/constants"
@@ -192,13 +192,13 @@ func (w *PodWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		gate(&pod.pod)
 
 		if features.Enabled(features.TopologyAwareScheduling) {
-			if val, ok := pod.pod.Annotations[kueuealpha.PodGroupPodIndexLabelAnnotation]; ok {
+			if val, ok := pod.pod.Annotations[kueue.PodGroupPodIndexLabelAnnotation]; ok {
 				if pod.pod.Labels == nil {
 					pod.pod.Labels = make(map[string]string, 1)
 				}
-				pod.pod.Labels[kueuealpha.PodGroupPodIndexLabel] = pod.pod.Labels[val]
+				pod.pod.Labels[kueue.PodGroupPodIndexLabel] = pod.pod.Labels[val]
 			}
-			utilpod.Gate(&pod.pod, kueuealpha.TopologySchedulingGate)
+			utilpod.Gate(&pod.pod, kueue.TopologySchedulingGate)
 		}
 		if err := pod.addRoleHash(); err != nil {
 			return err

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
-	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
@@ -358,11 +358,11 @@ func TestDefault(t *testing.T) {
 			namespaceSelector:             defaultNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
-				Annotation(kueuealpha.PodSetRequiredTopologyAnnotation, "block").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, "block").
 				Obj(),
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
-				Annotation(kueuealpha.PodSetRequiredTopologyAnnotation, "block").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, "block").
 				ManagedByKueueLabel().
 				KueueFinalizer().
 				RoleHash("a9f06f3a").
@@ -378,15 +378,15 @@ func TestDefault(t *testing.T) {
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
 				Label("test-label", "test-value").
-				Annotation(kueuealpha.PodGroupPodIndexLabelAnnotation, "test-label").
-				Annotation(kueuealpha.PodSetRequiredTopologyAnnotation, "block").
+				Annotation(kueue.PodGroupPodIndexLabelAnnotation, "test-label").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, "block").
 				Obj(),
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
-				Annotation(kueuealpha.PodGroupPodIndexLabelAnnotation, "test-label").
-				Annotation(kueuealpha.PodSetRequiredTopologyAnnotation, "block").
+				Annotation(kueue.PodGroupPodIndexLabelAnnotation, "test-label").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, "block").
 				Label("test-label", "test-value").
-				Label(kueuealpha.PodGroupPodIndexLabel, "test-value").
+				Label(kueue.PodGroupPodIndexLabel, "test-value").
 				ManagedByKueueLabel().
 				RoleHash("a9f06f3a").
 				KueueFinalizer().
@@ -732,14 +732,14 @@ func TestValidateCreate(t *testing.T) {
 		"valid topology request": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
-				Annotation(kueuealpha.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				Obj(),
 		},
 		"invalid topology request": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
-				Annotation(kueuealpha.PodSetRequiredTopologyAnnotation, "cloud.com/block").
-				Annotation(kueuealpha.PodSetPreferredTopologyAnnotation, "cloud.com/block").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+				Annotation(kueue.PodSetPreferredTopologyAnnotation, "cloud.com/block").
 				Obj(),
 			wantErr: field.ErrorList{
 				&field.Error{

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	"sigs.k8s.io/kueue/pkg/constants"
 	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
@@ -95,7 +95,7 @@ func (wh *Webhook) Default(ctx context.Context, obj runtime.Object) error {
 		ss.Spec.Template.Annotations[podconstants.GroupTotalCountAnnotation] = fmt.Sprint(ptr.Deref(ss.Spec.Replicas, 1))
 		ss.Spec.Template.Annotations[podconstants.GroupFastAdmissionAnnotationKey] = podconstants.GroupFastAdmissionAnnotationValue
 		ss.Spec.Template.Annotations[podconstants.GroupServingAnnotationKey] = podconstants.GroupServingAnnotationValue
-		ss.Spec.Template.Annotations[kueuealpha.PodGroupPodIndexLabelAnnotation] = appsv1.PodIndexLabel
+		ss.Spec.Template.Annotations[kueue.PodGroupPodIndexLabelAnnotation] = appsv1.PodIndexLabel
 	}
 
 	return nil

--- a/pkg/dra/claims_test.go
+++ b/pkg/dra/claims_test.go
@@ -32,14 +32,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
-	kueuev1beta1 "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/dra"
 )
 
 func Test_GetResourceRequests(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
-	_ = kueuev1beta1.AddToScheme(scheme)
+	_ = kueue.AddToScheme(scheme)
 	_ = resourcev1beta2.AddToScheme(scheme)
 
 	tmpl := &resourcev1beta2.ResourceClaimTemplate{
@@ -74,10 +74,10 @@ func Test_GetResourceRequests(t *testing.T) {
 		},
 	}
 
-	wl := &kueuev1beta1.Workload{
+	wl := &kueue.Workload{
 		ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},
-		Spec: kueuev1beta1.WorkloadSpec{
-			PodSets: []kueuev1beta1.PodSet{{
+		Spec: kueue.WorkloadSpec{
+			PodSets: []kueue.PodSet{{
 				Name:  "main",
 				Count: 1,
 				Template: corev1.PodTemplateSpec{
@@ -95,10 +95,10 @@ func Test_GetResourceRequests(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		modifyWL     func(w *kueuev1beta1.Workload)
+		modifyWL     func(w *kueue.Workload)
 		extraObjects []runtime.Object
 		lookup       func(corev1.ResourceName) (corev1.ResourceName, bool)
-		want         map[kueuev1beta1.PodSetReference]corev1.ResourceList
+		want         map[kueue.PodSetReference]corev1.ResourceList
 		wantErr      bool
 	}{
 		{
@@ -111,7 +111,7 @@ func Test_GetResourceRequests(t *testing.T) {
 				lr, ok := m[dc]
 				return lr, ok
 			},
-			want: map[kueuev1beta1.PodSetReference]corev1.ResourceList{
+			want: map[kueue.PodSetReference]corev1.ResourceList{
 				"main": {
 					"res-1": resource.MustParse("2"),
 				},
@@ -124,7 +124,7 @@ func Test_GetResourceRequests(t *testing.T) {
 		},
 		{
 			name: "Two containers each using different claim templates",
-			modifyWL: func(w *kueuev1beta1.Workload) {
+			modifyWL: func(w *kueue.Workload) {
 				w.Spec.PodSets[0].Template.Spec.Containers = []corev1.Container{
 					{
 						Name:  "c1",
@@ -157,11 +157,11 @@ func Test_GetResourceRequests(t *testing.T) {
 				lr, ok := m[dc]
 				return lr, ok
 			},
-			want: map[kueuev1beta1.PodSetReference]corev1.ResourceList{"main": {"res-1": resource.MustParse("2"), "res-2": resource.MustParse("1")}},
+			want: map[kueue.PodSetReference]corev1.ResourceList{"main": {"res-1": resource.MustParse("2"), "res-2": resource.MustParse("1")}},
 		},
 		{
 			name: "Two containers sharing one claim template",
-			modifyWL: func(w *kueuev1beta1.Workload) {
+			modifyWL: func(w *kueue.Workload) {
 				w.Spec.PodSets[0].Template.Spec.Containers = []corev1.Container{
 					{
 						Name:  "c1",
@@ -188,7 +188,7 @@ func Test_GetResourceRequests(t *testing.T) {
 				}
 				return "", false
 			},
-			want: map[kueuev1beta1.PodSetReference]corev1.ResourceList{"main": {"res-1": resource.MustParse("2")}},
+			want: map[kueue.PodSetReference]corev1.ResourceList{"main": {"res-1": resource.MustParse("2")}},
 		},
 		{
 			name: "Single template requesting two devices",
@@ -198,7 +198,7 @@ func Test_GetResourceRequests(t *testing.T) {
 					Spec:       resourcev1beta2.ResourceClaimTemplateSpec{Spec: resourcev1beta2.ResourceClaimSpec{Devices: resourcev1beta2.DeviceClaim{Requests: []resourcev1beta2.DeviceRequest{{Exactly: &resourcev1beta2.ExactDeviceRequest{AllocationMode: resourcev1beta2.DeviceAllocationModeExactCount, Count: 2, DeviceClassName: "test-deviceclass-1"}}}}}},
 				},
 			},
-			modifyWL: func(w *kueuev1beta1.Workload) {
+			modifyWL: func(w *kueue.Workload) {
 				w.Spec.PodSets[0].Template.Spec.Containers = []corev1.Container{
 					{
 						Name:  "c",
@@ -218,11 +218,11 @@ func Test_GetResourceRequests(t *testing.T) {
 				}
 				return "", false
 			},
-			want: map[kueuev1beta1.PodSetReference]corev1.ResourceList{"main": {"res-1": resource.MustParse("2")}},
+			want: map[kueue.PodSetReference]corev1.ResourceList{"main": {"res-1": resource.MustParse("2")}},
 		},
 		{
 			name: "Init and regular container sharing one template",
-			modifyWL: func(w *kueuev1beta1.Workload) {
+			modifyWL: func(w *kueue.Workload) {
 				w.Spec.PodSets[0].Template.Spec.InitContainers = []corev1.Container{
 					{
 						Name:  "init",
@@ -251,7 +251,7 @@ func Test_GetResourceRequests(t *testing.T) {
 				}
 				return "", false
 			},
-			want: map[kueuev1beta1.PodSetReference]corev1.ResourceList{"main": {"res-1": resource.MustParse("2")}},
+			want: map[kueue.PodSetReference]corev1.ResourceList{"main": {"res-1": resource.MustParse("2")}},
 		},
 	}
 

--- a/pkg/util/testing/defaults.go
+++ b/pkg/util/testing/defaults.go
@@ -21,7 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
 
 const (
@@ -30,21 +30,21 @@ const (
 )
 
 // MakeDefaultOneLevelTopology creates a default topology with hostname level.
-func MakeDefaultOneLevelTopology(name string) *kueuealpha.Topology {
+func MakeDefaultOneLevelTopology(name string) *kueue.Topology {
 	return MakeTopology(name).
 		Levels(corev1.LabelHostname).
 		Obj()
 }
 
 // MakeDefaultTwoLevelTopology creates a default topology with block and rack levels.
-func MakeDefaultTwoLevelTopology(name string) *kueuealpha.Topology {
+func MakeDefaultTwoLevelTopology(name string) *kueue.Topology {
 	return MakeTopology(name).
 		Levels(DefaultBlockTopologyLevel, DefaultRackTopologyLevel).
 		Obj()
 }
 
 // MakeDefaultThreeLevelTopology creates a default topology with block, rack and hostname levels.
-func MakeDefaultThreeLevelTopology(name string) *kueuealpha.Topology {
+func MakeDefaultThreeLevelTopology(name string) *kueue.Topology {
 	return MakeTopology(name).
 		Levels(DefaultBlockTopologyLevel, DefaultRackTopologyLevel, corev1.LabelHostname).
 		Obj()

--- a/pkg/util/testingjobs/statefulset/wrappers.go
+++ b/pkg/util/testingjobs/statefulset/wrappers.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/constants"
 	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
@@ -199,7 +199,7 @@ func (ss *StatefulSetWrapper) PodTemplateSpecPodGroupServingAnnotation() *Statef
 }
 
 func (ss *StatefulSetWrapper) PodTemplateSpecPodGroupPodIndexLabelAnnotation(labelName string) *StatefulSetWrapper {
-	return ss.PodTemplateSpecAnnotation(v1beta1.PodGroupPodIndexLabelAnnotation, labelName)
+	return ss.PodTemplateSpecAnnotation(kueue.PodGroupPodIndexLabelAnnotation, labelName)
 }
 
 func (ss *StatefulSetWrapper) Image(image string, args []string) *StatefulSetWrapper {

--- a/pkg/visibility/api/install.go
+++ b/pkg/visibility/api/install.go
@@ -24,9 +24,9 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 
-	visibilityv1beta1 "sigs.k8s.io/kueue/apis/visibility/v1beta1"
+	visibility "sigs.k8s.io/kueue/apis/visibility/v1beta1"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
-	apiv1beta1 "sigs.k8s.io/kueue/pkg/visibility/api/v1beta1"
+	visibilityapi "sigs.k8s.io/kueue/pkg/visibility/api/v1beta1"
 )
 
 var (
@@ -36,14 +36,14 @@ var (
 )
 
 func init() {
-	utilruntime.Must(visibilityv1beta1.AddToScheme(Scheme))
-	utilruntime.Must(Scheme.SetVersionPriority(visibilityv1beta1.GroupVersion))
+	utilruntime.Must(visibility.AddToScheme(Scheme))
+	utilruntime.Must(Scheme.SetVersionPriority(visibility.GroupVersion))
 	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
 }
 
 // Install installs API scheme and registers storages
 func Install(server *genericapiserver.GenericAPIServer, kueueMgr *qcache.Manager) error {
-	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(visibilityv1beta1.GroupVersion.Group, Scheme, ParameterCodec, Codecs)
-	apiGroupInfo.VersionedResourcesStorageMap[visibilityv1beta1.GroupVersion.Version] = apiv1beta1.NewStorage(kueueMgr)
+	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(visibility.GroupVersion.Group, Scheme, ParameterCodec, Codecs)
+	apiGroupInfo.VersionedResourcesStorageMap[visibility.GroupVersion.Version] = visibilityapi.NewStorage(kueueMgr)
 	return server.InstallAPIGroups(&apiGroupInfo)
 }

--- a/pkg/visibility/server.go
+++ b/pkg/visibility/server.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/component-base/version"
 
 	generatedopenapi "sigs.k8s.io/kueue/apis/visibility/openapi"
-	visibilityv1beta1 "sigs.k8s.io/kueue/apis/visibility/v1beta1"
+	visibility "sigs.k8s.io/kueue/apis/visibility/v1beta1"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	"sigs.k8s.io/kueue/pkg/visibility/api"
 
@@ -81,7 +81,7 @@ func CreateAndStartVisibilityServer(ctx context.Context, kueueMgr *qcache.Manage
 }
 
 func applyVisibilityServerOptions(config *genericapiserver.RecommendedConfig, enableInternalCertManagement bool) error {
-	o := genericoptions.NewRecommendedOptions("", api.Codecs.LegacyCodec(visibilityv1beta1.SchemeGroupVersion))
+	o := genericoptions.NewRecommendedOptions("", api.Codecs.LegacyCodec(visibility.SchemeGroupVersion))
 	o.Etcd = nil
 	o.SecureServing.BindPort = 8082
 	if enableInternalCertManagement {

--- a/test/e2e/certmanager/metrics_test.go
+++ b/test/e2e/certmanager/metrics_test.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingjobspod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 	"sigs.k8s.io/kueue/test/util"
@@ -43,7 +43,7 @@ const (
 var _ = ginkgo.Describe("Metrics", ginkgo.Ordered, func() {
 	var (
 		ns             *corev1.Namespace
-		resourceFlavor *v1beta1.ResourceFlavor
+		resourceFlavor *kueue.ResourceFlavor
 
 		metricsReaderClusterRoleBinding *rbacv1.ClusterRoleBinding
 
@@ -128,9 +128,9 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Ordered, func() {
 
 	ginkgo.When("workload is admitted", func() {
 		var (
-			clusterQueue *v1beta1.ClusterQueue
-			localQueue   *v1beta1.LocalQueue
-			workload     *v1beta1.Workload
+			clusterQueue *kueue.ClusterQueue
+			localQueue   *kueue.LocalQueue
+			workload     *kueue.Workload
 		)
 
 		ginkgo.BeforeEach(func() {
@@ -152,7 +152,7 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Ordered, func() {
 			gomega.Expect(k8sClient.Create(ctx, localQueue)).To(gomega.Succeed())
 
 			workload = utiltesting.MakeWorkload("test-workload", ns.Name).
-				Queue(v1beta1.LocalQueueName(localQueue.Name)).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
 				PodSets(
 					*utiltesting.MakePodSet("ps1", 1).Obj(),
 				).

--- a/test/e2e/singlecluster/fair_sharing_test.go
+++ b/test/e2e/singlecluster/fair_sharing_test.go
@@ -24,7 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	jobtesting "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 	"sigs.k8s.io/kueue/test/util"
@@ -33,13 +33,13 @@ import (
 var _ = ginkgo.Describe("Fair Sharing", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		ns  *corev1.Namespace
-		rf  *v1beta1.ResourceFlavor
-		cq1 *v1beta1.ClusterQueue
-		cq2 *v1beta1.ClusterQueue
-		cq3 *v1beta1.ClusterQueue
-		lq1 *v1beta1.LocalQueue
-		lq2 *v1beta1.LocalQueue
-		lq3 *v1beta1.LocalQueue
+		rf  *kueue.ResourceFlavor
+		cq1 *kueue.ClusterQueue
+		cq2 *kueue.ClusterQueue
+		cq3 *kueue.ClusterQueue
+		lq1 *kueue.LocalQueue
+		lq2 *kueue.LocalQueue
+		lq3 *kueue.LocalQueue
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -95,7 +95,7 @@ var _ = ginkgo.Describe("Fair Sharing", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			ginkgo.By("create jobs")
 			for i := range 4 {
 				job := jobtesting.MakeJob(fmt.Sprintf("j%d", i+1), ns.Name).
-					Queue(v1beta1.LocalQueueName(lq1.Name)).
+					Queue(kueue.LocalQueueName(lq1.Name)).
 					Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 					Parallelism(3).
 					Completions(3).

--- a/test/e2e/singlecluster/kueuectl_test.go
+++ b/test/e2e/singlecluster/kueuectl_test.go
@@ -24,7 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/test/util"
 )
@@ -32,7 +32,7 @@ import (
 var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		ns *corev1.Namespace
-		cq *v1beta1.ClusterQueue
+		cq *kueue.ClusterQueue
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -59,11 +59,11 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 			})
 
 			ginkgo.By("Check that the local queue successfully created", func() {
-				var createdQueue v1beta1.LocalQueue
+				var createdQueue kueue.LocalQueue
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lqName, Namespace: ns.Name}, &createdQueue)).To(gomega.Succeed())
 					g.Expect(createdQueue.Name).Should(gomega.Equal(lqName))
-					g.Expect(createdQueue.Spec.ClusterQueue).Should(gomega.Equal(v1beta1.ClusterQueueReference(cq.Name)))
+					g.Expect(createdQueue.Spec.ClusterQueue).Should(gomega.Equal(kueue.ClusterQueueReference(cq.Name)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
@@ -79,7 +79,7 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 			})
 
 			ginkgo.By("Check that the local queue did not create", func() {
-				var createdQueue v1beta1.LocalQueue
+				var createdQueue kueue.LocalQueue
 				gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lqName, Namespace: ns.Name}, &createdQueue)).ToNot(gomega.Succeed())
 			})
 		})

--- a/test/e2e/singlecluster/metrics_test.go
+++ b/test/e2e/singlecluster/metrics_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
@@ -45,7 +45,7 @@ const (
 var _ = ginkgo.Describe("Metrics", func() {
 	var (
 		ns             *corev1.Namespace
-		resourceFlavor *v1beta1.ResourceFlavor
+		resourceFlavor *kueue.ResourceFlavor
 
 		metricsReaderClusterRoleBinding *rbacv1.ClusterRoleBinding
 
@@ -100,9 +100,9 @@ var _ = ginkgo.Describe("Metrics", func() {
 
 	ginkgo.When("workload is admitted", func() {
 		var (
-			clusterQueue *v1beta1.ClusterQueue
-			localQueue   *v1beta1.LocalQueue
-			workload     *v1beta1.Workload
+			clusterQueue *kueue.ClusterQueue
+			localQueue   *kueue.LocalQueue
+			workload     *kueue.Workload
 		)
 
 		ginkgo.BeforeEach(func() {
@@ -124,7 +124,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 			util.MustCreate(ctx, k8sClient, localQueue)
 
 			workload = utiltesting.MakeWorkload("test-workload", ns.Name).
-				Queue(v1beta1.LocalQueueName(localQueue.Name)).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
 				PodSets(
 					*utiltesting.MakePodSet("ps1", 1).Obj(),
 				).
@@ -226,12 +226,12 @@ var _ = ginkgo.Describe("Metrics", func() {
 
 	ginkgo.When("workload is admitted with admission checks", func() {
 		var (
-			admissionCheck  *v1beta1.AdmissionCheck
-			clusterQueue    *v1beta1.ClusterQueue
-			localQueue      *v1beta1.LocalQueue
+			admissionCheck  *kueue.AdmissionCheck
+			clusterQueue    *kueue.ClusterQueue
+			localQueue      *kueue.LocalQueue
 			createdJob      *batchv1.Job
 			workloadKey     types.NamespacedName
-			createdWorkload *v1beta1.Workload
+			createdWorkload *kueue.Workload
 		)
 
 		ginkgo.BeforeEach(func() {
@@ -248,7 +248,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 						Resource(corev1.ResourceMemory, "1Gi").
 						Obj(),
 				).
-				AdmissionChecks(v1beta1.AdmissionCheckReference(admissionCheck.Name)).
+				AdmissionChecks(kueue.AdmissionCheckReference(admissionCheck.Name)).
 				Obj()
 			util.MustCreate(ctx, k8sClient, clusterQueue)
 
@@ -259,7 +259,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 			util.MustCreate(ctx, k8sClient, localQueue)
 
 			createdJob = testingjob.MakeJob("admission-checked-job", ns.Name).
-				Queue(v1beta1.LocalQueueName(localQueue.Name)).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
 				RequestAndLimit(corev1.ResourceCPU, "1").
 				Obj()
 			util.MustCreate(ctx, k8sClient, createdJob)
@@ -270,11 +270,11 @@ var _ = ginkgo.Describe("Metrics", func() {
 				Namespace: ns.Name,
 			}
 
-			createdWorkload = &v1beta1.Workload{}
+			createdWorkload = &kueue.Workload{}
 
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, workloadKey, createdWorkload)).Should(gomega.Succeed())
-				g.Expect(createdWorkload.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(v1beta1.WorkloadQuotaReserved))
+				g.Expect(createdWorkload.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
@@ -291,9 +291,9 @@ var _ = ginkgo.Describe("Metrics", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, workloadKey, createdWorkload)).Should(gomega.Succeed())
 					patch := util.BaseSSAWorkload(createdWorkload)
-					workload.SetAdmissionCheckState(&patch.Status.AdmissionChecks, v1beta1.AdmissionCheckState{
-						Name:  v1beta1.AdmissionCheckReference(admissionCheck.Name),
-						State: v1beta1.CheckStateReady,
+					workload.SetAdmissionCheckState(&patch.Status.AdmissionChecks, kueue.AdmissionCheckState{
+						Name:  kueue.AdmissionCheckReference(admissionCheck.Name),
+						State: kueue.CheckStateReady,
 					}, realClock)
 					g.Expect(k8sClient.Status().
 						Patch(ctx, patch, client.Apply, client.FieldOwner("test-admission-check-controller"), client.ForceOwnership)).
@@ -325,25 +325,25 @@ var _ = ginkgo.Describe("Metrics", func() {
 
 	ginkgo.When("workload is admitted with eviction and preemption", func() {
 		var (
-			clusterQueue1 *v1beta1.ClusterQueue
-			clusterQueue2 *v1beta1.ClusterQueue
+			clusterQueue1 *kueue.ClusterQueue
+			clusterQueue2 *kueue.ClusterQueue
 
-			localQueue1 *v1beta1.LocalQueue
-			localQueue2 *v1beta1.LocalQueue
+			localQueue1 *kueue.LocalQueue
+			localQueue2 *kueue.LocalQueue
 
 			highPriorityClass *schedulingv1.PriorityClass
 
 			lowerJob1         *batchv1.Job
 			lowerWorkload1Key types.NamespacedName
-			lowerWorkload1    *v1beta1.Workload
+			lowerWorkload1    *kueue.Workload
 
 			lowerJob2         *batchv1.Job
 			lowerWorkload2Key types.NamespacedName
-			lowerWorkload2    *v1beta1.Workload
+			lowerWorkload2    *kueue.Workload
 
 			blockerJob         *batchv1.Job
 			blockerWorkloadKey types.NamespacedName
-			blockerWorkload    *v1beta1.Workload
+			blockerWorkload    *kueue.Workload
 
 			higherJob1 *batchv1.Job
 			higherJob2 *batchv1.Job
@@ -358,11 +358,11 @@ var _ = ginkgo.Describe("Metrics", func() {
 						Resource(corev1.ResourceCPU, "2").
 						Obj(),
 				).
-				Preemption(v1beta1.ClusterQueuePreemption{
-					ReclaimWithinCohort: v1beta1.PreemptionPolicyLowerPriority,
-					WithinClusterQueue:  v1beta1.PreemptionPolicyLowerPriority,
-					BorrowWithinCohort: &v1beta1.BorrowWithinCohort{
-						Policy: v1beta1.BorrowWithinCohortPolicyLowerPriority,
+				Preemption(kueue.ClusterQueuePreemption{
+					ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
+					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+					BorrowWithinCohort: &kueue.BorrowWithinCohort{
+						Policy: kueue.BorrowWithinCohortPolicyLowerPriority,
 					},
 				}).
 				Obj()
@@ -376,11 +376,11 @@ var _ = ginkgo.Describe("Metrics", func() {
 						Resource(corev1.ResourceCPU, "3").
 						Obj(),
 				).
-				Preemption(v1beta1.ClusterQueuePreemption{
-					ReclaimWithinCohort: v1beta1.PreemptionPolicyLowerPriority,
-					WithinClusterQueue:  v1beta1.PreemptionPolicyLowerPriority,
-					BorrowWithinCohort: &v1beta1.BorrowWithinCohort{
-						Policy: v1beta1.BorrowWithinCohortPolicyLowerPriority,
+				Preemption(kueue.ClusterQueuePreemption{
+					ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
+					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+					BorrowWithinCohort: &kueue.BorrowWithinCohort{
+						Policy: kueue.BorrowWithinCohortPolicyLowerPriority,
 					},
 				}).
 				Obj()
@@ -402,7 +402,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 			util.MustCreate(ctx, k8sClient, highPriorityClass)
 
 			lowerJob1 = testingjob.MakeJob("lower-job-1", ns.Name).
-				Queue(v1beta1.LocalQueueName(localQueue1.Name)).
+				Queue(kueue.LocalQueueName(localQueue1.Name)).
 				RequestAndLimit(corev1.ResourceCPU, "1").
 				Obj()
 			util.MustCreate(ctx, k8sClient, lowerJob1)
@@ -412,7 +412,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 				Name:      lowerWLName1,
 				Namespace: ns.Name,
 			}
-			lowerWorkload1 = &v1beta1.Workload{}
+			lowerWorkload1 = &kueue.Workload{}
 
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, lowerWorkload1Key, lowerWorkload1)).To(gomega.Succeed())
@@ -421,7 +421,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, lowerWorkload1)
 
 			lowerJob2 = testingjob.MakeJob("lower-job-2", ns.Name).
-				Queue(v1beta1.LocalQueueName(localQueue2.Name)).
+				Queue(kueue.LocalQueueName(localQueue2.Name)).
 				RequestAndLimit(corev1.ResourceCPU, "1").
 				Obj()
 			util.MustCreate(ctx, k8sClient, lowerJob2)
@@ -431,7 +431,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 				Name:      lowerWLName2,
 				Namespace: ns.Name,
 			}
-			lowerWorkload2 = &v1beta1.Workload{}
+			lowerWorkload2 = &kueue.Workload{}
 
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, lowerWorkload2Key, lowerWorkload2)).To(gomega.Succeed())
@@ -440,7 +440,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, lowerWorkload2)
 
 			blockerJob = testingjob.MakeJob("blocker", ns.Name).
-				Queue(v1beta1.LocalQueueName(localQueue2.Name)).
+				Queue(kueue.LocalQueueName(localQueue2.Name)).
 				PriorityClass(highPriorityClass.Name).
 				RequestAndLimit(corev1.ResourceCPU, "3").
 				Obj()
@@ -451,7 +451,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 				Name:      blockerWLName,
 				Namespace: ns.Name,
 			}
-			blockerWorkload = &v1beta1.Workload{}
+			blockerWorkload = &kueue.Workload{}
 
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, blockerWorkloadKey, blockerWorkload)).To(gomega.Succeed())
@@ -460,14 +460,14 @@ var _ = ginkgo.Describe("Metrics", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, blockerWorkload)
 
 			higherJob1 = testingjob.MakeJob("high-large-1", ns.Name).
-				Queue(v1beta1.LocalQueueName(localQueue1.Name)).
+				Queue(kueue.LocalQueueName(localQueue1.Name)).
 				PriorityClass(highPriorityClass.Name).
 				RequestAndLimit(corev1.ResourceCPU, "4").
 				Obj()
 			util.MustCreate(ctx, k8sClient, higherJob1)
 
 			higherJob2 = testingjob.MakeJob("high-large-2", ns.Name).
-				Queue(v1beta1.LocalQueueName(localQueue2.Name)).
+				Queue(kueue.LocalQueueName(localQueue2.Name)).
 				PriorityClass(highPriorityClass.Name).
 				RequestAndLimit(corev1.ResourceCPU, "4").
 				Obj()
@@ -501,7 +501,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, blockerWorkloadKey, blockerWorkload)).To(gomega.Succeed())
-				g.Expect(blockerWorkload.Status.Conditions).To(utiltesting.HaveConditionStatusTrueAndReason(v1beta1.WorkloadEvicted, v1beta1.WorkloadDeactivated))
+				g.Expect(blockerWorkload.Status.Conditions).To(utiltesting.HaveConditionStatusTrueAndReason(kueue.WorkloadEvicted, kueue.WorkloadDeactivated))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("Expecting at least one of the high-priority jobs to be admitted", func() {

--- a/test/integration/singlecluster/kueuectl/create_test.go
+++ b/test/integration/singlecluster/kueuectl/create_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/test/util"
@@ -40,7 +40,7 @@ import (
 var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		ns *corev1.Namespace
-		cq *v1beta1.ClusterQueue
+		cq *kueue.ClusterQueue
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -72,11 +72,11 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 			})
 
 			ginkgo.By("Check that the local queue successfully created", func() {
-				var createdQueue v1beta1.LocalQueue
+				var createdQueue kueue.LocalQueue
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lqName, Namespace: ns.Name}, &createdQueue)).To(gomega.Succeed())
 					g.Expect(createdQueue.Name).Should(gomega.Equal(lqName))
-					g.Expect(createdQueue.Spec.ClusterQueue).Should(gomega.Equal(v1beta1.ClusterQueueReference(cq.Name)))
+					g.Expect(createdQueue.Spec.ClusterQueue).Should(gomega.Equal(kueue.ClusterQueueReference(cq.Name)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
@@ -98,11 +98,11 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 			})
 
 			ginkgo.By("Check that the local queue successfully created", func() {
-				var createdQueue v1beta1.LocalQueue
+				var createdQueue kueue.LocalQueue
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lqName, Namespace: ns.Name}, &createdQueue)).To(gomega.Succeed())
 					g.Expect(createdQueue.Name).Should(gomega.Equal(lqName))
-					g.Expect(createdQueue.Spec.ClusterQueue).Should(gomega.Equal(v1beta1.ClusterQueueReference(cqName)))
+					g.Expect(createdQueue.Spec.ClusterQueue).Should(gomega.Equal(kueue.ClusterQueueReference(cqName)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
@@ -125,11 +125,11 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 			})
 
 			ginkgo.By("Check that the local queue successfully created", func() {
-				var createdQueue v1beta1.LocalQueue
+				var createdQueue kueue.LocalQueue
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lqName, Namespace: ns.Name}, &createdQueue)).To(gomega.Succeed())
 					g.Expect(createdQueue.Name).Should(gomega.Equal(lqName))
-					g.Expect(createdQueue.Spec.ClusterQueue).Should(gomega.Equal(v1beta1.ClusterQueueReference(cq.Name)))
+					g.Expect(createdQueue.Spec.ClusterQueue).Should(gomega.Equal(kueue.ClusterQueueReference(cq.Name)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
@@ -139,7 +139,7 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 		const cqName = "cluster-queue"
 
 		ginkgo.AfterEach(func() {
-			var createdQueue v1beta1.ClusterQueue
+			var createdQueue kueue.ClusterQueue
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: cqName, Namespace: ns.Name}, &createdQueue)
 			gomega.Expect(client.IgnoreNotFound(err)).To(gomega.Succeed())
 			if !apierrors.IsNotFound(err) {
@@ -163,15 +163,15 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 			})
 
 			ginkgo.By("Check that the cluster queue successfully created", func() {
-				var createdQueue v1beta1.ClusterQueue
+				var createdQueue kueue.ClusterQueue
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cqName, Namespace: ns.Name}, &createdQueue)).To(gomega.Succeed())
 					g.Expect(createdQueue.Name).Should(gomega.Equal(cqName))
 					g.Expect(createdQueue.Spec.Cohort).Should(gomega.BeEmpty())
-					g.Expect(createdQueue.Spec.QueueingStrategy).Should(gomega.Equal(v1beta1.BestEffortFIFO))
+					g.Expect(createdQueue.Spec.QueueingStrategy).Should(gomega.Equal(kueue.BestEffortFIFO))
 					g.Expect(*createdQueue.Spec.NamespaceSelector).Should(gomega.Equal(metav1.LabelSelector{}))
-					g.Expect(createdQueue.Spec.Preemption.ReclaimWithinCohort).Should(gomega.Equal(v1beta1.PreemptionPolicyNever))
-					g.Expect(createdQueue.Spec.Preemption.WithinClusterQueue).Should(gomega.Equal(v1beta1.PreemptionPolicyNever))
+					g.Expect(createdQueue.Spec.Preemption.ReclaimWithinCohort).Should(gomega.Equal(kueue.PreemptionPolicyNever))
+					g.Expect(createdQueue.Spec.Preemption.WithinClusterQueue).Should(gomega.Equal(kueue.PreemptionPolicyNever))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
@@ -199,21 +199,21 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 			})
 
 			ginkgo.By("Check that the cluster queue successfully created", func() {
-				var createdQueue v1beta1.ClusterQueue
+				var createdQueue kueue.ClusterQueue
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cqName, Namespace: ns.Name}, &createdQueue)).To(gomega.Succeed())
 					g.Expect(createdQueue.Name).Should(gomega.Equal(cqName))
-					g.Expect(createdQueue.Spec.Cohort).Should(gomega.Equal(v1beta1.CohortReference("cohort")))
-					g.Expect(createdQueue.Spec.QueueingStrategy).Should(gomega.Equal(v1beta1.StrictFIFO))
+					g.Expect(createdQueue.Spec.Cohort).Should(gomega.Equal(kueue.CohortReference("cohort")))
+					g.Expect(createdQueue.Spec.QueueingStrategy).Should(gomega.Equal(kueue.StrictFIFO))
 					g.Expect(*createdQueue.Spec.NamespaceSelector).Should(gomega.Equal(metav1.LabelSelector{
 						MatchLabels: map[string]string{"fooX": "barX", "fooY": "barY"},
 					}))
-					g.Expect(createdQueue.Spec.Preemption.ReclaimWithinCohort).Should(gomega.Equal(v1beta1.PreemptionPolicyAny))
-					g.Expect(createdQueue.Spec.Preemption.WithinClusterQueue).Should(gomega.Equal(v1beta1.PreemptionPolicyLowerPriority))
-					g.Expect(createdQueue.Spec.ResourceGroups).Should(gomega.Equal([]v1beta1.ResourceGroup{
+					g.Expect(createdQueue.Spec.Preemption.ReclaimWithinCohort).Should(gomega.Equal(kueue.PreemptionPolicyAny))
+					g.Expect(createdQueue.Spec.Preemption.WithinClusterQueue).Should(gomega.Equal(kueue.PreemptionPolicyLowerPriority))
+					g.Expect(createdQueue.Spec.ResourceGroups).Should(gomega.Equal([]kueue.ResourceGroup{
 						{
 							CoveredResources: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
-							Flavors: []v1beta1.FlavorQuotas{
+							Flavors: []kueue.FlavorQuotas{
 								*testing.MakeFlavorQuotas("alpha").
 									Resource(corev1.ResourceCPU, "0").
 									Resource(corev1.ResourceMemory, "0").
@@ -243,14 +243,14 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 			})
 
 			ginkgo.By("Check that the cluster queue successfully created", func() {
-				var createdQueue v1beta1.ClusterQueue
+				var createdQueue kueue.ClusterQueue
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cqName, Namespace: ns.Name}, &createdQueue)).To(gomega.Succeed())
 					g.Expect(createdQueue.Name).Should(gomega.Equal(cqName))
-					g.Expect(createdQueue.Spec.ResourceGroups).Should(gomega.Equal([]v1beta1.ResourceGroup{
+					g.Expect(createdQueue.Spec.ResourceGroups).Should(gomega.Equal([]kueue.ResourceGroup{
 						{
 							CoveredResources: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
-							Flavors: []v1beta1.FlavorQuotas{
+							Flavors: []kueue.FlavorQuotas{
 								*testing.MakeFlavorQuotas("alpha").
 									Resource(corev1.ResourceCPU, "0").
 									Resource(corev1.ResourceMemory, "0").
@@ -284,14 +284,14 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 			})
 
 			ginkgo.By("Check that the cluster queue successfully created", func() {
-				var createdQueue v1beta1.ClusterQueue
+				var createdQueue kueue.ClusterQueue
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cqName, Namespace: ns.Name}, &createdQueue)).To(gomega.Succeed())
 					g.Expect(createdQueue.Name).Should(gomega.Equal(cqName))
-					g.Expect(createdQueue.Spec.ResourceGroups).Should(gomega.Equal([]v1beta1.ResourceGroup{
+					g.Expect(createdQueue.Spec.ResourceGroups).Should(gomega.Equal([]kueue.ResourceGroup{
 						{
 							CoveredResources: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
-							Flavors: []v1beta1.FlavorQuotas{
+							Flavors: []kueue.FlavorQuotas{
 								*testing.MakeFlavorQuotas("alpha").
 									Resource(corev1.ResourceCPU, "0").
 									Resource(corev1.ResourceMemory, "0").
@@ -304,7 +304,7 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 						},
 						{
 							CoveredResources: []corev1.ResourceName{"gpu"},
-							Flavors: []v1beta1.FlavorQuotas{
+							Flavors: []kueue.FlavorQuotas{
 								*testing.MakeFlavorQuotas("beta").
 									Resource("gpu", "0").
 									Obj(),
@@ -340,14 +340,14 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 			})
 
 			ginkgo.By("Check that the cluster queue successfully created", func() {
-				var createdQueue v1beta1.ClusterQueue
+				var createdQueue kueue.ClusterQueue
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cqName, Namespace: ns.Name}, &createdQueue)).To(gomega.Succeed())
 					g.Expect(createdQueue.Name).Should(gomega.Equal(cqName))
-					g.Expect(createdQueue.Spec.ResourceGroups).Should(gomega.Equal([]v1beta1.ResourceGroup{
+					g.Expect(createdQueue.Spec.ResourceGroups).Should(gomega.Equal([]kueue.ResourceGroup{
 						{
 							CoveredResources: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
-							Flavors: []v1beta1.FlavorQuotas{
+							Flavors: []kueue.FlavorQuotas{
 								*testing.MakeFlavorQuotas("alpha").
 									Resource(corev1.ResourceCPU, "0", "0", "0").
 									Resource(corev1.ResourceMemory, "0", "0", "0").
@@ -387,21 +387,21 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 			})
 
 			ginkgo.By("Check that the cluster queue successfully created", func() {
-				var createdQueue v1beta1.ClusterQueue
+				var createdQueue kueue.ClusterQueue
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cqName, Namespace: ns.Name}, &createdQueue)).To(gomega.Succeed())
 					g.Expect(createdQueue.Name).Should(gomega.Equal(cqName))
-					g.Expect(createdQueue.Spec.Cohort).Should(gomega.Equal(v1beta1.CohortReference("cohort")))
-					g.Expect(createdQueue.Spec.QueueingStrategy).Should(gomega.Equal(v1beta1.StrictFIFO))
+					g.Expect(createdQueue.Spec.Cohort).Should(gomega.Equal(kueue.CohortReference("cohort")))
+					g.Expect(createdQueue.Spec.QueueingStrategy).Should(gomega.Equal(kueue.StrictFIFO))
 					g.Expect(*createdQueue.Spec.NamespaceSelector).Should(gomega.Equal(metav1.LabelSelector{
 						MatchLabels: map[string]string{"fooX": "barX", "fooY": "barY"},
 					}))
-					g.Expect(createdQueue.Spec.Preemption.ReclaimWithinCohort).Should(gomega.Equal(v1beta1.PreemptionPolicyAny))
-					g.Expect(createdQueue.Spec.Preemption.WithinClusterQueue).Should(gomega.Equal(v1beta1.PreemptionPolicyLowerPriority))
-					g.Expect(createdQueue.Spec.ResourceGroups).Should(gomega.Equal([]v1beta1.ResourceGroup{
+					g.Expect(createdQueue.Spec.Preemption.ReclaimWithinCohort).Should(gomega.Equal(kueue.PreemptionPolicyAny))
+					g.Expect(createdQueue.Spec.Preemption.WithinClusterQueue).Should(gomega.Equal(kueue.PreemptionPolicyLowerPriority))
+					g.Expect(createdQueue.Spec.ResourceGroups).Should(gomega.Equal([]kueue.ResourceGroup{
 						{
 							CoveredResources: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
-							Flavors: []v1beta1.FlavorQuotas{
+							Flavors: []kueue.FlavorQuotas{
 								*testing.MakeFlavorQuotas("alpha").
 									Resource(corev1.ResourceCPU, "2", "1", "0").
 									Resource(corev1.ResourceMemory, "2", "1", "0").
@@ -414,7 +414,7 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 						},
 						{
 							CoveredResources: []corev1.ResourceName{"gpu"},
-							Flavors: []v1beta1.FlavorQuotas{
+							Flavors: []kueue.FlavorQuotas{
 								*testing.MakeFlavorQuotas("beta").
 									Resource("gpu", "2", "1", "0").
 									Obj(),
@@ -430,7 +430,7 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 		const rfName = "resource-flavor"
 
 		ginkgo.AfterEach(func() {
-			var resourceFlavor v1beta1.ResourceFlavor
+			var resourceFlavor kueue.ResourceFlavor
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: rfName}, &resourceFlavor)
 			gomega.Expect(client.IgnoreNotFound(err)).To(gomega.Succeed())
 			if !apierrors.IsNotFound(err) {
@@ -456,7 +456,7 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 			})
 
 			ginkgo.By("Check that the resource flavor successfully created", func() {
-				var resourceFlavor v1beta1.ResourceFlavor
+				var resourceFlavor kueue.ResourceFlavor
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: rfName, Namespace: ns.Name}, &resourceFlavor)).To(gomega.Succeed())
 					g.Expect(resourceFlavor.Name).Should(gomega.Equal(rfName))
@@ -489,7 +489,7 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 			})
 
 			ginkgo.By("Check that the resource flavor successfully created", func() {
-				var resourceFlavor v1beta1.ResourceFlavor
+				var resourceFlavor kueue.ResourceFlavor
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: rfName, Namespace: ns.Name}, &resourceFlavor)).To(gomega.Succeed())
 					g.Expect(resourceFlavor.Name).Should(gomega.Equal(rfName))
@@ -544,7 +544,7 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 			})
 
 			ginkgo.By("Check that the resource flavor not created", func() {
-				var resourceFlavor v1beta1.ResourceFlavor
+				var resourceFlavor kueue.ResourceFlavor
 				gomega.Eventually(func(g gomega.Gomega) {
 					rfKey := types.NamespacedName{Name: rfName, Namespace: ns.Name}
 					g.Expect(k8sClient.Get(ctx, rfKey, &resourceFlavor)).Should(testing.BeNotFoundError())

--- a/test/integration/singlecluster/kueuectl/list_test.go
+++ b/test/integration/singlecluster/kueuectl/list_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	testingclock "k8s.io/utils/clock/testing"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/list"
 	"sigs.k8s.io/kueue/pkg/util/testing"
@@ -49,9 +49,9 @@ var _ = ginkgo.Describe("Kueuectl List", ginkgo.Ordered, ginkgo.ContinueOnFailur
 
 	ginkgo.When("List LocalQueue", func() {
 		var (
-			lq1 *v1beta1.LocalQueue
-			lq2 *v1beta1.LocalQueue
-			lq3 *v1beta1.LocalQueue
+			lq1 *kueue.LocalQueue
+			lq2 *kueue.LocalQueue
+			lq3 *kueue.LocalQueue
 		)
 
 		ginkgo.JustBeforeEach(func() {
@@ -114,8 +114,8 @@ very-long-local-queue-name   cq1                            0                   
 
 	ginkgo.When("List ClusterQueue", func() {
 		var (
-			cq1 *v1beta1.ClusterQueue
-			cq2 *v1beta1.ClusterQueue
+			cq1 *kueue.ClusterQueue
+			cq2 *kueue.ClusterQueue
 		)
 
 		ginkgo.JustBeforeEach(func() {
@@ -177,9 +177,9 @@ very-long-cluster-queue-name            0                   0                   
 
 	ginkgo.When("List Workloads", func() {
 		var (
-			wl1 *v1beta1.Workload
-			wl2 *v1beta1.Workload
-			wl3 *v1beta1.Workload
+			wl1 *kueue.Workload
+			wl2 *kueue.Workload
+			wl3 *kueue.Workload
 		)
 
 		ginkgo.JustBeforeEach(func() {
@@ -239,8 +239,8 @@ wl2                                             very-long-local-queue-name      
 
 	ginkgo.When("List ResourceFlavors", func() {
 		var (
-			rf1 *v1beta1.ResourceFlavor
-			rf2 *v1beta1.ResourceFlavor
+			rf1 *kueue.ResourceFlavor
+			rf2 *kueue.ResourceFlavor
 		)
 
 		ginkgo.JustBeforeEach(func() {

--- a/test/integration/singlecluster/kueuectl/resume_test.go
+++ b/test/integration/singlecluster/kueuectl/resume_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -54,7 +54,7 @@ var _ = ginkgo.Describe("Kueuectl Resume", ginkgo.Ordered, ginkgo.ContinueOnFail
 			ginkgo.By("Create a Workload")
 			util.MustCreate(ctx, k8sClient, wl)
 
-			createdWorkload := &v1beta1.Workload{}
+			createdWorkload := &kueue.Workload{}
 
 			ginkgo.By("Get the created Workload", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -84,18 +84,18 @@ var _ = ginkgo.Describe("Kueuectl Resume", ginkgo.Ordered, ginkgo.ContinueOnFail
 
 	ginkgo.When("Resuming a LocalQueue", func() {
 		ginkgo.DescribeTable("Should resume a LocalQueue",
-			func(name string, wantInitialStopPolicy v1beta1.StopPolicy) {
+			func(name string, wantInitialStopPolicy kueue.StopPolicy) {
 				lq := testing.MakeLocalQueue(name, ns.Name).StopPolicy(wantInitialStopPolicy).Obj()
 
 				ginkgo.By("Create a LocalQueue", func() {
 					util.MustCreate(ctx, k8sClient, lq)
 				})
 
-				createdLocalQueue := &v1beta1.LocalQueue{}
+				createdLocalQueue := &kueue.LocalQueue{}
 				ginkgo.By("Get created LocalQueue", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lq), createdLocalQueue)).To(gomega.Succeed())
-						g.Expect(ptr.Deref(createdLocalQueue.Spec.StopPolicy, v1beta1.None)).Should(gomega.Equal(wantInitialStopPolicy))
+						g.Expect(ptr.Deref(createdLocalQueue.Spec.StopPolicy, kueue.None)).Should(gomega.Equal(wantInitialStopPolicy))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 
@@ -112,24 +112,24 @@ var _ = ginkgo.Describe("Kueuectl Resume", ginkgo.Ordered, ginkgo.ContinueOnFail
 				ginkgo.By("Check that the LocalQueue is successfully resumed", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(createdLocalQueue), createdLocalQueue)).To(gomega.Succeed())
-						g.Expect(ptr.Deref(createdLocalQueue.Spec.StopPolicy, v1beta1.None)).Should(gomega.Equal(v1beta1.None))
+						g.Expect(ptr.Deref(createdLocalQueue.Spec.StopPolicy, kueue.None)).Should(gomega.Equal(kueue.None))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 			},
 			ginkgo.Entry("HoldAndDrain",
 				"lq-1",
-				v1beta1.HoldAndDrain,
+				kueue.HoldAndDrain,
 			),
 			ginkgo.Entry("Hold",
 				"lq-2",
-				v1beta1.Hold,
+				kueue.Hold,
 			),
 		)
 	})
 
 	ginkgo.When("Resuming a ClusterQueue", func() {
 		ginkgo.DescribeTable("Should resume a ClusterQueue",
-			func(cq *v1beta1.ClusterQueue, wantInitialStopPolicy v1beta1.StopPolicy) {
+			func(cq *kueue.ClusterQueue, wantInitialStopPolicy kueue.StopPolicy) {
 				ginkgo.By("Create a ClusterQueue", func() {
 					util.MustCreate(ctx, k8sClient, cq)
 				})
@@ -138,11 +138,11 @@ var _ = ginkgo.Describe("Kueuectl Resume", ginkgo.Ordered, ginkgo.ContinueOnFail
 					util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
 				})
 
-				createdClusterQueue := &v1beta1.ClusterQueue{}
+				createdClusterQueue := &kueue.ClusterQueue{}
 				ginkgo.By("Get created ClusterQueue", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), createdClusterQueue)).To(gomega.Succeed())
-						g.Expect(ptr.Deref(createdClusterQueue.Spec.StopPolicy, v1beta1.None)).Should(gomega.Equal(wantInitialStopPolicy))
+						g.Expect(ptr.Deref(createdClusterQueue.Spec.StopPolicy, kueue.None)).Should(gomega.Equal(wantInitialStopPolicy))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 
@@ -159,17 +159,17 @@ var _ = ginkgo.Describe("Kueuectl Resume", ginkgo.Ordered, ginkgo.ContinueOnFail
 				ginkgo.By("Check that the ClusterQueue is successfully resumed", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(createdClusterQueue), createdClusterQueue)).To(gomega.Succeed())
-						g.Expect(ptr.Deref(createdClusterQueue.Spec.StopPolicy, v1beta1.None)).Should(gomega.Equal(v1beta1.None))
+						g.Expect(ptr.Deref(createdClusterQueue.Spec.StopPolicy, kueue.None)).Should(gomega.Equal(kueue.None))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 			},
 			ginkgo.Entry("HoldAndDrain",
-				testing.MakeClusterQueue("cq-1").StopPolicy(v1beta1.HoldAndDrain).Obj(),
-				v1beta1.HoldAndDrain,
+				testing.MakeClusterQueue("cq-1").StopPolicy(kueue.HoldAndDrain).Obj(),
+				kueue.HoldAndDrain,
 			),
 			ginkgo.Entry("Hold",
-				testing.MakeClusterQueue("cq-2").StopPolicy(v1beta1.Hold).Obj(),
-				v1beta1.Hold,
+				testing.MakeClusterQueue("cq-2").StopPolicy(kueue.Hold).Obj(),
+				kueue.Hold,
 			),
 		)
 	})

--- a/test/integration/singlecluster/kueuectl/stop_test.go
+++ b/test/integration/singlecluster/kueuectl/stop_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -54,7 +54,7 @@ var _ = ginkgo.Describe("Kueuectl Stop", ginkgo.Ordered, ginkgo.ContinueOnFailur
 			ginkgo.By("Create a Workload")
 			util.MustCreate(ctx, k8sClient, wl)
 
-			createdWorkload := &v1beta1.Workload{}
+			createdWorkload := &kueue.Workload{}
 
 			ginkgo.By("Get the created Workload", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -84,18 +84,18 @@ var _ = ginkgo.Describe("Kueuectl Stop", ginkgo.Ordered, ginkgo.ContinueOnFailur
 
 	ginkgo.When("Stopping a LocalQueue", func() {
 		ginkgo.DescribeTable("Should stop a LocalQueue",
-			func(name string, stopCmdArgs []string, wantStopPolicy v1beta1.StopPolicy) {
+			func(name string, stopCmdArgs []string, wantStopPolicy kueue.StopPolicy) {
 				lq := testing.MakeLocalQueue(name, ns.Name).Obj()
 
 				ginkgo.By("Create a LocalQueue", func() {
 					util.MustCreate(ctx, k8sClient, lq)
 				})
 
-				createdLocalQueue := &v1beta1.LocalQueue{}
+				createdLocalQueue := &kueue.LocalQueue{}
 				ginkgo.By("Get created LocalQueue", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lq), createdLocalQueue)).To(gomega.Succeed())
-						g.Expect(ptr.Deref(createdLocalQueue.Spec.StopPolicy, v1beta1.None)).Should(gomega.Equal(v1beta1.None))
+						g.Expect(ptr.Deref(createdLocalQueue.Spec.StopPolicy, kueue.None)).Should(gomega.Equal(kueue.None))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 
@@ -112,26 +112,26 @@ var _ = ginkgo.Describe("Kueuectl Stop", ginkgo.Ordered, ginkgo.ContinueOnFailur
 				ginkgo.By("Check that the LocalQueue is successfully stopped", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(createdLocalQueue), createdLocalQueue)).To(gomega.Succeed())
-						g.Expect(ptr.Deref(createdLocalQueue.Spec.StopPolicy, v1beta1.None)).Should(gomega.Equal(wantStopPolicy))
+						g.Expect(ptr.Deref(createdLocalQueue.Spec.StopPolicy, kueue.None)).Should(gomega.Equal(wantStopPolicy))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 			},
 			ginkgo.Entry("Stop a LocalQueue and drain workloads",
 				"lq-1",
 				[]string{},
-				v1beta1.HoldAndDrain,
+				kueue.HoldAndDrain,
 			),
 			ginkgo.Entry("Stop a LocalQueue and let the admitted workloads finish",
 				"lq-2",
 				[]string{"--keep-already-running"},
-				v1beta1.Hold,
+				kueue.Hold,
 			),
 		)
 	})
 
 	ginkgo.When("Stopping a ClusterQueue", func() {
 		ginkgo.DescribeTable("Should stop a ClusterQueue",
-			func(cq *v1beta1.ClusterQueue, stopCmdArgs []string, wantStopPolicy v1beta1.StopPolicy) {
+			func(cq *kueue.ClusterQueue, stopCmdArgs []string, wantStopPolicy kueue.StopPolicy) {
 				ginkgo.By("Create a ClusterQueue", func() {
 					util.MustCreate(ctx, k8sClient, cq)
 				})
@@ -140,11 +140,11 @@ var _ = ginkgo.Describe("Kueuectl Stop", ginkgo.Ordered, ginkgo.ContinueOnFailur
 					util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
 				})
 
-				createdClusterQueue := &v1beta1.ClusterQueue{}
+				createdClusterQueue := &kueue.ClusterQueue{}
 				ginkgo.By("Get created ClusterQueue", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), createdClusterQueue)).To(gomega.Succeed())
-						g.Expect(ptr.Deref(createdClusterQueue.Spec.StopPolicy, v1beta1.None)).Should(gomega.Equal(v1beta1.None))
+						g.Expect(ptr.Deref(createdClusterQueue.Spec.StopPolicy, kueue.None)).Should(gomega.Equal(kueue.None))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 
@@ -161,19 +161,19 @@ var _ = ginkgo.Describe("Kueuectl Stop", ginkgo.Ordered, ginkgo.ContinueOnFailur
 				ginkgo.By("Check that the ClusterQueue is successfully stopped", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(createdClusterQueue), createdClusterQueue)).To(gomega.Succeed())
-						g.Expect(ptr.Deref(createdClusterQueue.Spec.StopPolicy, v1beta1.None)).Should(gomega.Equal(wantStopPolicy))
+						g.Expect(ptr.Deref(createdClusterQueue.Spec.StopPolicy, kueue.None)).Should(gomega.Equal(wantStopPolicy))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 			},
 			ginkgo.Entry("Stop a ClusterQueue and drain workloads",
 				testing.MakeClusterQueue("cq-1").Obj(),
 				[]string{},
-				v1beta1.HoldAndDrain,
+				kueue.HoldAndDrain,
 			),
 			ginkgo.Entry("Stop a ClusterQueue and let the admitted workloads finish",
 				testing.MakeClusterQueue("cq-2").Obj(),
 				[]string{"--keep-already-running"},
-				v1beta1.Hold,
+				kueue.Hold,
 			),
 		)
 	})

--- a/test/integration/singlecluster/webhook/jobs/jobset_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/jobset_webhook_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 
-	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/jobset"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/jobset"
@@ -66,8 +66,8 @@ var _ = ginkgo.Describe("JobSet Webhook", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					testingjob.ReplicatedJobRequirements{
 						Name: "leader",
 						PodAnnotations: map[string]string{
-							kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block",
-							kueuealpha.PodSetRequiredTopologyAnnotation:  "cloud.com/block",
+							kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetRequiredTopologyAnnotation:  "cloud.com/block",
 						},
 					},
 				).
@@ -92,9 +92,9 @@ var _ = ginkgo.Describe("JobSet Webhook", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					Parallelism: parallelism,
 					Completions: parallelism,
 					PodAnnotations: map[string]string{
-						kueuealpha.PodSetPreferredTopologyAnnotation:     testing.DefaultBlockTopologyLevel,
-						kueuealpha.PodSetSliceRequiredTopologyAnnotation: testing.DefaultBlockTopologyLevel,
-						kueuealpha.PodSetSliceSizeAnnotation:             invalidSliceSize,
+						kueue.PodSetPreferredTopologyAnnotation:     testing.DefaultBlockTopologyLevel,
+						kueue.PodSetSliceRequiredTopologyAnnotation: testing.DefaultBlockTopologyLevel,
+						kueue.PodSetSliceSizeAnnotation:             invalidSliceSize,
 					},
 				}).
 				RequestAndLimit("replicated-job-1", "example.com/gpu", "1").

--- a/test/integration/singlecluster/webhook/jobs/paddlejob_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/paddlejob_webhook_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 
-	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs/paddlejob"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 	testingjobspaddlejob "sigs.k8s.io/kueue/pkg/util/testingjobs/paddlejob"
@@ -54,8 +54,8 @@ var _ = ginkgo.Describe("PaddleJob Webhook", ginkgo.Ordered, func() {
 						ReplicaType:  kftraining.PaddleJobReplicaTypeMaster,
 						ReplicaCount: 1,
 						Annotations: map[string]string{
-							kueuealpha.PodSetRequiredTopologyAnnotation:  "cloud.com/rack",
-							kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/rack",
+							kueue.PodSetRequiredTopologyAnnotation:  "cloud.com/rack",
+							kueue.PodSetPreferredTopologyAnnotation: "cloud.com/rack",
 						},
 					},
 				).

--- a/test/integration/singlecluster/webhook/jobs/pytorchjob_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/pytorchjob_webhook_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 
-	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs/pytorchjob"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 	testingjobspytorchjob "sigs.k8s.io/kueue/pkg/util/testingjobs/pytorchjob"
@@ -54,8 +54,8 @@ var _ = ginkgo.Describe("PyTorchJob Webhook", ginkgo.Ordered, func() {
 						ReplicaType:  kftraining.PyTorchJobReplicaTypeMaster,
 						ReplicaCount: 1,
 						Annotations: map[string]string{
-							kueuealpha.PodSetRequiredTopologyAnnotation:  "cloud.com/rack",
-							kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/rack",
+							kueue.PodSetRequiredTopologyAnnotation:  "cloud.com/rack",
+							kueue.PodSetPreferredTopologyAnnotation: "cloud.com/rack",
 						},
 					},
 				).

--- a/test/integration/singlecluster/webhook/jobs/tfjob_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/tfjob_webhook_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 
-	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs/tfjob"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 	testingjobstfjob "sigs.k8s.io/kueue/pkg/util/testingjobs/tfjob"
@@ -54,8 +54,8 @@ var _ = ginkgo.Describe("TFJob Webhook", ginkgo.Ordered, func() {
 						ReplicaType:  kftraining.TFJobReplicaTypeChief,
 						ReplicaCount: 1,
 						Annotations: map[string]string{
-							kueuealpha.PodSetRequiredTopologyAnnotation:  "cloud.com/rack",
-							kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/rack",
+							kueue.PodSetRequiredTopologyAnnotation:  "cloud.com/rack",
+							kueue.PodSetPreferredTopologyAnnotation: "cloud.com/rack",
 						},
 					},
 				).

--- a/test/integration/singlecluster/webhook/jobs/xgboostjob_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/xgboostjob_webhook_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 
-	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs/xgboostjob"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 	testingjobsxgboostjob "sigs.k8s.io/kueue/pkg/util/testingjobs/xgboostjob"
@@ -54,8 +54,8 @@ var _ = ginkgo.Describe("XGBoostJob Webhook", ginkgo.Ordered, func() {
 						ReplicaType:  kftraining.XGBoostJobReplicaTypeMaster,
 						ReplicaCount: 1,
 						Annotations: map[string]string{
-							kueuealpha.PodSetRequiredTopologyAnnotation:  "cloud.com/rack",
-							kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/rack",
+							kueue.PodSetRequiredTopologyAnnotation:  "cloud.com/rack",
+							kueue.PodSetPreferredTopologyAnnotation: "cloud.com/rack",
 						},
 					},
 				).


### PR DESCRIPTION
Cherry pick of #7267 on release-0.14.

#7267: Use alias for kueue and visibility consistently

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```