### PR TITLE
Automated cherry pick of #8047: Add deprecation warning on v1beta1

### DIFF
--- a/apis/kueue/v1beta1/admissioncheck_types.go
+++ b/apis/kueue/v1beta1/admissioncheck_types.go
@@ -104,6 +104,7 @@ const (
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="This version is deprecated. Use v1beta2 instead."
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
 

--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -540,6 +540,7 @@ type BorrowWithinCohort struct {
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="This version is deprecated. Use v1beta2 instead."
 // +kubebuilder:resource:scope=Cluster,shortName={cq}
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cohort",JSONPath=".spec.cohort",type=string,description="Cohort that this ClusterQueue belongs to"

--- a/apis/kueue/v1beta1/cohort_types.go
+++ b/apis/kueue/v1beta1/cohort_types.go
@@ -82,6 +82,7 @@ type CohortStatus struct {
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="This version is deprecated. Use v1beta2 instead."
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:subresource:status
 

--- a/apis/kueue/v1beta1/localqueue_types.go
+++ b/apis/kueue/v1beta1/localqueue_types.go
@@ -192,6 +192,7 @@ type LocalQueueResourceUsage struct {
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="This version is deprecated. Use v1beta2 instead."
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ClusterQueue",JSONPath=".spec.clusterQueue",type=string,description="Backing ClusterQueue"
 // +kubebuilder:printcolumn:name="Pending Workloads",JSONPath=".status.pendingWorkloads",type=integer,description="Number of pending workloads"

--- a/apis/kueue/v1beta1/multikueue_types.go
+++ b/apis/kueue/v1beta1/multikueue_types.go
@@ -93,6 +93,7 @@ type MultiKueueClusterStatus struct {
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="This version is deprecated. Use v1beta2 instead."
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
 

--- a/apis/kueue/v1beta1/provisioningrequestconfig_types.go
+++ b/apis/kueue/v1beta1/provisioningrequestconfig_types.go
@@ -158,6 +158,7 @@ type Parameter string
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="This version is deprecated. Use v1beta2 instead."
 // +kubebuilder:resource:scope=Cluster
 
 // ProvisioningRequestConfig is the Schema for the provisioningrequestconfig API

--- a/apis/kueue/v1beta1/resourceflavor_types.go
+++ b/apis/kueue/v1beta1/resourceflavor_types.go
@@ -25,6 +25,7 @@ import (
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="This version is deprecated. Use v1beta2 instead."
 // +kubebuilder:resource:scope=Cluster,shortName={flavor,flavors,rf}
 
 // ResourceFlavor is the Schema for the resourceflavors API.

--- a/apis/kueue/v1beta1/topology_types.go
+++ b/apis/kueue/v1beta1/topology_types.go
@@ -127,6 +127,7 @@ type TopologyLevel struct {
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="This version is deprecated. Use v1beta2 instead."
 // +kubebuilder:resource:scope=Cluster
 
 // Topology is the Schema for the topology API

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -777,6 +777,7 @@ const (
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="This version is deprecated. Use v1beta2 instead."
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Queue",JSONPath=".spec.queueName",type="string",description="Name of the queue this workload was submitted to"
 // +kubebuilder:printcolumn:name="Reserved in",JSONPath=".status.admission.clusterQueue",type="string",description="Name of the ClusterQueue where the workload is reserving quota"

--- a/apis/kueue/v1beta1/workloadpriorityclass_types.go
+++ b/apis/kueue/v1beta1/workloadpriorityclass_types.go
@@ -24,6 +24,7 @@ import (
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="This version is deprecated. Use v1beta2 instead."
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:printcolumn:name="Value",JSONPath=".value",type=integer,description="Value of workloadPriorityClass's Priority"
 

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
@@ -36,7 +36,9 @@ spec:
     singular: admissioncheck
   scope: Cluster
   versions:
-    - name: v1beta1
+    - deprecated: true
+      deprecationWarning: This version is deprecated. Use v1beta2 instead.
+      name: v1beta1
       schema:
         openAPIV3Schema:
           description: AdmissionCheck is the Schema for the admissionchecks API

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -67,6 +67,8 @@ spec:
           name: Admitted Workloads
           priority: 1
           type: integer
+      deprecated: true
+      deprecationWarning: This version is deprecated. Use v1beta2 instead.
       name: v1beta1
       schema:
         openAPIV3Schema:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_cohorts.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_cohorts.yaml
@@ -46,7 +46,9 @@ spec:
     singular: cohort
   scope: Cluster
   versions:
-    - name: v1beta1
+    - deprecated: true
+      deprecationWarning: This version is deprecated. Use v1beta2 instead.
+      name: v1beta1
       schema:
         openAPIV3Schema:
           description: |-

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_localqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_localqueues.yaml
@@ -63,6 +63,8 @@ spec:
           jsonPath: .status.admittedWorkloads
           name: Admitted Workloads
           type: integer
+      deprecated: true
+      deprecationWarning: This version is deprecated. Use v1beta2 instead.
       name: v1beta1
       schema:
         openAPIV3Schema:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
@@ -55,6 +55,8 @@ spec:
           jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
+      deprecated: true
+      deprecationWarning: This version is deprecated. Use v1beta2 instead.
       name: v1beta1
       schema:
         openAPIV3Schema:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_provisioningrequestconfigs.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_provisioningrequestconfigs.yaml
@@ -36,7 +36,9 @@ spec:
     singular: provisioningrequestconfig
   scope: Cluster
   versions:
-    - name: v1beta1
+    - deprecated: true
+      deprecationWarning: This version is deprecated. Use v1beta2 instead.
+      name: v1beta1
       schema:
         openAPIV3Schema:
           description: ProvisioningRequestConfig is the Schema for the provisioningrequestconfig API

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
@@ -40,7 +40,9 @@ spec:
     singular: resourceflavor
   scope: Cluster
   versions:
-    - name: v1beta1
+    - deprecated: true
+      deprecationWarning: This version is deprecated. Use v1beta2 instead.
+      name: v1beta1
       schema:
         openAPIV3Schema:
           description: ResourceFlavor is the Schema for the resourceflavors API.

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_topologies.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_topologies.yaml
@@ -36,7 +36,9 @@ spec:
     singular: topology
   scope: Cluster
   versions:
-    - name: v1beta1
+    - deprecated: true
+      deprecationWarning: This version is deprecated. Use v1beta2 instead.
+      name: v1beta1
       schema:
         openAPIV3Schema:
           description: Topology is the Schema for the topology API

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloadpriorityclasses.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloadpriorityclasses.yaml
@@ -41,6 +41,8 @@ spec:
           jsonPath: .value
           name: Value
           type: integer
+      deprecated: true
+      deprecationWarning: This version is deprecated. Use v1beta2 instead.
       name: v1beta1
       schema:
         openAPIV3Schema:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -69,6 +69,8 @@ spec:
           jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
+      deprecated: true
+      deprecationWarning: This version is deprecated. Use v1beta2 instead.
       name: v1beta1
       schema:
         openAPIV3Schema:

--- a/config/components/crd/bases/kueue.x-k8s.io_admissionchecks.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_admissionchecks.yaml
@@ -14,7 +14,9 @@ spec:
     singular: admissioncheck
   scope: Cluster
   versions:
-  - name: v1beta1
+  - deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta2 instead.
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: AdmissionCheck is the Schema for the admissionchecks API

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -35,6 +35,8 @@ spec:
       name: Admitted Workloads
       priority: 1
       type: integer
+    deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta2 instead.
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/components/crd/bases/kueue.x-k8s.io_cohorts.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_cohorts.yaml
@@ -14,7 +14,9 @@ spec:
     singular: cohort
   scope: Cluster
   versions:
-  - name: v1beta1
+  - deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta2 instead.
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: |-

--- a/config/components/crd/bases/kueue.x-k8s.io_localqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_localqueues.yaml
@@ -31,6 +31,8 @@ spec:
       jsonPath: .status.admittedWorkloads
       name: Admitted Workloads
       type: integer
+    deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta2 instead.
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/components/crd/bases/kueue.x-k8s.io_multikueueclusters.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_multikueueclusters.yaml
@@ -23,6 +23,8 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta2 instead.
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/components/crd/bases/kueue.x-k8s.io_provisioningrequestconfigs.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_provisioningrequestconfigs.yaml
@@ -14,7 +14,9 @@ spec:
     singular: provisioningrequestconfig
   scope: Cluster
   versions:
-  - name: v1beta1
+  - deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta2 instead.
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ProvisioningRequestConfig is the Schema for the provisioningrequestconfig

--- a/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
@@ -18,7 +18,9 @@ spec:
     singular: resourceflavor
   scope: Cluster
   versions:
-  - name: v1beta1
+  - deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta2 instead.
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ResourceFlavor is the Schema for the resourceflavors API.

--- a/config/components/crd/bases/kueue.x-k8s.io_topologies.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_topologies.yaml
@@ -14,7 +14,9 @@ spec:
     singular: topology
   scope: Cluster
   versions:
-  - name: v1beta1
+  - deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta2 instead.
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Topology is the Schema for the topology API

--- a/config/components/crd/bases/kueue.x-k8s.io_workloadpriorityclasses.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloadpriorityclasses.yaml
@@ -19,6 +19,8 @@ spec:
       jsonPath: .value
       name: Value
       type: integer
+    deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta2 instead.
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -37,6 +37,8 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: This version is deprecated. Use v1beta2 instead.
     name: v1beta1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
Cherry pick of #8047 on release-0.15.

#8047: Add deprecation warning on v1beta1

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```