### PR TITLE
Assign explicit name to `pod_termination_controller`

### DIFF
--- a/pkg/controller/failurerecovery/pod_termination_controller.go
+++ b/pkg/controller/failurerecovery/pod_termination_controller.go
@@ -199,12 +199,12 @@ func podEligibleForTermination(p *corev1.Pod) bool {
 
 func (r *TerminatingPodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		Named("pod_termination_controller").
 		WatchesRawSource(source.TypedKind(
 			mgr.GetCache(),
 			&corev1.Pod{},
 			&handler.TypedEnqueueRequestForObject[*corev1.Pod]{},
 			r,
 		)).
-		For(&corev1.Pod{}).
 		Complete(r)
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
If I understand correctly, since this controller calls `For(&corev1.Pod{})`, it would be called `"pod"` ([source](https://github.com/kubernetes-sigs/controller-runtime/blob/9758f5c2ef1436ed558c79f144013bb001945071/pkg/builder/controller.go#L380-L388)). Not only that, but a watch is already set up with `WatchesRawSource`, so `For` is not required.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```