### PR TITLE
enable ssa tags for kubernetes api linter

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -30,7 +30,7 @@ linters:
                                  # having the `omitempty` value in their `json` tag where appropriate.
               # - "optionalorrequired" # Every field should be marked as `+optional` or `+required`.
               # - "requiredfields" # Required fields should not be pointers, and should not have `omitempty`.
-              # - "ssatags" # Ensure array fields have the appropriate listType markers
+              - "ssatags" # Ensure array fields have the appropriate listType markers
               - "statusoptional" # Ensure all first children within status should be optional.
               - "statussubresource" # All root objects that have a `status` field should have a status subresource.
               - "uniquemarkers" # Ensure that types and fields do not contain more than a single definition of a marker that should only be present once.
@@ -57,12 +57,14 @@ linters:
             #    policy: SuggestFix # SuggestFix | Warn # The policy for pointers in optional fields. Defaults to `SuggestFix`.
             #  omitempty:
             #    policy: SuggestFix # SuggestFix | Warn | Ignore # The policy for omitempty in optional fields. Defaults to `SuggestFix`.
+            ssatags:
+              listTypeSetUsage: Ignore # The policy for listType=set usage on object arrays. Defaults to `Warn`.
 
   exclusions:
     generated: strict
     rules:
     ## KAL should only run on API folders.
-    - path-except: "apis/kueue/*"
+    - path-except: "apis/kueue/v1beta2/*"
       linters:
         - kubeapilinter
 

--- a/apis/kueue/v1beta2/clusterqueue_types.go
+++ b/apis/kueue/v1beta2/clusterqueue_types.go
@@ -112,7 +112,7 @@ type ClusterQueueSpec struct {
 	// admissionChecks lists the AdmissionChecks required by this ClusterQueue.
 	// Cannot be used along with AdmissionCheckStrategy.
 	// +optional
-	AdmissionChecks []AdmissionCheckReference `json:"admissionChecks,omitempty"`
+	AdmissionChecks []AdmissionCheckReference `json:"admissionChecks,omitempty"` //nolint:kubeapilinter // field is being removed
 
 	// admissionChecksStrategy defines a list of strategies to determine which ResourceFlavors require AdmissionChecks.
 	// This property cannot be used in conjunction with the 'admissionChecks' property.
@@ -147,6 +147,8 @@ type ClusterQueueSpec struct {
 // AdmissionChecksStrategy defines a strategy for a AdmissionCheck.
 type AdmissionChecksStrategy struct {
 	// admissionChecks is a list of strategies for AdmissionChecks
+	// +listType=map
+	// +listMapKey=name
 	AdmissionChecks []AdmissionCheckStrategyRule `json:"admissionChecks,omitempty"`
 }
 
@@ -158,6 +160,7 @@ type AdmissionCheckStrategyRule struct {
 	// onFlavors is a list of ResourceFlavors' names that this AdmissionCheck should run for.
 	// If empty, the AdmissionCheck will run for all workloads submitted to the ClusterQueue.
 	// +optional
+	// +listType=set
 	OnFlavors []ResourceFlavorReference `json:"onFlavors,omitempty"`
 }
 
@@ -184,6 +187,7 @@ type ResourceGroup struct {
 	// of up to 256 covered resources across all resource groups in the ClusterQueue.
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=64
+	// +listType=atomic
 	CoveredResources []corev1.ResourceName `json:"coveredResources"`
 
 	// flavors is the list of flavors that provide the resources of this group.

--- a/apis/kueue/v1beta2/provisioningrequestconfig_types.go
+++ b/apis/kueue/v1beta2/provisioningrequestconfig_types.go
@@ -95,6 +95,8 @@ type ProvisioningRequestPodSetUpdates struct {
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=8
+	// +listType=map
+	// +listMapKey=key
 	NodeSelector []ProvisioningRequestPodSetUpdatesNodeSelector `json:"nodeSelector,omitempty"`
 }
 

--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -276,6 +276,7 @@ type TopologyAssignment struct {
 	// the lowest level of the topology.
 	//
 	// +required
+	// +listType=atomic
 	Domains []TopologyDomainAssignment `json:"domains"`
 }
 
@@ -442,6 +443,8 @@ type WorkloadStatus struct {
 	// Requires enabling the TASFailedNodeReplacement feature gate.
 	//
 	// +optional
+	// +listType=map
+	// +listMapKey=name
 	UnhealthyNodes []UnhealthyNode `json:"unhealthyNodes,omitempty"`
 }
 
@@ -570,6 +573,7 @@ type PodSetUpdate struct {
 	// tolerations of the PodSet to modify.
 	// +optional
 	// +kubebuilder:validation:MaxItems=8
+	// +listType=atomic
 	// +kubebuilder:validation:XValidation:rule="self.all(x, !has(x.key) ? x.operator == 'Exists' : true)", message="operator must be Exists when 'key' is empty, which means 'match all values and all keys'"
 	// +kubebuilder:validation:XValidation:rule="self.all(x, has(x.tolerationSeconds) ? x.effect == 'NoExecute' : true)", message="effect must be 'NoExecute' when 'tolerationSeconds' is set"
 	// +kubebuilder:validation:XValidation:rule="self.all(x, !has(x.operator) || x.operator in ['Equal', 'Exists'])", message="supported toleration values: 'Equal'(default), 'Exists'"

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -855,10 +855,14 @@ spec:
                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string
                             type: array
+                            x-kubernetes-list-type: set
                         required:
                           - name
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
                   type: object
                 admissionScope:
                   description: admissionScope indicates whether ClusterQueue uses the Admission Fair Sharing
@@ -1122,6 +1126,7 @@ spec:
                         maxItems: 64
                         minItems: 1
                         type: array
+                        x-kubernetes-list-type: atomic
                       flavors:
                         description: |-
                           flavors is the list of flavors that provide the resources of this group.

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_cohorts.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_cohorts.yaml
@@ -405,6 +405,7 @@ spec:
                         maxItems: 64
                         minItems: 1
                         type: array
+                        x-kubernetes-list-type: atomic
                       flavors:
                         description: |-
                           flavors is the list of flavors that provide the resources of this group.

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_provisioningrequestconfigs.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_provisioningrequestconfigs.yaml
@@ -258,6 +258,9 @@ spec:
                         type: object
                       maxItems: 8
                       type: array
+                      x-kubernetes-list-map-keys:
+                        - key
+                      x-kubernetes-list-type: map
                   type: object
                 provisioningClassName:
                   description: |-

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -17288,6 +17288,7 @@ spec:
                                     - values
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               levels:
                                 description: |-
                                   levels is an ordered list of keys denoting the levels of the assigned
@@ -17404,6 +17405,7 @@ spec:
                                 type: object
                               maxItems: 8
                               type: array
+                              x-kubernetes-list-type: atomic
                               x-kubernetes-validations:
                                 - message: operator must be Exists when 'key' is empty, which means 'match all values and all keys'
                                   rule: 'self.all(x, !has(x.key) ? x.operator == ''Exists'' : true)'
@@ -17658,6 +17660,9 @@ spec:
                       - name
                     type: object
                   type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
               type: object
               x-kubernetes-validations:
                 - message: clusterName is immutable once set

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -858,10 +858,14 @@ spec:
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           type: array
+                          x-kubernetes-list-type: set
                       required:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                 type: object
               admissionScope:
                 description: admissionScope indicates whether ClusterQueue uses the
@@ -1130,6 +1134,7 @@ spec:
                       maxItems: 64
                       minItems: 1
                       type: array
+                      x-kubernetes-list-type: atomic
                     flavors:
                       description: |-
                         flavors is the list of flavors that provide the resources of this group.

--- a/config/components/crd/bases/kueue.x-k8s.io_cohorts.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_cohorts.yaml
@@ -404,6 +404,7 @@ spec:
                       maxItems: 64
                       minItems: 1
                       type: array
+                      x-kubernetes-list-type: atomic
                     flavors:
                       description: |-
                         flavors is the list of flavors that provide the resources of this group.

--- a/config/components/crd/bases/kueue.x-k8s.io_provisioningrequestconfigs.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_provisioningrequestconfigs.yaml
@@ -260,6 +260,9 @@ spec:
                       type: object
                     maxItems: 8
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - key
+                    x-kubernetes-list-type: map
                 type: object
               provisioningClassName:
                 description: |-

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -18287,6 +18287,7 @@ spec:
                                 - values
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             levels:
                               description: |-
                                 levels is an ordered list of keys denoting the levels of the assigned
@@ -18406,6 +18407,7 @@ spec:
                               type: object
                             maxItems: 8
                             type: array
+                            x-kubernetes-list-type: atomic
                             x-kubernetes-validations:
                             - message: operator must be Exists when 'key' is empty,
                                 which means 'match all values and all keys'
@@ -18676,6 +18678,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             type: object
             x-kubernetes-validations:
             - message: clusterName is immutable once set


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Enable ssatags for kube-api-linter.
https://github.com/kubernetes-sigs/kube-api-linter/blob/main/docs/linters.md#ssatags
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially address #7119 

#### Special notes for your reviewer:

Important Note on listType=set: The use of listType=set is discouraged for object arrays due to Server-Side Apply compatibility issues. When multiple controllers attempt to apply changes to an object array with listType=set, the merge behavior can be unpredictable and may lead to data loss or unexpected conflicts. For object arrays, use listType=atomic for simple replacement semantics or listType=map for granular field-level merging. listType=set is safe to use with primitive arrays (strings, integers, etc.).

For now, I just ignore existing listType=set.

If this note is concerning we could switch existing set tags as part of this PR.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```