### PR TITLE
Use `constants.PodSetLabel` instead of `controllerconsts.PodSetLabel`

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -41,4 +41,9 @@ const (
 	// ManagedByKueueLabelKey label that signalize that an object is managed by Kueue
 	ManagedByKueueLabelKey   = "kueue.x-k8s.io/managed"
 	ManagedByKueueLabelValue = "true"
+
+	// PodSetLabel is a label set on the Job's PodTemplate to indicate the name
+	// of the PodSet of the admitted Workload corresponding to the PodTemplate.
+	// The label is set when starting the Job, and removed on stopping the Job.
+	PodSetLabel = "kueue.x-k8s.io/podset"
 )

--- a/pkg/controller/constants/constants.go
+++ b/pkg/controller/constants/constants.go
@@ -43,9 +43,4 @@ const (
 
 	// MaxExecTimeSecondsLabel is the label key in the job that holds the maximum execution time.
 	MaxExecTimeSecondsLabel = `kueue.x-k8s.io/max-exec-time-seconds`
-
-	// PodSetLabel is a label set on the Job's PodTemplate to indicate the name
-	// of the PodSet of the admitted Workload corresponding to the PodTemplate.
-	// The label is set when starting the Job, and removed on stopping the Job.
-	PodSetLabel = "kueue.x-k8s.io/podset"
 )

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1352,7 +1352,7 @@ func getPodSetsInfoFromStatus(ctx context.Context, c client.Client, w *kueue.Wor
 			info.Annotations[kueue.WorkloadAnnotation] = w.Name
 		}
 
-		info.Labels[controllerconsts.PodSetLabel] = string(psAssignment.Name)
+		info.Labels[constants.PodSetLabel] = string(psAssignment.Name)
 
 		for _, admissionCheck := range w.Status.AdmissionChecks {
 			for _, podSetUpdate := range admissionCheck.PodSetUpdates {

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -38,6 +38,7 @@ import (
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/constants"
 	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -927,7 +928,7 @@ func TestReconciler(t *testing.T) {
 			job: *baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(false).
-				PodLabel(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+				PodLabel(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 				PodAnnotation(kueue.WorkloadAnnotation, "wl").
 				Obj(),
 			workloads: []kueue.Workload{
@@ -1022,7 +1023,7 @@ func TestReconciler(t *testing.T) {
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(false).
 				PodLabel("ac-key", "ac-value").
-				PodLabel(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+				PodLabel(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 				Obj(),
 			workloads: []kueue.Workload{
 				*baseWorkloadWrapper.Clone().
@@ -2327,7 +2328,7 @@ func TestReconciler(t *testing.T) {
 				PodAnnotation("annotation-key1", "common-value").
 				PodAnnotation("annotation-key2", "only-in-check1").
 				PodLabel("label-key1", "common-value").
-				PodLabel(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+				PodLabel(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 				NodeSelector("node-selector-key1", "common-value").
 				NodeSelector("node-selector-key2", "only-in-check2").
 				Obj(),
@@ -2434,7 +2435,7 @@ func TestReconciler(t *testing.T) {
 			job: *baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(false).
-				PodLabel(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+				PodLabel(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 				Obj(),
 			workloads: []kueue.Workload{
 				*baseWorkloadWrapper.Clone().
@@ -2521,7 +2522,7 @@ func TestReconciler(t *testing.T) {
 				SetAnnotation(JobMinParallelismAnnotation, "5").
 				Suspend(false).
 				Parallelism(8).
-				PodLabel(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+				PodLabel(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 				Obj(),
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("a", "ns").

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -41,6 +41,7 @@ import (
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/constants"
 	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
@@ -298,7 +299,7 @@ func TestReconciler(t *testing.T) {
 				ManagedByKueueLabel().
 				NodeSelector(corev1.LabelArchStable, "arm64").
 				KueueFinalizer().
-				Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+				Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 				Annotation(kueue.WorkloadAnnotation, "unit-test").
 				Obj()},
 			workloads: []kueue.Workload{
@@ -1056,7 +1057,7 @@ func TestReconciler(t *testing.T) {
 					Group("test-group").
 					GroupTotalCount("2").
 					NodeSelector(corev1.LabelArchStable, "arm64").
-					Label(controllerconsts.PodSetLabel, podUID).
+					Label(constants.PodSetLabel, podUID).
 					Annotation(kueue.WorkloadAnnotation, "test-group").
 					Obj(),
 				*basePodWrapper.
@@ -1067,7 +1068,7 @@ func TestReconciler(t *testing.T) {
 					Group("test-group").
 					GroupTotalCount("2").
 					NodeSelector(corev1.LabelArchStable, "arm64").
-					Label(controllerconsts.PodSetLabel, podUID).
+					Label(constants.PodSetLabel, podUID).
 					Annotation(kueue.WorkloadAnnotation, "test-group").
 					Obj(),
 			},
@@ -1624,7 +1625,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
-					Label(controllerconsts.PodSetLabel, podUID).
+					Label(constants.PodSetLabel, podUID).
 					Annotation(kueue.WorkloadAnnotation, "test-group").
 					Obj(),
 			},
@@ -1686,7 +1687,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
-					Label(controllerconsts.PodSetLabel, podUID).
+					Label(constants.PodSetLabel, podUID).
 					StatusPhase(corev1.PodRunning).
 					Obj(),
 				*basePodWrapper.
@@ -1740,7 +1741,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
-					Label(controllerconsts.PodSetLabel, podUID).
+					Label(constants.PodSetLabel, podUID).
 					StatusPhase(corev1.PodRunning).
 					Obj(),
 				*basePodWrapper.
@@ -1767,7 +1768,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
-					Label(controllerconsts.PodSetLabel, podUID).
+					Label(constants.PodSetLabel, podUID).
 					Annotation(kueue.WorkloadAnnotation, "test-group").
 					Obj(),
 			},
@@ -4474,7 +4475,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodRunning).
 					Group("test-group").
 					GroupTotalCount("2").
-					Label(controllerconsts.PodSetLabel, podUID).
+					Label(constants.PodSetLabel, podUID).
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 				*basePodWrapper.
@@ -4526,7 +4527,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodRunning).
 					Group("test-group").
 					GroupTotalCount("2").
-					Label(controllerconsts.PodSetLabel, podUID).
+					Label(constants.PodSetLabel, podUID).
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 				*basePodWrapper.
@@ -4536,7 +4537,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
-					Label(controllerconsts.PodSetLabel, podUID).
+					Label(constants.PodSetLabel, podUID).
 					Annotation(kueue.WorkloadAnnotation, "test-group").
 					CreationTimestamp(now).
 					Obj(),

--- a/pkg/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/podset"
@@ -328,8 +328,8 @@ func TestReconciler(t *testing.T) {
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(false).
 				NodeSelectorHeadGroup(corev1.LabelArchStable, "arm64").
-				NodeLabel(rayv1.HeadNode, controllerconsts.PodSetLabel, "head").
-				NodeLabel(rayv1.WorkerNode, controllerconsts.PodSetLabel, "workers-group-0").
+				NodeLabel(rayv1.HeadNode, constants.PodSetLabel, "head").
+				NodeLabel(rayv1.WorkerNode, constants.PodSetLabel, "workers-group-0").
 				NodeAnnotation(rayv1.HeadNode, kueue.WorkloadAnnotation, "test").
 				NodeAnnotation(rayv1.WorkerNode, kueue.WorkloadAnnotation, "test").
 				Obj(),
@@ -399,7 +399,7 @@ func TestReconciler(t *testing.T) {
 										Obj(),
 								},
 							}).
-							Labels(map[string]string{controllerconsts.PodSetLabel: "head"}).
+							Labels(map[string]string{constants.PodSetLabel: "head"}).
 							Obj(),
 						*utiltestingapi.MakePodSet("workers-group-0", 1).
 							PodSpec(corev1.PodSpec{
@@ -410,7 +410,7 @@ func TestReconciler(t *testing.T) {
 										Obj(),
 								},
 							}).
-							Labels(map[string]string{controllerconsts.PodSetLabel: "workers-group-0"}).
+							Labels(map[string]string{constants.PodSetLabel: "workers-group-0"}).
 							Obj(),
 					).
 					ReserveQuota(
@@ -560,8 +560,8 @@ func TestReconciler(t *testing.T) {
 				Suspend(false).
 				NodeSelectorHeadGroup(corev1.LabelArchStable, "arm64").
 				WithNumOfHosts("workers-group-0", 2).
-				NodeLabel(rayv1.HeadNode, controllerconsts.PodSetLabel, "head").
-				NodeLabel(rayv1.WorkerNode, controllerconsts.PodSetLabel, "workers-group-0").
+				NodeLabel(rayv1.HeadNode, constants.PodSetLabel, "head").
+				NodeLabel(rayv1.WorkerNode, constants.PodSetLabel, "workers-group-0").
 				NodeAnnotation(rayv1.HeadNode, kueue.WorkloadAnnotation, "test").
 				NodeAnnotation(rayv1.WorkerNode, kueue.WorkloadAnnotation, "test").
 				Obj(),

--- a/pkg/controller/jobs/trainjob/trainjob_controller.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller.go
@@ -41,7 +41,7 @@ import (
 	jobsetapplyapi "sigs.k8s.io/jobset/client-go/applyconfiguration/jobset/v1alpha2"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	workloadjobset "sigs.k8s.io/kueue/pkg/controller/jobs/jobset"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -311,7 +311,7 @@ func (t *TrainJob) Stop(ctx context.Context, c client.Client, podSetsInfo []pods
 func (t *TrainJob) RestorePodSetsInfo(_ []podset.PodSetInfo) bool {
 	for i, o := range t.Spec.PodTemplateOverrides {
 		if o.Metadata != nil {
-			_, exists := o.Metadata.Labels[controllerconsts.PodSetLabel]
+			_, exists := o.Metadata.Labels[constants.PodSetLabel]
 			if exists {
 				t.Spec.PodTemplateOverrides = t.Spec.PodTemplateOverrides[:i]
 				break

--- a/pkg/controller/jobs/trainjob/trainjob_controller_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller_test.go
@@ -32,7 +32,7 @@ import (
 	jobsetapi "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/podset"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -97,8 +97,8 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 						"test-annotation": "test",
 					},
 					Labels: map[string]string{
-						controllerconsts.PodSetLabel: "node",
-						"test-label":                 "label",
+						constants.PodSetLabel: "node",
+						"test-label":          "label",
 					},
 					NodeSelector:    map[string]string{"disktype": "ssd"},
 					Tolerations:     []corev1.Toleration{*toleration1.DeepCopy()},
@@ -116,8 +116,8 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 								"test-annotation": "test",
 							},
 							Labels: map[string]string{
-								controllerconsts.PodSetLabel: "node",
-								"test-label":                 "label",
+								constants.PodSetLabel: "node",
+								"test-label":          "label",
 							},
 						},
 						Spec: &kftrainerapi.PodTemplateSpecOverride{
@@ -152,8 +152,8 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 						"test-annotation": "test",
 					},
 					Labels: map[string]string{
-						controllerconsts.PodSetLabel: "node",
-						"test-label":                 "label",
+						constants.PodSetLabel: "node",
+						"test-label":          "label",
 					},
 					NodeSelector:    map[string]string{"gpu": "nvidia"},
 					Tolerations:     []corev1.Toleration{*toleration2.DeepCopy()},
@@ -181,8 +181,8 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 								"test-annotation": "test",
 							},
 							Labels: map[string]string{
-								controllerconsts.PodSetLabel: "node",
-								"test-label":                 "label",
+								constants.PodSetLabel: "node",
+								"test-label":          "label",
 							},
 						},
 						Spec: &kftrainerapi.PodTemplateSpecOverride{
@@ -288,7 +288,7 @@ func TestRestorePodSetsInfo(t *testing.T) {
 						},
 						Metadata: &metav1.ObjectMeta{
 							Labels: map[string]string{
-								controllerconsts.PodSetLabel: "kueue-provided-1",
+								constants.PodSetLabel: "kueue-provided-1",
 							},
 						},
 						Spec: &kftrainerapi.PodTemplateSpecOverride{
@@ -301,7 +301,7 @@ func TestRestorePodSetsInfo(t *testing.T) {
 						},
 						Metadata: &metav1.ObjectMeta{
 							Labels: map[string]string{
-								controllerconsts.PodSetLabel: "kueue-provided-2",
+								constants.PodSetLabel: "kueue-provided-2",
 							},
 						},
 						Spec: &kftrainerapi.PodTemplateSpecOverride{

--- a/pkg/controller/tas/topology_ungater.go
+++ b/pkg/controller/tas/topology_ungater.go
@@ -43,7 +43,6 @@ import (
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/constants"
-	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	utilclient "sigs.k8s.io/kueue/pkg/util/client"
@@ -281,7 +280,7 @@ func (r *topologyUngater) Generic(event.TypedGenericEvent[*kueue.Workload]) bool
 func (r *topologyUngater) podsForPodSet(ctx context.Context, ns, wlName string, psName kueue.PodSetReference) ([]*corev1.Pod, error) {
 	var pods corev1.PodList
 	if err := r.client.List(ctx, &pods, client.InNamespace(ns), client.MatchingLabels{
-		controllerconsts.PodSetLabel: string(psName),
+		constants.PodSetLabel: string(psName),
 	}, client.MatchingFields{
 		indexer.WorkloadNameKey: wlName,
 	}); err != nil {

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -37,7 +37,7 @@ import (
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -137,14 +137,14 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 			},
 			wantCounts: []counts{
@@ -178,23 +178,23 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("pod2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 				*testingpod.MakePod("pod2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 			},
 			wantCounts: []counts{
@@ -231,23 +231,23 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("pod2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 				*testingpod.MakePod("pod2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 			},
 			wantCounts: []counts{
@@ -276,14 +276,14 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -306,14 +306,14 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -339,14 +339,14 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -370,13 +370,13 @@ func TestReconcile(t *testing.T) {
 			},
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod", "ns").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod", "ns").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -431,7 +431,7 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Gate("example.com/gate").
@@ -440,7 +440,7 @@ func TestReconcile(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Gate("example.com/gate").
@@ -476,7 +476,7 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Gate("example.com/gate").
 					Obj(),
@@ -484,7 +484,7 @@ func TestReconcile(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Gate("example.com/gate").
@@ -520,28 +520,28 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod-already-running", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					StatusPhase(corev1.PodRunning).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("pod-gated", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod-already-running", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					StatusPhase(corev1.PodRunning).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("pod-gated", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -575,28 +575,28 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod-already-running", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					StatusPhase(corev1.PodFailed).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("pod-gated", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod-already-running", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					StatusPhase(corev1.PodFailed).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("pod-gated", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -632,26 +632,26 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").UID("x").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("pod2", "ns").UID("y").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").UID("x").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("pod2", "ns").UID("y").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -686,28 +686,28 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod-already-succeeded", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					StatusPhase(corev1.PodSucceeded).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("pod-gated", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod-already-succeeded", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					StatusPhase(corev1.PodSucceeded).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("pod-gated", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 			},
 			wantCounts: []counts{
@@ -742,26 +742,26 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").UID("x").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("pod2", "ns").UID("y").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").UID("x").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("pod2", "ns").UID("y").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -805,33 +805,33 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p3", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "3").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p4", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "4").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -840,35 +840,35 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
 				*testingpod.MakePod("p3", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "3").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p4", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "4").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -942,31 +942,31 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(leaderworkersetv1.WorkerIndexLabelKey, "0").
-					Label(controllerconsts.PodSetLabel, "leader").
+					Label(constants.PodSetLabel, "leader").
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(leaderworkersetv1.WorkerIndexLabelKey, "2").
-					Label(controllerconsts.PodSetLabel, "workers").
+					Label(constants.PodSetLabel, "workers").
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(leaderworkersetv1.WorkerIndexLabelKey, "1").
-					Label(controllerconsts.PodSetLabel, "workers").
+					Label(constants.PodSetLabel, "workers").
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p3", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(leaderworkersetv1.WorkerIndexLabelKey, "3").
-					Label(controllerconsts.PodSetLabel, "workers").
+					Label(constants.PodSetLabel, "workers").
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p4", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(leaderworkersetv1.WorkerIndexLabelKey, "4").
-					Label(controllerconsts.PodSetLabel, "workers").
+					Label(constants.PodSetLabel, "workers").
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -975,35 +975,35 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(leaderworkersetv1.WorkerIndexLabelKey, "0").
-					Label(controllerconsts.PodSetLabel, "leader").
+					Label(constants.PodSetLabel, "leader").
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(leaderworkersetv1.WorkerIndexLabelKey, "2").
-					Label(controllerconsts.PodSetLabel, "workers").
+					Label(constants.PodSetLabel, "workers").
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
 				*testingpod.MakePod("p2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(leaderworkersetv1.WorkerIndexLabelKey, "1").
-					Label(controllerconsts.PodSetLabel, "workers").
+					Label(constants.PodSetLabel, "workers").
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p3", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(leaderworkersetv1.WorkerIndexLabelKey, "3").
-					Label(controllerconsts.PodSetLabel, "workers").
+					Label(constants.PodSetLabel, "workers").
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p4", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(leaderworkersetv1.WorkerIndexLabelKey, "4").
-					Label(controllerconsts.PodSetLabel, "workers").
+					Label(constants.PodSetLabel, "workers").
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1061,31 +1061,31 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p3", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "3").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p4", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "4").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -1094,35 +1094,35 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
 				*testingpod.MakePod("p3", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "3").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p4", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "4").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1199,31 +1199,31 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(leaderworkersetv1.WorkerIndexLabelKey, "0").
-					Label(controllerconsts.PodSetLabel, "leader").
+					Label(constants.PodSetLabel, "leader").
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(leaderworkersetv1.WorkerIndexLabelKey, "0").
-					Label(controllerconsts.PodSetLabel, "workers").
+					Label(constants.PodSetLabel, "workers").
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(leaderworkersetv1.WorkerIndexLabelKey, "1").
-					Label(controllerconsts.PodSetLabel, "workers").
+					Label(constants.PodSetLabel, "workers").
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p3", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(leaderworkersetv1.WorkerIndexLabelKey, "2").
-					Label(controllerconsts.PodSetLabel, "workers").
+					Label(constants.PodSetLabel, "workers").
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p4", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(leaderworkersetv1.WorkerIndexLabelKey, "3").
-					Label(controllerconsts.PodSetLabel, "workers").
+					Label(constants.PodSetLabel, "workers").
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -1232,35 +1232,35 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(leaderworkersetv1.WorkerIndexLabelKey, "0").
-					Label(controllerconsts.PodSetLabel, "leader").
+					Label(constants.PodSetLabel, "leader").
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(leaderworkersetv1.WorkerIndexLabelKey, "0").
-					Label(controllerconsts.PodSetLabel, "workers").
+					Label(constants.PodSetLabel, "workers").
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(leaderworkersetv1.WorkerIndexLabelKey, "1").
-					Label(controllerconsts.PodSetLabel, "workers").
+					Label(constants.PodSetLabel, "workers").
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
 				*testingpod.MakePod("p3", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(leaderworkersetv1.WorkerIndexLabelKey, "2").
-					Label(controllerconsts.PodSetLabel, "workers").
+					Label(constants.PodSetLabel, "workers").
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p4", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(leaderworkersetv1.WorkerIndexLabelKey, "3").
-					Label(controllerconsts.PodSetLabel, "workers").
+					Label(constants.PodSetLabel, "workers").
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1319,25 +1319,25 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p3", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -1346,22 +1346,22 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 				*testingpod.MakePod("p1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 				*testingpod.MakePod("p2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 				*testingpod.MakePod("p3", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 			},
 			wantCounts: []counts{
@@ -1411,7 +1411,7 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					StatusPhase(corev1.PodFailed).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
@@ -1419,7 +1419,7 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -1428,7 +1428,7 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					StatusPhase(corev1.PodFailed).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
@@ -1436,7 +1436,7 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1484,7 +1484,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
 					Label(jobset.JobIndexKey, "0").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p1", "ns").
@@ -1492,7 +1492,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "0").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p2", "ns").
@@ -1500,7 +1500,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
 					Label(jobset.JobIndexKey, "1").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p3", "ns").
@@ -1508,7 +1508,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "1").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -1519,7 +1519,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
 					Label(jobset.JobIndexKey, "0").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1528,7 +1528,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "0").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1537,7 +1537,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
 					Label(jobset.JobIndexKey, "1").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
@@ -1546,7 +1546,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "1").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1608,7 +1608,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
 					Label(jobset.JobIndexKey, "0").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p1", "ns").
@@ -1616,7 +1616,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "0").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1625,7 +1625,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
 					Label(jobset.JobIndexKey, "1").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
@@ -1634,7 +1634,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "1").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -1645,7 +1645,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
 					Label(jobset.JobIndexKey, "0").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1654,7 +1654,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "0").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1663,7 +1663,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
 					Label(jobset.JobIndexKey, "1").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
@@ -1672,7 +1672,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "1").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1753,7 +1753,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "0").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p3", "ns").
@@ -1761,7 +1761,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "1").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -1772,7 +1772,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "0").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1781,7 +1781,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "1").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1832,28 +1832,28 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("l0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "launcher").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "0").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "1").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -1862,7 +1862,7 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("l0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "launcher").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1870,7 +1870,7 @@ func TestReconcile(t *testing.T) {
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "0").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1878,7 +1878,7 @@ func TestReconcile(t *testing.T) {
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "1").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
@@ -1886,7 +1886,7 @@ func TestReconcile(t *testing.T) {
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1944,21 +1944,21 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("l0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "launcher").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "0").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "1").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1966,7 +1966,7 @@ func TestReconcile(t *testing.T) {
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
@@ -1976,7 +1976,7 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("l0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "launcher").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1984,7 +1984,7 @@ func TestReconcile(t *testing.T) {
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "0").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1992,7 +1992,7 @@ func TestReconcile(t *testing.T) {
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "1").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -2000,7 +2000,7 @@ func TestReconcile(t *testing.T) {
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
@@ -2058,25 +2058,25 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("w0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kueue.PodGroupPodIndexLabel, "0").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kueue.PodGroupPodIndexLabel, "1").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kueue.PodGroupPodIndexLabel, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w3", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kueue.PodGroupPodIndexLabel, "3").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -2085,28 +2085,28 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("w0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kueue.PodGroupPodIndexLabel, "0").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("w1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kueue.PodGroupPodIndexLabel, "1").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("w2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kueue.PodGroupPodIndexLabel, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
 				*testingpod.MakePod("w3", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kueue.PodGroupPodIndexLabel, "3").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -2164,26 +2164,26 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("w0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kueue.PodGroupPodIndexLabel, "0").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kueue.PodGroupPodIndexLabel, "1").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("w2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kueue.PodGroupPodIndexLabel, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w3", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kueue.PodGroupPodIndexLabel, "3").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
@@ -2193,28 +2193,28 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("w0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kueue.PodGroupPodIndexLabel, "0").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("w1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kueue.PodGroupPodIndexLabel, "1").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("w2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kueue.PodGroupPodIndexLabel, "2").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
 				*testingpod.MakePod("w3", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kueue.PodGroupPodIndexLabel, "3").
-					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This moves the `PodSetLabel` constant to the generic `constants` package (not `controller`). https://github.com/kubernetes-sigs/kueue/pull/7312 highlighted that it's useful outside the `controller` package, notably as part of generic Pod utils.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```