### PR TITLE
Graduate WorkloadRequestUseMergePatch to Beta.

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -320,6 +320,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	WorkloadRequestUseMergePatch: {
 		{Version: version.MustParse("0.14"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.16"), Default: true, PreRelease: featuregate.Beta},
 	},
 	SanitizePodSets: {
 		{Version: version.MustParse("0.13"), Default: true, PreRelease: featuregate.Beta},

--- a/site/content/en/docs/concepts/workload.md
+++ b/site/content/en/docs/concepts/workload.md
@@ -172,22 +172,19 @@ If `maximumExecutionTimeSeconds` is not specified, the workload has no execution
 
 You can configure the `maximumExecutionTimeSeconds` of the Workload associated with any supported Kueue Job by specifying the desired value as `kueue.x-k8s.io/max-exec-time-seconds` label of the job. 
 
-## Workload updates by Kueue
+## Workload Updates Using Merge Patch
 
-{{< feature-state state="alpha" for_version="v0.14" >}}
+{{< feature-state state="beta" for_version="v0.16" >}}
 
 {{% alert title="Note" color="primary" %}}
-`WorkloadRequestUseMergePatch` is currently an alpha feature and is disabled by default.
+`WorkloadRequestUseMergePatch` is currently a beta feature and is enabled by default.
 
-You can enable it by editing the `WorkloadRequestUseMergePatch` feature gate. Refer to the
+You can disable it by editing the `WorkloadRequestUseMergePatch` feature gate. Refer to the
 [Installation guide](/docs/installation/#change-the-feature-gates-configuration)
 for instructions on configuring feature gates.
 {{% /alert %}}
 
-
-By default Workload status updates are performed by Kueue using the [Server-Side Apply (SSA)](https://kubernetes.io/docs/reference/using-api/server-side-apply/). 
-
-However due to the limitations of SSA ([missing support for duplicated key/value pairs](https://github.com/kubernetes/kubernetes/issues/113482)) we also offer to enable updating the Workload status
+Due to the limitations of SSA ([missing support for duplicated key/value pairs](https://github.com/kubernetes/kubernetes/issues/113482)) we offer to enable updating the Workload status
 with Merge Patches, by enabling the `WorkloadRequestUseMergePatch` feature gate. 
 
 In particular, this allows users of Kueue to handle the following two issues:

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -281,7 +281,7 @@ spec:
 ### Feature gates for alpha and beta features
 
 | Feature                                       | Default | Stage | Since | Until |
-| --------------------------------------------- |---------|-------|-------| ----- |
+| --------------------------------------------- |---------|-------|-------|-------|
 | `FlavorFungibility`                           | `true`  | Beta  | 0.5   |       |
 | `MultiKueue`                                  | `false` | Alpha | 0.6   | 0.8   |
 | `MultiKueue`                                  | `true`  | Beta  | 0.9   |       |
@@ -313,7 +313,8 @@ spec:
 | `ElasticJobsViaWorkloadSlices`                | `false` | Alpha | 0.13  |       |
 | `ManagedJobsNamespaceSelectorAlwaysRespected` | `false` | Alpha | 0.13  | 0.15  |
 | `ManagedJobsNamespaceSelectorAlwaysRespected` | `true`  | Beta  | 0.15  |       |
-| `WorkloadRequestUseMergePatch`                | `false` | Alpha | 0.14  |       |
+| `WorkloadRequestUseMergePatch`                | `false` | Alpha | 0.14  | 0.15  |
+| `WorkloadRequestUseMergePatch`                | `true`  | Beta  | 0.16  |       |
 | `SanitizePodSets`                             | `true`  | Beta  | 0.13  |       |
 | `MultiKueueAllowInsecureKubeconfigs`          | `false` | Alpha | 0.13  |       |
 | `ReclaimablePods`                             | `true`  | Beta  | 0.15  |       |

--- a/site/content/zh-CN/docs/installation/_index.md
+++ b/site/content/zh-CN/docs/installation/_index.md
@@ -293,7 +293,8 @@ spec:
 | `TASReplaceNodeOnPodTermination`              | `true`  | Beta  | 0.14 |      |
 | `ElasticJobsViaWorkloadSlices`                | `false` | Alpha | 0.13 |      |
 | `ManagedJobsNamespaceSelectorAlwaysRespected` | `false` | Alpha | 0.13 |      |
-| `WorkloadRequestUseMergePatch`                | `false` | Alpha | 0.14 |      |
+| `WorkloadRequestUseMergePatch`                | `false` | Alpha | 0.14 | 0.15 |
+| `WorkloadRequestUseMergePatch`                | `true`  | Beta  | 0.16 |      |
 | `SanitizePodSets`                             | `true`  | Beta  | 0.13 |      |
 | `MultiKueueAllowInsecureKubeconfigs`          | `false` | Alpha | 0.13 |      |
 | `SkipFinalizersForPodsSuspendedByParent`      | `true`  | Beta  | 0.16 |      |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Graduate WorkloadRequestUseMergePatch to Beta.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7035

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Graduate WorkloadRequestUseMergePatch to Beta.
```