### PR TITLE
Automated cherry pick of #7630: [Flake] Fairsharing preemption - add priority to the workloads

### DIFF
--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -1200,12 +1200,11 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 
 		ginkgo.It("Guaranteed workloads cause preemption of a single best effort workload", func() {
 			ginkgo.By("Creating two best effort workloads in each best effort CQ")
-			wlBestEffortA := createWorkload("best-effort-a", "4")
-			util.WaitForNextSecondAfterCreation(wlBestEffortA)
+			wlBestEffortA := createWorkloadWithPriority("best-effort-a", "4", 2)
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlBestEffortA)
 			util.ExpectAdmittedWorkloadsTotalMetric(bestEffortCQA, 1)
 			util.ExpectReservingActiveWorkloadsMetric(bestEffortCQA, 1)
-			wlBestEffortB := createWorkload("best-effort-b", "4")
+			wlBestEffortB := createWorkloadWithPriority("best-effort-b", "4", 1)
 			util.ExpectAdmittedWorkloadsTotalMetric(bestEffortCQB, 1)
 			util.ExpectReservingActiveWorkloadsMetric(bestEffortCQB, 1)
 


### PR DESCRIPTION
Cherry pick of #7630 on release-0.13.

#7630: [Flake] Fairsharing preemption - add priority to the workloads

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```