### PR TITLE
pkg: fix race condition in StrictFIFO priority ordering

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -660,3 +660,19 @@ func (c *ClusterQueue) deleteLocalQueue(lqKey utilqueue.LocalQueueReference) {
 	defer c.rwm.Unlock()
 	delete(c.localQueuesInClusterQueue, lqKey)
 }
+
+// HasStrictFIFOHigherPriorityPending returns true if the ClusterQueue uses
+// StrictFIFO queueing strategy and there is a workload in the heap with
+// higher priority than the given priority.
+func (c *ClusterQueue) HasStrictFIFOHigherPriorityPending(p int32) bool {
+	c.rwm.RLock()
+	defer c.rwm.RUnlock()
+	if c.queueingStrategy != kueue.StrictFIFO {
+		return false
+	}
+	head := c.heap.Peek()
+	if head == nil {
+		return false
+	}
+	return utilpriority.Priority(head.Obj) > p
+}

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -813,3 +813,16 @@ func (m *Manager) NotifyWorkloadUpdateWatchers(oldWorkload, newWorkload *kueue.W
 func (m *Manager) AddWorkloadUpdateWatcher(watcher WorkloadUpdateWatcher) {
 	m.workloadUpdateWatchers = append(m.workloadUpdateWatchers, watcher)
 }
+
+// HasStrictFIFOHigherPriorityPending returns true if the specified ClusterQueue
+// uses StrictFIFO queueing strategy and has a workload in its heap with higher
+// priority than the given priority.
+func (m *Manager) HasStrictFIFOHigherPriorityPending(cqName kueue.ClusterQueueReference, p int32) bool {
+	m.RLock()
+	defer m.RUnlock()
+	cq := m.hm.ClusterQueue(cqName)
+	if cq == nil {
+		return false
+	}
+	return cq.HasStrictFIFOHigherPriorityPending(p)
+}

--- a/pkg/util/heap/heap.go
+++ b/pkg/util/heap/heap.go
@@ -148,6 +148,19 @@ func (h *Heap[T, K]) Pop() *T {
 	return heap.Pop(&h.data).(*T)
 }
 
+// Peek returns the head of the heap without removing it.
+func (h *Heap[T, K]) Peek() *T {
+	if h.data.Len() == 0 {
+		return nil
+	}
+	key := h.data.keys[0]
+	item, exists := h.data.items[key]
+	if !exists {
+		return nil
+	}
+	return item.obj
+}
+
 // GetByKey returns the requested item, or sets exists=false.
 func (h *Heap[T, K]) GetByKey(key K) *T {
 	item, exists := h.data.items[key]

--- a/pkg/util/heap/heap_test.go
+++ b/pkg/util/heap/heap_test.go
@@ -232,6 +232,38 @@ func TestHeap_GetByKey(t *testing.T) {
 	}
 }
 
+// TestHeap_Peek tests Heap.Peek function.
+func TestHeap_Peek(t *testing.T) {
+	h := New(testHeapObjectKeyFunc, compareInts)
+
+	if obj := h.Peek(); obj != nil {
+		t.Fatalf("expected nil on empty heap, got %v", obj)
+	}
+
+	h.PushOrUpdate(mkHeapObj("foo", 10))
+	h.PushOrUpdate(mkHeapObj("bar", 1))
+	h.PushOrUpdate(mkHeapObj("baz", 11))
+
+	obj := h.Peek()
+	if obj == nil || obj.val != 1 {
+		t.Fatalf("expected value 1, got %v", obj)
+	}
+
+	if h.Len() != 3 {
+		t.Fatalf("expected length 3, got %d", h.Len())
+	}
+
+	poppedObj := h.Pop()
+	if poppedObj.val != 1 {
+		t.Fatalf("expected value 1, got %v", poppedObj)
+	}
+
+	obj = h.Peek()
+	if obj == nil || obj.val != 10 {
+		t.Fatalf("expected value 10, got %v", obj)
+	}
+}
+
 // TestHeap_List tests Heap.List function.
 func TestHeap_List(t *testing.T) {
 	h := New(testHeapObjectKeyFunc, compareInts)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake


#### What this PR does / why we need it:
When a workload is evicted and re-queued, it can be added back to the queue while the scheduler is processing an older batch. This causes lower-priority workloads to be admitted before higher-priority ones. This fixes the issue by checking the queue for higher-priority workloads right before admission.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/8141

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix StrictFIFO priority ordering when higher-priority workloads are re-queued during scheduling
```