### PR TITLE
[Cleanup] Cleanup workload.Finish

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -358,7 +358,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		}
 
 		// finish workload and copy the status to the local one
-		return reconcile.Result{}, workload.Finish(ctx, w.client, group.local, remoteFinishedCond.Reason, remoteFinishedCond.Message, kueue.MultiKueueControllerName, w.clock, workload.WithForceOwnership())
+		return reconcile.Result{}, workload.Finish(ctx, w.client, group.local, remoteFinishedCond.Reason, remoteFinishedCond.Message, kueue.MultiKueueControllerName, w.clock)
 	}
 
 	// 2. delete all workloads that are out of sync (other than scaled-down elastic workloads)

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -1313,53 +1313,17 @@ func Evict(ctx context.Context, c client.Client, recorder record.EventRecorder, 
 	return nil
 }
 
-type FinishOption func(*FinishOptions)
-
-type FinishOptions struct {
-	UsePatch       bool
-	ForceOwnership bool
-}
-
-func DefaultFinishOptions() *FinishOptions {
-	return &FinishOptions{
-		UsePatch:       false,
-		ForceOwnership: false,
-	}
-}
-
-func WithUsePatch() FinishOption {
-	return func(o *FinishOptions) {
-		o.UsePatch = true
-	}
-}
-
-func WithForceOwnership() FinishOption {
-	return func(o *FinishOptions) {
-		o.ForceOwnership = true
-	}
-}
-
-func Finish(ctx context.Context, c client.Client, wl *kueue.Workload, reason, msg, managerPrefix string, clock clock.Clock, options ...FinishOption) error {
-	optsFinish := DefaultFinishOptions()
-	for _, opt := range options {
-		opt(optsFinish)
-	}
-
-	if features.Enabled(features.WorkloadRequestUseMergePatch) || optsFinish.UsePatch {
+func Finish(ctx context.Context, c client.Client, wl *kueue.Workload, reason, msg, managerPrefix string, clock clock.Clock) error {
+	if features.Enabled(features.WorkloadRequestUseMergePatch) {
 		return clientutil.PatchStatus(ctx, c, wl, func() (client.Object, bool, error) {
 			update := SetFinishedCondition(wl, clock.Now(), reason, msg)
 			return wl, update, nil
 		})
 	} else {
-		newWl := BaseSSAWorkload(wl, false)
+		newWl := BaseSSAWorkload(wl, true)
 		SetFinishedCondition(newWl, clock.Now(), reason, msg)
-
 		fieldOwner := client.FieldOwner(managerPrefix + "-" + kueue.WorkloadFinished)
-		applyOpts := []client.SubResourcePatchOption{fieldOwner}
-		if optsFinish.ForceOwnership {
-			applyOpts = append(applyOpts, client.ForceOwnership)
-		}
-		return c.Status().Patch(ctx, newWl, client.Apply, applyOpts...)
+		return c.Status().Patch(ctx, newWl, client.Apply, fieldOwner, client.ForceOwnership)
 	}
 }
 

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -104,7 +104,7 @@ func Finish(ctx context.Context, clnt client.Client, clk clock.Clock, workloadSl
 	if apimeta.IsStatusConditionTrue(workloadSlice.Status.Conditions, kueue.WorkloadFinished) {
 		return nil
 	}
-	if err := workload.Finish(ctx, clnt, workloadSlice, reason, message, "", clk, workload.WithUsePatch()); err != nil {
+	if err := workload.Finish(ctx, clnt, workloadSlice, reason, message, "", clk); err != nil {
 		return fmt.Errorf("failed to patch workload slice status: %w", err)
 	}
 	return nil

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -347,7 +347,9 @@ func TestFinish(t *testing.T) {
 			args: args{
 				clnt: testWorkloadClientBuilder().
 					WithObjects(testWorkload("test", "test-job", "job-uid", now).Obj()).
-					WithStatusSubresource(testWorkload("test", "test-job", "job-uid", now).Obj()).Build(),
+					WithStatusSubresource(testWorkload("test", "test-job", "job-uid", now).Obj()).
+					WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).
+					Build(),
 				workloadSlice: testWorkload("test", "test-job", "job-uid", now).Obj(),
 				reason:        "TestReason",
 				message:       "Test Message.",
@@ -831,6 +833,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						Creation(now).
 						PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()).
 						Obj()).
+					WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).
 					Build(),
 				jobPodSets:   []kueue.PodSet{*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "1").Obj()},
 				jobObject:    testJobObject,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Follow up on the introduction of workload.Finish.
Remove UsePatch option and make workloadslice use SSA by default.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7587

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```