### PR TITLE
Add support for JobSet DependsOn with PodsReady

### DIFF
--- a/pkg/controller/jobs/jobset/jobset_controller_test.go
+++ b/pkg/controller/jobs/jobset/jobset_controller_test.go
@@ -101,6 +101,206 @@ func TestPodsReady(t *testing.T) {
 			).Obj(),
 			want: false,
 		},
+		"job 2 not started, depends on job 1 complete and job 1 is ready": {
+			jobSet: *testingjobset.MakeJobSet("jobset", "ns").ReplicatedJobs(
+				testingjobset.ReplicatedJobRequirements{
+					Name:        "replicated-job-1",
+					Replicas:    2,
+					Parallelism: 1,
+					Completions: 1,
+				},
+				testingjobset.ReplicatedJobRequirements{
+					Name:        "replicated-job-2",
+					Replicas:    3,
+					Parallelism: 1,
+					Completions: 1,
+					DependsOn: []jobset.DependsOn{
+						{
+							Name:   "replicated-job-1",
+							Status: jobset.DependencyComplete,
+						},
+					},
+				},
+			).JobsStatus(
+				jobset.ReplicatedJobStatus{
+					Name:      "replicated-job-1",
+					Ready:     2,
+					Active:    2,
+					Succeeded: 0,
+					Failed:    0,
+					Suspended: 0,
+				},
+				jobset.ReplicatedJobStatus{
+					Name:      "replicated-job-2",
+					Active:    0,
+					Ready:     0,
+					Succeeded: 0,
+					Failed:    0,
+					Suspended: 0,
+				},
+			).Obj(),
+			want: true,
+		},
+		"job 2 started, but not ready, depends on job 1 complete and job 1 is completed": {
+			jobSet: *testingjobset.MakeJobSet("jobset", "ns").ReplicatedJobs(
+				testingjobset.ReplicatedJobRequirements{
+					Name:        "replicated-job-1",
+					Replicas:    2,
+					Parallelism: 1,
+					Completions: 1,
+				},
+				testingjobset.ReplicatedJobRequirements{
+					Name:        "replicated-job-2",
+					Replicas:    3,
+					Parallelism: 1,
+					Completions: 1,
+					DependsOn: []jobset.DependsOn{
+						{
+							Name:   "replicated-job-1",
+							Status: jobset.DependencyComplete,
+						},
+					},
+				},
+			).JobsStatus(
+				jobset.ReplicatedJobStatus{
+					Name:      "replicated-job-1",
+					Ready:     0,
+					Active:    0,
+					Succeeded: 2,
+					Failed:    0,
+					Suspended: 0,
+				},
+				jobset.ReplicatedJobStatus{
+					Name:      "replicated-job-2",
+					Active:    3,
+					Ready:     0,
+					Succeeded: 0,
+					Failed:    0,
+					Suspended: 0,
+				},
+			).Obj(),
+			want: false,
+		},
+		"job 2 depends on job 1 ready and job 1 is not ready": {
+			jobSet: *testingjobset.MakeJobSet("jobset", "ns").ReplicatedJobs(
+				testingjobset.ReplicatedJobRequirements{
+					Name:        "replicated-job-1",
+					Replicas:    2,
+					Parallelism: 1,
+					Completions: 1,
+				},
+				testingjobset.ReplicatedJobRequirements{
+					Name:        "replicated-job-2",
+					Replicas:    3,
+					Parallelism: 1,
+					Completions: 1,
+					DependsOn: []jobset.DependsOn{
+						{
+							Name:   "replicated-job-1",
+							Status: jobset.DependencyReady,
+						},
+					},
+				},
+			).JobsStatus(
+				jobset.ReplicatedJobStatus{
+					Name:      "replicated-job-1",
+					Active:    2,
+					Ready:     0,
+					Succeeded: 0,
+					Failed:    0,
+					Suspended: 0,
+				},
+				jobset.ReplicatedJobStatus{
+					Name:      "replicated-job-2",
+					Active:    0,
+					Ready:     0,
+					Succeeded: 0,
+					Failed:    0,
+					Suspended: 0,
+				},
+			).Obj(),
+			want: false,
+		},
+		"job 2 depends on job 1 ready and job 1 is suspended": {
+			jobSet: *testingjobset.MakeJobSet("jobset", "ns").ReplicatedJobs(
+				testingjobset.ReplicatedJobRequirements{
+					Name:        "replicated-job-1",
+					Replicas:    2,
+					Parallelism: 1,
+					Completions: 1,
+				},
+				testingjobset.ReplicatedJobRequirements{
+					Name:        "replicated-job-2",
+					Replicas:    3,
+					Parallelism: 1,
+					Completions: 1,
+					DependsOn: []jobset.DependsOn{
+						{
+							Name:   "replicated-job-1",
+							Status: jobset.DependencyReady,
+						},
+					},
+				},
+			).JobsStatus(
+				jobset.ReplicatedJobStatus{
+					Name:      "replicated-job-1",
+					Active:    0,
+					Ready:     0,
+					Suspended: 2,
+					Succeeded: 0,
+					Failed:    0,
+				},
+				jobset.ReplicatedJobStatus{
+					Name:      "replicated-job-2",
+					Active:    0,
+					Ready:     0,
+					Succeeded: 0,
+					Failed:    0,
+					Suspended: 0,
+				},
+			).Obj(),
+			want: false,
+		},
+		"job 2 depends on job 1 ready and job 1 is ready, but job 2 failed": {
+			jobSet: *testingjobset.MakeJobSet("jobset", "ns").ReplicatedJobs(
+				testingjobset.ReplicatedJobRequirements{
+					Name:        "replicated-job-1",
+					Replicas:    2,
+					Parallelism: 1,
+					Completions: 1,
+				},
+				testingjobset.ReplicatedJobRequirements{
+					Name:        "replicated-job-2",
+					Replicas:    3,
+					Parallelism: 1,
+					Completions: 1,
+					DependsOn: []jobset.DependsOn{
+						{
+							Name:   "replicated-job-1",
+							Status: jobset.DependencyReady,
+						},
+					},
+				},
+			).JobsStatus(
+				jobset.ReplicatedJobStatus{
+					Name:      "replicated-job-1",
+					Active:    2,
+					Ready:     2,
+					Succeeded: 0,
+					Failed:    0,
+					Suspended: 0,
+				},
+				jobset.ReplicatedJobStatus{
+					Name:      "replicated-job-2",
+					Active:    0,
+					Ready:     0,
+					Failed:    3,
+					Succeeded: 0,
+					Suspended: 0,
+				},
+			).Obj(),
+			want: false,
+		},
 	}
 
 	for name, tc := range testcases {

--- a/test/e2e/customconfigs/waitforpodsready_test.go
+++ b/test/e2e/customconfigs/waitforpodsready_test.go
@@ -28,13 +28,16 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	jobsetapi "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
+	workloadjobset "sigs.k8s.io/kueue/pkg/controller/jobs/jobset"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
+	testingjobset "sigs.k8s.io/kueue/pkg/util/testingjobs/jobset"
 	testingjobspod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 	"sigs.k8s.io/kueue/test/util"
 )
@@ -482,6 +485,124 @@ var _ = ginkgo.Describe("WaitForPodsReady with default Timeout and a long Recove
 			util.ExpectMetricsNotToBeAvailable(ctx, cfg, restClient, curlPod.Name, curlContainerName, [][]string{
 				{"kueue_evicted_workloads_once_total", ns.Name},
 			})
+		})
+	})
+})
+
+var _ = ginkgo.Describe("WaitForPodsReady with for JobSet", ginkgo.Ordered, func() {
+	var (
+		ns *corev1.Namespace
+		rf *kueue.ResourceFlavor
+		cq *kueue.ClusterQueue
+		lq *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeAll(func() {
+		util.UpdateKueueConfiguration(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
+			cfg.WaitForPodsReady = &configapi.WaitForPodsReady{Timeout: metav1.Duration{Duration: util.LongTimeout}}
+		})
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "wfpr-")
+
+		rf = utiltestingapi.MakeResourceFlavor("default").Obj()
+		util.MustCreate(ctx, k8sClient, rf)
+
+		cq = utiltestingapi.MakeClusterQueue("cq").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(rf.Name).Resource(corev1.ResourceCPU, "10").Obj()).
+			Obj()
+		util.MustCreate(ctx, k8sClient, cq)
+
+		lq = utiltestingapi.MakeLocalQueue("lq", ns.Name).ClusterQueue(cq.Name).Obj()
+		util.MustCreate(ctx, k8sClient, lq)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, rf, true)
+		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
+	})
+
+	ginkgo.It("should update podReady condition correctly as jobs run", func() {
+		jobSet := testingjobset.MakeJobSet("job-set", ns.Name).
+			Queue(lq.Name).
+			ReplicatedJobs(
+				testingjobset.ReplicatedJobRequirements{
+					Name:        "replicated-job-1",
+					Image:       util.GetAgnHostImage(),
+					Args:        util.BehaviorWaitForDeletion,
+					Replicas:    1,
+					Parallelism: 1,
+					Completions: 1,
+				},
+				testingjobset.ReplicatedJobRequirements{
+					Name:  "replicated-job-2",
+					Image: util.GetAgnHostImage(),
+					Args:  util.BehaviorWaitForDeletion,
+					StartupProbe: &corev1.Probe{
+						InitialDelaySeconds: 5,
+						ProbeHandler: corev1.ProbeHandler{
+							Exec: &corev1.ExecAction{
+								Command: []string{"/bin/sh", "-c", "echo 'Hello, World!'"},
+							},
+						},
+					},
+					Replicas:    1,
+					Parallelism: 1,
+					Completions: 1,
+					DependsOn: []jobsetapi.DependsOn{
+						{
+							Name:   "replicated-job-1",
+							Status: jobsetapi.DependencyReady,
+						},
+					},
+				},
+			).
+			Obj()
+
+		ginkgo.By("Creating the jobSet", func() {
+			util.MustCreate(ctx, k8sClient, jobSet)
+		})
+
+		ginkgo.By("Waiting for podready condition to be true", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdLeaderWorkload := &kueue.Workload{}
+				wlLookupKey := types.NamespacedName{Name: workloadjobset.GetWorkloadNameForJobSet(jobSet.Name, jobSet.UID), Namespace: ns.Name}
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdLeaderWorkload)).To(gomega.Succeed())
+				g.Expect(createdLeaderWorkload.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.WorkloadPodsReady))
+			}, util.LongTimeout, util.ShortInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Waiting for podready condition to be false due to initialDelaySeconds on second job", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdLeaderWorkload := &kueue.Workload{}
+				wlLookupKey := types.NamespacedName{Name: workloadjobset.GetWorkloadNameForJobSet(jobSet.Name, jobSet.UID), Namespace: ns.Name}
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdLeaderWorkload)).To(gomega.Succeed())
+				// check that the workload is not ready as the initialDelaySeconds is set on the second job
+				g.Expect(createdLeaderWorkload.Status.Conditions).To(utiltesting.HaveConditionStatusFalse(kueue.WorkloadPodsReady))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Waiting for the second job to be ready", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				jobList := &batchv1.JobList{}
+				g.Expect(k8sClient.List(ctx, jobList, client.InNamespace(ns.Name), client.MatchingLabels{jobsetapi.ReplicatedJobNameKey: "replicated-job-2"})).To(gomega.Succeed())
+				g.Expect(jobList.Items).To(gomega.HaveLen(1))
+				g.Expect(jobList.Items[0].Status).ToNot(gomega.BeNil())
+				g.Expect(*jobList.Items[0].Status.Ready).To(gomega.Equal(int32(1)))
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Waiting for podready condition to be true", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdLeaderWorkload := &kueue.Workload{}
+				wlLookupKey := types.NamespacedName{Name: workloadjobset.GetWorkloadNameForJobSet(jobSet.Name, jobSet.UID), Namespace: ns.Name}
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdLeaderWorkload)).To(gomega.Succeed())
+				// check that the workload is ready when initialDelaySeconds has passed
+				g.Expect(createdLeaderWorkload.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.WorkloadPodsReady))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When a `dependsOn` is defined on a JobSet and the `waitForPodsReady`
is configured in Kueue, the PodsReady condition should be udpated
only for the Jobs that are started, which is not the case currently,
all the jobs, including the ones with dependsOn that are not started
are being considered when checking if the respective Pods are ready.
This commit fixes the issue by ensuring that whenever there is some
updated in the job, it means the job has started to be managed and
it should be taken into account when defining if all the Pods are
ready.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6796

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```