### PR TITLE
Remove applyPreemption stub.

### DIFF
--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -59,9 +59,6 @@ type Preemptor struct {
 	enableFairSharing bool
 	fsStrategies      []fairsharing.Strategy
 
-	// stubs
-	applyPreemption func(ctx context.Context, w *kueue.Workload, reason, message string) error
-
 	enabledAfs bool
 }
 
@@ -93,12 +90,7 @@ func New(
 		fsStrategies:      parseStrategies(fs.PreemptionStrategies),
 		enabledAfs:        enabledAfs,
 	}
-	p.applyPreemption = p.patchPreemption
 	return p
-}
-
-func (p *Preemptor) OverrideApply(f func(context.Context, *kueue.Workload, string, string) error) {
-	p.applyPreemption = f
 }
 
 type Target struct {
@@ -177,7 +169,11 @@ func (p *Preemptor) IssuePreemptions(ctx context.Context, preemptor *workload.In
 		target := targets[i]
 		if !meta.IsStatusConditionTrue(target.WorkloadInfo.Obj.Status.Conditions, kueue.WorkloadEvicted) {
 			message := preemptionMessage(preemptor.Obj, target.Reason)
-			err := p.applyPreemption(ctx, target.WorkloadInfo.Obj, target.Reason, message)
+			wlCopy := target.WorkloadInfo.Obj.DeepCopy()
+			err := workload.Evict(ctx, p.client, p.recorder, wlCopy, kueue.WorkloadEvictedByPreemption, message, "", p.clock, workload.WithCustomPrepare(func() (*kueue.Workload, error) {
+				workload.SetPreemptedCondition(wlCopy, p.clock.Now(), target.Reason, message)
+				return wlCopy, nil
+			}))
 			if err != nil {
 				errCh.SendErrorWithCancel(err, cancel)
 				return
@@ -192,14 +188,6 @@ func (p *Preemptor) IssuePreemptions(ctx context.Context, preemptor *workload.In
 		successfullyPreempted.Add(1)
 	})
 	return int(successfullyPreempted.Load()), errCh.ReceiveError()
-}
-
-func (p *Preemptor) patchPreemption(ctx context.Context, w *kueue.Workload, reason, message string) error {
-	w = w.DeepCopy()
-	return workload.Evict(ctx, p.client, p.recorder, w, kueue.WorkloadEvictedByPreemption, message, "", p.clock, workload.WithCustomPrepare(func() (*kueue.Workload, error) {
-		workload.SetPreemptedCondition(w, p.clock.Now(), reason, message)
-		return w, nil
-	}))
 }
 
 type preemptionAttemptOpts struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Remove applyPreemption stub.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6980

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```