### PR TITLE
enable optional fields, optionalorrequired and required fields

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -26,10 +26,10 @@ linters:
               - "nomaps" # Ensure maps are not used.
               - "nonullable" # Ensure that types and fields do not have the nullable marker.
               - "notimestamp" # Prevents usage of 'Timestamp' fields
-              # - "optionalfields" # Ensure that all fields marked as optional adhere to being pointers and
+              - "optionalfields" # Ensure that all fields marked as optional adhere to being pointers and
                                  # having the `omitempty` value in their `json` tag where appropriate.
-              # - "optionalorrequired" # Every field should be marked as `+optional` or `+required`.
-              # - "requiredfields" # Required fields should not be pointers, and should not have `omitempty`.
+              - "optionalorrequired" # Every field should be marked as `+optional` or `+required`.
+              - "requiredfields" # Required fields should not be pointers, and should not have `omitempty`.
               - "ssatags" # Ensure array fields have the appropriate listType markers
               - "statusoptional" # Ensure all first children within status should be optional.
               - "statussubresource" # All root objects that have a `status` field should have a status subresource.
@@ -70,3 +70,4 @@ linters:
 
 issues:
   max-same-issues: 0
+  max-issues-per-linter: 0

--- a/apis/kueue/v1beta2/admissioncheck_types.go
+++ b/apis/kueue/v1beta2/admissioncheck_types.go
@@ -48,11 +48,11 @@ const (
 type AdmissionCheckSpec struct {
 	// controllerName identifies the controller that processes the AdmissionCheck,
 	// not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.
-	// +kubebuilder:validation:Required
+	// +required
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="field is immutable"
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:MinLength=1
-	ControllerName string `json:"controllerName"`
+	ControllerName string `json:"controllerName"` //nolint:kubeapilinter // ignore omitempty
 
 	// parameters identifies a configuration with additional parameters for the
 	// check.
@@ -62,17 +62,23 @@ type AdmissionCheckSpec struct {
 
 type AdmissionCheckParametersReference struct {
 	// apiGroup is the group for the resource being referenced.
+	// +required
 	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
-	APIGroup string `json:"apiGroup"`
+	APIGroup string `json:"apiGroup,omitempty"`
 	// kind is the type of the resource being referenced.
+	// +required
 	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern="^(?i)[a-z]([-a-z0-9]*[a-z0-9])?$"
-	Kind string `json:"kind"`
+	Kind string `json:"kind,omitempty"`
 	// name is the name of the resource being referenced.
+	// +required
 	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 }
 
 // AdmissionCheckStatus defines the observed state of AdmissionCheck
@@ -105,13 +111,16 @@ const (
 type AdmissionCheck struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the metadata of the AdmissionCheck.
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the specification of the AdmissionCheck.
-	Spec AdmissionCheckSpec `json:"spec,omitempty"`
+	// +optional
+	Spec AdmissionCheckSpec `json:"spec"` //nolint:kubeapilinter // spec should not be a pointer
 
 	// status is the status of the AdmissionCheck.
-	Status AdmissionCheckStatus `json:"status,omitempty"`
+	// +optional
+	Status AdmissionCheckStatus `json:"status,omitempty"` //nolint:kubeapilinter // status should not be a pointer
 }
 
 // +kubebuilder:object:root=true

--- a/apis/kueue/v1beta2/clusterqueue_types.go
+++ b/apis/kueue/v1beta2/clusterqueue_types.go
@@ -62,6 +62,7 @@ type ClusterQueueSpec struct {
 	// resourceGroups can be up to 16, with a max of 256 total flavors across all groups.
 	// +listType=atomic
 	// +kubebuilder:validation:MaxItems=16
+	// +optional
 	ResourceGroups []ResourceGroup `json:"resourceGroups,omitempty"`
 
 	// cohortName that this ClusterQueue belongs to. CQs that belong to the
@@ -76,7 +77,8 @@ type ClusterQueueSpec struct {
 	//
 	// A cohort is a name that links CQs together, but it doesn't reference any
 	// object.
-	CohortName CohortReference `json:"cohortName,omitempty"`
+	// +optional
+	CohortName CohortReference `json:"cohortName,omitempty"` //nolint:kubeapilinter // should not be a pointer
 
 	// queueingStrategy indicates the queueing strategy of the workloads
 	// across the queues in this ClusterQueue.
@@ -89,24 +91,28 @@ type ClusterQueueSpec struct {
 	// however older workloads that can't be admitted will not block
 	// admitting newer workloads that fit existing quota.
 	//
+	// +optional
 	// +kubebuilder:default=BestEffortFIFO
 	// +kubebuilder:validation:Enum=StrictFIFO;BestEffortFIFO
-	QueueingStrategy QueueingStrategy `json:"queueingStrategy,omitempty"`
+	QueueingStrategy QueueingStrategy `json:"queueingStrategy,omitempty"` //nolint:kubeapilinter // should not be a pointer
 
 	// namespaceSelector defines which namespaces are allowed to submit workloads to
 	// this clusterQueue. Beyond this basic support for policy, a policy agent like
 	// Gatekeeper should be used to enforce more advanced policies.
 	// Defaults to null which is a nothing selector (no namespaces eligible).
 	// If set to an empty selector `{}`, then all namespaces are eligible.
+	// +optional
 	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector,omitempty"`
 
 	// flavorFungibility defines whether a workload should try the next flavor
 	// before borrowing or preempting in the flavor being evaluated.
+	// +optional
 	// +kubebuilder:default={}
 	FlavorFungibility *FlavorFungibility `json:"flavorFungibility,omitempty"`
 
 	// preemption defines the preemption policies.
 	// +kubebuilder:default={}
+	// +optional
 	Preemption *ClusterQueuePreemption `json:"preemption,omitempty"`
 
 	// admissionChecks lists the AdmissionChecks required by this ClusterQueue.
@@ -129,9 +135,9 @@ type ClusterQueueSpec struct {
 	// - HoldAndDrain - Admitted workloads are evicted and Reserving workloads will cancel the reservation.
 	// - Hold - Admitted workloads will run to completion and Reserving workloads will cancel the reservation.
 	//
-	// +optional
 	// +kubebuilder:validation:Enum=None;Hold;HoldAndDrain
 	// +kubebuilder:default="None"
+	// +optional
 	StopPolicy *StopPolicy `json:"stopPolicy,omitempty"`
 
 	// fairSharing defines the properties of the ClusterQueue when
@@ -150,6 +156,8 @@ type AdmissionChecksStrategy struct {
 	// admissionChecks is a list of strategies for AdmissionChecks
 	// +listType=map
 	// +listMapKey=name
+	// +required
+	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=64
 	AdmissionChecks []AdmissionCheckStrategyRule `json:"admissionChecks,omitempty"`
 }
@@ -157,7 +165,8 @@ type AdmissionChecksStrategy struct {
 // AdmissionCheckStrategyRule defines rules for a single AdmissionCheck
 type AdmissionCheckStrategyRule struct {
 	// name is an AdmissionCheck's name.
-	Name AdmissionCheckReference `json:"name"`
+	// +required
+	Name AdmissionCheckReference `json:"name,omitempty"`
 
 	// onFlavors is a list of ResourceFlavors' names that this AdmissionCheck should run for.
 	// If empty, the AdmissionCheck will run for all workloads submitted to the ClusterQueue.
@@ -191,7 +200,8 @@ type ResourceGroup struct {
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=64
 	// +listType=atomic
-	CoveredResources []corev1.ResourceName `json:"coveredResources"`
+	// +required
+	CoveredResources []corev1.ResourceName `json:"coveredResources,omitempty"`
 
 	// flavors is the list of flavors that provide the resources of this group.
 	// Typically, different flavors represent different hardware models
@@ -202,17 +212,19 @@ type ResourceGroup struct {
 	// The list cannot be empty and it can contain up to 64 flavors, with a max of
 	// 256 total flavors across all resource groups in the ClusterQueue.
 	// +listType=map
+	// +required
 	// +listMapKey=name
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=64
-	Flavors []FlavorQuotas `json:"flavors"`
+	Flavors []FlavorQuotas `json:"flavors,omitempty"`
 }
 
 type FlavorQuotas struct {
 	// name of this flavor. The name should match the .metadata.name of a
 	// ResourceFlavor. If a matching ResourceFlavor does not exist, the
 	// ClusterQueue will have an Active condition set to False.
-	Name ResourceFlavorReference `json:"name"`
+	// +required
+	Name ResourceFlavorReference `json:"name"` //nolint:kubeapilinter // should not be a pointer
 
 	// resources is the list of quotas for this flavor per resource.
 	// There could be up to 64 resources.
@@ -220,12 +232,14 @@ type FlavorQuotas struct {
 	// +listMapKey=name
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=64
-	Resources []ResourceQuota `json:"resources"`
+	// +required
+	Resources []ResourceQuota `json:"resources,omitempty"`
 }
 
 type ResourceQuota struct {
 	// name of this resource.
-	Name corev1.ResourceName `json:"name"`
+	// +required
+	Name corev1.ResourceName `json:"name,omitempty"`
 
 	// nominalQuota is the quantity of this resource that is available for
 	// Workloads admitted by this ClusterQueue at a point in time.
@@ -239,7 +253,8 @@ type ResourceQuota struct {
 	// If the ClusterQueue belongs to a cohort, the sum of the quotas for each
 	// (flavor, resource) combination defines the maximum quantity that can be
 	// allocated by a ClusterQueue in the cohort.
-	NominalQuota resource.Quantity `json:"nominalQuota"`
+	// +required
+	NominalQuota resource.Quantity `json:"nominalQuota,omitempty"`
 
 	// borrowingLimit is the maximum amount of quota for the [flavor, resource]
 	// combination that this ClusterQueue is allowed to borrow from the unused
@@ -290,7 +305,7 @@ type ClusterQueueStatus struct {
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=64
 	// +optional
-	FlavorsReservation []FlavorUsage `json:"flavorsReservation"`
+	FlavorsReservation []FlavorUsage `json:"flavorsReservation,omitempty"`
 
 	// flavorsUsage are the used quotas, by flavor, currently in use by the
 	// workloads admitted in this ClusterQueue.
@@ -298,22 +313,22 @@ type ClusterQueueStatus struct {
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=64
 	// +optional
-	FlavorsUsage []FlavorUsage `json:"flavorsUsage"`
+	FlavorsUsage []FlavorUsage `json:"flavorsUsage,omitempty"`
 
 	// pendingWorkloads is the number of workloads currently waiting to be
 	// admitted to this clusterQueue.
 	// +optional
-	PendingWorkloads int32 `json:"pendingWorkloads"`
+	PendingWorkloads int32 `json:"pendingWorkloads"` //nolint:kubeapilinter // should not be a pointer
 
 	// reservingWorkloads is the number of workloads currently reserving quota in this
 	// clusterQueue.
 	// +optional
-	ReservingWorkloads int32 `json:"reservingWorkloads"`
+	ReservingWorkloads int32 `json:"reservingWorkloads"` //nolint:kubeapilinter // should not be a pointer
 
 	// admittedWorkloads is the number of workloads currently admitted to this
 	// clusterQueue and haven't finished yet.
 	// +optional
-	AdmittedWorkloads int32 `json:"admittedWorkloads"`
+	AdmittedWorkloads int32 `json:"admittedWorkloads"` //nolint:kubeapilinter // should not be a pointer
 
 	// fairSharing contains the current state for this ClusterQueue
 	// when participating in Fair Sharing.
@@ -324,26 +339,31 @@ type ClusterQueueStatus struct {
 
 type FlavorUsage struct {
 	// name of the flavor.
-	Name ResourceFlavorReference `json:"name"`
+	// +required
+	Name ResourceFlavorReference `json:"name,omitempty"` //nolint:kubeapilinter // should not be a pointer
 
 	// resources lists the quota usage for the resources in this flavor.
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=64
-	Resources []ResourceUsage `json:"resources"`
+	// +required
+	Resources []ResourceUsage `json:"resources,omitempty"`
 }
 
 type ResourceUsage struct {
 	// name of the resource
-	Name corev1.ResourceName `json:"name"`
+	// +required
+	Name corev1.ResourceName `json:"name,omitempty"`
 
 	// total is the total quantity of used quota, including the amount borrowed
 	// from the cohort.
-	Total resource.Quantity `json:"total,omitempty"`
+	// +optional
+	Total resource.Quantity `json:"total,omitempty"` //nolint:kubeapilinter // should not be a pointer
 
 	// borrowed is quantity of quota that is borrowed from the cohort. In other
 	// words, it's the used quota that is over the nominalQuota.
-	Borrowed resource.Quantity `json:"borrowed,omitempty"`
+	// +optional
+	Borrowed resource.Quantity `json:"borrowed,omitempty"` //nolint:kubeapilinter // should not be a pointer
 }
 
 const (
@@ -383,7 +403,8 @@ type FlavorFungibility struct {
 	//
 	// +kubebuilder:validation:Enum={MayStopSearch,TryNextFlavor,Borrow}
 	// +kubebuilder:default="MayStopSearch"
-	WhenCanBorrow FlavorFungibilityPolicy `json:"whenCanBorrow,omitempty"`
+	// +optional
+	WhenCanBorrow FlavorFungibilityPolicy `json:"whenCanBorrow,omitempty"` //nolint:kubeapilinter // should not be a pointer
 	// whenCanPreempt determines whether a workload should try the next flavor
 	// before borrowing in current flavor. The possible values are:
 	//
@@ -395,7 +416,8 @@ type FlavorFungibility struct {
 	//
 	// +kubebuilder:validation:Enum={MayStopSearch,TryNextFlavor,Preempt}
 	// +kubebuilder:default="TryNextFlavor"
-	WhenCanPreempt FlavorFungibilityPolicy `json:"whenCanPreempt,omitempty"`
+	// +optional
+	WhenCanPreempt FlavorFungibilityPolicy `json:"whenCanPreempt,omitempty"` //nolint:kubeapilinter // should not be a pointer
 }
 
 // ClusterQueuePreemption contains policies to preempt Workloads from this
@@ -436,14 +458,16 @@ type ClusterQueuePreemption struct {
 	//    cohort, irrespective of priority. **Fair Sharing** preempt Workloads
 	//    in the cohort that satisfy the Fair Sharing preemptionStrategies.
 	//
+	// +optional
 	// +kubebuilder:default=Never
 	// +kubebuilder:validation:Enum=Never;LowerPriority;Any
-	ReclaimWithinCohort PreemptionPolicy `json:"reclaimWithinCohort,omitempty"`
+	ReclaimWithinCohort PreemptionPolicy `json:"reclaimWithinCohort,omitempty"` //nolint:kubeapilinter // should not be a pointer
 
 	// borrowWithinCohort determines whether a pending Workload can preempt
 	// Workloads from other ClusterQueues in the cohort if the workload requires borrowing.
 	// May only be configured with Classical Preemption, and __not__ with Fair Sharing.
 	// +kubebuilder:default={}
+	// +optional
 	BorrowWithinCohort *BorrowWithinCohort `json:"borrowWithinCohort,omitempty"`
 
 	// withinClusterQueue determines whether a pending Workload that doesn't fit
@@ -459,7 +483,8 @@ type ClusterQueuePreemption struct {
 	//
 	// +kubebuilder:default=Never
 	// +kubebuilder:validation:Enum=Never;LowerPriority;LowerOrNewerEqualPriority
-	WithinClusterQueue PreemptionPolicy `json:"withinClusterQueue,omitempty"`
+	// +optional
+	WithinClusterQueue PreemptionPolicy `json:"withinClusterQueue,omitempty"` //nolint:kubeapilinter // should not be a pointer
 }
 
 type BorrowWithinCohortPolicy string
@@ -483,8 +508,8 @@ type BorrowWithinCohort struct {
 	//
 	// +kubebuilder:default=Never
 	// +kubebuilder:validation:Enum=Never;LowerPriority
-	Policy BorrowWithinCohortPolicy `json:"policy,omitempty"`
-
+	// +optional
+	Policy BorrowWithinCohortPolicy `json:"policy,omitempty"` //nolint:kubeapilinter // should not be a pointer
 	// maxPriorityThreshold allows to restrict the set of workloads which
 	// might be preempted by a borrowing workload, to only workloads with
 	// priority less than or equal to the specified threshold priority.
@@ -509,12 +534,15 @@ type BorrowWithinCohort struct {
 type ClusterQueue struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the metadata of the ClusterQueue.
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the specification of the ClusterQueue.
-	Spec ClusterQueueSpec `json:"spec,omitempty"`
+	// +optional
+	Spec ClusterQueueSpec `json:"spec,omitempty"` //nolint:kubeapilinter // spec should not be a pointer
 	// status is the status of the ClusterQueue.
-	Status ClusterQueueStatus `json:"status,omitempty"`
+	// +optional
+	Status ClusterQueueStatus `json:"status,omitempty"` //nolint:kubeapilinter // status should not be a pointer
 }
 
 // +kubebuilder:object:root=true

--- a/apis/kueue/v1beta2/cohort_types.go
+++ b/apis/kueue/v1beta2/cohort_types.go
@@ -32,7 +32,8 @@ type CohortSpec struct {
 	// Cohort, including ClusterQueues, until the cycle is
 	// removed.  We prevent further admission while the cycle
 	// exists.
-	ParentName CohortReference `json:"parentName,omitempty"`
+	// +optional
+	ParentName CohortReference `json:"parentName,omitempty"` //nolint:kubeapilinter // should not be a pointer
 
 	// resourceGroups describes groupings of Resources and
 	// Flavors.  Each ResourceGroup defines a list of Resources
@@ -60,6 +61,7 @@ type CohortSpec struct {
 	//
 	// +listType=atomic
 	// +kubebuilder:validation:MaxItems=16
+	// +optional
 	ResourceGroups []ResourceGroup `json:"resourceGroups,omitempty"`
 
 	// fairSharing defines the properties of the Cohort when
@@ -91,12 +93,15 @@ type CohortStatus struct {
 type Cohort struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the metadata of the Cohort.
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the specification of the Cohort.
-	Spec CohortSpec `json:"spec,omitempty"`
+	// +optional
+	Spec CohortSpec `json:"spec"` //nolint:kubeapilinter // spec should not be a pointer
 	// status is the status of the Cohort.
-	Status CohortStatus `json:"status,omitempty"`
+	// +optional
+	Status CohortStatus `json:"status,omitempty"` //nolint:kubeapilinter // status should not be a pointer
 }
 
 // +kubebuilder:object:root=true

--- a/apis/kueue/v1beta2/fairsharing_types.go
+++ b/apis/kueue/v1beta2/fairsharing_types.go
@@ -41,6 +41,7 @@ type FairSharing struct {
 	// disadvantage against other ClusterQueues and Cohorts.
 	// When not 0, Weight must be greater than 10^-9.
 	// +kubebuilder:default=1
+	// +optional
 	Weight *resource.Quantity `json:"weight,omitempty"`
 }
 
@@ -53,7 +54,8 @@ type FairSharingStatus struct {
 	// the Node is below the nominal quota.  If the Node has a
 	// weight of zero and is borrowing, this will return
 	// 9223372036854775807, the maximum possible share value.
-	WeightedShare int64 `json:"weightedShare"`
+	// +required
+	WeightedShare int64 `json:"weightedShare"` //nolint:kubeapilinter // do not add omitempty
 
 	// admissionFairSharingStatus represents information relevant to the Admission Fair Sharing
 	// +optional
@@ -69,7 +71,7 @@ type AdmissionFairSharingStatus struct {
 
 	// lastUpdate is the time when share and consumed resources were updated.
 	// +required
-	LastUpdate metav1.Time `json:"lastUpdate"`
+	LastUpdate metav1.Time `json:"lastUpdate"` //nolint:kubeapilinter // exclude omitempty
 }
 
 type AdmissionScope struct {
@@ -80,7 +82,7 @@ type AdmissionScope struct {
 	//
 	// +kubebuilder:validation:Enum=UsageBasedAdmissionFairSharing;NoAdmissionFairSharing
 	// +required
-	AdmissionMode AdmissionMode `json:"admissionMode"`
+	AdmissionMode AdmissionMode `json:"admissionMode,omitempty"`
 }
 
 type AdmissionMode string

--- a/apis/kueue/v1beta2/localqueue_types.go
+++ b/apis/kueue/v1beta2/localqueue_types.go
@@ -33,7 +33,8 @@ type LocalQueueName string
 type LocalQueueSpec struct {
 	// clusterQueue is a reference to a clusterQueue that backs this localQueue.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="field is immutable"
-	ClusterQueue ClusterQueueReference `json:"clusterQueue,omitempty"`
+	// +optional
+	ClusterQueue ClusterQueueReference `json:"clusterQueue,omitempty"` //nolint:kubeapilinter // should not be a pointer
 
 	// stopPolicy - if set to a value different from None, the LocalQueue is considered Inactive,
 	// no new reservation being made.
@@ -60,18 +61,16 @@ type TopologyInfo struct {
 	// name is the name of the topology.
 	//
 	// +required
-	// +kubebuilder:validation:Required
-	Name TopologyReference `json:"name"`
+	Name TopologyReference `json:"name"` //nolint:kubeapilinter // should not be a pointer
 
 	// levels define the levels of topology.
 	//
 	// +required
 	// +listType=atomic
-	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=16
 	// +kubebuilder:validation:items:MaxLength=317
-	Levels []string `json:"levels"`
+	Levels []string `json:"levels,omitempty"`
 }
 
 // LocalQueueStatus defines the observed state of LocalQueue
@@ -89,17 +88,17 @@ type LocalQueueStatus struct {
 
 	// pendingWorkloads is the number of Workloads in the LocalQueue not yet admitted to a ClusterQueue
 	// +optional
-	PendingWorkloads int32 `json:"pendingWorkloads"`
+	PendingWorkloads int32 `json:"pendingWorkloads"` //nolint:kubeapilinter // should not be a pointer
 
 	// reservingWorkloads is the number of workloads in this LocalQueue
 	// reserving quota in a ClusterQueue and that haven't finished yet.
 	// +optional
-	ReservingWorkloads int32 `json:"reservingWorkloads"`
+	ReservingWorkloads int32 `json:"reservingWorkloads"` //nolint:kubeapilinter // should not be a pointer
 
 	// admittedWorkloads is the number of workloads in this LocalQueue
 	// admitted to a ClusterQueue and that haven't finished yet.
 	// +optional
-	AdmittedWorkloads int32 `json:"admittedWorkloads"`
+	AdmittedWorkloads int32 `json:"admittedWorkloads"` //nolint:kubeapilinter // should not be a pointer
 
 	// flavorsReservation are the reserved quotas, by flavor currently in use by the
 	// workloads assigned to this LocalQueue.
@@ -107,7 +106,7 @@ type LocalQueueStatus struct {
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=16
 	// +optional
-	FlavorsReservation []LocalQueueFlavorUsage `json:"flavorsReservation"`
+	FlavorsReservation []LocalQueueFlavorUsage `json:"flavorsReservation,omitempty"`
 
 	// flavorsUsage are the used quotas, by flavor currently in use by the
 	// workloads assigned to this LocalQueue.
@@ -115,7 +114,7 @@ type LocalQueueStatus struct {
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=16
 	// +optional
-	FlavorsUsage []LocalQueueFlavorUsage `json:"flavorsUsage"`
+	FlavorsUsage []LocalQueueFlavorUsage `json:"flavorsUsage,omitempty"`
 
 	// fairSharing contains the information about the current status of fair sharing.
 	// +optional
@@ -130,21 +129,25 @@ const (
 
 type LocalQueueFlavorUsage struct {
 	// name of the flavor.
-	Name ResourceFlavorReference `json:"name"`
+	// +required
+	Name ResourceFlavorReference `json:"name"` //nolint:kubeapilinter // should not be a pointer
 
 	// resources lists the quota usage for the resources in this flavor.
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=16
-	Resources []LocalQueueResourceUsage `json:"resources"`
+	// +required
+	Resources []LocalQueueResourceUsage `json:"resources,omitempty"`
 }
 
 type LocalQueueResourceUsage struct {
 	// name of the resource.
-	Name corev1.ResourceName `json:"name"`
+	// +required
+	Name corev1.ResourceName `json:"name,omitempty"`
 
 	// total is the total quantity of used quota.
-	Total resource.Quantity `json:"total,omitempty"`
+	// +optional
+	Total resource.Quantity `json:"total,omitempty"` //nolint:kubeapilinter // should not be a pointer
 }
 
 // +genclient
@@ -159,12 +162,15 @@ type LocalQueueResourceUsage struct {
 type LocalQueue struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the metadata of the LocalQueue.
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the specification of the LocalQueue.
-	Spec LocalQueueSpec `json:"spec,omitempty"`
+	// +optional
+	Spec LocalQueueSpec `json:"spec"` //nolint:kubeapilinter // should not be a pointer
 	// status is the status of the LocalQueue.
-	Status LocalQueueStatus `json:"status,omitempty"`
+	// +optional
+	Status LocalQueueStatus `json:"status,omitempty"` //nolint:kubeapilinter // should not be a pointer
 }
 
 // +kubebuilder:object:root=true

--- a/apis/kueue/v1beta2/multikueue_types.go
+++ b/apis/kueue/v1beta2/multikueue_types.go
@@ -50,18 +50,22 @@ type KubeConfig struct {
 	// If LocationType is Secret then Location is the name of the secret inside the namespace in
 	// which the kueue controller manager is running. The config should be stored in the "kubeconfig" key.
 	// +kubebuilder:validation:MaxLength=256
-	Location string `json:"location"`
+	// +kubebuilder:validation:MinLength=1
+	// +required
+	Location string `json:"location,omitempty"`
 
 	// locationType of the KubeConfig.
 	//
 	// +kubebuilder:default=Secret
+	// +optional
 	// +kubebuilder:validation:Enum=Secret;Path
-	LocationType LocationType `json:"locationType"`
+	LocationType LocationType `json:"locationType"` //nolint:kubeapilinter // should not be a pointer
 }
 
 type MultiKueueClusterSpec struct {
 	// kubeConfig is information on how to connect to the cluster.
-	KubeConfig KubeConfig `json:"kubeConfig"`
+	// +required
+	KubeConfig KubeConfig `json:"kubeConfig,omitempty,omitzero"`
 }
 
 type MultiKueueClusterStatus struct {
@@ -89,13 +93,16 @@ type MultiKueueClusterStatus struct {
 type MultiKueueCluster struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the metadata of the MultiKueueCluster.
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the specification of the MultiKueueCluster.
-	Spec MultiKueueClusterSpec `json:"spec,omitempty"`
+	// +optional
+	Spec MultiKueueClusterSpec `json:"spec,omitempty,omitzero"` //nolint:kubeapilinter // spec should not be a pointer
 
 	// status is the status of the MultiKueueCluster.
-	Status MultiKueueClusterStatus `json:"status,omitempty"`
+	// +optional
+	Status MultiKueueClusterStatus `json:"status,omitempty"` //nolint:kubeapilinter // status should not be a pointer
 }
 
 // +kubebuilder:object:root=true
@@ -115,7 +122,8 @@ type MultiKueueConfigSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=10
 	// +kubebuilder:validation:items:MaxLength=256
-	Clusters []string `json:"clusters"`
+	// +required
+	Clusters []string `json:"clusters,omitempty,omitzero"`
 }
 
 // +genclient
@@ -127,10 +135,12 @@ type MultiKueueConfigSpec struct {
 type MultiKueueConfig struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the metadata of the MultiKueueConfig.
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the specification of the MultiKueueConfig.
-	Spec MultiKueueConfigSpec `json:"spec,omitempty"`
+	// +optional
+	Spec MultiKueueConfigSpec `json:"spec,omitempty"` //nolint:kubeapilinter // spec should not be a pointer
 }
 
 // +kubebuilder:object:root=true

--- a/apis/kueue/v1beta2/provisioningrequestconfig_types.go
+++ b/apis/kueue/v1beta2/provisioningrequestconfig_types.go
@@ -37,10 +37,11 @@ type ProvisioningRequestConfigSpec struct {
 	// provisioningClassName describes the different modes of provisioning the resources.
 	// Check autoscaling.x-k8s.io ProvisioningRequestSpec.ProvisioningClassName for details.
 	//
-	// +kubebuilder:validation:Required
+	// +required
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 	// +kubebuilder:validation:MaxLength=253
-	ProvisioningClassName string `json:"provisioningClassName"`
+	// +kubebuilder:validation:MinLength=1
+	ProvisioningClassName string `json:"provisioningClassName,omitempty"`
 
 	// parameters contains all other parameters classes may require.
 	//
@@ -107,7 +108,7 @@ type ProvisioningRequestPodSetUpdatesNodeSelector struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=317
 	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
-	Key string `json:"key"`
+	Key string `json:"key,omitempty"`
 
 	// valueFromProvisioningClassDetail specifies the key of the
 	// ProvisioningRequest.status.provisioningClassDetails from which the value
@@ -116,7 +117,7 @@ type ProvisioningRequestPodSetUpdatesNodeSelector struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=32768
-	ValueFromProvisioningClassDetail string `json:"valueFromProvisioningClassDetail"`
+	ValueFromProvisioningClassDetail string `json:"valueFromProvisioningClassDetail,omitempty"`
 }
 
 type ProvisioningRequestRetryStrategy struct {
@@ -165,10 +166,12 @@ type Parameter string
 type ProvisioningRequestConfig struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard object metadata.
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the specification of the ProvisioningRequestConfig.
-	Spec ProvisioningRequestConfigSpec `json:"spec,omitempty"`
+	// +optional
+	Spec ProvisioningRequestConfigSpec `json:"spec"` //nolint:kubeapilinter // should not be a pointer
 }
 
 // +kubebuilder:object:root=true

--- a/apis/kueue/v1beta2/resourceflavor_types.go
+++ b/apis/kueue/v1beta2/resourceflavor_types.go
@@ -30,10 +30,12 @@ import (
 type ResourceFlavor struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the metadata of the ResourceFlavor.
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the specification of the ResourceFlavor.
-	Spec ResourceFlavorSpec `json:"spec,omitempty"`
+	// +optional
+	Spec ResourceFlavorSpec `json:"spec,omitempty"` //nolint:kubeapilinter // spec should not be a pointer
 }
 
 // TopologyReference is the name of the Topology.
@@ -103,7 +105,7 @@ type ResourceFlavorSpec struct {
 	// nodes matching to the Resource Flavor node labels.
 	//
 	// +optional
-	TopologyName *TopologyReference `json:"topologyName,omitempty"`
+	TopologyName *TopologyReference `json:"topologyName,omitempty"` //nolint:kubeapilinter // should be a pointer
 }
 
 // +kubebuilder:object:root=true

--- a/apis/kueue/v1beta2/topology_types.go
+++ b/apis/kueue/v1beta2/topology_types.go
@@ -116,11 +116,10 @@ type TopologyLevel struct {
 	// - cloud.provider.com/topology-rack
 	//
 	// +required
-	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=316
 	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
-	NodeLabel string `json:"nodeLabel"`
+	NodeLabel string `json:"nodeLabel,omitempty"`
 }
 
 // +genclient
@@ -132,10 +131,12 @@ type TopologyLevel struct {
 type Topology struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the metadata of the Topology.
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the specification of the Topology.
-	Spec TopologySpec `json:"spec,omitempty"`
+	// +optional
+	Spec TopologySpec `json:"spec"` //nolint:kubeapilinter // spec should not be a pointer
 }
 
 // +kubebuilder:object:root=true

--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -35,11 +35,13 @@ type WorkloadSpec struct {
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=8
 	// +kubebuilder:validation:MinItems=1
-	PodSets []PodSet `json:"podSets"`
+	// +optional
+	PodSets []PodSet `json:"podSets"` //nolint:kubeapilinter // do not add omitempty tag
 
 	// queueName is the name of the LocalQueue the Workload is associated with.
 	// queueName cannot be changed while .status.admission is not null.
-	QueueName LocalQueueName `json:"queueName,omitempty"`
+	// +optional
+	QueueName LocalQueueName `json:"queueName,omitempty"` //nolint:kubeapilinter // should not be a pointer
 
 	// priorityClassName is the name of the PriorityClass the Workload is associated with.
 	// If specified, indicates the workload's priority.
@@ -49,14 +51,17 @@ type WorkloadSpec struct {
 	// PriorityClass object with that name. If not specified, the workload
 	// priority will be default or zero if there is no default.
 	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
-	PriorityClassName string `json:"priorityClassName,omitempty"`
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"` //nolint:kubeapilinter // should not be a pointer
 
 	// priority determines the order of access to the resources managed by the
 	// ClusterQueue where the workload is queued.
 	// The priority value is populated from PriorityClassName.
 	// The higher the value, the higher the priority.
 	// If priorityClassName is specified, priority must not be null.
+	// +optional
 	Priority *int32 `json:"priority,omitempty"`
 
 	// priorityClassSource determines whether the priorityClass field refers to a pod PriorityClass or kueue.x-k8s.io/workloadpriorityclass.
@@ -64,7 +69,8 @@ type WorkloadSpec struct {
 	// When using pod PriorityClass, a priorityClassSource field has the scheduling.k8s.io/priorityclass value.
 	// +kubebuilder:default=""
 	// +kubebuilder:validation:Enum=kueue.x-k8s.io/workloadpriorityclass;scheduling.k8s.io/priorityclass;""
-	PriorityClassSource string `json:"priorityClassSource,omitempty"`
+	// +optional
+	PriorityClassSource string `json:"priorityClassSource,omitempty"` //nolint:kubeapilinter // should not be a pointer
 
 	// active determines if a workload can be admitted into a queue.
 	// Changing active from true to false will evict any running workloads.
@@ -122,16 +128,19 @@ type PodSetTopologyRequest struct {
 	// - Kubeflow: training.kubeflow.org/replica-index
 	// 	This is limited to 317 characters.
 	// +kubebuilder:validation:MaxLength=317
+	// +optional
 	PodIndexLabel *string `json:"podIndexLabel,omitempty"`
 
 	// subGroupIndexLabel indicates the name of the label indexing the instances of replicated Jobs (groups)
 	// within a PodSet. For example, in the context of JobSet this is jobset.sigs.k8s.io/job-index.
 	// 	This is limited to 317 characters.
 	// +kubebuilder:validation:MaxLength=317
+	// +optional
 	SubGroupIndexLabel *string `json:"subGroupIndexLabel,omitempty"`
 
 	// subGroupCount indicates the count of replicated Jobs (groups) within a PodSet.
 	// For example, in the context of JobSet this value is read from jobset.sigs.k8s.io/replicatedjob-replicas.
+	// +optional
 	SubGroupCount *int32 `json:"subGroupCount,omitempty"`
 
 	// podSetGroupName indicates the name of the group of PodSets to which this PodSet belongs to.
@@ -159,13 +168,15 @@ type PodSetTopologyRequest struct {
 
 type Admission struct {
 	// clusterQueue is the name of the ClusterQueue that admitted this workload.
-	ClusterQueue ClusterQueueReference `json:"clusterQueue"`
+	// +optional
+	ClusterQueue ClusterQueueReference `json:"clusterQueue"` //nolint:kubeapilinter // should not be a pointer
 
 	// podSetAssignments hold the admission results for each of the .spec.podSets entries.
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=8
-	PodSetAssignments []PodSetAssignment `json:"podSetAssignments"`
+	// +optional
+	PodSetAssignments []PodSetAssignment `json:"podSetAssignments"` //nolint:kubeapilinter // do not add omitempty
 }
 
 // PodSetReference is the name of a PodSet.
@@ -180,9 +191,11 @@ func NewPodSetReference(name string) PodSetReference {
 type PodSetAssignment struct {
 	// name is the name of the podSet. It should match one of the names in .spec.podSets.
 	// +kubebuilder:default=main
-	Name PodSetReference `json:"name"`
+	// +optional
+	Name PodSetReference `json:"name"` //nolint:kubeapilinter // should not be a pointer
 
 	// flavors are the flavors assigned to the workload for each resource.
+	// +optional
 	Flavors map[corev1.ResourceName]ResourceFlavorReference `json:"flavors,omitempty"`
 
 	// resourceUsage keeps track of the total resources all the pods in the podset need to run.
@@ -190,6 +203,7 @@ type PodSetAssignment struct {
 	// Beside what is provided in podSet's specs, this calculation takes into account
 	// the LimitRange defaults and RuntimeClass overheads at the moment of admission.
 	// This field will not change in case of quota reclaim.
+	// +optional
 	ResourceUsage corev1.ResourceList `json:"resourceUsage,omitempty"` //nolint:kubeapilinter // map type is required for standard Kubernetes ResourceList
 
 	// count is the number of pods taken into account at admission time.
@@ -284,7 +298,7 @@ type TopologyAssignment struct {
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=16
 	// +kubebuilder:validation:items:MaxLength=317
-	Levels []string `json:"levels"`
+	Levels []string `json:"levels,omitempty"`
 
 	// domains is a list of topology assignments split by topology domains at
 	// the lowest level of the topology.
@@ -292,7 +306,7 @@ type TopologyAssignment struct {
 	// +required
 	// +listType=atomic
 	// +kubebuilder:validation:MaxItems=100000
-	Domains []TopologyDomainAssignment `json:"domains"`
+	Domains []TopologyDomainAssignment `json:"domains,omitempty"`
 }
 
 type TopologyDomainAssignment struct {
@@ -305,21 +319,22 @@ type TopologyDomainAssignment struct {
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=16
 	// +kubebuilder:validation:items:MaxLength=63
-	Values []string `json:"values"`
+	Values []string `json:"values,omitempty"`
 
 	// count indicates the number of Pods to be scheduled in the topology
 	// domain indicated by the values field.
 	//
 	// +required
 	// +kubebuilder:validation:Minimum=1
-	Count int32 `json:"count"`
+	Count int32 `json:"count,omitempty"`
 }
 
 // +kubebuilder:validation:XValidation:rule="has(self.minCount) ? self.minCount <= self.count : true", message="minCount should be positive and less or equal to count"
 type PodSet struct {
 	// name is the PodSet name.
 	// +kubebuilder:default=main
-	Name PodSetReference `json:"name,omitempty"`
+	// +optional
+	Name PodSetReference `json:"name,omitempty"` //nolint:kubeapilinter // should not be a pointer
 
 	// template is the Pod template.
 	//
@@ -334,12 +349,14 @@ type PodSet struct {
 	// the keys in the nodeLabels from the ResourceFlavors considered for this
 	// Workload are used to filter the ResourceFlavors that can be assigned to
 	// this podSet.
-	Template corev1.PodTemplateSpec `json:"template"`
+	// +required
+	Template corev1.PodTemplateSpec `json:"template,omitempty"`
 
 	// count is the number of pods for the spec.
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Minimum=0
-	Count int32 `json:"count"`
+	// +optional
+	Count int32 `json:"count"` //nolint:kubeapilinter // should not be a pointer
 
 	// minCount is the minimum number of pods for the spec acceptable
 	// if the workload supports partial admission.
@@ -491,32 +508,28 @@ type WorkloadSchedulingStatsEviction struct {
 	// reason specifies the programmatic identifier for the eviction cause.
 	//
 	// +required
-	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MaxLength=316
-	Reason string `json:"reason"`
+	Reason string `json:"reason"` //nolint:kubeapilinter // should not be a pointer
 
 	// underlyingCause specifies a finer-grained explanation that complements the eviction reason.
 	// This may be an empty string.
 	//
 	// +required
-	// +kubebuilder:validation:Required
-	UnderlyingCause EvictionUnderlyingCause `json:"underlyingCause"`
+	UnderlyingCause EvictionUnderlyingCause `json:"underlyingCause"` //nolint:kubeapilinter // should not be a pointer
 
 	// count tracks the number of evictions for this reason and detailed reason.
 	//
 	// +required
-	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=0
-	Count int32 `json:"count"`
+	Count int32 `json:"count"` //nolint:kubeapilinter // should not be a pointer
 }
 
 type UnhealthyNode struct {
 	// name is the name of the unhealthy node.
 	//
 	// +required
-	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MaxLength=63
-	Name string `json:"name"`
+	Name string `json:"name"` //nolint:kubeapilinter // should not be a pointer
 }
 
 type RequeueState struct {
@@ -538,31 +551,28 @@ type RequeueState struct {
 
 // AdmissionCheckReference is the name of an AdmissionCheck.
 // +kubebuilder:validation:MaxLength=316
+// +kubebuilder:validation:MinLength=1
 type AdmissionCheckReference string
 
 type AdmissionCheckState struct {
 	// name identifies the admission check.
 	// +required
-	// +kubebuilder:validation:Required
-	Name AdmissionCheckReference `json:"name"`
+	Name AdmissionCheckReference `json:"name,omitempty"`
 	// state of the admissionCheck, one of Pending, Ready, Retry, Rejected
 	// +required
-	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=Pending;Ready;Retry;Rejected
-	State CheckState `json:"state"`
+	State CheckState `json:"state,omitempty"`
 	// lastTransitionTime is the last time the condition transitioned from one status to another.
 	// This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
 	// +required
-	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Format=date-time
-	LastTransitionTime metav1.Time `json:"lastTransitionTime"`
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty,omitzero"`
 	// message is a human readable message indicating details about the transition.
 	// This may be an empty string.
 	// +required
-	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MaxLength=32768
-	Message string `json:"message" protobuf:"bytes,6,opt,name=message"`
+	Message string `json:"message" protobuf:"bytes,6,opt,name=message"` //nolint:kubeapilinter // disable should be a pointer rule
 
 	// podSetUpdates contains a list of pod set modifications suggested by AdmissionChecks.
 	// +optional
@@ -578,8 +588,7 @@ type AdmissionCheckState struct {
 type PodSetUpdate struct {
 	// name of the PodSet to modify. Should match to one of the Workload's PodSets.
 	// +required
-	// +kubebuilder:validation:Required
-	Name PodSetReference `json:"name"`
+	Name PodSetReference `json:"name"` //nolint:kubeapilinter // duplicatemarkers seems to say these are duplicates
 
 	// labels of the PodSet to modify.
 	// +optional
@@ -608,18 +617,18 @@ type PodSetUpdate struct {
 type ReclaimablePod struct {
 	// name is the PodSet name.
 	// +required
-	Name PodSetReference `json:"name"`
+	Name PodSetReference `json:"name"` //nolint:kubeapilinter // duplicatemarkers seems to say these are duplicates
 
 	// count is the number of pods for which the requested resources are no longer needed.
 	// +kubebuilder:validation:Minimum=0
-	Count int32 `json:"count"`
+	// +required
+	Count int32 `json:"count"` //nolint:kubeapilinter // should not be a pointer
 }
 
 type PodSetRequest struct {
 	// name is the name of the podSet. It should match one of the names in .spec.podSets.
-	// +kubebuilder:validation:Required
 	// +required
-	Name PodSetReference `json:"name"`
+	Name PodSetReference `json:"name"` //nolint:kubeapilinter // duplicatemarkers seems to say these are duplicates
 
 	// resources is the total resources all the pods in the podset need to run.
 	//
@@ -798,12 +807,15 @@ const (
 type Workload struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the metadata of the Workload.
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the specification of the Workload.
-	Spec WorkloadSpec `json:"spec,omitempty"`
+	// +optional
+	Spec WorkloadSpec `json:"spec"` //nolint:kubeapilinter // spec should not be a pointer
 	// status is the status of the Workload.
-	Status WorkloadStatus `json:"status,omitempty"`
+	// +optional
+	Status WorkloadStatus `json:"status,omitempty"` //nolint:kubeapilinter // status should not be a pointer
 }
 
 // +kubebuilder:object:root=true

--- a/apis/kueue/v1beta2/workloadpriorityclass_types.go
+++ b/apis/kueue/v1beta2/workloadpriorityclass_types.go
@@ -30,19 +30,21 @@ import (
 type WorkloadPriorityClass struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the metadata of the WorkloadPriorityClass.
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// value represents the integer value of this workloadPriorityClass. This is the actual priority that workloads
 	// receive when jobs have the name of this class in their workloadPriorityClass label.
 	// Changing the value of workloadPriorityClass doesn't affect the priority of workloads that were already created.
-	Value int32 `json:"value"`
+	// +required
+	Value int32 `json:"value"` //nolint:kubeapilinter // disabling should be a pointer
 
 	// description is an arbitrary string that usually provides guidelines on
 	// when this workloadPriorityClass should be used.
 	// The description is limited to a maximum of 2048 characters.
 	// +optional
 	// +kubebuilder:validation:MaxLength=2048
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty"` //nolint:kubeapilinter // disabling should not be a pointer
 }
 
 // +kubebuilder:object:root=true

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
@@ -219,16 +219,19 @@ spec:
                     apiGroup:
                       description: apiGroup is the group for the resource being referenced.
                       maxLength: 253
+                      minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     kind:
                       description: kind is the type of the resource being referenced.
                       maxLength: 63
+                      minLength: 1
                       pattern: ^(?i)[a-z]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     name:
                       description: name is the name of the resource being referenced.
                       maxLength: 63
+                      minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                   required:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -846,6 +846,7 @@ spec:
                   items:
                     description: AdmissionCheckReference is the name of an AdmissionCheck.
                     maxLength: 316
+                    minLength: 1
                     type: string
                   type: array
                 admissionChecksStrategy:
@@ -861,6 +862,7 @@ spec:
                           name:
                             description: name is an AdmissionCheck's name.
                             maxLength: 316
+                            minLength: 1
                             type: string
                           onFlavors:
                             description: |-
@@ -878,10 +880,13 @@ spec:
                           - name
                         type: object
                       maxItems: 64
+                      minItems: 1
                       type: array
                       x-kubernetes-list-map-keys:
                         - name
                       x-kubernetes-list-type: map
+                  required:
+                    - admissionChecks
                   type: object
                 admissionScope:
                   description: admissionScope indicates whether ClusterQueue uses the Admission Fair Sharing

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
@@ -208,6 +208,7 @@ spec:
                         If LocationType is Secret then Location is the name of the secret inside the namespace in
                         which the kueue controller manager is running. The config should be stored in the "kubeconfig" key.
                       maxLength: 256
+                      minLength: 1
                       type: string
                     locationType:
                       default: Secret
@@ -218,7 +219,6 @@ spec:
                       type: string
                   required:
                     - location
-                    - locationType
                   type: object
               required:
                 - kubeConfig

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_provisioningrequestconfigs.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_provisioningrequestconfigs.yaml
@@ -283,6 +283,7 @@ spec:
                     provisioningClassName describes the different modes of provisioning the resources.
                     Check autoscaling.x-k8s.io ProvisioningRequestSpec.ProvisioningClassName for details.
                   maxLength: 253
+                  minLength: 1
                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                   type: string
                 retryStrategy:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -17104,7 +17104,6 @@ spec:
                             type: boolean
                         type: object
                     required:
-                      - count
                       - template
                     type: object
                     x-kubernetes-validations:
@@ -17135,6 +17134,7 @@ spec:
                     PriorityClass object with that name. If not specified, the workload
                     priority will be default or zero if there is no default.
                   maxLength: 253
+                  minLength: 1
                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                   type: string
                 priorityClassSource:
@@ -17155,8 +17155,6 @@ spec:
                   maxLength: 253
                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                   type: string
-              required:
-                - podSets
               type: object
               x-kubernetes-validations:
                 - message: priority should not be nil when priorityClassName is set
@@ -17327,17 +17325,12 @@ spec:
                               - domains
                               - levels
                             type: object
-                        required:
-                          - name
                         type: object
                       maxItems: 8
                       type: array
                       x-kubernetes-list-map-keys:
                         - name
                       x-kubernetes-list-type: map
-                  required:
-                    - clusterQueue
-                    - podSetAssignments
                   type: object
                 admissionChecks:
                   description: admissionChecks list all the admission checks required by the workload and the current status
@@ -17358,6 +17351,7 @@ spec:
                       name:
                         description: name identifies the admission check.
                         maxLength: 316
+                        minLength: 1
                         type: string
                       podSetUpdates:
                         description: podSetUpdates contains a list of pod set modifications suggested by AdmissionChecks.

--- a/config/components/crd/bases/kueue.x-k8s.io_admissionchecks.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_admissionchecks.yaml
@@ -198,16 +198,19 @@ spec:
                   apiGroup:
                     description: apiGroup is the group for the resource being referenced.
                     maxLength: 253
+                    minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
                     description: kind is the type of the resource being referenced.
                     maxLength: 63
+                    minLength: 1
                     pattern: ^(?i)[a-z]([-a-z0-9]*[a-z0-9])?$
                     type: string
                   name:
                     description: name is the name of the resource being referenced.
                     maxLength: 63
+                    minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                 required:

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -831,6 +831,7 @@ spec:
                 items:
                   description: AdmissionCheckReference is the name of an AdmissionCheck.
                   maxLength: 316
+                  minLength: 1
                   type: string
                 type: array
               admissionChecksStrategy:
@@ -847,6 +848,7 @@ spec:
                         name:
                           description: name is an AdmissionCheck's name.
                           maxLength: 316
+                          minLength: 1
                           type: string
                         onFlavors:
                           description: |-
@@ -865,10 +867,13 @@ spec:
                       - name
                       type: object
                     maxItems: 64
+                    minItems: 1
                     type: array
                     x-kubernetes-list-map-keys:
                     - name
                     x-kubernetes-list-type: map
+                required:
+                - admissionChecks
                 type: object
               admissionScope:
                 description: admissionScope indicates whether ClusterQueue uses the

--- a/config/components/crd/bases/kueue.x-k8s.io_multikueueclusters.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_multikueueclusters.yaml
@@ -187,6 +187,7 @@ spec:
                       If LocationType is Secret then Location is the name of the secret inside the namespace in
                       which the kueue controller manager is running. The config should be stored in the "kubeconfig" key.
                     maxLength: 256
+                    minLength: 1
                     type: string
                   locationType:
                     default: Secret
@@ -197,7 +198,6 @@ spec:
                     type: string
                 required:
                 - location
-                - locationType
                 type: object
             required:
             - kubeConfig

--- a/config/components/crd/bases/kueue.x-k8s.io_provisioningrequestconfigs.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_provisioningrequestconfigs.yaml
@@ -269,6 +269,7 @@ spec:
                   provisioningClassName describes the different modes of provisioning the resources.
                   Check autoscaling.x-k8s.io ProvisioningRequestSpec.ProvisioningClassName for details.
                 maxLength: 253
+                minLength: 1
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
               retryStrategy:

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -18093,7 +18093,6 @@ spec:
                           type: boolean
                       type: object
                   required:
-                  - count
                   - template
                   type: object
                   x-kubernetes-validations:
@@ -18124,6 +18123,7 @@ spec:
                   PriorityClass object with that name. If not specified, the workload
                   priority will be default or zero if there is no default.
                 maxLength: 253
+                minLength: 1
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
               priorityClassSource:
@@ -18144,8 +18144,6 @@ spec:
                 maxLength: 253
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
-            required:
-            - podSets
             type: object
             x-kubernetes-validations:
             - message: priority should not be nil when priorityClassName is set
@@ -18321,17 +18319,12 @@ spec:
                           - domains
                           - levels
                           type: object
-                      required:
-                      - name
                       type: object
                     maxItems: 8
                     type: array
                     x-kubernetes-list-map-keys:
                     - name
                     x-kubernetes-list-type: map
-                required:
-                - clusterQueue
-                - podSetAssignments
                 type: object
               admissionChecks:
                 description: admissionChecks list all the admission checks required
@@ -18353,6 +18346,7 @@ spec:
                     name:
                       description: name identifies the admission check.
                       maxLength: 316
+                      minLength: 1
                       type: string
                     podSetUpdates:
                       description: podSetUpdates contains a list of pod set modifications

--- a/site/content/en/docs/reference/kueue.v1beta2.md
+++ b/site/content/en/docs/reference/kueue.v1beta2.md
@@ -41,14 +41,14 @@ description: Generated API reference documentation for kueue.x-k8s.io/v1beta2.
 <tr><td><code>kind</code><br/>string</td><td><code>AdmissionCheck</code></td></tr>
     
   
-<tr><td><code>spec</code> <B>[Required]</B><br/>
+<tr><td><code>spec</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-AdmissionCheckSpec"><code>AdmissionCheckSpec</code></a>
 </td>
 <td>
    <p>spec is the specification of the AdmissionCheck.</p>
 </td>
 </tr>
-<tr><td><code>status</code> <B>[Required]</B><br/>
+<tr><td><code>status</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-AdmissionCheckStatus"><code>AdmissionCheckStatus</code></a>
 </td>
 <td>
@@ -76,14 +76,14 @@ description: Generated API reference documentation for kueue.x-k8s.io/v1beta2.
 <tr><td><code>kind</code><br/>string</td><td><code>ClusterQueue</code></td></tr>
     
   
-<tr><td><code>spec</code> <B>[Required]</B><br/>
+<tr><td><code>spec</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-ClusterQueueSpec"><code>ClusterQueueSpec</code></a>
 </td>
 <td>
    <p>spec is the specification of the ClusterQueue.</p>
 </td>
 </tr>
-<tr><td><code>status</code> <B>[Required]</B><br/>
+<tr><td><code>status</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-ClusterQueueStatus"><code>ClusterQueueStatus</code></a>
 </td>
 <td>
@@ -114,14 +114,14 @@ V0.9 and V0.10 is unsupported, and results in undefined behavior.</p>
 <tr><td><code>kind</code><br/>string</td><td><code>Cohort</code></td></tr>
     
   
-<tr><td><code>spec</code> <B>[Required]</B><br/>
+<tr><td><code>spec</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-CohortSpec"><code>CohortSpec</code></a>
 </td>
 <td>
    <p>spec is the specification of the Cohort.</p>
 </td>
 </tr>
-<tr><td><code>status</code> <B>[Required]</B><br/>
+<tr><td><code>status</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-CohortStatus"><code>CohortStatus</code></a>
 </td>
 <td>
@@ -149,14 +149,14 @@ V0.9 and V0.10 is unsupported, and results in undefined behavior.</p>
 <tr><td><code>kind</code><br/>string</td><td><code>LocalQueue</code></td></tr>
     
   
-<tr><td><code>spec</code> <B>[Required]</B><br/>
+<tr><td><code>spec</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-LocalQueueSpec"><code>LocalQueueSpec</code></a>
 </td>
 <td>
    <p>spec is the specification of the LocalQueue.</p>
 </td>
 </tr>
-<tr><td><code>status</code> <B>[Required]</B><br/>
+<tr><td><code>status</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-LocalQueueStatus"><code>LocalQueueStatus</code></a>
 </td>
 <td>
@@ -184,14 +184,14 @@ V0.9 and V0.10 is unsupported, and results in undefined behavior.</p>
 <tr><td><code>kind</code><br/>string</td><td><code>MultiKueueCluster</code></td></tr>
     
   
-<tr><td><code>spec</code> <B>[Required]</B><br/>
+<tr><td><code>spec,omitempty,omitzero</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-MultiKueueClusterSpec"><code>MultiKueueClusterSpec</code></a>
 </td>
 <td>
    <p>spec is the specification of the MultiKueueCluster.</p>
 </td>
 </tr>
-<tr><td><code>status</code> <B>[Required]</B><br/>
+<tr><td><code>status</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-MultiKueueClusterStatus"><code>MultiKueueClusterStatus</code></a>
 </td>
 <td>
@@ -219,7 +219,7 @@ V0.9 and V0.10 is unsupported, and results in undefined behavior.</p>
 <tr><td><code>kind</code><br/>string</td><td><code>MultiKueueConfig</code></td></tr>
     
   
-<tr><td><code>spec</code> <B>[Required]</B><br/>
+<tr><td><code>spec</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-MultiKueueConfigSpec"><code>MultiKueueConfigSpec</code></a>
 </td>
 <td>
@@ -247,7 +247,7 @@ V0.9 and V0.10 is unsupported, and results in undefined behavior.</p>
 <tr><td><code>kind</code><br/>string</td><td><code>ProvisioningRequestConfig</code></td></tr>
     
   
-<tr><td><code>spec</code> <B>[Required]</B><br/>
+<tr><td><code>spec</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-ProvisioningRequestConfigSpec"><code>ProvisioningRequestConfigSpec</code></a>
 </td>
 <td>
@@ -275,7 +275,7 @@ V0.9 and V0.10 is unsupported, and results in undefined behavior.</p>
 <tr><td><code>kind</code><br/>string</td><td><code>ResourceFlavor</code></td></tr>
     
   
-<tr><td><code>spec</code> <B>[Required]</B><br/>
+<tr><td><code>spec</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-ResourceFlavorSpec"><code>ResourceFlavorSpec</code></a>
 </td>
 <td>
@@ -303,7 +303,7 @@ V0.9 and V0.10 is unsupported, and results in undefined behavior.</p>
 <tr><td><code>kind</code><br/>string</td><td><code>Topology</code></td></tr>
     
   
-<tr><td><code>spec</code> <B>[Required]</B><br/>
+<tr><td><code>spec</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-TopologySpec"><code>TopologySpec</code></a>
 </td>
 <td>
@@ -331,14 +331,14 @@ V0.9 and V0.10 is unsupported, and results in undefined behavior.</p>
 <tr><td><code>kind</code><br/>string</td><td><code>Workload</code></td></tr>
     
   
-<tr><td><code>spec</code> <B>[Required]</B><br/>
+<tr><td><code>spec</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-WorkloadSpec"><code>WorkloadSpec</code></a>
 </td>
 <td>
    <p>spec is the specification of the Workload.</p>
 </td>
 </tr>
-<tr><td><code>status</code> <B>[Required]</B><br/>
+<tr><td><code>status</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-WorkloadStatus"><code>WorkloadStatus</code></a>
 </td>
 <td>
@@ -401,14 +401,14 @@ The description is limited to a maximum of 2048 characters.</p>
 <tbody>
     
   
-<tr><td><code>clusterQueue</code> <B>[Required]</B><br/>
+<tr><td><code>clusterQueue</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-ClusterQueueReference"><code>ClusterQueueReference</code></a>
 </td>
 <td>
    <p>clusterQueue is the name of the ClusterQueue that admitted this workload.</p>
 </td>
 </tr>
-<tr><td><code>podSetAssignments</code> <B>[Required]</B><br/>
+<tr><td><code>podSetAssignments</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-PodSetAssignment"><code>[]PodSetAssignment</code></a>
 </td>
 <td>
@@ -537,7 +537,7 @@ check.</p>
    <p>state of the admissionCheck, one of Pending, Ready, Retry, Rejected</p>
 </td>
 </tr>
-<tr><td><code>lastTransitionTime</code> <B>[Required]</B><br/>
+<tr><td><code>lastTransitionTime,omitempty,omitzero</code> <B>[Required]</B><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.Time</code></a>
 </td>
 <td>
@@ -743,7 +743,7 @@ within cohort while borrowing. It only works with Classical Preemption,
 <tbody>
     
   
-<tr><td><code>policy</code> <B>[Required]</B><br/>
+<tr><td><code>policy</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-BorrowWithinCohortPolicy"><code>BorrowWithinCohortPolicy</code></a>
 </td>
 <td>
@@ -830,7 +830,7 @@ lower priority first.</p>
 <tbody>
     
   
-<tr><td><code>reclaimWithinCohort</code> <B>[Required]</B><br/>
+<tr><td><code>reclaimWithinCohort</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-PreemptionPolicy"><code>PreemptionPolicy</code></a>
 </td>
 <td>
@@ -852,7 +852,7 @@ in the cohort that satisfy the Fair Sharing preemptionStrategies.</li>
 </ul>
 </td>
 </tr>
-<tr><td><code>borrowWithinCohort</code> <B>[Required]</B><br/>
+<tr><td><code>borrowWithinCohort</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-BorrowWithinCohort"><code>BorrowWithinCohort</code></a>
 </td>
 <td>
@@ -861,7 +861,7 @@ Workloads from other ClusterQueues in the cohort if the workload requires borrow
 May only be configured with Classical Preemption, and <strong>not</strong> with Fair Sharing.</p>
 </td>
 </tr>
-<tr><td><code>withinClusterQueue</code> <B>[Required]</B><br/>
+<tr><td><code>withinClusterQueue</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-PreemptionPolicy"><code>PreemptionPolicy</code></a>
 </td>
 <td>
@@ -914,7 +914,7 @@ It must be a DNS (RFC 1123) and has the maximum length of 253 characters.</p>
 <tbody>
     
   
-<tr><td><code>resourceGroups</code> <B>[Required]</B><br/>
+<tr><td><code>resourceGroups</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-ResourceGroup"><code>[]ResourceGroup</code></a>
 </td>
 <td>
@@ -925,7 +925,7 @@ Each resource and each flavor can only form part of one resource group.
 resourceGroups can be up to 16, with a max of 256 total flavors across all groups.</p>
 </td>
 </tr>
-<tr><td><code>cohortName</code> <B>[Required]</B><br/>
+<tr><td><code>cohortName</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-CohortReference"><code>CohortReference</code></a>
 </td>
 <td>
@@ -941,7 +941,7 @@ vice versa.</p>
 object.</p>
 </td>
 </tr>
-<tr><td><code>queueingStrategy</code> <B>[Required]</B><br/>
+<tr><td><code>queueingStrategy</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-QueueingStrategy"><code>QueueingStrategy</code></a>
 </td>
 <td>
@@ -958,7 +958,7 @@ admitting newer workloads that fit existing quota.</li>
 </ul>
 </td>
 </tr>
-<tr><td><code>namespaceSelector</code> <B>[Required]</B><br/>
+<tr><td><code>namespaceSelector</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector</code></a>
 </td>
 <td>
@@ -969,7 +969,7 @@ Defaults to null which is a nothing selector (no namespaces eligible).
 If set to an empty selector <code>{}</code>, then all namespaces are eligible.</p>
 </td>
 </tr>
-<tr><td><code>flavorFungibility</code> <B>[Required]</B><br/>
+<tr><td><code>flavorFungibility</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-FlavorFungibility"><code>FlavorFungibility</code></a>
 </td>
 <td>
@@ -977,7 +977,7 @@ If set to an empty selector <code>{}</code>, then all namespaces are eligible.</
 before borrowing or preempting in the flavor being evaluated.</p>
 </td>
 </tr>
-<tr><td><code>preemption</code> <B>[Required]</B><br/>
+<tr><td><code>preemption</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-ClusterQueuePreemption"><code>ClusterQueuePreemption</code></a>
 </td>
 <td>
@@ -1146,7 +1146,7 @@ subdomain in DNS (RFC 1123).</p>
 <tbody>
     
   
-<tr><td><code>parentName</code> <B>[Required]</B><br/>
+<tr><td><code>parentName</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-CohortReference"><code>CohortReference</code></a>
 </td>
 <td>
@@ -1163,7 +1163,7 @@ removed.  We prevent further admission while the cycle
 exists.</p>
 </td>
 </tr>
-<tr><td><code>resourceGroups</code> <B>[Required]</B><br/>
+<tr><td><code>resourceGroups</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-ResourceGroup"><code>[]ResourceGroup</code></a>
 </td>
 <td>
@@ -1280,7 +1280,7 @@ V0.9 and V0.10 is unsupported, and results in undefined behavior.</p>
 <tbody>
     
   
-<tr><td><code>weight</code> <B>[Required]</B><br/>
+<tr><td><code>weight</code><br/>
 <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity"><code>k8s.io/apimachinery/pkg/api/resource.Quantity</code></a>
 </td>
 <td>
@@ -1360,7 +1360,7 @@ before borrowing or preempting in current flavor.</p>
 <tbody>
     
   
-<tr><td><code>whenCanBorrow</code> <B>[Required]</B><br/>
+<tr><td><code>whenCanBorrow</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-FlavorFungibilityPolicy"><code>FlavorFungibilityPolicy</code></a>
 </td>
 <td>
@@ -1374,7 +1374,7 @@ fits or requires borrowing to fit.</li>
 </ul>
 </td>
 </tr>
-<tr><td><code>whenCanPreempt</code> <B>[Required]</B><br/>
+<tr><td><code>whenCanPreempt</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-FlavorFungibilityPolicy"><code>FlavorFungibilityPolicy</code></a>
 </td>
 <td>
@@ -1492,7 +1492,7 @@ There could be up to 64 resources.</p>
 which the kueue controller manager is running. The config should be stored in the &quot;kubeconfig&quot; key.</p>
 </td>
 </tr>
-<tr><td><code>locationType</code> <B>[Required]</B><br/>
+<tr><td><code>locationType</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-LocationType"><code>LocationType</code></a>
 </td>
 <td>
@@ -1569,7 +1569,7 @@ It must be a DNS (RFC 1123) and has the maximum length of 253 characters.</p>
    <p>name of the resource.</p>
 </td>
 </tr>
-<tr><td><code>total</code> <B>[Required]</B><br/>
+<tr><td><code>total</code><br/>
 <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity"><code>k8s.io/apimachinery/pkg/api/resource.Quantity</code></a>
 </td>
 <td>
@@ -1595,7 +1595,7 @@ It must be a DNS (RFC 1123) and has the maximum length of 253 characters.</p>
 <tbody>
     
   
-<tr><td><code>clusterQueue</code> <B>[Required]</B><br/>
+<tr><td><code>clusterQueue</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-ClusterQueueReference"><code>ClusterQueueReference</code></a>
 </td>
 <td>
@@ -1728,7 +1728,7 @@ workloads assigned to this LocalQueue.</p>
 <tbody>
     
   
-<tr><td><code>kubeConfig</code> <B>[Required]</B><br/>
+<tr><td><code>kubeConfig,omitempty,omitzero</code> <B>[Required]</B><br/>
 <a href="#kueue-x-k8s-io-v1beta2-KubeConfig"><code>KubeConfig</code></a>
 </td>
 <td>
@@ -1780,7 +1780,7 @@ conditions are limited to 16 elements.</p>
 <tbody>
     
   
-<tr><td><code>clusters</code> <B>[Required]</B><br/>
+<tr><td><code>clusters,omitempty,omitzero</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
@@ -1818,7 +1818,7 @@ conditions are limited to 16 elements.</p>
 <tbody>
     
   
-<tr><td><code>name</code> <B>[Required]</B><br/>
+<tr><td><code>name</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-PodSetReference"><code>PodSetReference</code></a>
 </td>
 <td>
@@ -1841,7 +1841,7 @@ Workload are used to filter the ResourceFlavors that can be assigned to
 this podSet.</p>
 </td>
 </tr>
-<tr><td><code>count</code> <B>[Required]</B><br/>
+<tr><td><code>count</code><br/>
 <code>int32</code>
 </td>
 <td>
@@ -1884,21 +1884,21 @@ enabled.</p>
 <tbody>
     
   
-<tr><td><code>name</code> <B>[Required]</B><br/>
+<tr><td><code>name</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-PodSetReference"><code>PodSetReference</code></a>
 </td>
 <td>
    <p>name is the name of the podSet. It should match one of the names in .spec.podSets.</p>
 </td>
 </tr>
-<tr><td><code>flavors</code> <B>[Required]</B><br/>
+<tr><td><code>flavors</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-ResourceFlavorReference"><code>map[ResourceName]ResourceFlavorReference</code></a>
 </td>
 <td>
    <p>flavors are the flavors assigned to the workload for each resource.</p>
 </td>
 </tr>
-<tr><td><code>resourceUsage</code> <B>[Required]</B><br/>
+<tr><td><code>resourceUsage</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcelist-v1-core"><code>k8s.io/api/core/v1.ResourceList</code></a>
 </td>
 <td>
@@ -2085,7 +2085,7 @@ the entire available capacity, without constraints on the compactness of the pla
 This is indicated by the <code>kueue.x-k8s.io/podset-unconstrained-topology</code> PodSet annotation.</p>
 </td>
 </tr>
-<tr><td><code>podIndexLabel</code> <B>[Required]</B><br/>
+<tr><td><code>podIndexLabel</code><br/>
 <code>string</code>
 </td>
 <td>
@@ -2099,7 +2099,7 @@ This is limited to 317 characters.</li>
 </ul>
 </td>
 </tr>
-<tr><td><code>subGroupIndexLabel</code> <B>[Required]</B><br/>
+<tr><td><code>subGroupIndexLabel</code><br/>
 <code>string</code>
 </td>
 <td>
@@ -2108,7 +2108,7 @@ within a PodSet. For example, in the context of JobSet this is jobset.sigs.k8s.i
 This is limited to 317 characters.</p>
 </td>
 </tr>
-<tr><td><code>subGroupCount</code> <B>[Required]</B><br/>
+<tr><td><code>subGroupCount</code><br/>
 <code>int32</code>
 </td>
 <td>
@@ -2717,7 +2717,7 @@ This field is in beta stage and is enabled by default.</p>
    <p>name of the resource</p>
 </td>
 </tr>
-<tr><td><code>total</code> <B>[Required]</B><br/>
+<tr><td><code>total</code><br/>
 <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity"><code>k8s.io/apimachinery/pkg/api/resource.Quantity</code></a>
 </td>
 <td>
@@ -2725,7 +2725,7 @@ This field is in beta stage and is enabled by default.</p>
 from the cohort.</p>
 </td>
 </tr>
-<tr><td><code>borrowed</code> <B>[Required]</B><br/>
+<tr><td><code>borrowed</code><br/>
 <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity"><code>k8s.io/apimachinery/pkg/api/resource.Quantity</code></a>
 </td>
 <td>
@@ -2994,7 +2994,7 @@ This may be an empty string.</p>
 <tbody>
     
   
-<tr><td><code>podSets</code> <B>[Required]</B><br/>
+<tr><td><code>podSets</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-PodSet"><code>[]PodSet</code></a>
 </td>
 <td>
@@ -3004,7 +3004,7 @@ There must be at least one element and at most 8.
 podSets cannot be changed.</p>
 </td>
 </tr>
-<tr><td><code>queueName</code> <B>[Required]</B><br/>
+<tr><td><code>queueName</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-LocalQueueName"><code>LocalQueueName</code></a>
 </td>
 <td>
@@ -3012,7 +3012,7 @@ podSets cannot be changed.</p>
 queueName cannot be changed while .status.admission is not null.</p>
 </td>
 </tr>
-<tr><td><code>priorityClassName</code> <B>[Required]</B><br/>
+<tr><td><code>priorityClassName</code><br/>
 <code>string</code>
 </td>
 <td>
@@ -3025,7 +3025,7 @@ PriorityClass object with that name. If not specified, the workload
 priority will be default or zero if there is no default.</p>
 </td>
 </tr>
-<tr><td><code>priority</code> <B>[Required]</B><br/>
+<tr><td><code>priority</code><br/>
 <code>int32</code>
 </td>
 <td>
@@ -3036,7 +3036,7 @@ The higher the value, the higher the priority.
 If priorityClassName is specified, priority must not be null.</p>
 </td>
 </tr>
-<tr><td><code>priorityClassSource</code> <B>[Required]</B><br/>
+<tr><td><code>priorityClassSource</code><br/>
 <code>string</code>
 </td>
 <td>


### PR DESCRIPTION
Enable all linter checks.

This is just to display the failures so we can decide if we should apply these.