### PR TITLE
Fix DelayedTopologyRequestState enum validation.

### DIFF
--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -276,15 +276,15 @@ type PodSetAssignment struct {
 
 // DelayedTopologyRequestState indicates the state of the delayed TopologyRequest.
 // +enum
-// +kubebuilder:validation:enum=Pending;Ready
+// +kubebuilder:validation:Enum=Pending;Ready
 // +kubebuilder:validation:MaxLength=7
 type DelayedTopologyRequestState string
 
 const (
-	// This state indicates the delayed TopologyRequest is waiting for determining.
+	// DelayedTopologyRequestStatePending indicates the delayed TopologyRequest is waiting for determining.
 	DelayedTopologyRequestStatePending DelayedTopologyRequestState = "Pending"
 
-	// This state indicates the delayed TopologyRequest is was requested and completed.
+	// DelayedTopologyRequestStateReady indicates the delayed TopologyRequest is was requested and completed.
 	DelayedTopologyRequestStateReady DelayedTopologyRequestState = "Ready"
 )
 

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -17200,6 +17200,9 @@ spec:
                               Kueue schedules the second pass of scheduling for each workload with at
                               least one PodSet which has delayedTopologyRequest=true and without
                               topologyAssignment.
+                            enum:
+                              - Pending
+                              - Ready
                             maxLength: 7
                             type: string
                           flavors:

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -18191,6 +18191,9 @@ spec:
                             Kueue schedules the second pass of scheduling for each workload with at
                             least one PodSet which has delayedTopologyRequest=true and without
                             topologyAssignment.
+                          enum:
+                          - Pending
+                          - Ready
                           maxLength: 7
                           type: string
                         flavors:

--- a/test/integration/singlecluster/webhook/core/workload_test.go
+++ b/test/integration/singlecluster/webhook/core/workload_test.go
@@ -369,6 +369,60 @@ var _ = ginkgo.Describe("Workload validating webhook", ginkgo.Ordered, func() {
 						Obj()).
 					Obj(),
 				utiltesting.BeForbiddenError()),
+			ginkgo.Entry("Pending delayedTopologyRequest",
+				func() *kueue.Workload {
+					return utiltestingapi.MakeWorkload(workloadName, ns.Name).
+						PodSets(
+							*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).
+								Request(corev1.ResourceCPU, "1").
+								Obj(),
+						).
+						Obj()
+				},
+				utiltestingapi.MakeAdmission("cluster-queue").
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "flv", "3").
+						Count(3).
+						DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+						Obj()).
+					Obj(),
+				gomega.Succeed()),
+			ginkgo.Entry("Ready delayedTopologyRequest",
+				func() *kueue.Workload {
+					return utiltestingapi.MakeWorkload(workloadName, ns.Name).
+						PodSets(
+							*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).
+								Request(corev1.ResourceCPU, "1").
+								Obj(),
+						).
+						Obj()
+				},
+				utiltestingapi.MakeAdmission("cluster-queue").
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "flv", "3").
+						Count(3).
+						DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
+						Obj()).
+					Obj(),
+				gomega.Succeed()),
+			ginkgo.Entry("invalid delayedTopologyRequest",
+				func() *kueue.Workload {
+					return utiltestingapi.MakeWorkload(workloadName, ns.Name).
+						PodSets(
+							*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).
+								Request(corev1.ResourceCPU, "1").
+								Obj(),
+						).
+						Obj()
+				},
+				utiltestingapi.MakeAdmission("cluster-queue").
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "flv", "3").
+						Count(3).
+						DelayedTopologyRequest("invalid").
+						Obj()).
+					Obj(),
+				utiltesting.BeInvalidError()),
 		)
 
 		ginkgo.DescribeTable("Should have valid values when setting AdmissionCheckState", func(w func() *kueue.Workload, acs kueue.AdmissionCheckState) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind api-change

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix DelayedTopologyRequestState enum validation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```