### PR TITLE
Fix formatting error in failure recovery doc

### DIFF
--- a/site/content/en/docs/tasks/manage/setup_failure_recovery.md
+++ b/site/content/en/docs/tasks/manage/setup_failure_recovery.md
@@ -49,7 +49,7 @@ spec:
 
 {{% alert title="Note" color="primary" %}}
 
-The controller is **not** limited to pods managed by Kueue (i.e. having the `kueue.x-k8s.io/managed` or `kueue.x-k8s.io/podset label`).
+The controller is **not** limited to pods managed by Kueue (i.e. having the `kueue.x-k8s.io/managed` or `kueue.x-k8s.io/podset` label).
 All pods in the cluster that have the new annotation will be affected.
 
 {{% /alert %}}


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
It's a tiny formatting issue in the recently merged failure recovery doc. I noticed it when reading the deployed documentation.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
It's a tiny change, but I figured I'll fix it since this was merged recently. No point leaving this around.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```