### PR TITLE
refactor: enable 'revive.use-waitgroup-go' rule

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -71,6 +71,7 @@ linters:
         - name: var-naming
         - name: redundant-import-alias
         - name: use-any
+        - name: use-waitgroup-go
     forbidigo:
       forbid:
         - pattern: ^sort\.Slice$

--- a/pkg/controller/admissionchecks/multikueue/fswatch_test.go
+++ b/pkg/controller/admissionchecks/multikueue/fswatch_test.go
@@ -156,9 +156,7 @@ func TestFSWatch(t *testing.T) {
 			// start the recorder
 			gotEventsForClusters := set.New[string]()
 			wg := sync.WaitGroup{}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				for {
 					select {
 					case ev := <-watcher.reconcile:
@@ -170,7 +168,7 @@ func TestFSWatch(t *testing.T) {
 						return
 					}
 				}
-			}()
+			})
 			_ = watcher.Start(ctx)
 
 			gotAddErrors := map[string]error{}

--- a/test/performance/scheduler/runner/main.go
+++ b/test/performance/scheduler/runner/main.go
@@ -292,9 +292,7 @@ func runCommand(ctx context.Context, workDir, cmdPath, kubeconfig string, withCP
 	}
 	startTime := time.Now()
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		err := cmd.Wait()
 		if err != nil {
 			select {
@@ -325,7 +323,7 @@ func runCommand(ctx context.Context, workDir, cmdPath, kubeconfig string, withCP
 		if err != nil {
 			log.Error(err, "Writing cmd stats")
 		}
-	}()
+	})
 	return nil
 }
 
@@ -346,9 +344,7 @@ func runGenerator(ctx context.Context, cfg *rest.Config, generatorConfig string,
 	}
 
 	statTime := time.Now()
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		defer close(genDone)
 		err := generator.Generate(ctx, c, cohorts)
 		if err != nil {
@@ -357,7 +353,7 @@ func runGenerator(ctx context.Context, cfg *rest.Config, generatorConfig string,
 			return
 		}
 		log.Info("Generator done", "duration", time.Since(statTime))
-	}()
+	})
 
 	log.Info("Generator started", "qps", cfg.QPS, "burst", cfg.Burst)
 	return nil
@@ -366,9 +362,7 @@ func runGenerator(ctx context.Context, cfg *rest.Config, generatorConfig string,
 func startRecorder(ctx context.Context, errCh chan<- error, wg *sync.WaitGroup, genDone <-chan struct{}, recordTimeout time.Duration) (*recorder.Recorder, error) {
 	log := ctrl.LoggerFrom(ctx).WithName("Start recorder")
 	recorder := recorder.New(recordTimeout)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		err := recorder.Run(ctx, genDone)
 		if err != nil {
 			log.Error(err, "Recorder run")
@@ -376,7 +370,7 @@ func startRecorder(ctx context.Context, errCh chan<- error, wg *sync.WaitGroup, 
 			log.Info("Recorder done")
 		}
 		errCh <- err
-	}()
+	})
 
 	log.Info("Recorder started", "timeout", recordTimeout)
 	return recorder, nil
@@ -408,9 +402,7 @@ func runManager(ctx context.Context, cfg *rest.Config, errCh chan<- error, wg *s
 		return err
 	}
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		log.Info("Starting manager")
 		if err := mgr.Start(ctx); err != nil {
 			log.Error(err, "Could not run manager")
@@ -418,7 +410,7 @@ func runManager(ctx context.Context, cfg *rest.Config, errCh chan<- error, wg *s
 		} else {
 			log.Info("End manager")
 		}
-	}()
+	})
 
 	log.Info("Manager started")
 	return nil
@@ -429,9 +421,7 @@ func runScraper(ctx context.Context, interval time.Duration, output, url string,
 
 	s := scraper.NewScraper(interval, url, "%d.prometheus")
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		err := s.Run(ctx, output)
 		if err != nil {
 			log.Error(err, "Running the scraper")
@@ -439,7 +429,7 @@ func runScraper(ctx context.Context, interval time.Duration, output, url string,
 			return
 		}
 		log.Info("Scrape done")
-	}()
+	})
 
 	log.Info("Scrape started")
 	return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR refactors code to use the `WaitGroup.Go` method instead of `wg.Add` + `go` + `wg.Done`. This refactoring inspired by the `revive.use-waitgroup-go` rule.

#### Special notes for your reviewer:

The function [`WaitGroup.Go`](https://pkg.go.dev/sync#WaitGroup.Go) was added in Go 1.25.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```