### PR TITLE
[Cleanup] Remove namespace from ClusterProfileReference

### DIFF
--- a/apis/kueue/v1beta2/multikueue_types.go
+++ b/apis/kueue/v1beta2/multikueue_types.go
@@ -85,12 +85,6 @@ type ClusterProfileReference struct {
 	// +kubebuilder:validation:MinLength=1
 	// +required
 	Name string `json:"name,omitempty"`
-
-	// namespace of the ClusterProfile.
-	// +kubebuilder:validation:MaxLength=256
-	// +kubebuilder:validation:MinLength=1
-	// +required
-	Namespace string `json:"namespace,omitempty"`
 }
 
 type MultiKueueClusterStatus struct {

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
@@ -209,14 +209,8 @@ spec:
                           maxLength: 256
                           minLength: 1
                           type: string
-                        namespace:
-                          description: namespace of the ClusterProfile.
-                          maxLength: 256
-                          minLength: 1
-                          type: string
                       required:
                         - name
-                        - namespace
                       type: object
                     kubeConfig:
                       description: kubeConfig is information on how to connect to the cluster.

--- a/client-go/applyconfiguration/kueue/v1beta2/clusterprofilereference.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/clusterprofilereference.go
@@ -20,8 +20,7 @@ package v1beta2
 // ClusterProfileReferenceApplyConfiguration represents a declarative configuration of the ClusterProfileReference type for use
 // with apply.
 type ClusterProfileReferenceApplyConfiguration struct {
-	Name      *string `json:"name,omitempty"`
-	Namespace *string `json:"namespace,omitempty"`
+	Name *string `json:"name,omitempty"`
 }
 
 // ClusterProfileReferenceApplyConfiguration constructs a declarative configuration of the ClusterProfileReference type for use with
@@ -35,13 +34,5 @@ func ClusterProfileReference() *ClusterProfileReferenceApplyConfiguration {
 // If called multiple times, the Name field is set to the value of the last call.
 func (b *ClusterProfileReferenceApplyConfiguration) WithName(value string) *ClusterProfileReferenceApplyConfiguration {
 	b.Name = &value
-	return b
-}
-
-// WithNamespace sets the Namespace field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the Namespace field is set to the value of the last call.
-func (b *ClusterProfileReferenceApplyConfiguration) WithNamespace(value string) *ClusterProfileReferenceApplyConfiguration {
-	b.Namespace = &value
 	return b
 }

--- a/config/components/crd/bases/kueue.x-k8s.io_multikueueclusters.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_multikueueclusters.yaml
@@ -189,14 +189,8 @@ spec:
                         maxLength: 256
                         minLength: 1
                         type: string
-                      namespace:
-                        description: namespace of the ClusterProfile.
-                        maxLength: 256
-                        minLength: 1
-                        type: string
                     required:
                     - name
-                    - namespace
                     type: object
                   kubeConfig:
                     description: kubeConfig is information on how to connect to the

--- a/pkg/controller/admissionchecks/multikueue/indexer_test.go
+++ b/pkg/controller/admissionchecks/multikueue/indexer_test.go
@@ -135,22 +135,22 @@ func TestListMultiKueueClustersUsingClusterProfile(t *testing.T) {
 		},
 		"single cluster, single match": {
 			clusters: []*kueue.MultiKueueCluster{
-				utiltestingapi.MakeMultiKueueCluster("cluster1").ClusterProfile("clusterprofile1", TestNamespace).Obj(),
+				utiltestingapi.MakeMultiKueueCluster("cluster1").ClusterProfile("clusterprofile1").Obj(),
 			},
 			filter:   client.MatchingFields{UsingClusterProfiles: TestNamespace + "/clusterprofile1"},
 			wantList: []string{"cluster1"},
 		},
 		"single cluster, no match": {
 			clusters: []*kueue.MultiKueueCluster{
-				utiltestingapi.MakeMultiKueueCluster("cluster2").ClusterProfile("clusterprofile2", TestNamespace).Obj(),
+				utiltestingapi.MakeMultiKueueCluster("cluster2").ClusterProfile("clusterprofile2").Obj(),
 			},
 			filter:   client.MatchingFields{UsingClusterProfiles: TestNamespace + "/clusterprofile1"},
 			wantList: []string{},
 		},
 		"multiple clusters, single match": {
 			clusters: []*kueue.MultiKueueCluster{
-				utiltestingapi.MakeMultiKueueCluster("cluster1").ClusterProfile("clusterprofile1", TestNamespace).Obj(),
-				utiltestingapi.MakeMultiKueueCluster("cluster2").ClusterProfile("clusterprofile2", TestNamespace).Obj(),
+				utiltestingapi.MakeMultiKueueCluster("cluster1").ClusterProfile("clusterprofile1").Obj(),
+				utiltestingapi.MakeMultiKueueCluster("cluster2").ClusterProfile("clusterprofile2").Obj(),
 			},
 			filter:   client.MatchingFields{UsingClusterProfiles: TestNamespace + "/clusterprofile1"},
 			wantList: []string{"cluster1"},

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -583,7 +583,7 @@ func (c *clustersReconciler) getKubeConfig(ctx context.Context, ref *kueue.KubeC
 
 func (c *clustersReconciler) getRestConfigFromClusterProfile(ctx context.Context, profileRef *kueue.ClusterProfileReference) (*rest.Config, bool, error) {
 	cp := &inventoryv1alpha1.ClusterProfile{}
-	if err := c.localClient.Get(ctx, types.NamespacedName{Name: profileRef.Name, Namespace: profileRef.Namespace}, cp); err != nil {
+	if err := c.localClient.Get(ctx, types.NamespacedName{Name: profileRef.Name, Namespace: c.configNamespace}, cp); err != nil {
 		return nil, !apierrors.IsNotFound(err), err
 	}
 

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -535,7 +535,7 @@ func TestUpdateConfig(t *testing.T) {
 			reconcileFor: "worker1",
 			clusters: []kueue.MultiKueueCluster{
 				*utiltestingapi.MakeMultiKueueCluster("worker1").
-					ClusterProfile("worker1", TestNamespace).
+					ClusterProfile("worker1").
 					Generation(1).
 					Obj(),
 			},
@@ -550,7 +550,7 @@ func TestUpdateConfig(t *testing.T) {
 			},
 			wantClusters: []kueue.MultiKueueCluster{
 				*utiltestingapi.MakeMultiKueueCluster("worker1").
-					ClusterProfile("worker1", TestNamespace).
+					ClusterProfile("worker1").
 					Active(metav1.ConditionTrue, "Active", "Connected", 1).
 					Generation(1).
 					Obj(),
@@ -567,7 +567,7 @@ func TestUpdateConfig(t *testing.T) {
 			reconcileFor: "worker1",
 			clusters: []kueue.MultiKueueCluster{
 				*utiltestingapi.MakeMultiKueueCluster("worker1").
-					ClusterProfile("worker1", TestNamespace).
+					ClusterProfile("worker1").
 					Generation(1).
 					Obj(),
 			},
@@ -580,7 +580,7 @@ func TestUpdateConfig(t *testing.T) {
 			},
 			wantClusters: []kueue.MultiKueueCluster{
 				*utiltestingapi.MakeMultiKueueCluster("worker1").
-					ClusterProfile("worker1", TestNamespace).
+					ClusterProfile("worker1").
 					Active(metav1.ConditionFalse, "BadClusterProfile", "load client config failed: unsupported credential provider", 1).
 					Generation(1).
 					Obj(),
@@ -591,7 +591,7 @@ func TestUpdateConfig(t *testing.T) {
 			reconcileFor: "worker1",
 			clusters: []kueue.MultiKueueCluster{
 				*utiltestingapi.MakeMultiKueueCluster("worker1").
-					ClusterProfile("worker1", TestNamespace).
+					ClusterProfile("worker1").
 					Generation(1).
 					Obj(),
 			},
@@ -604,7 +604,7 @@ func TestUpdateConfig(t *testing.T) {
 			},
 			wantClusters: []kueue.MultiKueueCluster{
 				*utiltestingapi.MakeMultiKueueCluster("worker1").
-					ClusterProfile("worker1", TestNamespace).
+					ClusterProfile("worker1").
 					Active(metav1.ConditionFalse, "BadClusterProfile", "load client config failed: clusterprofiles.multicluster.x-k8s.io \"worker1\" not found", 1).
 					Generation(1).
 					Obj(),
@@ -615,7 +615,7 @@ func TestUpdateConfig(t *testing.T) {
 			reconcileFor: "worker1",
 			clusters: []kueue.MultiKueueCluster{
 				*utiltestingapi.MakeMultiKueueCluster("worker1").
-					ClusterProfile("worker1", TestNamespace).
+					ClusterProfile("worker1").
 					Generation(1).
 					Obj(),
 			},
@@ -625,7 +625,7 @@ func TestUpdateConfig(t *testing.T) {
 			},
 			wantClusters: []kueue.MultiKueueCluster{
 				*utiltestingapi.MakeMultiKueueCluster("worker1").
-					ClusterProfile("worker1", TestNamespace).
+					ClusterProfile("worker1").
 					Active(metav1.ConditionFalse, "MultiKueueClusterProfileFeatureDisabled", "load client config failed: MultiKueueClusterProfile feature gate is disabled", 1).
 					Generation(1).
 					Obj(),
@@ -636,7 +636,7 @@ func TestUpdateConfig(t *testing.T) {
 			reconcileFor: "invalid",
 			clusters: []kueue.MultiKueueCluster{
 				*utiltestingapi.MakeMultiKueueCluster("invalid").
-					ClusterProfile("invalid", TestNamespace).
+					ClusterProfile("invalid").
 					Generation(1).
 					Obj(),
 			},
@@ -651,7 +651,7 @@ func TestUpdateConfig(t *testing.T) {
 			},
 			wantClusters: []kueue.MultiKueueCluster{
 				*utiltestingapi.MakeMultiKueueCluster("invalid").
-					ClusterProfile("invalid", TestNamespace).
+					ClusterProfile("invalid").
 					Active(metav1.ConditionFalse, "BadRestConfig", "load client config failed: bearerTokenFile is not allowed", 1).
 					Generation(1).
 					Obj(),

--- a/pkg/util/testing/v1beta2/wrappers.go
+++ b/pkg/util/testing/v1beta2/wrappers.go
@@ -1439,10 +1439,9 @@ func (mkc *MultiKueueClusterWrapper) KubeConfig(locationType kueue.LocationType,
 	return mkc
 }
 
-func (mkc *MultiKueueClusterWrapper) ClusterProfile(name, namespace string) *MultiKueueClusterWrapper {
+func (mkc *MultiKueueClusterWrapper) ClusterProfile(name string) *MultiKueueClusterWrapper {
 	mkc.Spec.ClusterSource.ClusterProfileRef = &kueue.ClusterProfileReference{
-		Name:      name,
-		Namespace: namespace,
+		Name: name,
 	}
 	return mkc
 }

--- a/site/content/en/docs/reference/kueue.v1beta2.md
+++ b/site/content/en/docs/reference/kueue.v1beta2.md
@@ -804,13 +804,6 @@ policy can be preempted by the borrowing workload.</p>
    <p>name of the ClusterProfile.</p>
 </td>
 </tr>
-<tr><td><code>namespace</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   <p>namespace of the ClusterProfile.</p>
-</td>
-</tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Follow-up on https://github.com/kubernetes-sigs/kueue/pull/7188

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates #6968

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```