### PR TITLE
Avoid unintentional patches to Quantity fields

### DIFF
--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package resources
 
 import (
+	"encoding/json"
 	"math"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestCountIn(t *testing.T) {
@@ -117,6 +119,89 @@ func TestCountIn(t *testing.T) {
 			gotResult := tc.requests.CountIn(tc.capacity)
 			if tc.wantResult != gotResult {
 				t.Errorf("unexpected result, want=%d, got=%d", tc.wantResult, gotResult)
+			}
+		})
+	}
+}
+
+func TestResourceQuantityRoundTrips(t *testing.T) {
+	cases := map[string]struct {
+		resource corev1.ResourceName
+		value    int64
+		expected string
+	}{
+		"1": {
+			resource: corev1.ResourceMemory,
+			value:    1,
+			expected: "1",
+		},
+		"1k": {
+			resource: corev1.ResourceMemory,
+			value:    1000,
+			expected: "1k",
+		},
+		"100k": {
+			resource: corev1.ResourceMemory,
+			value:    100000,
+			expected: "100k",
+		},
+		"1M": {
+			resource: corev1.ResourceMemory,
+			value:    1000000,
+			expected: "1M",
+		},
+		"1500k (1.5M)": {
+			resource: corev1.ResourceMemory,
+			value:    1500000,
+			expected: "1500k",
+		},
+		"1Ki": {
+			resource: corev1.ResourceMemory,
+			value:    1024,
+			expected: "1Ki",
+		},
+		"125Ki (128k)": {
+			resource: corev1.ResourceMemory,
+			value:    128000,
+			expected: "125Ki",
+		},
+		"1Mi": {
+			resource: corev1.ResourceMemory,
+			value:    1024 * 1024,
+			expected: "1Mi",
+		},
+		"1536Ki (1.5Mi)": {
+			resource: corev1.ResourceMemory,
+			value:    1024 * 1024 * 1.5,
+			expected: "1536Ki",
+		},
+		"1Gi": {
+			resource: corev1.ResourceMemory,
+			value:    1024 * 1024 * 1024,
+			expected: "1Gi",
+		},
+		"976562500Ki (10G)": {
+			resource: corev1.ResourceMemory,
+			value:    10000000000,
+			expected: "9765625Ki",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			quantity := ResourceQuantity(tc.resource, tc.value)
+			initial := quantity.String()
+
+			if initial != tc.expected {
+				t.Errorf("unexpected result, want=%s, got=%s", tc.expected, initial)
+			}
+
+			serialized, _ := json.Marshal(quantity)
+			var deserialized resource.Quantity
+			_ = json.Unmarshal(serialized, &deserialized)
+			roundtrip := deserialized.String()
+
+			if roundtrip != tc.expected {
+				t.Errorf("unexpected result after roundtrip, want=%s, got=%s", tc.expected, roundtrip)
 			}
 		})
 	}

--- a/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
@@ -1886,5 +1886,123 @@ var _ = ginkgo.Describe("Provisioning with scheduling", ginkgo.Ordered, ginkgo.C
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
+
+		ginkgo.It("Should be successfully re-admitted on another flavor with a decimal memory request", func() {
+			ginkgo.By("Set up ClusterQueue and LocalQueue", func() {
+				cq = utiltestingapi.MakeClusterQueue("cluster-queue").
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
+					}).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(rf1.Name).
+							Resource(corev1.ResourceCPU, "0.75").
+							Resource(corev1.ResourceMemory, "5G").
+							Obj(),
+						*utiltestingapi.MakeFlavorQuotas(rf2.Name).
+							Resource(corev1.ResourceCPU, "0.5").
+							Resource(corev1.ResourceMemory, "5G").
+							Obj(),
+					).
+					AdmissionCheckStrategy(kueue.AdmissionCheckStrategyRule{
+						Name:      ac1Ref,
+						OnFlavors: []kueue.ResourceFlavorReference{flavor1Ref},
+					}).
+					Obj()
+				util.MustCreate(ctx, k8sClient, cq)
+				util.ExpectClusterQueuesToBeActive(ctx, k8sClient, cq)
+
+				lq = utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue(cq.Name).Obj()
+				util.MustCreate(ctx, k8sClient, lq)
+				util.ExpectLocalQueuesToBeActive(ctx, k8sClient, lq)
+			})
+
+			ginkgo.By("submit the Job", func() {
+				job1 := testingjob.MakeJob("job1", ns.Name).
+					Queue(kueue.LocalQueueName(lq.Name)).
+					Request(corev1.ResourceCPU, "500m").
+					Request(corev1.ResourceMemory, "220M").
+					Obj()
+				util.MustCreate(ctx, k8sClient, job1)
+				ginkgo.DeferCleanup(func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, job1, true)
+				})
+				wl1Key = types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job1.Name, job1.UID), Namespace: ns.Name}
+			})
+
+			ginkgo.By("await for wl1 to be created", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wl1Key, &wlObj)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("await for wl1 to have QuotaReserved on flavor-1", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					gomega.Expect(k8sClient.Get(ctx, wl1Key, &wlObj)).Should(gomega.Succeed())
+					g.Expect(workload.Status(&wlObj)).To(gomega.Equal(workload.StatusQuotaReserved))
+					psa := wlObj.Status.Admission.PodSetAssignments
+					g.Expect(psa).Should(gomega.HaveLen(1))
+					g.Expect(psa[0].Flavors).To(gomega.Equal(map[corev1.ResourceName]kueue.ResourceFlavorReference{
+						corev1.ResourceCPU:    flavor1Ref,
+						corev1.ResourceMemory: flavor1Ref,
+					}))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("await for the ProvisioningRequest on flavor-1 to be created", func() {
+				provReqKey = types.NamespacedName{
+					Namespace: wl1Key.Namespace,
+					Name:      provisioning.ProvisioningRequestName(wl1Key.Name, ac1Ref, 1),
+				}
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, provReqKey, &createdRequest)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("set the ProvisioningRequest on flavor-1 as Provisioned", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, provReqKey, &createdRequest)).Should(gomega.Succeed())
+					apimeta.SetStatusCondition(&createdRequest.Status.Conditions, metav1.Condition{
+						Type:   autoscaling.Provisioned,
+						Status: metav1.ConditionTrue,
+						Reason: autoscaling.Provisioned,
+					})
+					g.Expect(k8sClient.Status().Update(ctx, &createdRequest)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("await for wl1 to be Admitted", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					gomega.Expect(k8sClient.Get(ctx, wl1Key, &wlObj)).Should(gomega.Succeed())
+					g.Expect(workload.Status(&wlObj)).To(gomega.Equal(workload.StatusAdmitted))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("submit a high-priority job2", func() {
+				job2 := testingjob.MakeJob("job2", ns.Name).
+					Queue(kueue.LocalQueueName(lq.Name)).
+					WorkloadPriorityClass(priorityClassName).
+					Request(corev1.ResourceCPU, "750m").
+					Obj()
+				util.MustCreate(ctx, k8sClient, job2)
+				ginkgo.DeferCleanup(func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, job2, true)
+				})
+				wl2Key = types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job2.Name, job2.UID), Namespace: ns.Name}
+			})
+
+			ginkgo.By("await for wl1 to be Admitted on flavor-2", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					gomega.Expect(k8sClient.Get(ctx, wl1Key, &wlObj)).Should(gomega.Succeed())
+					g.Expect(workload.Status(&wlObj)).To(gomega.Equal(workload.StatusAdmitted))
+					psa := wlObj.Status.Admission.PodSetAssignments
+					g.Expect(psa).Should(gomega.HaveLen(1))
+					g.Expect(psa[0].Flavors).To(gomega.Equal(map[corev1.ResourceName]kueue.ResourceFlavorReference{
+						corev1.ResourceCPU:    flavor2Ref,
+						corev1.ResourceMemory: flavor2Ref,
+					}))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

In case the job requests memory in decimal format (e.g. "1G"), the Workload's `status.admission.podSetAssignments[].resourceUsage.memory` is unintentionally patched due to Quantity round trip issues.

For example:

1. User requests 1G
2. 1G is converted to an internal representation (int64) as 1000000000
3. 1000000000 is converted to Quantity with BinarySI format
4. Quantity is sent to the API as "1000000000" because it isn't representable with a binary suffix
5. Quantity is read from the API as "1G" because lack of suffix is interpreted as DecimalSI format
6. The "1G" value is then sent to the API in a patch request intended for another field as a diff.

This PR changes no.3 to auto-detect the format and avoid unintentional diff.

While normally such diff shouldn't really matter other than adding some noise in managed fields, it hits https://github.com/kubernetes/kubernetes/issues/134902, which makes the workload impossible to evict.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6966 

#### Special notes for your reviewer:

This change makes it much more expensive to compute the Quantity.

I've considered a couple of alternatives:

1. Always use DecimalSI. This would fix the issue, but the Workload wouldn't use binary suffixes, e.g. "1Mi" would end up as "1048576"
2. Leave it be and wait for a fix to https://github.com/kubernetes/kubernetes/issues/134902. I think it's worth addressing this unintentional patch anyway, to avoid unintended consequences in the future.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix eviction of jobs with memory requests in decimal format
```