### PR TITLE
Set blockAdmission to false in workload retention docs

### DIFF
--- a/site/content/en/docs/tasks/manage/setup_wait_for_pods_ready.md
+++ b/site/content/en/docs/tasks/manage/setup_wait_for_pods_ready.md
@@ -43,7 +43,7 @@ fields:
     waitForPodsReady:
       timeout: 10m
       recoveryTimeout: 3m
-      blockAdmission: false
+      blockAdmission: true
       requeuingStrategy:
         timestamp: Eviction | Creation
         backoffLimitCount: 5

--- a/site/content/zh-CN/docs/tasks/manage/setup_wait_for_pods_ready.md
+++ b/site/content/zh-CN/docs/tasks/manage/setup_wait_for_pods_ready.md
@@ -38,7 +38,7 @@ description: 基于超时的全有或全无调度实现
       enable: true
       timeout: 10m
       recoveryTimeout: 3m
-      blockAdmission: false
+      blockAdmission: true
       requeuingStrategy:
         timestamp: Eviction | Creation
         backoffLimitCount: 5


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Set blockAdmission to false as that is our intended default.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially address #7656 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```