### PR TITLE
v1beta2: Fix cohort client-go bug

### DIFF
--- a/apis/kueue/v1beta2/cohort_types.go
+++ b/apis/kueue/v1beta2/cohort_types.go
@@ -81,6 +81,7 @@ type CohortStatus struct {
 }
 
 // +genclient
+// +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:subresource:status

--- a/client-go/applyconfiguration/kueue/v1beta2/cohort.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/cohort.go
@@ -34,10 +34,9 @@ type CohortApplyConfiguration struct {
 
 // Cohort constructs a declarative configuration of the Cohort type for use with
 // apply.
-func Cohort(name, namespace string) *CohortApplyConfiguration {
+func Cohort(name string) *CohortApplyConfiguration {
 	b := &CohortApplyConfiguration{}
 	b.WithName(name)
-	b.WithNamespace(namespace)
 	b.WithKind("Cohort")
 	b.WithAPIVersion("kueue.x-k8s.io/v1beta2")
 	return b

--- a/client-go/clientset/versioned/typed/kueue/v1beta2/cohort.go
+++ b/client-go/clientset/versioned/typed/kueue/v1beta2/cohort.go
@@ -32,7 +32,7 @@ import (
 // CohortsGetter has a method to return a CohortInterface.
 // A group's client should implement this interface.
 type CohortsGetter interface {
-	Cohorts(namespace string) CohortInterface
+	Cohorts() CohortInterface
 }
 
 // CohortInterface has methods to work with Cohort resources.
@@ -59,13 +59,13 @@ type cohorts struct {
 }
 
 // newCohorts returns a Cohorts
-func newCohorts(c *KueueV1beta2Client, namespace string) *cohorts {
+func newCohorts(c *KueueV1beta2Client) *cohorts {
 	return &cohorts{
 		gentype.NewClientWithListAndApply[*kueuev1beta2.Cohort, *kueuev1beta2.CohortList, *applyconfigurationkueuev1beta2.CohortApplyConfiguration](
 			"cohorts",
 			c.RESTClient(),
 			scheme.ParameterCodec,
-			namespace,
+			"",
 			func() *kueuev1beta2.Cohort { return &kueuev1beta2.Cohort{} },
 			func() *kueuev1beta2.CohortList { return &kueuev1beta2.CohortList{} },
 		),

--- a/client-go/clientset/versioned/typed/kueue/v1beta2/fake/fake_cohort.go
+++ b/client-go/clientset/versioned/typed/kueue/v1beta2/fake/fake_cohort.go
@@ -30,11 +30,11 @@ type fakeCohorts struct {
 	Fake *FakeKueueV1beta2
 }
 
-func newFakeCohorts(fake *FakeKueueV1beta2, namespace string) typedkueuev1beta2.CohortInterface {
+func newFakeCohorts(fake *FakeKueueV1beta2) typedkueuev1beta2.CohortInterface {
 	return &fakeCohorts{
 		gentype.NewFakeClientWithListAndApply[*v1beta2.Cohort, *v1beta2.CohortList, *kueuev1beta2.CohortApplyConfiguration](
 			fake.Fake,
-			namespace,
+			"",
 			v1beta2.SchemeGroupVersion.WithResource("cohorts"),
 			v1beta2.SchemeGroupVersion.WithKind("Cohort"),
 			func() *v1beta2.Cohort { return &v1beta2.Cohort{} },

--- a/client-go/clientset/versioned/typed/kueue/v1beta2/fake/fake_kueue_client.go
+++ b/client-go/clientset/versioned/typed/kueue/v1beta2/fake/fake_kueue_client.go
@@ -35,8 +35,8 @@ func (c *FakeKueueV1beta2) ClusterQueues() v1beta2.ClusterQueueInterface {
 	return newFakeClusterQueues(c)
 }
 
-func (c *FakeKueueV1beta2) Cohorts(namespace string) v1beta2.CohortInterface {
-	return newFakeCohorts(c, namespace)
+func (c *FakeKueueV1beta2) Cohorts() v1beta2.CohortInterface {
+	return newFakeCohorts(c)
 }
 
 func (c *FakeKueueV1beta2) LocalQueues(namespace string) v1beta2.LocalQueueInterface {

--- a/client-go/clientset/versioned/typed/kueue/v1beta2/kueue_client.go
+++ b/client-go/clientset/versioned/typed/kueue/v1beta2/kueue_client.go
@@ -53,8 +53,8 @@ func (c *KueueV1beta2Client) ClusterQueues() ClusterQueueInterface {
 	return newClusterQueues(c)
 }
 
-func (c *KueueV1beta2Client) Cohorts(namespace string) CohortInterface {
-	return newCohorts(c, namespace)
+func (c *KueueV1beta2Client) Cohorts() CohortInterface {
+	return newCohorts(c)
 }
 
 func (c *KueueV1beta2Client) LocalQueues(namespace string) LocalQueueInterface {

--- a/client-go/informers/externalversions/kueue/v1beta2/cohort.go
+++ b/client-go/informers/externalversions/kueue/v1beta2/cohort.go
@@ -41,45 +41,44 @@ type CohortInformer interface {
 type cohortInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewCohortInformer constructs a new informer for Cohort type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewCohortInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredCohortInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewCohortInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredCohortInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredCohortInformer constructs a new informer for Cohort type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredCohortInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredCohortInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KueueV1beta2().Cohorts(namespace).List(context.Background(), options)
+				return client.KueueV1beta2().Cohorts().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KueueV1beta2().Cohorts(namespace).Watch(context.Background(), options)
+				return client.KueueV1beta2().Cohorts().Watch(context.Background(), options)
 			},
 			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KueueV1beta2().Cohorts(namespace).List(ctx, options)
+				return client.KueueV1beta2().Cohorts().List(ctx, options)
 			},
 			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KueueV1beta2().Cohorts(namespace).Watch(ctx, options)
+				return client.KueueV1beta2().Cohorts().Watch(ctx, options)
 			},
 		},
 		&apiskueuev1beta2.Cohort{},
@@ -89,7 +88,7 @@ func NewFilteredCohortInformer(client versioned.Interface, namespace string, res
 }
 
 func (f *cohortInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCohortInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredCohortInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *cohortInformer) Informer() cache.SharedIndexInformer {

--- a/client-go/informers/externalversions/kueue/v1beta2/interface.go
+++ b/client-go/informers/externalversions/kueue/v1beta2/interface.go
@@ -70,7 +70,7 @@ func (v *version) ClusterQueues() ClusterQueueInformer {
 
 // Cohorts returns a CohortInformer.
 func (v *version) Cohorts() CohortInformer {
-	return &cohortInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &cohortInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 // LocalQueues returns a LocalQueueInformer.

--- a/client-go/listers/kueue/v1beta2/cohort.go
+++ b/client-go/listers/kueue/v1beta2/cohort.go
@@ -30,8 +30,9 @@ type CohortLister interface {
 	// List lists all Cohorts in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*kueuev1beta2.Cohort, err error)
-	// Cohorts returns an object that can list and get Cohorts.
-	Cohorts(namespace string) CohortNamespaceLister
+	// Get retrieves the Cohort from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*kueuev1beta2.Cohort, error)
 	CohortListerExpansion
 }
 
@@ -43,27 +44,4 @@ type cohortLister struct {
 // NewCohortLister returns a new CohortLister.
 func NewCohortLister(indexer cache.Indexer) CohortLister {
 	return &cohortLister{listers.New[*kueuev1beta2.Cohort](indexer, kueuev1beta2.Resource("cohort"))}
-}
-
-// Cohorts returns an object that can list and get Cohorts.
-func (s *cohortLister) Cohorts(namespace string) CohortNamespaceLister {
-	return cohortNamespaceLister{listers.NewNamespaced[*kueuev1beta2.Cohort](s.ResourceIndexer, namespace)}
-}
-
-// CohortNamespaceLister helps list and get Cohorts.
-// All objects returned here must be treated as read-only.
-type CohortNamespaceLister interface {
-	// List lists all Cohorts in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*kueuev1beta2.Cohort, err error)
-	// Get retrieves the Cohort from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*kueuev1beta2.Cohort, error)
-	CohortNamespaceListerExpansion
-}
-
-// cohortNamespaceLister implements the CohortNamespaceLister
-// interface.
-type cohortNamespaceLister struct {
-	listers.ResourceIndexer[*kueuev1beta2.Cohort]
 }

--- a/client-go/listers/kueue/v1beta2/expansion_generated.go
+++ b/client-go/listers/kueue/v1beta2/expansion_generated.go
@@ -29,10 +29,6 @@ type ClusterQueueListerExpansion interface{}
 // CohortLister.
 type CohortListerExpansion interface{}
 
-// CohortNamespaceListerExpansion allows custom methods to be added to
-// CohortNamespaceLister.
-type CohortNamespaceListerExpansion interface{}
-
 // LocalQueueListerExpansion allows custom methods to be added to
 // LocalQueueLister.
 type LocalQueueListerExpansion interface{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Even though Cohort is Cluster-scope resource, the client-go is generated for namespaced resource.
I will submit another PR for v1beta1 so that we can easy make cherry-pick PRs.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```