### PR TITLE
formatting issue: add space after comments for apigeneration tags

### DIFF
--- a/apis/kueue/v1beta1/cohort_types.go
+++ b/apis/kueue/v1beta1/cohort_types.go
@@ -58,8 +58,8 @@ type CohortSpec struct {
 	// Cohort has a parent.  Otherwise, the Cohort create/update
 	// will be rejected by the webhook.
 	//
-	//+listType=atomic
-	//+kubebuilder:validation:MaxItems=16
+	// +listType=atomic
+	// +kubebuilder:validation:MaxItems=16
 	ResourceGroups []ResourceGroup `json:"resourceGroups,omitempty"`
 
 	// fairSharing defines the properties of the Cohort when

--- a/apis/kueue/v1beta1/topology_types.go
+++ b/apis/kueue/v1beta1/topology_types.go
@@ -139,7 +139,7 @@ type Topology struct {
 	Spec TopologySpec `json:"spec,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // TopologyList contains a list of Topology
 type TopologyList struct {

--- a/apis/kueue/v1beta1/types.go
+++ b/apis/kueue/v1beta1/types.go
@@ -20,4 +20,4 @@ This file is needed for kubernetes/code-generator/kube_codegen.sh script used in
 
 package v1beta1
 
-//+genclient
+// +genclient

--- a/apis/kueue/v1beta2/cohort_types.go
+++ b/apis/kueue/v1beta2/cohort_types.go
@@ -58,8 +58,8 @@ type CohortSpec struct {
 	// Cohort has a parent.  Otherwise, the Cohort create/update
 	// will be rejected by the webhook.
 	//
-	//+listType=atomic
-	//+kubebuilder:validation:MaxItems=16
+	// +listType=atomic
+	// +kubebuilder:validation:MaxItems=16
 	ResourceGroups []ResourceGroup `json:"resourceGroups,omitempty"`
 
 	// fairSharing defines the properties of the Cohort when

--- a/apis/kueue/v1beta2/topology_types.go
+++ b/apis/kueue/v1beta2/topology_types.go
@@ -138,7 +138,7 @@ type Topology struct {
 	Spec TopologySpec `json:"spec,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // TopologyList contains a list of Topology
 type TopologyList struct {

--- a/apis/kueue/v1beta2/types.go
+++ b/apis/kueue/v1beta2/types.go
@@ -20,4 +20,4 @@ This file is needed for kubernetes/code-generator/kube_codegen.sh script used in
 
 package v1beta2
 
-//+genclient
+// +genclient


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Have api generation tags follow proper syntax

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```