### PR TITLE
Automated cherry pick of #7780: [AFS] Implement cache for AFS consumed resources

### DIFF
--- a/pkg/cache/queue/afs/consumed_resources.go
+++ b/pkg/cache/queue/afs/consumed_resources.go
@@ -1,0 +1,62 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package afs
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
+	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
+)
+
+// ConsumedResourcesEntry stores the consumed resources for a LocalQueue with timestamp
+type ConsumedResourcesEntry struct {
+	Resources  corev1.ResourceList
+	LastUpdate time.Time
+}
+
+// AfsConsumedResources manages the fair sharing consumed resources cache
+type AfsConsumedResources struct {
+	resources *utilmaps.SyncMap[utilqueue.LocalQueueReference, ConsumedResourcesEntry]
+}
+
+// NewAfsConsumedResources creates a new AfsConsumedResources cache
+func NewAfsConsumedResources() *AfsConsumedResources {
+	return &AfsConsumedResources{
+		resources: utilmaps.NewSyncMap[utilqueue.LocalQueueReference, ConsumedResourcesEntry](0),
+	}
+}
+
+// Set updates the consumed resources for a LocalQueue
+func (a *AfsConsumedResources) Set(lqKey utilqueue.LocalQueueReference, resources corev1.ResourceList, lastUpdate time.Time) {
+	a.resources.Add(lqKey, ConsumedResourcesEntry{
+		Resources:  resources,
+		LastUpdate: lastUpdate,
+	})
+}
+
+// Get retrieves the consumed resources for a LocalQueue
+func (a *AfsConsumedResources) Get(lqKey utilqueue.LocalQueueReference) (ConsumedResourcesEntry, bool) {
+	return a.resources.Get(lqKey)
+}
+
+// Delete removes the consumed resources entry for a LocalQueue
+func (a *AfsConsumedResources) Delete(lqKey utilqueue.LocalQueueReference) {
+	a.resources.Delete(lqKey)
+}

--- a/pkg/cache/queue/afs_entry_penalties.go
+++ b/pkg/cache/queue/afs_entry_penalties.go
@@ -60,20 +60,6 @@ func (m *AfsEntryPenalties) peek(lqKey utilqueue.LocalQueueReference) corev1.Res
 	return penalty
 }
 
-func (m *AfsEntryPenalties) updateWithPenalty(lqKey utilqueue.LocalQueueReference, fn func(penalty corev1.ResourceList) error) error {
-	m.Lock()
-	defer m.Unlock()
-	penalty, found := m.penalties.Get(lqKey)
-	if !found {
-		penalty = corev1.ResourceList{}
-	}
-	if err := fn(penalty); err != nil {
-		return err
-	}
-	m.penalties.Delete(lqKey)
-	return nil
-}
-
 func (m *AfsEntryPenalties) hasPendingFor(lqKey utilqueue.LocalQueueReference) bool {
 	_, found := m.penalties.Get(lqKey)
 	return found

--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -34,6 +34,7 @@ import (
 	config "sigs.k8s.io/kueue/apis/config/v1beta1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/cache/hierarchy"
+	queueafs "sigs.k8s.io/kueue/pkg/cache/queue/afs"
 	afs "sigs.k8s.io/kueue/pkg/util/admissionfairsharing"
 	"sigs.k8s.io/kueue/pkg/util/heap"
 	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
@@ -125,9 +126,9 @@ func workloadKey(i *workload.Info) workload.Reference {
 	return workload.Key(i.Obj)
 }
 
-func newClusterQueue(ctx context.Context, client client.Client, cq *kueue.ClusterQueue, wo workload.Ordering, afsConfig *config.AdmissionFairSharing, afsEntryPenalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList]) (*ClusterQueue, error) {
+func newClusterQueue(ctx context.Context, client client.Client, cq *kueue.ClusterQueue, wo workload.Ordering, afsConfig *config.AdmissionFairSharing, afsEntryPenalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList], afsConsumedResources *queueafs.AfsConsumedResources) (*ClusterQueue, error) {
 	enableAdmissionFs, fsResWeights := afs.ResourceWeights(cq.Spec.AdmissionScope, afsConfig)
-	cqImpl := newClusterQueueImpl(ctx, client, wo, realClock, fsResWeights, enableAdmissionFs, afsEntryPenalties)
+	cqImpl := newClusterQueueImpl(ctx, client, wo, realClock, fsResWeights, enableAdmissionFs, afsEntryPenalties, afsConsumedResources)
 	err := cqImpl.Update(cq)
 	if err != nil {
 		return nil, err
@@ -135,9 +136,9 @@ func newClusterQueue(ctx context.Context, client client.Client, cq *kueue.Cluste
 	return cqImpl, nil
 }
 
-func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.Ordering, clock clock.Clock, fsResWeights map[corev1.ResourceName]float64, enableAdmissionFs bool, afsEntryPenalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList]) *ClusterQueue {
+func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.Ordering, clock clock.Clock, fsResWeights map[corev1.ResourceName]float64, enableAdmissionFs bool, afsEntryPenalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList], afsConsumedResources *queueafs.AfsConsumedResources) *ClusterQueue {
 	sw := stickyWorkload{}
-	lessFunc := queueOrderingFunc(ctx, client, wo, fsResWeights, enableAdmissionFs, afsEntryPenalties, &sw)
+	lessFunc := queueOrderingFunc(ctx, client, wo, fsResWeights, enableAdmissionFs, afsEntryPenalties, afsConsumedResources, &sw)
 	return &ClusterQueue{
 		heap:                      *heap.New(workloadKey, lessFunc),
 		inadmissibleWorkloads:     make(map[workload.Reference]*workload.Info),
@@ -549,12 +550,12 @@ func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.
 // to sort workloads. The function sorts workloads based on their priority.
 // When priorities are equal, it uses the workload's creation or eviction
 // time.
-func queueOrderingFunc(ctx context.Context, c client.Client, wo workload.Ordering, fsResWeights map[corev1.ResourceName]float64, enableAdmissionFs bool, afsEntryPenalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList], sw *stickyWorkload) func(a, b *workload.Info) bool {
+func queueOrderingFunc(ctx context.Context, c client.Client, wo workload.Ordering, fsResWeights map[corev1.ResourceName]float64, enableAdmissionFs bool, afsEntryPenalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList], afsConsumedResources *queueafs.AfsConsumedResources, sw *stickyWorkload) func(a, b *workload.Info) bool {
 	log := ctrl.LoggerFrom(ctx)
 	return func(a, b *workload.Info) bool {
 		if enableAdmissionFs {
-			lqAUsage, errA := a.CalcLocalQueueFSUsage(ctx, c, fsResWeights, afsEntryPenalties)
-			lqBUsage, errB := b.CalcLocalQueueFSUsage(ctx, c, fsResWeights, afsEntryPenalties)
+			lqAUsage, errA := a.CalcLocalQueueFSUsage(ctx, c, fsResWeights, afsEntryPenalties, afsConsumedResources)
+			lqBUsage, errB := b.CalcLocalQueueFSUsage(ctx, c, fsResWeights, afsEntryPenalties, afsConsumedResources)
 			switch {
 			case errA != nil:
 				log.V(2).Error(errA, "Error determining LocalQueue usage")

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -35,6 +35,7 @@ import (
 	config "sigs.k8s.io/kueue/apis/config/v1beta1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/cache/hierarchy"
+	queueafs "sigs.k8s.io/kueue/pkg/cache/queue/afs"
 	utilindexer "sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
@@ -124,6 +125,7 @@ type Manager struct {
 	secondPassQueue            *secondPassQueue
 
 	afsEntryPenalties      *AfsEntryPenalties
+	AfsConsumedResources   *queueafs.AfsConsumedResources
 	workloadUpdateWatchers []WorkloadUpdateWatcher
 
 	draReconcileChannel chan<- event.TypedGenericEvent[*kueue.Workload]
@@ -146,6 +148,7 @@ func NewManager(client client.Client, checker StatusChecker, options ...Option) 
 		topologyUpdateWatchers: make([]TopologyUpdateWatcher, 0),
 		secondPassQueue:        newSecondPassQueue(),
 		afsEntryPenalties:      newPenaltyMap(),
+		AfsConsumedResources:   queueafs.NewAfsConsumedResources(),
 	}
 	for _, option := range options {
 		option(m)
@@ -191,10 +194,12 @@ func (m *Manager) AddClusterQueue(ctx context.Context, cq *kueue.ClusterQueue) e
 	}
 
 	var afsEntryPenalties *utilmaps.SyncMap[queue.LocalQueueReference, corev1.ResourceList]
+	var afsConsumedResources *queueafs.AfsConsumedResources
 	if afs.Enabled(m.admissionFairSharingConfig) {
 		afsEntryPenalties = m.afsEntryPenalties.getPenalties()
+		afsConsumedResources = m.AfsConsumedResources
 	}
-	cqImpl, err := newClusterQueue(ctx, m.client, cq, m.workloadOrdering, m.admissionFairSharingConfig, afsEntryPenalties)
+	cqImpl, err := newClusterQueue(ctx, m.client, cq, m.workloadOrdering, m.admissionFairSharingConfig, afsEntryPenalties, afsConsumedResources)
 	if err != nil {
 		return err
 	}
@@ -847,10 +852,6 @@ func (m *Manager) PushEntryPenalty(lqKey queue.LocalQueueReference, penalty core
 
 func (m *Manager) SubEntryPenalty(lqKey queue.LocalQueueReference, penalty corev1.ResourceList) {
 	m.afsEntryPenalties.sub(lqKey, penalty)
-}
-
-func (m *Manager) UpdateWithPenalty(lqKey queue.LocalQueueReference, fn func(penalty corev1.ResourceList) error) error {
-	return m.afsEntryPenalties.updateWithPenalty(lqKey, fn)
 }
 
 func (m *Manager) HasPendingPenaltyFor(lqKey queue.LocalQueueReference) bool {

--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -518,17 +518,27 @@ func (c *Cache) DeleteLocalQueue(q *kueue.LocalQueue) {
 	cq.deleteLocalQueue(q)
 }
 
-func (c *Cache) GetCacheLocalQueue(cqName kueue.ClusterQueueReference, lq *kueue.LocalQueue) (*LocalQueue, error) {
+func (c *Cache) GetCacheLocalQueue(cqName kueue.ClusterQueueReference, lqKey queue.LocalQueueReference) (*LocalQueue, error) {
 	c.Lock()
 	defer c.Unlock()
 	cq := c.hm.ClusterQueue(cqName)
 	if cq == nil {
 		return nil, ErrCqNotFound
 	}
-	if cacheLq, ok := cq.localQueues[queueKey(lq)]; ok {
+	if cacheLq, ok := cq.localQueues[lqKey]; ok {
 		return cacheLq, nil
 	}
 	return nil, errQNotFound
+}
+
+func (c *Cache) ClusterQueueUsesAdmissionFairSharing(cqName kueue.ClusterQueueReference) bool {
+	c.RLock()
+	defer c.RUnlock()
+	cq := c.hm.ClusterQueue(cqName)
+	if cq == nil || cq.AdmissionScope == nil {
+		return false
+	}
+	return cq.AdmissionScope.AdmissionMode == kueue.UsageBasedAdmissionFairSharing
 }
 
 func (c *Cache) UpdateLocalQueue(oldQ, newQ *kueue.LocalQueue) error {

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -2368,7 +2368,8 @@ func TestGetCacheLQ(t *testing.T) {
 				t.Fatalf("Adding LocalQueue: %v", err)
 			}
 
-			gotLq, gotErr := cache.GetCacheLocalQueue(tc.getCQReference, tc.getLq)
+			lqKey := queue.Key(tc.getLq)
+			gotLq, gotErr := cache.GetCacheLocalQueue(tc.getCQReference, lqKey)
 			if diff := cmp.Diff(tc.wantLq, gotLq, cmp.AllowUnexported(LocalQueue{}), cmpopts.EquateEmpty(), cmpopts.IgnoreTypes(sync.RWMutex{})); diff != "" {
 				t.Errorf("Unexpected localQueues (-want,+got):\n%s", diff)
 			}

--- a/pkg/cache/scheduler/snapshot.go
+++ b/pkg/cache/scheduler/snapshot.go
@@ -31,6 +31,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/cache/hierarchy"
+	queueafs "sigs.k8s.io/kueue/pkg/cache/queue/afs"
 	"sigs.k8s.io/kueue/pkg/features"
 	afs "sigs.k8s.io/kueue/pkg/util/admissionfairsharing"
 	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
@@ -130,7 +131,8 @@ func (s *Snapshot) Log(log logr.Logger) {
 }
 
 type snapshotOption struct {
-	afsEntryPenalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList]
+	afsEntryPenalties    *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList]
+	afsConsumedResources *queueafs.AfsConsumedResources
 }
 
 type SnapshotOption func(*snapshotOption)
@@ -138,6 +140,12 @@ type SnapshotOption func(*snapshotOption)
 func WithAfsEntryPenalties(penalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList]) SnapshotOption {
 	return func(o *snapshotOption) {
 		o.afsEntryPenalties = penalties
+	}
+}
+
+func WithAfsConsumedResources(consumedResources *queueafs.AfsConsumedResources) SnapshotOption {
+	return func(o *snapshotOption) {
+		o.afsConsumedResources = consumedResources
 	}
 }
 
@@ -182,7 +190,7 @@ func (c *Cache) Snapshot(ctx context.Context, options ...SnapshotOption) (*Snaps
 			snap.InactiveClusterQueueSets.Insert(cq.Name)
 			continue
 		}
-		cqSnapshot, err := c.snapshotClusterQueue(ctx, cq, opts.afsEntryPenalties)
+		cqSnapshot, err := c.snapshotClusterQueue(ctx, cq, opts.afsEntryPenalties, opts.afsConsumedResources)
 		if err != nil {
 			return nil, err
 		}
@@ -205,7 +213,7 @@ func (c *Cache) Snapshot(ctx context.Context, options ...SnapshotOption) (*Snaps
 
 // snapshotClusterQueue creates a copy of ClusterQueue that includes
 // references to immutable objects and deep copies of changing ones.
-func (c *Cache) snapshotClusterQueue(ctx context.Context, cq *clusterQueue, afsEntryPenalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList]) (*ClusterQueueSnapshot, error) {
+func (c *Cache) snapshotClusterQueue(ctx context.Context, cq *clusterQueue, afsEntryPenalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList], afsConsumedResources *queueafs.AfsConsumedResources) (*ClusterQueueSnapshot, error) {
 	log := log.FromContext(ctx)
 	cc := &ClusterQueueSnapshot{
 		Name:                          cq.Name,
@@ -235,7 +243,7 @@ func (c *Cache) snapshotClusterQueue(ctx context.Context, cq *clusterQueue, afsE
 			return cc, nil
 		}
 		for _, wl := range cc.Workloads {
-			usage, err := wl.CalcLocalQueueFSUsage(ctx, c.client, resourceWeights, afsEntryPenalties)
+			usage, err := wl.CalcLocalQueueFSUsage(ctx, c.client, resourceWeights, afsEntryPenalties, afsConsumedResources)
 			if err != nil {
 				return nil, fmt.Errorf("failed to calculate LocalQueue FS usage for LocalQueue %v", client.ObjectKey{Namespace: wl.Obj.Namespace, Name: string(wl.Obj.Spec.QueueName)})
 			}

--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -173,10 +174,15 @@ func (r *LocalQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	if afs.Enabled(r.admissionFSConfig) {
-		updated := r.initializeAdmissionFsStatus(&queueObj)
-		sinceLastUpdate := r.clock.Now().Sub(queueObj.Status.FairSharing.AdmissionFairSharingStatus.LastUpdate.Time)
+		initNeeded := r.initializeAfsIfNeeded(&queueObj)
 		lqKey := utilqueue.Key(&queueObj)
-		if interval := r.admissionFSConfig.UsageSamplingInterval.Duration; !updated && sinceLastUpdate < interval && !r.queues.HasPendingPenaltyFor(lqKey) {
+		entry, found := r.queues.AfsConsumedResources.Get(lqKey)
+		if !found {
+			log.V(3).Info("AFS cache entry deleted concurrently, skipping reconciliation")
+			return ctrl.Result{}, nil
+		}
+		sinceLastUpdate := r.clock.Now().Sub(entry.LastUpdate)
+		if interval := r.admissionFSConfig.UsageSamplingInterval.Duration; !initNeeded && sinceLastUpdate < interval && !r.queues.HasPendingPenaltyFor(lqKey) {
 			return ctrl.Result{RequeueAfter: interval - sinceLastUpdate}, nil
 		}
 		if err := r.reconcileConsumedUsage(ctx, &queueObj); err != nil {
@@ -215,6 +221,9 @@ func (r *LocalQueueReconciler) Create(e event.TypedCreateEvent[*kueue.LocalQueue
 func (r *LocalQueueReconciler) Delete(e event.TypedDeleteEvent[*kueue.LocalQueue]) bool {
 	if features.Enabled(features.LocalQueueMetrics) {
 		metrics.ClearLocalQueueResourceMetrics(localQueueReferenceFromLocalQueue(e.Object))
+	}
+	if afs.Enabled(r.admissionFSConfig) {
+		r.queues.AfsConsumedResources.Delete(utilqueue.Key(e.Object))
 	}
 
 	r.log.V(2).Info("LocalQueue delete event", "localQueue", klog.KObj(e.Object))
@@ -259,55 +268,81 @@ func (r *LocalQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.LocalQueue
 	return true
 }
 
-func (r *LocalQueueReconciler) initializeAdmissionFsStatus(lq *kueue.LocalQueue) bool {
+func (r *LocalQueueReconciler) initializeAfsIfNeeded(lq *kueue.LocalQueue) bool {
 	if lq.Status.FairSharing == nil {
 		lq.Status.FairSharing = &kueue.FairSharingStatus{}
 	}
-	if lq.Status.FairSharing.AdmissionFairSharingStatus == nil {
-		lq.Status.FairSharing.AdmissionFairSharingStatus = &kueue.AdmissionFairSharingStatus{
-			LastUpdate: metav1.NewTime(r.clock.Now()),
-		}
-		return true
+
+	lqKey := utilqueue.Key(lq)
+	hasStatus := lq.Status.FairSharing.AdmissionFairSharingStatus != nil
+	_, hasCache := r.queues.AfsConsumedResources.Get(lqKey)
+	if hasStatus && hasCache {
+		return false
 	}
-	return false
+
+	now := r.clock.Now()
+
+	if !hasStatus {
+		lq.Status.FairSharing.AdmissionFairSharingStatus = &kueue.AdmissionFairSharingStatus{
+			LastUpdate: metav1.NewTime(now),
+		}
+	}
+
+	if !hasCache {
+		currentUsage := r.getCurrentUsageForLocalQueue(lq.Spec.ClusterQueue, lqKey)
+		r.queues.AfsConsumedResources.Set(lqKey, currentUsage, now)
+	}
+
+	return true
+}
+
+func (r *LocalQueueReconciler) getCurrentUsageForLocalQueue(cqName kueue.ClusterQueueReference, lqKey utilqueue.LocalQueueReference) corev1.ResourceList {
+	cacheLq, err := r.cache.GetCacheLocalQueue(cqName, lqKey)
+	if err != nil {
+		return corev1.ResourceList{}
+	}
+	return cacheLq.GetAdmittedUsage()
 }
 
 func (r *LocalQueueReconciler) reconcileConsumedUsage(ctx context.Context, lq *kueue.LocalQueue) error {
+	lqKey := utilqueue.Key(lq)
 	halfLifeTime := r.admissionFSConfig.UsageHalfLifeTime.Seconds()
-	// reset usage to 0 if halfLife is 0
+	now := r.clock.Now()
+
 	if halfLifeTime == 0 {
-		return r.updateAdmissionFsStatus(ctx, lq, corev1.ResourceList{})
+		if err := r.updateAdmissionFsStatus(ctx, lq, corev1.ResourceList{}, now); err != nil {
+			r.log.V(2).Info("Failed to reset LocalQueue status", "namespace", lq.Namespace, "name", lq.Name, "error", err)
+			return err
+		}
+		r.queues.AfsConsumedResources.Set(lqKey, corev1.ResourceList{}, now)
+		r.log.V(2).Info("Reset AFS consumed resources cache", "namespace", lq.Namespace, "name", lq.Name)
+		return nil
 	}
-	cacheLq, err := r.cache.GetCacheLocalQueue(lq.Spec.ClusterQueue, lq)
+
+	entry, _ := r.queues.AfsConsumedResources.Get(lqKey)
+
+	cacheLq, err := r.cache.GetCacheLocalQueue(lq.Spec.ClusterQueue, lqKey)
 	if err != nil {
 		return err
 	}
-	// calculate alpha rate
-	oldUsage := lq.Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources
-	newUsage := cacheLq.GetAdmittedUsage()
-	alpha := afs.CalculateAlphaRate(
-		r.clock.Now().Sub(lq.Status.FairSharing.AdmissionFairSharingStatus.LastUpdate.Time).Seconds(),
-		halfLifeTime,
-	)
-	// calculate weighted average of old and new usage
-	scaledNewUsage := resource.MulByFloat(newUsage, alpha)
-	scaledOldUsage := resource.MulByFloat(oldUsage, 1-alpha)
-	sum := resource.MergeResourceListKeepSum(scaledOldUsage, scaledNewUsage)
-	// Add penalty to the final usage
-	lqKey := utilqueue.Key(lq)
-	err = r.queues.UpdateWithPenalty(lqKey, func(penalty corev1.ResourceList) error {
-		sum = resource.MergeResourceListKeepSum(sum, penalty)
 
-		// update status
-		return r.updateAdmissionFsStatus(ctx, lq, sum)
-	})
-	return err
+	oldUsage := entry.Resources
+	newUsage := cacheLq.GetAdmittedUsage()
+	elapsed := now.Sub(entry.LastUpdate).Seconds()
+	newConsumed := afs.CalculateDecayedConsumed(oldUsage, newUsage, elapsed, halfLifeTime)
+
+	if err := r.updateAdmissionFsStatus(ctx, lq, newConsumed, now); err != nil {
+		r.log.V(2).Info("Failed to update LocalQueue status", "namespace", lq.Namespace, "name", lq.Name, "error", err)
+		return err
+	}
+	r.queues.AfsConsumedResources.Set(lqKey, newConsumed, now)
+	r.log.V(2).Info("Updated AFS consumed resources cache", "namespace", lq.Namespace, "name", lq.Name, "consumedResources", newConsumed)
+	return nil
 }
 
-func (r *LocalQueueReconciler) updateAdmissionFsStatus(ctx context.Context, lq *kueue.LocalQueue, consumedResources corev1.ResourceList) error {
+func (r *LocalQueueReconciler) updateAdmissionFsStatus(ctx context.Context, lq *kueue.LocalQueue, consumedResources corev1.ResourceList, lastUpdate time.Time) error {
 	lq.Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources = consumedResources
-	lq.Status.FairSharing.AdmissionFairSharingStatus.LastUpdate = metav1.NewTime(r.clock.Now())
-	r.log.V(3).Info("Updated LocalQueue fair sharing status", "namespace", lq.Namespace, "name", lq.Name, "consumedResources", consumedResources)
+	lq.Status.FairSharing.AdmissionFairSharingStatus.LastUpdate = metav1.NewTime(lastUpdate)
 	return r.client.Status().Update(ctx, lq)
 }
 

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -36,22 +36,29 @@ import (
 	config "sigs.k8s.io/kueue/apis/config/v1beta1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	queueafs "sigs.k8s.io/kueue/pkg/cache/queue/afs"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/features"
+	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/test/util"
+)
+
+const (
+	resourceGPU = corev1.ResourceName("GPU")
 )
 
 func TestLocalQueueReconcile(t *testing.T) {
 	clock := testingclock.NewFakeClock(time.Now().Truncate(time.Second))
 	cases := map[string]struct {
-		clusterQueue     *kueue.ClusterQueue
-		localQueue       *kueue.LocalQueue
-		wantLocalQueue   *kueue.LocalQueue
-		wantError        error
-		afsConfig        *config.AdmissionFairSharing
-		runningWls       []kueue.Workload
-		wantRequeueAfter *time.Duration
+		clusterQueue             *kueue.ClusterQueue
+		localQueue               *kueue.LocalQueue
+		wantLocalQueue           *kueue.LocalQueue
+		wantError                error
+		afsConfig                *config.AdmissionFairSharing
+		runningWls               []kueue.Workload
+		wantRequeueAfter         *time.Duration
+		initialConsumedResources queueafs.ConsumedResourcesEntry
 	}{
 		"local queue with Hold StopPolicy": {
 			clusterQueue: utiltesting.MakeClusterQueue("test-cluster-queue").
@@ -133,15 +140,13 @@ func TestLocalQueueReconcile(t *testing.T) {
 				FairSharing(&kueue.FairSharing{
 					Weight: ptr.To(resource.MustParse("1")),
 				}).
-				FairSharingStatus(
-					&kueue.FairSharingStatus{
-						AdmissionFairSharingStatus: &kueue.AdmissionFairSharingStatus{
-							LastUpdate: metav1.NewTime(clock.Now().Add(-5 * time.Minute)),
-							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
-								corev1.ResourceCPU: resource.MustParse("8")},
-						},
-					}).
 				Obj(),
+			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("8"),
+				},
+				LastUpdate: clock.Now().Add(-5 * time.Minute),
+			},
 			wantLocalQueue: utiltesting.MakeLocalQueue("test-queue", "default").
 				ClusterQueue("cq").
 				Active(metav1.ConditionTrue).
@@ -172,15 +177,13 @@ func TestLocalQueueReconcile(t *testing.T) {
 				FairSharing(&kueue.FairSharing{
 					Weight: ptr.To(resource.MustParse("1")),
 				}).
-				FairSharingStatus(
-					&kueue.FairSharingStatus{
-						AdmissionFairSharingStatus: &kueue.AdmissionFairSharingStatus{
-							LastUpdate: metav1.NewTime(clock.Now().Add(-5 * time.Minute)),
-							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
-								corev1.ResourceCPU: resource.MustParse("8")},
-						},
-					}).
 				Obj(),
+			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("8"),
+				},
+				LastUpdate: clock.Now().Add(-5 * time.Minute),
+			},
 			wantLocalQueue: utiltesting.MakeLocalQueue("lq", "default").
 				ClusterQueue("cq").
 				Active(metav1.ConditionTrue).
@@ -221,17 +224,14 @@ func TestLocalQueueReconcile(t *testing.T) {
 				FairSharing(&kueue.FairSharing{
 					Weight: ptr.To(resource.MustParse("1")),
 				}).
-				FairSharingStatus(
-					&kueue.FairSharingStatus{
-						AdmissionFairSharingStatus: &kueue.AdmissionFairSharingStatus{
-							LastUpdate: metav1.NewTime(clock.Now().Add(-5 * time.Minute)),
-							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
-								corev1.ResourceCPU: resource.MustParse("8"),
-								"GPU":              resource.MustParse("16"),
-							},
-						},
-					}).
 				Obj(),
+			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("8"),
+					resourceGPU:        resource.MustParse("16"),
+				},
+				LastUpdate: clock.Now().Add(-5 * time.Minute),
+			},
 			wantLocalQueue: utiltesting.MakeLocalQueue("lq", "default").
 				ClusterQueue("cq").
 				Active(metav1.ConditionTrue).
@@ -285,15 +285,13 @@ func TestLocalQueueReconcile(t *testing.T) {
 				FairSharing(&kueue.FairSharing{
 					Weight: ptr.To(resource.MustParse("1")),
 				}).
-				FairSharingStatus(
-					&kueue.FairSharingStatus{
-						AdmissionFairSharingStatus: &kueue.AdmissionFairSharingStatus{
-							LastUpdate: metav1.NewTime(clock.Now().Add(-5 * time.Minute)),
-							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
-								corev1.ResourceCPU: resource.MustParse("8")},
-						},
-					}).
 				Obj(),
+			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("8"),
+				},
+				LastUpdate: clock.Now().Add(-5 * time.Minute),
+			},
 			wantLocalQueue: utiltesting.MakeLocalQueue("lq", "default").
 				ClusterQueue("cq").
 				Active(metav1.ConditionTrue).
@@ -334,15 +332,13 @@ func TestLocalQueueReconcile(t *testing.T) {
 				FairSharing(&kueue.FairSharing{
 					Weight: ptr.To(resource.MustParse("1")),
 				}).
-				FairSharingStatus(
-					&kueue.FairSharingStatus{
-						AdmissionFairSharingStatus: &kueue.AdmissionFairSharingStatus{
-							LastUpdate: metav1.NewTime(clock.Now().Add(-5 * time.Minute)),
-							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
-								corev1.ResourceCPU: resource.MustParse("8")},
-						},
-					}).
 				Obj(),
+			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("8"),
+				},
+				LastUpdate: clock.Now().Add(-5 * time.Minute),
+			},
 			wantLocalQueue: utiltesting.MakeLocalQueue("lq", "default").
 				ClusterQueue("cq").
 				Active(metav1.ConditionTrue).
@@ -373,15 +369,13 @@ func TestLocalQueueReconcile(t *testing.T) {
 				FairSharing(&kueue.FairSharing{
 					Weight: ptr.To(resource.MustParse("1")),
 				}).
-				FairSharingStatus(
-					&kueue.FairSharingStatus{
-						AdmissionFairSharingStatus: &kueue.AdmissionFairSharingStatus{
-							LastUpdate: metav1.NewTime(clock.Now().Add(-5 * time.Minute)),
-							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
-								"GPU": resource.MustParse("8")},
-						},
-					}).
 				Obj(),
+			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+				Resources: corev1.ResourceList{
+					resourceGPU: resource.MustParse("8"),
+				},
+				LastUpdate: clock.Now().Add(-5 * time.Minute),
+			},
 			wantLocalQueue: utiltesting.MakeLocalQueue("lq", "default").
 				ClusterQueue("cq").
 				Active(metav1.ConditionTrue).
@@ -394,7 +388,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 					&kueue.FairSharingStatus{
 						AdmissionFairSharingStatus: &kueue.AdmissionFairSharingStatus{
 							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
-								"GPU": resource.MustParse("6827m"),
+								resourceGPU: resource.MustParse("6827m"),
 							},
 						},
 					}).
@@ -422,15 +416,13 @@ func TestLocalQueueReconcile(t *testing.T) {
 				FairSharing(&kueue.FairSharing{
 					Weight: ptr.To(resource.MustParse("1")),
 				}).
-				FairSharingStatus(
-					&kueue.FairSharingStatus{
-						AdmissionFairSharingStatus: &kueue.AdmissionFairSharingStatus{
-							LastUpdate: metav1.NewTime(clock.Now().Add(-5 * time.Minute)),
-							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
-								"GPU": resource.MustParse("8")},
-						},
-					}).
 				Obj(),
+			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+				Resources: corev1.ResourceList{
+					resourceGPU: resource.MustParse("8"),
+				},
+				LastUpdate: clock.Now().Add(-5 * time.Minute),
+			},
 			wantLocalQueue: utiltesting.MakeLocalQueue("lq", "default").
 				ClusterQueue("cq").
 				Active(metav1.ConditionTrue).
@@ -476,6 +468,12 @@ func TestLocalQueueReconcile(t *testing.T) {
 						},
 					}).
 				Obj(),
+			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("8"),
+				},
+				LastUpdate: clock.Now().Add(-4 * time.Minute),
+			},
 			wantLocalQueue: utiltesting.MakeLocalQueue("test-queue", "default").
 				ClusterQueue("cq").
 				Active(metav1.ConditionTrue).
@@ -492,6 +490,78 @@ func TestLocalQueueReconcile(t *testing.T) {
 					}).
 				Obj(),
 			wantRequeueAfter: ptr.To(time.Minute),
+			afsConfig: &config.AdmissionFairSharing{
+				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
+				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
+			},
+		},
+		"local queue with uninitialized cache initializes status": {
+			clusterQueue: utiltesting.MakeClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				Obj(),
+			localQueue: utiltesting.MakeLocalQueue("lq", "default").
+				ClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				FairSharing(&kueue.FairSharing{
+					Weight: ptr.To(resource.MustParse("1")),
+				}).
+				Obj(),
+			wantLocalQueue: utiltesting.MakeLocalQueue("lq", "default").
+				ClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				FairSharing(&kueue.FairSharing{
+					Weight: ptr.To(resource.MustParse("1")),
+				}).
+				FairSharingStatus(
+					&kueue.FairSharingStatus{
+						AdmissionFairSharingStatus: &kueue.AdmissionFairSharingStatus{
+							LastUpdate:        metav1.NewTime(clock.Now()),
+							ConsumedResources: corev1.ResourceList{},
+						},
+					}).
+				Obj(),
+			afsConfig: &config.AdmissionFairSharing{
+				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
+				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
+			},
+		},
+		"local queue with uninitialized cache captures current usage": {
+			clusterQueue: utiltesting.MakeClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				Obj(),
+			localQueue: utiltesting.MakeLocalQueue("lq", "default").
+				ClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				FairSharing(&kueue.FairSharing{
+					Weight: ptr.To(resource.MustParse("1")),
+				}).
+				Obj(),
+			runningWls: []kueue.Workload{
+				*utiltesting.MakeWorkload("wl", "default").
+					Queue("lq").
+					Request(corev1.ResourceCPU, "4").
+					SimpleReserveQuota("cq", "rf", clock.Now()).
+					Admitted(true).
+					Obj(),
+			},
+			wantLocalQueue: utiltesting.MakeLocalQueue("lq", "default").
+				ClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				ReservingWorkloads(1).
+				AdmittedWorkloads(1).
+				FairSharing(&kueue.FairSharing{
+					Weight: ptr.To(resource.MustParse("1")),
+				}).
+				FairSharingStatus(
+					&kueue.FairSharingStatus{
+						AdmissionFairSharingStatus: &kueue.AdmissionFairSharingStatus{
+							LastUpdate: metav1.NewTime(clock.Now()),
+							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceCPU: resource.MustParse("4"),
+							},
+						},
+					}).
+				Obj(),
 			afsConfig: &config.AdmissionFairSharing{
 				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
@@ -526,6 +596,10 @@ func TestLocalQueueReconcile(t *testing.T) {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 			_ = qManager.AddLocalQueue(ctxWithLogger, tc.localQueue)
+			if tc.initialConsumedResources.Resources != nil {
+				lqKey := utilqueue.Key(tc.localQueue)
+				qManager.AfsConsumedResources.Set(lqKey, tc.initialConsumedResources.Resources, tc.initialConsumedResources.LastUpdate)
+			}
 			reconciler := NewLocalQueueReconciler(cl, qManager, cqCache,
 				WithClock(clock),
 				WithAdmissionFairSharingConfig(tc.afsConfig))

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -57,7 +57,10 @@ import (
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
+	afs "sigs.k8s.io/kueue/pkg/util/admissionfairsharing"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
+	qutil "sigs.k8s.io/kueue/pkg/util/queue"
+	"sigs.k8s.io/kueue/pkg/util/resource"
 	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
 	stringsutils "sigs.k8s.io/kueue/pkg/util/strings"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -105,6 +108,13 @@ func WithWorkloadRetention(value *workloadRetentionConfig) Option {
 	}
 }
 
+// WithAdmissionFairSharing allows to specify the admission fair sharing configuration
+func WithAdmissionFairSharing(value *config.AdmissionFairSharing) Option {
+	return func(r *WorkloadReconciler) {
+		r.admissionFSConfig = value
+	}
+}
+
 type WorkloadUpdateWatcher interface {
 	NotifyWorkloadUpdate(oldWl, newWl *kueue.Workload)
 }
@@ -121,6 +131,7 @@ type WorkloadReconciler struct {
 	clock               clock.Clock
 	workloadRetention   *workloadRetentionConfig
 	draReconcileChannel chan event.TypedGenericEvent[*kueue.Workload]
+	admissionFSConfig   *config.AdmissionFairSharing
 }
 
 var _ reconcile.Reconciler = (*WorkloadReconciler)(nil)
@@ -849,6 +860,9 @@ func (r *WorkloadReconciler) Update(e event.TypedUpdateEvent[*kueue.Workload]) b
 		if !r.cache.AddOrUpdateWorkload(log, wlCopy) {
 			log.V(2).Info("ClusterQueue for workload didn't exist; ignored for now")
 		}
+		if afs.Enabled(r.admissionFSConfig) && status == workload.StatusAdmitted && r.cache.ClusterQueueUsesAdmissionFairSharing(wlCopy.Status.Admission.ClusterQueue) {
+			r.updateAfsConsumedUsage(log, wlCopy)
+		}
 	case (prevStatus == workload.StatusQuotaReserved || prevStatus == workload.StatusAdmitted) && status == workload.StatusPending:
 		var backoff time.Duration
 		if wlCopy.Status.RequeueState != nil && wlCopy.Status.RequeueState.RequeueAt != nil {
@@ -923,6 +937,34 @@ func (r *WorkloadReconciler) Update(e event.TypedUpdateEvent[*kueue.Workload]) b
 func (r *WorkloadReconciler) Generic(e event.TypedGenericEvent[*kueue.Workload]) bool {
 	r.log.V(3).Info("Ignore Workload generic event", "workload", klog.KObj(e.Object))
 	return false
+}
+
+func (r *WorkloadReconciler) updateAfsConsumedUsage(log logr.Logger, wl *kueue.Workload) {
+	lqKey := qutil.KeyFromWorkload(wl)
+	penalty := afs.CalculateEntryPenalty(workload.NewInfo(wl).SumTotalRequests(), r.admissionFSConfig)
+	now := r.clock.Now()
+
+	oldEntry, found := r.queues.AfsConsumedResources.Get(lqKey)
+	if !found {
+		oldEntry.LastUpdate = now
+	}
+
+	cacheLq, err := r.cache.GetCacheLocalQueue(wl.Status.Admission.ClusterQueue, lqKey)
+	if err != nil {
+		log.V(2).Info("Failed to get cache LocalQueue", "error", err)
+		return
+	}
+
+	oldUsage := oldEntry.Resources
+	newUsage := cacheLq.GetAdmittedUsage()
+	elapsed := now.Sub(oldEntry.LastUpdate).Seconds()
+	newConsumed := afs.CalculateDecayedConsumed(oldUsage, newUsage, elapsed, r.admissionFSConfig.UsageHalfLifeTime.Seconds())
+	newConsumed = resource.MergeResourceListKeepSum(newConsumed, penalty)
+
+	r.queues.AfsConsumedResources.Set(lqKey, newConsumed, now)
+	r.queues.SubEntryPenalty(lqKey, penalty)
+
+	log.V(2).Info("Updated AFS consumed usage", "localQueue", klog.KRef(wl.Namespace, string(wl.Spec.QueueName)), "consumed", newConsumed)
 }
 
 func (r *WorkloadReconciler) notifyWatchers(oldWl, newWl *kueue.Workload) {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -202,6 +202,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 	var snapshotOpts []schdcache.SnapshotOption
 	if afs.Enabled(s.admissionFairSharing) {
 		snapshotOpts = append(snapshotOpts, schdcache.WithAfsEntryPenalties(s.queues.GetAfsEntryPenalties()))
+		snapshotOpts = append(snapshotOpts, schdcache.WithAfsConsumedResources(s.queues.AfsConsumedResources))
 	}
 	snapshot, err := s.cache.Snapshot(ctx, snapshotOpts...)
 	if err != nil {

--- a/pkg/scheduler/scheduler_afs_test.go
+++ b/pkg/scheduler/scheduler_afs_test.go
@@ -18,6 +18,7 @@ package scheduler
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -36,6 +37,7 @@ import (
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/features"
+	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 	"sigs.k8s.io/kueue/pkg/util/routine"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
@@ -62,32 +64,14 @@ func TestScheduleForAFS(t *testing.T) {
 		*utiltesting.MakeLocalQueue("lq-a", "default").
 			FairSharing(&kueue.FairSharing{Weight: ptr.To(resource.MustParse("1"))}).
 			ClusterQueue("cq1").
-			FairSharingStatus(&kueue.FairSharingStatus{
-				WeightedShare: 1,
-				AdmissionFairSharingStatus: &kueue.AdmissionFairSharingStatus{
-					ConsumedResources: corev1.ResourceList{},
-				},
-			}).
 			Obj(),
 		*utiltesting.MakeLocalQueue("lq-b", "default").
 			FairSharing(&kueue.FairSharing{Weight: ptr.To(resource.MustParse("1"))}).
 			ClusterQueue("cq1").
-			FairSharingStatus(&kueue.FairSharingStatus{
-				WeightedShare: 1,
-				AdmissionFairSharingStatus: &kueue.AdmissionFairSharingStatus{
-					ConsumedResources: corev1.ResourceList{},
-				},
-			}).
 			Obj(),
 		*utiltesting.MakeLocalQueue("lq-c", "default").
 			FairSharing(&kueue.FairSharing{Weight: ptr.To(resource.MustParse("1"))}).
 			ClusterQueue("cq1").
-			FairSharingStatus(&kueue.FairSharingStatus{
-				WeightedShare: 1,
-				AdmissionFairSharingStatus: &kueue.AdmissionFairSharingStatus{
-					ConsumedResources: corev1.ResourceList{},
-				},
-			}).
 			Obj(),
 	}
 
@@ -510,18 +494,87 @@ func TestScheduleForAFS(t *testing.T) {
 					Obj(),
 			},
 		},
+		"admits workload from lq-b with uninitialized cache": {
+			enableFairSharing: true,
+			initialUsage: map[string]corev1.ResourceList{
+				"lq-a": {corev1.ResourceCPU: resource.MustParse("8")},
+			},
+			workloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("wl-a1", "default").
+					Queue("lq-a").
+					PodSets(*utiltesting.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "8").
+						Obj()).
+					Creation(now).
+					Obj(),
+				*utiltesting.MakeWorkload("wl-b1", "default").
+					Queue("lq-b").
+					PodSets(*utiltesting.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "8").
+						Obj()).
+					Creation(now.Add(1 * time.Second)).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("wl-a1", "default").
+					Queue("lq-a").
+					PodSets(*utiltesting.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "8").
+						Obj()).
+					Creation(now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             "Pending",
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor default, 8 more needed",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "one",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("8"),
+						},
+					}).
+					Obj(),
+				*utiltesting.MakeWorkload("wl-b1", "default").
+					Queue("lq-b").
+					PodSets(*utiltesting.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "8").
+						Obj()).
+					Creation(now.Add(1 * time.Second)).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionTrue,
+						Reason:             "QuotaReserved",
+						Message:            "Quota reserved in ClusterQueue cq1",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Admitted",
+						Message:            "The workload is admitted",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Admission(
+						utiltesting.MakeAdmission("cq1").
+							PodSets(
+								utiltesting.MakePodSetAssignment("one").
+									Assignment(corev1.ResourceCPU, "default", "8").
+									Count(1).
+									Obj(),
+							).
+							Obj(),
+					).
+					Obj(),
+			},
+		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			if tc.enableFairSharing {
 				features.SetFeatureGateDuringTest(t, features.AdmissionFairSharing, true)
-			}
-
-			for i, q := range queues {
-				if resList, found := tc.initialUsage[q.Name]; found {
-					queues[i].Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources = resList
-				}
 			}
 
 			clientBuilder := utiltesting.NewClientBuilder().
@@ -547,6 +600,10 @@ func TestScheduleForAFS(t *testing.T) {
 				if err := qManager.AddLocalQueue(ctx, &q); err != nil {
 					t.Fatalf("Inserting queue %s/%s in manager: %v", q.Namespace, q.Name, err)
 				}
+			}
+			for lqName, resources := range tc.initialUsage {
+				lqKey := utilqueue.LocalQueueReference(fmt.Sprintf("default/%s", lqName))
+				qManager.AfsConsumedResources.Set(lqKey, resources, fakeClock.Now())
 			}
 			for _, rf := range resourceFlavors {
 				cqCache.AddOrUpdateResourceFlavor(log, rf)

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -42,6 +42,7 @@ import (
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	queueafs "sigs.k8s.io/kueue/pkg/cache/queue/afs"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
@@ -51,6 +52,7 @@ import (
 	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
 	utilptr "sigs.k8s.io/kueue/pkg/util/ptr"
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
+	"sigs.k8s.io/kueue/pkg/util/resource"
 	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
 )
 
@@ -319,36 +321,37 @@ func dropExcludedResources(input corev1.ResourceList, excludedPrefixes []string)
 	return res
 }
 
-func (i *Info) CalcLocalQueueFSUsage(ctx context.Context, c client.Client, resWeights map[corev1.ResourceName]float64, afsEntryPenalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList]) (float64, error) {
-	var lq kueue.LocalQueue
-	lqKey := client.ObjectKey{Namespace: i.Obj.Namespace, Name: string(i.Obj.Spec.QueueName)}
-	if err := c.Get(ctx, lqKey, &lq); err != nil {
-		return 0, err
-	}
+func (i *Info) CalcLocalQueueFSUsage(ctx context.Context, c client.Client, resWeights map[corev1.ResourceName]float64, afsEntryPenalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList], afsConsumedResources *queueafs.AfsConsumedResources) (float64, error) {
 	var usage float64
-	if lq.Status.FairSharing == nil || lq.Status.FairSharing.AdmissionFairSharingStatus == nil {
-		// If FairSharing is not enabled or initialized, return 0 usage.
-		return 0, nil
+	lqKey := utilqueue.KeyFromWorkload(i.Obj)
+
+	consumed := corev1.ResourceList{}
+	if afsConsumedResources != nil {
+		entry, found := afsConsumedResources.Get(lqKey)
+		if found {
+			consumed = entry.Resources
+		}
 	}
-	for resName, resVal := range lq.Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources {
+
+	penalty := corev1.ResourceList{}
+	if afsEntryPenalties != nil {
+		penalty, _ = afsEntryPenalties.Get(lqKey)
+	}
+
+	allResources := resource.MergeResourceListKeepSum(consumed, penalty)
+	for resName, resVal := range allResources {
 		weight, found := resWeights[resName]
 		if !found {
 			weight = 1
 		}
 		usage += weight * resVal.AsApproximateFloat64()
 	}
-	penalty := corev1.ResourceList{}
-	if afsEntryPenalties != nil {
-		penalty, _ = afsEntryPenalties.Get(utilqueue.Key(&lq))
-	}
-	for resName, penaltyVal := range penalty {
-		weight, found := resWeights[resName]
-		if !found {
-			weight = 1
-		}
-		usage += weight * penaltyVal.AsApproximateFloat64()
-	}
 
+	var lq kueue.LocalQueue
+	lqObjKey := client.ObjectKey{Namespace: i.Obj.Namespace, Name: string(i.Obj.Spec.QueueName)}
+	if err := c.Get(ctx, lqObjKey, &lq); err != nil {
+		return 0, err
+	}
 	if lq.Spec.FairSharing != nil && lq.Spec.FairSharing.Weight != nil {
 		// if no weight for lq was defined, use default weight of 1
 		usage /= lq.Spec.FairSharing.Weight.AsApproximateFloat64()


### PR DESCRIPTION
Cherry pick of #7780 on release-0.14.

#7780: [AFS] Implement cache for AFS consumed resources

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
AdmissionFairSharing: Fix the bug that occasionally a workload may get admitted from a busy LocalQueue,
bypassing the entry penalties.
```