### PR TITLE
Automated cherry pick of #7473: Replace preemption stub with interceptor function in TestSchedule.

### DIFF
--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	utilResource "sigs.k8s.io/kueue/pkg/util/resource"
 )
 
@@ -95,6 +96,10 @@ func (w *WorkloadWrapper) Clone() *WorkloadWrapper {
 func (w *WorkloadWrapper) UID(uid types.UID) *WorkloadWrapper {
 	w.Workload.UID = uid
 	return w
+}
+
+func (w *WorkloadWrapper) JobUID(uid string) *WorkloadWrapper {
+	return w.Label(constants.JobUIDLabel, uid)
 }
 
 // Generation sets the generation of the Workload.


### PR DESCRIPTION
Cherry pick of #7473 on release-0.14.

#7473: Replace preemption stub with interceptor function in TestSchedule.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```