### PR TITLE
Use main context for CertBootstrap

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -211,7 +211,7 @@ func main() {
 	// Bootstrap certificates before creating the main manager
 	// This ensures certs are ready and CA bundles are injected into conversion CRDs
 	if cfg.InternalCertManagement != nil && *cfg.InternalCertManagement.Enable {
-		if err := cert.BootstrapCerts(kubeConfig, cfg); err != nil {
+		if err := cert.BootstrapCerts(ctx, kubeConfig, cfg); err != nil {
 			setupLog.Error(err, "Unable to bootstrap certificates")
 			os.Exit(1)
 		}

--- a/pkg/util/cert/cert.go
+++ b/pkg/util/cert/cert.go
@@ -43,7 +43,7 @@ const (
 
 // BootstrapCerts creates a minimal manager to generate certificates and inject CA bundles.
 // This function blocks until certificates are ready and CA bundles are injected into CRDs.
-func BootstrapCerts(kubeConfig *rest.Config, cfg config.Configuration) error {
+func BootstrapCerts(ctx context.Context, kubeConfig *rest.Config, cfg config.Configuration) error {
 	log := ctrl.Log.WithName("cert-bootstrap")
 
 	// Create a minimal bootstrap manager with leader election.
@@ -72,7 +72,7 @@ func BootstrapCerts(kubeConfig *rest.Config, cfg config.Configuration) error {
 		return fmt.Errorf("unable to add cert rotator to bootstrap manager: %w", err)
 	}
 
-	bootstrapCtx, bootstrapCancel := context.WithCancel(context.Background())
+	bootstrapCtx, bootstrapCancel := context.WithCancel(ctx)
 	defer bootstrapCancel()
 
 	managerStopped := make(chan struct{})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

To avoid using the Background context. Now when Kueue receives the stop signal it will also start closing the bootstrap manager.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```