### PR TITLE
Fix should admit workload which fits in a required topology domain test.

### DIFF
--- a/test/integration/singlecluster/controller/jobs/jobset/jobset_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/jobset/jobset_controller_test.go
@@ -1191,6 +1191,7 @@ var _ = ginkgo.Describe("JobSet controller with TopologyAwareScheduling", ginkgo
 
 		localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
 		util.MustCreate(ctx, k8sClient, localQueue)
+		util.ExpectLocalQueuesToBeActive(ctx, k8sClient, localQueue)
 	})
 
 	ginkgo.AfterEach(func() {

--- a/test/integration/singlecluster/controller/jobs/jobset/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/jobset/suite_test.go
@@ -31,6 +31,7 @@ import (
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/jobset"
 	"sigs.k8s.io/kueue/pkg/controller/tas"
@@ -100,6 +101,9 @@ func managerAndSchedulerSetup(setupTASControllers bool, opts ...jobframework.Opt
 
 		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
+
+		err = indexer.Setup(ctx, mgr.GetFieldIndexer())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		if setupTASControllers {
 			failedCtrl, err = tas.SetupControllers(mgr, queues, cCache, configuration)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind failing-test
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix should admit workload which fits in a required topology domain test.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7980

#### Special notes for your reviewer:

I didn’t catch any error during the stress test, but I did hit this one:

```
  2025-11-27T16:05:14.567423986Z	ERROR	localqueue-reconciler	core/localqueue_controller.go:206	Failed to add localQueue to the queueing system	{"localQueue": {"name":"local-queue","namespace":"tas-jobset-bzxfg"}, "error": "listing workloads that match the queue: Index with name field:spec.queueName does not exist"}
  sigs.k8s.io/kueue/pkg/controller/core.(*LocalQueueReconciler).Create
  	/home/prow/go/src/kubernetes-sigs/kueue/pkg/controller/core/localqueue_controller.go:206
  sigs.k8s.io/controller-runtime/pkg/internal/source.(*EventHandler[...]).OnAdd
  	/home/prow/go/src/kubernetes-sigs/kueue/vendor/sigs.k8s.io/controller-runtime/pkg/internal/source/event_handler.go:78
  k8s.io/client-go/tools/cache.(*processorListener).run.func1
  	/home/prow/go/src/kubernetes-sigs/kueue/vendor/k8s.io/client-go/tools/cache/shared_informer.go:1076
  k8s.io/client-go/tools/cache.(*processorListener).run
  	/home/prow/go/src/kubernetes-sigs/kueue/vendor/k8s.io/client-go/tools/cache/shared_informer.go:1086
  k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1
  	/home/prow/go/src/kubernetes-sigs/kueue/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:72

job-6d703","namespace":"tas-jobset-bzxfg"}, "queue": "local-queue", "status": "admitted", "prevStatus": "pending", "clusterQueue": "cluster-queue", "error": "Index with name field:spec.hasContainerType does not exist"}
  sigs.k8s.io/kueue/pkg/workload.AdjustResources
  	/home/prow/go/src/kubernetes-sigs/kueue/pkg/workload/resources.go:127
  sigs.k8s.io/kueue/pkg/controller/core.(*WorkloadReconciler).Update
  	/home/prow/go/src/kubernetes-sigs/kueue/pkg/controller/core/workload_controller.go:828
  sigs.k8s.io/controller-runtime/pkg/internal/source.(*EventHandler[...]).OnUpdate
  	/home/prow/go/src/kubernetes-sigs/kueue/vendor/sigs.k8s.io/controller-runtime/pkg/internal/source/event_handler.go:111
  k8s.io/client-go/tools/cache.(*processorListener).run.func1
  	/home/prow/go/src/kubernetes-sigs/kueue/vendor/k8s.io/client-go/tools/cache/shared_informer.go:1074
  k8s.io/client-go/tools/cache.(*processorListener).run
  	/home/prow/go/src/kubernetes-sigs/kueue/vendor/k8s.io/client-go/tools/cache/shared_informer.go:1086
  k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1
  	/home/prow/go/src/kubernetes-sigs/kueue/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:72
```

This looks like a real issue (the spec.queueName index is missing at the moment the LocalQueue is added).


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```