### PR TITLE
Automated cherry pick of #7479: Fix: StatefulSet integration when StatefulSet created should allow to scale up after scale down to zero

### DIFF
--- a/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
@@ -666,6 +666,37 @@ func TestValidateUpdate(t *testing.T) {
 				},
 			}.ToAggregate(),
 		},
+		"scale up from zero blocked by existing workload": {
+			objs: []runtime.Object{
+				utiltesting.MakeWorkload(GetWorkloadName("test-statefulset"), "test-ns").Obj(),
+			},
+			oldObj: testingstatefulset.MakeStatefulSet("test-statefulset", "test-ns").
+				Queue("test-queue").
+				Replicas(0).
+				Obj(),
+			newObj: testingstatefulset.MakeStatefulSet("test-statefulset", "test-ns").
+				Queue("test-queue").
+				Replicas(3).
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeForbidden,
+					Field: replicasPath.String(),
+				},
+			}.ToAggregate(),
+		},
+		"scale up from zero allowed when workload does not exist": {
+			oldObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
+				UID("test-sts-uid").
+				Queue("test-queue").
+				Replicas(0).
+				Obj(),
+			newObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
+				UID("test-sts-uid").
+				Queue("test-queue").
+				Replicas(3).
+				Obj(),
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
Cherry pick of #7479 on release-0.14.

#7479: Fix: StatefulSet integration when StatefulSet created should allow to scale up after scale down to zero

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix the bug for the StatefulSet integration that the scale up could get stuck if
triggered immediately after scale down to zero.
```