### PR TITLE
Add verify and test targets for `kueue-populator` to root Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -429,21 +429,9 @@ kueue-populator-test-integration: ## Run integration tests for kueue-populator.
 kueue-populator-test-e2e: ## Run e2e tests for kueue-populator.
 	$(MAKE) -C cmd/experimental/kueue-populator test-e2e
 
-.PHONY: kueue-populator-helm-lint
-kueue-populator-helm-lint: ## Run Helm chart lint test for kueue-populator.
-	$(MAKE) -C cmd/experimental/kueue-populator helm-lint
-
-.PHONY: kueue-populator-helm-verify
-kueue-populator-helm-verify: ## Run Helm chart verification for kueue-populator.
-	$(MAKE) -C cmd/experimental/kueue-populator helm-verify
-
-.PHONY: kueue-populator-helm-unit-test
-kueue-populator-helm-unit-test: ## Run Helm chart unit tests for kueue-populator.
-	$(MAKE) -C cmd/experimental/kueue-populator helm-unit-test
-
-.PHONY: kueue-populator-helm-test
-kueue-populator-helm-test: ## Run Helm chart integration tests for kueue-populator.
-	$(MAKE) -C cmd/experimental/kueue-populator helm-test
+.PHONY: kueue-populator-verify
+kueue-populator-verify: ## Run all verification tests for kueue-populator.
+	$(MAKE) -C cmd/experimental/kueue-populator verify
 
 ##@ Debug
 

--- a/cmd/experimental/kueue-populator/Makefile
+++ b/cmd/experimental/kueue-populator/Makefile
@@ -121,3 +121,5 @@ helm-unit-test:
 helm-test: ## Run Helm chart integration tests (requires active cluster).
 	$(HELM) test kueue-populator
 
+.PHONY: verify
+verify: vet helm-verify helm-unit-test ## Run all verification tests.


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

- adds verify and test targets for `kueue-populator` that will be later called as a CI job

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```