### PR TITLE
Helm: request conversion webhooks only for types requiring it

### DIFF
--- a/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
@@ -12,16 +12,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.19.0
   name: admissionchecks.kueue.x-k8s.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: '{{ include "kueue.fullname" . }}-webhook-service'
-          namespace: '{{ .Release.Namespace }}'
-          path: /convert
-      conversionReviewVersions:
-        - v1
   group: kueue.x-k8s.io
   names:
     kind: AdmissionCheck

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_cohorts.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_cohorts.yaml
@@ -12,16 +12,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.19.0
   name: cohorts.kueue.x-k8s.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: '{{ include "kueue.fullname" . }}-webhook-service'
-          namespace: '{{ .Release.Namespace }}'
-          path: /convert
-      conversionReviewVersions:
-        - v1
   group: kueue.x-k8s.io
   names:
     kind: Cohort

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
@@ -12,16 +12,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.19.0
   name: multikueueclusters.kueue.x-k8s.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: '{{ include "kueue.fullname" . }}-webhook-service'
-          namespace: '{{ .Release.Namespace }}'
-          path: /convert
-      conversionReviewVersions:
-        - v1
   group: kueue.x-k8s.io
   names:
     kind: MultiKueueCluster

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueconfigs.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueconfigs.yaml
@@ -12,16 +12,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.19.0
   name: multikueueconfigs.kueue.x-k8s.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: '{{ include "kueue.fullname" . }}-webhook-service'
-          namespace: '{{ .Release.Namespace }}'
-          path: /convert
-      conversionReviewVersions:
-        - v1
   group: kueue.x-k8s.io
   names:
     kind: MultiKueueConfig

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_provisioningrequestconfigs.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_provisioningrequestconfigs.yaml
@@ -12,16 +12,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.19.0
   name: provisioningrequestconfigs.kueue.x-k8s.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: '{{ include "kueue.fullname" . }}-webhook-service'
-          namespace: '{{ .Release.Namespace }}'
-          path: /convert
-      conversionReviewVersions:
-        - v1
   group: kueue.x-k8s.io
   names:
     kind: ProvisioningRequestConfig

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
@@ -12,16 +12,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.19.0
   name: resourceflavors.kueue.x-k8s.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: '{{ include "kueue.fullname" . }}-webhook-service'
-          namespace: '{{ .Release.Namespace }}'
-          path: /convert
-      conversionReviewVersions:
-        - v1
   group: kueue.x-k8s.io
   names:
     kind: ResourceFlavor

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_topologies.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_topologies.yaml
@@ -12,16 +12,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.19.0
   name: topologies.kueue.x-k8s.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: '{{ include "kueue.fullname" . }}-webhook-service'
-          namespace: '{{ .Release.Namespace }}'
-          path: /convert
-      conversionReviewVersions:
-        - v1
   group: kueue.x-k8s.io
   names:
     kind: Topology

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloadpriorityclasses.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloadpriorityclasses.yaml
@@ -12,16 +12,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.19.0
   name: workloadpriorityclasses.kueue.x-k8s.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: '{{ include "kueue.fullname" . }}-webhook-service'
-          namespace: '{{ .Release.Namespace }}'
-          path: /convert
-      conversionReviewVersions:
-        - v1
   group: kueue.x-k8s.io
   names:
     kind: WorkloadPriorityClass

--- a/hack/processing-plan.yaml
+++ b/hack/processing-plan.yaml
@@ -8,6 +8,7 @@ files:
     operations:
       - type: INSERT_OBJECT
         key: .spec
+        onFileCondition: '{"Workload": true, "LocalQueue": true, "ClusterQueue": true}[.spec.names.kind]'
         value: |
           conversion:
               strategy: Webhook


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Part of #7113

#### Special notes for your reviewer:

We should disable conversion webhooks for all types not supporting them. Otherwise attempts to use v1beta2 fail.

No release note because this only a problem for the coming 0.15 release which will support for v1beta1 and v1beta2.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```