### PR TITLE
Rename ClusterProfile to ClusterProfileRef.

### DIFF
--- a/apis/kueue/v1beta1/zz_generated.conversion.go
+++ b/apis/kueue/v1beta1/zz_generated.conversion.go
@@ -1742,7 +1742,7 @@ func autoConvert_v1beta1_MultiKueueClusterSpec_To_v1beta2_MultiKueueClusterSpec(
 
 func autoConvert_v1beta2_MultiKueueClusterSpec_To_v1beta1_MultiKueueClusterSpec(in *v1beta2.MultiKueueClusterSpec, out *MultiKueueClusterSpec, s conversion.Scope) error {
 	// WARNING: in.KubeConfig requires manual conversion: inconvertible types (*sigs.k8s.io/kueue/apis/kueue/v1beta2.KubeConfig vs sigs.k8s.io/kueue/apis/kueue/v1beta1.KubeConfig)
-	// WARNING: in.ClusterProfile requires manual conversion: does not exist in peer-type
+	// WARNING: in.ClusterProfileRef requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/apis/kueue/v1beta2/multikueue_types.go
+++ b/apis/kueue/v1beta2/multikueue_types.go
@@ -62,26 +62,26 @@ type KubeConfig struct {
 	LocationType LocationType `json:"locationType"`
 }
 
-// +kubebuilder:validation:ExactlyOneOf=kubeConfig;clusterProfile
+// +kubebuilder:validation:ExactlyOneOf=kubeConfig;clusterProfileRef
 
 type MultiKueueClusterSpec struct {
 	// kubeConfig is information on how to connect to the cluster.
 	// +optional
 	KubeConfig *KubeConfig `json:"kubeConfig,omitempty,omitzero"`
 
-	// clusterProfile is the reference to the ClusterProfile object used to connect to the cluster.
+	// clusterProfileRef is the reference to the ClusterProfile object used to connect to the cluster.
 	// +optional
-	ClusterProfile *ClusterProfileReference `json:"clusterProfile,omitempty"`
+	ClusterProfileRef *ClusterProfileReference `json:"clusterProfileRef,omitempty"`
 }
 
 type ClusterProfileReference struct {
-	// name of the ClusterProfile.
+	// name of the ClusterProfileRef.
 	// +kubebuilder:validation:MaxLength=256
 	// +kubebuilder:validation:MinLength=1
 	// +required
 	Name string `json:"name,omitempty"`
 
-	// namespace of the ClusterProfile.
+	// namespace of the ClusterProfileRef.
 	// +kubebuilder:validation:MaxLength=256
 	// +kubebuilder:validation:MinLength=1
 	// +required

--- a/apis/kueue/v1beta2/zz_generated.deepcopy.go
+++ b/apis/kueue/v1beta2/zz_generated.deepcopy.go
@@ -959,8 +959,8 @@ func (in *MultiKueueClusterSpec) DeepCopyInto(out *MultiKueueClusterSpec) {
 		*out = new(KubeConfig)
 		**out = **in
 	}
-	if in.ClusterProfile != nil {
-		in, out := &in.ClusterProfile, &out.ClusterProfile
+	if in.ClusterProfileRef != nil {
+		in, out := &in.ClusterProfileRef, &out.ClusterProfileRef
 		*out = new(ClusterProfileReference)
 		**out = **in
 	}

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
@@ -198,16 +198,16 @@ spec:
             spec:
               description: spec is the specification of the MultiKueueCluster.
               properties:
-                clusterProfile:
-                  description: clusterProfile is the reference to the ClusterProfile object used to connect to the cluster.
+                clusterProfileRef:
+                  description: clusterProfileRef is the reference to the ClusterProfile object used to connect to the cluster.
                   properties:
                     name:
-                      description: name of the ClusterProfile.
+                      description: name of the ClusterProfileRef.
                       maxLength: 256
                       minLength: 1
                       type: string
                     namespace:
-                      description: namespace of the ClusterProfile.
+                      description: namespace of the ClusterProfileRef.
                       maxLength: 256
                       minLength: 1
                       type: string
@@ -239,8 +239,8 @@ spec:
                   type: object
               type: object
               x-kubernetes-validations:
-                - message: exactly one of the fields in [kubeConfig clusterProfile] must be set
-                  rule: '[has(self.kubeConfig),has(self.clusterProfile)].filter(x,x==true).size() == 1'
+                - message: exactly one of the fields in [kubeConfig clusterProfileRef] must be set
+                  rule: '[has(self.kubeConfig),has(self.clusterProfileRef)].filter(x,x==true).size() == 1'
             status:
               description: status is the status of the MultiKueueCluster.
               properties:

--- a/client-go/applyconfiguration/kueue/v1beta2/multikueueclusterspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/multikueueclusterspec.go
@@ -20,8 +20,8 @@ package v1beta2
 // MultiKueueClusterSpecApplyConfiguration represents a declarative configuration of the MultiKueueClusterSpec type for use
 // with apply.
 type MultiKueueClusterSpecApplyConfiguration struct {
-	KubeConfig     *KubeConfigApplyConfiguration              `json:"kubeConfig,omitempty"`
-	ClusterProfile *ClusterProfileReferenceApplyConfiguration `json:"clusterProfile,omitempty"`
+	KubeConfig        *KubeConfigApplyConfiguration              `json:"kubeConfig,omitempty"`
+	ClusterProfileRef *ClusterProfileReferenceApplyConfiguration `json:"clusterProfileRef,omitempty"`
 }
 
 // MultiKueueClusterSpecApplyConfiguration constructs a declarative configuration of the MultiKueueClusterSpec type for use with
@@ -38,10 +38,10 @@ func (b *MultiKueueClusterSpecApplyConfiguration) WithKubeConfig(value *KubeConf
 	return b
 }
 
-// WithClusterProfile sets the ClusterProfile field in the declarative configuration to the given value
+// WithClusterProfileRef sets the ClusterProfileRef field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the ClusterProfile field is set to the value of the last call.
-func (b *MultiKueueClusterSpecApplyConfiguration) WithClusterProfile(value *ClusterProfileReferenceApplyConfiguration) *MultiKueueClusterSpecApplyConfiguration {
-	b.ClusterProfile = value
+// If called multiple times, the ClusterProfileRef field is set to the value of the last call.
+func (b *MultiKueueClusterSpecApplyConfiguration) WithClusterProfileRef(value *ClusterProfileReferenceApplyConfiguration) *MultiKueueClusterSpecApplyConfiguration {
+	b.ClusterProfileRef = value
 	return b
 }

--- a/config/components/crd/bases/kueue.x-k8s.io_multikueueclusters.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_multikueueclusters.yaml
@@ -177,17 +177,17 @@ spec:
           spec:
             description: spec is the specification of the MultiKueueCluster.
             properties:
-              clusterProfile:
-                description: clusterProfile is the reference to the ClusterProfile
+              clusterProfileRef:
+                description: clusterProfileRef is the reference to the ClusterProfile
                   object used to connect to the cluster.
                 properties:
                   name:
-                    description: name of the ClusterProfile.
+                    description: name of the ClusterProfileRef.
                     maxLength: 256
                     minLength: 1
                     type: string
                   namespace:
-                    description: namespace of the ClusterProfile.
+                    description: namespace of the ClusterProfileRef.
                     maxLength: 256
                     minLength: 1
                     type: string
@@ -219,9 +219,9 @@ spec:
                 type: object
             type: object
             x-kubernetes-validations:
-            - message: exactly one of the fields in [kubeConfig clusterProfile] must
-                be set
-              rule: '[has(self.kubeConfig),has(self.clusterProfile)].filter(x,x==true).size()
+            - message: exactly one of the fields in [kubeConfig clusterProfileRef]
+                must be set
+              rule: '[has(self.kubeConfig),has(self.clusterProfileRef)].filter(x,x==true).size()
                 == 1'
           status:
             description: status is the status of the MultiKueueCluster.

--- a/pkg/controller/admissionchecks/multikueue/indexer.go
+++ b/pkg/controller/admissionchecks/multikueue/indexer.go
@@ -59,10 +59,10 @@ func getIndexUsingClusterProfiles(configNamespace string) func(obj client.Object
 		if !isCluster {
 			return nil
 		}
-		if cluster.Spec.ClusterProfile == nil {
+		if cluster.Spec.ClusterProfileRef == nil {
 			return nil
 		}
-		return []string{strings.Join([]string{configNamespace, cluster.Spec.ClusterProfile.Namespace, cluster.Spec.ClusterProfile.Name}, "/")}
+		return []string{strings.Join([]string{configNamespace, cluster.Spec.ClusterProfileRef.Namespace, cluster.Spec.ClusterProfileRef.Name}, "/")}
 	}
 }
 

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -450,11 +450,11 @@ func (c *clustersReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 
 func (c *clustersReconciler) loadClientConfig(ctx context.Context, cluster *kueue.MultiKueueCluster) (*clientConfig, bool, string, error) {
 	log := ctrl.LoggerFrom(ctx)
-	if cluster.Spec.ClusterProfile != nil {
+	if cluster.Spec.ClusterProfileRef != nil {
 		if !features.Enabled(features.MultiKueueClusterProfile) {
 			return nil, false, "MultiKueueClusterProfileFeatureDisabled", errors.New("MultiKueueClusterProfile feature gate is disabled")
 		}
-		restConfig, retry, err := c.getRestConfigFromClusterProfile(ctx, cluster.Spec.ClusterProfile)
+		restConfig, retry, err := c.getRestConfigFromClusterProfile(ctx, cluster.Spec.ClusterProfileRef)
 		if err != nil {
 			return nil, retry, "BadClusterProfile", err
 		}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -220,7 +220,7 @@ const (
 	// owner: @hdp617
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/693-multikueue
 	//
-	// Enables ClusterProfile integration for MultiKueue.
+	// Enables ClusterProfileRef integration for MultiKueue.
 	MultiKueueClusterProfile featuregate.Feature = "MultiKueueClusterProfile"
 
 	// owner: @kshalot

--- a/pkg/util/testing/v1beta2/wrappers.go
+++ b/pkg/util/testing/v1beta2/wrappers.go
@@ -1440,7 +1440,7 @@ func (mkc *MultiKueueClusterWrapper) KubeConfig(locationType kueue.LocationType,
 }
 
 func (mkc *MultiKueueClusterWrapper) ClusterProfile(name string, namespace string) *MultiKueueClusterWrapper {
-	mkc.Spec.ClusterProfile = &kueue.ClusterProfileReference{
+	mkc.Spec.ClusterProfileRef = &kueue.ClusterProfileReference{
 		Name:      name,
 		Namespace: namespace,
 	}

--- a/site/content/en/docs/reference/kueue.v1beta2.md
+++ b/site/content/en/docs/reference/kueue.v1beta2.md
@@ -801,14 +801,14 @@ policy can be preempted by the borrowing workload.</p>
 <code>string</code>
 </td>
 <td>
-   <p>name of the ClusterProfile.</p>
+   <p>name of the ClusterProfileRef.</p>
 </td>
 </tr>
 <tr><td><code>namespace</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   <p>namespace of the ClusterProfile.</p>
+   <p>namespace of the ClusterProfileRef.</p>
 </td>
 </tr>
 </tbody>
@@ -1834,11 +1834,11 @@ workloads assigned to this LocalQueue.</p>
    <p>kubeConfig is information on how to connect to the cluster.</p>
 </td>
 </tr>
-<tr><td><code>clusterProfile</code><br/>
+<tr><td><code>clusterProfileRef</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-ClusterProfileReference"><code>ClusterProfileReference</code></a>
 </td>
 <td>
-   <p>clusterProfile is the reference to the ClusterProfile object used to connect to the cluster.</p>
+   <p>clusterProfileRef is the reference to the ClusterProfile object used to connect to the cluster.</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Rename ClusterProfile to ClusterProfileRef.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Follow up for https://github.com/kubernetes-sigs/kueue/pull/7570#discussion_r2543766166.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```