### PR TITLE
Fix preemption logic to only check borrowing constraints for resources requiring preemption

### DIFF
--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -503,7 +503,8 @@ func cqIsBorrowing(cq *schdcache.ClusterQueueSnapshot, frsNeedPreemption sets.Se
 // if it belongs to one.
 func workloadFits(preemptionCtx *preemptionCtx, allowBorrowing bool) bool {
 	for fr, v := range preemptionCtx.workloadUsage.Quota {
-		if !allowBorrowing && preemptionCtx.preemptorCQ.BorrowingWith(fr, v) {
+		_, needsPreemption := preemptionCtx.frsNeedPreemption[fr]
+		if needsPreemption && !allowBorrowing && preemptionCtx.preemptorCQ.BorrowingWith(fr, v) {
 			return false
 		}
 		if v > preemptionCtx.preemptorCQ.Available(fr) {

--- a/test/integration/singlecluster/scheduler/preemption_test.go
+++ b/test/integration/singlecluster/scheduler/preemption_test.go
@@ -1095,13 +1095,13 @@ var _ = ginkgo.Describe("Preemption", func() {
 				Cohort("gpu-cohort").
 				ResourceGroup(
 					*utiltestingapi.MakeFlavorQuotas("alpha").
-						Resource(corev1.ResourceCPU, "10", "100"). // nominal=10, can borrow up to 100
+						Resource(corev1.ResourceCPU, "10", "100").        // nominal=10, can borrow up to 100
 						Resource(corev1.ResourceMemory, "20Gi", "200Gi"). // nominal=20Gi, can borrow up to 200Gi
 						Obj(),
 				).
 				ResourceGroup(
 					*utiltestingapi.MakeFlavorQuotas("beta").
-						Resource("vcuda-core", "100", "0"). // nominal=100, no borrowing
+						Resource("vcuda-core", "100", "0").    // nominal=100, no borrowing
 						Resource("vcuda-memory", "1000", "0"). // nominal=1000, no borrowing
 						Obj(),
 				).
@@ -1126,7 +1126,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 				).
 				ResourceGroup(
 					*utiltestingapi.MakeFlavorQuotas("beta").
-						Resource("vcuda-core", "10", "100"). // nominal=10, can borrow up to 100
+						Resource("vcuda-core", "10", "100").     // nominal=10, can borrow up to 100
 						Resource("vcuda-memory", "100", "1000"). // nominal=100, can borrow up to 1000
 						Obj(),
 				).
@@ -1170,7 +1170,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 			util.MustCreate(ctx, k8sClient, betaWl1)
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, betaCQ.Name, betaWl1)
 
-			ginkgo.By("Creating a high priority workload in alpha-cq that uses vcuda resources and borrows CPU/Memory")
+			ginkgo.By("Creating a workload in alpha-cq that uses vcuda resources and borrows CPU/Memory")
 			// This workload:
 			// - Uses 20 CPU (borrows 20 from betaCQ, as alphaCQ already used 20)
 			// - Uses 40Gi memory (borrows 40Gi from betaCQ, as alphaCQ already used 40Gi)
@@ -1185,16 +1185,16 @@ var _ = ginkgo.Describe("Preemption", func() {
 				Obj()
 			util.MustCreate(ctx, k8sClient, alphaWlPreempting)
 
-			// The alphaWlPreempting workload should trigger preemption of the betaWl1 workload
+			ginkgo.By("The alphaWlPreempting workload should trigger preemption of the betaWl1 workload.")
 			// CPU and memory can be borrowed from beta-cq and should not block the reclamation of vCUDA resources from beta-cq.
 			util.ExpectWorkloadsToBePreempted(ctx, k8sClient, betaWl1)
 			util.FinishEvictionForWorkloads(ctx, k8sClient, betaWl1)
 
-			// Verify the high priority workload is admitted
+			ginkgo.By("Verifying the workload requiring preemption has been admitted.")
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, alphaCQ.Name, alphaWlPreempting)
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, betaWl1)
 
-			// The workload that was borrowing should still be admitted
+			ginkgo.By("The alphaWl1 workload that was borrowing should still be admitted.")
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, alphaCQ.Name, alphaWl1)
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The `workloadFits` function incorrectly fails preemption when any resource requires borrowing, even if the resources that actually need preemption (specified in `frsNeedPreemption`) are available after preemption.

Actual issue encountered:

The following queue fails to reclaim `vcuda-memory` and `vcuda-ratio` resources because CPU and memory have borrowed resources from other queues. This causes the reclamation of `vcuda-memory` and `vcuda-ratio` to fail, which is undesirable—since reclaiming only `vcuda-memory` and `vcuda-ratio` should be sufficient for our job to be handled by the admit
```
apiVersion: kueue.x-k8s.io/v1beta1
  kind: ClusterQueue
  metadata:
    finalizers:
    - kueue.x-k8s.io/resource-in-use
    generation: 5
    name: queue-3e
  spec:
    cohort: group-60
    flavorFungibility:
      whenCanBorrow: Borrow
      whenCanPreempt: Preempt
    preemption:
      borrowWithinCohort:
        policy: Never
      reclaimWithinCohort: Any
      withinClusterQueue: Never
    queueingStrategy: BestEffortFIFO
    resourceGroups:
    - coveredResources:
      - cpu
      - memory
      - pods
      - storage
      - rdma_devices
      flavors:
      - name: group-60-normal
        resources:
        - borrowingLimit: "40"
          name: cpu
          nominalQuota: "660"
        - borrowingLimit: 250Gi
          name: memory
          nominalQuota: 3450Gi
        - borrowingLimit: "2147483647"
          name: pods
          nominalQuota: "2147483647"
        - borrowingLimit: "35183298347008"
          name: storage
          nominalQuota: "35183298347008"
        - borrowingLimit: "35183298347008"
          name: rdma_devices
          nominalQuota: "35183298347008

    - coveredResources:
      - vcuda-core
      - vcuda-ratio
      - vcuda-memory
      flavors:
      - name: group-60-b
        resources:
        - borrowingLimit: "0"
          name: vcuda-core
          nominalQuota: "560"
        - borrowingLimit: "0"
          name: vcuda-ratio
          nominalQuota: "3500"
        - borrowingLimit: "0"
          name: vcuda-memory
          nominalQuota: "6265"
    stopPolicy: None

flavorsUsage:
    - name: group-60-normal
      resources:
      - borrowed: 8900m
        name: cpu
        total: 668900m
      - borrowed: "0"
        name: rdma_devices
        total: "0"
      - borrowed: 79700Mi
        name: memory
        total: 3612500Mi
      - borrowed: "0"
        name: pods
        total: "34"
      - borrowed: "0"
        name: storage
        total: "0"

    - name: group-60-b
      resources:
      - borrowed: "0"
        name: vcuda-core
        total: "34"
      - borrowed: "0"
        name: vcuda-memory
        total: "5186"
      - borrowed: "0"
        name: vcuda-ratio
        total: "2900"
```

**Root Cause**
```
// Before fix - checks ALL resources
for fr, v := range preemptionCtx.workloadUsage.Quota {
    if !allowBorrowing && preemptionCtx.preemptorCQ.BorrowingWith(fr, v) {
        return false  // ❌ Fails if ANY resource needs borrowing
    }
}
```

**Solution**
Only check borrowing constraints for resources that actually require preemption:
```
// After fix - only checks resources needing preemption
for fr, v := range preemptionCtx.workloadUsage.Quota {
    _, needsPreemption := preemptionCtx.frsNeedPreemption[fr]
    if needsPreemption && !allowBorrowing && preemptionCtx.preemptorCQ.BorrowingWith(fr, v) {
        return false  // ✅ Only fails if preemption-needed resources need borrowing
    }
}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7393

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed an issue where reclaiming resources from one resource group would incorrectly fail due to borrowed usage in a different resource group. Reclamation now validates only the resources being reclaimed, enabling jobs to be admitted as soon as sufficient quota is freed. No user action required.
```