### PR TITLE
Fix DRA race conditions.

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -275,12 +275,12 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 
 		if workload.IsActive(&wl) && !workload.HasQuotaReservation(&wl) {
-			if err := r.queues.AddOrUpdateWorkload(log, &wl, queueOptions...); err != nil {
+			if err := r.queues.AddOrUpdateWorkload(log, wl.DeepCopy(), queueOptions...); err != nil {
 				log.V(2).Info("Failed to add DRA workload to queue", "error", err)
 				return ctrl.Result{}, err
 			}
 		} else {
-			if !r.cache.AddOrUpdateWorkload(log, &wl) {
+			if !r.cache.AddOrUpdateWorkload(log, wl.DeepCopy()) {
 				log.V(2).Info("ClusterQueue for workload didn't exist; ignored for now")
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Unfortunately prow logs doesn't show it (https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_kueue/8063/pull-kueue-test-integration-baseline-main/1996558209136988160). I catch it locally.

```
WARNING: DATA RACE
  Read at 0x00c001810288 by goroutine 363:
    sigs.k8s.io/kueue/pkg/util/queue.KeyFromWorkload()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/pkg/util/queue/local_queue.go:54 +0x2ec
    sigs.k8s.io/kueue/pkg/cache/queue.(*Manager).heads()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/pkg/cache/queue/manager.go:694 +0x2bc
    sigs.k8s.io/kueue/pkg/cache/queue.(*Manager).Heads()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/pkg/cache/queue/manager.go:665 +0x108
    sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).schedule()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/pkg/scheduler/scheduler.go:195 +0x218
    sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).schedule-fm()
        <autogenerated>:1 +0x44
    sigs.k8s.io/kueue/pkg/util/wait.untilWithBackoff.func1()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/pkg/util/wait/backoff.go:76 +0x4c
    k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:233 +0x30
    k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:255 +0x7c
    k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:256 +0xb0
    k8s.io/apimachinery/pkg/util/wait.BackoffUntil()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:233 +0x78
    sigs.k8s.io/kueue/pkg/util/wait.untilWithBackoff()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/pkg/util/wait/backoff.go:75 +0x10c
    sigs.k8s.io/kueue/pkg/util/wait.UntilWithBackoff()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/pkg/util/wait/backoff.go:67 +0xc4
    sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).Start.gowrap1()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/pkg/scheduler/scheduler.go:158 +0x48



  Previous write at 0x00c001810288 by goroutine 521:
    k8s.io/apimachinery/pkg/apis/meta/v1.(*ObjectMeta).DeepCopyInto()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/zz_generated.deepcopy.go:694 +0x50
    sigs.k8s.io/kueue/apis/kueue/v1beta2.(*Workload).DeepCopyInto()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/apis/kueue/v1beta2/zz_generated.deepcopy.go:1960 +0x124
    sigs.k8s.io/kueue/pkg/workload.patchStatus()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/pkg/workload/workload.go:1058 +0x120
    sigs.k8s.io/kueue/pkg/workload.PatchAdmissionStatus()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/pkg/workload/workload.go:1075 +0xe0
    sigs.k8s.io/kueue/pkg/controller/core.(*WorkloadReconciler).Reconcile()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/pkg/controller/core/workload_controller.go:445 +0x1d08
    sigs.k8s.io/kueue/pkg/controller/core.(*leaderAwareReconciler).Reconcile()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/pkg/controller/core/leader_aware_reconciler.go:77 +0x184
    sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).Reconcile()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:216 +0x164
    sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).reconcileHandler()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:461 +0x374
    sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).processNextWorkItem()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:421 +0x23c
    sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[go.shape.struct { k8s.io/apimachinery/pkg/types.NamespacedName }]).Start.func1.1()
        /Users/mykhailo_bobrovskyi/Projects/epam/kueue/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:296 +0xb8
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
DRA: fix the race condition bug leading to undefined behavior due to concurrent operations
on the Workload object, manifested by the "WARNING: DATA RACE" in test logs.
```