### PR TITLE
Add PropagateBatchJobLabelsToWorkload feature (#7613)

### DIFF
--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -233,11 +233,15 @@ var (
 	// the legacy names are no longer defined in the api, only in k/2/apis/batch
 	legacyJobNameLabel       = "job-name"
 	legacyControllerUIDLabel = "controller-uid"
-	ManagedLabels            = []string{legacyJobNameLabel, legacyControllerUIDLabel, batchv1.JobNameLabel, batchv1.ControllerUidLabel}
+	managedLabels            = []string{legacyJobNameLabel, legacyControllerUIDLabel, batchv1.JobNameLabel, batchv1.ControllerUidLabel}
 )
 
-func cleanManagedLabels(pt *corev1.PodTemplateSpec) *corev1.PodTemplateSpec {
-	for _, managedLabel := range ManagedLabels {
+// Clean labels that are managed by the job controller except job-name label.
+func cleanLabels(pt *corev1.PodTemplateSpec) *corev1.PodTemplateSpec {
+	for _, managedLabel := range managedLabels {
+		if features.Enabled(features.PropagateBatchJobLabelsToWorkload) && managedLabel == batchv1.JobNameLabel {
+			continue
+		}
 		delete(pt.Labels, managedLabel)
 	}
 	return pt
@@ -246,7 +250,7 @@ func cleanManagedLabels(pt *corev1.PodTemplateSpec) *corev1.PodTemplateSpec {
 func (j *Job) PodSets() ([]kueue.PodSet, error) {
 	podSet := kueue.PodSet{
 		Name:     kueue.DefaultPodSetName,
-		Template: *cleanManagedLabels(j.Spec.Template.DeepCopy()),
+		Template: *cleanLabels(j.Spec.Template.DeepCopy()),
 		Count:    j.podsCount(),
 		MinCount: j.minPodsCount(),
 	}
@@ -296,7 +300,7 @@ func (j *Job) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
 		}
 	}
 	info := podSetsInfo[0]
-	for _, managedLabel := range ManagedLabels {
+	for _, managedLabel := range managedLabels {
 		if v, found := j.Spec.Template.Labels[managedLabel]; found {
 			info.AddOrUpdateLabel(managedLabel, v)
 		}

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -3977,3 +3977,53 @@ func TestReconciler(t *testing.T) {
 		})
 	}
 }
+
+func TestCleanLabels(t *testing.T) {
+	cases := map[string]struct {
+		featureEnabled bool
+		labels         map[string]string
+		wantLabels     map[string]string
+	}{
+		"feature disabled": {
+			featureEnabled: false,
+			labels: map[string]string{
+				"foo":                      "bar",
+				batchv1.JobNameLabel:       "job-name",
+				"controller-uid":           "uid",
+				batchv1.ControllerUidLabel: "uid",
+			},
+			wantLabels: map[string]string{
+				"foo": "bar",
+			},
+		},
+		"feature enabled": {
+			featureEnabled: true,
+			labels: map[string]string{
+				"foo":                      "bar",
+				batchv1.JobNameLabel:       "job-name",
+				"controller-uid":           "uid",
+				batchv1.ControllerUidLabel: "uid",
+			},
+			wantLabels: map[string]string{
+				"foo":                "bar",
+				batchv1.JobNameLabel: "job-name",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			print(tc.labels)
+			features.SetFeatureGateDuringTest(t, features.PropagateBatchJobLabelsToWorkload, tc.featureEnabled)
+			pt := &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: tc.labels,
+				},
+			}
+			cleanLabels(pt)
+			if diff := cmp.Diff(tc.wantLabels, pt.Labels); diff != "" {
+				t.Errorf("cleanLabels() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -97,9 +97,7 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	// drop the selector
 	remoteJob.Spec.Selector = nil
 	// drop the templates cleanup labels
-	for _, cl := range ManagedLabels {
-		delete(remoteJob.Spec.Template.Labels, cl)
-	}
+	cleanLabels(&remoteJob.Spec.Template)
 
 	// add the prebuilt workload
 	if remoteJob.Labels == nil {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -208,6 +208,12 @@ const (
 	//
 	// Enables reclaimable pods counting towards quota.
 	ReclaimablePods featuregate.Feature = "ReclaimablePods"
+
+	// owner: @yaroslva-serdiuk
+	//
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/7597
+	// Do not remove job-name label from Workload PodTemplate object.
+	PropagateBatchJobLabelsToWorkload featuregate.Feature = "PropagateBatchJobLabelsToWorkload"
 )
 
 func init() {
@@ -317,6 +323,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.13"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	ReclaimablePods: {
+		{Version: version.MustParse("0.13"), Default: true, PreRelease: featuregate.Beta},
+	},
+	PropagateBatchJobLabelsToWorkload: {
 		{Version: version.MustParse("0.13"), Default: true, PreRelease: featuregate.Beta},
 	},
 }


### PR DESCRIPTION
Cherry pick of [Add PropagateBatchJobLabelsToWorkload feature](https://github.com/kubernetes-sigs/kueue/pull/7613)
with updated version of feature gate to 0.13

/kind bug
/kind feature

https://github.com/kubernetes-sigs/kueue/issues/7597

```release-note
Fix the bug that the kubernetes.io/job-name label was not propagated from the k8s Job to the PodTemplate in
the Workload object, and later to the pod template in the ProvisioningRequest. 

As a consequence the ClusterAutoscaler could not properly resolve pod affinities referring to that label,
via podAffinity.requiredDuringSchedulingIgnoredDuringExecution.labelSelector. For example, 
such pod affinities can be used to request ClusterAutoscaler to provision a single node which is large enough
to accommodate all Pods on a single Node.

We also introduce the PropagateBatchJobLabelsToWorkload feature gate to disable the new behavior in case of 
complications.
```