### PR TITLE
MultiKueue documentation: update the status of Cluster Role Sharing

### DIFF
--- a/site/content/en/docs/concepts/multikueue.md
+++ b/site/content/en/docs/concepts/multikueue.md
@@ -43,6 +43,12 @@ The worker cluster acts like a standalone Kueue cluster.
 The **MultiKueue Admission Check Controller**, running in the manager cluster,
 creates and deletes Workloads and Jobs in the worker clusters as needed.
 
+### Using manager to run workloads
+
+MultiKueue supports running regular Jobs regular Jobs on the manager when using 
+a dedicated ClusterQueue. However, we do not support currently role sharing where the manager
+cluster is also one of workers for itself, see [limitations](#limitations)
+
 ## Job Flow
 
 To enable multi-cluster dispatching, you need to assign a Job to a ClusterQueue configured with a MultiKueue `AdmissionCheck`.
@@ -132,3 +138,7 @@ Kueue handles delegation to the appropriate worker cluster without requiring any
 
 - [Set up a MultiKueue environment](/docs/tasks/manage/setup_multikueue/)
 - [Run Jobs in a MultiKueue environment](/docs/tasks/run/multikueue)
+
+## Limitation
+
+- we do not support currently running manager cluster as one of workers for itself.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Update the MultiKueue documentation to include the capability of using manager cluster to run workloads.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```