### PR TITLE
Cleanup FinishEvictionOfWorkloadsInCQ

### DIFF
--- a/test/util/util_scheduling.go
+++ b/test/util/util_scheduling.go
@@ -45,7 +45,7 @@ func FinishRunningWorkloadsInCQ(ctx context.Context, k8sClient client.Client, cq
 	gomega.ExpectWithOffset(1, finished).To(gomega.Equal(n), "Not enough workloads finished")
 }
 
-func FinishEvictionsOfAnyWorkloadsInCq(ctx context.Context, k8sClient client.Client, cq *kueue.ClusterQueue) int {
+func finishEvictionsOfAnyWorkloadsInCq(ctx context.Context, k8sClient client.Client, cq *kueue.ClusterQueue) sets.Set[types.UID] {
 	var realClock = clock.RealClock{}
 	finished := sets.New[types.UID]()
 	var wList kueue.WorkloadList
@@ -64,13 +64,13 @@ func FinishEvictionsOfAnyWorkloadsInCq(ctx context.Context, k8sClient client.Cli
 			finished.Insert(wl.UID)
 		}
 	}
-	return finished.Len()
+	return finished
 }
 
 func FinishEvictionOfWorkloadsInCQ(ctx context.Context, k8sClient client.Client, cq *kueue.ClusterQueue, n int) {
-	finished := 0
+	finished := sets.New[types.UID]()
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
-		finished += FinishEvictionsOfAnyWorkloadsInCq(ctx, k8sClient, cq)
-		g.Expect(finished).Should(gomega.Equal(n), "Not enough workloads evicted")
+		finished.Insert(finishEvictionsOfAnyWorkloadsInCq(ctx, k8sClient, cq).UnsortedList()...)
+		g.Expect(finished.Len()).Should(gomega.Equal(n), "Not enough workloads evicted")
 	}, Timeout, Interval).Should(gomega.Succeed())
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

To make sure the function does not double-count finished workloads twice.

#### Which issue(s) this PR fixes:

Inspired by #7470 but it is not fixing the issue as shown by experiments here: https://github.com/kubernetes-sigs/kueue/pull/7521

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```