### PR TITLE
Automated cherry pick of #7486: [Fix] Remove remote client of insecurely setup cluster

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -424,6 +424,7 @@ func (c *clustersReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 		err = validateKubeconfig(kubeConfig)
 		if err != nil {
 			log.Error(err, "validating kubeconfig failed")
+			c.stopAndRemoveCluster(req.Name)
 			if updateErr := c.updateStatus(ctx, cluster, false, "InsecureKubeConfig", fmt.Sprintf("insecure kubeconfig: %v", err)); updateErr != nil {
 				return reconcile.Result{}, fmt.Errorf("failed to update MultiKueueCluster status: %w after detecting insecure kubeconfig: %w", updateErr, err)
 			}

--- a/test/integration/multikueue/setup_test.go
+++ b/test/integration/multikueue/setup_test.go
@@ -27,14 +27,17 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 	"sigs.k8s.io/kueue/test/util"
 )
 
@@ -717,6 +720,103 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 						Reason:  "Active",
 						Message: "The admission check is active",
 					}, util.IgnoreConditionTimestampsAndObservedGeneration)))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	})
+
+	ginkgo.It("Should properly detect insecure kubeconfig of MultiKueueClusters and remove remote client", func() {
+		var w1KubeconfigInvalidBytes []byte
+		ginkgo.By("Create a kubeconfig with an invalid certificate authority path", func() {
+			cfg, err := worker1TestCluster.kubeConfigBytes()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			w1KubeconfigInvalid, err := clientcmd.Load(cfg)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(w1KubeconfigInvalid).NotTo(gomega.BeNil())
+
+			w1KubeconfigInvalid.Clusters["default-cluster"].CertificateAuthority = "/some/random/path"
+			w1KubeconfigInvalidBytes, err = clientcmd.Write(*w1KubeconfigInvalid)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testing-secret",
+				Namespace: managersConfigNamespace.Name,
+			},
+			Data: map[string][]byte{
+				kueue.MultiKueueConfigSecretKey: w1KubeconfigInvalidBytes,
+			},
+		}
+
+		ginkgo.By("creating the secret, with insecure kubeconfig", func() {
+			gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, secret)).Should(gomega.Succeed())
+			ginkgo.DeferCleanup(func() error { return managerTestCluster.client.Delete(managerTestCluster.ctx, secret) })
+		})
+
+		clusterKey := client.ObjectKeyFromObject(workerCluster1)
+		acKey := client.ObjectKeyFromObject(multiKueueAC)
+
+		ginkgo.By("updating the cluster, the worker1 cluster becomes inactive", func() {
+			updatedCluster := kueue.MultiKueueCluster{}
+			ginkgo.By("updating the cluster spec", func() {
+				gomega.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, clusterKey, &updatedCluster)).To(gomega.Succeed())
+				updatedCluster.Spec.KubeConfig.LocationType = kueue.SecretLocationType
+				updatedCluster.Spec.KubeConfig.Location = secret.Name
+				gomega.Expect(managerTestCluster.client.Update(managerTestCluster.ctx, &updatedCluster)).To(gomega.Succeed())
+			})
+
+			ginkgo.By("wait for the status update", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, clusterKey, &updatedCluster)).To(gomega.Succeed())
+					g.Expect(updatedCluster.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(metav1.Condition{
+						Type:    kueue.MultiKueueClusterActive,
+						Status:  metav1.ConditionFalse,
+						Reason:  "InsecureKubeConfig",
+						Message: "insecure kubeconfig: certificate-authority file paths are not allowed, use certificate-authority-data for cluster default-cluster",
+					}, util.IgnoreConditionTimestampsAndObservedGeneration)))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, acKey, multiKueueAC)).To(gomega.Succeed())
+					g.Expect(multiKueueAC.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(metav1.Condition{
+						Type:    kueue.AdmissionCheckActive,
+						Status:  metav1.ConditionTrue,
+						Reason:  "SomeActiveClusters",
+						Message: "Inactive clusters: [worker1]",
+					}, util.IgnoreConditionTimestampsAndObservedGeneration)))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		job := testingjob.MakeJob("job1", managerNs.Name).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
+			Obj()
+		ginkgo.By("create a job and reserve quota, only existing remoteClients are part of the NominatedClusterNames", func() {
+			util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, job)
+			wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
+
+			ginkgo.By("setting workload reservation in the management cluster", func() {
+				admission := utiltesting.MakeAdmission(managerCq.Name).Obj()
+				gomega.Eventually(func(g gomega.Gomega) {
+					managerWl := &kueue.Workload{}
+					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
+					g.Expect(util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, managerWl, admission)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verify remote clients are managed correctly: worker1 was removed and worker2 is still active", func() {
+				managerWl := &kueue.Workload{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
+					g.Expect(managerWl.Status.NominatedClusterNames).NotTo(gomega.ContainElements(workerCluster1.Name))
+					g.Expect(managerWl.Status.NominatedClusterNames).To(gomega.ContainElements(workerCluster2.Name))
+
+					createdWorkload := &kueue.Workload{}
+					g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, wlLookupKey, createdWorkload)).To(utiltesting.BeNotFoundError())
+					g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+					g.Expect(createdWorkload.Spec).To(gomega.BeComparableTo(managerWl.Spec))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})


### PR DESCRIPTION
Cherry pick of #7486 on release-0.13.

#7486: [Fix] Remove remote client of insecurely setup cluster

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
MultiKueue: Remove remoteClient from clusterReconciler when kubeconfig is detected as invalid or insecure, preventing workloads from being admitted to misconfigured clusters.
```