### PR TITLE
Automated cherry pick of #6732: Fix MultiKueue workload re-evaluation bug

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/indexer.go
+++ b/pkg/controller/admissionchecks/multikueue/indexer.go
@@ -25,17 +25,17 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
+	"sigs.k8s.io/kueue/pkg/util/slices"
 )
 
 const (
-	UsingKubeConfigs             = "spec.kubeconfigs"
-	UsingMultiKueueClusters      = "spec.multiKueueClusters"
-	AdmissionCheckUsingConfigKey = "spec.multiKueueConfig"
+	UsingKubeConfigs               = "spec.kubeconfigs"
+	UsingMultiKueueClusters        = "spec.multiKueueClusters"
+	AdmissionCheckUsingConfigKey   = "spec.multiKueueConfig"
+	WorkloadsWithAdmissionCheckKey = "status.admissionChecks"
 )
 
-var (
-	configGVK = kueue.GroupVersion.WithKind("MultiKueueConfig")
-)
+var configGVK = kueue.GroupVersion.WithKind("MultiKueueConfig")
 
 func getIndexUsingKubeConfigs(configNamespace string) func(obj client.Object) []string {
 	return func(obj client.Object) []string {
@@ -55,6 +55,16 @@ func indexUsingMultiKueueClusters(obj client.Object) []string {
 	return config.Spec.Clusters
 }
 
+func indexWorkloadsAdmissionChecks(obj client.Object) []string {
+	workload, isWorkload := obj.(*kueue.Workload)
+	if !isWorkload || len(workload.Status.AdmissionChecks) == 0 {
+		return nil
+	}
+	return slices.Map(workload.Status.AdmissionChecks, func(checkState *kueue.AdmissionCheckState) string {
+		return string(checkState.Name)
+	})
+}
+
 func SetupIndexer(ctx context.Context, indexer client.FieldIndexer, configNamespace string) error {
 	if err := indexer.IndexField(ctx, &kueue.MultiKueueCluster{}, UsingKubeConfigs, getIndexUsingKubeConfigs(configNamespace)); err != nil {
 		return fmt.Errorf("setting index on clusters using kubeconfig: %w", err)
@@ -64,6 +74,9 @@ func SetupIndexer(ctx context.Context, indexer client.FieldIndexer, configNamesp
 	}
 	if err := indexer.IndexField(ctx, &kueue.AdmissionCheck{}, AdmissionCheckUsingConfigKey, admissioncheck.IndexerByConfigFunction(kueue.MultiKueueControllerName, configGVK)); err != nil {
 		return fmt.Errorf("setting index on admission checks config: %w", err)
+	}
+	if err := indexer.IndexField(ctx, &kueue.Workload{}, WorkloadsWithAdmissionCheckKey, indexWorkloadsAdmissionChecks); err != nil {
+		return fmt.Errorf("setting index on workloads admission checks: %w", err)
 	}
 	return nil
 }

--- a/pkg/controller/admissionchecks/multikueue/indexer_test.go
+++ b/pkg/controller/admissionchecks/multikueue/indexer_test.go
@@ -171,3 +171,77 @@ func TestListMultiKueueConfigsUsingMultiKueueClusters(t *testing.T) {
 		})
 	}
 }
+
+func TestListWorkloadsWithAdmissionCheck(t *testing.T) {
+	cases := map[string]struct {
+		workloads     []*kueue.Workload
+		filter        client.ListOption
+		wantListError error
+		wantList      []string
+	}{
+		"no workloads": {
+			filter: client.MatchingFields{WorkloadsWithAdmissionCheckKey: "ac1"},
+		},
+		"single workload, single match": {
+			workloads: []*kueue.Workload{
+				utiltesting.MakeWorkload("wl1", TestNamespace).
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:  "ac1",
+						State: kueue.CheckStatePending,
+					}).Obj(),
+			},
+			filter:   client.MatchingFields{WorkloadsWithAdmissionCheckKey: "ac1"},
+			wantList: []string{"wl1"},
+		},
+		"single workload, no match": {
+			workloads: []*kueue.Workload{
+				utiltesting.MakeWorkload("wl2", TestNamespace).
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:  "ac2",
+						State: kueue.CheckStatePending,
+					}).Obj(),
+			},
+			filter: client.MatchingFields{WorkloadsWithAdmissionCheckKey: "ac1"},
+		},
+		"multiple workloads, single match": {
+			workloads: []*kueue.Workload{
+				utiltesting.MakeWorkload("wl1", TestNamespace).
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:  "ac1",
+						State: kueue.CheckStatePending,
+					}).Obj(),
+				utiltesting.MakeWorkload("wl2", TestNamespace).
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:  "ac2",
+						State: kueue.CheckStatePending,
+					}).Obj(),
+			},
+			filter:   client.MatchingFields{WorkloadsWithAdmissionCheckKey: "ac1"},
+			wantList: []string{"wl1"},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			builder := getClientBuilder(ctx)
+			k8sClient := builder.Build()
+			for _, wl := range tc.workloads {
+				if err := k8sClient.Create(ctx, wl); err != nil {
+					t.Fatalf("Unable to create %q workload: %v", client.ObjectKeyFromObject(wl), err)
+				}
+			}
+
+			lst := &kueue.WorkloadList{}
+
+			gotListErr := k8sClient.List(ctx, lst, tc.filter)
+			if diff := cmp.Diff(tc.wantListError, gotListErr); diff != "" {
+				t.Errorf("unexpected error (-want/+got):\n%s", diff)
+			}
+
+			gotList := slices.Map(lst.Items, func(wl *kueue.Workload) string { return wl.Name })
+			if diff := cmp.Diff(tc.wantList, gotList, cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
+				t.Errorf("unexpected (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -54,9 +54,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
-var (
-	realClock = clock.RealClock{}
-)
+var realClock = clock.RealClock{}
 
 type wlReconciler struct {
 	client            client.Client
@@ -559,6 +557,62 @@ func newWlReconciler(c client.Client, helper *admissioncheck.MultiKueueStoreHelp
 	return r
 }
 
+type configHandler struct {
+	client client.Client
+}
+
+func (c *configHandler) Create(context.Context, event.CreateEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	// no-op as we don't need to react to new configs
+}
+
+func (c *configHandler) Update(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	oldConfig, isOldConfig := e.ObjectOld.(*kueue.MultiKueueConfig)
+	newConfig, isNewConfig := e.ObjectNew.(*kueue.MultiKueueConfig)
+	if !isOldConfig || !isNewConfig {
+		return
+	}
+	if equality.Semantic.DeepEqual(oldConfig.Spec.Clusters, newConfig.Spec.Clusters) {
+		return
+	}
+	if err := c.queueWorkloadsForConfig(ctx, oldConfig.Name, q); err != nil {
+		ctrl.LoggerFrom(ctx).V(2).Error(err, "Failed to queue workloads on config update", "multiKueueConfig", klog.KObj(oldConfig))
+	}
+}
+
+func (c *configHandler) Delete(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	config, isConfig := e.Object.(*kueue.MultiKueueConfig)
+	if !isConfig {
+		return
+	}
+	if err := c.queueWorkloadsForConfig(ctx, config.Name, q); err != nil {
+		ctrl.LoggerFrom(ctx).V(2).Error(err, "Failed to queue workloads on config deletion", "multiKueueConfig", klog.KObj(config))
+	}
+}
+
+func (c *configHandler) Generic(context.Context, event.GenericEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	// no-op as we don't need to react to generic
+}
+
+func (c *configHandler) queueWorkloadsForConfig(ctx context.Context, configName string, q workqueue.TypedRateLimitingInterface[reconcile.Request]) error {
+	admissionChecks := &kueue.AdmissionCheckList{}
+	if err := c.client.List(ctx, admissionChecks, client.MatchingFields{AdmissionCheckUsingConfigKey: configName}); err != nil {
+		return err
+	}
+
+	var errs []error
+	for _, admissionCheck := range admissionChecks.Items {
+		workloads := &kueue.WorkloadList{}
+		if err := c.client.List(ctx, workloads, client.MatchingFields{WorkloadsWithAdmissionCheckKey: admissionCheck.Name}); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		for _, workload := range workloads.Items {
+			q.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&workload)})
+		}
+	}
+	return errors.Join(errs...)
+}
+
 func (w *wlReconciler) setupWithManager(mgr ctrl.Manager) error {
 	syncHndl := handler.Funcs{
 		GenericFunc: func(_ context.Context, e event.GenericEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
@@ -573,6 +627,7 @@ func (w *wlReconciler) setupWithManager(mgr ctrl.Manager) error {
 		Named("multikueue_workload").
 		For(&kueue.Workload{}).
 		WatchesRawSource(source.Channel(w.clusters.wlUpdateCh, syncHndl)).
+		Watches(&kueue.MultiKueueConfig{}, &configHandler{client: w.client}).
 		WithEventFilter(w).
 		Complete(w)
 }

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -54,9 +54,7 @@ import (
 	_ "sigs.k8s.io/kueue/pkg/controller/jobs"
 )
 
-var (
-	errFake = errors.New("fake error")
-)
+var errFake = errors.New("fake error")
 
 func TestWlReconcile(t *testing.T) {
 	now := time.Now()
@@ -1744,5 +1742,164 @@ func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
 				t.Errorf("unexpected created remotes (-want/+got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// mockQueue implements workqueue.TypedRateLimitingInterface for testing
+type mockQueue struct {
+	addedItems []reconcile.Request
+}
+
+func (m *mockQueue) Add(item reconcile.Request) {
+	m.addedItems = append(m.addedItems, item)
+}
+
+func (m *mockQueue) Len() int                                  { return 0 }
+func (m *mockQueue) Get() (reconcile.Request, bool)            { return reconcile.Request{}, false }
+func (m *mockQueue) Done(reconcile.Request)                    {}
+func (m *mockQueue) Forget(reconcile.Request)                  {}
+func (m *mockQueue) NumRequeues(reconcile.Request) int         { return 0 }
+func (m *mockQueue) AddRateLimited(reconcile.Request)          {}
+func (m *mockQueue) AddAfter(reconcile.Request, time.Duration) {}
+func (m *mockQueue) ShutDown()                                 {}
+func (m *mockQueue) ShutDownWithDrain()                        {}
+func (m *mockQueue) ShuttingDown() bool                        { return false }
+
+func TestConfigHandlerUpdate(t *testing.T) {
+	cases := map[string]struct {
+		admissionChecks   []kueue.AdmissionCheck
+		workloads         []kueue.Workload
+		oldConfig         *kueue.MultiKueueConfig
+		newConfig         *kueue.MultiKueueConfig
+		expectedQueuedWLs []string
+	}{
+		"clusters unchanged - no workloads queued": {
+			admissionChecks: []kueue.AdmissionCheck{
+				*utiltesting.MakeAdmissionCheck("ac1").
+					ControllerName(kueue.MultiKueueControllerName).
+					Parameters(kueue.GroupVersion.Group, "MultiKueueConfig", "config1").
+					Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("wl1", TestNamespace).
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					Obj(),
+			},
+			oldConfig:         utiltesting.MakeMultiKueueConfig("config1").Clusters("cluster1", "cluster2").Obj(),
+			newConfig:         utiltesting.MakeMultiKueueConfig("config1").Clusters("cluster1", "cluster2").Obj(),
+			expectedQueuedWLs: nil, // No workloads should be queued
+		},
+		"clusters changed - workloads queued": {
+			admissionChecks: []kueue.AdmissionCheck{
+				*utiltesting.MakeAdmissionCheck("ac1").
+					ControllerName(kueue.MultiKueueControllerName).
+					Parameters(kueue.GroupVersion.Group, "MultiKueueConfig", "config1").
+					Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("wl1", TestNamespace).
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					Obj(),
+				*utiltesting.MakeWorkload("wl2", TestNamespace).
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStateReady}).
+					Obj(),
+			},
+			oldConfig:         utiltesting.MakeMultiKueueConfig("config1").Clusters("cluster1").Obj(),
+			newConfig:         utiltesting.MakeMultiKueueConfig("config1").Clusters("cluster1", "cluster2").Obj(),
+			expectedQueuedWLs: []string{"wl1", "wl2"}, // Both workloads should be queued
+		},
+		"multiple configs - only affected workloads queued": {
+			admissionChecks: []kueue.AdmissionCheck{
+				*utiltesting.MakeAdmissionCheck("ac1").
+					ControllerName(kueue.MultiKueueControllerName).
+					Parameters(kueue.GroupVersion.Group, "MultiKueueConfig", "config1").
+					Obj(),
+				*utiltesting.MakeAdmissionCheck("ac2").
+					ControllerName(kueue.MultiKueueControllerName).
+					Parameters(kueue.GroupVersion.Group, "MultiKueueConfig", "other-config").
+					Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("wl1", TestNamespace).
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					Obj(),
+				*utiltesting.MakeWorkload("wl2", TestNamespace).
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac2", State: kueue.CheckStatePending}).
+					Obj(),
+			},
+			oldConfig:         utiltesting.MakeMultiKueueConfig("config1").Clusters("cluster1").Obj(),
+			newConfig:         utiltesting.MakeMultiKueueConfig("config1").Clusters("cluster1", "cluster2").Obj(),
+			expectedQueuedWLs: []string{"wl1"}, // Only wl1 uses config1, wl2 uses other-config
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			clientBuilder := getClientBuilder(ctx)
+
+			for i := range tc.admissionChecks {
+				clientBuilder = clientBuilder.WithObjects(&tc.admissionChecks[i])
+			}
+			for i := range tc.workloads {
+				clientBuilder = clientBuilder.WithObjects(&tc.workloads[i])
+			}
+
+			fakeClient := clientBuilder.Build()
+			handler := &configHandler{client: fakeClient}
+			mockQ := &mockQueue{}
+
+			updateEvent := event.UpdateEvent{
+				ObjectOld: tc.oldConfig,
+				ObjectNew: tc.newConfig,
+			}
+
+			handler.Update(ctx, updateEvent, mockQ)
+
+			var actualQueuedWLs []string
+			for _, req := range mockQ.addedItems {
+				actualQueuedWLs = append(actualQueuedWLs, req.Name)
+			}
+			sort.Strings(actualQueuedWLs)
+			sort.Strings(tc.expectedQueuedWLs)
+
+			if diff := cmp.Diff(tc.expectedQueuedWLs, actualQueuedWLs); diff != "" {
+				t.Errorf("unexpected queued workloads (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestConfigHandlerDelete(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	admissionCheck := utiltesting.MakeAdmissionCheck("ac1").
+		ControllerName(kueue.MultiKueueControllerName).
+		Parameters(kueue.GroupVersion.Group, "MultiKueueConfig", "config1").
+		Obj()
+
+	workload := utiltesting.MakeWorkload("wl1", TestNamespace).
+		AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+		Obj()
+
+	clientBuilder := getClientBuilder(ctx)
+	clientBuilder = clientBuilder.WithObjects(admissionCheck, workload)
+	fakeClient := clientBuilder.Build()
+
+	handler := &configHandler{client: fakeClient}
+	mockQ := &mockQueue{}
+
+	config := utiltesting.MakeMultiKueueConfig("config1").Clusters("cluster1").Obj()
+	deleteEvent := event.DeleteEvent{
+		Object: config,
+	}
+
+	handler.Delete(ctx, deleteEvent, mockQ)
+
+	if len(mockQ.addedItems) != 1 {
+		t.Errorf("expected 1 workload to be queued, got %d", len(mockQ.addedItems))
+	}
+	if mockQ.addedItems[0].Name != "wl1" {
+		t.Errorf("expected workload wl1 to be queued, got %s", mockQ.addedItems[0].Name)
 	}
 }

--- a/test/integration/multikueue/dispatcher_test.go
+++ b/test/integration/multikueue/dispatcher_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -719,5 +720,346 @@ var _ = ginkgo.Describe("MultiKueueDispatcherAllAtOnce", ginkgo.Ordered, ginkgo.
 				g.Expect(state.State).To(gomega.Equal(kueue.CheckStateReady))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
+	})
+})
+var _ = ginkgo.Describe("MultiKueueConfig Re-evaluation", ginkgo.Ordered, func() {
+	var (
+		managerNs *corev1.Namespace
+		worker1Ns *corev1.Namespace
+		worker2Ns *corev1.Namespace
+
+		managerMultiKueueSecret1 *corev1.Secret
+		managerMultiKueueSecret2 *corev1.Secret
+		workerCluster1           *kueue.MultiKueueCluster
+		workerCluster2           *kueue.MultiKueueCluster
+		managerMultiKueueConfig  *kueue.MultiKueueConfig
+		multiKueueAC             *kueue.AdmissionCheck
+		managerCq                *kueue.ClusterQueue
+		managerLq                *kueue.LocalQueue
+
+		worker1Cq *kueue.ClusterQueue
+		worker2Cq *kueue.ClusterQueue
+	)
+
+	ginkgo.BeforeAll(func() {
+		managerTestCluster.fwk.StartManager(managerTestCluster.ctx, managerTestCluster.cfg, func(ctx context.Context, mgr manager.Manager) {
+			managerAndMultiKueueSetup(ctx, mgr, 2*time.Second, defaultEnabledIntegrations, config.MultiKueueDispatcherModeAllAtOnce)
+		})
+	})
+
+	ginkgo.AfterAll(func() {
+		managerTestCluster.fwk.StopManager(managerTestCluster.ctx)
+	})
+
+	ginkgo.BeforeEach(func() {
+		managerNs = util.CreateNamespaceFromPrefixWithLog(managerTestCluster.ctx, managerTestCluster.client, "multikueue-re-eval-")
+		worker1Ns = util.CreateNamespaceWithLog(worker1TestCluster.ctx, worker1TestCluster.client, managerNs.Name)
+		worker2Ns = util.CreateNamespaceWithLog(worker2TestCluster.ctx, worker2TestCluster.client, managerNs.Name)
+
+		w1Kubeconfig, err := worker1TestCluster.kubeConfigBytes()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		w2Kubeconfig, err := worker2TestCluster.kubeConfigBytes()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		managerMultiKueueSecret1 = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "multikueue1-re-eval",
+				Namespace: managersConfigNamespace.Name,
+			},
+			Data: map[string][]byte{
+				kueue.MultiKueueConfigSecretKey: w1Kubeconfig,
+			},
+		}
+		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, managerMultiKueueSecret1)).To(gomega.Succeed())
+
+		managerMultiKueueSecret2 = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "multikueue2-re-eval",
+				Namespace: managersConfigNamespace.Name,
+			},
+			Data: map[string][]byte{
+				kueue.MultiKueueConfigSecretKey: w2Kubeconfig,
+			},
+		}
+		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, managerMultiKueueSecret2)).To(gomega.Succeed())
+
+		workerCluster1 = utiltesting.MakeMultiKueueCluster("worker1-re-eval").KubeConfig(kueue.SecretLocationType, managerMultiKueueSecret1.Name).Obj()
+		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, workerCluster1)).To(gomega.Succeed())
+
+		workerCluster2 = utiltesting.MakeMultiKueueCluster("worker2-re-eval").KubeConfig(kueue.SecretLocationType, managerMultiKueueSecret2.Name).Obj()
+		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, workerCluster2)).To(gomega.Succeed())
+
+		managerMultiKueueConfig = utiltesting.MakeMultiKueueConfig("isolated-config").Clusters(workerCluster1.Name).Obj()
+		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, managerMultiKueueConfig)).To(gomega.Succeed())
+
+		multiKueueAC = utiltesting.MakeAdmissionCheck("isolated-ac").
+			ControllerName(kueue.MultiKueueControllerName).
+			Parameters(kueue.GroupVersion.Group, "MultiKueueConfig", managerMultiKueueConfig.Name).
+			Obj()
+		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, multiKueueAC)).To(gomega.Succeed())
+
+		ginkgo.By("wait for check active", func() {
+			updatedAc := kueue.AdmissionCheck{}
+			acKey := client.ObjectKeyFromObject(multiKueueAC)
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, acKey, &updatedAc)).To(gomega.Succeed())
+				g.Expect(updatedAc.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.AdmissionCheckActive))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		managerCq = utiltesting.MakeClusterQueue("isolated-cq").
+			AdmissionChecks(kueue.AdmissionCheckReference(multiKueueAC.Name)).
+			Obj()
+		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, managerCq)).To(gomega.Succeed())
+		util.ExpectClusterQueuesToBeActive(managerTestCluster.ctx, managerTestCluster.client, managerCq)
+
+		managerLq = utiltesting.MakeLocalQueue("isolated-lq", managerNs.Name).ClusterQueue(managerCq.Name).Obj()
+		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, managerLq)).To(gomega.Succeed())
+		util.ExpectLocalQueuesToBeActive(managerTestCluster.ctx, managerTestCluster.client, managerLq)
+
+		worker1Cq = utiltesting.MakeClusterQueue("q1-re-eval").Obj()
+		gomega.Expect(worker1TestCluster.client.Create(worker1TestCluster.ctx, worker1Cq)).Should(gomega.Succeed())
+
+		worker2Cq = utiltesting.MakeClusterQueue("q1-re-eval").Obj()
+		gomega.Expect(worker2TestCluster.client.Create(worker2TestCluster.ctx, worker2Cq)).Should(gomega.Succeed())
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(managerTestCluster.ctx, managerTestCluster.client, managerNs)).To(gomega.Succeed())
+		gomega.Expect(util.DeleteNamespace(worker1TestCluster.ctx, worker1TestCluster.client, worker1Ns)).To(gomega.Succeed())
+		gomega.Expect(util.DeleteNamespace(worker2TestCluster.ctx, worker2TestCluster.client, worker2Ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, managerCq, true)
+		util.ExpectObjectToBeDeleted(worker1TestCluster.ctx, worker1TestCluster.client, worker1Cq, true)
+		util.ExpectObjectToBeDeleted(worker2TestCluster.ctx, worker2TestCluster.client, worker2Cq, true)
+		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, multiKueueAC, true)
+		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, managerMultiKueueConfig, true)
+		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, workerCluster1, true)
+		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, workerCluster2, true)
+		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, managerMultiKueueSecret1, true)
+		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, managerMultiKueueSecret2, true)
+	})
+
+	ginkgo.It("should create workload that requires more CPU than worker1 can provide", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueBatchJobWithManagedBy, true)
+		job := testingjob.MakeJob("cpu-job", managerNs.Name).
+			ManagedBy(kueue.MultiKueueControllerName).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
+			Request(corev1.ResourceCPU, "100m").
+			Obj()
+		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, job)).To(gomega.Succeed())
+	})
+
+	ginkgo.It("should initially nominate only worker1 and set reservation", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueBatchJobWithManagedBy, true)
+		createdWorkload := &kueue.Workload{}
+		admission := utiltesting.MakeAdmission(managerCq.Name).Obj()
+
+		job := testingjob.MakeJob("cpu-job", managerNs.Name).
+			ManagedBy(kueue.MultiKueueControllerName).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
+			Request(corev1.ResourceCPU, "100m").
+			Obj()
+		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, job)).To(gomega.Succeed())
+		workloadLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
+
+		gomega.Eventually(func() error {
+			if err := managerTestCluster.client.Get(managerTestCluster.ctx, workloadLookupKey, createdWorkload); err != nil {
+				return err
+			}
+			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, workloadLookupKey, admission)
+			return nil
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		gomega.Eventually(func(g gomega.Gomega) {
+			managerWorkload := &kueue.Workload{}
+			g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, workloadLookupKey, managerWorkload)).To(gomega.Succeed())
+			g.Expect(managerWorkload.Status.NominatedClusterNames).To(gomega.ConsistOf(workerCluster1.Name))
+			g.Expect(managerWorkload.Status.ClusterName).To(gomega.BeNil())
+
+			remoteWorkload := &kueue.Workload{}
+			g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, workloadLookupKey, remoteWorkload)).To(gomega.Succeed())
+
+			g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, workloadLookupKey, remoteWorkload)).To(utiltesting.BeNotFoundError())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("should re-evaluate existing workload when worker2 is added to config", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueBatchJobWithManagedBy, true)
+
+		// First, create a workload when only worker1 is in the config
+		job := testingjob.MakeJob("cpu-job", managerNs.Name).
+			ManagedBy(kueue.MultiKueueControllerName).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
+			Request(corev1.ResourceCPU, "100m").
+			Obj()
+		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, job)).To(gomega.Succeed())
+		workloadLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
+
+		// Set quota reservation to trigger MultiKueue processing
+		createdWorkload := &kueue.Workload{}
+		admission := utiltesting.MakeAdmission(managerCq.Name).Obj()
+		gomega.Eventually(func() error {
+			if err := managerTestCluster.client.Get(managerTestCluster.ctx, workloadLookupKey, createdWorkload); err != nil {
+				return err
+			}
+			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, workloadLookupKey, admission)
+			return nil
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		// Verify workload initially only sees worker1
+		gomega.Eventually(func(g gomega.Gomega) {
+			managerWorkload := &kueue.Workload{}
+			g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, workloadLookupKey, managerWorkload)).To(gomega.Succeed())
+			g.Expect(managerWorkload.Status.NominatedClusterNames).To(gomega.ConsistOf(workerCluster1.Name))
+
+			// Workload should be created on worker1
+			remoteWorkload := &kueue.Workload{}
+			g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, workloadLookupKey, remoteWorkload)).To(gomega.Succeed())
+
+			// But not on worker2 (not in config yet)
+			g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, workloadLookupKey, remoteWorkload)).To(utiltesting.BeNotFoundError())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		// Now add worker2 to the MultiKueueConfig
+		gomega.Eventually(func() error {
+			if err := managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(managerMultiKueueConfig), managerMultiKueueConfig); err != nil {
+				return err
+			}
+			managerMultiKueueConfig.Spec.Clusters = []string{workerCluster1.Name, workerCluster2.Name}
+			return managerTestCluster.client.Update(managerTestCluster.ctx, managerMultiKueueConfig)
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		// Wait for admission check to remain active with both clusters
+		gomega.Eventually(func(g gomega.Gomega) {
+			updatedAdmissionCheck := kueue.AdmissionCheck{}
+			g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(multiKueueAC), &updatedAdmissionCheck)).To(gomega.Succeed())
+			g.Expect(updatedAdmissionCheck.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.AdmissionCheckActive))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		// Wait for worker2 cluster to become active
+		gomega.Eventually(func(g gomega.Gomega) {
+			cluster2 := &kueue.MultiKueueCluster{}
+			g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(workerCluster2), cluster2)).To(gomega.Succeed())
+			g.Expect(cluster2.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.MultiKueueClusterActive))
+		}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+
+		// Verify existing workload gets re-evaluated and sees both workers
+		gomega.Eventually(func(g gomega.Gomega) {
+			managerWorkload := &kueue.Workload{}
+			g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, workloadLookupKey, managerWorkload)).To(gomega.Succeed())
+			actualClusters := sets.New(managerWorkload.Status.NominatedClusterNames...)
+			g.Expect(actualClusters.Has(workerCluster2.Name)).To(gomega.BeTrue(),
+				"workload should see worker2 after it's added to MultiKueueConfig")
+			g.Expect(actualClusters.Has(workerCluster1.Name)).To(gomega.BeTrue(),
+				"workload should still see worker1")
+		}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+
+		// Verify workloads get created on both worker clusters
+		gomega.Eventually(func(g gomega.Gomega) {
+			remoteWorkload1 := &kueue.Workload{}
+			g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, workloadLookupKey, remoteWorkload1)).To(gomega.Succeed())
+			remoteWorkload2 := &kueue.Workload{}
+			g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, workloadLookupKey, remoteWorkload2)).To(gomega.Succeed())
+		}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("should assign workload to worker2 after reservation", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueBatchJobWithManagedBy, true)
+
+		// Configure worker1 with 50m CPU (insufficient)
+		worker1ResourceFlavor := utiltesting.MakeResourceFlavor("w1-re-eval-flavor").Obj()
+		gomega.Expect(worker1TestCluster.client.Create(worker1TestCluster.ctx, worker1ResourceFlavor)).To(gomega.Succeed())
+		gomega.Eventually(func() error {
+			if err := worker1TestCluster.client.Get(worker1TestCluster.ctx, client.ObjectKeyFromObject(worker1Cq), worker1Cq); err != nil {
+				return err
+			}
+			worker1Cq.Spec.ResourceGroups = []kueue.ResourceGroup{
+				{
+					CoveredResources: []corev1.ResourceName{corev1.ResourceCPU},
+					Flavors: []kueue.FlavorQuotas{
+						*utiltesting.MakeFlavorQuotas("w1-re-eval-flavor").Resource(corev1.ResourceCPU, "50m").Obj(),
+					},
+				},
+			}
+			return worker1TestCluster.client.Update(worker1TestCluster.ctx, worker1Cq)
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		// Configure worker2 with 200m CPU (sufficient)
+		worker2ResourceFlavor := utiltesting.MakeResourceFlavor("w2-re-eval-flavor").Obj()
+		gomega.Expect(worker2TestCluster.client.Create(worker2TestCluster.ctx, worker2ResourceFlavor)).To(gomega.Succeed())
+		gomega.Eventually(func() error {
+			if err := worker2TestCluster.client.Get(worker2TestCluster.ctx, client.ObjectKeyFromObject(worker2Cq), worker2Cq); err != nil {
+				return err
+			}
+			worker2Cq.Spec.ResourceGroups = []kueue.ResourceGroup{
+				{
+					CoveredResources: []corev1.ResourceName{corev1.ResourceCPU},
+					Flavors: []kueue.FlavorQuotas{
+						*utiltesting.MakeFlavorQuotas("w2-re-eval-flavor").Resource(corev1.ResourceCPU, "200m").Obj(),
+					},
+				},
+			}
+			return worker2TestCluster.client.Update(worker2TestCluster.ctx, worker2Cq)
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		util.ExpectClusterQueuesToBeActive(worker1TestCluster.ctx, worker1TestCluster.client, worker1Cq)
+		util.ExpectClusterQueuesToBeActive(worker2TestCluster.ctx, worker2TestCluster.client, worker2Cq)
+
+		// Update the config to include both clusters
+		gomega.Eventually(func() error {
+			if err := managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(managerMultiKueueConfig), managerMultiKueueConfig); err != nil {
+				return err
+			}
+			managerMultiKueueConfig.Spec.Clusters = []string{workerCluster1.Name, workerCluster2.Name}
+			return managerTestCluster.client.Update(managerTestCluster.ctx, managerMultiKueueConfig)
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		admission := utiltesting.MakeAdmission(managerCq.Name).Obj()
+
+		job := testingjob.MakeJob("cpu-job", managerNs.Name).
+			ManagedBy(kueue.MultiKueueControllerName).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
+			Request(corev1.ResourceCPU, "100m").
+			Obj()
+		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, job)).To(gomega.Succeed())
+		workloadLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
+
+		// First, wait for workload to be created on manager cluster and set reservation
+		createdWorkload := &kueue.Workload{}
+		gomega.Eventually(func() error {
+			if err := managerTestCluster.client.Get(managerTestCluster.ctx, workloadLookupKey, createdWorkload); err != nil {
+				return err
+			}
+			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, workloadLookupKey, admission)
+			return nil
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		// Wait for workload to be propagated to worker2 and set reservation there
+		gomega.Eventually(func(g gomega.Gomega) {
+			remoteWorkload := &kueue.Workload{}
+			g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, workloadLookupKey, remoteWorkload)).To(gomega.Succeed())
+			util.SetQuotaReservation(worker2TestCluster.ctx, worker2TestCluster.client, workloadLookupKey, admission)
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		gomega.Eventually(func(g gomega.Gomega) {
+			remoteWorkload := &kueue.Workload{}
+			g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, workloadLookupKey, remoteWorkload)).To(utiltesting.BeNotFoundError())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		gomega.Eventually(func(g gomega.Gomega) {
+			managerWorkload := &kueue.Workload{}
+			g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, workloadLookupKey, managerWorkload)).To(gomega.Succeed())
+			g.Expect(managerWorkload.Status.ClusterName).ToNot(gomega.BeNil(),
+				"workload should be assigned to a worker cluster")
+			assignedCluster := *managerWorkload.Status.ClusterName
+			g.Expect(assignedCluster).To(gomega.Equal(workerCluster2.Name),
+				"workload should be assigned to worker2 (200m CPU) not worker1 (50m CPU)")
+			g.Expect(managerWorkload.Status.NominatedClusterNames).To(gomega.BeEmpty(),
+				"nominated clusters should be cleared when workload is assigned")
+			admissionCheckState := admissioncheck.FindAdmissionCheck(managerWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
+			g.Expect(admissionCheckState).ToNot(gomega.BeNil())
+			g.Expect(admissionCheckState.State).To(gomega.Equal(kueue.CheckStateReady))
+		}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 	})
 })


### PR DESCRIPTION
Cherry pick of #6732 on release-0.14.

#6732: Fix MultiKueue workload re-evaluation bug

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix existing workloads not being re-evaluated when new clusters are added to MultiKueueConfig. Previously, only newly created workloads would see updated cluster lists.
```