### PR TITLE
Fix deep-exit lint errors by moving flag.Parse() to main()

### DIFF
--- a/hack/internal/tools/yaml-processor/main.go
+++ b/hack/internal/tools/yaml-processor/main.go
@@ -35,8 +35,9 @@ type options struct {
 }
 
 func main() {
-	opts, err := parseOptions()
-	if err != nil {
+	opts := initFlags()
+	flag.Parse()
+	if err := opts.validate(); err != nil {
 		log.Fatalf("Failed to parse options: %v", err)
 	}
 
@@ -67,7 +68,7 @@ func main() {
 	fileProcessor.ProcessPlan(*processingPlan)
 }
 
-func parseOptions() (*options, error) {
+func initFlags() *options {
 	opts := &options{}
 
 	flag.StringVar(&opts.LogLevel, "zap-log-level", "info", "Minimum enabled logging level")
@@ -76,15 +77,16 @@ func parseOptions() (*options, error) {
 		flag.PrintDefaults()
 	}
 
-	flag.Parse()
+	return opts
+}
+
+func (o *options) validate() error {
 	if flag.NArg() != 1 {
 		flag.Usage()
-		return nil, errors.New("exactly one processing plan file argument is required")
+		return errors.New("exactly one processing plan file argument is required")
 	}
-
-	opts.ProcessingPlan = flag.Arg(0)
-
-	return opts, nil
+	o.ProcessingPlan = flag.Arg(0)
+	return nil
 }
 
 func newLogger(logLevel string) (*zap.Logger, error) {

--- a/test/performance/scheduler/minimalkueue/main.go
+++ b/test/performance/scheduler/minimalkueue/main.go
@@ -66,20 +66,24 @@ func init() {
 }
 
 func main() {
-	os.Exit(mainWithExitCode())
+	initFlags()
+	flag.Parse()
+	os.Exit(run())
 }
 
-func mainWithExitCode() int {
-	opts := zap.Options{
-		TimeEncoder: zapcore.RFC3339NanoTimeEncoder,
-		ZapOpts:     []zaplog.Option{zaplog.AddCaller()},
-		Development: true,
-		Level:       zaplog.NewAtomicLevelAt(zapcore.ErrorLevel),
-	}
-	opts.BindFlags(flag.CommandLine)
-	flag.Parse()
-	log := zap.New(zap.UseFlagOptions(&opts))
+var logOptions = zap.Options{
+	TimeEncoder: zapcore.RFC3339NanoTimeEncoder,
+	ZapOpts:     []zaplog.Option{zaplog.AddCaller()},
+	Development: true,
+	Level:       zaplog.NewAtomicLevelAt(zapcore.ErrorLevel),
+}
 
+func initFlags() {
+	logOptions.BindFlags(flag.CommandLine)
+}
+
+func run() int {
+	log := zap.New(zap.UseFlagOptions(&logOptions))
 	ctrl.SetLogger(log)
 	log.Info("Start")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Fixes `deep-exit` lint errors reported by `make verify` when bumping `golangci-lint/v2` from 2.6.2 to 2.7.2. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #8121 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```