### PR TITLE
Remove ConfigurableResourceTransformations feature gate.

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -245,7 +245,7 @@ func main() {
 		cacheOptions = append(cacheOptions, schdcache.WithExcludedResourcePrefixes(cfg.Resources.ExcludeResourcePrefixes))
 		queueOptions = append(queueOptions, qcache.WithExcludedResourcePrefixes(cfg.Resources.ExcludeResourcePrefixes))
 	}
-	if features.Enabled(features.ConfigurableResourceTransformations) && cfg.Resources != nil && len(cfg.Resources.Transformations) > 0 {
+	if cfg.Resources != nil && len(cfg.Resources.Transformations) > 0 {
 		cacheOptions = append(cacheOptions, schdcache.WithResourceTransformations(cfg.Resources.Transformations))
 		queueOptions = append(queueOptions, qcache.WithResourceTransformations(cfg.Resources.Transformations))
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -77,13 +77,6 @@ const (
 	// to put them on closely located nodes (e.g. within the same rack or block).
 	TopologyAwareScheduling featuregate.Feature = "TopologyAwareScheduling"
 
-	// owner: @dgrove-oss
-	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2937-resource-transformer
-	//
-	// Enable applying configurable resource transformations when computing
-	// the resource requests of a Workload
-	ConfigurableResourceTransformations featuregate.Feature = "ConfigurableResourceTransformations"
-
 	// owner: @kpostoffice
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/1833-metrics-for-local-queue
 	//
@@ -271,11 +264,6 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	TopologyAwareScheduling: {
 		{Version: version.MustParse("0.9"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("0.14"), Default: true, PreRelease: featuregate.Beta},
-	},
-	ConfigurableResourceTransformations: {
-		{Version: version.MustParse("0.9"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("0.10"), Default: true, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("0.14"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 0.16
 	},
 	LocalQueueMetrics: {
 		{Version: version.MustParse("0.10"), Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -497,9 +497,7 @@ func totalRequestsFromPodSets(wl *kueue.Workload, info *InfoOptions) []PodSetRes
 		}
 		specRequests := resourcehelpers.PodRequests(&corev1.Pod{Spec: ps.Template.Spec}, resourcehelpers.PodResourcesOptions{})
 		effectiveRequests := dropExcludedResources(specRequests, info.excludedResourcePrefixes)
-		if features.Enabled(features.ConfigurableResourceTransformations) {
-			effectiveRequests = applyResourceTransformations(effectiveRequests, info.resourceTransformations)
-		}
+		effectiveRequests = applyResourceTransformations(effectiveRequests, info.resourceTransformations)
 		setRes.Requests = resources.NewRequests(effectiveRequests)
 		if features.Enabled(features.DynamicResourceAllocation) && info.preprocessedDRAResources != nil {
 			if draRes, exists := info.preprocessedDRAResources[ps.Name]; exists {

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -332,9 +332,6 @@ The PropagateBatchJobLabelsToWorkload feature is available starting from version
 
 | Feature                               | Default | Stage      | Since | Until |
 | ------------------------------------- | ------- | ---------- | ----- | ----- |
-| `ConfigurableResourceTransformations` | `false` | Alpha      | 0.9   | 0.9   |
-| `ConfigurableResourceTransformations` | `true`  | Beta       | 0.10  | 0.13  |
-| `ConfigurableResourceTransformations` | `true`  | GA         | 0.14  |       |
 | `TASProfileMostFreeCapacity`          | `false` | Deprecated | 0.11  | 0.13  |
 | `TASProfileLeastFreeCapacity`         | `false` | Deprecated | 0.11  |       |
 | `TASProfileMixed`                     | `false` | Deprecated | 0.11  |       |

--- a/site/content/en/docs/reference/components-tools/feature-gate-removed.md
+++ b/site/content/en/docs/reference/components-tools/feature-gate-removed.md
@@ -22,22 +22,25 @@ In the following table:
   If the feature stage is either "Deprecated" or "GA", the "To" column is the Kueue release when the feature 
   is removed.
 
-| Feature                           | Default | Stage      | From | To   |
-|-----------------------------------|---------|------------|------|------|
-| `AdmissionCheckValidationRules`   | `false` | Deprecated | 0.9  | 0.12 |
-| `KeepQuotaForProvReqRetry`        | `false` | Deprecated | 0.9  | 0.12 |
-| `MultiplePreemptions`             | `false` | Alpha      | 0.8  | 0.8  |
-| `MultiplePreemptions`             | `true`  | Beta       | 0.9  | 0.9  |
-| `MultiplePreemptions`             | `true`  | GA         | 0.10 | 0.13 |
-| `WorkloadResourceRequestsSummary` | `false` | Alpha      | 0.9  | 0.10 |
-| `WorkloadResourceRequestsSummary` | `true`  | Beta       | 0.10 | 0.11 |
-| `WorkloadResourceRequestsSummary` | `true`  | GA         | 0.11 | 0.13 |
-| `QueueVisibility`                 | `false` | Alpha      | 0.5  | 0.9  |
-| `QueueVisibility`                 | `false` | Deprecated | 0.9  | 0.14 |
-| `ManagedJobsNamespaceSelector`    | `true`  | Beta       | 0.10 | 0.13 |
-| `ManagedJobsNamespaceSelector`    | `true`  | GA         | 0.13 | 0.15 |
-| `ProvisioningACC`                 | `false` | Alpha      | 0.5  | 0.6  |
-| `ProvisioningACC`                 | `true`  | Beta       | 0.7  | 0.14 |
-| `ProvisioningACC`                 | `true`  | GA         | 0.14 | 0.15 |
-| `ExposeFlavorsInLocalQueue`       | `false` | Beta       | 0.9  | 0.15 |
-| `ExposeFlavorsInLocalQueue`       | `false` | Deprecated | 0.15 | 0.15 |
+| Feature                               | Default | Stage      | From | To   |
+|---------------------------------------|---------|------------|------|------|
+| `AdmissionCheckValidationRules`       | `false` | Deprecated | 0.9  | 0.12 |
+| `KeepQuotaForProvReqRetry`            | `false` | Deprecated | 0.9  | 0.12 |
+| `MultiplePreemptions`                 | `false` | Alpha      | 0.8  | 0.8  |
+| `MultiplePreemptions`                 | `true`  | Beta       | 0.9  | 0.9  |
+| `MultiplePreemptions`                 | `true`  | GA         | 0.10 | 0.13 |
+| `WorkloadResourceRequestsSummary`     | `false` | Alpha      | 0.9  | 0.10 |
+| `WorkloadResourceRequestsSummary`     | `true`  | Beta       | 0.10 | 0.11 |
+| `WorkloadResourceRequestsSummary`     | `true`  | GA         | 0.11 | 0.13 |
+| `QueueVisibility`                     | `false` | Alpha      | 0.5  | 0.9  |
+| `QueueVisibility`                     | `false` | Deprecated | 0.9  | 0.14 |
+| `ManagedJobsNamespaceSelector`        | `true`  | Beta       | 0.10 | 0.13 |
+| `ManagedJobsNamespaceSelector`        | `true`  | GA         | 0.13 | 0.15 |
+| `ProvisioningACC`                     | `false` | Alpha      | 0.5  | 0.6  |
+| `ProvisioningACC`                     | `true`  | Beta       | 0.7  | 0.14 |
+| `ProvisioningACC`                     | `true`  | GA         | 0.14 | 0.15 |
+| `ExposeFlavorsInLocalQueue`           | `false` | Beta       | 0.9  | 0.15 |
+| `ExposeFlavorsInLocalQueue`           | `false` | Deprecated | 0.15 | 0.15 |
+| `ConfigurableResourceTransformations` | `false` | Alpha      | 0.9  | 0.9  |
+| `ConfigurableResourceTransformations` | `true`  | Beta       | 0.10 | 0.13 |
+| `ConfigurableResourceTransformations` | `true`  | GA         | 0.14 | 0.16 |

--- a/site/content/zh-CN/docs/installation/_index.md
+++ b/site/content/zh-CN/docs/installation/_index.md
@@ -304,9 +304,6 @@ spec:
 |---------------------------------------|---------|------------|------|------|
 | `ManagedJobsNamespaceSelector`        | `true`  | Beta       | 0.10 | 0.13 |
 | `ManagedJobsNamespaceSelector`        | `true`  | GA         | 0.13 |      |
-| `ConfigurableResourceTransformations` | `false` | Alpha      | 0.9  | 0.9  |
-| `ConfigurableResourceTransformations` | `true`  | Beta       | 0.10 | 0.13 |
-| `ConfigurableResourceTransformations` | `true`  | GA         | 0.14 |      |
 | `TASProfileMostFreeCapacity`          | `false` | Deprecated | 0.11 | 0.13 |
 | `TASProfileLeastFreeCapacity`         | `false` | Deprecated | 0.11 |      |
 | `TASProfileMixed`                     | `false` | Deprecated | 0.11 |      |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Remove ConfigurableResourceTransformations feature gate.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Removes ConfigurableResourceTransformations feature gate.
```