### PR TITLE
Add `FailureRecoveryPolicy` feature gate to docs table

### DIFF
--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -321,6 +321,7 @@ spec:
 | `MultiKueueAdaptersForCustomJobs`             | `false` | Alpha | 0.14  | 0.14  |
 | `MultiKueueAdaptersForCustomJobs`             | `true`  | Beta  | 0.15  |       |
 | `PropagateBatchJobLabelsToWorkload`           | `true`  | Beta  | 0.15  |       |
+| `FailureRecoveryPolicy`                       | `false` | Alpha | 0.15  |       |
 
 {{% alert title="Note" color="primary" %}}
 The SanitizePodSets and MultiKueueAllowInsecureKubeconfigs features are available starting from versions 0.13.8 and 0.14.3.


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
The existence of this feature gate should be documented.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
This feature will be further documented either as a `FailureRecoveryPolicy` concept or (more likely since right now it's the most reasonable use-case) in the [Job task page](https://kueue.sigs.k8s.io/docs/tasks/run/jobs/) alongside `podReplacementPolicy`. But adding it to the table seems like the minimum before it's included in the release, so I'm posting this in a separate PR.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```