### PR TITLE
Use wrappers in cluster_queue_test.go.

### DIFF
--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -726,96 +726,60 @@ func TestStrictFIFO(t *testing.T) {
 	}{
 		{
 			name: "w1.priority is higher than w2.priority",
-			w1: &kueue.Workload{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "w1",
-					CreationTimestamp: metav1.NewTime(t1),
-				},
-				Spec: kueue.WorkloadSpec{
-					PriorityClassName: "highPriority",
-					Priority:          ptr.To(highPriority),
-				},
-			},
-			w2: &kueue.Workload{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "w2",
-					CreationTimestamp: metav1.NewTime(t2),
-				},
-				Spec: kueue.WorkloadSpec{
-					PriorityClassName: "lowPriority",
-					Priority:          ptr.To(lowPriority),
-				},
-			},
+			w1: utiltestingapi.MakeWorkload("w1", "").
+				Creation(t1).
+				PriorityClass("highPriority").
+				Priority(highPriority).
+				Obj(),
+			w2: utiltestingapi.MakeWorkload("w2", "").
+				Creation(t2).
+				PriorityClass("lowPriority").
+				Priority(lowPriority).
+				Obj(),
 			expected: "w1",
 		},
 		{
 			name: "w1.priority equals w2.priority and w1.create time is earlier than w2.create time",
-			w1: &kueue.Workload{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "w1",
-					CreationTimestamp: metav1.NewTime(t1),
-				},
-			},
-			w2: &kueue.Workload{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "w2",
-					CreationTimestamp: metav1.NewTime(t2),
-				},
-			},
+			w1: utiltestingapi.MakeWorkload("w1", "").
+				Creation(t1).
+				Obj(),
+			w2: utiltestingapi.MakeWorkload("w2", "").
+				Creation(t2).
+				Obj(),
 			expected: "w1",
 		},
 		{
 			name: "w1.priority equals w2.priority and w1.create time is earlier than w2.create time but w1 was evicted",
-			w1: &kueue.Workload{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "w1",
-					CreationTimestamp: metav1.NewTime(t1),
-				},
-				Status: kueue.WorkloadStatus{
-					Conditions: []metav1.Condition{
-						{
-							Type:               kueue.WorkloadEvicted,
-							Status:             metav1.ConditionTrue,
-							LastTransitionTime: metav1.NewTime(t3),
-							Reason:             kueue.WorkloadEvictedByPodsReadyTimeout,
-							Message:            "by test",
-						},
-					},
-				},
-			},
-			w2: &kueue.Workload{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "w2",
-					CreationTimestamp: metav1.NewTime(t2),
-				},
-			},
+			w1: utiltestingapi.MakeWorkload("w1", "").
+				Creation(t1).
+				Condition(metav1.Condition{
+					Type:               kueue.WorkloadEvicted,
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(t3),
+					Reason:             kueue.WorkloadEvictedByPodsReadyTimeout,
+					Message:            "by test",
+				}).
+				Obj(),
+			w2: utiltestingapi.MakeWorkload("w2", "").
+				Creation(t2).
+				Obj(),
 			expected: "w2",
 		},
 		{
 			name: "w1.priority equals w2.priority and w1.create time is earlier than w2.create time and w1 was evicted but kueue is configured to always use the creation timestamp",
-			w1: &kueue.Workload{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "w1",
-					CreationTimestamp: metav1.NewTime(t1),
-				},
-				Status: kueue.WorkloadStatus{
-					Conditions: []metav1.Condition{
-						{
-							Type:               kueue.WorkloadEvicted,
-							Status:             metav1.ConditionTrue,
-							LastTransitionTime: metav1.NewTime(t3),
-							Reason:             kueue.WorkloadEvictedByPodsReadyTimeout,
-							Message:            "by test",
-						},
-					},
-				},
-			},
-			w2: &kueue.Workload{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "w2",
-					CreationTimestamp: metav1.NewTime(t2),
-				},
-			},
+			w1: utiltestingapi.MakeWorkload("w1", "").
+				Creation(t1).
+				Condition(metav1.Condition{
+					Type:               kueue.WorkloadEvicted,
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(t3),
+					Reason:             kueue.WorkloadEvictedByPodsReadyTimeout,
+					Message:            "by test",
+				}).
+				Obj(),
+			w2: utiltestingapi.MakeWorkload("w2", "").
+				Creation(t2).
+				Obj(),
 			workloadOrdering: &workload.Ordering{
 				PodsReadyRequeuingTimestamp: config.CreationTimestamp,
 			},
@@ -823,26 +787,16 @@ func TestStrictFIFO(t *testing.T) {
 		},
 		{
 			name: "p1.priority is lower than p2.priority and w1.create time is earlier than w2.create time",
-			w1: &kueue.Workload{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "w1",
-					CreationTimestamp: metav1.NewTime(t1),
-				},
-				Spec: kueue.WorkloadSpec{
-					PriorityClassName: "lowPriority",
-					Priority:          ptr.To(lowPriority),
-				},
-			},
-			w2: &kueue.Workload{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "w2",
-					CreationTimestamp: metav1.NewTime(t2),
-				},
-				Spec: kueue.WorkloadSpec{
-					PriorityClassName: "highPriority",
-					Priority:          ptr.To(highPriority),
-				},
-			},
+			w1: utiltestingapi.MakeWorkload("w1", "").
+				Creation(t1).
+				PriorityClass("lowPriority").
+				Priority(lowPriority).
+				Obj(),
+			w2: utiltestingapi.MakeWorkload("w2", "").
+				Creation(t2).
+				PriorityClass("highPriority").
+				Priority(highPriority).
+				Obj(),
 			expected: "w2",
 		},
 	} {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Use wrappers in cluster_queue_test.go.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Prepare for https://github.com/kubernetes-sigs/kueue/pull/7540.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```