### PR TITLE
chore: Leverage utiltesting fake client in DRA tests

### DIFF
--- a/pkg/dra/claims_test.go
+++ b/pkg/dra/claims_test.go
@@ -22,14 +22,11 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -38,11 +35,6 @@ import (
 )
 
 func Test_GetResourceRequests(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = clientgoscheme.AddToScheme(scheme)
-	_ = kueue.AddToScheme(scheme)
-	_ = resourcev1.AddToScheme(scheme)
-
 	tmpl := utiltesting.MakeResourceClaimTemplate("claim-tmpl-1", "ns1").
 		DeviceRequest("device-request", "test-deviceclass-1", 2).
 		Obj()
@@ -258,7 +250,7 @@ func Test_GetResourceRequests(t *testing.T) {
 					objs = append(objs, o.(client.Object))
 				}
 			}
-			baseClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+			baseClient := utiltesting.NewClientBuilder().WithObjects(objs...).Build()
 
 			wlCopy := wl.DeepCopy()
 			if tc.modifyWL != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We should use utiltesting fake client in tests as opposed to directly use controller-runtime fake client:

https://github.com/kubernetes-sigs/kueue/blob/d6b73af9e0bdf4ef31041b9373ccb4993f8e48a8/pkg/dra/claims_test.go#L41-L44
https://github.com/kubernetes-sigs/kueue/blob/d6b73af9e0bdf4ef31041b9373ccb4993f8e48a8/pkg/dra/claims_test.go#L261

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```