### PR TITLE
services: add label app to services to be able to use a labelSelector

### DIFF
--- a/charts/kueue/templates/_helpers.tpl
+++ b/charts/kueue/templates/_helpers.tpl
@@ -56,7 +56,31 @@ Labels for metrics service
 */}}
 {{- define "kueue.metricsService.labels" -}}
 {{ include "kueue.labels" . }}
-app.kubernetes.io/component: metrics
+app.kubernetes.io/component: metrics-service
+{{- end }}
+
+{{/*
+Labels for webhook service
+*/}}
+{{- define "kueue.webhookService.labels" -}}
+{{ include "kueue.labels" . }}
+app.kubernetes.io/component: webhook-service
+{{- end }}
+
+{{/*
+Labels for visibility service
+*/}}
+{{- define "kueue.visibilityService.labels" -}}
+{{ include "kueue.labels" . }}
+app.kubernetes.io/component: visibility-service
+{{- end }}
+
+{{/*
+Labels for controller-manager
+*/}}
+{{- define "kueue.controllerManager.labels" -}}
+{{ include "kueue.labels" . }}
+app.kubernetes.io/component: controller
 {{- end }}
 
 {{/*

--- a/charts/kueue/templates/manager/manager.yaml
+++ b/charts/kueue/templates/manager/manager.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "kueue.fullname" . }}-controller-manager
   namespace: '{{ .Release.Namespace }}'
   labels:
-  {{- include "kueue.labels" . | nindent 4 }}
+  {{- include "kueue.controllerManager.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.controllerManager.replicas }}
   selector:

--- a/charts/kueue/templates/visibility/apiservice_v1beta1.yaml
+++ b/charts/kueue/templates/visibility/apiservice_v1beta1.yaml
@@ -8,7 +8,7 @@ metadata:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-visibility-server-cert'
   {{- end }}
   labels:
-  {{- include "kueue.labels" . | nindent 4 }}
+  {{- include "kueue.visibilityService.labels" . | nindent 4 }}
   name: v1beta1.visibility.kueue.x-k8s.io
 spec:
   {{- if not .Values.enableCertManager }}

--- a/charts/kueue/templates/visibility/role_binding.yaml
+++ b/charts/kueue/templates/visibility/role_binding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-  {{- include "kueue.labels" . | nindent 4 }}
+  {{- include "kueue.visibilityService.labels" . | nindent 4 }}
   name: '{{ include "kueue.fullname" . }}-visibility-server-auth-reader'
   namespace: kube-system
 roleRef:

--- a/charts/kueue/templates/visibility/service.yaml
+++ b/charts/kueue/templates/visibility/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-  {{- include "kueue.labels" . | nindent 4 }}
+  {{- include "kueue.visibilityService.labels" . | nindent 4 }}
   name: '{{ include "kueue.fullname" . }}-visibility-server'
   namespace: '{{ .Release.Namespace }}'
 spec:

--- a/charts/kueue/templates/webhook/service.yaml
+++ b/charts/kueue/templates/webhook/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-  {{- include "kueue.labels" . | nindent 4 }}
+  {{- include "kueue.webhookService.labels" . | nindent 4 }}
   name: '{{ include "kueue.fullname" . }}-webhook-service'
   namespace: '{{ .Release.Namespace }}'
 spec:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -11,7 +11,6 @@ namePrefix: kueue-
 labels:
   - pairs:
       app.kubernetes.io/name: kueue
-      app.kubernetes.io/component: controller
     includeTemplates: true
   - pairs:
       control-plane: controller-manager
@@ -51,6 +50,40 @@ patches:
 
 # Expose port used by the metrics service
 - path: manager_metrics_patch.yaml
+
+# Add component labels to services
+- patch: |-
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: webhook-service
+      namespace: system
+      labels:
+        app.kubernetes.io/component: webhook-service
+- patch: |-
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: visibility-server
+      namespace: kueue-system
+      labels:
+        app.kubernetes.io/component: visibility-service
+- patch: |-
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: controller-manager-metrics-service
+      namespace: system
+      labels:
+        app.kubernetes.io/component: metrics-service
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: controller-manager
+      namespace: system
+      labels:
+        app.kubernetes.io/component: controller
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.

--- a/hack/processing-plan.yaml
+++ b/hack/processing-plan.yaml
@@ -104,7 +104,7 @@ files:
         key: .metadata
         value: |
           labels:
-          {{- include "kueue.labels" . | nindent 4 }}
+          {{- include "kueue.visibilityService.labels" . | nindent 4 }}
         indentation: 2
       - type: INSERT_TEXT
         key: .spec
@@ -191,7 +191,7 @@ files:
         key: .metadata
         value: |
           labels:
-          {{- include "kueue.labels" . | nindent 4 }}
+          {{- include "kueue.webhookService.labels" . | nindent 4 }}
         indentation: 2
       - type: INSERT_TEXT
         key: .spec.type


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR is trivial though important. There is not a current way to individually select a service by a labelSelector. For instance, `control-plane: controller-manager` matches numerous components.

It becomes more important when wiring up Prometheus to a specific endpoint. Not all the services export a /metrics endpoint thus causing Prometheus to fail on requests to that endpoint, so matching on everything with `control-plane: controller-manager` does not work.

The PR adds a unique label - the same name as the service - so a labelSelector can be used to select a particular service.

_I would like to request this patch be backported to 0.14._

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Services: fix the setting of the `app.kubernetes.io/component` label to discriminate between different service components within Kueue as follows:
- controller-manager-metrics-service for kueue-controller-manager-metrics-service 
- visibility-service for kueue-visibility-server
- webhook-service for kueue-webhook-service
```