### PR TITLE
Automated cherry pick of #7444: Fix SanitizePodSets feature gate version.

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -198,6 +198,15 @@ const (
 	//
 	// Enable all updates to Workload objects to use Patch Merge instead of Patch Apply.
 	WorkloadRequestUseMergePatch featuregate.Feature = "WorkloadRequestUseMergePatch"
+
+	// owner: @mbobrovskyi
+	//
+	// SanitizePodSets enables automatic sanitization of PodSets when creating the Workload object.
+	// The main use case it deduplication of environment variables
+	// in PodSet templates within Workload objects. When enabled, duplicate env var entries
+	// are resolved by keeping only the last occurrence, allowing workload creation to succeed
+	// even when duplicates are present in the spec.
+	SanitizePodSets featuregate.Feature = "SanitizePodSets"
 )
 
 func init() {
@@ -311,6 +320,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	WorkloadRequestUseMergePatch: {
 		{Version: version.MustParse("0.14"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	SanitizePodSets: {
+		{Version: version.MustParse("0.13"), Default: true, PreRelease: featuregate.Beta},
 	},
 }
 

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -295,6 +295,11 @@ spec:
 | `ManagedJobsNamespaceSelectorAlwaysRespected` | `false` | Alpha | 0.13  |       |
 | `FlavorFungibilityImplicitPreferenceDefault`  | `false` | Alpha | 0.13  |       |
 | `WorkloadRequestUseMergePatch`                | `false` | Alpha | 0.14  |       |
+| `SanitizePodSets`                             | `true`  | Beta  | 0.13  |       |
+
+{{% alert title="Note" color="primary" %}}
+The SanitizePodSets feature is available starting from versions 0.13.8 and 0.14.3.
+{{% /alert %}}
 
 ### Feature gates for graduated or deprecated features
 

--- a/site/content/zh-CN/docs/installation/_index.md
+++ b/site/content/zh-CN/docs/installation/_index.md
@@ -263,8 +263,8 @@ spec:
 
 ### Alpha 和 Beta 级别特性的特性门控 {#feature-gates-for-alpha-and-beta-features}
 
-| 功能                                          | 默认值  | 阶段  | 起始版本 | 截止版本 |
-| --------------------------------------------- | ------- | ----- | -------- | -------- |
+| 功能                                          | 默认值  | 阶段  | 起始版本     | 截止版本 |
+| --------------------------------------------- | ------- | ----- |----------| -------- |
 | `FlavorFungibility`                           | `true`  | Beta  | 0.5      |          |
 | `MultiKueue`                                  | `false` | Alpha | 0.6      | 0.8      |
 | `MultiKueue`                                  | `true`  | Beta  | 0.9      |          |
@@ -291,6 +291,7 @@ spec:
 | `ManagedJobsNamespaceSelectorAlwaysRespected` | `false` | Alpha | 0.13     |          |
 | `FlavorFungibilityImplicitPreferenceDefault`  | `false` | Alpha | 0.13     |          |
 | `WorkloadRequestUseMergePatch`                | `false` | Alpha | 0.14     |          |
+| `SanitizePodSets`                             | `true`  | Beta  | 0.13     |          |
 
 ### 已毕业或已弃用特性的特性门控 {#feature-gates-for-graduated-or-deprecated-features}
 


### PR DESCRIPTION
Cherry pick of #7444 on website.

#7444: Fix SanitizePodSets feature gate version.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```