### PR TITLE
MultiKueue: move cluster profile initialization code under feature-gate

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -26,10 +26,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/go-logr/logr"
 	zaplog "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	schedulingv1 "k8s.io/api/scheduling/v1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -43,7 +44,9 @@ import (
 	"k8s.io/utils/ptr"
 	inventoryv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -133,8 +136,7 @@ func main() {
 	flag.Parse()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	ctx := ctrl.SetupSignalHandler()
-	options, cfg, err := apply(ctx, setupLog, configFile)
+	options, cfg, err := apply(configFile)
 	if err != nil {
 		setupLog.Error(err, "Unable to load the configuration")
 		os.Exit(1)
@@ -208,11 +210,19 @@ func main() {
 	}
 	setupLog.V(2).Info("K8S Client", "qps", *cfg.ClientConnection.QPS, "burst", *cfg.ClientConnection.Burst)
 
+	ctx := ctrl.SetupSignalHandler()
 	// Bootstrap certificates before creating the main manager
 	// This ensures certs are ready and CA bundles are injected into conversion CRDs
 	if cfg.InternalCertManagement != nil && *cfg.InternalCertManagement.Enable {
 		if err := cert.BootstrapCerts(ctx, kubeConfig, cfg); err != nil {
 			setupLog.Error(err, "Unable to bootstrap certificates")
+			os.Exit(1)
+		}
+	}
+
+	if features.Enabled(features.MultiKueueClusterProfile) {
+		if err := configureClusterProfileCache(ctx, &options, kubeConfig, cfg); err != nil {
+			setupLog.Error(err, "Unable to configure cluster profile")
 			os.Exit(1)
 		}
 	}
@@ -511,12 +521,8 @@ func podsReadyRequeuingTimestamp(cfg *configapi.Configuration) configapi.Requeui
 	return configapi.EvictionTimestamp
 }
 
-func apply(ctx context.Context, log logr.Logger, configFile string) (ctrl.Options, configapi.Configuration, error) {
-	configHelper, err := config.NewConfigHelper(log)
-	if err != nil {
-		return ctrl.Options{}, configapi.Configuration{}, err
-	}
-	options, cfg, err := configHelper.Load(ctx, scheme, configFile)
+func apply(configFile string) (ctrl.Options, configapi.Configuration, error) {
+	options, cfg, err := config.Load(scheme, configFile)
 	if err != nil {
 		return options, cfg, err
 	}
@@ -526,4 +532,28 @@ func apply(ctx context.Context, log logr.Logger, configFile string) (ctrl.Option
 	}
 	setupLog.Info("Successfully loaded configuration", "config", cfgStr)
 	return options, cfg, nil
+}
+
+func configureClusterProfileCache(ctx context.Context, options *ctrl.Options, kubeConfig *rest.Config, cfg configapi.Configuration) error {
+	crdClient, err := apiextensionsclient.NewForConfig(kubeConfig)
+	if err != nil {
+		return fmt.Errorf("%w: failed creating the CRD client", err)
+	}
+	if _, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, "clusterprofiles.multicluster.x-k8s.io", metav1.GetOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			setupLog.Info("Skipping MultiKueue ClusterProfile setup as the ClusterProfile CRD is not installed")
+			return nil
+		}
+		return fmt.Errorf("%w: failed loading the ClusterProfile CRD", err)
+	}
+	objectKeyClusterProfile := new(inventoryv1alpha1.ClusterProfile)
+	if options.Cache.ByObject == nil {
+		options.Cache.ByObject = make(map[ctrlclient.Object]ctrlcache.ByObject)
+	}
+	options.Cache.ByObject[objectKeyClusterProfile] = ctrlcache.ByObject{
+		Namespaces: map[string]ctrlcache.Config{
+			*cfg.Namespace: {},
+		},
+	}
+	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -29,8 +29,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -46,7 +44,6 @@ import (
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
-	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/pkg/util/waitforpodsready"
 
 	_ "sigs.k8s.io/kueue/pkg/controller/jobs"
@@ -85,23 +82,6 @@ func defaultControlOptions(namespace string) ctrl.Options {
 			},
 		},
 	}
-}
-
-func controlOptionsWithClusterProfile(namespace string) ctrl.Options {
-	cOpts := defaultControlOptions(namespace)
-	cOpts.Cache.ByObject[objectKeyClusterProfile] = ctrlcache.ByObject{
-		Namespaces: map[string]ctrlcache.Config{
-			namespace: {},
-		},
-	}
-	return cOpts
-}
-
-func NewFakeClient(log logr.Logger, objects ...runtime.Object) *ConfigHelper {
-	fakeClient := apiextensionsfake.NewSimpleClientset(
-		objects...,
-	)
-	return &ConfigHelper{CRDClient: fakeClient}
 }
 
 func TestLoad(t *testing.T) {
@@ -816,31 +796,6 @@ objectRetentionPolicies:
 			wantOptions: defaultControlOptions(configapi.DefaultNamespace),
 		},
 		{
-			name:                 "multiKueue config with clusterProfile",
-			configFile:           multiKueueConfig,
-			enableClusterProfile: true,
-			withClusterProfile:   true,
-			wantConfiguration: configapi.Configuration{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: configapi.GroupVersion.String(),
-					Kind:       "Configuration",
-				},
-				Namespace:                  ptr.To(configapi.DefaultNamespace),
-				ManageJobsWithoutQueueName: false,
-				InternalCertManagement:     enableDefaultInternalCertManagement,
-				ClientConnection:           defaultClientConnection,
-				Integrations:               defaultIntegrations,
-				MultiKueue: &configapi.MultiKueue{
-					GCInterval:        &metav1.Duration{Duration: 90 * time.Second},
-					Origin:            ptr.To("multikueue-manager1"),
-					WorkerLostTimeout: &metav1.Duration{Duration: 10 * time.Minute},
-					DispatcherName:    ptr.To(configapi.MultiKueueDispatcherModeIncremental),
-				},
-				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
-			},
-			wantOptions: controlOptionsWithClusterProfile(configapi.DefaultNamespace),
-		},
-		{
 			name:       "resourceTransform config",
 			configFile: resourceTransformConfig,
 			wantConfiguration: configapi.Configuration{
@@ -921,19 +876,7 @@ objectRetentionPolicies:
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, log := utiltesting.ContextWithLog(t)
-			var crdObjs []runtime.Object
-			if tc.withClusterProfile {
-				crdObjs = append(crdObjs,
-					&apiextensionsv1.CustomResourceDefinition{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "clusterprofiles.multicluster.x-k8s.io",
-						},
-					},
-				)
-			}
-			configHelper := NewFakeClient(log, crdObjs...)
-			options, cfg, err := configHelper.Load(ctx, testScheme, tc.configFile)
+			options, cfg, err := Load(testScheme, tc.configFile)
 			if tc.wantError == nil {
 				if err != nil {
 					t.Errorf("Unexpected error:%s", err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Main changes:
1. move the initialization code for ClusterProfiles cache under the dedicated feature gate
2. fail in case crd client fails, this will kill the container and retry rather than run Kueue without ClusterProfile support
3. log info when no ClusterProfile CRD rather than error

Follow up to PR https://github.com/kubernetes-sigs/kueue/pull/7843

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7870

#### Special notes for your reviewer:

I had to remove the unit tests temporarily as they were at the config loading level. 

I think we need to have e2e tests for that.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```