### PR TITLE
Remove deprecated AdmissionChecks field from v1beta2 ClusterQueue API

### DIFF
--- a/apis/kueue/v1beta1/clusterqueue_conversion.go
+++ b/apis/kueue/v1beta1/clusterqueue_conversion.go
@@ -38,6 +38,19 @@ func (dst *ClusterQueue) ConvertFrom(srcRaw conversion.Hub) error {
 
 func Convert_v1beta1_ClusterQueueSpec_To_v1beta2_ClusterQueueSpec(in *ClusterQueueSpec, out *v1beta2.ClusterQueueSpec, s conversionapi.Scope) error {
 	out.CohortName = v1beta2.CohortReference(in.Cohort)
+
+	// Convert AdmissionChecks to AdmissionChecksStrategy before autoConvert
+	if len(in.AdmissionChecks) > 0 {
+		out.AdmissionChecksStrategy = &v1beta2.AdmissionChecksStrategy{
+			AdmissionChecks: make([]v1beta2.AdmissionCheckStrategyRule, len(in.AdmissionChecks)),
+		}
+		for i, checkRef := range in.AdmissionChecks {
+			out.AdmissionChecksStrategy.AdmissionChecks[i] = v1beta2.AdmissionCheckStrategyRule{
+				Name: v1beta2.AdmissionCheckReference(checkRef),
+			}
+		}
+	}
+
 	if in.FlavorFungibility != nil && out.FlavorFungibility != nil {
 		if in.FlavorFungibility.WhenCanPreempt == Preempt {
 			out.FlavorFungibility.WhenCanPreempt = v1beta2.MayStopSearch
@@ -46,6 +59,7 @@ func Convert_v1beta1_ClusterQueueSpec_To_v1beta2_ClusterQueueSpec(in *ClusterQue
 			out.FlavorFungibility.WhenCanBorrow = v1beta2.MayStopSearch
 		}
 	}
+
 	return autoConvert_v1beta1_ClusterQueueSpec_To_v1beta2_ClusterQueueSpec(in, out, s)
 }
 

--- a/apis/kueue/v1beta1/zz_generated.conversion.go
+++ b/apis/kueue/v1beta1/zz_generated.conversion.go
@@ -1188,7 +1188,7 @@ func autoConvert_v1beta1_ClusterQueueSpec_To_v1beta2_ClusterQueueSpec(in *Cluste
 	out.NamespaceSelector = (*v1.LabelSelector)(unsafe.Pointer(in.NamespaceSelector))
 	out.FlavorFungibility = (*v1beta2.FlavorFungibility)(unsafe.Pointer(in.FlavorFungibility))
 	out.Preemption = (*v1beta2.ClusterQueuePreemption)(unsafe.Pointer(in.Preemption))
-	out.AdmissionChecks = *(*[]v1beta2.AdmissionCheckReference)(unsafe.Pointer(&in.AdmissionChecks))
+	// WARNING: in.AdmissionChecks requires manual conversion: does not exist in peer-type
 	out.AdmissionChecksStrategy = (*v1beta2.AdmissionChecksStrategy)(unsafe.Pointer(in.AdmissionChecksStrategy))
 	out.StopPolicy = (*v1beta2.StopPolicy)(unsafe.Pointer(in.StopPolicy))
 	out.FairSharing = (*v1beta2.FairSharing)(unsafe.Pointer(in.FairSharing))
@@ -1203,7 +1203,6 @@ func autoConvert_v1beta2_ClusterQueueSpec_To_v1beta1_ClusterQueueSpec(in *v1beta
 	out.NamespaceSelector = (*v1.LabelSelector)(unsafe.Pointer(in.NamespaceSelector))
 	out.FlavorFungibility = (*FlavorFungibility)(unsafe.Pointer(in.FlavorFungibility))
 	out.Preemption = (*ClusterQueuePreemption)(unsafe.Pointer(in.Preemption))
-	out.AdmissionChecks = *(*[]AdmissionCheckReference)(unsafe.Pointer(&in.AdmissionChecks))
 	out.AdmissionChecksStrategy = (*AdmissionChecksStrategy)(unsafe.Pointer(in.AdmissionChecksStrategy))
 	out.StopPolicy = (*StopPolicy)(unsafe.Pointer(in.StopPolicy))
 	out.FairSharing = (*FairSharing)(unsafe.Pointer(in.FairSharing))

--- a/apis/kueue/v1beta2/clusterqueue_types.go
+++ b/apis/kueue/v1beta2/clusterqueue_types.go
@@ -115,14 +115,7 @@ type ClusterQueueSpec struct {
 	// +optional
 	Preemption *ClusterQueuePreemption `json:"preemption,omitempty"`
 
-	// admissionChecks lists the AdmissionChecks required by this ClusterQueue.
-	// Cannot be used along with AdmissionCheckStrategy.
-	// Admission checks are limited to at most 64 items.
-	// +optional
-	AdmissionChecks []AdmissionCheckReference `json:"admissionChecks,omitempty"` //nolint:kubeapilinter // field is being removed
-
 	// admissionChecksStrategy defines a list of strategies to determine which ResourceFlavors require AdmissionChecks.
-	// This property cannot be used in conjunction with the 'admissionChecks' property.
 	// +optional
 	AdmissionChecksStrategy *AdmissionChecksStrategy `json:"admissionChecksStrategy,omitempty"`
 

--- a/apis/kueue/v1beta2/zz_generated.deepcopy.go
+++ b/apis/kueue/v1beta2/zz_generated.deepcopy.go
@@ -391,11 +391,6 @@ func (in *ClusterQueueSpec) DeepCopyInto(out *ClusterQueueSpec) {
 		*out = new(ClusterQueuePreemption)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.AdmissionChecks != nil {
-		in, out := &in.AdmissionChecks, &out.AdmissionChecks
-		*out = make([]AdmissionCheckReference, len(*in))
-		copy(*out, *in)
-	}
 	if in.AdmissionChecksStrategy != nil {
 		in, out := &in.AdmissionChecksStrategy, &out.AdmissionChecksStrategy
 		*out = new(AdmissionChecksStrategy)

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -838,21 +838,8 @@ spec:
             spec:
               description: spec is the specification of the ClusterQueue.
               properties:
-                admissionChecks:
-                  description: |-
-                    admissionChecks lists the AdmissionChecks required by this ClusterQueue.
-                    Cannot be used along with AdmissionCheckStrategy.
-                    Admission checks are limited to at most 64 items.
-                  items:
-                    description: AdmissionCheckReference is the name of an AdmissionCheck.
-                    maxLength: 316
-                    minLength: 1
-                    type: string
-                  type: array
                 admissionChecksStrategy:
-                  description: |-
-                    admissionChecksStrategy defines a list of strategies to determine which ResourceFlavors require AdmissionChecks.
-                    This property cannot be used in conjunction with the 'admissionChecks' property.
+                  description: admissionChecksStrategy defines a list of strategies to determine which ResourceFlavors require AdmissionChecks.
                   properties:
                     admissionChecks:
                       description: admissionChecks is a list of strategies for AdmissionChecks

--- a/client-go/applyconfiguration/kueue/v1beta2/clusterqueuespec.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/clusterqueuespec.go
@@ -31,7 +31,6 @@ type ClusterQueueSpecApplyConfiguration struct {
 	NamespaceSelector       *v1.LabelSelectorApplyConfiguration        `json:"namespaceSelector,omitempty"`
 	FlavorFungibility       *FlavorFungibilityApplyConfiguration       `json:"flavorFungibility,omitempty"`
 	Preemption              *ClusterQueuePreemptionApplyConfiguration  `json:"preemption,omitempty"`
-	AdmissionChecks         []kueuev1beta2.AdmissionCheckReference     `json:"admissionChecks,omitempty"`
 	AdmissionChecksStrategy *AdmissionChecksStrategyApplyConfiguration `json:"admissionChecksStrategy,omitempty"`
 	StopPolicy              *kueuev1beta2.StopPolicy                   `json:"stopPolicy,omitempty"`
 	FairSharing             *FairSharingApplyConfiguration             `json:"fairSharing,omitempty"`
@@ -94,16 +93,6 @@ func (b *ClusterQueueSpecApplyConfiguration) WithFlavorFungibility(value *Flavor
 // If called multiple times, the Preemption field is set to the value of the last call.
 func (b *ClusterQueueSpecApplyConfiguration) WithPreemption(value *ClusterQueuePreemptionApplyConfiguration) *ClusterQueueSpecApplyConfiguration {
 	b.Preemption = value
-	return b
-}
-
-// WithAdmissionChecks adds the given value to the AdmissionChecks field in the declarative configuration
-// and returns the receiver, so that objects can be build by chaining "With" function invocations.
-// If called multiple times, values provided by each call will be appended to the AdmissionChecks field.
-func (b *ClusterQueueSpecApplyConfiguration) WithAdmissionChecks(values ...kueuev1beta2.AdmissionCheckReference) *ClusterQueueSpecApplyConfiguration {
-	for i := range values {
-		b.AdmissionChecks = append(b.AdmissionChecks, values[i])
-	}
 	return b
 }
 

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -823,21 +823,9 @@ spec:
           spec:
             description: spec is the specification of the ClusterQueue.
             properties:
-              admissionChecks:
-                description: |-
-                  admissionChecks lists the AdmissionChecks required by this ClusterQueue.
-                  Cannot be used along with AdmissionCheckStrategy.
-                  Admission checks are limited to at most 64 items.
-                items:
-                  description: AdmissionCheckReference is the name of an AdmissionCheck.
-                  maxLength: 316
-                  minLength: 1
-                  type: string
-                type: array
               admissionChecksStrategy:
-                description: |-
-                  admissionChecksStrategy defines a list of strategies to determine which ResourceFlavors require AdmissionChecks.
-                  This property cannot be used in conjunction with the 'admissionChecks' property.
+                description: admissionChecksStrategy defines a list of strategies
+                  to determine which ResourceFlavors require AdmissionChecks.
                 properties:
                   admissionChecks:
                     description: admissionChecks is a list of strategies for AdmissionChecks

--- a/pkg/controller/core/admissioncheck_controller.go
+++ b/pkg/controller/core/admissioncheck_controller.go
@@ -164,7 +164,20 @@ func (r *AdmissionCheckReconciler) Generic(e event.TypedGenericEvent[*kueue.Admi
 func (r *AdmissionCheckReconciler) NotifyClusterQueueUpdate(oldCq *kueue.ClusterQueue, newCq *kueue.ClusterQueue) {
 	log := r.log.WithValues("oldClusterQueue", klog.KObj(oldCq), "newClusterQueue", klog.KObj(newCq))
 	log.V(5).Info("Cluster queue notification")
-	noChange := newCq != nil && oldCq != nil && slices.CmpNoOrder(oldCq.Spec.AdmissionChecks, newCq.Spec.AdmissionChecks)
+
+	// Helper to extract admission check names from strategy
+	getAcNames := func(cq *kueue.ClusterQueue) []kueue.AdmissionCheckReference {
+		if cq.Spec.AdmissionChecksStrategy == nil {
+			return nil
+		}
+		names := make([]kueue.AdmissionCheckReference, len(cq.Spec.AdmissionChecksStrategy.AdmissionChecks))
+		for i, ac := range cq.Spec.AdmissionChecksStrategy.AdmissionChecks {
+			names[i] = ac.Name
+		}
+		return names
+	}
+
+	noChange := newCq != nil && oldCq != nil && slices.CmpNoOrder(getAcNames(oldCq), getAcNames(newCq))
 	if noChange {
 		return
 	}
@@ -196,14 +209,16 @@ func (h *acCqHandler) Generic(ctx context.Context, e event.GenericEvent, q workq
 	log := log.FromContext(ctx).WithValues("clusterQueue", klog.KObj(cq))
 	log.V(6).Info("Cluster queue generic event")
 
-	for _, ac := range cq.Spec.AdmissionChecks {
-		if cqs := h.cache.ClusterQueuesUsingAdmissionCheck(ac); len(cqs) == 0 {
-			req := reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name: string(ac),
-				},
+	if cq.Spec.AdmissionChecksStrategy != nil {
+		for _, ac := range cq.Spec.AdmissionChecksStrategy.AdmissionChecks {
+			if cqs := h.cache.ClusterQueuesUsingAdmissionCheck(ac.Name); len(cqs) == 0 {
+				req := reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name: string(ac.Name),
+					},
+				}
+				q.Add(req)
 			}
-			q.Add(req)
 		}
 	}
 }

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -1113,7 +1113,6 @@ func (w *workloadQueueHandler) Update(ctx context.Context, ev event.UpdateEvent,
 		log.V(5).Info("Workload cluster queue update event")
 
 		if !newCq.DeletionTimestamp.IsZero() ||
-			!utilslices.CmpNoOrder(oldCq.Spec.AdmissionChecks, newCq.Spec.AdmissionChecks) ||
 			!gocmp.Equal(oldCq.Spec.AdmissionChecksStrategy, newCq.Spec.AdmissionChecksStrategy) ||
 			!ptr.Equal(oldCq.Spec.StopPolicy, newCq.Spec.StopPolicy) {
 			w.queueReconcileForWorkloadsOfClusterQueue(ctx, newCq.Name, wq)

--- a/pkg/util/admissioncheck/admissioncheck.go
+++ b/pkg/util/admissioncheck/admissioncheck.go
@@ -163,7 +163,7 @@ func FilterProvReqAnnotations(annotations map[string]string) map[string]string {
 	return res
 }
 
-// NewAdmissionChecks aggregates AdmissionChecks from .spec.AdmissionChecks and .spec.AdmissionChecksStrategy
+// NewAdmissionChecks aggregates AdmissionChecks from .spec.AdmissionChecksStrategy
 func NewAdmissionChecks(cq *kueue.ClusterQueue) map[kueue.AdmissionCheckReference]sets.Set[kueue.ResourceFlavorReference] {
 	var checks map[kueue.AdmissionCheckReference]sets.Set[kueue.ResourceFlavorReference]
 	if cq.Spec.AdmissionChecksStrategy != nil {
@@ -176,10 +176,7 @@ func NewAdmissionChecks(cq *kueue.ClusterQueue) map[kueue.AdmissionCheckReferenc
 			}
 		}
 	} else {
-		checks = make(map[kueue.AdmissionCheckReference]sets.Set[kueue.ResourceFlavorReference], len(cq.Spec.AdmissionChecks))
-		for _, checkName := range cq.Spec.AdmissionChecks {
-			checks[checkName] = allFlavors(cq)
-		}
+		checks = make(map[kueue.AdmissionCheckReference]sets.Set[kueue.ResourceFlavorReference], 0)
 	}
 	return checks
 }

--- a/pkg/util/testing/v1beta2/wrappers.go
+++ b/pkg/util/testing/v1beta2/wrappers.go
@@ -935,9 +935,19 @@ func (c *ClusterQueueWrapper) ResourceGroup(flavors ...kueue.FlavorQuotas) *Clus
 	return c
 }
 
-// AdmissionChecks replaces the queue additional checks
+// AdmissionChecks replaces the queue additional checks.
+// This is a convenience wrapper that converts to the AdmissionChecksStrategy format.
 func (c *ClusterQueueWrapper) AdmissionChecks(checks ...kueue.AdmissionCheckReference) *ClusterQueueWrapper {
-	c.Spec.AdmissionChecks = checks
+	// Convert simple admission check references to the strategy format
+	acs := make([]kueue.AdmissionCheckStrategyRule, len(checks))
+	for i, check := range checks {
+		acs[i] = kueue.AdmissionCheckStrategyRule{
+			Name: check,
+		}
+	}
+	c.Spec.AdmissionChecksStrategy = &kueue.AdmissionChecksStrategy{
+		AdmissionChecks: acs,
+	}
 	return c
 }
 

--- a/pkg/webhooks/clusterqueue_webhook.go
+++ b/pkg/webhooks/clusterqueue_webhook.go
@@ -105,7 +105,6 @@ func ValidateClusterQueue(cq *kueue.ClusterQueue) field.ErrorList {
 	allErrs = append(allErrs, validateResourceGroups(cq.Spec.ResourceGroups, config, path.Child("resourceGroups"), false)...)
 	allErrs = append(allErrs,
 		validation.ValidateLabelSelector(cq.Spec.NamespaceSelector, validation.LabelSelectorValidationOptions{}, path.Child("namespaceSelector"))...)
-	allErrs = append(allErrs, validateCQAdmissionChecks(&cq.Spec, path)...)
 	if cq.Spec.Preemption != nil {
 		allErrs = append(allErrs, validatePreemption(cq.Spec.Preemption, path.Child("preemption"))...)
 	}
@@ -171,15 +170,6 @@ func validatePreemption(preemption *kueue.ClusterQueuePreemption, path *field.Pa
 		preemption.BorrowWithinCohort.Policy != kueue.BorrowWithinCohortPolicyNever {
 		allErrs = append(allErrs, field.Invalid(path, preemption, "reclaimWithinCohort=Never and borrowWithinCohort.Policy!=Never"))
 	}
-	return allErrs
-}
-
-func validateCQAdmissionChecks(spec *kueue.ClusterQueueSpec, path *field.Path) field.ErrorList {
-	var allErrs field.ErrorList
-	if spec.AdmissionChecksStrategy != nil && len(spec.AdmissionChecks) != 0 {
-		allErrs = append(allErrs, field.Invalid(path, spec, "Either AdmissionChecks or AdmissionCheckStrategy can be set, but not both"))
-	}
-
 	return allErrs
 }
 

--- a/pkg/webhooks/clusterqueue_webhook_test.go
+++ b/pkg/webhooks/clusterqueue_webhook_test.go
@@ -72,15 +72,6 @@ func TestValidateClusterQueue(t *testing.T) {
 				).Obj(),
 		},
 		{
-			name: "both admissionChecks and admissionCheckStrategy is defined",
-			clusterQueue: utiltestingapi.MakeClusterQueue("cluster-queue").
-				AdmissionChecks("ac1").
-				AdmissionCheckStrategy().Obj(),
-			wantErr: field.ErrorList{
-				field.Invalid(specPath, "spec", "Either AdmissionChecks or AdmissionCheckStrategy can be set, but not both"),
-			},
-		},
-		{
 			name:         "in cohort",
 			clusterQueue: utiltestingapi.MakeClusterQueue("cluster-queue").Cohort("prod").Obj(),
 		},

--- a/site/content/en/docs/reference/kueue.v1beta2.md
+++ b/site/content/en/docs/reference/kueue.v1beta2.md
@@ -466,8 +466,6 @@ The description is limited to a maximum of 2048 characters.</p>
 
 - [AdmissionCheckStrategyRule](#kueue-x-k8s-io-v1beta2-AdmissionCheckStrategyRule)
 
-- [ClusterQueueSpec](#kueue-x-k8s-io-v1beta2-ClusterQueueSpec)
-
 
 <p>AdmissionCheckReference is the name of an AdmissionCheck.</p>
 
@@ -984,21 +982,11 @@ before borrowing or preempting in the flavor being evaluated.</p>
    <p>preemption defines the preemption policies.</p>
 </td>
 </tr>
-<tr><td><code>admissionChecks</code><br/>
-<a href="#kueue-x-k8s-io-v1beta2-AdmissionCheckReference"><code>[]AdmissionCheckReference</code></a>
-</td>
-<td>
-   <p>admissionChecks lists the AdmissionChecks required by this ClusterQueue.
-Cannot be used along with AdmissionCheckStrategy.
-Admission checks are limited to at most 64 items.</p>
-</td>
-</tr>
 <tr><td><code>admissionChecksStrategy</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-AdmissionChecksStrategy"><code>AdmissionChecksStrategy</code></a>
 </td>
 <td>
-   <p>admissionChecksStrategy defines a list of strategies to determine which ResourceFlavors require AdmissionChecks.
-This property cannot be used in conjunction with the 'admissionChecks' property.</p>
+   <p>admissionChecksStrategy defines a list of strategies to determine which ResourceFlavors require AdmissionChecks.</p>
 </td>
 </tr>
 <tr><td><code>stopPolicy</code><br/>

--- a/test/integration/singlecluster/controller/core/admissioncheck_controller_test.go
+++ b/test/integration/singlecluster/controller/core/admissioncheck_controller_test.go
@@ -101,7 +101,11 @@ var _ = ginkgo.Describe("AdmissionCheck controller", ginkgo.Ordered, ginkgo.Cont
 			ginkgo.By("Change clusterQueue's checks")
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &cq)).Should(gomega.Succeed())
-				cq.Spec.AdmissionChecks = []kueue.AdmissionCheckReference{"check2"}
+				cq.Spec.AdmissionChecksStrategy = &kueue.AdmissionChecksStrategy{
+					AdmissionChecks: []kueue.AdmissionCheckStrategyRule{
+						{Name: "check2"},
+					},
+				}
 				g.Expect(k8sClient.Update(ctx, &cq)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 

--- a/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
@@ -799,7 +799,6 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 			gomega.Eventually(func(g gomega.Gomega) {
 				updatedCq := &kueue.ClusterQueue{}
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), updatedCq)).Should(gomega.Succeed())
-				updatedCq.Spec.AdmissionChecks = nil
 				updatedCq.Spec.AdmissionChecksStrategy = &kueue.AdmissionChecksStrategy{
 					AdmissionChecks: []kueue.AdmissionCheckStrategyRule{
 						*utiltestingapi.MakeAdmissionCheckStrategyRule("check1", flavorCPUArchA).Obj(),
@@ -831,8 +830,11 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 			gomega.Eventually(func(g gomega.Gomega) {
 				var updatedCq kueue.ClusterQueue
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &updatedCq)).Should(gomega.Succeed())
-				updatedCq.Spec.AdmissionChecks = []kueue.AdmissionCheckReference{"check1"}
-				updatedCq.Spec.AdmissionChecksStrategy = nil
+				updatedCq.Spec.AdmissionChecksStrategy = &kueue.AdmissionChecksStrategy{
+					AdmissionChecks: []kueue.AdmissionCheckStrategyRule{
+						{Name: "check1"},
+					},
+				}
 				g.Expect(k8sClient.Update(ctx, &updatedCq)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -246,7 +246,12 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Ordered, ginkgo.ContinueOn
 				queueKey := client.ObjectKeyFromObject(clusterQueue)
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, queueKey, &createdQueue)).To(gomega.Succeed())
-					createdQueue.Spec.AdmissionChecks = []kueue.AdmissionCheckReference{"check2", "check3"}
+					createdQueue.Spec.AdmissionChecksStrategy = &kueue.AdmissionChecksStrategy{
+						AdmissionChecks: []kueue.AdmissionCheckStrategyRule{
+							{Name: "check2"},
+							{Name: "check3"},
+						},
+					}
 					g.Expect(k8sClient.Update(ctx, &createdQueue)).Should(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 


### PR DESCRIPTION
## Summary

- Removes the deprecated `.spec.admissionChecks` field from v1beta2 ClusterQueue API
- Completes the migration to `.spec.admissionChecksStrategy` for v1beta2 stabilization

Fixes #7362

## Changes

- **API**: Removed `AdmissionChecks` field from v1beta2 `ClusterQueueSpec`
- **Conversion**: Added bidirectional conversion logic between v1beta1 ↔ v1beta2 to preserve compatibility
- **Controllers**: Updated `admissioncheck_controller` and `workload_controller` to use `AdmissionChecksStrategy` exclusively
- **Webhooks**: Removed validation for the deprecated field
- **Tests**: Updated integration tests and test utilities to use the new field structure
- **Generated files**: Regenerated CRDs, client-go, deepcopy, conversion, and documentation

## Testing

- All unit tests pass (3499 tests)
- All linting checks pass
- `make verify` passes

```release-note
v1beta2: remove deprecated .spec.admissionChecks field from ClusterQueue API in favor of .spec.admissionChecksStrategy.
```