### PR TITLE
Fix  trainjob controller not setting the trainer podset count value c…

### DIFF
--- a/pkg/controller/jobs/trainjob/trainjob_controller.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller.go
@@ -177,6 +177,15 @@ func getChildJobSet(ctx context.Context, t *TrainJob) (*jobsetapi.JobSet, error)
 	if !ok {
 		return nil, err
 	}
+
+	// Jobset replicaJob parallelism/completions are set outside of the jobset builder
+	for psIdx, ps := range info.TemplateSpec.PodSets {
+		if ps.Count != nil {
+			jobSetSpec.ReplicatedJobs[psIdx].Template.Spec.Parallelism = ps.Count
+			jobSetSpec.ReplicatedJobs[psIdx].Template.Spec.Completions = ps.Count
+		}
+	}
+
 	jobsetApply := kftrainerjobset.NewBuilder(jobsetapplyapi.JobSet(t.Name, t.Namespace).
 		WithSpec(jobSetSpec)).Initializer(trainJob).Trainer(info, trainJob).PodLabels(info.Scheduler.PodLabels).Build()
 

--- a/pkg/controller/jobs/trainjob/trainjob_controller_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller_test.go
@@ -79,6 +79,9 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 	testJobset := testingjobset.MakeJobSet("", "").ReplicatedJobs(
 		testingjobset.ReplicatedJobRequirements{
 			Name: "node",
+			Labels: map[string]string{
+				"trainer.kubeflow.org/trainjob-ancestor-step": "trainer",
+			},
 		}).Obj()
 	testCtr := testingtrainjob.MakeClusterTrainingRuntime("test", testJobset.Spec)
 
@@ -361,6 +364,15 @@ func TestReconciler(t *testing.T) {
 			Replicas:    1,
 			Parallelism: 1,
 			Completions: 1,
+			Labels: map[string]string{
+				"trainer.kubeflow.org/trainjob-ancestor-step": "trainer",
+			},
+		},
+		testingjobset.ReplicatedJobRequirements{
+			Name:        "foo",
+			Replicas:    1,
+			Parallelism: 1,
+			Completions: 1,
 		}).Obj()
 	testCtr := testingtrainjob.MakeClusterTrainingRuntime("test", testJobset.Spec)
 
@@ -382,6 +394,35 @@ func TestReconciler(t *testing.T) {
 				*utiltestingapi.MakeWorkload(testTrainJob.Name, testTrainJob.Namespace).
 					PodSets(
 						*utiltestingapi.MakePodSet("node", 1).
+							PodIndexLabel(ptr.To("batch.kubernetes.io/job-completion-index")).
+							SubGroupIndexLabel(ptr.To(jobsetapi.JobIndexKey)).
+							SubGroupCount(ptr.To[int32](1)).
+							Obj(),
+						*utiltestingapi.MakePodSet("foo", 1).
+							PodIndexLabel(ptr.To("batch.kubernetes.io/job-completion-index")).
+							SubGroupIndexLabel(ptr.To(jobsetapi.JobIndexKey)).
+							SubGroupCount(ptr.To[int32](1)).
+							Obj(),
+					).
+					Obj(),
+			},
+		},
+		"podset count for the trainer job is set to .Spec.Trainer.NumNodes": {
+			reconcilerOptions: []jobframework.Option{
+				jobframework.WithManageJobsWithoutQueueName(true),
+				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
+			},
+			trainJob:     testTrainJob.Clone().TrainerNumNodes(2).Obj(),
+			wantTrainJob: testTrainJob.Clone().TrainerNumNodes(2).Obj(),
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(testTrainJob.Name, testTrainJob.Namespace).
+					PodSets(
+						*utiltestingapi.MakePodSet("node", 2).
+							PodIndexLabel(ptr.To("batch.kubernetes.io/job-completion-index")).
+							SubGroupIndexLabel(ptr.To(jobsetapi.JobIndexKey)).
+							SubGroupCount(ptr.To[int32](1)).
+							Obj(),
+						*utiltestingapi.MakePodSet("foo", 1).
 							PodIndexLabel(ptr.To("batch.kubernetes.io/job-completion-index")).
 							SubGroupIndexLabel(ptr.To(jobsetapi.JobIndexKey)).
 							SubGroupCount(ptr.To[int32](1)).

--- a/pkg/util/testingjobs/trainjob/wrappers.go
+++ b/pkg/util/testingjobs/trainjob/wrappers.go
@@ -79,6 +79,12 @@ func (t *TrainJobWrapper) TrainerImage(image string, cmd, args []string) *TrainJ
 	return t
 }
 
+// TrainerNumNodes sets a the number of nodes that will be used in the Trainer job
+func (t *TrainJobWrapper) TrainerNumNodes(numNodes int32) *TrainJobWrapper {
+	t.Spec.Trainer.NumNodes = ptr.To(numNodes)
+	return t
+}
+
 // Label sets a Trainjob annotation key and value
 func (t *TrainJobWrapper) Annotation(key, value string) *TrainJobWrapper {
 	if t.Annotations == nil {

--- a/test/integration/singlecluster/controller/jobs/trainjob/trainjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/trainjob/trainjob_controller_test.go
@@ -92,6 +92,13 @@ var _ = ginkgo.Describe("Trainjob controller", ginkgo.Ordered, ginkgo.ContinueOn
 				testingjobset.ReplicatedJobRequirements{
 					Name:     "node",
 					Replicas: 1,
+					Labels: map[string]string{
+						"trainer.kubeflow.org/trainjob-ancestor-step": "trainer",
+					},
+				},
+				testingjobset.ReplicatedJobRequirements{
+					Name:     "foo",
+					Replicas: 1,
 				}).
 				Obj()
 			testCtr = testingtrainjob.MakeClusterTrainingRuntime("test", testJobSet.Spec)
@@ -126,6 +133,7 @@ var _ = ginkgo.Describe("Trainjob controller", ginkgo.Ordered, ginkgo.ContinueOn
 					Name:     "test",
 					Kind:     ptr.To("ClusterTrainingRuntime"),
 				}).
+					TrainerNumNodes(2).
 					Suspend(false).
 					Queue("local-queue").
 					Obj()
@@ -136,11 +144,14 @@ var _ = ginkgo.Describe("Trainjob controller", ginkgo.Ordered, ginkgo.ContinueOn
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			ginkgo.By("checking the workload is created", func() {
+			ginkgo.By("checking the workload is created with the correct values", func() {
 				wlLookupKey = types.NamespacedName{Name: workloadtrainjob.GetWorkloadNameForTrainJob(createdTrainJob.Name, createdTrainJob.UID), Namespace: ns.Name}
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 					g.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(kueue.LocalQueueName("local-queue")))
+					g.Expect(createdWorkload.Spec.PodSets).Should(gomega.HaveLen(2))
+					g.Expect(createdWorkload.Spec.PodSets[0].Count).Should(gomega.Equal(int32(2)))
+					g.Expect(createdWorkload.Spec.PodSets[1].Count).Should(gomega.Equal(int32(1)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -156,6 +167,12 @@ var _ = ginkgo.Describe("Trainjob controller", ginkgo.Ordered, ginkgo.ContinueOn
 				admission := utiltestingapi.MakeAdmission(clusterQueue.Name).PodSets(
 					kueue.PodSetAssignment{
 						Name: createdWorkload.Spec.PodSets[0].Name,
+						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+							corev1.ResourceCPU: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+						},
+					},
+					kueue.PodSetAssignment{
+						Name: createdWorkload.Spec.PodSets[1].Name,
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU: kueue.ResourceFlavorReference(onDemandFlavor.Name),
 						},
@@ -230,6 +247,12 @@ var _ = ginkgo.Describe("Trainjob controller", ginkgo.Ordered, ginkgo.ContinueOn
 				admission := utiltestingapi.MakeAdmission(localQueue.Name).PodSets(
 					kueue.PodSetAssignment{
 						Name: createdWorkload.Spec.PodSets[0].Name,
+						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+							corev1.ResourceCPU: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+						},
+					},
+					kueue.PodSetAssignment{
+						Name: createdWorkload.Spec.PodSets[1].Name,
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU: kueue.ResourceFlavorReference(onDemandFlavor.Name),
 						},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The TrainJob controller is not setting the `podset.count` value correctly for the trainer job when it creates more than one pod, which prevents Kueue from ungating all the pods

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8101 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix `TrainJob` controller not correctly setting the `PodSet` count value based on `numNodes` for the expected number of training nodes.
```