### PR TITLE
Automated cherry pick of #7754: Don't use eventually inside eventually.

### DIFF
--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -3166,7 +3166,7 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 					g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
 					g.Expect(workloads.Items).Should(gomega.HaveLen(1))
 					testJobWorkload = &workloads.Items[0]
-					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, testJobWorkload)
+					g.Expect(workload.IsAdmitted(testJobWorkload)).Should(gomega.BeTrue())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 				ginkgo.By("the job is unsuspended")
@@ -3204,10 +3204,10 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 					workloads := &kueue.WorkloadList{}
 					g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
 					g.Expect(workloads.Items).Should(gomega.HaveLen(1))
-					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, testJobWorkload)
 					g.Expect(workloads.Items[0].Spec.PodSets[0].Count).Should(gomega.BeEquivalentTo(int32(1)))
 					g.Expect(workloads.Items[0].UID).Should(gomega.BeEquivalentTo(testJobWorkload.UID))
 					testJobWorkload = &workloads.Items[0]
+					g.Expect(workload.IsAdmitted(testJobWorkload)).Should(gomega.BeTrue())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 				ginkgo.By("increasing the job's parallelism to emulate scale-up operation")
@@ -3237,7 +3237,7 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 							continue
 						}
 						testJobWorkload = &workloads.Items[i]
-						util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, testJobWorkload)
+						g.Expect(workload.IsAdmitted(testJobWorkload)).Should(gomega.BeTrue())
 					}
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -3265,7 +3265,7 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 					g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJobA.Namespace))).Should(gomega.Succeed())
 					g.Expect(workloads.Items).Should(gomega.HaveLen(1))
 					testJobAWorkload = &workloads.Items[0]
-					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, testJobAWorkload)
+					g.Expect(workload.IsAdmitted(testJobAWorkload)).Should(gomega.BeTrue())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 				ginkgo.By("the job-a is unsuspended")
@@ -3297,7 +3297,7 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 					g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJobA.Namespace), client.MatchingLabels{constants.JobUIDLabel: string(testJobB.UID)})).Should(gomega.Succeed())
 					g.Expect(workloads.Items).Should(gomega.HaveLen(1))
 					testJobBWorkload = &workloads.Items[0]
-					util.ExpectWorkloadsToBePending(ctx, k8sClient, testJobBWorkload)
+					g.Expect(testJobBWorkload.Status.Conditions).Should(testing.HaveConditionStatusFalseAndReason(kueue.WorkloadQuotaReserved, "Pending"))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 				ginkgo.By("scale-down job-a to make room for job-b")
@@ -3309,7 +3309,7 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 				ginkgo.By("admitting the job-b workload")
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJobBWorkload), testJobBWorkload)).Should(gomega.Succeed())
-					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, testJobBWorkload)
+					g.Expect(workload.IsAdmitted(testJobBWorkload)).Should(gomega.BeTrue())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 				ginkgo.By("the job-b is unsuspended")


### PR DESCRIPTION
Cherry pick of #7754 on release-0.13.

#7754: Don't use eventually inside eventually.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```