### PR TITLE
Fix test environment not being torn down in the RayJob integration test suite

### DIFF
--- a/test/integration/singlecluster/controller/jobs/rayjob/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/suite_test.go
@@ -65,7 +65,7 @@ var _ = ginkgo.BeforeSuite(func() {
 })
 
 var _ = ginkgo.AfterSuite(func() {
-	fwk.StopManager(ctx)
+	fwk.Teardown()
 })
 
 func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
The suite is not cleaning up the test env after finishing. This causes processes (etcd, kube-apiserver etc.) to keep running after the tests have finished - the file descriptors won't be released which might hit system limits (especially noticeable during local development).

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
Thanks to @olekzabl for raising the issue. I was able to quickly spot the issue, so posting a PR.

To see the impact of this PR, run:
```sh
INTEGRATION_TARGET='test/integration/singlecluster/controller/jobs/rayjob' make test-integration
```
on the `main` branch. Then:
```sh
ps -ef | grep -E 'kube-apiserver|etcd'
```
should show 8 leftover processes running (4 etcd, 4 kube-apiserver - since the default parallelism is set to 4). 

The test itself is stopping the manager anyway, so the removed line seemed to be a no-op anyway.
https://github.com/kubernetes-sigs/kueue/blob/cbcb721b0e1b3821183446c060b6d99639618598/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go#L70-L72

#### Does this PR introduce a user-facing change?
```release-note
NONE
```