### PR TITLE
Automated cherry pick of #8138: build(deps): upgrade react to 19.2.1 to fix CVE-2025-55182

### DIFF
--- a/cmd/kueueviz/frontend/package-lock.json
+++ b/cmd/kueueviz/frontend/package-lock.json
@@ -13,11 +13,11 @@
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^7.3.2",
         "@mui/material": "^7.3.1",
-        "ace-builds": "^1.43.3",
-        "react": "^19.1.1",
+        "ace-builds": "^1.43.4",
+        "react": "^19.2.1",
         "react-ace": "^14.0.1",
-        "react-dom": "^19.1.1",
-        "react-router-dom": "^7.9.1",
+        "react-dom": "^19.2.1",
+        "react-router-dom": "^7.9.6",
         "react-toastify": "^11.0.5"
       },
       "devDependencies": {
@@ -2812,9 +2812,9 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
-      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
+      "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2838,15 +2838,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
-      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
+      "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.26.0"
       },
       "peerDependencies": {
-        "react": "^19.1.1"
+        "react": "^19.2.1"
       }
     },
     "node_modules/react-is": {

--- a/cmd/kueueviz/frontend/package.json
+++ b/cmd/kueueviz/frontend/package.json
@@ -17,11 +17,11 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.3.2",
     "@mui/material": "^7.3.1",
-    "ace-builds": "^1.43.3",
-    "react": "^19.1.1",
+    "ace-builds": "^1.43.4",
+    "react": "^19.2.1",
     "react-ace": "^14.0.1",
-    "react-dom": "^19.1.1",
-    "react-router-dom": "^7.9.1",
+    "react-dom": "^19.2.1",
+    "react-router-dom": "^7.9.6",
     "react-toastify": "^11.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Cherry pick of #8138 on release-0.14.

#8138: build(deps): upgrade react to 19.2.1 to fix CVE-2025-55182

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```