### PR TITLE
docs: Fix dead links

### DIFF
--- a/site/content/en/docs/concepts/multikueue.md
+++ b/site/content/en/docs/concepts/multikueue.md
@@ -119,7 +119,7 @@ MultiKueue supports a wide variety of workloads. You can learn how to:
 
 - [Dispatch a Kueue managed Deployment](docs/tasks/run/multikueue/deployment).
 - [Dispatch a Kueue managed batch/Job](docs/tasks/run/multikueue/job).
-- [Dispatch a Kueue managed JobSet](docs/tasks/run/multikueue/jobset).
+- [Dispatch a Kueue managed JobSet](docs/tasks/run/multikueue/jobsets).
 - [Dispatch a Kueue managed Kubeflow Jobs](docs/tasks/run/multikueue/kubeflow).
 - [Dispatch a Kueue managed KubeRay workloads](docs/tasks/run/multikueue/kuberay).
 - [Dispatch a Kueue managed MPIJob](docs/tasks/run/multikueue/mpijob).

--- a/site/content/en/docs/tasks/_index.md
+++ b/site/content/en/docs/tasks/_index.md
@@ -27,7 +27,7 @@ As a batch administrator, you can learn how to:
   [monitor pending workloads](manage/monitor_pending_workloads).
 - As a batch administrator, you can learn how to [run a Kueue managed Jobs with a custom WorkloadPriority](manage/run_job_with_workload_priority).
 - As a batch administrator, you can learn how to [setup a MultiKueue environment](manage/setup_multikueue).
-- As a batch administrator, you can learn how to [use third-party certificate authority with Kueue](manage/cert_manager).
+- As a batch administrator, you can learn how to [use third-party certificate authority with Kueue](manage/productization/cert_manager).
 
 ### Batch user
 

--- a/site/content/en/docs/tasks/dev/integrate_a_custom_job.md
+++ b/site/content/en/docs/tasks/dev/integrate_a_custom_job.md
@@ -11,7 +11,7 @@ Kubernetes batch Job, MPIJob, RayJob and JobSet.
 
 There are three options for using Kueue to manage Job-like CRDs that lack built-in integrations.
 - Leverage the built-in AppWrapper integration by wrapping instances of the custom Job in an AppWrapper.
-  See [Running a Wrapped Custom Workload](/docs/tasks/run/wrapped_custom_workload) for details.
+  See [Running a Wrapped Custom Workload](/docs/tasks/run/external_workloads/wrapped_custom_workload) for details.
 - Build a new integration as part of the Kueue repository.
 - Build a new integration as an external controller.
 

--- a/site/content/en/docs/tasks/dev/setup_multikueue_tas.md
+++ b/site/content/en/docs/tasks/dev/setup_multikueue_tas.md
@@ -6,7 +6,7 @@ description: >
   Configure MultiKueue with Topology-Aware Scheduling for local development and testing.
 ---
 
-This tutorial explains how you can configure a manager cluster and worker clusters to run jobs with [Topology-Aware Scheduling (TAS)](/docs/tasks/run/topology_aware_scheduling/) in a MultiKueue environment. We also outline the automated steps using Kind for local testing.
+This tutorial explains how you can configure a manager cluster and worker clusters to run jobs with [Topology-Aware Scheduling (TAS)](/docs/tasks/run/leaderworkerset/#configure-topology-aware-scheduling) in a MultiKueue environment. We also outline the automated steps using Kind for local testing.
 
 Check the concepts section for a [MultiKueue overview](/docs/concepts/multikueue/) and [Topology-Aware Scheduling overview](/docs/concepts/topology_aware_scheduling/).
 

--- a/site/content/en/docs/tasks/manage/setup_multikueue.md
+++ b/site/content/en/docs/tasks/manage/setup_multikueue.md
@@ -6,7 +6,7 @@ description: >
   Additional steps needed to setup the multikueue clusters.
 ---
 
-This tutorial explains how you can configure a management cluster and one worker cluster to run [JobSets](/docs/tasks/run_jobsets/#jobset-definition) and [batch/Jobs](/docs/tasks/run_jobs/#1-define-the-job) in a MultiKueue environment.
+This tutorial explains how you can configure a management cluster and one worker cluster to run [JobSets](/docs/tasks/run/jobsets/#jobset-definition) and [batch/Jobs](/docs/tasks/run/jobs/#1-define-the-job) in a MultiKueue environment.
 
 Check the concepts section for a [MultiKueue overview](/docs/concepts/multikueue/). 
 

--- a/site/content/en/docs/tasks/run/external_workloads/argo_workflow.md
+++ b/site/content/en/docs/tasks/run/external_workloads/argo_workflow.md
@@ -12,7 +12,7 @@ This page shows how to leverage Kueue's scheduling and resource management capab
 This guide is for [batch users](/docs/tasks#batch-user) that have a basic understanding of Kueue. For more information, see [Kueue's overview](/docs/overview).
 
 Currently Kueue doesn't support Argo Workflows [Workflow](https://argo-workflows.readthedocs.io/en/latest/workflow-concepts/) resources directly,
-but you can take advantage of the ability for Kueue to [manage plain pods](/docs/tasks/run_plain_pods) to integrate them.
+but you can take advantage of the ability for Kueue to [manage plain pods](/docs/tasks/run/plain_pods) to integrate them.
 
 ## Before you begin
 

--- a/site/content/en/docs/tasks/run/external_workloads/tektoncd.md
+++ b/site/content/en/docs/tasks/run/external_workloads/tektoncd.md
@@ -11,7 +11,7 @@ This page shows how to leverage Kueue's scheduling and resource management capab
 
 This guide is for [batch users](/docs/tasks#batch-user) that have a basic understanding of Kueue. For more information, see [Kueue's overview](/docs/overview).
 
-We demonstrate how to support scheduling Tekton Pipelines Tasks in Kueue based on the [Plain Pod](/docs/tasks/run_plain_pods) integration, where every Pod from a Pipeline is represented as a single independent Plain Pod.
+We demonstrate how to support scheduling Tekton Pipelines Tasks in Kueue based on the [Plain Pod](/docs/tasks/run/plain_pods) integration, where every Pod from a Pipeline is represented as a single independent Plain Pod.
 
 ## Before you begin
 

--- a/site/content/en/docs/tasks/run/python_jobs.md
+++ b/site/content/en/docs/tasks/run/python_jobs.md
@@ -276,7 +276,7 @@ hello world
 ```
 
 You can further customize the job, and can ask questions on the [Flux Operator issues board](https://github.com/flux-framework/flux-operator/issues).
-Finally, for instructions for how to do this with YAML outside of Python, see [Run A Flux MiniCluster](/docs/tasks/run_flux_minicluster/).
+Finally, for instructions for how to do this with YAML outside of Python, see [Run A Flux MiniCluster](/docs/tasks/run/external_workloads/flux_miniclusters/).
 
 ### MPI Operator Job
 
@@ -376,5 +376,4 @@ pi is approximately 3.1410376000000002
 ```
 
 That looks like pi! 🎉️🥧️
-If you are interested in running this same example with YAML outside of Python, see [Run an MPIJob](/docs/tasks/run_kubeflow_jobs/run_mpijobs/).
-
+If you are interested in running this same example with YAML outside of Python, see [Run an MPIJob](/docs/tasks/run/kubeflow/mpijobs/).

--- a/site/content/en/docs/tasks/run/run_cronjobs.md
+++ b/site/content/en/docs/tasks/run/run_cronjobs.md
@@ -18,7 +18,7 @@ Make sure the following conditions are met:
 - A Kubernetes cluster is running.
 - The kubectl command-line tool has communication with your cluster.
 - [Kueue is installed](/docs/installation).
-- The cluster has [quotas configured](/docs/tasks/administer_cluster_quotas).
+- The cluster has [quotas configured](/docs/tasks/manage/administer_cluster_quotas).
 
 ## 0. Identify the queues available in your namespace
 
@@ -81,4 +81,4 @@ job-sample-cronjob-28373363-e2aa0   user-queue   cluster-queue   68m
 job-sample-cronjob-28373364-b42ac   user-queue   cluster-queue   67m
 ```
 
-You can also [Monitoring Status of the Workload](/docs/tasks/run_jobs#3-optional-monitor-the-status-of-the-workload).
+You can also [Monitoring Status of the Workload](/docs/tasks/run/jobs#3-optional-monitor-the-status-of-the-workload).

--- a/site/content/zh-CN/docs/concepts/multikueue.md
+++ b/site/content/zh-CN/docs/concepts/multikueue.md
@@ -55,7 +55,7 @@ Multikueue 系统的工作方式如下：
 MultiKueue 支持多种工作负载，你可以学习如何：
 - [调度 Kueue 管理的 Deployment](docs/tasks/run/multikueue/deployment)。
 - [调度 Kueue 管理的 batch/Job](docs/tasks/run/multikueue/job)。
-- [调度 Kueue 管理的 JobSet](docs/tasks/run/multikueue/jobset)。
+- [调度 Kueue 管理的 JobSet](docs/tasks/run/multikueue/jobsets)。
 - [调度 Kueue 管理的 Kubeflow Job](docs/tasks/run/multikueue/kubeflow)。
 - [调度 Kueue 管理的 KubeRay 工作负载](docs/tasks/run/multikueue/kuberay)。
 - [调度 Kueue 管理的 MPIJob](docs/tasks/run/multikueue/mpijob)。

--- a/site/content/zh-CN/docs/tasks/_index.md
+++ b/site/content/zh-CN/docs/tasks/_index.md
@@ -26,7 +26,7 @@ As a batch administrator, you can learn how to:
   [monitor pending workloads](manage/monitor_pending_workloads).
 - As a batch administrator, you can learn how to [run a Kueue managed Jobs with a custom WorkloadPriority](manage/run_job_with_workload_priority).
 - As a batch administrator, you can learn how to [setup a MultiKueue environment](manage/setup_multikueue).
-- As a batch administrator, you can learn how to [use third-party certificate authority with Kueue](manage/cert_manager).
+- As a batch administrator, you can learn how to [use third-party certificate authority with Kueue](manage/productization/cert_manager).
 
 ### Batch user
 

--- a/site/content/zh-CN/docs/tasks/dev/integrate_a_custom_job.md
+++ b/site/content/zh-CN/docs/tasks/dev/integrate_a_custom_job.md
@@ -12,7 +12,7 @@ Kubernetes batch Job、MPIJob、RayJob 和 JobSet。
 使用 Kueue 管理缺乏内置集成的类 Job CRD 有三种选择：
 
 - 通过将自定义 Job 实例包装在 AppWrapper 中来利用内置的 AppWrapper 集成。
-  详情请参阅[运行包装的自定义工作负载](/docs/tasks/run/wrapped_custom_workload)。
+  详情请参阅[运行包装的自定义工作负载](/docs/tasks/run/external_workloads/wrapped_custom_workload)。
 - 作为 Kueue 仓库的一部分构建新的集成。
 - 作为外部控制器构建新的集成。
 

--- a/site/content/zh-CN/docs/tasks/manage/setup_multikueue.md
+++ b/site/content/zh-CN/docs/tasks/manage/setup_multikueue.md
@@ -6,7 +6,7 @@ description: >
   设置 MultiKueue 集群所需的额外步骤。
 ---
 
-本教程解释了如何在 MultiKueue 环境中配置管理集群和一个工作集群来运行 [JobSets](/zh-CN/docs/tasks/run_jobsets/#jobset-definition) 和 [batch/Jobs](/zh-CN/docs/tasks/run_jobs/#1-define-the-job)。
+本教程解释了如何在 MultiKueue 环境中配置管理集群和一个工作集群来运行 [JobSets](/zh-CN/docs/tasks/run/jobsets/#jobset-definition) 和 [batch/Jobs](/zh-CN/docs/tasks/run/jobs/#1-define-the-job)。
 
 请查看概念部分了解 [MultiKueue 概述](/zh-CN/docs/concepts/multikueue/)。
 

--- a/site/content/zh-CN/docs/tasks/run/external_workloads/argo_workflow.md
+++ b/site/content/zh-CN/docs/tasks/run/external_workloads/argo_workflow.md
@@ -14,7 +14,7 @@ description: >
 欲了解更多信息，请参见 [Kueue 概述](/zh-CN/docs/overview)。
 
 目前，Kueue 不直接支持 Argo Workflow 的 [Workflow](https://argo-workflows.readthedocs.io/en/latest/workflow-concepts/) 资源，
-但你可以利用 Kueue [管理普通 Pod](/zh-CN/docs/tasks/run_plain_pods) 的能力来集成它们。
+但你可以利用 Kueue [管理普通 Pod](/zh-CN/docs/tasks/run/plain_pods) 的能力来集成它们。
 
 ## 开始之前
 

--- a/site/content/zh-CN/docs/tasks/run/external_workloads/tektoncd.md
+++ b/site/content/zh-CN/docs/tasks/run/external_workloads/tektoncd.md
@@ -13,7 +13,7 @@ description: >
 本指南适用于对 Kueue 有基本了解的[批处理用户](/zh-CN/docs/tasks#batch-user)。
 欲了解更多，请参阅 [Kueue 概述](/zh-CN/docs/overview)。
 
-我们将演示如何基于 [Plain Pod](/zh-CN/docs/tasks/run_plain_pods) 集成，
+我们将演示如何基于 [Plain Pod](/zh-CN/docs/tasks/run/plain_pods) 集成，
 在 Kueue 中支持 Tekton Pipeline 任务的调度，其中来自 Pipeline 的每个 Pod 都表现为单个独立的 Plain Pod。
 
 ## 开始之前

--- a/site/content/zh-CN/docs/tasks/run/python_jobs.md
+++ b/site/content/zh-CN/docs/tasks/run/python_jobs.md
@@ -275,7 +275,7 @@ hello world
 ```
 
 你可以进一步自定义作业，并可以在 [Flux Operator 问题板](https://github.com/flux-framework/flux-operator/issues)上提问。
-最后，有关如何使用 YAML 在 Python 之外完成此操作的说明，请参见[运行 Flux MiniCluster](/zh-CN/docs/tasks/run_flux_minicluster/)。
+最后，有关如何使用 YAML 在 Python 之外完成此操作的说明，请参见[运行 Flux MiniCluster](/zh-CN/docs/tasks/run/external_workloads/flux_miniclusters/)。
 
 ### MPI Operator  {#mpi-operator-job}
 
@@ -378,5 +378,4 @@ pi is approximately 3.1410376000000002
 ```
 
 看起来像是 pi！🎉️🥧️
-如果你有兴趣在 Python 之外使用 YAML 运行此示例，请参见[运行 MPIJob](/zh-CN/docs/tasks/run_kubeflow_jobs/run_mpijobs/)。
-
+如果你有兴趣在 Python 之外使用 YAML 运行此示例，请参见[运行 MPIJob](/zh-CN/docs/tasks/run/kubeflow/mpijobs/)。

--- a/site/content/zh-CN/docs/tasks/run/run_cronjobs.md
+++ b/site/content/zh-CN/docs/tasks/run/run_cronjobs.md
@@ -17,7 +17,7 @@ description: 在启用了 Kueue 的环境里运行 CronJob
 - 已运行 Kubernetes 集群。
 - kubectl 命令行工具已与你的集群建立通信。
 - [Kueue 安装文档](/zh-CN/docs/installation)。
-- 集群已配置 [配额](/zh-CN/docs/tasks/administer_cluster_quotas)。
+- 集群已配置 [配额](/zh-CN/docs/tasks/manage/administer_cluster_quotas)。
 
 ## 0. 识别你命名空间中的可用队列 {#0-identify-the-queues-available-in-your-namespace}
 
@@ -80,4 +80,4 @@ job-sample-cronjob-28373363-e2aa0   user-queue   cluster-queue   68m
 job-sample-cronjob-28373364-b42ac   user-queue   cluster-queue   67m
 ```
 
-你还可以[监控 Workload 的状态](/zh-CN/docs/tasks/run_jobs#3-optional-monitor-the-status-of-the-workload)。
+你还可以[监控 Workload 的状态](/zh-CN/docs/tasks/run/jobs#3-optional-monitor-the-status-of-the-workload)。


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR fixes website dead links.

#### Which issue(s) this PR fixes:

Fixes #7285

#### Special notes for your reviewer:

I deployed the website locally check links using the [linkcheck](https://github.com/filiph/linkcheck) tool.

Before PR:

```console
$ linkcheck --no-check-anchors http://localhost:1313/docs/
Done crawling.                   

http://localhost:1313/docs/concepts/multikueue/
- (1200:4) 'Dispatch..' => http://localhost:1313/docs/concepts/multikueue/docs/tasks/run/multikueue/jobset (HTTP 404)

http://localhost:1313/docs/tasks/
- (1002:51) 'use thir..' => http://localhost:1313/docs/tasks/manage/cert_manager (HTTP 404)

http://localhost:1313/docs/tasks/dev/integrate_a_custom_job/
- (996:4) 'Running ..' => http://localhost:1313/docs/tasks/run/wrapped_custom_workload (HTTP 404)

http://localhost:1313/docs/tasks/dev/setup_multikueue_tas/
- (964:104) 'Topology..' => http://localhost:1313/docs/tasks/run/topology_aware_scheduling/ (HTTP 404)

http://localhost:1313/docs/tasks/manage/setup_multikueue/
- (1000:100) 'JobSets' => http://localhost:1313/docs/tasks/run_jobsets/#jobset-definition (HTTP 404)
- (1000:169) 'batch/Jobs' => http://localhost:1313/docs/tasks/run_jobs/#1-define-the-job (HTTP 404)

http://localhost:1313/docs/tasks/run/external_workloads/argo_workflow/
- (989:55) 'manage p..' => http://localhost:1313/docs/tasks/run_plain_pods (HTTP 404)

http://localhost:1313/docs/tasks/run/external_workloads/tektoncd/
- (988:89) 'Plain Pod' => http://localhost:1313/docs/tasks/run_plain_pods (HTTP 404)

http://localhost:1313/docs/tasks/run/python_jobs/
- (1684:78) 'Run A Fl..' => http://localhost:1313/docs/tasks/run_flux_minicluster/ (HTTP 404)
- (1915:84) 'Run an M..' => http://localhost:1313/docs/tasks/run_kubeflow_jobs/run_mpijobs/ (HTTP 404)

http://localhost:1313/docs/tasks/run/run_cronjobs/
- (996:20) 'quotas c..' => http://localhost:1313/docs/tasks/administer_cluster_quotas (HTTP 404)
- (1108:49) 'Monitori..' => http://localhost:1313/docs/tasks/run_jobs#3-optional-monitor-the-status-of-the-workload (HTTP 404)

Errors. Checked 33401 links, 193 destination URLs (1007 ignored), 11 have errors, 0 have warnings.

```

After:

```console
$ linkcheck --no-check-anchors http://localhost:1313/docs/
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```