### PR TITLE
Fix: StatefulSet integration when StatefulSet created should allow to scale up after scale down to zero

### DIFF
--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -174,8 +174,22 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Ob
 			)...)
 		}
 
-		if oldReplicas == 0 && newReplicas > 0 && newStatefulSet.Status.Replicas > 0 {
-			allErrs = append(allErrs, field.Forbidden(replicasPath, "scaling down is still in progress"))
+		if oldReplicas == 0 && newReplicas > 0 {
+			if newStatefulSet.Status.Replicas > 0 {
+				// Block if pods are still terminating
+				allErrs = append(allErrs, field.Forbidden(replicasPath, "scaling down is still in progress"))
+			} else {
+				// Block if workload is still being deleted
+				workloadName := GetWorkloadName(oldStatefulSet.GetName())
+				wlKey := client.ObjectKey{Namespace: oldStatefulSet.GetNamespace(), Name: workloadName}
+				var wl kueue.Workload
+				err := wh.client.Get(ctx, wlKey, &wl)
+				if client.IgnoreNotFound(err) != nil {
+					return nil, err
+				} else if err == nil {
+					allErrs = append(allErrs, field.Forbidden(replicasPath, "workload from previous scale-down is still being deleted"))
+				}
+			}
 		}
 	}
 

--- a/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
@@ -780,6 +780,37 @@ func TestValidateUpdate(t *testing.T) {
 				},
 			}.ToAggregate(),
 		},
+		"scale up from zero blocked by existing workload": {
+			objs: []runtime.Object{
+				utiltestingapi.MakeWorkload(GetWorkloadName("test-statefulset"), "test-ns").Obj(),
+			},
+			oldObj: testingstatefulset.MakeStatefulSet("test-statefulset", "test-ns").
+				Queue("test-queue").
+				Replicas(0).
+				Obj(),
+			newObj: testingstatefulset.MakeStatefulSet("test-statefulset", "test-ns").
+				Queue("test-queue").
+				Replicas(3).
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeForbidden,
+					Field: replicasPath.String(),
+				},
+			}.ToAggregate(),
+		},
+		"scale up from zero allowed when workload does not exist": {
+			oldObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
+				UID("test-sts-uid").
+				Queue("test-queue").
+				Replicas(0).
+				Obj(),
+			newObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
+				UID("test-sts-uid").
+				Queue("test-queue").
+				Replicas(3).
+				Obj(),
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
/kind flake

#### What this PR does / why we need it:

The loose ReadyReplicas < 3 check allowed scaling up before workload deletion completed, causing a race condition. This fix ensures the scale-down is completely finished before attempting scale-up.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7390 

#### Special notes for your reviewer:

I ran the test over 500 times successfully with the fix.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix the bug for the StatefulSet integration that the scale up could get stuck if
triggered immediately after scale down to zero.
```