### PR TITLE
Add DRA ResourceClaim wrappers for test infrastructure

### DIFF
--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -427,20 +427,11 @@ func TestReconcile(t *testing.T) {
 					ResourceClaim("gpu", "rc1").
 					Obj()).
 				Obj(),
-			resourceClaims: []*resourcev1.ResourceClaim{{
-				ObjectMeta: metav1.ObjectMeta{Name: "rc1", Namespace: "ns"},
-				Spec: resourcev1.ResourceClaimSpec{
-					Devices: resourcev1.DeviceClaim{
-						Requests: []resourcev1.DeviceRequest{{
-							Exactly: &resourcev1.ExactDeviceRequest{
-								DeviceClassName: "gpu.example.com",
-								AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
-								Count:           1,
-							},
-						}},
-					},
-				},
-			}},
+			resourceClaims: []*resourcev1.ResourceClaim{
+				utiltesting.MakeResourceClaim("rc1", "ns").
+					DeviceRequest("", "gpu.example.com", 1).
+					Obj(),
+			},
 			cq: utiltestingapi.MakeClusterQueue("cq").
 				ResourceGroup(
 					*utiltestingapi.MakeFlavorQuotas("flavor1").
@@ -477,23 +468,11 @@ func TestReconcile(t *testing.T) {
 					ResourceClaimTemplate("gpu", "gpu-template").
 					Obj()).
 				Obj(),
-			resourceClaimTemplates: []*resourcev1.ResourceClaimTemplate{{
-				ObjectMeta: metav1.ObjectMeta{Name: "gpu-template", Namespace: "ns"},
-				Spec: resourcev1.ResourceClaimTemplateSpec{
-					Spec: resourcev1.ResourceClaimSpec{
-						Devices: resourcev1.DeviceClaim{
-							Requests: []resourcev1.DeviceRequest{{
-								Name: "gpu-request",
-								Exactly: &resourcev1.ExactDeviceRequest{
-									DeviceClassName: "gpu.example.com",
-									AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
-									Count:           1,
-								},
-							}},
-						},
-					},
-				},
-			}},
+			resourceClaimTemplates: []*resourcev1.ResourceClaimTemplate{
+				utiltesting.MakeResourceClaimTemplate("gpu-template", "ns").
+					DeviceRequest("gpu-request", "gpu.example.com", 1).
+					Obj(),
+			},
 			cq: utiltestingapi.MakeClusterQueue("cq").
 				ResourceGroup(
 					*utiltestingapi.MakeFlavorQuotas("flavor1").
@@ -524,23 +503,11 @@ func TestReconcile(t *testing.T) {
 					ResourceClaimTemplate("gpu", "gpu-template").
 					Obj()).
 				Obj(),
-			resourceClaimTemplates: []*resourcev1.ResourceClaimTemplate{{
-				ObjectMeta: metav1.ObjectMeta{Name: "gpu-template", Namespace: "ns"},
-				Spec: resourcev1.ResourceClaimTemplateSpec{
-					Spec: resourcev1.ResourceClaimSpec{
-						Devices: resourcev1.DeviceClaim{
-							Requests: []resourcev1.DeviceRequest{{
-								Name: "gpu-request",
-								Exactly: &resourcev1.ExactDeviceRequest{
-									DeviceClassName: "gpu.example.com",
-									AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
-									Count:           2,
-								},
-							}},
-						},
-					},
-				},
-			}},
+			resourceClaimTemplates: []*resourcev1.ResourceClaimTemplate{
+				utiltesting.MakeResourceClaimTemplate("gpu-template", "ns").
+					DeviceRequest("gpu-request", "gpu.example.com", 2).
+					Obj(),
+			},
 			cq: utiltestingapi.MakeClusterQueue("cq").
 				ResourceGroup(
 					*utiltestingapi.MakeFlavorQuotas("flavor1").
@@ -569,23 +536,11 @@ func TestReconcile(t *testing.T) {
 					ResourceClaimTemplate("gpu", "gpu-template").
 					Obj()).
 				Obj(),
-			resourceClaimTemplates: []*resourcev1.ResourceClaimTemplate{{
-				ObjectMeta: metav1.ObjectMeta{Name: "gpu-template", Namespace: "ns"},
-				Spec: resourcev1.ResourceClaimTemplateSpec{
-					Spec: resourcev1.ResourceClaimSpec{
-						Devices: resourcev1.DeviceClaim{
-							Requests: []resourcev1.DeviceRequest{{
-								Name: "gpu-request",
-								Exactly: &resourcev1.ExactDeviceRequest{
-									DeviceClassName: "unmapped.example.com",
-									AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
-									Count:           1,
-								},
-							}},
-						},
-					},
-				},
-			}},
+			resourceClaimTemplates: []*resourcev1.ResourceClaimTemplate{
+				utiltesting.MakeResourceClaimTemplate("gpu-template", "ns").
+					DeviceRequest("gpu-request", "unmapped.example.com", 1).
+					Obj(),
+			},
 			cq: utiltestingapi.MakeClusterQueue("cq").
 				ResourceGroup(
 					*utiltestingapi.MakeFlavorQuotas("flavor1").

--- a/test/integration/singlecluster/controller/dra/suite_test.go
+++ b/test/integration/singlecluster/controller/dra/suite_test.go
@@ -23,8 +23,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	resourcev1 "k8s.io/api/resource/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -139,24 +137,5 @@ func managerSetup(modifyConfig func(*config.Configuration)) framework.ManagerSet
 		)
 		err = mgr.Add(sched)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	}
-}
-
-// Helper function to create a ResourceClaim
-func makeResourceClaim(name, namespace, deviceClassName string, count int64) *resourcev1.ResourceClaim {
-	return &resourcev1.ResourceClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Spec: resourcev1.ResourceClaimSpec{
-			Devices: resourcev1.DeviceClaim{
-				Requests: []resourcev1.DeviceRequest{{
-					Name: "device-request",
-					Exactly: &resourcev1.ExactDeviceRequest{
-						DeviceClassName: deviceClassName,
-						AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
-						Count:           count,
-					},
-				}},
-			},
-		},
 	}
 }


### PR DESCRIPTION
This commit introduces test helper wrappers for DRA ResourceClaim and ResourceClaimTemplate objects to improve test readability and reduce boilerplate.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add DRA ResourceClaim wrappers for test infrastructure.
This commit introduces test helper wrappers for DRA
ResourceClaim and ResourceClaimTemplate objects to improve
test readability and reduce boilerplate.

Related to, 
https://github.com/kubernetes-sigs/kueue/pull/7226#discussion_r2436221638

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```