### PR TITLE
Use WithLooseOnApply() in scheduler eviction.

### DIFF
--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -169,9 +169,13 @@ func (p *Preemptor) IssuePreemptions(ctx context.Context, preemptor *workload.In
 
 			message := preemptionMessage(preemptor.Obj, target.Reason, preemptorPath, preempteePath)
 			wlCopy := target.WorkloadInfo.Obj.DeepCopy()
-			err := workload.Evict(ctx, p.client, p.recorder, wlCopy, kueue.WorkloadEvictedByPreemption, message, "", p.clock, workload.WithCustomPrepare(func(wl *kueue.Workload) {
-				workload.SetPreemptedCondition(wl, p.clock.Now(), target.Reason, message)
-			}))
+			err := workload.Evict(
+				ctx, p.client, p.recorder, wlCopy, kueue.WorkloadEvictedByPreemption, message, "", p.clock,
+				workload.WithCustomPrepare(func(wl *kueue.Workload) {
+					workload.SetPreemptedCondition(wl, p.clock.Now(), target.Reason, message)
+				}),
+				workload.EvictWithLooseOnApply(), workload.EvictWithRetryOnConflictForPatch(),
+			)
 			if err != nil {
 				errCh.SendErrorWithCancel(err, cancel)
 				preemptionErrors.Add(1)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -579,7 +579,11 @@ func (s *Scheduler) getInitialAssignments(log logr.Logger, wl *workload.Info, sn
 func (s *Scheduler) evictWorkloadAfterFailedTASReplacement(ctx context.Context, log logr.Logger, wl *kueue.Workload) error {
 	log.V(3).Info("Evicting workload after failed try to find a node replacement; TASFailedNodeReplacementFailFast enabled")
 	msg := fmt.Sprintf("Workload was evicted as there was no replacement for a failed node: %s", wl.Status.UnhealthyNodes[0].Name)
-	if err := workload.Evict(ctx, s.client, s.recorder, wl, kueue.WorkloadEvictedDueToNodeFailures, msg, "", s.clock); err != nil {
+	err := workload.Evict(
+		ctx, s.client, s.recorder, wl, kueue.WorkloadEvictedDueToNodeFailures, msg, "", s.clock,
+		workload.EvictWithLooseOnApply(), workload.EvictWithRetryOnConflictForPatch(),
+	)
+	if err != nil {
 		return err
 	}
 	return nil

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -1320,12 +1320,15 @@ func AdmissionChecksForWorkload(log logr.Logger, wl *kueue.Workload, admissionCh
 type EvictOption func(*EvictOptions)
 
 type EvictOptions struct {
-	CustomPrepare func(wl *kueue.Workload)
+	CustomPrepare           func(wl *kueue.Workload)
+	StrictApply             bool
+	RetryOnConflictForPatch bool
 }
 
 func DefaultEvictOptions() *EvictOptions {
 	return &EvictOptions{
 		CustomPrepare: nil,
+		StrictApply:   true,
 	}
 }
 
@@ -1334,6 +1337,18 @@ func WithCustomPrepare(customPrepare func(wl *kueue.Workload)) EvictOption {
 		if customPrepare != nil {
 			o.CustomPrepare = customPrepare
 		}
+	}
+}
+
+func EvictWithLooseOnApply() EvictOption {
+	return func(o *EvictOptions) {
+		o.StrictApply = false
+	}
+}
+
+func EvictWithRetryOnConflictForPatch() EvictOption {
+	return func(o *EvictOptions) {
+		o.RetryOnConflictForPatch = true
 	}
 }
 
@@ -1348,6 +1363,16 @@ func Evict(ctx context.Context, c client.Client, recorder record.EventRecorder, 
 		reportWorkloadEvictedOnce bool
 	)
 
+	var patchOpts []PatchStatusOption
+
+	if !opts.StrictApply {
+		patchOpts = append(patchOpts, WithLooseOnApply())
+	}
+
+	if opts.RetryOnConflictForPatch {
+		patchOpts = append(patchOpts, WithRetryOnConflictForPatch())
+	}
+
 	if err := PatchAdmissionStatus(ctx, c, wl, clock, func(wl *kueue.Workload) (bool, error) {
 		if opts.CustomPrepare != nil {
 			opts.CustomPrepare(wl)
@@ -1360,7 +1385,7 @@ func Evict(ctx context.Context, c client.Client, recorder record.EventRecorder, 
 		prepareForEviction(wl, clock.Now(), evictionReason, msg)
 		reportWorkloadEvictedOnce = workloadEvictionStateInc(wl, reason, underlyingCause)
 		return true, nil
-	}); err != nil {
+	}, patchOpts...); err != nil {
 		return err
 	}
 	if !hadAdmission {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Use WithLooseOnApply() in evictWorkloadAfterFailedTASReplacement.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #8258

#### Special notes for your reviewer:

On race condition, when we're trying to evict a workload, we hit an error [here](https://github.com/epam/kubernetes-kueue/blob/2b4593a38f46eacea69769c90729201f76e9db3f/pkg/scheduler/scheduler.go#L243-L244) and just continue without evicting. This is incorrect because it results in a different event reason and message.

Here’s an example of what we get in the unit tests if we revert the changes:

```
[]v1beta2.Workload{
          	{
          		TypeMeta: {},
          		ObjectMeta: v1.ObjectMeta{
          			... // 3 identical fields
          			SelfLink:          "",
          			UID:               "",
        - 			ResourceVersion:   "3",
        + 			ResourceVersion:   "2",
          			Generation:        0,
          			CreationTimestamp: {},
          			... // 1 ignored and 6 identical fields
          		},
          		Spec: {PodSets: {{Name: "one", Template: {Spec: {Containers: {{Name: "c", Resources: {Requests: {s"cpu": {i: {...}, s: "1", Format: "DecimalSI"}}}}}, RestartPolicy: "Never"}}, Count: 1, TopologyRequest: &{Preferred: &"cloud.provider.com/rack"}}}, QueueName: "tas-main"},
          		Status: v1beta2.WorkloadStatus{
          			Conditions: []v1.Condition(Inverse(cmpopts.SortSlices, []v1.Condition{
          				{Type: "Admitted", Status: "True", Reason: "ByTest", Message: "Admitted by ClusterQueue cq", ...},
        - 				{
        - 					Type:               "Evicted",
        - 					Status:             "True",
        - 					LastTransitionTime: s"2025-11-27 13:26:33 +0530 IST",
        - 					Reason:             "NodeFailures",
        - 					Message:            "Workload was evicted as there was no replacement for a failed node: x0",
        - 				},
          				{Type: "QuotaReserved", Status: "True", Reason: "AdmittedByTest", Message: "Admitted by ClusterQueue cq", ...},
          			})),
          			Admission:    &{ClusterQueue: "cq", PodSetAssignments: {{Name: "one", Flavors: {s"cpu": "rf"}, ResourceUsage: {s"cpu": {i: {...}, Format: "DecimalSI"}}, Count: &1, ...}}},
          			RequeueState: nil,
          			... // 2 identical fields
          			ResourceRequests:                    nil,
          			AccumulatedPastExecutionTimeSeconds: nil,
        - 			SchedulingStats: &v1beta2.SchedulingStats{
        - 				Evictions: []v1beta2.WorkloadSchedulingStatsEviction{{Reason: "NodeFailures", Count: 1}},
        - 			},
        + 			SchedulingStats:       nil,
          			NominatedClusterNames: nil,
          			ClusterName:           nil,
          			... // 1 ignored field
          		},
          	},
          }
    scheduler_tas_test.go:5713: Unexpected events (-want/+got):
          []testing.EventRecord{
          	{
          		Key:       {Namespace: "default", Name: "wl"},
        - 		EventType: "Normal",
        + 		EventType: "Warning",
        - 		Reason:    "EvictedDueToNodeFailures",
        + 		Reason:    "SecondPassFailed",
          		... // 1 ignored field
          	},
          }
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Scheduling: fix a bug that evictions submitted by scheduler (preemptions and eviction due to TAS NodeHotSwap failing)
could result in conflict in case of concurrent workload modification by another controller.
This could lead to indefinite failing requests sent by scheduler in some scenarios when eviction is initiated by
TAS NodeHotSwap.
```