### PR TITLE
[flaky integration test] Scheduler when ClusterQueue head has inadmissible workload sticky workload deleted, next workload can admit

### DIFF
--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -918,12 +918,13 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			ginkgo.By("Validate pending workloads")
 			util.ExpectPendingWorkloadsMetric(cq1, 1, 1)
 
-			gomega.Eventually(func(g gomega.Gomega) {
-				util.FinishEvictionsOfAnyWorkloadsInCq(ctx, k8sClient, cq2)
-				util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 1)
-				util.ExpectClusterQueueWeightedShareMetric(cq1, 0)
-				util.ExpectClusterQueueWeightedShareMetric(cq2, 0)
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			ginkgo.By("Complete preemption")
+			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cq2, 2)
+
+			ginkgo.By("Expected Total Admitted Workloads and Weighted Share")
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 1)
+			util.ExpectClusterQueueWeightedShareMetric(cq1, 0)
+			util.ExpectClusterQueueWeightedShareMetric(cq2, 0)
 		})
 
 		ginkgo.It("sticky workload deleted, next workload can admit", func() {
@@ -950,13 +951,13 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			ginkgo.By("Validate pending workloads")
 			util.ExpectPendingWorkloadsMetric(cq1, 1, 1)
 
+			ginkgo.By("Complete preemption")
+			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cq2, 2)
+
 			ginkgo.By("Expected Total Admitted Workloads and Weighted Share")
-			gomega.Eventually(func(g gomega.Gomega) {
-				util.FinishEvictionsOfAnyWorkloadsInCq(ctx, k8sClient, cq2)
-				util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 1)
-				util.ExpectClusterQueueWeightedShareMetric(cq1, 0)
-				util.ExpectClusterQueueWeightedShareMetric(cq2, 0)
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 1)
+			util.ExpectClusterQueueWeightedShareMetric(cq1, 0)
+			util.ExpectClusterQueueWeightedShareMetric(cq2, 0)
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
It deflakes an integration test ([analysis of the flaking scenario](https://github.com/kubernetes-sigs/kueue/issues/7250#issuecomment-3421528241)).

It is safer to use the `FinishEvictionOfWorkloadsInCQ` instead of `FinishEvictionsOfAnyWorkloadsInCq` because the former is waiting in the `Eventually` block for the workloads to become ready for eviction. 

Also, the `ExpectMetric` util functions are calling an `Eventually` inside them. So it makes no sense to have the enclosing `Eventually`.

Updated two tests. Tested by running >100 times in a loop.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7250

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```