### PR TITLE
[Trainer] Use podset label to identify Kueue injected config

### DIFF
--- a/test/e2e/singlecluster/tas_test.go
+++ b/test/e2e/singlecluster/tas_test.go
@@ -18,7 +18,6 @@ package e2e
 
 import (
 	"fmt"
-	"strconv"
 
 	kftrainerapi "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/onsi/ginkgo/v2"
@@ -523,12 +522,8 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 			})
 
 			ginkgo.By("verify the TrainJob has nodeSelector set", func() {
-				firstKueueOverride, exists := trainjob.Annotations["kueue.x-k8s.io/trainjob-override-idx"]
-				gomega.Expect(exists).Should(gomega.BeTrue())
-				firstKueueOverrideIdx, err := strconv.Atoi(firstKueueOverride)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				gomega.Expect(trainjob.Spec.PodTemplateOverrides[firstKueueOverrideIdx].Spec.NodeSelector).To(gomega.Equal(
+				gomega.Expect(trainjob.Spec.PodTemplateOverrides).To(gomega.HaveLen(2))
+				gomega.Expect(trainjob.Spec.PodTemplateOverrides[1].Spec.NodeSelector).To(gomega.Equal(
 					map[string]string{
 						"instance-type": "on-demand",
 					},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
In order to inject the scheduling config at job resume time, Kueue uses the PodTemplateOverride API of the Trainjob object. 
The current implementation makes use of a ad-hoc annotation to identify on which entry the Kueue config starts. 

This implementation is brittle and hard to reason  about, so this PR replaces it by identifying the Kueue config entries by the `podset` label

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #7000

#### Special notes for your reviewer:
As agreed, the final implementation would make use of a potential `manager` field in the `PodTemplateOverrides` object

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```