### PR TITLE
Kubebuilder cross-validation tests for TopologyAssignment v1beta2

### DIFF
--- a/test/integration/singlecluster/webhook/core/workload_test.go
+++ b/test/integration/singlecluster/webhook/core/workload_test.go
@@ -1580,9 +1580,7 @@ var _ = ginkgo.Describe("TopologyAssignment validation", ginkgo.Ordered, func() 
 	})
 
 	ginkgo.BeforeAll(func() {
-		fwk.StartManager(ctx, cfg, func(ctx context.Context, mgr manager.Manager) {
-			managerSetup(ctx, mgr)
-		})
+		fwk.StartManager(ctx, cfg, managerSetup)
 	})
 
 	ginkgo.AfterAll(func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR adds some test coverage for the more complex Kubebuilder `XValidation` rules added in #7544 for TopologyAssignment v1beta2 format.

By "more complex rules", I mean specifically these 3:

https://github.com/kubernetes-sigs/kueue/blob/952b9f8df59ad3b3e0091f47d35a87354713abb8/apis/kueue/v1beta2/workload_types.go#L417-L418

https://github.com/kubernetes-sigs/kueue/blob/952b9f8df59ad3b3e0091f47d35a87354713abb8/apis/kueue/v1beta2/workload_types.go#L438-L440

To me, they feel complex enough to "ideally deserve some testing".

#### Which issue(s) this PR fixes:

Fixes #7639 (I'd say so; see "special notes" below).

#### Special notes for your reviewer:

1. There are more Kubebuilder validation rules introduced by #7544, e.g.

https://github.com/kubernetes-sigs/kueue/blob/952b9f8df59ad3b3e0091f47d35a87354713abb8/apis/kueue/v1beta2/workload_types.go#L418-L428

https://github.com/kubernetes-sigs/kueue/blob/952b9f8df59ad3b3e0091f47d35a87354713abb8/apis/kueue/v1beta2/workload_types.go#L459-L460

However, these are all much simpler, and I think testing those would be overly pedantic.

2. Also, keep in mind that `TopologyAssignment` is a part of workload **status**.
   This means that we don't realistically expect updates to it requested by end users, which makes all these validation rules a bit less "essential", and thus reduces importance of covering them with tests.
   (One could even ask if we should have this validation at all - however, they existed also in v1beta1 TopologyAssignment, presumably mostly as a way of documenting the semantics of the data format).

Altogether, I'm hoping that this PR brings a "reasonable coverage" to close #7639 (not too little, not absurdly too much ;). 

If you disagree, please speak up.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```