### PR TITLE
Break looping when workload is already known to run on node

### DIFF
--- a/pkg/controller/tas/node_failure_controller.go
+++ b/pkg/controller/tas/node_failure_controller.go
@@ -179,28 +179,33 @@ func (r *nodeFailureReconciler) getWorkloadsOnNode(ctx context.Context, nodeName
 		return nil, fmt.Errorf("failed to list workloads: %w", err)
 	}
 	tasWorkloadsOnNode := sets.New[types.NamespacedName]()
-loopThroughWorkloads:
 	for _, wl := range allWorkloads.Items {
-		if !isAdmittedByTAS(&wl) {
-			continue
-		}
-		for _, podSetAssignment := range wl.Status.Admission.PodSetAssignments {
-			topologyAssignment := podSetAssignment.TopologyAssignment
-			if topologyAssignment == nil {
-				continue
-			}
-			if !utiltas.IsLowestLevelHostname(topologyAssignment.Levels) {
-				continue
-			}
-			for value := range utiltas.LowestLevelValues(topologyAssignment) {
-				if value == nodeName {
-					tasWorkloadsOnNode.Insert(types.NamespacedName{Name: wl.Name, Namespace: wl.Namespace})
-					continue loopThroughWorkloads
-				}
-			}
+		if hasTASAssignmentOnNode(&wl, nodeName) {
+			tasWorkloadsOnNode.Insert(types.NamespacedName{Name: wl.Name, Namespace: wl.Namespace})
 		}
 	}
 	return tasWorkloadsOnNode, nil
+}
+
+func hasTASAssignmentOnNode(wl *kueue.Workload, nodeName string) bool {
+	if !isAdmittedByTAS(wl) {
+		return false
+	}
+	for _, podSetAssignment := range wl.Status.Admission.PodSetAssignments {
+		topologyAssignment := podSetAssignment.TopologyAssignment
+		if topologyAssignment == nil {
+			continue
+		}
+		if !utiltas.IsLowestLevelHostname(topologyAssignment.Levels) {
+			continue
+		}
+		for value := range utiltas.LowestLevelValues(topologyAssignment) {
+			if value == nodeName {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (r *nodeFailureReconciler) getWorkloadsForImmediateReplacement(ctx context.Context, nodeName string) (sets.Set[types.NamespacedName], error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

In `node_failure_controller.go`, there's a function finding all workloads running on a node:

https://github.com/kubernetes-sigs/kueue/blob/f79008ecfd3e6fcc813778f830eeccd070328b3f/pkg/controller/tas/node_failure_controller.go#L176

https://github.com/kubernetes-sigs/kueue/blob/f79008ecfd3e6fcc813778f830eeccd070328b3f/pkg/controller/tas/node_failure_controller.go#L181-L182

https://github.com/kubernetes-sigs/kueue/blob/f79008ecfd3e6fcc813778f830eeccd070328b3f/pkg/controller/tas/node_failure_controller.go#L186

https://github.com/kubernetes-sigs/kueue/blob/f79008ecfd3e6fcc813778f830eeccd070328b3f/pkg/controller/tas/node_failure_controller.go#L194-L198

Once we determined that `wl` is running on `nodeName`, there's no point in doing anything else for that `wl`. (Even if we happen to see the same `nodeName` again - doesn't matter, as we `Insert` into a `Set`).

When this happens, we're free to break out of 2 loop levels (over PSAs & over nodes). ~I propose to capture this with an explicit `continue` targetting the outermost per-workload loop. This is exactly the intent.~

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```