### PR TITLE
Automated cherry pick of #7668: Rename wrongly named variable in test

### DIFF
--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -2640,16 +2640,16 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq1LowPriority, admission)
 			}
 
-			cq2HighPriority := createWorkloadWithPriority("cq1", "1", 9999)
+			cq1HighPriority := createWorkloadWithPriority("cq1", "1", 9999)
 			{
 				admission := testing.MakeAdmission("cq1").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "f1", "1").Obj()).Obj()
-				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq2HighPriority, admission)
+				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq1HighPriority, admission)
 			}
 
 			cq2MiddlePriority := createWorkloadWithPriority("cq2", "1", 105)
 			{
-				util.ExpectWorkloadsToBePreempted(ctx, k8sClient, cq2HighPriority)
-				util.FinishEvictionForWorkloads(ctx, k8sClient, cq2HighPriority)
+				util.ExpectWorkloadsToBePreempted(ctx, k8sClient, cq1HighPriority)
+				util.FinishEvictionForWorkloads(ctx, k8sClient, cq1HighPriority)
 
 				admission := testing.MakeAdmission("cq2").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "f1", "1").Obj()).Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq2MiddlePriority, admission)
@@ -2660,7 +2660,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.FinishEvictionForWorkloads(ctx, k8sClient, cq1LowPriority)
 
 				admission := testing.MakeAdmission("cq1").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "f2", "1").Obj()).Obj()
-				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq2HighPriority, admission)
+				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq1HighPriority, admission)
 			}
 		})
 	})


### PR DESCRIPTION
Cherry pick of #7668 on release-0.13.

#7668: Rename wrongly named variable in test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```