### PR TITLE
Automated cherry pick of #7423: increase topology limits to 16 to match topology updates

### DIFF
--- a/apis/kueue/v1beta1/localqueue_types.go
+++ b/apis/kueue/v1beta1/localqueue_types.go
@@ -104,7 +104,7 @@ type TopologyInfo struct {
 	// +listType=atomic
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=8
+	// +kubebuilder:validation:MaxItems=16
 	Levels []string `json:"levels"`
 }
 

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -268,7 +268,7 @@ type TopologyAssignment struct {
 	// +required
 	// +listType=atomic
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=8
+	// +kubebuilder:validation:MaxItems=16
 	Levels []string `json:"levels"`
 
 	// domains is a list of topology assignments split by topology domains at
@@ -286,7 +286,7 @@ type TopologyDomainAssignment struct {
 	// +required
 	// +listType=atomic
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=8
+	// +kubebuilder:validation:MaxItems=16
 	Values []string `json:"values"`
 
 	// count indicates the number of Pods to be scheduled in the topology

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_localqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_localqueues.yaml
@@ -346,7 +346,7 @@ spec:
                             description: levels define the levels of topology.
                             items:
                               type: string
-                            maxItems: 8
+                            maxItems: 16
                             minItems: 1
                             type: array
                             x-kubernetes-list-type: atomic

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -8076,7 +8076,7 @@ spec:
                                         the highest to the lowest.
                                       items:
                                         type: string
-                                      maxItems: 8
+                                      maxItems: 16
                                       minItems: 1
                                       type: array
                                       x-kubernetes-list-type: atomic
@@ -8092,7 +8092,7 @@ spec:
                                   the topology.
                                 items:
                                   type: string
-                                maxItems: 8
+                                maxItems: 16
                                 minItems: 1
                                 type: array
                                 x-kubernetes-list-type: atomic

--- a/config/components/crd/bases/kueue.x-k8s.io_localqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_localqueues.yaml
@@ -340,7 +340,7 @@ spec:
                           description: levels define the levels of topology.
                           items:
                             type: string
-                          maxItems: 8
+                          maxItems: 16
                           minItems: 1
                           type: array
                           x-kubernetes-list-type: atomic

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -8545,7 +8545,7 @@ spec:
                                       the highest to the lowest.
                                     items:
                                       type: string
-                                    maxItems: 8
+                                    maxItems: 16
                                     minItems: 1
                                     type: array
                                     x-kubernetes-list-type: atomic
@@ -8561,7 +8561,7 @@ spec:
                                 the topology.
                               items:
                                 type: string
-                              maxItems: 8
+                              maxItems: 16
                               minItems: 1
                               type: array
                               x-kubernetes-list-type: atomic


### PR DESCRIPTION
Cherry pick of #7423 on release-0.13.

#7423: increase topology limits to 16 to match topology updates

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
TAS: Increase the number of Topology levels limitations for localqueue and workloads to 16
```