### PR TITLE
feat: include more detailed preemption information in flavor attempt events

### DIFF
--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -429,6 +429,21 @@ func fromPreemptionPossibility(preemptionPossibility preemptioncommon.Preemption
 	panic(fmt.Sprintf("illegal PreemptionPossibility: %d", preemptionPossibility))
 }
 
+func (mode preemptionMode) preemptionPossibility() *preemptioncommon.PreemptionPossibility {
+	switch mode {
+	case noPreemptionCandidates:
+		return ptr.To(preemptioncommon.NoCandidates)
+	case preempt:
+		return ptr.To(preemptioncommon.Preempt)
+	case reclaim:
+		return ptr.To(preemptioncommon.Reclaim)
+	case fit, noFit:
+		return nil
+	default:
+		panic(fmt.Sprintf("illegal preemptionMode: %d", mode))
+	}
+}
+
 func (mode preemptionMode) flavorAssignmentMode() FlavorAssignmentMode {
 	switch mode {
 	case noFit:
@@ -795,7 +810,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 			}
 		}
 
-		consideredFlavors.AddRepresentativeModeFlavorAttempt(fName, representativeMode.preemptionMode.flavorAssignmentMode(), maxBorrow, flavorQuotaReasons)
+		consideredFlavors.AddRepresentativeModeFlavorAttempt(fName, representativeMode.preemptionMode, maxBorrow, flavorQuotaReasons)
 
 		if features.Enabled(features.FlavorFungibility) {
 			if !shouldTryNextFlavor(representativeMode, a.cq.FlavorFungibility) {

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/component-base/featuregate"
+	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
@@ -341,9 +342,10 @@ func TestAssignFlavors(t *testing.T) {
 					Status: *NewStatus("insufficient unused quota for cpu in flavor default, 1 more needed"),
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "default",
-							Mode:    Preempt,
-							Reasons: []string{"insufficient unused quota for cpu in flavor default, 1 more needed"},
+							Flavor:                "default",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							Reasons:               []string{"insufficient unused quota for cpu in flavor default, 1 more needed"},
 						},
 					},
 					Count: 1,
@@ -800,19 +802,21 @@ func TestAssignFlavors(t *testing.T) {
 					),
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "b_one",
-							Mode:    Preempt,
-							Reasons: []string{"insufficient unused quota for example.com/gpu in flavor b_one, 1 more needed"},
+							Flavor:                "b_one",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							Reasons:               []string{"insufficient unused quota for example.com/gpu in flavor b_one, 1 more needed"},
 						},
 						{
 							Flavor:  "one",
 							Mode:    NoFit,
 							Reasons: []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (3) > maximum capacity (2)"}},
 						{
-							Flavor:  "two",
-							Mode:    Preempt,
-							Borrow:  1,
-							Reasons: []string{"insufficient unused quota for memory in flavor two, 5Mi more needed"},
+							Flavor:                "two",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							Borrow:                1,
+							Reasons:               []string{"insufficient unused quota for memory in flavor two, 5Mi more needed"},
 						},
 					},
 					Count: 1,
@@ -1366,10 +1370,11 @@ func TestAssignFlavors(t *testing.T) {
 					Status: *NewStatus("insufficient unused quota for cpu in flavor one, 1 more needed"),
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    Preempt,
-							Borrow:  1,
-							Reasons: []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
+							Flavor:                "one",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							Borrow:                1,
+							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
 						},
 					},
 					Count: 1,
@@ -1408,9 +1413,10 @@ func TestAssignFlavors(t *testing.T) {
 					Status: *NewStatus("insufficient unused quota for cpu in flavor one, 1 more needed"),
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    Preempt,
-							Reasons: []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
+							Flavor:                "one",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
 						},
 					},
 					Count: 1,
@@ -1462,10 +1468,11 @@ func TestAssignFlavors(t *testing.T) {
 					Status: *NewStatus("insufficient unused quota for cpu in flavor one, 2 more needed"),
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    Preempt,
-							Borrow:  1,
-							Reasons: []string{"insufficient unused quota for cpu in flavor one, 2 more needed"},
+							Flavor:                "one",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							Borrow:                1,
+							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 2 more needed"},
 						},
 					},
 					Count: 1,
@@ -1518,9 +1525,10 @@ func TestAssignFlavors(t *testing.T) {
 							Reasons: []string{"flavor one doesn't match node affinity"},
 						},
 						{
-							Flavor:  "two",
-							Mode:    Preempt,
-							Reasons: []string{"insufficient unused quota for cpu in flavor two, 1 more needed"},
+							Flavor:                "two",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							Reasons:               []string{"insufficient unused quota for cpu in flavor two, 1 more needed"},
 						},
 					},
 					Count: 1,
@@ -1575,9 +1583,10 @@ func TestAssignFlavors(t *testing.T) {
 						),
 						FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 							{
-								Flavor:  "one",
-								Mode:    Preempt,
-								Reasons: []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
+								Flavor:                "one",
+								Mode:                  Preempt,
+								PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+								Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
 							},
 							{
 								Flavor:  "tainted",
@@ -1606,9 +1615,10 @@ func TestAssignFlavors(t *testing.T) {
 								Reasons: []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (2) + current podset request (10) > maximum capacity (4)"},
 							},
 							{
-								Flavor:  "tainted",
-								Mode:    Preempt,
-								Reasons: []string{"insufficient unused quota for cpu in flavor tainted, 3 more needed"},
+								Flavor:                "tainted",
+								Mode:                  Preempt,
+								PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+								Reasons:               []string{"insufficient unused quota for cpu in flavor tainted, 3 more needed"},
 							},
 						},
 						Count: 10,
@@ -1837,9 +1847,10 @@ func TestAssignFlavors(t *testing.T) {
 					Status: *NewStatus("insufficient unused quota for cpu in flavor one, 1 more needed"),
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    Preempt,
-							Reasons: []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
+							Flavor:                "one",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
 						},
 					},
 					Count: 1,
@@ -1886,9 +1897,10 @@ func TestAssignFlavors(t *testing.T) {
 					Status: *NewStatus("insufficient unused quota for cpu in flavor one, 1 more needed"),
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    Preempt,
-							Reasons: []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
+							Flavor:                "one",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
 						},
 					},
 					Count: 1,
@@ -1933,9 +1945,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    Preempt,
-							Reasons: []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
+							Flavor:                "one",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
 						},
 						{Flavor: "two", Mode: Fit},
 					},
@@ -2166,10 +2179,11 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    Preempt,
-							Borrow:  1,
-							Reasons: []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
+							Flavor:                "one",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							Borrow:                1,
+							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
 						},
 					},
 					Count: 1,
@@ -2232,10 +2246,11 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    Preempt,
-							Borrow:  1,
-							Reasons: []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
+							Flavor:                "one",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							Borrow:                1,
+							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
 						},
 					},
 					Count: 1,
@@ -2298,10 +2313,11 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    Preempt,
-							Borrow:  1,
-							Reasons: []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
+							Flavor:                "one",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							Borrow:                1,
+							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
 						},
 					},
 					Count: 1,
@@ -2364,10 +2380,11 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    Preempt,
-							Borrow:  1,
-							Reasons: []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
+							Flavor:                "one",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							Borrow:                1,
+							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
 						},
 					},
 					Count: 1,
@@ -2707,9 +2724,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    Preempt,
-							Reasons: []string{"insufficient unused quota for cpu in flavor one, 2 more needed"},
+							Flavor:                "one",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.NoCandidates),
+							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 2 more needed"},
 						},
 						{Flavor: "two", Mode: Fit, Borrow: 1},
 					},
@@ -2773,9 +2791,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    Preempt,
-							Reasons: []string{"insufficient unused quota for cpu in flavor one, 2 more needed"},
+							Flavor:                "one",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.NoCandidates),
+							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 2 more needed"},
 						},
 						{Flavor: "two", Mode: Fit, Borrow: 1},
 					},
@@ -2830,10 +2849,11 @@ func TestAssignFlavors(t *testing.T) {
 					Status: *NewStatus("insufficient unused quota for cpu in flavor one, 1 more needed"),
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    Preempt,
-							Borrow:  1,
-							Reasons: []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
+							Flavor:                "one",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							Borrow:                1,
+							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
 						},
 					},
 					Count: 1,
@@ -2891,10 +2911,11 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    Preempt,
-							Borrow:  1,
-							Reasons: []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
+							Flavor:                "one",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							Borrow:                1,
+							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
 						},
 					},
 					Count: 1,
@@ -2950,10 +2971,11 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    Preempt,
-							Borrow:  1,
-							Reasons: []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
+							Flavor:                "one",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							Borrow:                1,
+							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
 						},
 					},
 					Count: 1,
@@ -3257,9 +3279,10 @@ func TestAssignFlavors(t *testing.T) {
 					Count:  1,
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    Preempt,
-							Reasons: []string{"insufficient unused quota for cpu in flavor one, 5 more needed"},
+							Flavor:                "one",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 5 more needed"},
 						},
 						{Flavor: "two", Mode: Fit, Borrow: 1},
 					},
@@ -3319,9 +3342,10 @@ func TestAssignFlavors(t *testing.T) {
 					Count:  1,
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    Preempt,
-							Reasons: []string{"insufficient unused quota for cpu in flavor one, 5 more needed"},
+							Flavor:                "one",
+							Mode:                  Preempt,
+							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 5 more needed"},
 						},
 						{Flavor: "two", Mode: Fit, Borrow: 1},
 					},

--- a/pkg/scheduler/preemption/common/types.go
+++ b/pkg/scheduler/preemption/common/types.go
@@ -30,3 +30,15 @@ const (
 	// ClusterQueue.
 	Reclaim
 )
+
+func (p PreemptionPossibility) String() string {
+	switch p {
+	case NoCandidates:
+		return "NoCandidates"
+	case Preempt:
+		return "Preempt"
+	case Reclaim:
+		return "Reclaim"
+	}
+	return "Unknown"
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Display more detailed information on preemption in the flavor assignment attempt block in events
Follow-up for [#7646](https://github.com/kubernetes-sigs/kueue/pull/7646)
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #7137 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Observability: Add more details (the preemptionMode) to the QuotaReserved condition message,
and the related event, about the skipped flavors which were considered for preemption. 
Before: "Quota reserved in ClusterQueue preempt-attempts-cq, wait time since queued was 9223372037s; Flavors considered: main: on-demand(Preempt;insufficient unused quota for cpu in flavor on-demand, 1 more needed)"
After: "Quota reserved in ClusterQueue preempt-attempts-cq, wait time since queued was 9223372037s; Flavors considered: main: on-demand(preemptionMode=Preempt;insufficient unused quota for cpu in flavor on-demand, 1 more needed)"
```