### PR TITLE
Automated cherry pick of #7486: [Fix] Remove remote client of insecurely setup cluster

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -424,6 +424,7 @@ func (c *clustersReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 		err = validateKubeconfig(kubeConfig)
 		if err != nil {
 			log.Error(err, "validating kubeconfig failed")
+			c.stopAndRemoveCluster(req.Name)
 			if updateErr := c.updateStatus(ctx, cluster, false, "InsecureKubeConfig", fmt.Sprintf("insecure kubeconfig: %v", err)); updateErr != nil {
 				return reconcile.Result{}, fmt.Errorf("failed to update MultiKueueCluster status: %w after detecting insecure kubeconfig: %w", updateErr, err)
 			}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -423,6 +423,31 @@ func TestUpdateConfig(t *testing.T) {
 			},
 			wantErr: fmt.Errorf("validating kubeconfig failed: %w", errors.New("tokenFile is not allowed")),
 		},
+		"remove client with invalid kubeconfig": {
+			reconcileFor: "worker1",
+			clusters: []kueue.MultiKueueCluster{
+				*utiltesting.MakeMultiKueueCluster("worker1").
+					KubeConfig(kueue.SecretLocationType, "worker1").
+					Generation(1).
+					Obj(),
+			},
+			secrets: []corev1.Secret{
+				makeTestSecret("worker1", testKubeconfigInsecure("worker1", ptr.To("/path/to/tokenfile"))),
+			},
+			remoteClients: map[string]*remoteClient{
+				"worker1": newTestClient(ctx, "worker1 old kubeconfig", cancelCalled),
+			},
+			wantClusters: []kueue.MultiKueueCluster{
+				*utiltesting.MakeMultiKueueCluster("worker1").
+					KubeConfig(kueue.SecretLocationType, "worker1").
+					Active(metav1.ConditionFalse, "InsecureKubeConfig", "insecure kubeconfig: tokenFile is not allowed", 1).
+					Generation(1).
+					Obj(),
+			},
+			wantRemoteClients: map[string]*remoteClient{},
+			wantCancelCalled:  1,
+			wantErr:           fmt.Errorf("validating kubeconfig failed: %w", errors.New("tokenFile is not allowed")),
+		},
 		"skip insecure kubeconfig validation": {
 			reconcileFor: "worker1",
 			clusters: []kueue.MultiKueueCluster{


### PR DESCRIPTION
Cherry pick of #7486 on release-0.14.

#7486: [Fix] Remove remote client of insecurely setup cluster

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
MultiKueue: Remove remoteClient from clusterReconciler when kubeconfig is detected as invalid or insecure, preventing workloads from being admitted to misconfigured clusters.
```