### PR TITLE
Fix typo in exepectWorkladsToBeAdmitted().

### DIFF
--- a/test/integration/singlecluster/importer/importer_test.go
+++ b/test/integration/singlecluster/importer/importer_test.go
@@ -105,7 +105,7 @@ var _ = ginkgo.Describe("Importer", func() {
 				gomega.Expect(k8sClient.Get(ctx, wl2LookupKey, wl2)).To(gomega.Succeed())
 
 				ginkgo.By("Verify workload2 is correct")
-				exepectWorkladsToBeAdmitted(ctx, k8sClient, wl1, wl2)
+				expectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl2)
 			})
 
 			wl1UID := wl1.UID
@@ -142,14 +142,14 @@ var _ = ginkgo.Describe("Importer", func() {
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 				expectWorkloadsToBePending(ctx, k8sClient, wl3)
-				exepectWorkladsToBeAdmitted(ctx, k8sClient, wl1, wl2)
+				expectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl2)
 			})
 
 			ginkgo.By("By finishing an imported pod, the new one's Workload should be admitted", func() {
 				util.SetPodsPhase(ctx, k8sClient, corev1.PodSucceeded, pod2)
 
 				util.ExpectWorkloadToFinish(ctx, k8sClient, wl2LookupKey)
-				exepectWorkladsToBeAdmitted(ctx, k8sClient, wl1, wl3)
+				expectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl3)
 			})
 
 			ginkgo.By("Checking the imported Workloads are not recreated", func() {
@@ -162,7 +162,7 @@ var _ = ginkgo.Describe("Importer", func() {
 	})
 })
 
-func exepectWorkladsToBeAdmitted(ctx context.Context, k8sClient client.Client, wls ...*kueue.Workload) {
+func expectWorkloadsToBeAdmitted(ctx context.Context, k8sClient client.Client, wls ...*kueue.Workload) {
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
 		admitted := 0
 		var updatedWorkload kueue.Workload


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix typo in exepectWorkladsToBeAdmitted().

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```