### PR TITLE
[release-0.13] introduce JobWithCustomWorkloadActivation interface

### DIFF
--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -153,6 +153,12 @@ type JobWithCustomWorkloadConditions interface {
 	CustomWorkloadConditions(wl *kueue.Workload) ([]metav1.Condition, bool)
 }
 
+// JobWithCustomWorkloadActivation interface should be implemented by generic jobs,
+// when custom logic is needed to determine if the workload is active.
+type JobWithCustomWorkloadActivation interface {
+	IsWorkloadActive() bool
+}
+
 // JobWithManagedBy interface should be implemented by generic jobs
 // that implement the managedBy protocol for Multi-Kueue
 type JobWithManagedBy interface {

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -411,6 +411,16 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 		}
 	}
 
+	if jobact, ok := job.(JobWithCustomWorkloadActivation); wl != nil && ok {
+		active := jobact.IsWorkloadActive()
+		if workload.IsActive(wl) != active {
+			wl.Spec.Active = ptr.To(active)
+			if err := r.client.Update(ctx, wl); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	}
+
 	if wl != nil && apimeta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadFinished) {
 		if err := r.finalizeJob(ctx, job); err != nil {
 			return ctrl.Result{}, err


### PR DESCRIPTION
This is a manually cherry-pick of https://github.com/kubernetes-sigs/kueue/pull/7199

/assign mimowo

Introduce an optional interface for custom Jobs, called JobWithCustomWorkloadActivation, which can be used to deactivate or active a custom CRD workload.

```release-note
JobFramework: Introduce an optional interface for custom Jobs, called JobWithCustomWorkloadActivation, which can be used to deactivate or active a custom CRD workload.
```