### PR TITLE
[WIP] Fix: Set Requeued condition for standalone workloads during admission check eviction

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -205,17 +205,6 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, nil
 	}
 
-	if requeueAt := workload.NeedsRequeueAtUpdate(&wl, r.clock); requeueAt != nil {
-		err := workload.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-			if wl.Status.RequeueState == nil {
-				wl.Status.RequeueState = &kueue.RequeueState{}
-			}
-			log.V(2).Info("At least one admission check set a retry time", "requeueAt", requeueAt, "current", wl.Status.RequeueState.RequeueAt)
-			workload.SetRequeueState(wl, *requeueAt, false)
-			return true, nil
-		})
-		return reconcile.Result{}, client.IgnoreNotFound(err)
-	}
 	if features.Enabled(features.DynamicResourceAllocation) && workload.Status(&wl) == workload.StatusPending &&
 		workload.HasDRA(&wl) {
 		workload.AdjustResources(ctx, r.client, &wl)
@@ -601,7 +590,15 @@ func (r *WorkloadReconciler) reconcileCheckBasedEviction(ctx context.Context, wl
 	}
 	// at this point we know a Workload has at least one Retry AdmissionCheck
 	message := "At least one admission check is false"
-	if err := workload.Evict(ctx, r.client, r.recorder, wl, kueue.WorkloadEvictedByAdmissionCheck, message, "", r.clock); err != nil {
+	// Calculate the retry time from admission checks before eviction resets them.
+	maxRetryTime := workload.GetMaxRetryTime(wl)
+	if err := workload.Evict(ctx, r.client, r.recorder, wl, kueue.WorkloadEvictedByAdmissionCheck, message, "", r.clock, workload.WithCustomPrepare(func(wl *kueue.Workload) {
+		// Set Requeued=false to track eviction, matching jobframework behavior
+		workload.SetRequeuedCondition(wl, kueue.WorkloadEvictedByAdmissionCheck, "Evicted due to admission check retry", false)
+		if !maxRetryTime.IsZero() {
+			workload.SetRequeueState(wl, maxRetryTime, false)
+		}
+	})); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -981,6 +981,12 @@ func TestReconcile(t *testing.T) {
 					Reason:  "AdmissionCheck",
 					Message: "At least one admission check is false",
 				}).
+				Condition(metav1.Condition{
+					Type:    "Requeued",
+					Status:  "False",
+					Reason:  "AdmissionCheck",
+					Message: "Evicted due to admission check retry",
+				}).
 				SchedulingStatsEviction(
 					kueue.WorkloadSchedulingStatsEviction{
 						Reason: kueue.WorkloadEvictedByAdmissionCheck,


### PR DESCRIPTION
Previously, only job-managed workloads had the Requeued condition set during admission check eviction (via jobframework). Standalone workloads had no code path setting this condition.

This change adds the condition to standalone workloads, ensuring consistent behavior between job-managed and standalone workloads.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/pull/7620#discussion_r2527941815

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Set Requeued condition for standalone workloads during admission check eviction
```