### PR TITLE
build(deps): upgrade react to 19.2.1 to fix CVE-2025-55182

### DIFF
--- a/cmd/kueueviz/frontend/package-lock.json
+++ b/cmd/kueueviz/frontend/package-lock.json
@@ -14,9 +14,9 @@
         "@mui/icons-material": "^7.3.5",
         "@mui/material": "^7.3.1",
         "ace-builds": "^1.43.4",
-        "react": "^19.2.0",
+        "react": "^19.2.1",
         "react-ace": "^14.0.1",
-        "react-dom": "^19.2.0",
+        "react-dom": "^19.2.1",
         "react-router-dom": "^7.9.6",
         "react-toastify": "^11.0.5"
       },
@@ -2809,9 +2809,9 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
-      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
+      "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2835,15 +2835,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
-      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
+      "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.0"
+        "react": "^19.2.1"
       }
     },
     "node_modules/react-is": {

--- a/cmd/kueueviz/frontend/package.json
+++ b/cmd/kueueviz/frontend/package.json
@@ -18,9 +18,9 @@
     "@mui/icons-material": "^7.3.5",
     "@mui/material": "^7.3.1",
     "ace-builds": "^1.43.4",
-    "react": "^19.2.0",
+    "react": "^19.2.1",
     "react-ace": "^14.0.1",
-    "react-dom": "^19.2.0",
+    "react-dom": "^19.2.1",
     "react-router-dom": "^7.9.6",
     "react-toastify": "^11.0.5"
   },


### PR DESCRIPTION
Upgrade react to 19.2.1 to fix CVE-2025-55182