### PR TITLE
Replace ExpectReservingActiveWorkloadsMetric with counter

### DIFF
--- a/test/integration/singlecluster/controller/jobs/appwrapper/appwrapper_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/appwrapper/appwrapper_controller_test.go
@@ -830,7 +830,7 @@ var _ = ginkgo.Describe("AppWrapper controller interacting with scheduler", gink
 		gomega.Expect(createdAppWrapper.Spec.Components[0].PodSetInfos[0].NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
 		gomega.Expect(createdAppWrapper.Spec.Components[1].PodSetInfos[0].NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
 		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
-		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 	})
 })
 
@@ -937,7 +937,7 @@ var _ = ginkgo.Describe("AppWrapper controller with TopologyAwareScheduling", gi
 
 		ginkgo.By("verify the workload is admitted", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 		})
 
 		ginkgo.By("verify admission for the workload", func() {

--- a/test/integration/singlecluster/controller/jobs/jaxjob/jaxjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/jaxjob/jaxjob_controller_test.go
@@ -667,7 +667,7 @@ var _ = ginkgo.Describe("JAXJob controller with TopologyAwareScheduling", ginkgo
 
 		ginkgo.By("verify the workload is admitted", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 		})
 
 		ginkgo.By("verify admission for the workload", func() {

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -1391,7 +1391,7 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		gomega.Expect(createdProdJob1.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
 		util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 0)
-		util.ExpectReservingActiveWorkloadsMetric(prodClusterQ, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, "", 1)
 
 		ginkgo.By("checking a second no-fit prod job does not start")
 		prodJob2 := testingjob.MakeJob("prod-job2", ns.Name).Queue(kueue.LocalQueueName(prodLocalQ.Name)).Request(corev1.ResourceCPU, "5").Obj()
@@ -1403,7 +1403,7 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 			g.Expect(createdProdJob2.Spec.Suspend).Should(gomega.Equal(ptr.To(true)))
 		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 		util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 1)
-		util.ExpectReservingActiveWorkloadsMetric(prodClusterQ, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, "", 1)
 
 		ginkgo.By("checking a dev job starts")
 		devJob := testingjob.MakeJob("dev-job", ns.Name).Queue(kueue.LocalQueueName(devLocalQ.Name)).Request(corev1.ResourceCPU, "5").Obj()
@@ -1415,7 +1415,7 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		gomega.Expect(createdDevJob.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
 		util.ExpectPendingWorkloadsMetric(devClusterQ, 0, 0)
-		util.ExpectReservingActiveWorkloadsMetric(devClusterQ, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(devClusterQ, "", 1)
 
 		ginkgo.By("checking the second prod job starts when the first finishes")
 		gomega.Eventually(func(g gomega.Gomega) {
@@ -1673,7 +1673,7 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			gomega.Expect(createdJob1.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
 			util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 0)
-			util.ExpectReservingActiveWorkloadsMetric(prodClusterQ, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, "", 1)
 		})
 
 		job2 := testingjob.MakeJob("job2", ns.Name).Queue(kueue.LocalQueueName(prodLocalQ.Name)).Request(corev1.ResourceCPU, "3").Obj()
@@ -2448,7 +2448,7 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-				util.ExpectReservingActiveWorkloadsMetric(cq, 1)
+				util.ExpectAdmittedWorkloadsTotalMetric(cq, "", 1)
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
@@ -2611,7 +2611,7 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-				util.ExpectReservingActiveWorkloadsMetric(cq, 1)
+				util.ExpectAdmittedWorkloadsTotalMetric(cq, "", 1)
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
@@ -2935,7 +2935,7 @@ var _ = ginkgo.Describe("Job controller with TopologyAwareScheduling", ginkgo.Or
 
 		ginkgo.By("verify the workload is admitted", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 		})
 
 		ginkgo.By("verify admission for the workload", func() {
@@ -2988,7 +2988,7 @@ var _ = ginkgo.Describe("Job controller with TopologyAwareScheduling", ginkgo.Or
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 		})
 
 		ginkgo.By("verify admission for the workload", func() {

--- a/test/integration/singlecluster/controller/jobs/jobset/jobset_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/jobset/jobset_controller_test.go
@@ -1026,7 +1026,7 @@ var _ = ginkgo.Describe("JobSet controller interacting with scheduler", ginkgo.O
 		gomega.Expect(createdJobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
 		gomega.Expect(createdJobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
 		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
-		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 	})
 
 	ginkgo.It("Should allow reclaim of resources that are no longer needed", func() {
@@ -1061,7 +1061,7 @@ var _ = ginkgo.Describe("JobSet controller interacting with scheduler", ginkgo.O
 				g.Expect(*createdJobSet1.Spec.Suspend).Should(gomega.BeFalse())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 		})
 
 		jobSet2 := testingjobset.MakeJobSet("dev-jobset2", ns.Name).ReplicatedJobs(
@@ -1274,7 +1274,7 @@ var _ = ginkgo.Describe("JobSet controller with TopologyAwareScheduling", ginkgo
 
 		ginkgo.By("verify the workload is admitted", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 		})
 
 		ginkgo.By("verify admission for the workload", func() {

--- a/test/integration/singlecluster/controller/jobs/kubeflow/kubeflowjob.go
+++ b/test/integration/singlecluster/controller/jobs/kubeflow/kubeflowjob.go
@@ -304,7 +304,7 @@ func ShouldScheduleJobsAsTheyFitInTheirClusterQueue(ctx context.Context, k8sClie
 		gomega.ExpectWithOffset(1, createdJob.KFJobControl.ReplicaSpecs()[psr.RoleName].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(string(psr.ResourceCPU)))
 	}
 	util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
-	util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+	util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 }
 
 type PodSetsResource struct {

--- a/test/integration/singlecluster/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/mpijob/mpijob_controller_test.go
@@ -817,7 +817,7 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 		gomega.Expect(createdJob.Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
 		gomega.Expect(createdJob.Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
 		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
-		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 	})
 
 	ginkgo.When("The workload's admission is removed", func() {
@@ -1005,7 +1005,7 @@ var _ = ginkgo.Describe("MPIJob controller with TopologyAwareScheduling", ginkgo
 
 		ginkgo.By("verify the workload is admitted", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 		})
 
 		ginkgo.By("verify admission for the workload", func() {

--- a/test/integration/singlecluster/controller/jobs/paddlejob/paddlejob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/paddlejob/paddlejob_controller_test.go
@@ -405,7 +405,7 @@ var _ = ginkgo.Describe("PaddleJob controller with TopologyAwareScheduling", fra
 
 		ginkgo.By("verify the workload is admitted", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 		})
 
 		ginkgo.By("verify admission for the workload", func() {

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -2247,7 +2247,7 @@ var _ = ginkgo.Describe("Pod controller with TopologyAwareScheduling", ginkgo.Or
 		})
 
 		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 
 		ginkgo.By("verify admission for the workload", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -2298,7 +2298,7 @@ var _ = ginkgo.Describe("Pod controller with TopologyAwareScheduling", ginkgo.Or
 		})
 
 		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 
 		ginkgo.By("verify admission for the workload", func() {
 			gomega.Eventually(func(g gomega.Gomega) {

--- a/test/integration/singlecluster/controller/jobs/pytorchjob/pytorchjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pytorchjob/pytorchjob_controller_test.go
@@ -704,7 +704,7 @@ var _ = ginkgo.Describe("PyTorchJob controller with TopologyAwareScheduling", gi
 
 		ginkgo.By("verify the workload is admitted", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 		})
 
 		ginkgo.By("verify admission for the workload", func() {

--- a/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go
@@ -531,7 +531,7 @@ var _ = ginkgo.Describe("RayCluster Job controller interacting with scheduler", 
 		gomega.Expect(createdJob.Spec.HeadGroupSpec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
 		gomega.Expect(createdJob.Spec.WorkerGroupSpecs[0].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
 		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
-		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 
 		ginkgo.By("checking a second no-fit RayCluster does not start")
 		job2 := testingraycluster.MakeCluster("dev-job2", ns.Name).Queue(localQueue.Name).
@@ -545,7 +545,7 @@ var _ = ginkgo.Describe("RayCluster Job controller interacting with scheduler", 
 			g.Expect(createdJob2.Spec.Suspend).Should(gomega.Equal(ptr.To(true)))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
-		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 
 		ginkgo.By("deleting the job", func() {
 			gomega.Expect(k8sClient.Delete(ctx, job)).Should(gomega.Succeed())
@@ -571,7 +571,7 @@ var _ = ginkgo.Describe("RayCluster Job controller interacting with scheduler", 
 		gomega.Expect(createdJob2.Spec.HeadGroupSpec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
 		gomega.Expect(createdJob2.Spec.WorkerGroupSpecs[0].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
 		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
-		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 2)
 	})
 })
 

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -560,7 +560,7 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 		gomega.Expect(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
 		gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
 		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
-		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 	})
 })
 

--- a/test/integration/singlecluster/controller/jobs/tfjob/tfjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/tfjob/tfjob_controller_test.go
@@ -435,7 +435,7 @@ var _ = ginkgo.Describe("TFJob controller with TopologyAwareScheduling", framewo
 
 		ginkgo.By("verify the workload is admitted", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 		})
 
 		ginkgo.By("verify admission for the workload", func() {

--- a/test/integration/singlecluster/controller/jobs/trainjob/trainjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/trainjob/trainjob_controller_test.go
@@ -433,7 +433,7 @@ var _ = ginkgo.Describe("TrainJob controller interacting with scheduler", ginkgo
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
-		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 	})
 
 	ginkgo.It("Should allow reclaim of resources that are no longer needed", func() {
@@ -477,7 +477,7 @@ var _ = ginkgo.Describe("TrainJob controller interacting with scheduler", ginkgo
 				g.Expect(*createdTrainJob1.Spec.Suspend).Should(gomega.BeFalse())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 		})
 
 		testJobset2 := testingjobset.MakeJobSet("", "").ReplicatedJobs(

--- a/test/integration/singlecluster/controller/jobs/xgboostjob/xgboostjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/xgboostjob/xgboostjob_controller_test.go
@@ -402,7 +402,7 @@ var _ = ginkgo.Describe("XGBoostJob controller with TopologyAwareScheduling", fr
 
 		ginkgo.By("verify the workload is admitted", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 		})
 
 		ginkgo.By("verify admission for the workload", func() {

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -346,7 +346,10 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			wlA1 := createWorkloadWithPriority("best-effort-cq-a", "4", 9001)
 			wlA2 := createWorkloadWithPriority("best-effort-cq-a", "4", 100)
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlA1, wlA2)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqA, "", 2)
+			// Sanity check asserting reserving_active_workloads to verify metric correctness after update
 			util.ExpectReservingActiveWorkloadsMetric(cqA, 2)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqB, "", 0)
 			util.ExpectReservingActiveWorkloadsMetric(cqB, 0)
 
 			ginkgo.By("Creating a workload in cqB that should preempt one from cqA")
@@ -416,7 +419,9 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 				createWorkload("second-right", "1")
 			}
 
+			util.ExpectAdmittedWorkloadsTotalMetric(cqSecondLeft, "", 5)
 			util.ExpectReservingActiveWorkloadsMetric(cqSecondLeft, 5)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqSecondRight, "", 5)
 			util.ExpectReservingActiveWorkloadsMetric(cqSecondRight, 5)
 			expectCohortWeightedShare(cohortFirstLeft.Name, 429)
 			expectCohortWeightedShare(cohortFirstRight.Name, 0)
@@ -459,7 +464,9 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			}
 			expectCohortWeightedShare("best-effort", 1000)
 			expectCohortWeightedShare("physics", 500)
+			util.ExpectAdmittedWorkloadsTotalMetric(bestEffortQueue, "", 6)
 			util.ExpectReservingActiveWorkloadsMetric(bestEffortQueue, 6)
+			util.ExpectAdmittedWorkloadsTotalMetric(physicsQueue, "", 6)
 			util.ExpectReservingActiveWorkloadsMetric(physicsQueue, 6)
 
 			ginkgo.By("create high priority workloads")
@@ -597,6 +604,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 				createWorkload("cq-p1", "1")
 			}
 			ginkgo.By("Workloads active")
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, "", 18)
 			util.ExpectReservingActiveWorkloadsMetric(cqp1, 18)
 
 			ginkgo.By("Expected Weighted Shares")
@@ -609,6 +617,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 				createWorkload("cq-p1", "1")
 			}
 			ginkgo.By("Workloads active")
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, "", 18)
 			util.ExpectReservingActiveWorkloadsMetric(cqp1, 18)
 
 			ginkgo.By("Expected Weighted Shares")
@@ -627,6 +636,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			for range 20 {
 				createWorkload("cq-p1", "1")
 			}
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, "", 20)
 			util.ExpectReservingActiveWorkloadsMetric(cqp1, 20)
 			expectCohortWeightedShare("cohort-a", 100)
 
@@ -991,6 +1001,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 				createWorkload("lq-a", "4"),
 				createWorkload("lq-b", "4"),
 			}
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 2)
 			util.ExpectReservingActiveWorkloadsMetric(cq1, 2)
 
 			ginkgo.By("Creating two pending workloads for each lq")
@@ -1024,6 +1035,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 				createWorkload("lq-a", "4"),
 				createWorkload("lq-a", "4"),
 			}
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 2)
 			util.ExpectReservingActiveWorkloadsMetric(cq1, 2)
 
 			ginkgo.By("Creating pending workloads for lq-a")
@@ -1052,6 +1064,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 				createWorkload("lq-a", "4"),
 				createWorkload("lq-b", "4"),
 			}
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 2)
 			util.ExpectReservingActiveWorkloadsMetric(cq1, 2)
 
 			ginkgo.By("Creating pending workloads for lq-a and lq-b")
@@ -1083,6 +1096,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 				createWorkload("lq-a", "4"),
 				createWorkload("lq-a", "4"),
 			}
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 2)
 			util.ExpectReservingActiveWorkloadsMetric(cq1, 2)
 
 			ginkgo.By("Creating pending workloads for lq-b")
@@ -1184,8 +1198,10 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			wlBestEffortA := createWorkload("best-effort-a", "4")
 			util.WaitForNextSecondAfterCreation(wlBestEffortA)
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlBestEffortA)
+			util.ExpectAdmittedWorkloadsTotalMetric(bestEffortCQA, "", 1)
 			util.ExpectReservingActiveWorkloadsMetric(bestEffortCQA, 1)
 			wlBestEffortB := createWorkload("best-effort-b", "4")
+			util.ExpectAdmittedWorkloadsTotalMetric(bestEffortCQB, "", 1)
 			util.ExpectReservingActiveWorkloadsMetric(bestEffortCQB, 1)
 
 			ginkgo.By("Creating a guaranteed workload in the guaranteed CQ, that should reclaim quota")
@@ -1341,6 +1357,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 
 			ginkgo.By("Admitting the workload")
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 1)
 			util.ExpectReservingActiveWorkloadsMetric(cq1, 1)
 
 			ginkgo.By("Checking that LQ's resource usage is updated")
@@ -1362,6 +1379,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			ginkgo.By("Creating workloads in CQ1 that borrow from CQ2")
 			wlHighA := createWorkloadWithPriority("lq-a", "20", 10)
 			_ = createWorkloadWithPriority("lq-b", "12", 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 2)
 			util.ExpectReservingActiveWorkloadsMetric(cq1, 2)
 
 			ginkgo.By("Checking that LQs' resource usage is updated")
@@ -1465,6 +1483,7 @@ var _ = ginkgo.Describe("Scheduler with AdmissionFairSharing = nil", ginkgo.Orde
 
 			ginkgo.By("Admitting the workload")
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 1)
 			util.ExpectReservingActiveWorkloadsMetric(cq1, 1)
 
 			ginkgo.By("Checking that FairSharing status is nil")

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -465,14 +465,14 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, firstWl)
 				util.ExpectPendingWorkloadsMetric(preemptionClusterQ, 0, 0)
-				util.ExpectReservingActiveWorkloadsMetric(preemptionClusterQ, 1)
+				util.ExpectAdmittedWorkloadsTotalMetric(preemptionClusterQ, "", 1)
 			})
 
 			ginkgo.By("Reclaim one pod from the first workload", func() {
 				gomega.Expect(workload.UpdateReclaimablePods(ctx, k8sClient, firstWl, []kueue.ReclaimablePod{{Name: "third", Count: 1}})).To(gomega.Succeed())
 
 				util.ExpectPendingWorkloadsMetric(preemptionClusterQ, 0, 0)
-				util.ExpectReservingActiveWorkloadsMetric(preemptionClusterQ, 1)
+				util.ExpectAdmittedWorkloadsTotalMetric(preemptionClusterQ, "", 1)
 			})
 
 			secondWl := testing.MakeWorkload("second-wl", ns.Name).Queue(kueue.LocalQueueName(preemptionQueue.Name)).
@@ -544,7 +544,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.MustCreate(ctx, k8sClient, wlHigh2)
 
 				util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 5)
-				util.ExpectReservingActiveWorkloadsMetric(prodClusterQ, 0)
+				util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, "", 0)
 
 				util.UnholdClusterQueue(ctx, k8sClient, prodClusterQ)
 
@@ -592,7 +592,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.MustCreate(ctx, k8sClient, wlHigh2)
 
 				util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 0)
-				util.ExpectReservingActiveWorkloadsMetric(prodClusterQ, 0)
+				util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, "", 0)
 
 				util.UnholdLocalQueue(ctx, k8sClient, prodQueue)
 
@@ -637,7 +637,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, smallWl1, smallWl2)
 			util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 2)
-			util.ExpectReservingActiveWorkloadsMetric(prodClusterQ, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, "", 1)
 
 			ginkgo.By("Marking the big workload as finished")
 			util.FinishWorkloads(ctx, k8sClient, bigWl)
@@ -658,14 +658,14 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
 				util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 1)
-				util.ExpectReservingActiveWorkloadsMetric(prodClusterQ, 0)
+				util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, "", 0)
 			})
 			ginkgo.By("Mark one pod as reclaimable", func() {
 				gomega.Expect(workload.UpdateReclaimablePods(ctx, k8sClient, wl, []kueue.ReclaimablePod{{Name: kueue.DefaultPodSetName, Count: 1}})).To(gomega.Succeed())
 
 				util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, prodClusterQ.Name, wl)
 				util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 0)
-				util.ExpectReservingActiveWorkloadsMetric(prodClusterQ, 1)
+				util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, "", 1)
 
 				createWl := &kueue.Workload{}
 				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), createWl)).To(gomega.Succeed())
@@ -1965,7 +1965,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.MustCreate(ctx, k8sClient, wl1)
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
-			util.ExpectReservingActiveWorkloadsMetric(cq, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq, "", 1)
 
 			ginkgo.By("Stopping the ClusterQueue")
 			var clusterQueue kueue.ClusterQueue
@@ -2049,7 +2049,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
-			util.ExpectReservingActiveWorkloadsMetric(cq, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq, "", 1)
 
 			createdLq := &kueue.LocalQueue{}
 
@@ -2455,7 +2455,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			ginkgo.By("creating first foundation workload which admits immediately")
 			createWorkloadWithPriority("foundation-queue", "1", 1000)
-			util.ExpectReservingActiveWorkloadsMetric(cq1, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 1)
 			util.ExpectPendingWorkloadsMetric(cq1, 0, 0)
 
 			ginkgo.By("creating second foundation workload which cannot admit")
@@ -2467,7 +2467,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			createWorkloadWithPriority("best-effort-queue", "1", 0)
 			createWorkloadWithPriority("best-effort-queue", "1", 0)
 
-			util.ExpectReservingActiveWorkloadsMetric(cq2, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq2, "", 1)
 			util.ExpectPendingWorkloadsMetric(cq2, 0, 1)
 
 			ginkgo.By("finish first foundation workload")
@@ -2512,7 +2512,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			ginkgo.By("creating first foundation workload which admits immediately")
 			createWorkloadWithPriority("foundation-queue", "1", 1000)
-			util.ExpectReservingActiveWorkloadsMetric(cq1, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 1)
 			util.ExpectPendingWorkloadsMetric(cq1, 0, 0)
 
 			ginkgo.By("creating second foundation workload which cannot admit")

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -393,7 +393,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 				})
 
 				ginkgo.By("verify admission for the workload1", func() {
@@ -435,7 +435,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl2)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 2)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 2)
 				})
 
 				ginkgo.By("verify admission for the workload2", func() {
@@ -470,7 +470,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the wl3 is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl2, wl3)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 3)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 3)
 				})
 
 				ginkgo.By("verify admission for the wl3", func() {
@@ -511,7 +511,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the wl4 is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl2, wl4)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 3)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 4)
 				})
 
 				ginkgo.By("verify admission for the wl4", func() {
@@ -550,7 +550,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify wl1 is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 				})
 
 				ginkgo.By("create wl2 which is blocked by wl1", func() {
@@ -658,7 +658,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 				})
 
 				ginkgo.By("verify admission for the workload", func() {
@@ -727,7 +727,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 				})
 
 				ginkgo.By("verify admission for the workload", func() {
@@ -865,7 +865,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 				})
 
 				ginkgo.By("creating second a workload which cannot fit", func() {
@@ -1597,7 +1597,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 				})
 
 				ginkgo.By("creating a mid priority workload which can fit", func() {
@@ -1612,7 +1612,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the wl2 gets admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl2)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 2)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 2)
 				})
 
 				ginkgo.By("creating a high priority workload which requires preemption", func() {
@@ -1743,7 +1743,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 				})
 
 				ginkgo.By("creating a workload in CQB which reclaims its quota", func() {
@@ -1843,7 +1843,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
 				})
 			})
@@ -1936,7 +1936,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload gets admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
 				})
 			})
@@ -2004,7 +2004,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload gets admitted after label is added", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
 				})
 			})
@@ -2200,7 +2200,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
 				})
 			})
@@ -2320,7 +2320,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
 				})
 			})
@@ -2443,7 +2443,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("Verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
 				})
 
@@ -2835,7 +2835,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 				})
 
 				ginkgo.By("verify admission for the workload1", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
See https://github.com/kubernetes-sigs/kueue/issues/7172#issuecomment-3401438607.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #7172, #7155

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```