### PR TITLE
Drop graduated ProvisioningACC feature gate.

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -41,12 +41,6 @@ const (
 	// Enables flavor fungibility.
 	FlavorFungibility featuregate.Feature = "FlavorFungibility"
 
-	// owner: @trasc
-	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/1136-provisioning-request-support
-	//
-	// Enables Provisioning Admission Check Controller.
-	ProvisioningACC featuregate.Feature = "ProvisioningACC"
-
 	// owner: @pbundyra
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/168-2-pending-workloads-visibility
 	//
@@ -228,10 +222,6 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 
 	FlavorFungibility: {
 		{Version: version.MustParse("0.5"), Default: true, PreRelease: featuregate.Beta},
-	},
-	ProvisioningACC: {
-		{Version: version.MustParse("0.5"), Default: true, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("0.14"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 0.15
 	},
 	VisibilityOnDemand: {
 		{Version: version.MustParse("0.6"), Default: false, PreRelease: featuregate.Alpha},

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -307,9 +307,6 @@ The SanitizePodSets and MultiKueueAllowInsecureKubeconfigs features are availabl
 
 | Feature                               | Default | Stage      | Since | Until |
 |---------------------------------------|---------|------------|-------|-------|
-| `ProvisioningACC`                     | `false` | Alpha      | 0.5   | 0.6   |
-| `ProvisioningACC`                     | `true`  | Beta       | 0.7   |       |
-| `ProvisioningACC`                     | `true`  | GA         | 0.14  |       |
 | `ConfigurableResourceTransformations` | `false` | Alpha      | 0.9   | 0.9   |
 | `ConfigurableResourceTransformations` | `true`  | Beta       | 0.10  | 0.13  |
 | `ConfigurableResourceTransformations` | `true`  | GA         | 0.14  |       |

--- a/site/content/en/docs/reference/components-tools/feature-gate-removed.md
+++ b/site/content/en/docs/reference/components-tools/feature-gate-removed.md
@@ -36,3 +36,6 @@ In the following table:
 | `QueueVisibility`                 | `false` | Deprecated | 0.9  | 0.14 |
 | `ManagedJobsNamespaceSelector`    | `true`  | Beta       | 0.10 | 0.13 |
 | `ManagedJobsNamespaceSelector`    | `true`  | GA         | 0.13 | 0.15 |
+| `ProvisioningACC`                 | `false` | Alpha      | 0.5  | 0.6  |
+| `ProvisioningACC`                 | `true`  | Beta       | 0.7  | 0.14 |
+| `ProvisioningACC`                 | `true`  | GA         | 0.14 | 0.15 |

--- a/site/content/zh-CN/docs/installation/_index.md
+++ b/site/content/zh-CN/docs/installation/_index.md
@@ -303,9 +303,8 @@ spec:
 
 | 功能                                    | 默认值     | 阶段         | 起始版本 | 截止版本 |
 |---------------------------------------|---------|------------|------|------|
-| `ProvisioningACC`                     | `false` | Alpha      | 0.5  | 0.6  |
-| `ProvisioningACC`                     | `true`  | Beta       | 0.7  |      |
-| `ProvisioningACC`                     | `true`  | GA         | 0.14 |      |
+| `ManagedJobsNamespaceSelector`        | `true`  | Beta       | 0.10 | 0.13 |
+| `ManagedJobsNamespaceSelector`        | `true`  | GA         | 0.13 |      |
 | `ConfigurableResourceTransformations` | `false` | Alpha      | 0.9  | 0.9  |
 | `ConfigurableResourceTransformations` | `true`  | Beta       | 0.10 | 0.13 |
 | `ConfigurableResourceTransformations` | `true`  | GA         | 0.14 |      |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Drop graduated ProvisioningACC feature gate.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```