### PR TITLE
Small fixes to MultiKueue KEP

### DIFF
--- a/keps/693-multikueue/README.md
+++ b/keps/693-multikueue/README.md
@@ -399,7 +399,7 @@ if the connection with its reserving worker cluster is lost.
 Since Kueue 0.13, in order to meet the requirements of [Story 3](#story-3), we introduce an API for custom dispatching algorithms.
 When a custom Dispatcher API is used, instead of creating the copy of the workload on all clusters the
 the MultiKueue Workload Controller only creates the copy of the workload on the subset of worker clusters
-specified in the workload's .status.nominatedClusterNames field.
+specified in the workload's `.status.nominatedClusterNames` field.
 
 Additionally, we implement a built-in incremental dispatcher as a reference implementation.
 Including the pre-existing dispatching algorithm until 0.12, we distinguish the following dispatchers:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

It's a bag of fixes for small issues which I randomly spotted while reading the KEP.
Specifically:

* Adjust `listType` of `nominatedClusterNames` to reality. (It was changed from `set` to `atomic` in [this commit](https://github.com/kubernetes-sigs/kueue/pull/5782/commits/ffa6e2b495cad318746fe59f913f0d27481ec43d)).
* Rephrase the non-goal of "distribute running Jobs across multiple clusters", which, at the first glance, looks very much like the main goal of MultiKueue :).
* Rename "Workload Controller" to "MultiKueue Workload Controller", to avoid confusion with the core one.
* Fix some grammar & style issues.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```