### PR TITLE
Automated cherry pick of #6732: Fix MultiKueue workload re-evaluation bug

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/indexer.go
+++ b/pkg/controller/admissionchecks/multikueue/indexer.go
@@ -35,7 +35,9 @@ const (
 	WorkloadsWithAdmissionCheckKey = "status.admissionChecks"
 )
 
-var configGVK = kueue.GroupVersion.WithKind("MultiKueueConfig")
+var (
+	configGVK = kueue.GroupVersion.WithKind("MultiKueueConfig")
+)
 
 func getIndexUsingKubeConfigs(configNamespace string) func(obj client.Object) []string {
 	return func(obj client.Object) []string {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -54,7 +54,9 @@ import (
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
-var realClock = clock.RealClock{}
+var (
+	realClock = clock.RealClock{}
+)
 
 type wlReconciler struct {
 	client            client.Client
@@ -558,7 +560,8 @@ func newWlReconciler(c client.Client, helper *admissioncheck.MultiKueueStoreHelp
 }
 
 type configHandler struct {
-	client client.Client
+	client            client.Client
+	eventsBatchPeriod time.Duration
 }
 
 func (c *configHandler) Create(context.Context, event.CreateEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
@@ -595,11 +598,13 @@ func (c *configHandler) Generic(context.Context, event.GenericEvent, workqueue.T
 
 func (c *configHandler) queueWorkloadsForConfig(ctx context.Context, configName string, q workqueue.TypedRateLimitingInterface[reconcile.Request]) error {
 	admissionChecks := &kueue.AdmissionCheckList{}
+	var errs []error
+
 	if err := c.client.List(ctx, admissionChecks, client.MatchingFields{AdmissionCheckUsingConfigKey: configName}); err != nil {
-		return err
+		errs = append(errs, err)
+		return errors.Join(errs...)
 	}
 
-	var errs []error
 	for _, admissionCheck := range admissionChecks.Items {
 		workloads := &kueue.WorkloadList{}
 		if err := c.client.List(ctx, workloads, client.MatchingFields{WorkloadsWithAdmissionCheckKey: admissionCheck.Name}); err != nil {
@@ -607,7 +612,7 @@ func (c *configHandler) queueWorkloadsForConfig(ctx context.Context, configName 
 			continue
 		}
 		for _, workload := range workloads.Items {
-			q.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&workload)})
+			q.AddAfter(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&workload)}, c.eventsBatchPeriod)
 		}
 	}
 	return errors.Join(errs...)
@@ -627,7 +632,7 @@ func (w *wlReconciler) setupWithManager(mgr ctrl.Manager) error {
 		Named("multikueue_workload").
 		For(&kueue.Workload{}).
 		WatchesRawSource(source.Channel(w.clusters.wlUpdateCh, syncHndl)).
-		Watches(&kueue.MultiKueueConfig{}, &configHandler{client: w.client}).
+		Watches(&kueue.MultiKueueConfig{}, &configHandler{client: w.client, eventsBatchPeriod: w.eventsBatchPeriod}).
 		WithEventFilter(w).
 		Complete(w)
 }

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -1754,16 +1754,18 @@ func (m *mockQueue) Add(item reconcile.Request) {
 	m.addedItems = append(m.addedItems, item)
 }
 
-func (m *mockQueue) Len() int                                  { return 0 }
-func (m *mockQueue) Get() (reconcile.Request, bool)            { return reconcile.Request{}, false }
-func (m *mockQueue) Done(reconcile.Request)                    {}
-func (m *mockQueue) Forget(reconcile.Request)                  {}
-func (m *mockQueue) NumRequeues(reconcile.Request) int         { return 0 }
-func (m *mockQueue) AddRateLimited(reconcile.Request)          {}
-func (m *mockQueue) AddAfter(reconcile.Request, time.Duration) {}
-func (m *mockQueue) ShutDown()                                 {}
-func (m *mockQueue) ShutDownWithDrain()                        {}
-func (m *mockQueue) ShuttingDown() bool                        { return false }
+func (m *mockQueue) Len() int                          { return 0 }
+func (m *mockQueue) Get() (reconcile.Request, bool)    { return reconcile.Request{}, false }
+func (m *mockQueue) Done(reconcile.Request)            {}
+func (m *mockQueue) Forget(reconcile.Request)          {}
+func (m *mockQueue) NumRequeues(reconcile.Request) int { return 0 }
+func (m *mockQueue) AddRateLimited(reconcile.Request)  {}
+func (m *mockQueue) AddAfter(item reconcile.Request, duration time.Duration) {
+	m.addedItems = append(m.addedItems, item)
+}
+func (m *mockQueue) ShutDown()          {}
+func (m *mockQueue) ShutDownWithDrain() {}
+func (m *mockQueue) ShuttingDown() bool { return false }
 
 func TestConfigHandlerUpdate(t *testing.T) {
 	cases := map[string]struct {
@@ -1846,7 +1848,7 @@ func TestConfigHandlerUpdate(t *testing.T) {
 			}
 
 			fakeClient := clientBuilder.Build()
-			handler := &configHandler{client: fakeClient}
+			handler := &configHandler{client: fakeClient, eventsBatchPeriod: time.Second}
 			mockQ := &mockQueue{}
 
 			updateEvent := event.UpdateEvent{
@@ -1886,7 +1888,7 @@ func TestConfigHandlerDelete(t *testing.T) {
 	clientBuilder = clientBuilder.WithObjects(admissionCheck, workload)
 	fakeClient := clientBuilder.Build()
 
-	handler := &configHandler{client: fakeClient}
+	handler := &configHandler{client: fakeClient, eventsBatchPeriod: time.Second}
 	mockQ := &mockQueue{}
 
 	config := utiltesting.MakeMultiKueueConfig("config1").Clusters("cluster1").Obj()

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1042,6 +1042,16 @@ func ExpectLocalQueuesToBeActive(ctx context.Context, c client.Client, lqs ...*k
 	}, Timeout, Interval).Should(gomega.Succeed())
 }
 
+func ExpectAdmissionChecksToBeActive(ctx context.Context, c client.Client, acs ...*kueue.AdmissionCheck) {
+	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
+		readAc := &kueue.AdmissionCheck{}
+		for _, ac := range acs {
+			g.Expect(c.Get(ctx, client.ObjectKeyFromObject(ac), readAc)).To(gomega.Succeed())
+			g.Expect(readAc.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.AdmissionCheckActive))
+		}
+	}, Timeout, Interval).Should(gomega.Succeed())
+}
+
 func ExpectJobUnsuspendedWithNodeSelectors(ctx context.Context, c client.Client, key types.NamespacedName, nodeSelector map[string]string) {
 	job := &batchv1.Job{}
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {


### PR DESCRIPTION
Cherry pick of #6732 on release-0.14.

#6732: Fix MultiKueue workload re-evaluation bug

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```