### PR TITLE
Automated cherry pick of #7325: [flaky integration test] Scheduler when ClusterQueue head has inadmissible workload sticky workload deleted, next workload can admit

### DIFF
--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -918,12 +918,13 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			ginkgo.By("Validate pending workloads")
 			util.ExpectPendingWorkloadsMetric(cq1, 1, 1)
 
-			gomega.Eventually(func(g gomega.Gomega) {
-				util.FinishEvictionsOfAnyWorkloadsInCq(ctx, k8sClient, cq2)
-				util.ExpectAdmittedWorkloadsTotalMetric(cq1, 1)
-				util.ExpectClusterQueueWeightedShareMetric(cq1, 0)
-				util.ExpectClusterQueueWeightedShareMetric(cq2, 0)
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			ginkgo.By("Complete preemption")
+			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cq2, 2)
+
+			ginkgo.By("Expected Total Admitted Workloads and Weighted Share")
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, 1)
+			util.ExpectClusterQueueWeightedShareMetric(cq1, 0)
+			util.ExpectClusterQueueWeightedShareMetric(cq2, 0)
 		})
 
 		ginkgo.It("sticky workload deleted, next workload can admit", func() {
@@ -950,13 +951,13 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			ginkgo.By("Validate pending workloads")
 			util.ExpectPendingWorkloadsMetric(cq1, 1, 1)
 
+			ginkgo.By("Complete preemption")
+			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cq2, 2)
+
 			ginkgo.By("Expected Total Admitted Workloads and Weighted Share")
-			gomega.Eventually(func(g gomega.Gomega) {
-				util.FinishEvictionsOfAnyWorkloadsInCq(ctx, k8sClient, cq2)
-				util.ExpectAdmittedWorkloadsTotalMetric(cq1, 1)
-				util.ExpectClusterQueueWeightedShareMetric(cq1, 0)
-				util.ExpectClusterQueueWeightedShareMetric(cq2, 0)
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, 1)
+			util.ExpectClusterQueueWeightedShareMetric(cq1, 0)
+			util.ExpectClusterQueueWeightedShareMetric(cq2, 0)
 		})
 	})
 


### PR DESCRIPTION
Cherry pick of #7325 on release-0.13.

#7325: [flaky integration test] Scheduler when ClusterQueue head has inadmissible workload sticky workload deleted, next workload can admit

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```