### PR TITLE
Add replica-role field to logs for HA debugging

### DIFF
--- a/pkg/controller/core/admissioncheck_controller.go
+++ b/pkg/controller/core/admissioncheck_controller.go
@@ -40,6 +40,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 )
 
@@ -49,12 +50,13 @@ type AdmissionCheckUpdateWatcher interface {
 
 // AdmissionCheckReconciler reconciles a AdmissionCheck object
 type AdmissionCheckReconciler struct {
-	log        logr.Logger
-	qManager   *qcache.Manager
-	client     client.Client
-	cache      *schdcache.Cache
-	cqUpdateCh chan event.GenericEvent
-	watchers   []AdmissionCheckUpdateWatcher
+	log         logr.Logger
+	qManager    *qcache.Manager
+	client      client.Client
+	cache       *schdcache.Cache
+	cqUpdateCh  chan event.GenericEvent
+	watchers    []AdmissionCheckUpdateWatcher
+	roleTracker *roletracker.RoleTracker
 }
 
 var _ reconcile.Reconciler = (*AdmissionCheckReconciler)(nil)
@@ -64,13 +66,15 @@ func NewAdmissionCheckReconciler(
 	client client.Client,
 	qMgr *qcache.Manager,
 	cache *schdcache.Cache,
+	roleTracker *roletracker.RoleTracker,
 ) *AdmissionCheckReconciler {
 	return &AdmissionCheckReconciler{
-		log:        ctrl.Log.WithName("admissioncheck-reconciler"),
-		qManager:   qMgr,
-		client:     client,
-		cache:      cache,
-		cqUpdateCh: make(chan event.GenericEvent, updateChBuffer),
+		log:         ctrl.Log.WithName("admissioncheck-reconciler"),
+		qManager:    qMgr,
+		client:      client,
+		cache:       cache,
+		cqUpdateCh:  make(chan event.GenericEvent, updateChBuffer),
+		roleTracker: roleTracker,
 	}
 }
 
@@ -239,6 +243,7 @@ func (r *AdmissionCheckReconciler) SetupWithManager(mgr ctrl.Manager, cfg *confi
 		WithOptions(controller.Options{
 			NeedLeaderElection:      ptr.To(false),
 			MaxConcurrentReconciles: mgr.GetControllerOptions().GroupKindConcurrency[kueue.GroupVersion.WithKind("AdmissionCheck").GroupKind().String()],
+			LogConstructor:          roletracker.NewLogConstructor(r.roleTracker, "admissioncheck-reconciler"),
 		}).
 		WatchesRawSource(source.Channel(r.cqUpdateCh, &h)).
 		Complete(WithLeadingManager(mgr, r, &kueue.AdmissionCheck{}, cfg))

--- a/pkg/controller/core/cohort_controller.go
+++ b/pkg/controller/core/cohort_controller.go
@@ -39,10 +39,12 @@ import (
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/metrics"
+	"sigs.k8s.io/kueue/pkg/util/roletracker"
 )
 
 type CohortReconcilerOptions struct {
 	FairSharingEnabled bool
+	roleTracker        *roletracker.RoleTracker
 }
 
 type CohortReconcilerOption func(*CohortReconcilerOptions)
@@ -50,6 +52,12 @@ type CohortReconcilerOption func(*CohortReconcilerOptions)
 func CohortReconcilerWithFairSharing(enabled bool) CohortReconcilerOption {
 	return func(o *CohortReconcilerOptions) {
 		o.FairSharingEnabled = enabled
+	}
+}
+
+func CohortReconcilerWithRoleTracker(tracker *roletracker.RoleTracker) CohortReconcilerOption {
+	return func(o *CohortReconcilerOptions) {
+		o.roleTracker = tracker
 	}
 }
 
@@ -63,6 +71,7 @@ type CohortReconciler struct {
 	qManager           *qcache.Manager
 	cqUpdateCh         chan event.GenericEvent
 	fairSharingEnabled bool
+	roleTracker        *roletracker.RoleTracker
 }
 
 func NewCohortReconciler(
@@ -83,6 +92,7 @@ func NewCohortReconciler(
 		qManager:           qManager,
 		cqUpdateCh:         make(chan event.GenericEvent, updateChBuffer),
 		fairSharingEnabled: options.FairSharingEnabled,
+		roleTracker:        options.roleTracker,
 	}
 }
 
@@ -101,6 +111,7 @@ func (r *CohortReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.Config
 		WithOptions(controller.Options{
 			NeedLeaderElection:      ptr.To(false),
 			MaxConcurrentReconciles: mgr.GetControllerOptions().GroupKindConcurrency[kueue.GroupVersion.WithKind("Cohort").GroupKind().String()],
+			LogConstructor:          roletracker.NewLogConstructor(r.roleTracker, "cohort-reconciler"),
 		}).
 		WatchesRawSource(source.Channel(r.cqUpdateCh, cqHandler)).
 		Complete(WithLeadingManager(mgr, r, &kueue.Cohort{}, cfg))

--- a/pkg/controller/failurerecovery/pod_termination_controller.go
+++ b/pkg/controller/failurerecovery/pod_termination_controller.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	utilclient "sigs.k8s.io/kueue/pkg/util/client"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
+	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	utiltaints "sigs.k8s.io/kueue/pkg/util/taints"
 )
 
@@ -58,11 +59,13 @@ type TerminatingPodReconciler struct {
 	clock                          clock.Clock
 	forcefulTerminationGracePeriod time.Duration
 	recorder                       record.EventRecorder
+	roleTracker                    *roletracker.RoleTracker
 }
 
 type TerminatingPodReconcilerOptions struct {
 	clock                          clock.Clock
 	forcefulTerminationGracePeriod time.Duration
+	roleTracker                    *roletracker.RoleTracker
 }
 
 type TerminatingPodReconcilerOption func(*TerminatingPodReconcilerOptions)
@@ -76,6 +79,13 @@ func WithClock(c clock.Clock) TerminatingPodReconcilerOption {
 func WithForcefulTerminationGracePeriod(t time.Duration) TerminatingPodReconcilerOption {
 	return func(o *TerminatingPodReconcilerOptions) {
 		o.forcefulTerminationGracePeriod = t
+	}
+}
+
+// WithRoleTracker sets the roleTracker for HA logging.
+func WithRoleTracker(tracker *roletracker.RoleTracker) TerminatingPodReconcilerOption {
+	return func(o *TerminatingPodReconcilerOptions) {
+		o.roleTracker = tracker
 	}
 }
 
@@ -99,6 +109,7 @@ func NewTerminatingPodReconciler(
 		clock:                          options.clock,
 		forcefulTerminationGracePeriod: options.forcefulTerminationGracePeriod,
 		recorder:                       recorder,
+		roleTracker:                    options.roleTracker,
 	}
 }
 
@@ -201,8 +212,10 @@ func podEligibleForTermination(p *corev1.Pod) bool {
 	return true
 }
 
+const ControllerName = "failure-recovery-pod-termination-controller"
+
 func (r *TerminatingPodReconciler) SetupWithManager(mgr ctrl.Manager, cfg *configapi.Configuration) (string, error) {
-	return "failure-recovery-pod-termination-controller", ctrl.NewControllerManagedBy(mgr).
+	return ControllerName, ctrl.NewControllerManagedBy(mgr).
 		Named("pod_termination_controller").
 		WatchesRawSource(source.TypedKind(
 			mgr.GetCache(),
@@ -214,5 +227,6 @@ func (r *TerminatingPodReconciler) SetupWithManager(mgr ctrl.Manager, cfg *confi
 			NeedLeaderElection:      ptr.To(false),
 			MaxConcurrentReconciles: mgr.GetControllerOptions().GroupKindConcurrency[kueue.GroupVersion.WithKind("Pod").GroupKind().String()],
 		}).
+		WithLogConstructor(roletracker.NewLogConstructor(r.roleTracker, ControllerName)).
 		Complete(core.WithLeadingManager(mgr, r, &corev1.Pod{}, cfg))
 }

--- a/pkg/controller/jobframework/base_webhook.go
+++ b/pkg/controller/jobframework/base_webhook.go
@@ -55,6 +55,7 @@ func BaseWebhookFactory(job GenericJob, fromObject func(runtime.Object) GenericJ
 			For(job.Object()).
 			WithMutationHandler(admission.WithCustomDefaulter(mgr.GetScheme(), job.Object(), wh)).
 			WithValidator(wh).
+			WithRoleTracker(options.RoleTracker).
 			Complete()
 	}
 }

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -56,6 +56,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/equality"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
 	utilpriority "sigs.k8s.io/kueue/pkg/util/priority"
+	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	"sigs.k8s.io/kueue/pkg/util/waitforpodsready"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -106,6 +107,7 @@ type Options struct {
 	Cache                        *schdcache.Cache
 	Clock                        clock.Clock
 	WorkloadRetentionPolicy      WorkloadRetentionPolicy
+	RoleTracker                  *roletracker.RoleTracker
 }
 
 // Option configures the reconciler.
@@ -221,6 +223,13 @@ func WithObjectRetentionPolicies(value *configapi.ObjectRetentionPolicies) Optio
 		if value != nil && value.Workloads != nil && value.Workloads.AfterDeactivatedByKueue != nil {
 			o.WorkloadRetentionPolicy.AfterDeactivatedByKueue = &value.Workloads.AfterDeactivatedByKueue.Duration
 		}
+	}
+}
+
+// WithRoleTracker sets the roleTracker for HA logging.
+func WithRoleTracker(tracker *roletracker.RoleTracker) Option {
+	return func(o *Options) {
+		o.RoleTracker = tracker
 	}
 }
 

--- a/pkg/controller/jobs/deployment/deployment_webhook.go
+++ b/pkg/controller/jobs/deployment/deployment_webhook.go
@@ -56,6 +56,7 @@ func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 		For(obj).
 		WithMutationHandler(admission.WithCustomDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).
+		WithRoleTracker(options.RoleTracker).
 		Complete()
 }
 

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -89,6 +89,7 @@ func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 		For(obj).
 		WithMutationHandler(admission.WithCustomDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).
+		WithRoleTracker(options.RoleTracker).
 		Complete()
 }
 

--- a/pkg/controller/jobs/jobset/jobset_webhook.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook.go
@@ -63,6 +63,7 @@ func SetupJobSetWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 		For(obj).
 		WithMutationHandler(admission.WithCustomDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).
+		WithRoleTracker(options.RoleTracker).
 		Complete()
 }
 

--- a/pkg/controller/jobs/mpijob/mpijob_webhook.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook.go
@@ -74,6 +74,7 @@ func SetupMPIJobWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 		For(obj).
 		WithMutationHandler(admission.WithCustomDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).
+		WithRoleTracker(options.RoleTracker).
 		Complete()
 }
 

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -76,6 +76,7 @@ func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 		For(obj).
 		WithMutationHandler(admission.WithCustomDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).
+		WithRoleTracker(options.RoleTracker).
 		Complete()
 }
 

--- a/pkg/controller/jobs/raycluster/raycluster_webhook.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook.go
@@ -74,6 +74,7 @@ func SetupRayClusterWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error
 		For(obj).
 		WithMutationHandler(admission.WithCustomDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).
+		WithRoleTracker(options.RoleTracker).
 		Complete()
 }
 

--- a/pkg/controller/jobs/rayjob/rayjob_webhook.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook.go
@@ -67,6 +67,7 @@ func SetupRayJobWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 		For(obj).
 		WithMutationHandler(admission.WithCustomDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).
+		WithRoleTracker(options.RoleTracker).
 		Complete()
 }
 

--- a/pkg/controller/jobs/trainjob/trainjob_webhook.go
+++ b/pkg/controller/jobs/trainjob/trainjob_webhook.go
@@ -58,6 +58,7 @@ func SetupTrainJobWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 		For(obj).
 		WithMutationHandler(admission.WithCustomDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).
+		WithRoleTracker(options.RoleTracker).
 		Complete()
 }
 

--- a/pkg/controller/tas/node_failure_controller.go
+++ b/pkg/controller/tas/node_failure_controller.go
@@ -49,6 +49,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
+	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -60,10 +61,11 @@ const (
 
 // nodeFailureReconciler reconciles Nodes to detect failures and update affected Workloads
 type nodeFailureReconciler struct {
-	client   client.Client
-	clock    clock.Clock
-	log      logr.Logger
-	recorder record.EventRecorder
+	client      client.Client
+	clock       clock.Clock
+	log         logr.Logger
+	recorder    record.EventRecorder
+	roleTracker *roletracker.RoleTracker
 }
 
 func (r *nodeFailureReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -147,12 +149,13 @@ func (r *nodeFailureReconciler) Delete(e event.TypedDeleteEvent[*corev1.Node]) b
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads,verbs=get;list;watch;patch
 
-func newNodeFailureReconciler(client client.Client, recorder record.EventRecorder) *nodeFailureReconciler {
+func newNodeFailureReconciler(client client.Client, recorder record.EventRecorder, roleTracker *roletracker.RoleTracker) *nodeFailureReconciler {
 	return &nodeFailureReconciler{
-		client:   client,
-		log:      ctrl.Log.WithName(TASNodeFailureController),
-		clock:    clock.RealClock{},
-		recorder: recorder,
+		client:      client,
+		log:         ctrl.Log.WithName(TASNodeFailureController),
+		clock:       clock.RealClock{},
+		recorder:    recorder,
+		roleTracker: roleTracker,
 	}
 }
 
@@ -168,6 +171,7 @@ func (r *nodeFailureReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.C
 		WithOptions(controller.Options{
 			NeedLeaderElection:      ptr.To(false),
 			MaxConcurrentReconciles: mgr.GetControllerOptions().GroupKindConcurrency[corev1.SchemeGroupVersion.WithKind("Node").GroupKind().String()],
+			LogConstructor:          roletracker.NewLogConstructor(r.roleTracker, "tas-node-failure-reconciler"),
 		}).
 		Complete(core.WithLeadingManager(mgr, r, &corev1.Node{}, cfg))
 }

--- a/pkg/controller/tas/node_failure_controller_test.go
+++ b/pkg/controller/tas/node_failure_controller_test.go
@@ -37,6 +37,7 @@ import (
 	podcontroller "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	"sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
@@ -289,7 +290,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 			}
 			cl := clientBuilder.Build()
 			recorder := &utiltesting.EventRecorder{}
-			r := newNodeFailureReconciler(cl, recorder)
+			r := newNodeFailureReconciler(cl, recorder, roletracker.NewFakeRoleTracker(roletracker.RoleStandalone))
 			r.clock = fakeClock
 
 			var result reconcile.Result

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
+	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/util/tas"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -2269,7 +2270,7 @@ func TestReconcile(t *testing.T) {
 					t.Fatalf("Could not create workload: %v", err)
 				}
 			}
-			topologyUngater := newTopologyUngater(kClient)
+			topologyUngater := newTopologyUngater(kClient, roletracker.NewFakeRoleTracker(roletracker.RoleStandalone))
 			key := client.ObjectKeyFromObject(&tc.workloads[0])
 			request := reconcile.Request{NamespacedName: key}
 			if len(tc.expectUIDs) > 0 {

--- a/pkg/util/roletracker/logger.go
+++ b/pkg/util/roletracker/logger.go
@@ -1,0 +1,64 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roletracker
+
+import (
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// WithReplicaRole adds replica-role to the logger. Returns "standalone" if tracker is nil.
+func WithReplicaRole(log logr.Logger, tracker *RoleTracker) logr.Logger {
+	return log.WithValues("replica-role", GetRole(tracker))
+}
+
+// WithRequestContext adds namespace and name to the logger.
+func WithRequestContext(log logr.Logger, namespace, name string) logr.Logger {
+	if namespace != "" {
+		return log.WithValues("namespace", namespace, "name", name)
+	}
+	return log.WithValues("name", name)
+}
+
+// NewLogConstructor creates a controller LogConstructor with replica-role and request context.
+func NewLogConstructor(tracker *RoleTracker, baseName string) func(*reconcile.Request) logr.Logger {
+	return func(req *reconcile.Request) logr.Logger {
+		log := ctrl.Log.WithName(baseName).WithValues("replica-role", GetRole(tracker))
+		if req == nil {
+			return log
+		}
+		return WithRequestContext(log, req.Namespace, req.Name)
+	}
+}
+
+// GetRole returns the role, or "standalone" if tracker is nil.
+func GetRole(tracker *RoleTracker) string {
+	if tracker == nil {
+		return RoleStandalone
+	}
+	return tracker.GetRole()
+}
+
+// WebhookLogConstructor wraps admission.DefaultLogConstructor and adds replica-role.
+func WebhookLogConstructor(tracker *RoleTracker) func(logr.Logger, *admission.Request) logr.Logger {
+	return func(base logr.Logger, req *admission.Request) logr.Logger {
+		log := admission.DefaultLogConstructor(base, req)
+		return log.WithValues("replica-role", GetRole(tracker))
+	}
+}

--- a/pkg/util/roletracker/logger_test.go
+++ b/pkg/util/roletracker/logger_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roletracker
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+)
+
+func TestWithReplicaRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		tracker  *RoleTracker
+		expected string
+	}{
+		{
+			name:     "nil tracker returns standalone",
+			tracker:  nil,
+			expected: RoleStandalone,
+		},
+		{
+			name:     "leader tracker returns leader",
+			tracker:  NewFakeRoleTracker(RoleLeader),
+			expected: RoleLeader,
+		},
+		{
+			name:     "follower tracker returns follower",
+			tracker:  NewFakeRoleTracker(RoleFollower),
+			expected: RoleFollower,
+		},
+		{
+			name:     "standalone tracker returns standalone",
+			tracker:  NewFakeRoleTracker(RoleStandalone),
+			expected: RoleStandalone,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			baseLogger := funcr.New(func(prefix, args string) {
+			}, funcr.Options{})
+
+			logger := WithReplicaRole(baseLogger, tc.tracker)
+
+			if logger == (logr.Logger{}) {
+				t.Error("WithReplicaRole returned zero-value logger")
+			}
+
+			role := GetRole(tc.tracker)
+			if role != tc.expected {
+				t.Errorf("Expected role %q, got %q", tc.expected, role)
+			}
+		})
+	}
+}
+
+func TestNewLogConstructor(t *testing.T) {
+	tests := []struct {
+		name     string
+		tracker  *RoleTracker
+		expected string
+	}{
+		{
+			name:     "nil tracker",
+			tracker:  nil,
+			expected: RoleStandalone,
+		},
+		{
+			name:     "leader tracker",
+			tracker:  NewFakeRoleTracker(RoleLeader),
+			expected: RoleLeader,
+		},
+		{
+			name:     "follower tracker",
+			tracker:  NewFakeRoleTracker(RoleFollower),
+			expected: RoleFollower,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			constructor := NewLogConstructor(tc.tracker, "test-controller")
+
+			if constructor == nil {
+				t.Fatal("NewLogConstructor returned nil")
+			}
+
+			logger := constructor(nil)
+			if logger == (logr.Logger{}) {
+				t.Error("LogConstructor returned zero-value logger")
+			}
+		})
+	}
+}

--- a/pkg/util/roletracker/tracker.go
+++ b/pkg/util/roletracker/tracker.go
@@ -1,0 +1,67 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roletracker
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/go-logr/logr"
+)
+
+const (
+	RoleLeader     = "leader"
+	RoleFollower   = "follower"
+	RoleStandalone = "standalone"
+)
+
+// RoleTracker provides thread-safe access to the current HA role.
+type RoleTracker struct {
+	role        atomic.Value
+	electedChan <-chan struct{}
+}
+
+// NewRoleTracker creates a RoleTracker that starts as follower and becomes leader when electedChan closes.
+func NewRoleTracker(electedChan <-chan struct{}) *RoleTracker {
+	rt := &RoleTracker{
+		electedChan: electedChan,
+	}
+	rt.role.Store(RoleFollower)
+	return rt
+}
+
+// NewFakeRoleTracker creates a RoleTracker with a fixed role for testing.
+func NewFakeRoleTracker(role string) *RoleTracker {
+	rt := &RoleTracker{}
+	rt.role.Store(role)
+	return rt
+}
+
+// Start blocks until leadership is acquired or context is cancelled.
+func (rt *RoleTracker) Start(ctx context.Context, log logr.Logger) {
+	select {
+	case <-rt.electedChan:
+		rt.role.Store(RoleLeader)
+		log.Info("RoleTracker: transitioned to leader")
+	case <-ctx.Done():
+		return
+	}
+}
+
+func (rt *RoleTracker) GetRole() string {
+	return rt.role.Load().(string)
+}

--- a/pkg/util/roletracker/tracker_test.go
+++ b/pkg/util/roletracker/tracker_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roletracker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func TestNewRoleTracker(t *testing.T) {
+	electedChan := make(chan struct{})
+	rt := NewRoleTracker(electedChan)
+
+	if rt == nil {
+		t.Fatal("NewRoleTracker returned nil")
+	}
+
+	if got := rt.GetRole(); got != RoleFollower {
+		t.Errorf("NewRoleTracker initial role = %q, want %q", got, RoleFollower)
+	}
+}
+
+func TestRoleTracker_StartLeaderElection(t *testing.T) {
+	tests := []struct {
+		name          string
+		closeChannel  bool
+		cancelContext bool
+		expectedRole  string
+	}{
+		{
+			name:         "becomes leader when elected",
+			closeChannel: true,
+			expectedRole: RoleLeader,
+		},
+		{
+			name:          "stays follower when context cancelled",
+			cancelContext: true,
+			expectedRole:  RoleFollower,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			electedChan := make(chan struct{})
+			rt := NewRoleTracker(electedChan)
+
+			if got := rt.GetRole(); got != RoleFollower {
+				t.Errorf("Initial role = %q, want %q", got, RoleFollower)
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			done := make(chan struct{})
+			go func() {
+				rt.Start(ctx, logr.Discard())
+				close(done)
+			}()
+
+			if tc.closeChannel {
+				close(electedChan)
+			}
+			if tc.cancelContext {
+				cancel()
+			}
+
+			<-done
+
+			if got := rt.GetRole(); got != tc.expectedRole {
+				t.Errorf("After election, role = %q, want %q", got, tc.expectedRole)
+			}
+		})
+	}
+}
+
+func TestGetMetricsRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		tracker  *RoleTracker
+		expected string
+	}{
+		{
+			name:     "nil tracker returns standalone",
+			tracker:  nil,
+			expected: RoleStandalone,
+		},
+		{
+			name:     "follower tracker returns follower",
+			tracker:  NewFakeRoleTracker(RoleFollower),
+			expected: RoleFollower,
+		},
+		{
+			name:     "leader tracker returns leader",
+			tracker:  NewFakeRoleTracker(RoleLeader),
+			expected: RoleLeader,
+		},
+		{
+			name:     "standalone tracker returns standalone",
+			tracker:  NewFakeRoleTracker(RoleStandalone),
+			expected: RoleStandalone,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GetRole(tc.tracker)
+			if got != tc.expected {
+				t.Errorf("GetMetricsRole() = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/webhooks/clusterqueue_webhook.go
+++ b/pkg/webhooks/clusterqueue_webhook.go
@@ -34,6 +34,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/util/roletracker"
 )
 
 const (
@@ -43,11 +44,12 @@ const (
 
 type ClusterQueueWebhook struct{}
 
-func setupWebhookForClusterQueue(mgr ctrl.Manager) error {
+func setupWebhookForClusterQueue(mgr ctrl.Manager, roleTracker *roletracker.RoleTracker) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&kueue.ClusterQueue{}).
 		WithDefaulter(&ClusterQueueWebhook{}).
 		WithValidator(&ClusterQueueWebhook{}).
+		WithLogConstructor(roletracker.WebhookLogConstructor(roleTracker)).
 		Complete()
 }
 

--- a/pkg/webhooks/cohort_webhook.go
+++ b/pkg/webhooks/cohort_webhook.go
@@ -26,14 +26,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/util/roletracker"
 )
 
 type CohortWebhook struct{}
 
-func setupWebhookForCohort(mgr ctrl.Manager) error {
+func setupWebhookForCohort(mgr ctrl.Manager, roleTracker *roletracker.RoleTracker) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&kueue.Cohort{}).
 		WithValidator(&CohortWebhook{}).
+		WithLogConstructor(roletracker.WebhookLogConstructor(roleTracker)).
 		Complete()
 }
 

--- a/pkg/webhooks/resourceflavor_webhook.go
+++ b/pkg/webhooks/resourceflavor_webhook.go
@@ -32,15 +32,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/util/roletracker"
 )
 
 type ResourceFlavorWebhook struct{}
 
-func setupWebhookForResourceFlavor(mgr ctrl.Manager) error {
+func setupWebhookForResourceFlavor(mgr ctrl.Manager, roleTracker *roletracker.RoleTracker) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&kueue.ResourceFlavor{}).
 		WithDefaulter(&ResourceFlavorWebhook{}).
 		WithValidator(&ResourceFlavorWebhook{}).
+		WithLogConstructor(roletracker.WebhookLogConstructor(roleTracker)).
 		Complete()
 }
 

--- a/pkg/webhooks/webhooks.go
+++ b/pkg/webhooks/webhooks.go
@@ -20,30 +20,57 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/util/roletracker"
 )
+
+// SetupOption configures webhook Setup.
+type SetupOption func(*setupOptions)
+
+type setupOptions struct {
+	roleTracker *roletracker.RoleTracker
+}
+
+// WithRoleTracker sets the role tracker for HA setups.
+func WithRoleTracker(tracker *roletracker.RoleTracker) SetupOption {
+	return func(o *setupOptions) {
+		o.roleTracker = tracker
+	}
+}
 
 // Setup sets up the webhooks for core controllers. It returns the name of the
 // webhook that failed to create and an error, if any.
-func Setup(mgr ctrl.Manager) (string, error) {
-	if err := setupWebhookForWorkload(mgr); err != nil {
+func Setup(mgr ctrl.Manager, opts ...SetupOption) (string, error) {
+	options := &setupOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	if err := setupWebhookForWorkload(mgr, options.roleTracker); err != nil {
 		return "Workload", err
 	}
 
-	if err := setupWebhookForResourceFlavor(mgr); err != nil {
+	if err := setupWebhookForResourceFlavor(mgr, options.roleTracker); err != nil {
 		return "ResourceFlavor", err
 	}
 
-	if err := setupWebhookForClusterQueue(mgr); err != nil {
+	if err := setupWebhookForClusterQueue(mgr, options.roleTracker); err != nil {
 		return "ClusterQueue", err
 	}
 
-	if err := setupWebhookForCohort(mgr); err != nil {
+	if err := setupWebhookForCohort(mgr, options.roleTracker); err != nil {
 		return "Cohort", err
 	}
 
-	if err := ctrl.NewWebhookManagedBy(mgr).For(&kueue.LocalQueue{}).Complete(); err != nil {
+	if err := setupWebhookForLocalQueue(mgr, options.roleTracker); err != nil {
 		return "LocalQueue", err
 	}
 
 	return "", nil
+}
+
+func setupWebhookForLocalQueue(mgr ctrl.Manager, roleTracker *roletracker.RoleTracker) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&kueue.LocalQueue{}).
+		WithLogConstructor(roletracker.WebhookLogConstructor(roleTracker)).
+		Complete()
 }

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -36,6 +36,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
+	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
 	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
@@ -43,12 +44,13 @@ import (
 
 type WorkloadWebhook struct{}
 
-func setupWebhookForWorkload(mgr ctrl.Manager) error {
+func setupWebhookForWorkload(mgr ctrl.Manager, roleTracker *roletracker.RoleTracker) error {
 	wh := &WorkloadWebhook{}
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&kueue.Workload{}).
 		WithDefaulter(wh).
 		WithValidator(wh).
+		WithLogConstructor(roletracker.WebhookLogConstructor(roleTracker)).
 		Complete()
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Adds replica-role field to logs to indicate whether they were emitted by the leader, a follower, or a standalone Kueue instance (default when leader election is disabled).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #6772 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Logs now include `replica-role` field to identify Kueue instance roles (leader/follower/standalone).
```