### PR TITLE
Automated cherry pick of #8186: Fix the bug that allows adding a finished workload to the queue.

### DIFF
--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -47,6 +47,7 @@ var (
 	ErrLocalQueueDoesNotExistOrInactive = errors.New("localQueue doesn't exist or inactive")
 	ErrClusterQueueDoesNotExist         = errors.New("clusterQueue doesn't exist")
 	errClusterQueueAlreadyExists        = errors.New("clusterQueue already exists")
+	errWorkloadIsInadmissible           = errors.New("workload is inadmissible and can't be added to a LocalQueue")
 )
 
 // Option configures the manager.
@@ -320,7 +321,7 @@ func (m *Manager) AddLocalQueue(ctx context.Context, q *kueue.LocalQueue) error 
 		return fmt.Errorf("listing workloads that match the queue: %w", err)
 	}
 	for _, w := range workloads.Items {
-		if !workload.IsActive(&w) || workload.HasQuotaReservation(&w) {
+		if !workload.IsAdmissible(&w) {
 			continue
 		}
 
@@ -444,11 +445,8 @@ func (m *Manager) AddOrUpdateWorkload(w *kueue.Workload, opts ...workload.InfoOp
 }
 
 func (m *Manager) AddOrUpdateWorkloadWithoutLock(w *kueue.Workload, opts ...workload.InfoOption) error {
-	if !workload.IsActive(w) {
-		return fmt.Errorf("workload %q is inactive and can't be added to a LocalQueue", w.Name)
-	}
-	if workload.HasQuotaReservation(w) {
-		return fmt.Errorf("workload %q already has quota reserved and can't be added to a LocalQueue", w.Name)
+	if !workload.IsAdmissible(w) {
+		return errWorkloadIsInadmissible
 	}
 	qKey := queue.KeyFromWorkload(w)
 	q := m.localQueues[qKey]

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -56,6 +56,8 @@ func TestAddLocalQueueOrphans(t *testing.T) {
 		utiltestingapi.MakeWorkload("c", "earth").Queue("foo").Obj(),
 		utiltestingapi.MakeWorkload("d", "earth").Queue("foo").
 			ReserveQuota(utiltestingapi.MakeAdmission("cq").Obj()).Obj(),
+		utiltestingapi.MakeWorkload("e", "earth").Queue("foo").Active(false).Obj(),
+		utiltestingapi.MakeWorkload("f", "earth").Queue("foo").Finished().Obj(),
 		utiltestingapi.MakeWorkload("a", "moon").Queue("foo").Obj(),
 	)
 	manager := NewManager(kClient, nil)
@@ -412,6 +414,30 @@ func TestAddWorkload(t *testing.T) {
 		wantErr  error
 	}{
 		{
+			workload: utiltestingapi.MakeWorkload("finished", "earth").
+				Queue("foo").
+				Finished().
+				Obj(),
+			wantErr: errWorkloadIsInadmissible,
+		},
+		{
+			workload: utiltestingapi.MakeWorkload("inactive", "earth").
+				Queue("foo").
+				Active(false).
+				Obj(),
+			wantErr: errWorkloadIsInadmissible,
+		},
+		{
+			workload: utiltestingapi.MakeWorkload("quota_already_reserved", "earth").
+				Queue("foo").
+				ReserveQuota(&kueue.Admission{
+					ClusterQueue:      kueue.ClusterQueueReference(cq.Name),
+					PodSetAssignments: nil,
+				}).
+				Obj(),
+			wantErr: errWorkloadIsInadmissible,
+		},
+		{
 			workload: &kueue.Workload{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "earth",
@@ -421,33 +447,21 @@ func TestAddWorkload(t *testing.T) {
 			},
 		},
 		{
-			workload: &kueue.Workload{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "earth",
-					Name:      "non_existing_queue",
-				},
-				Spec: kueue.WorkloadSpec{QueueName: "baz"},
-			},
+			workload: utiltestingapi.MakeWorkload("non_existing_local_queue", "earth").
+				Queue("baz").
+				Obj(),
 			wantErr: ErrLocalQueueDoesNotExistOrInactive,
 		},
 		{
-			workload: &kueue.Workload{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "mars",
-					Name:      "non_existing_cluster_queue",
-				},
-				Spec: kueue.WorkloadSpec{QueueName: "bar"},
-			},
+			workload: utiltestingapi.MakeWorkload("non_existing_cluster_queue", "mars").
+				Queue("bar").
+				Obj(),
 			wantErr: ErrClusterQueueDoesNotExist,
 		},
 		{
-			workload: &kueue.Workload{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "mars",
-					Name:      "wrong_namespace",
-				},
-				Spec: kueue.WorkloadSpec{QueueName: "foo"},
-			},
+			workload: utiltestingapi.MakeWorkload("wrong_namespace", "mars").
+				Queue("foo").
+				Obj(),
 			wantErr: ErrLocalQueueDoesNotExistOrInactive,
 		},
 	}

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -266,8 +266,8 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			queueOptions = append(queueOptions, workload.WithPreprocessedDRAResources(draResources))
 		}
 
-		if workload.IsActive(&wl) && !workload.HasQuotaReservation(&wl) {
-			if err := r.queues.AddOrUpdateWorkload(&wl, queueOptions...); err != nil {
+		if workload.IsAdmissible(&wl) {
+			if err := r.queues.AddOrUpdateWorkload(wl.DeepCopy(), queueOptions...); err != nil {
 				log.V(2).Info("Failed to add DRA workload to queue", "error", err)
 				return ctrl.Result{}, err
 			}
@@ -802,7 +802,7 @@ func (r *WorkloadReconciler) Create(e event.TypedCreateEvent[*kueue.Workload]) b
 		return true
 	}
 
-	if workload.IsActive(e.Object) && !workload.HasQuotaReservation(e.Object) {
+	if workload.IsAdmissible(e.Object) {
 		if err := r.queues.AddOrUpdateWorkload(wlCopy); err != nil {
 			log.V(2).Info("ignored an error for now", "error", err)
 		}
@@ -1149,7 +1149,7 @@ func (h *resourceUpdatesHandler) queueReconcileForPending(ctx context.Context, q
 			continue
 		}
 
-		if workload.IsActive(wlCopy) && !workload.HasQuotaReservation(wlCopy) {
+		if workload.IsAdmissible(wlCopy) {
 			if err = h.r.queues.AddOrUpdateWorkload(wlCopy); err != nil {
 				log.V(2).Info("ignored an error for now", "error", err)
 			}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -1129,6 +1129,11 @@ func IsActive(w *kueue.Workload) bool {
 	return ptr.Deref(w.Spec.Active, true)
 }
 
+// IsAdmissible returns true if the workload can be added to the queue.
+func IsAdmissible(w *kueue.Workload) bool {
+	return !IsFinished(w) && IsActive(w) && !HasQuotaReservation(w)
+}
+
 // HasDRA returns true if the workload has DRA resources (ResourceClaims or ResourceClaimTemplates).
 func HasDRA(w *kueue.Workload) bool {
 	return HasResourceClaim(w) || HasResourceClaimTemplates(w)

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -699,6 +699,64 @@ var _ = ginkgo.Describe("Workload controller interaction with scheduler", ginkgo
 				}, util.ShortTimeout, util.Interval).ShouldNot(gomega.Succeed())
 			})
 		})
+
+		ginkgo.It("should not temporarily admit a finished workload", func() {
+			wl = utiltestingapi.MakeWorkload("wl1", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "1").
+				RuntimeClass(runtimeClassName).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+
+			wlKey := client.ObjectKeyFromObject(wl)
+
+			ginkgo.By("creating a workload", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("waiting for admission", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+			})
+
+			ginkgo.By("finishing the workload", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
+					g.Expect(workload.Finish(ctx, k8sClient, wl, "ByTest", "By test", util.RealClock)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("waiting for finish", func() {
+				util.ExpectWorkloadToFinish(ctx, k8sClient, wlKey)
+			})
+
+			ginkgo.By("changing the runtime class", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					runtimeClassKey := client.ObjectKeyFromObject(runtimeClass)
+					g.Expect(k8sClient.Get(ctx, runtimeClassKey, runtimeClass)).To(gomega.Succeed())
+					if runtimeClass.ObjectMeta.Annotations == nil {
+						runtimeClass.ObjectMeta.Annotations = map[string]string{}
+					}
+					runtimeClass.ObjectMeta.Annotations["foo"] = "bar"
+					g.Expect(k8sClient.Update(ctx, runtimeClass)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("checking no 'quota reserved' event appearing for the workload", func() {
+				gomega.Consistently(func(g gomega.Gomega) {
+					count, err := utiltesting.HasMatchingEventAppearedTimes(ctx, k8sClient, func(e *corev1.Event) bool {
+						return e.Reason == "QuotaReserved" &&
+							e.Type == corev1.EventTypeNormal &&
+							e.InvolvedObject.Kind == "Workload" &&
+							e.InvolvedObject.Name == wl.Name &&
+							e.InvolvedObject.Namespace == wl.Namespace
+					})
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+					g.Expect(count).To(gomega.Equal(1))
+				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
Cherry pick of #8186 on release-0.15.

#8186: Fix the bug that allows adding a finished workload to the queue.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed a bug that Kueue's scheduler would re-evaluate and update already finished workloads, significantly
impacting overall scheduling throughput. This re-evaluation of a finished workload would be triggered when:
1. Kueue is restarted
2. There is any event related to LimitRange or RuntimeClass instances referenced by the workload
```