### PR TITLE
Refactor Pending() and add PendingTotal().

### DIFF
--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -160,11 +160,11 @@ func Test_PushOrUpdate(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
 			cq := newClusterQueueImpl(ctx, nil, defaultOrdering, fakeClock, nil, false, nil)
 
-			if cq.Pending() != 0 {
+			if cq.PendingTotal() != 0 {
 				t.Error("ClusterQueue should be empty")
 			}
 			cq.PushOrUpdate(workload.NewInfo(tc.workload.Clone().Obj()))
-			if cq.Pending() != 1 {
+			if cq.PendingTotal() != 1 {
 				t.Error("ClusterQueue should have one workload")
 			}
 
@@ -172,8 +172,8 @@ func Test_PushOrUpdate(t *testing.T) {
 			updatedWl := tc.workload.Clone().ResourceVersion("1").Obj()
 			cq.PushOrUpdate(workload.NewInfo(updatedWl))
 			newWl := cq.Pop()
-			if newWl != nil && cq.Pending() != 1 {
-				t.Errorf("unexpected count of pending workloads (want=%d, got=%d)", 1, cq.Pending())
+			if newWl != nil && cq.PendingTotal() != 1 {
+				t.Errorf("unexpected count of pending workloads (want=%d, got=%d)", 1, cq.PendingTotal())
 			}
 			if diff := cmp.Diff(tc.wantWorkload, newWl, cmpOpts...); len(diff) != 0 {
 				t.Errorf("Unexpected workloads in heap (-want,+got):\n%s", diff)
@@ -216,17 +216,17 @@ func Test_Delete(t *testing.T) {
 	wl2 := utiltestingapi.MakeWorkload("workload-2", defaultNamespace).Obj()
 	cq.PushOrUpdate(workload.NewInfo(wl1))
 	cq.PushOrUpdate(workload.NewInfo(wl2))
-	if cq.Pending() != 2 {
+	if cq.PendingTotal() != 2 {
 		t.Error("ClusterQueue should have two workload")
 	}
 	cq.Delete(wl1)
-	if cq.Pending() != 1 {
+	if cq.PendingTotal() != 1 {
 		t.Error("ClusterQueue should have only one workload")
 	}
 	// Change workload item, ClusterQueue.Delete should only care about the namespace and name.
 	wl2.Spec = kueue.WorkloadSpec{QueueName: "default"}
 	cq.Delete(wl2)
-	if cq.Pending() != 0 {
+	if cq.PendingTotal() != 0 {
 		t.Error("ClusterQueue should have be empty")
 	}
 }
@@ -288,15 +288,15 @@ func Test_DeleteFromLocalQueue(t *testing.T) {
 	}
 
 	wantPending := len(admissibleworkloads) + len(inadmissibleWorkloads)
-	if pending := cq.Pending(); pending != wantPending {
-		t.Errorf("clusterQueue's workload number not right, want %v, got %v", wantPending, pending)
+	if cq.PendingTotal() != wantPending {
+		t.Errorf("clusterQueue's workload number not right, want %v, got %v", wantPending, cq.PendingTotal())
 	}
 	if len(cq.inadmissibleWorkloads) != len(inadmissibleWorkloads) {
 		t.Errorf("clusterQueue's workload number in inadmissibleWorkloads not right, want %v, got %v", len(inadmissibleWorkloads), len(cq.inadmissibleWorkloads))
 	}
 
 	cq.DeleteFromLocalQueue(qImpl)
-	if cq.Pending() != 0 {
+	if cq.PendingTotal() != 0 {
 		t.Error("clusterQueue should be empty")
 	}
 }
@@ -466,8 +466,8 @@ func TestClusterQueueImpl(t *testing.T) {
 			if diff := cmp.Diff(test.wantActiveWorkloads, gotWorkloads, cmpDump...); diff != "" {
 				t.Errorf("Unexpected active workloads in cluster foo (-want,+got):\n%s", diff)
 			}
-			if got := cq.Pending(); got != test.wantPending {
-				t.Errorf("Got %d pending workloads, want %d", got, test.wantPending)
+			if cq.PendingTotal() != test.wantPending {
+				t.Errorf("Got %d pending workloads, want %d", cq.PendingTotal(), test.wantPending)
 			}
 		})
 	}

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -406,7 +406,7 @@ func (m *Manager) Pending(cq *kueue.ClusterQueue) (int, error) {
 		return 0, ErrClusterQueueDoesNotExist
 	}
 
-	return cqImpl.Pending(), nil
+	return cqImpl.PendingTotal(), nil
 }
 
 func (m *Manager) QueueForWorkloadExists(wl *kueue.Workload) bool {
@@ -708,8 +708,7 @@ func (m *Manager) reportLQPendingWorkloads(lq *LocalQueue) {
 }
 
 func (m *Manager) reportPendingWorkloads(cqName kueue.ClusterQueueReference, cq *ClusterQueue) {
-	active := cq.PendingActive()
-	inadmissible := cq.PendingInadmissible()
+	active, inadmissible := cq.Pending()
 	if m.statusChecker != nil && !m.statusChecker.ClusterQueueActive(cqName) {
 		inadmissible += active
 		active = 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add RLock on PendingInadmissible().

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```