### PR TITLE
Automated cherry pick of #8242: Self-nominate as approver for dependencies go.mod, go.sum and tests.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,19 +1,24 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-approvers:
-- gabesaba
-- mimowo
-- tenzen-y
+filters:
+  # Catch-all (required when using filters)
+  ".*":
+    approvers:
+      - kueue-approvers
+    reviewers:
+      - kueue-reviewers
+    emeritus_approvers:
+      - ahg-g
+      - alculquicondor
+      - denkensk
+      - kerthcet
 
-reviewers:
-- gabesaba
-- mbobrovskyi
-- mimowo
-- pbundyra
-- tenzen-y
+  # Any directory depth: go.mod or go.sum
+  "go\\.(mod|sum\\.sum)$":
+    approvers:
+      - dependency-approvers
 
-emeritus_approvers:
-- ahg-g
-- alculquicondor
-- denkensk
-- kerthcet
+  # Any directory depth: *_test.go
+  "*_test.go$":
+    approvers:
+      - test-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,17 @@
+aliases:
+  kueue-approvers:
+    - gabesaba
+    - mimowo
+    - tenzen-y
+  kueue-reviewers:
+    - gabesaba
+    - mbobrovskyi
+    - mimowo
+    - pbundyra
+    - tenzen-y
+    - kannon92
+    - pajakd
+  dependency-approvers:
+    - mbobrovskyi
+  test-approvers:
+    - mbobrovskyi

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -5,3 +5,6 @@ reviewers:
 
 emeritus_approvers:
 - trasc
+
+approvers:
+- test-approvers


### PR DESCRIPTION
Cherry pick of #8242 on release-0.14.

#8242: Self-nominate as approver for dependencies go.mod, go.sum and tests.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```