### PR TITLE
Fix feature gates tables.

### DIFF
--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -264,7 +264,7 @@ spec:
 ### Feature gates for alpha and beta features
 
 | Feature                                       | Default | Stage | Since | Until |
-| --------------------------------------------- |---------|-------|-------|-------|
+|-----------------------------------------------|---------|-------|-------|-------|
 | `FlavorFungibility`                           | `true`  | Beta  | 0.5   |       |
 | `MultiKueue`                                  | `false` | Alpha | 0.6   | 0.8   |
 | `MultiKueue`                                  | `true`  | Beta  | 0.9   |       |
@@ -297,16 +297,16 @@ spec:
 | `FlavorFungibilityImplicitPreferenceDefault`  | `false` | Alpha | 0.13  |       |
 | `WorkloadRequestUseMergePatch`                | `false` | Alpha | 0.14  |       |
 | `SanitizePodSets`                             | `true`  | Beta  | 0.13  |       |
+| `MultiKueueAllowInsecureKubeconfigs`          | `false` | Alpha | 0.13  |       |
 
 {{% alert title="Note" color="primary" %}}
-The SanitizePodSets feature is available starting from versions 0.13.8 and 0.14.3.
+The SanitizePodSets and MultiKueueAllowInsecureKubeconfigs features are available starting from versions 0.13.8 and 0.14.3.
 {{% /alert %}}
-| `MultiKueueAllowInsecureKubeconfigs`          | `false` | Alpha | 0.15  |       |
 
 ### Feature gates for graduated or deprecated features
 
 | Feature                               | Default | Stage      | Since | Until |
-|---------------------------------------| ------- | ---------- | ----- | ----- |
+|---------------------------------------|---------|------------|-------|-------|
 | `ProvisioningACC`                     | `false` | Alpha      | 0.5   | 0.6   |
 | `ProvisioningACC`                     | `true`  | Beta       | 0.7   |       |
 | `ProvisioningACC`                     | `true`  | GA         | 0.14  |       |

--- a/site/content/zh-CN/docs/installation/_index.md
+++ b/site/content/zh-CN/docs/installation/_index.md
@@ -263,36 +263,41 @@ spec:
 
 ### Alpha 和 Beta 级别特性的特性门控 {#feature-gates-for-alpha-and-beta-features}
 
-| 功能                                          | 默认值  | 阶段  | 起始版本     | 截止版本 |
-| --------------------------------------------- | ------- | ----- |----------| -------- |
-| `FlavorFungibility`                           | `true`  | Beta  | 0.5      |          |
-| `MultiKueue`                                  | `false` | Alpha | 0.6      | 0.8      |
-| `MultiKueue`                                  | `true`  | Beta  | 0.9      |          |
-| `MultiKueueBatchJobWithManagedBy`             | `false` | Alpha | 0.8      |          |
-| `PartialAdmission`                            | `false` | Alpha | 0.4      | 0.4      |
-| `PartialAdmission`                            | `true`  | Beta  | 0.5      |          |
-| `VisibilityOnDemand`                          | `false` | Alpha | 0.6      | 0.8      |
-| `VisibilityOnDemand`                          | `true`  | Beta  | 0.9      |          |
-| `PrioritySortingWithinCohort`                 | `true`  | Beta  | 0.6      |          |
-| `LendingLimit`                                | `false` | Alpha | 0.6      | 0.8      |
-| `LendingLimit`                                | `true`  | Beta  | 0.9      |          |
-| `TopologyAwareScheduling`                     | `false` | Alpha | 0.9      |          |
-| `LocalQueueDefaulting`                        | `false` | Alpha | 0.10     | 0.11     |
-| `LocalQueueDefaulting`                        | `true`  | Beta  | 0.12     |          |
-| `LocalQueueMetrics`                           | `false` | Alpha | 0.10     |          |
-| `HierarchicalCohort`                          | `true`  | Beta  | 0.11     |          |
-| `ObjectRetentionPolicies`                     | `false` | Alpha | 0.12     | 0.12     |
-| `ObjectRetentionPolicies`                     | `true`  | Beta  | 0.13     |          |
-| `TASFailedNodeReplacement`                    | `false` | Alpha | 0.12     |          |
-| `AdmissionFairSharing`                        | `false` | Alpha | 0.12     |          |
-| `TASFailedNodeReplacementFailFast`            | `false` | Alpha | 0.12     |          |
-| `TASReplaceNodeOnPodTermination`              | `false` | Alpha | 0.13     |          |
-| `ElasticJobsViaWorkloadSlices`                | `false` | Alpha | 0.13     |          |
-| `ManagedJobsNamespaceSelectorAlwaysRespected` | `false` | Alpha | 0.13     |          |
-| `FlavorFungibilityImplicitPreferenceDefault`  | `false` | Alpha | 0.13     |          |
-| `WorkloadRequestUseMergePatch`                | `false` | Alpha | 0.14     |          |
-| `SanitizePodSets`                             | `true`  | Beta  | 0.13     |          |
-| `MultiKueueAllowInsecureKubeconfigs`          | `false` | Alpha | 0.15     |          |
+| 功能                                          | 默认值  | 阶段  | 起始版本    | 截止版本 |
+| --------------------------------------------- | ------- | ----- |---------|------|
+| `FlavorFungibility`                           | `true`  | Beta  | 0.5     |      |
+| `MultiKueue`                                  | `false` | Alpha | 0.6     | 0.8  |
+| `MultiKueue`                                  | `true`  | Beta  | 0.9     |      |
+| `MultiKueueBatchJobWithManagedBy`             | `false` | Alpha | 0.8     |      |
+| `MultiKueueBatchJobWithManagedBy`             | `true`  | Beta  | 0.15    |      |
+| `PartialAdmission`                            | `false` | Alpha | 0.4     | 0.4  |
+| `PartialAdmission`                            | `true`  | Beta  | 0.5     |      |
+| `VisibilityOnDemand`                          | `false` | Alpha | 0.6     | 0.8  |
+| `VisibilityOnDemand`                          | `true`  | Beta  | 0.9     |      |
+| `PrioritySortingWithinCohort`                 | `true`  | Beta  | 0.6     |      |
+| `LendingLimit`                                | `false` | Alpha | 0.6     | 0.8  |
+| `LendingLimit`                                | `true`  | Beta  | 0.9     |      |
+| `TopologyAwareScheduling`                     | `false` | Alpha | 0.9     |      |
+| `TopologyAwareScheduling`                     | `true`  | Beta  | 0.14    |      |
+| `LocalQueueDefaulting`                        | `false` | Alpha | 0.10    | 0.11 |
+| `LocalQueueDefaulting`                        | `true`  | Beta  | 0.12    |      |
+| `LocalQueueMetrics`                           | `false` | Alpha | 0.10    |      |
+| `HierarchicalCohort`                          | `true`  | Beta  | 0.11    |      |
+| `ObjectRetentionPolicies`                     | `false` | Alpha | 0.12    | 0.12 |
+| `ObjectRetentionPolicies`                     | `true`  | Beta  | 0.13    |      |
+| `TASFailedNodeReplacement`                    | `false` | Alpha | 0.12    |      |
+| `TASFailedNodeReplacement`                    | `true`  | Beta  | 0.14    |      |
+| `AdmissionFairSharing`                        | `false` | Alpha | 0.12    |      |
+| `TASFailedNodeReplacementFailFast`            | `false` | Alpha | 0.12    |      |
+| `TASFailedNodeReplacementFailFast`            | `true`  | Beta  | 0.14    |      |
+| `TASReplaceNodeOnPodTermination`              | `false` | Alpha | 0.13    |      |
+| `TASReplaceNodeOnPodTermination`              | `true`  | Beta  | 0.14    |      |
+| `ElasticJobsViaWorkloadSlices`                | `false` | Alpha | 0.13    |      |
+| `ManagedJobsNamespaceSelectorAlwaysRespected` | `false` | Alpha | 0.13    |      |
+| `FlavorFungibilityImplicitPreferenceDefault`  | `false` | Alpha | 0.13    |      |
+| `WorkloadRequestUseMergePatch`                | `false` | Alpha | 0.14    |      |
+| `SanitizePodSets`                             | `true`  | Beta  | 0.13    |      |
+| `MultiKueueAllowInsecureKubeconfigs`          | `false` | Alpha | 0.13    |      |
 
 ### 已毕业或已弃用特性的特性门控 {#feature-gates-for-graduated-or-deprecated-features}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix feature gates tables.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```