### PR TITLE
Automated cherry pick of #7281: Replace ExpectReservingActiveWorkloadsMetric with counter

### DIFF
--- a/test/integration/singlecluster/controller/jobs/appwrapper/appwrapper_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/appwrapper/appwrapper_controller_test.go
@@ -839,7 +839,7 @@ var _ = ginkgo.Describe("AppWrapper controller interacting with scheduler", gink
 		gomega.Expect(createdAppWrapper.Spec.Components[0].PodSetInfos[0].NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
 		gomega.Expect(createdAppWrapper.Spec.Components[1].PodSetInfos[0].NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
 		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
-		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 	})
 })
 
@@ -948,7 +948,7 @@ var _ = ginkgo.Describe("AppWrapper controller when TopologyAwareScheduling enab
 
 		ginkgo.By("verify the workload is admitted", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 		})
 
 		ginkgo.By("verify admission for the workload", func() {

--- a/test/integration/singlecluster/controller/jobs/jaxjob/jaxjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/jaxjob/jaxjob_controller_test.go
@@ -674,7 +674,7 @@ var _ = ginkgo.Describe("JAXJob controller when TopologyAwareScheduling enabled"
 
 		ginkgo.By("verify the workload is admitted", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 		})
 
 		ginkgo.By("verify admission for the workload", func() {

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -1398,7 +1398,7 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		gomega.Expect(createdProdJob1.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
 		util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 0)
-		util.ExpectReservingActiveWorkloadsMetric(prodClusterQ, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 1)
 
 		ginkgo.By("checking a second no-fit prod job does not start")
 		prodJob2 := testingjob.MakeJob("prod-job2", ns.Name).Queue(kueue.LocalQueueName(prodLocalQ.Name)).Request(corev1.ResourceCPU, "5").Obj()
@@ -1410,7 +1410,7 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 			g.Expect(createdProdJob2.Spec.Suspend).Should(gomega.Equal(ptr.To(true)))
 		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 		util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 1)
-		util.ExpectReservingActiveWorkloadsMetric(prodClusterQ, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 1)
 
 		ginkgo.By("checking a dev job starts")
 		devJob := testingjob.MakeJob("dev-job", ns.Name).Queue(kueue.LocalQueueName(devLocalQ.Name)).Request(corev1.ResourceCPU, "5").Obj()
@@ -1422,7 +1422,7 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		gomega.Expect(createdDevJob.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
 		util.ExpectPendingWorkloadsMetric(devClusterQ, 0, 0)
-		util.ExpectReservingActiveWorkloadsMetric(devClusterQ, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(devClusterQ, 1)
 
 		ginkgo.By("checking the second prod job starts when the first finishes")
 		gomega.Eventually(func(g gomega.Gomega) {
@@ -1681,7 +1681,7 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			gomega.Expect(createdJob1.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
 			util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 0)
-			util.ExpectReservingActiveWorkloadsMetric(prodClusterQ, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 1)
 		})
 
 		job2 := testingjob.MakeJob("job2", ns.Name).Queue(kueue.LocalQueueName(prodLocalQ.Name)).Request(corev1.ResourceCPU, "3").Obj()
@@ -2316,7 +2316,7 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-				util.ExpectReservingActiveWorkloadsMetric(cq, 1)
+				util.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
@@ -2485,7 +2485,7 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-				util.ExpectReservingActiveWorkloadsMetric(cq, 1)
+				util.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
@@ -2709,7 +2709,7 @@ var _ = ginkgo.Describe("Job controller when TopologyAwareScheduling enabled", g
 
 		ginkgo.By("verify the workload is admitted", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 		})
 
 		ginkgo.By("verify admission for the workload", func() {
@@ -2762,7 +2762,7 @@ var _ = ginkgo.Describe("Job controller when TopologyAwareScheduling enabled", g
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 		})
 
 		ginkgo.By("verify admission for the workload", func() {

--- a/test/integration/singlecluster/controller/jobs/jobset/jobset_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/jobset/jobset_controller_test.go
@@ -1022,7 +1022,7 @@ var _ = ginkgo.Describe("JobSet controller interacting with scheduler", ginkgo.O
 		gomega.Expect(createdJobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
 		gomega.Expect(createdJobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
 		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
-		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 	})
 
 	ginkgo.It("Should allow reclaim of resources that are no longer needed", func() {
@@ -1057,7 +1057,7 @@ var _ = ginkgo.Describe("JobSet controller interacting with scheduler", ginkgo.O
 				g.Expect(*createdJobSet1.Spec.Suspend).Should(gomega.BeFalse())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 		})
 
 		jobSet2 := testingjobset.MakeJobSet("dev-jobset2", ns.Name).ReplicatedJobs(
@@ -1272,7 +1272,7 @@ var _ = ginkgo.Describe("JobSet controller when TopologyAwareScheduling enabled"
 
 		ginkgo.By("verify the workload is admitted", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 		})
 
 		ginkgo.By("verify admission for the workload", func() {

--- a/test/integration/singlecluster/controller/jobs/kubeflow/kubeflowjob.go
+++ b/test/integration/singlecluster/controller/jobs/kubeflow/kubeflowjob.go
@@ -309,7 +309,7 @@ func ShouldScheduleJobsAsTheyFitInTheirClusterQueue(ctx context.Context, k8sClie
 		gomega.ExpectWithOffset(1, createdJob.KFJobControl.ReplicaSpecs()[psr.RoleName].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(string(psr.ResourceCPU)))
 	}
 	util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
-	util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+	util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 }
 
 type PodSetsResource struct {

--- a/test/integration/singlecluster/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/mpijob/mpijob_controller_test.go
@@ -826,7 +826,7 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 		gomega.Expect(createdJob.Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
 		gomega.Expect(createdJob.Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
 		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
-		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 	})
 
 	ginkgo.When("The workload's admission is removed", func() {
@@ -1017,7 +1017,7 @@ var _ = ginkgo.Describe("MPIJob controller when TopologyAwareScheduling enabled"
 
 		ginkgo.By("verify the workload is admitted", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 		})
 
 		ginkgo.By("verify admission for the workload", func() {

--- a/test/integration/singlecluster/controller/jobs/paddlejob/paddlejob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/paddlejob/paddlejob_controller_test.go
@@ -409,7 +409,7 @@ var _ = ginkgo.Describe("PaddleJob controller when TopologyAwareScheduling enabl
 
 		ginkgo.By("verify the workload is admitted", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 		})
 
 		ginkgo.By("verify admission for the workload", func() {

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -2251,7 +2251,7 @@ var _ = ginkgo.Describe("Pod controller when TopologyAwareScheduling enabled", g
 		})
 
 		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 
 		ginkgo.By("verify admission for the workload", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -2302,7 +2302,7 @@ var _ = ginkgo.Describe("Pod controller when TopologyAwareScheduling enabled", g
 		})
 
 		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 
 		ginkgo.By("verify admission for the workload", func() {
 			gomega.Eventually(func(g gomega.Gomega) {

--- a/test/integration/singlecluster/controller/jobs/pytorchjob/pytorchjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pytorchjob/pytorchjob_controller_test.go
@@ -711,7 +711,7 @@ var _ = ginkgo.Describe("PyTorchJob controller when TopologyAwareScheduling enab
 
 		ginkgo.By("verify the workload is admitted", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 		})
 
 		ginkgo.By("verify admission for the workload", func() {

--- a/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go
@@ -530,7 +530,7 @@ var _ = ginkgo.Describe("RayCluster Job controller interacting with scheduler", 
 		gomega.Expect(createdJob.Spec.HeadGroupSpec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
 		gomega.Expect(createdJob.Spec.WorkerGroupSpecs[0].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
 		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
-		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 
 		ginkgo.By("checking a second no-fit RayCluster does not start")
 		job2 := testingraycluster.MakeCluster("dev-job2", ns.Name).Queue(localQueue.Name).
@@ -544,7 +544,7 @@ var _ = ginkgo.Describe("RayCluster Job controller interacting with scheduler", 
 			g.Expect(createdJob2.Spec.Suspend).Should(gomega.Equal(ptr.To(true)))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
-		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 
 		ginkgo.By("deleting the job", func() {
 			gomega.Expect(k8sClient.Delete(ctx, job)).Should(gomega.Succeed())
@@ -570,7 +570,7 @@ var _ = ginkgo.Describe("RayCluster Job controller interacting with scheduler", 
 		gomega.Expect(createdJob2.Spec.HeadGroupSpec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
 		gomega.Expect(createdJob2.Spec.WorkerGroupSpecs[0].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
 		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
-		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 2)
 	})
 })
 

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -565,7 +565,7 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 		gomega.Expect(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
 		gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
 		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
-		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+		util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 	})
 })
 

--- a/test/integration/singlecluster/controller/jobs/tfjob/tfjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/tfjob/tfjob_controller_test.go
@@ -439,7 +439,7 @@ var _ = ginkgo.Describe("TFJob controller when TopologyAwareScheduling enabled",
 
 		ginkgo.By("verify the workload is admitted", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 		})
 
 		ginkgo.By("verify admission for the workload", func() {

--- a/test/integration/singlecluster/controller/jobs/xgboostjob/xgboostjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/xgboostjob/xgboostjob_controller_test.go
@@ -406,7 +406,7 @@ var _ = ginkgo.Describe("XGBoostJob controller when TopologyAwareScheduling enab
 
 		ginkgo.By("verify the workload is admitted", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 		})
 
 		ginkgo.By("verify admission for the workload", func() {

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -346,7 +346,10 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			wlA1 := createWorkloadWithPriority("best-effort-cq-a", "4", 9001)
 			wlA2 := createWorkloadWithPriority("best-effort-cq-a", "4", 100)
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlA1, wlA2)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqA, 2)
+			// Sanity check asserting reserving_active_workloads to verify metric correctness after update
 			util.ExpectReservingActiveWorkloadsMetric(cqA, 2)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqB, 0)
 			util.ExpectReservingActiveWorkloadsMetric(cqB, 0)
 
 			ginkgo.By("Creating a workload in cqB that should preempt one from cqA")
@@ -416,7 +419,9 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 				createWorkload("second-right", "1")
 			}
 
+			util.ExpectAdmittedWorkloadsTotalMetric(cqSecondLeft, 5)
 			util.ExpectReservingActiveWorkloadsMetric(cqSecondLeft, 5)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqSecondRight, 5)
 			util.ExpectReservingActiveWorkloadsMetric(cqSecondRight, 5)
 			expectCohortWeightedShare(cohortFirstLeft.Name, 429)
 			expectCohortWeightedShare(cohortFirstRight.Name, 0)
@@ -459,7 +464,9 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			}
 			expectCohortWeightedShare("best-effort", 1000)
 			expectCohortWeightedShare("physics", 500)
+			util.ExpectAdmittedWorkloadsTotalMetric(bestEffortQueue, 6)
 			util.ExpectReservingActiveWorkloadsMetric(bestEffortQueue, 6)
+			util.ExpectAdmittedWorkloadsTotalMetric(physicsQueue, 6)
 			util.ExpectReservingActiveWorkloadsMetric(physicsQueue, 6)
 
 			ginkgo.By("create high priority workloads")
@@ -597,6 +604,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 				createWorkload("cq-p1", "1")
 			}
 			ginkgo.By("Workloads active")
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, 18)
 			util.ExpectReservingActiveWorkloadsMetric(cqp1, 18)
 
 			ginkgo.By("Expected Weighted Shares")
@@ -609,6 +617,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 				createWorkload("cq-p1", "1")
 			}
 			ginkgo.By("Workloads active")
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, 18)
 			util.ExpectReservingActiveWorkloadsMetric(cqp1, 18)
 
 			ginkgo.By("Expected Weighted Shares")
@@ -627,6 +636,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			for range 20 {
 				createWorkload("cq-p1", "1")
 			}
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, 20)
 			util.ExpectReservingActiveWorkloadsMetric(cqp1, 20)
 			expectCohortWeightedShare("cohort-a", 100)
 
@@ -992,6 +1002,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 				createWorkload("lq-a", "4"),
 				createWorkload("lq-b", "4"),
 			}
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, 2)
 			util.ExpectReservingActiveWorkloadsMetric(cq1, 2)
 
 			ginkgo.By("Creating two pending workloads for each lq")
@@ -1025,6 +1036,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 				createWorkload("lq-a", "4"),
 				createWorkload("lq-a", "4"),
 			}
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, 2)
 			util.ExpectReservingActiveWorkloadsMetric(cq1, 2)
 
 			ginkgo.By("Creating pending workloads for lq-a")
@@ -1053,6 +1065,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 				createWorkload("lq-a", "4"),
 				createWorkload("lq-b", "4"),
 			}
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, 2)
 			util.ExpectReservingActiveWorkloadsMetric(cq1, 2)
 
 			ginkgo.By("Creating pending workloads for lq-a and lq-b")
@@ -1084,6 +1097,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 				createWorkload("lq-a", "4"),
 				createWorkload("lq-a", "4"),
 			}
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, 2)
 			util.ExpectReservingActiveWorkloadsMetric(cq1, 2)
 
 			ginkgo.By("Creating pending workloads for lq-b")
@@ -1185,8 +1199,10 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			wlBestEffortA := createWorkload("best-effort-a", "4")
 			util.WaitForNextSecondAfterCreation(wlBestEffortA)
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlBestEffortA)
+			util.ExpectAdmittedWorkloadsTotalMetric(bestEffortCQA, 1)
 			util.ExpectReservingActiveWorkloadsMetric(bestEffortCQA, 1)
 			wlBestEffortB := createWorkload("best-effort-b", "4")
+			util.ExpectAdmittedWorkloadsTotalMetric(bestEffortCQB, 1)
 			util.ExpectReservingActiveWorkloadsMetric(bestEffortCQB, 1)
 
 			ginkgo.By("Creating a guaranteed workload in the guaranteed CQ, that should reclaim quota")
@@ -1346,6 +1362,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 
 			ginkgo.By("Admitting the workload")
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, 1)
 			util.ExpectReservingActiveWorkloadsMetric(cq1, 1)
 
 			ginkgo.By("Checking that LQ's resource usage is updated")
@@ -1367,6 +1384,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			ginkgo.By("Creating workloads in CQ1 that borrow from CQ2")
 			wlHighA := createWorkloadWithPriority("lq-a", "20", 10)
 			_ = createWorkloadWithPriority("lq-b", "12", 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, 2)
 			util.ExpectReservingActiveWorkloadsMetric(cq1, 2)
 
 			ginkgo.By("Checking that LQs' resource usage is updated")
@@ -1470,6 +1488,7 @@ var _ = ginkgo.Describe("Scheduler with AdmissionFairSharing = nil", ginkgo.Orde
 
 			ginkgo.By("Admitting the workload")
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, 1)
 			util.ExpectReservingActiveWorkloadsMetric(cq1, 1)
 
 			ginkgo.By("Checking that FairSharing status is nil")

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -460,14 +460,14 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, firstWl)
 				util.ExpectPendingWorkloadsMetric(preemptionClusterQ, 0, 0)
-				util.ExpectReservingActiveWorkloadsMetric(preemptionClusterQ, 1)
+				util.ExpectAdmittedWorkloadsTotalMetric(preemptionClusterQ, 1)
 			})
 
 			ginkgo.By("Reclaim one pod from the first workload", func() {
 				gomega.Expect(workload.UpdateReclaimablePods(ctx, k8sClient, firstWl, []kueue.ReclaimablePod{{Name: "third", Count: 1}})).To(gomega.Succeed())
 
 				util.ExpectPendingWorkloadsMetric(preemptionClusterQ, 0, 0)
-				util.ExpectReservingActiveWorkloadsMetric(preemptionClusterQ, 1)
+				util.ExpectAdmittedWorkloadsTotalMetric(preemptionClusterQ, 1)
 			})
 
 			secondWl := testing.MakeWorkload("second-wl", ns.Name).Queue(kueue.LocalQueueName(preemptionQueue.Name)).
@@ -539,7 +539,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.MustCreate(ctx, k8sClient, wlHigh2)
 
 				util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 5)
-				util.ExpectReservingActiveWorkloadsMetric(prodClusterQ, 0)
+				util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 0)
 
 				util.UnholdClusterQueue(ctx, k8sClient, prodClusterQ)
 
@@ -587,7 +587,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.MustCreate(ctx, k8sClient, wlHigh2)
 
 				util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 0)
-				util.ExpectReservingActiveWorkloadsMetric(prodClusterQ, 0)
+				util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 0)
 
 				util.UnholdLocalQueue(ctx, k8sClient, prodQueue)
 
@@ -632,7 +632,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, smallWl1, smallWl2)
 			util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 2)
-			util.ExpectReservingActiveWorkloadsMetric(prodClusterQ, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 1)
 
 			ginkgo.By("Marking the big workload as finished")
 			util.FinishWorkloads(ctx, k8sClient, bigWl)
@@ -653,14 +653,14 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
 				util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 1)
-				util.ExpectReservingActiveWorkloadsMetric(prodClusterQ, 0)
+				util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 0)
 			})
 			ginkgo.By("Mark one pod as reclaimable", func() {
 				gomega.Expect(workload.UpdateReclaimablePods(ctx, k8sClient, wl, []kueue.ReclaimablePod{{Name: kueue.DefaultPodSetName, Count: 1}})).To(gomega.Succeed())
 
 				util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, prodClusterQ.Name, wl)
 				util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 0)
-				util.ExpectReservingActiveWorkloadsMetric(prodClusterQ, 1)
+				util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 1)
 
 				createWl := &kueue.Workload{}
 				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), createWl)).To(gomega.Succeed())
@@ -1960,7 +1960,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.MustCreate(ctx, k8sClient, wl1)
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
-			util.ExpectReservingActiveWorkloadsMetric(cq, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
 
 			ginkgo.By("Stopping the ClusterQueue")
 			var clusterQueue kueue.ClusterQueue
@@ -2044,7 +2044,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
-			util.ExpectReservingActiveWorkloadsMetric(cq, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
 
 			createdLq := &kueue.LocalQueue{}
 
@@ -2450,7 +2450,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			ginkgo.By("creating first foundation workload which admits immediately")
 			createWorkloadWithPriority("foundation-queue", "1", 1000)
-			util.ExpectReservingActiveWorkloadsMetric(cq1, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, 1)
 			util.ExpectPendingWorkloadsMetric(cq1, 0, 0)
 
 			ginkgo.By("creating second foundation workload which cannot admit")
@@ -2462,7 +2462,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			createWorkloadWithPriority("best-effort-queue", "1", 0)
 			createWorkloadWithPriority("best-effort-queue", "1", 0)
 
-			util.ExpectReservingActiveWorkloadsMetric(cq2, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq2, 1)
 			util.ExpectPendingWorkloadsMetric(cq2, 0, 1)
 
 			ginkgo.By("finish first foundation workload")
@@ -2507,7 +2507,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			ginkgo.By("creating first foundation workload which admits immediately")
 			createWorkloadWithPriority("foundation-queue", "1", 1000)
-			util.ExpectReservingActiveWorkloadsMetric(cq1, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, 1)
 			util.ExpectPendingWorkloadsMetric(cq1, 0, 0)
 
 			ginkgo.By("creating second foundation workload which cannot admit")

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -395,7 +395,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 				})
 
 				ginkgo.By("verify admission for the workload1", func() {
@@ -437,7 +437,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl2)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 2)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 2)
 				})
 
 				ginkgo.By("verify admission for the workload2", func() {
@@ -472,7 +472,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the wl3 is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl2, wl3)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 3)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 3)
 				})
 
 				ginkgo.By("verify admission for the wl3", func() {
@@ -513,7 +513,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the wl4 is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl2, wl4)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 3)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 4)
 				})
 
 				ginkgo.By("verify admission for the wl4", func() {
@@ -552,7 +552,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify wl1 is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 				})
 
 				ginkgo.By("create wl2 which is blocked by wl1", func() {
@@ -660,7 +660,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 				})
 
 				ginkgo.By("verify admission for the workload", func() {
@@ -729,7 +729,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 				})
 
 				ginkgo.By("verify admission for the workload", func() {
@@ -862,7 +862,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 				})
 
 				ginkgo.By("creating second a workload which cannot fit", func() {
@@ -1594,7 +1594,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 				})
 
 				ginkgo.By("creating a mid priority workload which can fit", func() {
@@ -1609,7 +1609,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the wl2 gets admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl2)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 2)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 2)
 				})
 
 				ginkgo.By("creating a high priority workload which requires preemption", func() {
@@ -1735,7 +1735,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 				})
 
 				ginkgo.By("creating a workload in CQB which reclaims its quota", func() {
@@ -1835,7 +1835,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
 				})
 			})
@@ -1928,7 +1928,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload gets admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
 				})
 			})
@@ -1996,7 +1996,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload gets admitted after label is added", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
 				})
 			})
@@ -2192,7 +2192,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
 				})
 			})
@@ -2307,7 +2307,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
 				})
 			})
@@ -2430,7 +2430,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("Verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
 				})
 
@@ -2686,7 +2686,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, 1)
 				})
 
 				ginkgo.By("verify admission for the workload1", func() {


### PR DESCRIPTION
Cherry pick of #7281 on release-0.13.

#7281: Replace ExpectReservingActiveWorkloadsMetric with counter

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```