### PR TITLE
[Follow-up] Remove unused KeepAdmissionCheckPending method

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter.go
+++ b/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter.go
@@ -160,13 +160,6 @@ func (a *Adapter) DeleteRemoteObject(ctx context.Context, remoteClient client.Cl
 	return client.IgnoreNotFound(remoteClient.Delete(ctx, obj, client.PropagationPolicy(metav1.DeletePropagationBackground)))
 }
 
-// KeepAdmissionCheckPending returns false,
-// indicating that admission checks should not be kept pending by default.
-// This can be overridden by specific adapters if needed.
-func (a *Adapter) KeepAdmissionCheckPending() bool {
-	return false
-}
-
 // IsJobManagedByKueue checks if the job object identified by the given key is managed by Kueue.
 // It returns:
 // - a bool indicating if the job is managed by Kueue

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -245,10 +245,6 @@ type MultiKueueAdapter interface {
 	// - a reason indicating why the job is not managed by Kueue
 	// - any API error encountered during the check
 	IsJobManagedByKueue(ctx context.Context, localClient client.Client, key types.NamespacedName) (bool, string, error)
-	// KeepAdmissionCheckPending returns true if the state of the multikueue admission check should be
-	// kept Pending while the job runs in a worker. This might be needed to keep the managers job
-	// suspended and not start the execution locally.
-	KeepAdmissionCheckPending() bool
 	// GVK returns GVK (Group Version Kind) for the job.
 	GVK() schema.GroupVersionKind
 }

--- a/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter.go
@@ -99,10 +99,6 @@ func (b *multiKueueAdapter) GVK() schema.GroupVersionKind {
 	return gvk
 }
 
-func (b *multiKueueAdapter) KeepAdmissionCheckPending() bool {
-	return false
-}
-
 func (b *multiKueueAdapter) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName) (bool, string, error) {
 	aw := awv1beta2.AppWrapper{}
 	err := c.Get(ctx, key, &aw)

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -170,10 +170,6 @@ func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, remoteClient
 	return client.IgnoreNotFound(remoteClient.Delete(ctx, &job, client.PropagationPolicy(metav1.DeletePropagationBackground)))
 }
 
-func (b *multiKueueAdapter) KeepAdmissionCheckPending() bool {
-	return false
-}
-
 func (b *multiKueueAdapter) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName) (bool, string, error) {
 	if !features.Enabled(features.MultiKueueBatchJobWithManagedBy) {
 		return true, "", nil

--- a/pkg/controller/jobs/jobset/jobset_multikueue_adapter.go
+++ b/pkg/controller/jobs/jobset/jobset_multikueue_adapter.go
@@ -95,10 +95,6 @@ func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, remoteClient
 	return client.IgnoreNotFound(remoteClient.Delete(ctx, &job))
 }
 
-func (b *multiKueueAdapter) KeepAdmissionCheckPending() bool {
-	return false
-}
-
 func (b *multiKueueAdapter) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName) (bool, string, error) {
 	js := jobset.JobSet{}
 	err := c.Get(ctx, key, &js)

--- a/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_multikueue_adapter.go
+++ b/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_multikueue_adapter.go
@@ -74,10 +74,6 @@ func (a adapter[PtrT, T]) GVK() schema.GroupVersionKind {
 	return a.gvk
 }
 
-func (a adapter[PtrT, T]) KeepAdmissionCheckPending() bool {
-	return false
-}
-
 func (a adapter[PtrT, T]) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName) (bool, string, error) {
 	kJobObj := PtrT(new(T))
 	err := c.Get(ctx, key, kJobObj)

--- a/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter.go
+++ b/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter.go
@@ -95,10 +95,6 @@ func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, remoteClient
 	return client.IgnoreNotFound(remoteClient.Delete(ctx, &job))
 }
 
-func (b *multiKueueAdapter) KeepAdmissionCheckPending() bool {
-	return false
-}
-
 func (b *multiKueueAdapter) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName) (bool, string, error) {
 	job := kfmpi.MPIJob{}
 	err := c.Get(ctx, key, &job)

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter.go
@@ -86,10 +86,6 @@ func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, remoteClient
 	return nil
 }
 
-func (b *multiKueueAdapter) KeepAdmissionCheckPending() bool {
-	return false
-}
-
 func (b *multiKueueAdapter) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName) (bool, string, error) {
 	return true, "", nil
 }

--- a/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter.go
+++ b/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter.go
@@ -95,10 +95,6 @@ func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, remoteClient
 	return client.IgnoreNotFound(remoteClient.Delete(ctx, &job))
 }
 
-func (b *multiKueueAdapter) KeepAdmissionCheckPending() bool {
-	return false
-}
-
 func (b *multiKueueAdapter) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName) (bool, string, error) {
 	job := rayv1.RayCluster{}
 	err := c.Get(ctx, key, &job)

--- a/pkg/controller/jobs/rayjob/rayjob_multikueue_adapter.go
+++ b/pkg/controller/jobs/rayjob/rayjob_multikueue_adapter.go
@@ -94,10 +94,6 @@ func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, remoteClient
 	return client.IgnoreNotFound(remoteClient.Delete(ctx, &job))
 }
 
-func (b *multiKueueAdapter) KeepAdmissionCheckPending() bool {
-	return false
-}
-
 func (b *multiKueueAdapter) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName) (bool, string, error) {
 	job := rayv1.RayJob{}
 	err := c.Get(ctx, key, &job)

--- a/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter.go
+++ b/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter.go
@@ -95,10 +95,6 @@ func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, remoteClient
 	return client.IgnoreNotFound(remoteClient.Delete(ctx, &job))
 }
 
-func (b *multiKueueAdapter) KeepAdmissionCheckPending() bool {
-	return false
-}
-
 func (b *multiKueueAdapter) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName) (bool, string, error) {
 	trainjob := kftrainerapi.TrainJob{}
 	err := c.Get(ctx, key, &trainjob)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
The KeepAdmissionCheckPending() method is no longer needed after the fix #8189. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #5891 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```