### PR TITLE
add field multiplyBy for ResourceTransformation

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -487,6 +487,13 @@ type ResourceTransformation struct {
 	// Defaults to Retain
 	Strategy *ResourceTransformationStrategy `json:"strategy,omitempty"`
 
+	// MultiplyBy indicates the resource name requested by a workload, if
+	// specified.
+	// The requested amount of the resource is used to multiply the requested
+	// amount of the resource indicated by the "input" field.
+	// +optional
+	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
+
 	// Outputs specifies the output resources and quantities per unit of input resource.
 	// An empty Outputs combined with a `Replace` Strategy causes the Input resource to be ignored by Kueue.
 	Outputs corev1.ResourceList `json:"outputs,omitempty"`

--- a/apis/config/v1beta1/zz_generated.conversion.go
+++ b/apis/config/v1beta1/zz_generated.conversion.go
@@ -702,6 +702,7 @@ func Convert_v1beta2_RequeuingStrategy_To_v1beta1_RequeuingStrategy(in *v1beta2.
 func autoConvert_v1beta1_ResourceTransformation_To_v1beta2_ResourceTransformation(in *ResourceTransformation, out *v1beta2.ResourceTransformation, s conversion.Scope) error {
 	out.Input = v1.ResourceName(in.Input)
 	out.Strategy = (*v1beta2.ResourceTransformationStrategy)(unsafe.Pointer(in.Strategy))
+	out.MultiplyBy = v1.ResourceName(in.MultiplyBy)
 	out.Outputs = *(*v1.ResourceList)(unsafe.Pointer(&in.Outputs))
 	return nil
 }
@@ -714,6 +715,7 @@ func Convert_v1beta1_ResourceTransformation_To_v1beta2_ResourceTransformation(in
 func autoConvert_v1beta2_ResourceTransformation_To_v1beta1_ResourceTransformation(in *v1beta2.ResourceTransformation, out *ResourceTransformation, s conversion.Scope) error {
 	out.Input = v1.ResourceName(in.Input)
 	out.Strategy = (*ResourceTransformationStrategy)(unsafe.Pointer(in.Strategy))
+	out.MultiplyBy = v1.ResourceName(in.MultiplyBy)
 	out.Outputs = *(*v1.ResourceList)(unsafe.Pointer(&in.Outputs))
 	return nil
 }

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -459,6 +459,13 @@ type ResourceTransformation struct {
 	// Defaults to Retain
 	Strategy *ResourceTransformationStrategy `json:"strategy,omitempty"`
 
+	// MultiplyBy indicates the resource name requested by a workload, if
+	// specified.
+	// The requested amount of the resource is used to multiply the requested
+	// amount of the resource indicated by the "input" field.
+	// +optional
+	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
+
 	// Outputs specifies the output resources and quantities per unit of input resource.
 	// An empty Outputs combined with a `Replace` Strategy causes the Input resource to be ignored by Kueue.
 	Outputs corev1.ResourceList `json:"outputs,omitempty"`

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -419,6 +419,14 @@ func applyResourceTransformations(input corev1.ResourceList, transforms map[core
 	output := make(corev1.ResourceList)
 	for inputName, inputQuantity := range input {
 		if mapping, ok := transforms[inputName]; ok {
+			// If MultiplyBy is specified, multiply the input quantity by
+			// the value of the resource specified in MultiplyBy.
+			if mapping.MultiplyBy != "" {
+				if q, ok := input[mapping.MultiplyBy]; ok {
+					inputQuantity.Mul(q.Value())
+				}
+			}
+
 			for outputName, baseFactor := range mapping.Outputs {
 				outputQuantity := baseFactor.DeepCopy()
 				outputQuantity.Mul(inputQuantity.Value())

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -861,6 +861,16 @@ re-queuing an evicted workload.</p>
 Defaults to Retain</p>
 </td>
 </tr>
+<tr><td><code>multiplyBy</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcename-v1-core"><code>k8s.io/api/core/v1.ResourceName</code></a>
+</td>
+<td>
+   <p>MultiplyBy indicates the resource name requested by a workload, if
+specified.
+The requested amount of the resource is used to multiply the requested
+amount of the resource indicated by the &quot;input&quot; field.</p>
+</td>
+</tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcelist-v1-core"><code>k8s.io/api/core/v1.ResourceList</code></a>
 </td>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -816,6 +816,16 @@ re-queuing an evicted workload.</p>
 Defaults to Retain</p>
 </td>
 </tr>
+<tr><td><code>multiplyBy</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcename-v1-core"><code>k8s.io/api/core/v1.ResourceName</code></a>
+</td>
+<td>
+   <p>MultiplyBy indicates the resource name requested by a workload, if
+specified.
+The requested amount of the resource is used to multiply the requested
+amount of the resource indicated by the &quot;input&quot; field.</p>
+</td>
+</tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcelist-v1-core"><code>k8s.io/api/core/v1.ResourceList</code></a>
 </td>

--- a/test/integration/singlecluster/scheduler/resourcetransformations/resource_transformations_test.go
+++ b/test/integration/singlecluster/scheduler/resourcetransformations/resource_transformations_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetransformations
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	config "sigs.k8s.io/kueue/apis/config/v1beta2"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("Resource Transformations", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+	var (
+		defaultFlavor *kueue.ResourceFlavor
+		ns            *corev1.Namespace
+		clusterQueue  *kueue.ClusterQueue
+		localQueue    *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeAll(func() {
+		// Configure resource transformations for testing
+		transformations := []config.ResourceTransformation{
+			{
+				Input:    "nvidia.com/mig-1g.5gb",
+				Strategy: ptr.To(config.Replace),
+				Outputs: corev1.ResourceList{
+					"example.com/accelerator-memory": resource.MustParse("5Ki"),
+					"example.com/credits":            resource.MustParse("10"),
+				},
+			},
+			{
+				Input:      "nvidia.com/gpucores",
+				Strategy:   ptr.To(config.Replace),
+				MultiplyBy: "nvidia.com/gpu",
+				Outputs: corev1.ResourceList{
+					"nvidia.com/total-gpucores": resource.MustParse("1"),
+				},
+			},
+			{
+				Input:      "nvidia.com/gpumem",
+				Strategy:   ptr.To(config.Replace),
+				MultiplyBy: "nvidia.com/gpu",
+				Outputs: corev1.ResourceList{
+					"nvidia.com/total-gpumem": resource.MustParse("1"),
+				},
+			},
+		}
+		fwk.StartManager(ctx, cfg, managerAndSchedulerSetup(transformations))
+	})
+
+	ginkgo.BeforeEach(func() {
+		defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
+		util.MustCreate(ctx, k8sClient, defaultFlavor)
+
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "resource-transformations-")
+
+		clusterQueue = utiltestingapi.MakeClusterQueue("test-cq").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("default").
+					Resource("example.com/accelerator-memory", "100Gi").
+					Resource("example.com/credits", "1000").
+					Resource("nvidia.com/gpu", "50").
+					Resource("nvidia.com/total-gpucores", "1000").
+					Resource("nvidia.com/total-gpumem", "102400").
+					Obj(),
+			).Obj()
+		util.MustCreate(ctx, k8sClient, clusterQueue)
+
+		localQueue = utiltestingapi.MakeLocalQueue("test-lq", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+		util.MustCreate(ctx, k8sClient, localQueue)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, defaultFlavor, true)
+	})
+
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.It("should transform resources with MultiplyBy", func() {
+		ginkgo.By("Creating a workload with vgpu resources")
+		wl := utiltestingapi.MakeWorkload("multiply-wl", ns.Name).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request("nvidia.com/gpu", "2").
+			Request("nvidia.com/gpucores", "20").
+			Request("nvidia.com/gpumem", "1024").
+			Obj()
+		util.MustCreate(ctx, k8sClient, wl)
+
+		ginkgo.By("Waiting for workload to be admitted")
+		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+
+		ginkgo.By("Verifying MultiplyBy transformation", func() {
+			wlLookupKey := client.ObjectKeyFromObject(wl)
+			createdWorkload := &kueue.Workload{}
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				g.Expect(createdWorkload.Status.Admission).NotTo(gomega.BeNil())
+
+				resourceUsage := createdWorkload.Status.Admission.PodSetAssignments[0].ResourceUsage
+				g.Expect(resourceUsage).To(gomega.BeComparableTo(corev1.ResourceList{
+					"nvidia.com/gpu":            resource.MustParse("2"),
+					"nvidia.com/total-gpucores": resource.MustParse("40"),
+					"nvidia.com/total-gpumem":   resource.MustParse("2048"),
+				}))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.It("should handle multiple PodSets with transformations", func() {
+		ginkgo.By("Creating a workload with multiple PodSets")
+		wl := utiltestingapi.MakeWorkload("multi-podset-wl", ns.Name).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			PodSets(
+				*utiltestingapi.MakePodSet("ps01", 1).
+					Request("nvidia.com/mig-1g.5gb", "2").
+					Obj(),
+				*utiltestingapi.MakePodSet("ps02", 2).
+					Request("nvidia.com/gpu", "1").
+					Request("nvidia.com/gpucores", "10").
+					Obj(),
+			).
+			Obj()
+		util.MustCreate(ctx, k8sClient, wl)
+
+		ginkgo.By("Waiting for workload to be admitted")
+		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+
+		ginkgo.By("Verifying transformations for each PodSet", func() {
+			wlLookupKey := client.ObjectKeyFromObject(wl)
+			createdWorkload := &kueue.Workload{}
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+
+				g.Expect(createdWorkload.Status.Admission).NotTo(gomega.BeNil())
+				g.Expect(createdWorkload.Status.Admission.PodSetAssignments).To(gomega.HaveLen(2))
+
+				ps1Usage := createdWorkload.Status.Admission.PodSetAssignments[0].ResourceUsage
+				g.Expect(ps1Usage).To(gomega.BeComparableTo(corev1.ResourceList{
+					"example.com/accelerator-memory": resource.MustParse("10240"),
+					"example.com/credits":            resource.MustParse("20"),
+				}))
+
+				ps2Usage := createdWorkload.Status.Admission.PodSetAssignments[1].ResourceUsage
+				g.Expect(ps2Usage).To(gomega.BeComparableTo(corev1.ResourceList{
+					"nvidia.com/gpu":            resource.MustParse("2"),
+					"nvidia.com/total-gpucores": resource.MustParse("20"),
+				}))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+})

--- a/test/integration/singlecluster/scheduler/resourcetransformations/suite_test.go
+++ b/test/integration/singlecluster/scheduler/resourcetransformations/suite_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetransformations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	config "sigs.k8s.io/kueue/apis/config/v1beta2"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/constants"
+	"sigs.k8s.io/kueue/pkg/controller/core"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
+	"sigs.k8s.io/kueue/pkg/scheduler"
+	"sigs.k8s.io/kueue/pkg/webhooks"
+	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
+)
+
+func TestResourceTransformations(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+
+	ginkgo.RunSpecs(t,
+		"Resource Transformations Suite",
+	)
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	fwk = &framework.Framework{
+		WebhookPath: util.WebhookPath,
+	}
+	cfg = fwk.Init()
+	ctx, k8sClient = fwk.SetupClient(cfg)
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	fwk.Teardown()
+})
+
+func managerAndSchedulerSetup(transformations []config.ResourceTransformation) framework.ManagerSetup {
+	return func(ctx context.Context, mgr manager.Manager) {
+		err := indexer.Setup(ctx, mgr.GetFieldIndexer())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		cCache := schdcache.New(mgr.GetClient())
+		var queueOptions []qcache.Option
+		if len(transformations) > 0 {
+			queueOptions = append(queueOptions, qcache.WithResourceTransformations(transformations))
+		}
+		queues := qcache.NewManager(mgr.GetClient(), cCache, queueOptions...)
+
+		configuration := &config.Configuration{}
+		mgr.GetScheme().Default(configuration)
+
+		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration, nil)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
+
+		failedWebhook, err := webhooks.Setup(mgr, nil)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
+
+		err = workloadjob.SetupIndexes(ctx, mgr.GetFieldIndexer())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		sched := scheduler.New(queues, cCache, mgr.GetClient(), mgr.GetEventRecorderFor(constants.AdmissionName))
+		err = sched.Start(ctx)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind api-change

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref: https://github.com/kubernetes-sigs/kueue/pull/7231

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
add field multiplyBy for ResourceTransformation
```