### PR TITLE
add support for maxlength linter command for kubernetes-api-linter

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -19,7 +19,7 @@ linters:
               - "duplicatemarkers" # Ensure there are no exact duplicate markers. for types and fields.
               - "integers" # Ensure only int32 and int64 are used for integers.
               - "jsontags" # Ensure every field has a json tag.
-              # - "maxlength" # Ensure all strings and arrays have maximum lengths/maximum items.
+              - "maxlength" # Ensure all strings and arrays have maximum lengths/maximum items.
               # - "nobools" # Bools do not evolve over time, should use enums instead.
               - "nodurations" # Prevents usage of `Duration` types.
               - "nofloats" # Ensure floats are not used.
@@ -64,7 +64,7 @@ linters:
     generated: strict
     rules:
     ## KAL should only run on API folders.
-    - path-except: "apis/kueue/v1beta2/*"
+    - path-except: "apis/kueue/v1beta2"
       linters:
         - kubeapilinter
 

--- a/apis/kueue/v1beta2/admissioncheck_types.go
+++ b/apis/kueue/v1beta2/admissioncheck_types.go
@@ -50,6 +50,8 @@ type AdmissionCheckSpec struct {
 	// not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="field is immutable"
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:MinLength=1
 	ControllerName string `json:"controllerName"`
 
 	// retryDelayMinutes specifies how long to keep the workload suspended after
@@ -85,11 +87,13 @@ type AdmissionCheckParametersReference struct {
 type AdmissionCheckStatus struct {
 	// conditions hold the latest available observations of the AdmissionCheck
 	// current state.
+	// This is limited to at most 16 separate conditions.
 	// +optional
 	// +listType=map
 	// +listMapKey=type
 	// +patchStrategy=merge
 	// +patchMergeKey=type
+	// +kubebuilder:validation:MaxItems=16
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 

--- a/apis/kueue/v1beta2/clusterqueue_types.go
+++ b/apis/kueue/v1beta2/clusterqueue_types.go
@@ -111,6 +111,7 @@ type ClusterQueueSpec struct {
 
 	// admissionChecks lists the AdmissionChecks required by this ClusterQueue.
 	// Cannot be used along with AdmissionCheckStrategy.
+	// Admission checks are limited to at most 64 items.
 	// +optional
 	AdmissionChecks []AdmissionCheckReference `json:"admissionChecks,omitempty"` //nolint:kubeapilinter // field is being removed
 
@@ -149,6 +150,7 @@ type AdmissionChecksStrategy struct {
 	// admissionChecks is a list of strategies for AdmissionChecks
 	// +listType=map
 	// +listMapKey=name
+	// +kubebuilder:validation:MaxItems=64
 	AdmissionChecks []AdmissionCheckStrategyRule `json:"admissionChecks,omitempty"`
 }
 
@@ -161,6 +163,7 @@ type AdmissionCheckStrategyRule struct {
 	// If empty, the AdmissionCheck will run for all workloads submitted to the ClusterQueue.
 	// +optional
 	// +listType=set
+	// +kubebuilder:validation:MaxItems=64
 	OnFlavors []ResourceFlavorReference `json:"onFlavors,omitempty"`
 }
 
@@ -272,14 +275,17 @@ type ResourceFlavorReference string
 type ClusterQueueStatus struct {
 	// conditions hold the latest available observations of the ClusterQueue
 	// current state.
+	// conditions are limited to 16 elements.
 	// +optional
 	// +listType=map
 	// +listMapKey=type
 	// +patchStrategy=merge
 	// +patchMergeKey=type
+	// +kubebuilder:validation:MaxItems=16
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	// flavorsReservation are the reserved quotas, by flavor, currently in use by the
 	// workloads assigned to this ClusterQueue.
+	// flavorsReservation are limited to 64 elements.
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=64
@@ -329,7 +335,7 @@ type ClusterQueuePendingWorkloadsStatus struct {
 	// clusterQueuePendingWorkload contains the list of top pending workloads.
 	// +listType=atomic
 	// +optional
-	Head []ClusterQueuePendingWorkload `json:"clusterQueuePendingWorkload"`
+	Head []ClusterQueuePendingWorkload `json:"clusterQueuePendingWorkload"` //nolint:kubeapilinter // field is being removed
 
 	// lastChangeTime indicates the time of the last change of the structure.
 	LastChangeTime metav1.Time `json:"lastChangeTime"`
@@ -339,9 +345,11 @@ type ClusterQueuePendingWorkloadsStatus struct {
 // in the cluster queue.
 type ClusterQueuePendingWorkload struct {
 	// name indicates the name of the pending workload.
+	// +kubebuilder:validation:MaxLength=256
 	Name string `json:"name"`
 
 	// namespace indicates the name of the pending workload.
+	// +kubebuilder:validation:MaxLength=63
 	Namespace string `json:"namespace"`
 }
 

--- a/apis/kueue/v1beta2/fairsharing_types.go
+++ b/apis/kueue/v1beta2/fairsharing_types.go
@@ -78,6 +78,7 @@ type AdmissionScope struct {
 	// - UsageBasedAdmissionFairSharing
 	// - NoAdmissionFairSharing
 	//
+	// +kubebuilder:validation:Enum=UsageBasedAdmissionFairSharing;NoAdmissionFairSharing
 	// +required
 	AdmissionMode AdmissionMode `json:"admissionMode"`
 }

--- a/apis/kueue/v1beta2/localqueue_types.go
+++ b/apis/kueue/v1beta2/localqueue_types.go
@@ -106,6 +106,7 @@ type TopologyInfo struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:items:MaxLength=317
 	Levels []string `json:"levels"`
 }
 
@@ -113,11 +114,13 @@ type TopologyInfo struct {
 type LocalQueueStatus struct {
 	// conditions hold the latest available observations of the LocalQueue
 	// current state.
+	// conditions are limited to 16 items.
 	// +optional
 	// +listType=map
 	// +listMapKey=type
 	// +patchStrategy=merge
 	// +patchMergeKey=type
+	// +kubebuilder:validation:MaxItems=16
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
 	// pendingWorkloads is the number of Workloads in the LocalQueue not yet admitted to a ClusterQueue

--- a/apis/kueue/v1beta2/multikueue_types.go
+++ b/apis/kueue/v1beta2/multikueue_types.go
@@ -49,6 +49,7 @@ type KubeConfig struct {
 	//
 	// If LocationType is Secret then Location is the name of the secret inside the namespace in
 	// which the kueue controller manager is running. The config should be stored in the "kubeconfig" key.
+	// +kubebuilder:validation:MaxLength=256
 	Location string `json:"location"`
 
 	// locationType of the KubeConfig.
@@ -66,11 +67,13 @@ type MultiKueueClusterSpec struct {
 type MultiKueueClusterStatus struct {
 	// conditions hold the latest available observations of the MultiKueueCluster
 	// current state.
+	// conditions are limited to 16 elements.
 	// +optional
 	// +listType=map
 	// +listMapKey=type
 	// +patchStrategy=merge
 	// +patchMergeKey=type
+	// +kubebuilder:validation:MaxItems=16
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
@@ -111,6 +114,7 @@ type MultiKueueConfigSpec struct {
 	// +listType=set
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=10
+	// +kubebuilder:validation:items:MaxLength=256
 	Clusters []string `json:"clusters"`
 }
 

--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -92,15 +92,19 @@ type PodSetTopologyRequest struct {
 	// required indicates the topology level required by the PodSet, as
 	// indicated by the `kueue.x-k8s.io/podset-required-topology` PodSet
 	// annotation.
+	// This is limited to 63 characters.
 	//
 	// +optional
+	// +kubebuilder:validation:MaxLength=63
 	Required *string `json:"required,omitempty"`
 
 	// preferred indicates the topology level preferred by the PodSet, as
 	// indicated by the `kueue.x-k8s.io/podset-preferred-topology` PodSet
 	// annotation.
+	// This is limited to 63 characters.
 	//
 	// +optional
+	// +kubebuilder:validation:MaxLength=63
 	Preferred *string `json:"preferred,omitempty"`
 
 	// unconstrained indicates that Kueue has the freedom to schedule the PodSet within
@@ -116,10 +120,14 @@ type PodSetTopologyRequest struct {
 	// - kubernetes job this is: kubernetes.io/job-completion-index
 	// - JobSet: kubernetes.io/job-completion-index (inherited from Job)
 	// - Kubeflow: training.kubeflow.org/replica-index
+	// 	This is limited to 317 characters.
+	// +kubebuilder:validation:MaxLength=317
 	PodIndexLabel *string `json:"podIndexLabel,omitempty"`
 
 	// subGroupIndexLabel indicates the name of the label indexing the instances of replicated Jobs (groups)
 	// within a PodSet. For example, in the context of JobSet this is jobset.sigs.k8s.io/job-index.
+	// 	This is limited to 317 characters.
+	// +kubebuilder:validation:MaxLength=317
 	SubGroupIndexLabel *string `json:"subGroupIndexLabel,omitempty"`
 
 	// subGroupCount indicates the count of replicated Jobs (groups) within a PodSet.
@@ -130,12 +138,15 @@ type PodSetTopologyRequest struct {
 	// PodSets with the same `PodSetGroupName` should be assigned the same ResourceFlavor
 	//
 	// +optional
+	// +kubebuilder:validation:MaxLength=256
 	PodSetGroupName *string `json:"podSetGroupName,omitempty"`
 
 	// podSetSliceRequiredTopology indicates the topology level required by the PodSet slice, as
 	// indicated by the `kueue.x-k8s.io/podset-slice-required-topology` annotation.
 	//
+	// This is limited to 63
 	// +optional
+	// +kubebuilder:validation:MaxLength=63
 	PodSetSliceRequiredTopology *string `json:"podSetSliceRequiredTopology,omitempty"`
 
 	// podSetSliceSize indicates the size of a subgroup of pods in a PodSet for which
@@ -251,6 +262,8 @@ type PodSetAssignment struct {
 
 // DelayedTopologyRequestState indicates the state of the delayed TopologyRequest.
 // +enum
+// +kubebuilder:validation:enum=Pending;Ready
+// +kubebuilder:validation:MaxLength=7
 type DelayedTopologyRequestState string
 
 const (
@@ -270,6 +283,7 @@ type TopologyAssignment struct {
 	// +listType=atomic
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:items:MaxLength=317
 	Levels []string `json:"levels"`
 
 	// domains is a list of topology assignments split by topology domains at
@@ -277,6 +291,7 @@ type TopologyAssignment struct {
 	//
 	// +required
 	// +listType=atomic
+	// +kubebuilder:validation:MaxItems=100000
 	Domains []TopologyDomainAssignment `json:"domains"`
 }
 
@@ -289,6 +304,7 @@ type TopologyDomainAssignment struct {
 	// +listType=atomic
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:items:MaxLength=63
 	Values []string `json:"values"`
 
 	// count indicates the number of Pods to be scheduled in the topology
@@ -358,12 +374,14 @@ type WorkloadStatus struct {
 	// - Finished: the associated workload finished running (failed or succeeded).
 	// - PodsReady: at least `.spec.podSets[*].count` Pods are ready or have
 	// succeeded.
+	// conditions are limited to 16 items.
 	//
 	// +optional
 	// +listType=map
 	// +listMapKey=type
 	// +patchStrategy=merge
 	// +patchMergeKey=type
+	// +kubebuilder:validation:MaxItems=16
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
 	// admission holds the parameters of the admission of the workload by a
@@ -424,6 +442,7 @@ type WorkloadStatus struct {
 	//
 	// +listType=atomic
 	// +kubebuilder:validation:MaxItems=10
+	// +kubebuilder:validation:items:MaxLength=256
 	// +optional
 	NominatedClusterNames []string `json:"nominatedClusterNames,omitempty"`
 
@@ -435,6 +454,7 @@ type WorkloadStatus struct {
 	//
 	// This field is reset after the Workload is evicted.
 	// +optional
+	// +kubebuilder:validation:MaxLength=256
 	ClusterName *string `json:"clusterName,omitempty"`
 
 	// unhealthyNodes holds the failed nodes running at least one pod of this workload
@@ -445,6 +465,7 @@ type WorkloadStatus struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=name
+	// +kubebuilder:validation:MaxItems=8
 	UnhealthyNodes []UnhealthyNode `json:"unhealthyNodes,omitempty"`
 }
 
@@ -458,6 +479,7 @@ type SchedulingStats struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=reason
 	// +patchMergeKey=underlyingCause
+	// +kubebuilder:validation:MaxItems=256
 	Evictions []WorkloadSchedulingStatsEviction `json:"evictions,omitempty"`
 }
 
@@ -493,6 +515,7 @@ type UnhealthyNode struct {
 	//
 	// +required
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 }
 

--- a/apis/kueue/v1beta2/workloadpriorityclass_types.go
+++ b/apis/kueue/v1beta2/workloadpriorityclass_types.go
@@ -39,7 +39,9 @@ type WorkloadPriorityClass struct {
 
 	// description is an arbitrary string that usually provides guidelines on
 	// when this workloadPriorityClass should be used.
+	// The description is limited to a maximum of 2048 characters.
 	// +optional
+	// +kubebuilder:validation:MaxLength=2048
 	Description string `json:"description,omitempty"`
 }
 

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
@@ -205,6 +205,8 @@ spec:
                   description: |-
                     controllerName identifies the controller that processes the AdmissionCheck,
                     not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.
+                  maxLength: 253
+                  minLength: 1
                   type: string
                   x-kubernetes-validations:
                     - message: field is immutable
@@ -253,6 +255,7 @@ spec:
                   description: |-
                     conditions hold the latest available observations of the AdmissionCheck
                     current state.
+                    This is limited to at most 16 separate conditions.
                   items:
                     description: Condition contains details for one aspect of the current state of this API Resource.
                     properties:
@@ -306,6 +309,7 @@ spec:
                       - status
                       - type
                     type: object
+                  maxItems: 16
                   type: array
                   x-kubernetes-list-map-keys:
                     - type

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -842,6 +842,7 @@ spec:
                   description: |-
                     admissionChecks lists the AdmissionChecks required by this ClusterQueue.
                     Cannot be used along with AdmissionCheckStrategy.
+                    Admission checks are limited to at most 64 items.
                   items:
                     description: AdmissionCheckReference is the name of an AdmissionCheck.
                     maxLength: 316
@@ -870,11 +871,13 @@ spec:
                               maxLength: 253
                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string
+                            maxItems: 64
                             type: array
                             x-kubernetes-list-type: set
                         required:
                           - name
                         type: object
+                      maxItems: 64
                       type: array
                       x-kubernetes-list-map-keys:
                         - name
@@ -887,6 +890,9 @@ spec:
                       description: |-
                         admissionMode indicates which mode for AdmissionFairSharing should be used
                         in the AdmissionScope. Possible values are:
+                        - UsageBasedAdmissionFairSharing
+                        - NoAdmissionFairSharing
+                      enum:
                         - UsageBasedAdmissionFairSharing
                         - NoAdmissionFairSharing
                       type: string
@@ -1286,6 +1292,7 @@ spec:
                   description: |-
                     conditions hold the latest available observations of the ClusterQueue
                     current state.
+                    conditions are limited to 16 elements.
                   items:
                     description: Condition contains details for one aspect of the current state of this API Resource.
                     properties:
@@ -1339,6 +1346,7 @@ spec:
                       - status
                       - type
                     type: object
+                  maxItems: 16
                   type: array
                   x-kubernetes-list-map-keys:
                     - type
@@ -1390,6 +1398,7 @@ spec:
                   description: |-
                     flavorsReservation are the reserved quotas, by flavor, currently in use by the
                     workloads assigned to this ClusterQueue.
+                    flavorsReservation are limited to 64 elements.
                   items:
                     properties:
                       name:
@@ -1516,9 +1525,11 @@ spec:
                         properties:
                           name:
                             description: name indicates the name of the pending workload.
+                            maxLength: 256
                             type: string
                           namespace:
                             description: namespace indicates the name of the pending workload.
+                            maxLength: 63
                             type: string
                         required:
                           - name

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_localqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_localqueues.yaml
@@ -544,6 +544,7 @@ spec:
                   description: |-
                     conditions hold the latest available observations of the LocalQueue
                     current state.
+                    conditions are limited to 16 items.
                   items:
                     description: Condition contains details for one aspect of the current state of this API Resource.
                     properties:
@@ -597,6 +598,7 @@ spec:
                       - status
                       - type
                     type: object
+                  maxItems: 16
                   type: array
                   x-kubernetes-list-map-keys:
                     - type
@@ -712,6 +714,7 @@ spec:
                           levels:
                             description: levels define the levels of topology.
                             items:
+                              maxLength: 317
                               type: string
                             maxItems: 16
                             minItems: 1

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
@@ -207,6 +207,7 @@ spec:
 
                         If LocationType is Secret then Location is the name of the secret inside the namespace in
                         which the kueue controller manager is running. The config should be stored in the "kubeconfig" key.
+                      maxLength: 256
                       type: string
                     locationType:
                       default: Secret
@@ -229,6 +230,7 @@ spec:
                   description: |-
                     conditions hold the latest available observations of the MultiKueueCluster
                     current state.
+                    conditions are limited to 16 elements.
                   items:
                     description: Condition contains details for one aspect of the current state of this API Resource.
                     properties:
@@ -282,6 +284,7 @@ spec:
                       - status
                       - type
                     type: object
+                  maxItems: 16
                   type: array
                   x-kubernetes-list-map-keys:
                     - type

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueconfigs.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueconfigs.yaml
@@ -103,6 +103,7 @@ spec:
                 clusters:
                   description: clusters is a list of MultiKueueClusters names where the workloads from the ClusterQueue should be distributed.
                   items:
+                    maxLength: 256
                     type: string
                   maxItems: 10
                   minItems: 1

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloadpriorityclasses.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloadpriorityclasses.yaml
@@ -102,6 +102,8 @@ spec:
               description: |-
                 description is an arbitrary string that usually provides guidelines on
                 when this workloadPriorityClass should be used.
+                The description is limited to a maximum of 2048 characters.
+              maxLength: 2048
               type: string
             kind:
               description: |-

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -17046,22 +17046,22 @@ spec:
                         description: topologyRequest defines the topology request for the PodSet.
                         properties:
                           podIndexLabel:
-                            description: |-
-                              podIndexLabel indicates the name of the label indexing the pods.
-                              For example, in the context of
-                              - kubernetes job this is: kubernetes.io/job-completion-index
-                              - JobSet: kubernetes.io/job-completion-index (inherited from Job)
-                              - Kubeflow: training.kubeflow.org/replica-index
+                            description: "podIndexLabel indicates the name of the label indexing the pods.\nFor example, in the context of\n- kubernetes job this is: kubernetes.io/job-completion-index\n- JobSet: kubernetes.io/job-completion-index (inherited from Job)\n- Kubeflow: training.kubeflow.org/replica-index\n\tThis is limited to 317 characters."
+                            maxLength: 317
                             type: string
                           podSetGroupName:
                             description: |-
                               podSetGroupName indicates the name of the group of PodSets to which this PodSet belongs to.
                               PodSets with the same `PodSetGroupName` should be assigned the same ResourceFlavor
+                            maxLength: 256
                             type: string
                           podSetSliceRequiredTopology:
                             description: |-
                               podSetSliceRequiredTopology indicates the topology level required by the PodSet slice, as
                               indicated by the `kueue.x-k8s.io/podset-slice-required-topology` annotation.
+
+                              This is limited to 63
+                            maxLength: 63
                             type: string
                           podSetSliceSize:
                             description: |-
@@ -17075,12 +17075,16 @@ spec:
                               preferred indicates the topology level preferred by the PodSet, as
                               indicated by the `kueue.x-k8s.io/podset-preferred-topology` PodSet
                               annotation.
+                              This is limited to 63 characters.
+                            maxLength: 63
                             type: string
                           required:
                             description: |-
                               required indicates the topology level required by the PodSet, as
                               indicated by the `kueue.x-k8s.io/podset-required-topology` PodSet
                               annotation.
+                              This is limited to 63 characters.
+                            maxLength: 63
                             type: string
                           subGroupCount:
                             description: |-
@@ -17089,9 +17093,8 @@ spec:
                             format: int32
                             type: integer
                           subGroupIndexLabel:
-                            description: |-
-                              subGroupIndexLabel indicates the name of the label indexing the instances of replicated Jobs (groups)
-                              within a PodSet. For example, in the context of JobSet this is jobset.sigs.k8s.io/job-index.
+                            description: "subGroupIndexLabel indicates the name of the label indexing the instances of replicated Jobs (groups)\nwithin a PodSet. For example, in the context of JobSet this is jobset.sigs.k8s.io/job-index.\n\tThis is limited to 317 characters."
+                            maxLength: 317
                             type: string
                           unconstrained:
                             description: |-
@@ -17199,6 +17202,7 @@ spec:
                               Kueue schedules the second pass of scheduling for each workload with at
                               least one PodSet which has delayedTopologyRequest=true and without
                               topologyAssignment.
+                            maxLength: 7
                             type: string
                           flavors:
                             additionalProperties:
@@ -17294,6 +17298,7 @@ spec:
                                         domain. The values correspond to the consecutive topology levels, from
                                         the highest to the lowest.
                                       items:
+                                        maxLength: 63
                                         type: string
                                       maxItems: 16
                                       minItems: 1
@@ -17303,6 +17308,7 @@ spec:
                                     - count
                                     - values
                                   type: object
+                                maxItems: 100000
                                 type: array
                                 x-kubernetes-list-type: atomic
                               levels:
@@ -17311,6 +17317,7 @@ spec:
                                   topology (i.e. node label keys), from the highest to the lowest level of
                                   the topology.
                                 items:
+                                  maxLength: 317
                                   type: string
                                 maxItems: 16
                                 minItems: 1
@@ -17467,6 +17474,7 @@ spec:
                     affinity or propagation policies across workload slices.
 
                     This field is reset after the Workload is evicted.
+                  maxLength: 256
                   type: string
                 conditions:
                   description: |-
@@ -17479,6 +17487,7 @@ spec:
                     - Finished: the associated workload finished running (failed or succeeded).
                     - PodsReady: at least `.spec.podSets[*].count` Pods are ready or have
                     succeeded.
+                    conditions are limited to 16 items.
                   items:
                     description: Condition contains details for one aspect of the current state of this API Resource.
                     properties:
@@ -17532,6 +17541,7 @@ spec:
                       - status
                       - type
                     type: object
+                  maxItems: 16
                   type: array
                   x-kubernetes-list-map-keys:
                     - type
@@ -17543,6 +17553,7 @@ spec:
                     `status.clusterName` is set.
                     This field is optional.
                   items:
+                    maxLength: 256
                     type: string
                   maxItems: 10
                   type: array
@@ -17655,6 +17666,7 @@ spec:
                           - reason
                           - underlyingCause
                         type: object
+                      maxItems: 256
                       type: array
                       x-kubernetes-list-map-keys:
                         - reason
@@ -17671,10 +17683,12 @@ spec:
                     properties:
                       name:
                         description: name is the name of the unhealthy node.
+                        maxLength: 63
                         type: string
                     required:
                       - name
                     type: object
+                  maxItems: 8
                   type: array
                   x-kubernetes-list-map-keys:
                     - name

--- a/config/components/crd/bases/kueue.x-k8s.io_admissionchecks.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_admissionchecks.yaml
@@ -184,6 +184,8 @@ spec:
                 description: |-
                   controllerName identifies the controller that processes the AdmissionCheck,
                   not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.
+                maxLength: 253
+                minLength: 1
                 type: string
                 x-kubernetes-validations:
                 - message: field is immutable
@@ -232,6 +234,7 @@ spec:
                 description: |-
                   conditions hold the latest available observations of the AdmissionCheck
                   current state.
+                  This is limited to at most 16 separate conditions.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -286,6 +289,7 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 16
                 type: array
                 x-kubernetes-list-map-keys:
                 - type

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -827,6 +827,7 @@ spec:
                 description: |-
                   admissionChecks lists the AdmissionChecks required by this ClusterQueue.
                   Cannot be used along with AdmissionCheckStrategy.
+                  Admission checks are limited to at most 64 items.
                 items:
                   description: AdmissionCheckReference is the name of an AdmissionCheck.
                   maxLength: 316
@@ -857,11 +858,13 @@ spec:
                             maxLength: 253
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
+                          maxItems: 64
                           type: array
                           x-kubernetes-list-type: set
                       required:
                       - name
                       type: object
+                    maxItems: 64
                     type: array
                     x-kubernetes-list-map-keys:
                     - name
@@ -877,6 +880,9 @@ spec:
                       in the AdmissionScope. Possible values are:
                       - UsageBasedAdmissionFairSharing
                       - NoAdmissionFairSharing
+                    enum:
+                    - UsageBasedAdmissionFairSharing
+                    - NoAdmissionFairSharing
                     type: string
                 required:
                 - admissionMode
@@ -1280,6 +1286,7 @@ spec:
                 description: |-
                   conditions hold the latest available observations of the ClusterQueue
                   current state.
+                  conditions are limited to 16 elements.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -1334,6 +1341,7 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 16
                 type: array
                 x-kubernetes-list-map-keys:
                 - type
@@ -1387,6 +1395,7 @@ spec:
                 description: |-
                   flavorsReservation are the reserved quotas, by flavor, currently in use by the
                   workloads assigned to this ClusterQueue.
+                  flavorsReservation are limited to 64 elements.
                 items:
                   properties:
                     name:
@@ -1516,10 +1525,12 @@ spec:
                       properties:
                         name:
                           description: name indicates the name of the pending workload.
+                          maxLength: 256
                           type: string
                         namespace:
                           description: namespace indicates the name of the pending
                             workload.
+                          maxLength: 63
                           type: string
                       required:
                       - name

--- a/config/components/crd/bases/kueue.x-k8s.io_localqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_localqueues.yaml
@@ -526,6 +526,7 @@ spec:
                 description: |-
                   conditions hold the latest available observations of the LocalQueue
                   current state.
+                  conditions are limited to 16 items.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -580,6 +581,7 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 16
                 type: array
                 x-kubernetes-list-map-keys:
                 - type
@@ -703,6 +705,7 @@ spec:
                         levels:
                           description: levels define the levels of topology.
                           items:
+                            maxLength: 317
                             type: string
                           maxItems: 16
                           minItems: 1

--- a/config/components/crd/bases/kueue.x-k8s.io_multikueueclusters.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_multikueueclusters.yaml
@@ -186,6 +186,7 @@ spec:
 
                       If LocationType is Secret then Location is the name of the secret inside the namespace in
                       which the kueue controller manager is running. The config should be stored in the "kubeconfig" key.
+                    maxLength: 256
                     type: string
                   locationType:
                     default: Secret
@@ -208,6 +209,7 @@ spec:
                 description: |-
                   conditions hold the latest available observations of the MultiKueueCluster
                   current state.
+                  conditions are limited to 16 elements.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -262,6 +264,7 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 16
                 type: array
                 x-kubernetes-list-map-keys:
                 - type

--- a/config/components/crd/bases/kueue.x-k8s.io_multikueueconfigs.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_multikueueconfigs.yaml
@@ -83,6 +83,7 @@ spec:
                 description: clusters is a list of MultiKueueClusters names where
                   the workloads from the ClusterQueue should be distributed.
                 items:
+                  maxLength: 256
                   type: string
                 maxItems: 10
                 minItems: 1

--- a/config/components/crd/bases/kueue.x-k8s.io_workloadpriorityclasses.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloadpriorityclasses.yaml
@@ -82,6 +82,8 @@ spec:
             description: |-
               description is an arbitrary string that usually provides guidelines on
               when this workloadPriorityClass should be used.
+              The description is limited to a maximum of 2048 characters.
+            maxLength: 2048
             type: string
           kind:
             description: |-

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -18026,22 +18026,27 @@ spec:
                         the PodSet.
                       properties:
                         podIndexLabel:
-                          description: |-
-                            podIndexLabel indicates the name of the label indexing the pods.
-                            For example, in the context of
-                            - kubernetes job this is: kubernetes.io/job-completion-index
-                            - JobSet: kubernetes.io/job-completion-index (inherited from Job)
-                            - Kubeflow: training.kubeflow.org/replica-index
+                          description: "podIndexLabel indicates the name of the label
+                            indexing the pods.\nFor example, in the context of\n-
+                            kubernetes job this is: kubernetes.io/job-completion-index\n-
+                            JobSet: kubernetes.io/job-completion-index (inherited
+                            from Job)\n- Kubeflow: training.kubeflow.org/replica-index\n\tThis
+                            is limited to 317 characters."
+                          maxLength: 317
                           type: string
                         podSetGroupName:
                           description: |-
                             podSetGroupName indicates the name of the group of PodSets to which this PodSet belongs to.
                             PodSets with the same `PodSetGroupName` should be assigned the same ResourceFlavor
+                          maxLength: 256
                           type: string
                         podSetSliceRequiredTopology:
                           description: |-
                             podSetSliceRequiredTopology indicates the topology level required by the PodSet slice, as
                             indicated by the `kueue.x-k8s.io/podset-slice-required-topology` annotation.
+
+                            This is limited to 63
+                          maxLength: 63
                           type: string
                         podSetSliceSize:
                           description: |-
@@ -18055,12 +18060,16 @@ spec:
                             preferred indicates the topology level preferred by the PodSet, as
                             indicated by the `kueue.x-k8s.io/podset-preferred-topology` PodSet
                             annotation.
+                            This is limited to 63 characters.
+                          maxLength: 63
                           type: string
                         required:
                           description: |-
                             required indicates the topology level required by the PodSet, as
                             indicated by the `kueue.x-k8s.io/podset-required-topology` PodSet
                             annotation.
+                            This is limited to 63 characters.
+                          maxLength: 63
                           type: string
                         subGroupCount:
                           description: |-
@@ -18069,9 +18078,12 @@ spec:
                           format: int32
                           type: integer
                         subGroupIndexLabel:
-                          description: |-
-                            subGroupIndexLabel indicates the name of the label indexing the instances of replicated Jobs (groups)
-                            within a PodSet. For example, in the context of JobSet this is jobset.sigs.k8s.io/job-index.
+                          description: "subGroupIndexLabel indicates the name of the
+                            label indexing the instances of replicated Jobs (groups)\nwithin
+                            a PodSet. For example, in the context of JobSet this is
+                            jobset.sigs.k8s.io/job-index.\n\tThis is limited to 317
+                            characters."
+                          maxLength: 317
                           type: string
                         unconstrained:
                           description: |-
@@ -18181,6 +18193,7 @@ spec:
                             Kueue schedules the second pass of scheduling for each workload with at
                             least one PodSet which has delayedTopologyRequest=true and without
                             topologyAssignment.
+                          maxLength: 7
                           type: string
                         flavors:
                           additionalProperties:
@@ -18279,6 +18292,7 @@ spec:
                                       domain. The values correspond to the consecutive topology levels, from
                                       the highest to the lowest.
                                     items:
+                                      maxLength: 63
                                       type: string
                                     maxItems: 16
                                     minItems: 1
@@ -18288,6 +18302,7 @@ spec:
                                 - count
                                 - values
                                 type: object
+                              maxItems: 100000
                               type: array
                               x-kubernetes-list-type: atomic
                             levels:
@@ -18296,6 +18311,7 @@ spec:
                                 topology (i.e. node label keys), from the highest to the lowest level of
                                 the topology.
                               items:
+                                maxLength: 317
                                 type: string
                               maxItems: 16
                               minItems: 1
@@ -18465,6 +18481,7 @@ spec:
                   affinity or propagation policies across workload slices.
 
                   This field is reset after the Workload is evicted.
+                maxLength: 256
                 type: string
               conditions:
                 description: |-
@@ -18477,6 +18494,7 @@ spec:
                   - Finished: the associated workload finished running (failed or succeeded).
                   - PodsReady: at least `.spec.podSets[*].count` Pods are ready or have
                   succeeded.
+                  conditions are limited to 16 items.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -18531,6 +18549,7 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 16
                 type: array
                 x-kubernetes-list-map-keys:
                 - type
@@ -18542,6 +18561,7 @@ spec:
                   `status.clusterName` is set.
                   This field is optional.
                 items:
+                  maxLength: 256
                   type: string
                 maxItems: 10
                 type: array
@@ -18659,6 +18679,7 @@ spec:
                       - reason
                       - underlyingCause
                       type: object
+                    maxItems: 256
                     type: array
                     x-kubernetes-list-map-keys:
                     - reason
@@ -18675,10 +18696,12 @@ spec:
                   properties:
                     name:
                       description: name is the name of the unhealthy node.
+                      maxLength: 63
                       type: string
                   required:
                   - name
                   type: object
+                maxItems: 8
                 type: array
                 x-kubernetes-list-map-keys:
                 - name

--- a/site/content/en/docs/reference/kueue.v1beta2.md
+++ b/site/content/en/docs/reference/kueue.v1beta2.md
@@ -380,7 +380,8 @@ Changing the value of workloadPriorityClass doesn't affect the priority of workl
 </td>
 <td>
    <p>description is an arbitrary string that usually provides guidelines on
-when this workloadPriorityClass should be used.</p>
+when this workloadPriorityClass should be used.
+The description is limited to a maximum of 2048 characters.</p>
 </td>
 </tr>
 </tbody>
@@ -593,7 +594,8 @@ This may be an empty string.</p>
 </td>
 <td>
    <p>conditions hold the latest available observations of the AdmissionCheck
-current state.</p>
+current state.
+This is limited to at most 16 separate conditions.</p>
 </td>
 </tr>
 </tbody>
@@ -1062,7 +1064,8 @@ before borrowing or preempting in the flavor being evaluated.</p>
 </td>
 <td>
    <p>admissionChecks lists the AdmissionChecks required by this ClusterQueue.
-Cannot be used along with AdmissionCheckStrategy.</p>
+Cannot be used along with AdmissionCheckStrategy.
+Admission checks are limited to at most 64 items.</p>
 </td>
 </tr>
 <tr><td><code>admissionChecksStrategy</code><br/>
@@ -1127,7 +1130,8 @@ if FairSharing is enabled in the Kueue configuration.</p>
 </td>
 <td>
    <p>conditions hold the latest available observations of the ClusterQueue
-current state.</p>
+current state.
+conditions are limited to 16 elements.</p>
 </td>
 </tr>
 <tr><td><code>flavorsReservation</code><br/>
@@ -1135,7 +1139,8 @@ current state.</p>
 </td>
 <td>
    <p>flavorsReservation are the reserved quotas, by flavor, currently in use by the
-workloads assigned to this ClusterQueue.</p>
+workloads assigned to this ClusterQueue.
+flavorsReservation are limited to 64 elements.</p>
 </td>
 </tr>
 <tr><td><code>flavorsUsage</code><br/>
@@ -1789,7 +1794,8 @@ if AdmissionFairSharing is enabled in the Kueue configuration.</p>
 </td>
 <td>
    <p>conditions hold the latest available observations of the LocalQueue
-current state.</p>
+current state.
+conditions are limited to 16 items.</p>
 </td>
 </tr>
 <tr><td><code>pendingWorkloads</code><br/>
@@ -1904,7 +1910,8 @@ Deprecated: Flavors is deprecated and marked for removal in v1beta2.</p>
 </td>
 <td>
    <p>conditions hold the latest available observations of the MultiKueueCluster
-current state.</p>
+current state.
+conditions are limited to 16 elements.</p>
 </td>
 </tr>
 </tbody>
@@ -2208,7 +2215,8 @@ and the application of resource.excludeResourcePrefixes and resource.transformat
 <td>
    <p>required indicates the topology level required by the PodSet, as
 indicated by the <code>kueue.x-k8s.io/podset-required-topology</code> PodSet
-annotation.</p>
+annotation.
+This is limited to 63 characters.</p>
 </td>
 </tr>
 <tr><td><code>preferred</code><br/>
@@ -2217,7 +2225,8 @@ annotation.</p>
 <td>
    <p>preferred indicates the topology level preferred by the PodSet, as
 indicated by the <code>kueue.x-k8s.io/podset-preferred-topology</code> PodSet
-annotation.</p>
+annotation.
+This is limited to 63 characters.</p>
 </td>
 </tr>
 <tr><td><code>unconstrained</code><br/>
@@ -2238,7 +2247,8 @@ For example, in the context of</p>
 <ul>
 <li>kubernetes job this is: kubernetes.io/job-completion-index</li>
 <li>JobSet: kubernetes.io/job-completion-index (inherited from Job)</li>
-<li>Kubeflow: training.kubeflow.org/replica-index</li>
+<li>Kubeflow: training.kubeflow.org/replica-index
+This is limited to 317 characters.</li>
 </ul>
 </td>
 </tr>
@@ -2247,7 +2257,8 @@ For example, in the context of</p>
 </td>
 <td>
    <p>subGroupIndexLabel indicates the name of the label indexing the instances of replicated Jobs (groups)
-within a PodSet. For example, in the context of JobSet this is jobset.sigs.k8s.io/job-index.</p>
+within a PodSet. For example, in the context of JobSet this is jobset.sigs.k8s.io/job-index.
+This is limited to 317 characters.</p>
 </td>
 </tr>
 <tr><td><code>subGroupCount</code> <B>[Required]</B><br/>
@@ -2272,6 +2283,7 @@ PodSets with the same <code>PodSetGroupName</code> should be assigned the same R
 <td>
    <p>podSetSliceRequiredTopology indicates the topology level required by the PodSet slice, as
 indicated by the <code>kueue.x-k8s.io/podset-slice-required-topology</code> annotation.</p>
+<p>This is limited to 63</p>
 </td>
 </tr>
 <tr><td><code>podSetSliceSize</code><br/>
@@ -3273,7 +3285,8 @@ current state.</p>
 <li>Admitted: the Workload was admitted through a ClusterQueue.</li>
 <li>Finished: the associated workload finished running (failed or succeeded).</li>
 <li>PodsReady: at least <code>.spec.podSets[*].count</code> Pods are ready or have
-succeeded.</li>
+succeeded.
+conditions are limited to 16 items.</li>
 </ul>
 </td>
 </tr>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Enable [MaxLength](https://github.com/kubernetes-sigs/kube-api-linter/blob/main/docs/linters.md#maxlength).
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially address #7119 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```