### PR TITLE
Remove inadequate comment

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -518,13 +518,7 @@ func (c *ClusterQueue) Active() bool {
 }
 
 // RequeueIfNotPresent inserts a workload that was not
-// admitted back into the ClusterQueue. If the boolean is true,
-// the workloads should be put back in the queue immediately,
-// because we couldn't determine if the workload was admissible
-// in the last cycle. If the boolean is false, the implementation might
-// choose to keep it in temporary placeholder stage where it doesn't
-// compete with other workloads, until cluster events free up quota.
-// The workload should not be reinserted if it's already in the ClusterQueue.
+// admitted back into the ClusterQueue.
 // Returns true if the workload was inserted.
 func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.Info, reason RequeueReason) bool {
 	// when preemptions are in-progress, we keep attempting to


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

It removes a part of comment which seems inadequate.

In line 2, "the boolean" is mentioned - but the function accepts no boolean. (And, I guess, it's not about its `bool` result, as that is documented in the last line of the comment, in a very different way).

https://github.com/kubernetes-sigs/kueue/blob/f79008ecfd3e6fcc813778f830eeccd070328b3f/pkg/cache/queue/cluster_queue.go#L520-L529

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

My **guess** is that "the boolean" was meant to refer to the `immediate` param of the private helper:

https://github.com/kubernetes-sigs/kueue/blob/f79008ecfd3e6fcc813778f830eeccd070328b3f/pkg/cache/queue/cluster_queue.go#L277-L282

But then, as it's not exposed from the public function, there seems to be no point in mentioning it in the public function comment.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```