### PR TITLE
Fix capitalization in KEP template

### DIFF
--- a/keps/NNNN-template/README.md
+++ b/keps/NNNN-template/README.md
@@ -31,7 +31,7 @@ tags, and then generate with `hack/update-toc.sh`.
   - [Test Plan](#test-plan)
       - [Prerequisite testing updates](#prerequisite-testing-updates)
     - [Unit Tests](#unit-tests)
-    - [Integration tests](#integration-tests)
+    - [Integration Tests](#integration-tests)
   - [Graduation Criteria](#graduation-criteria)
 - [Implementation History](#implementation-history)
 - [Drawbacks](#drawbacks)
@@ -185,7 +185,7 @@ extending the production code to implement this enhancement.
 
 - `<package>`: `<date>` - `<test coverage>`
 
-#### Integration tests
+#### Integration Tests
 
 <!--
 Describe what tests will be added to ensure proper quality of the enhancement.


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
When writing #7311, I noticed that the "Integration tests" heading is capitalized in a different way from the rest of them - "tests" is not capitalized, while other heading capitalize every word.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```