### PR TITLE
Encapsulate inadmissible workloads map with wrapper type

### DIFF
--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -70,7 +70,7 @@ func Test_PushOrUpdate(t *testing.T) {
 	cases := map[string]struct {
 		workload                  *utiltestingapi.WorkloadWrapper
 		wantWorkload              *workload.Info
-		wantInAdmissibleWorkloads map[workload.Reference]*workload.Info
+		wantInAdmissibleWorkloads inadmissibleWorkloads
 	}{
 		"workload doesn't have re-queue state": {
 			workload:     wlBase.Clone(),
@@ -88,7 +88,7 @@ func Test_PushOrUpdate(t *testing.T) {
 					Type:   kueue.WorkloadRequeued,
 					Status: metav1.ConditionFalse,
 				}),
-			wantInAdmissibleWorkloads: map[workload.Reference]*workload.Info{
+			wantInAdmissibleWorkloads: inadmissibleWorkloads{
 				"default/workload-1": workload.NewInfo(wlBase.Clone().
 					ResourceVersion("1").
 					RequeueState(ptr.To[int32](10), ptr.To(metav1.NewTime(minuteLater))).
@@ -115,7 +115,7 @@ func Test_PushOrUpdate(t *testing.T) {
 					Type:   kueue.WorkloadRequeued,
 					Status: metav1.ConditionFalse,
 				}),
-			wantInAdmissibleWorkloads: map[workload.Reference]*workload.Info{
+			wantInAdmissibleWorkloads: inadmissibleWorkloads{
 				"default/workload-1": workload.NewInfo(wlBase.Clone().
 					ResourceVersion("1").
 					Condition(metav1.Condition{

--- a/pkg/cache/queue/inadmissible_workloads.go
+++ b/pkg/cache/queue/inadmissible_workloads.go
@@ -1,0 +1,66 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+// inadmissibleWorkloads is a thin wrapper around a map to encapsulate
+// operations on inadmissible workloads and prevent direct map access.
+type inadmissibleWorkloads map[workload.Reference]*workload.Info
+
+// get retrieves a workload from the inadmissible workloads map.
+// Returns the workload if it exists, otherwise returns nil.
+func (iw inadmissibleWorkloads) get(key workload.Reference) *workload.Info {
+	return iw[key]
+}
+
+// delete removes a workload from the inadmissible workloads map.
+func (iw inadmissibleWorkloads) delete(key workload.Reference) {
+	delete(iw, key)
+}
+
+// insert adds a workload to the inadmissible workloads map.
+func (iw inadmissibleWorkloads) insert(key workload.Reference, wInfo *workload.Info) {
+	iw[key] = wInfo
+}
+
+// len returns the number of inadmissible workloads.
+func (iw inadmissibleWorkloads) len() int {
+	return len(iw)
+}
+
+// empty returns true if there are no inadmissible workloads.
+func (iw inadmissibleWorkloads) empty() bool {
+	return len(iw) == 0
+}
+
+// forEach iterates over all inadmissible workloads and calls the provided function.
+// The iteration can be stopped early by returning false from the function.
+func (iw inadmissibleWorkloads) forEach(f func(key workload.Reference, wInfo *workload.Info) bool) {
+	for key, wInfo := range iw {
+		if !f(key, wInfo) {
+			return
+		}
+	}
+}
+
+// replaceAll replaces all inadmissible workloads with the provided map.
+func (iw *inadmissibleWorkloads) replaceAll(newMap map[workload.Reference]*workload.Info) {
+	*iw = newMap
+}

--- a/pkg/cache/queue/inadmissible_workloads_test.go
+++ b/pkg/cache/queue/inadmissible_workloads_test.go
@@ -1,0 +1,418 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"maps"
+	"testing"
+
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+func TestInadmissibleWorkloads_Get(t *testing.T) {
+	wl1 := workload.NewInfo(utiltestingapi.MakeWorkload("wl1", "ns1").Obj())
+	wl2 := workload.NewInfo(utiltestingapi.MakeWorkload("wl2", "ns2").Obj())
+	key1 := workload.Key(wl1.Obj)
+	key2 := workload.Key(wl2.Obj)
+
+	testcases := []struct {
+		name         string
+		initial      map[workload.Reference]*workload.Info
+		key          workload.Reference
+		wantWorkload *workload.Info
+	}{
+		{
+			name:         "returns nil for non-existent workload",
+			initial:      nil,
+			key:          key1,
+			wantWorkload: nil,
+		},
+		{
+			name: "returns workload when exists",
+			initial: map[workload.Reference]*workload.Info{
+				key1: wl1,
+			},
+			key:          key1,
+			wantWorkload: wl1,
+		},
+		{
+			name: "returns nil for different key",
+			initial: map[workload.Reference]*workload.Info{
+				key1: wl1,
+			},
+			key:          key2,
+			wantWorkload: nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			iw := make(inadmissibleWorkloads)
+			maps.Copy(iw, tc.initial)
+
+			got := iw.get(tc.key)
+			if got != tc.wantWorkload {
+				t.Errorf("get() = %v, want %v", got, tc.wantWorkload)
+			}
+		})
+	}
+}
+
+func TestInadmissibleWorkloads_Insert(t *testing.T) {
+	wl1 := workload.NewInfo(utiltestingapi.MakeWorkload("wl1", "ns1").Obj())
+	wl2 := workload.NewInfo(utiltestingapi.MakeWorkload("wl2", "ns2").Obj())
+	key1 := workload.Key(wl1.Obj)
+	key2 := workload.Key(wl2.Obj)
+
+	testcases := []struct {
+		name    string
+		initial map[workload.Reference]*workload.Info
+		key     workload.Reference
+		value   *workload.Info
+		wantLen int
+	}{
+		{
+			name:    "insert into empty map",
+			initial: nil,
+			key:     key1,
+			value:   wl1,
+			wantLen: 1,
+		},
+		{
+			name: "insert new workload",
+			initial: map[workload.Reference]*workload.Info{
+				key1: wl1,
+			},
+			key:     key2,
+			value:   wl2,
+			wantLen: 2,
+		},
+		{
+			name: "overwrite existing workload",
+			initial: map[workload.Reference]*workload.Info{
+				key1: wl1,
+			},
+			key:     key1,
+			value:   wl2,
+			wantLen: 1,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			iw := make(inadmissibleWorkloads)
+			maps.Copy(iw, tc.initial)
+
+			iw.insert(tc.key, tc.value)
+
+			if got := iw.len(); got != tc.wantLen {
+				t.Errorf("after insert, len() = %d, want %d", got, tc.wantLen)
+			}
+			if got := iw.get(tc.key); got != tc.value {
+				t.Errorf("after insert, get() = %v, want %v", got, tc.value)
+			}
+		})
+	}
+}
+
+func TestInadmissibleWorkloads_Delete(t *testing.T) {
+	wl1 := workload.NewInfo(utiltestingapi.MakeWorkload("wl1", "ns1").Obj())
+	wl2 := workload.NewInfo(utiltestingapi.MakeWorkload("wl2", "ns2").Obj())
+	key1 := workload.Key(wl1.Obj)
+	key2 := workload.Key(wl2.Obj)
+
+	testcases := []struct {
+		name    string
+		initial map[workload.Reference]*workload.Info
+		key     workload.Reference
+		wantLen int
+	}{
+		{
+			name:    "delete from empty map",
+			initial: nil,
+			key:     key1,
+			wantLen: 0,
+		},
+		{
+			name: "delete existing workload",
+			initial: map[workload.Reference]*workload.Info{
+				key1: wl1,
+			},
+			key:     key1,
+			wantLen: 0,
+		},
+		{
+			name: "delete non-existent workload",
+			initial: map[workload.Reference]*workload.Info{
+				key1: wl1,
+			},
+			key:     key2,
+			wantLen: 1,
+		},
+		{
+			name: "delete one of multiple workloads",
+			initial: map[workload.Reference]*workload.Info{
+				key1: wl1,
+				key2: wl2,
+			},
+			key:     key1,
+			wantLen: 1,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			iw := make(inadmissibleWorkloads)
+			maps.Copy(iw, tc.initial)
+
+			iw.delete(tc.key)
+
+			if got := iw.len(); got != tc.wantLen {
+				t.Errorf("after delete, len() = %d, want %d", got, tc.wantLen)
+			}
+			if got := iw.get(tc.key); got != nil {
+				t.Errorf("after delete, get() = %v, want nil", got)
+			}
+		})
+	}
+}
+
+func TestInadmissibleWorkloads_Len(t *testing.T) {
+	wl1 := workload.NewInfo(utiltestingapi.MakeWorkload("wl1", "ns1").Obj())
+	wl2 := workload.NewInfo(utiltestingapi.MakeWorkload("wl2", "ns2").Obj())
+	key1 := workload.Key(wl1.Obj)
+	key2 := workload.Key(wl2.Obj)
+
+	testcases := []struct {
+		name    string
+		initial map[workload.Reference]*workload.Info
+		wantLen int
+	}{
+		{
+			name:    "empty map",
+			initial: nil,
+			wantLen: 0,
+		},
+		{
+			name: "single workload",
+			initial: map[workload.Reference]*workload.Info{
+				key1: wl1,
+			},
+			wantLen: 1,
+		},
+		{
+			name: "multiple workloads",
+			initial: map[workload.Reference]*workload.Info{
+				key1: wl1,
+				key2: wl2,
+			},
+			wantLen: 2,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			iw := make(inadmissibleWorkloads)
+			maps.Copy(iw, tc.initial)
+
+			if got := iw.len(); got != tc.wantLen {
+				t.Errorf("len() = %d, want %d", got, tc.wantLen)
+			}
+		})
+	}
+}
+
+func TestInadmissibleWorkloads_Empty(t *testing.T) {
+	wl1 := workload.NewInfo(utiltestingapi.MakeWorkload("wl1", "ns1").Obj())
+	key1 := workload.Key(wl1.Obj)
+
+	testcases := []struct {
+		name      string
+		initial   map[workload.Reference]*workload.Info
+		wantEmpty bool
+	}{
+		{
+			name:      "empty map",
+			initial:   nil,
+			wantEmpty: true,
+		},
+		{
+			name: "non-empty map",
+			initial: map[workload.Reference]*workload.Info{
+				key1: wl1,
+			},
+			wantEmpty: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			iw := make(inadmissibleWorkloads)
+			maps.Copy(iw, tc.initial)
+
+			if got := iw.empty(); got != tc.wantEmpty {
+				t.Errorf("empty() = %v, want %v", got, tc.wantEmpty)
+			}
+		})
+	}
+}
+
+func TestInadmissibleWorkloads_ForEach(t *testing.T) {
+	wl1 := workload.NewInfo(utiltestingapi.MakeWorkload("wl1", "ns1").Obj())
+	wl2 := workload.NewInfo(utiltestingapi.MakeWorkload("wl2", "ns2").Obj())
+	key1 := workload.Key(wl1.Obj)
+	key2 := workload.Key(wl2.Obj)
+
+	testcases := []struct {
+		name           string
+		initial        map[workload.Reference]*workload.Info
+		stopAfter      int
+		wantVisited    int
+		wantAllVisited bool
+	}{
+		{
+			name:           "iterate over empty map",
+			initial:        nil,
+			stopAfter:      0,
+			wantVisited:    0,
+			wantAllVisited: true,
+		},
+		{
+			name: "iterate over all workloads",
+			initial: map[workload.Reference]*workload.Info{
+				key1: wl1,
+				key2: wl2,
+			},
+			stopAfter:      2,
+			wantVisited:    2,
+			wantAllVisited: true,
+		},
+		{
+			name: "stop early",
+			initial: map[workload.Reference]*workload.Info{
+				key1: wl1,
+				key2: wl2,
+			},
+			stopAfter:      1,
+			wantVisited:    1,
+			wantAllVisited: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			iw := make(inadmissibleWorkloads)
+			maps.Copy(iw, tc.initial)
+
+			visited := 0
+			seen := make(map[workload.Reference]bool)
+			iw.forEach(func(key workload.Reference, wInfo *workload.Info) bool {
+				visited++
+				seen[key] = true
+				return visited < tc.stopAfter
+			})
+
+			if visited != tc.wantVisited {
+				t.Errorf("visited %d workloads, want %d", visited, tc.wantVisited)
+			}
+
+			if tc.wantAllVisited {
+				for k := range tc.initial {
+					if !seen[k] {
+						t.Errorf("workload %v was not visited", k)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestInadmissibleWorkloads_ReplaceAll(t *testing.T) {
+	wl1 := workload.NewInfo(utiltestingapi.MakeWorkload("wl1", "ns1").Obj())
+	wl2 := workload.NewInfo(utiltestingapi.MakeWorkload("wl2", "ns2").Obj())
+	wl3 := workload.NewInfo(utiltestingapi.MakeWorkload("wl3", "ns3").Obj())
+	key1 := workload.Key(wl1.Obj)
+	key2 := workload.Key(wl2.Obj)
+	key3 := workload.Key(wl3.Obj)
+
+	testcases := []struct {
+		name       string
+		initial    map[workload.Reference]*workload.Info
+		newMap     map[workload.Reference]*workload.Info
+		wantLen    int
+		checkKeys  []workload.Reference
+		wantExists []bool
+	}{
+		{
+			name: "replace with empty map",
+			initial: map[workload.Reference]*workload.Info{
+				key1: wl1,
+			},
+			newMap:     map[workload.Reference]*workload.Info{},
+			wantLen:    0,
+			checkKeys:  []workload.Reference{key1},
+			wantExists: []bool{false},
+		},
+		{
+			name: "replace with different workloads",
+			initial: map[workload.Reference]*workload.Info{
+				key1: wl1,
+			},
+			newMap: map[workload.Reference]*workload.Info{
+				key2: wl2,
+			},
+			wantLen:    1,
+			checkKeys:  []workload.Reference{key1, key2},
+			wantExists: []bool{false, true},
+		},
+		{
+			name: "replace with multiple workloads",
+			initial: map[workload.Reference]*workload.Info{
+				key1: wl1,
+			},
+			newMap: map[workload.Reference]*workload.Info{
+				key2: wl2,
+				key3: wl3,
+			},
+			wantLen:    2,
+			checkKeys:  []workload.Reference{key1, key2, key3},
+			wantExists: []bool{false, true, true},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			iw := make(inadmissibleWorkloads)
+			maps.Copy(iw, tc.initial)
+
+			iw.replaceAll(tc.newMap)
+
+			if got := iw.len(); got != tc.wantLen {
+				t.Errorf("after replaceAll, len() = %d, want %d", got, tc.wantLen)
+			}
+
+			for i, key := range tc.checkKeys {
+				got := iw.get(key)
+				exists := got != nil
+				if exists != tc.wantExists[i] {
+					t.Errorf("after replaceAll, key %v exists = %v, want %v", key, exists, tc.wantExists[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Introduces `InadmissibleWorkloads` wrapper type to encapsulate map operations in ClusterQueue, following the [`PreemptedWorkloads`](https://github.com/kubernetes-sigs/kueue/blob/main/pkg/scheduler/preemption/preempted_workloads.go#L23) pattern.

Changes:
- Added `InadmissibleWorkloads` wrapper type
- Replaced direct map access with wrapper methods
- Added unit tests

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Addresses https://github.com/kubernetes-sigs/kueue/pull/7725#discussion_r2545123675

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```