### PR TITLE
Add performance tests for v1beta2 TopologyAssignment encoding

### DIFF
--- a/pkg/util/tas/tas_assignment_performance_test.go
+++ b/pkg/util/tas/tas_assignment_performance_test.go
@@ -195,10 +195,10 @@ type performanceTestCase struct {
 
 var performanceTestCases = []performanceTestCase{
 	{
-		name: "pool-and-node-based naming (100 node pools)",
+		name: "pool-and-node-based naming (1000 node pools)",
 		naming: poolAndNodeBasedNaming(poolAndNodeBasedNamingConfig{
-			pools:        100, // happens in practice, at least in GKE
-			nodeIDLength: 6,   // reached in AKS
+			pools:        1000, // happens in practice, at least in GKE
+			nodeIDLength: 6,    // reached in AKS
 
 			// reachable in AKS (<pool-name>-<8-char-id>-vmss, then let <pool-name> have 8 chars)
 			poolIDLength: 22,
@@ -207,9 +207,12 @@ var performanceTestCases = []performanceTestCase{
 		}),
 	},
 	{
-		name: "pool-and-node-based naming (1 node pool)",
+		name: "pool-and-node-based naming (10 node pools)",
 		naming: poolAndNodeBasedNaming(poolAndNodeBasedNamingConfig{
-			pools:                      1,
+			// Vendors tend to restrict "node pools" to 4k nodes or less,
+			// so, as we care about 40k+ nodes, it seems 10+ pools will always exist.
+			pools: 10,
+
 			nodeIDLength:               6,
 			poolIDLength:               22,
 			fixedPrefixAndSuffixLength: 20,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As described in #7640, it adds 2 kinds of unit tests verifying the behavior of the v1beta2 TopologyAssignment encoding:

- a check that, for the most popular naming schemes, we can fit sufficiently many nodes;
- a benchmark of the latency spent on generating the "packed" v1beta2 representation.

This serves 2 purposes: 

- it improves test coverage for PR #7544 ;
- it lays ground for assessment of any alternative encoding strategies in the future.

#### Which issue(s) this PR fixes:

Fixes #7640

#### Special notes for your reviewer:

The specific performance results depend significantly on the "node naming scheme", which is heavily vendor-dependent. OTOH, I wanted to keep my tests possibly simple, without diving into implementation details of numerous vendors.

As a middle ground, I checked the most typical naming schemes used by ~10 top vendors, and defined 3 `namingScheme`s, intended to act as "upper bounds" for all those real-life schemes (in terms of the length of each functional part of the node name).
These schemes are parametrized by numeric parameters, which are explicitly set inside individual test cases, to make those test cases more self-describing.

Still, to get some concrete numbers, I needed to take additional assumptions, e.g.
- If "node pools" are a concept, then:
  - there's no more than 100 of them
  - if their names contribute to node names, than these names aren't longer than 8 characters
- If "regions" contribute to node names, then there's no more than 100 of them
- Cluster name isn't longer than 16 characters.

These assumptions _may not hold_ in some rare cases - but I simply had to assume something on this.

---

Under these assumptions, the worst test case shows a limit of **46.8k nodes** fitting within a single etcd entry. That's worse than my initially forecasted 60k, apologies for that. Note though, tiny details matter: for example, in the "pool-and-node-based" scheme, once we assume that node pools are named `pool-<number>` (as I did in my early experiments), the pool-based part gets effectively shortened by 5 characters (as `pool-` becomes part of a single common prefix), and that alone increases the limit from 46.8k to 55.5k. So, user naming patterns matter, and (as long as we stick to the "single prefix & suffix" encoding strategy) there's nothing we can do about that.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```