### PR TITLE
Cache deletion validation

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -254,6 +254,10 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 }
 
 func (w *wlReconciler) validateCacheDeletion(ctx context.Context, wl *kueue.Workload, mkAc *kueue.AdmissionCheckState) (bool, error) {
+	if mkAc == nil {
+		return true, nil
+	}
+
 	clients, err := w.remoteClientsForAC(ctx, mkAc.Name)
 	if err != nil {
 		if errors.Is(err, admissioncheck.ErrNoActiveClusters) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Adds a safety check before removing workloads from `deletedWlCache`.
The controller now verifies that no remote workloads exist on any worker cluster before deleting the entry. This prevents accidentally dropping workloads that were propagated to workers.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?