### PR TITLE
fix: Align allowed origins with validateOrigin logic

### DIFF
--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -125,7 +125,7 @@ The following table lists the configurable parameters of the kueue chart and the
 | enableVisibilityAPF | bool | `false` | Enable API Priority and Fairness configuration for the visibility API |
 | fullnameOverride | string | `""` | Override the resource name |
 | kubernetesClusterDomain | string | `"cluster.local"` | Kubernetes cluster's domain |
-| kueueViz.backend.env | list | `[{"name":"KUEUEVIZ_ALLOWED_ORIGINS","value":"frontend.kueueviz.local"}]` | Environment variables for KueueViz backend deployment |
+| kueueViz.backend.env | list | `[{"name":"KUEUEVIZ_ALLOWED_ORIGINS","value":"https://frontend.kueueviz.local"}]` | Environment variables for KueueViz backend deployment |
 | kueueViz.backend.image.pullPolicy | string | `"Always"` | KueueViz dashboard backend image pullPolicy. This should be set to 'IfNotPresent' for released version |
 | kueueViz.backend.image.repository | string | `"us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-backend"` | KueueViz dashboard backend image repository |
 | kueueViz.backend.image.tag | string | `"main"` | KueueViz dashboard backend image tag |

--- a/charts/kueue/tests/kueue_test.yaml
+++ b/charts/kueue/tests/kueue_test.yaml
@@ -200,7 +200,7 @@ tests:
         backend:
           env:
             - name: KUEUEVIZ_ALLOWED_ORIGINS
-              value: "frontend.kueueviz.local"
+              value: "https://frontend.kueueviz.local"
             - name: KUEUEVIZ_PORT
               value: "8080"
     asserts:
@@ -209,7 +209,7 @@ tests:
           value: KUEUEVIZ_ALLOWED_ORIGINS
       - equal:
           path: spec.template.spec.containers[0].env[0].value
-          value: "frontend.kueueviz.local"
+          value: "https://frontend.kueueviz.local"
       - equal:
           path: spec.template.spec.containers[0].env[1].name
           value: KUEUEVIZ_PORT

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -224,7 +224,7 @@ kueueViz:
     # -- Environment variables for KueueViz backend deployment
     env:
       - name: KUEUEVIZ_ALLOWED_ORIGINS
-        value: "http://frontend.kueueviz.local"
+        value: "https://frontend.kueueviz.local"
     ingress:
       # -- KueueViz dashboard backend ingress annotations
       annotations:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The [default values](https://github.com/kubernetes-sigs/kueue/blob/main/charts/kueue/values.yaml) for KueueViz offer `frontend.kueueviz.local` as the `KUEUEVIZ_ALLOWED_ORIGIN`.

However, the origins are validated [here](https://github.com/kubernetes-sigs/kueue/blob/1f6804fc5ea95f17e868b8a603689f49ac666eff/cmd/kueueviz/backend/middleware/cors.go#L33) which has a [specific check](https://github.com/kubernetes-sigs/kueue/blob/1f6804fc5ea95f17e868b8a603689f49ac666eff/cmd/kueueviz/backend/middleware/cors.go#L45) to ensure that the url has a scheme of either HTTP or HTTPS. I.e. the provided default value is invalid.

This PR updates the default value to have a passing value.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8028

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```