### PR TITLE
typo: fix ray-cluster-sample.yaml 

### DIFF
--- a/site/static/examples/jobs/ray-cluster-sample.yaml
+++ b/site/static/examples/jobs/ray-cluster-sample.yaml
@@ -53,9 +53,9 @@ spec:
                 cpu: "1"
                 memory: "2G"
               requests:
-                # For production use-cases, we recommend specifying integer CPU reqests and limits.
+                # For production use-cases, we recommend specifying integer CPU requests and limits.
                 # We also recommend setting requests equal to limits for both CPU and memory.
-                # For this example, we use a 500m CPU request to accomodate resource-constrained local
+                # For this example, we use a 500m CPU request to accommodate resource-constrained local
                 # Kubernetes testing environments such as KinD and minikube.
                 cpu: "1"
                 memory: "2G"
@@ -108,14 +108,14 @@ spec:
                 limits:
                   cpu: "1"
                   memory: "1G"
-                # For production use-cases, we recommend specifying integer CPU reqests and limits.
+                # For production use-cases, we recommend specifying integer CPU requests and limits.
                 # We also recommend setting requests equal to limits for both CPU and memory.
-                # For this example, we use a 500m CPU request to accomodate resource-constrained local
+                # For this example, we use a 500m CPU request to accommodate resource-constrained local
                 # Kubernetes testing environments such as KinD and minikube.
                 requests:
-                  # For production use-cases, we recommend specifying integer CPU reqests and limits.
+                  # For production use-cases, we recommend specifying integer CPU requests and limits.
                   # We also recommend setting requests equal to limits for both CPU and memory.
-                  # For this example, we use a 500m CPU request to accomodate resource-constrained local
+                  # For this example, we use a 500m CPU request to accommodate resource-constrained local
                   # Kubernetes testing environments such as KinD and minikube.
                   cpu: "1"
                   # For production use-cases, we recommend allocating at least 8Gb memory for each Ray container.


### PR DESCRIPTION
- `reqests` -> `requests`
- `accomodate` -> `accommodate`