### PR TITLE
[Flake] Fairsharing preemption - add priority to the workloads

### DIFF
--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -1223,12 +1223,11 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 
 		ginkgo.It("Guaranteed workloads cause preemption of a single best effort workload", func() {
 			ginkgo.By("Creating two best effort workloads in each best effort CQ")
-			wlBestEffortA := createWorkload("best-effort-a", "4")
-			util.WaitForNextSecondAfterCreation(wlBestEffortA)
+			wlBestEffortA := createWorkloadWithPriority("best-effort-a", "4", 2)
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlBestEffortA)
 			util.ExpectAdmittedWorkloadsTotalMetric(bestEffortCQA, "", 1)
 			util.ExpectReservingActiveWorkloadsMetric(bestEffortCQA, 1)
-			wlBestEffortB := createWorkload("best-effort-b", "4")
+			wlBestEffortB := createWorkloadWithPriority("best-effort-b", "4", 1)
 			util.ExpectAdmittedWorkloadsTotalMetric(bestEffortCQB, "", 1)
 			util.ExpectReservingActiveWorkloadsMetric(bestEffortCQB, 1)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Creation timestamp does not matter for fair sharing tie-breaking, rather Quota Reserved timestamp.
Thus we decide to add priority to the best-effort cqs workloads to ensure desired outcome.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7004 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```