### PR TITLE
Remove outdated suspend: true requirement from docs and examples

### DIFF
--- a/site/content/en/docs/tasks/run/jobs.md
+++ b/site/content/en/docs/tasks/run/jobs.md
@@ -47,13 +47,14 @@ Queue.
 ## 1. Define the Job
 
 Running a Job in Kueue is similar to [running a Job in a Kubernetes cluster](https://kubernetes.io/docs/tasks/job/)
-without Kueue. However, you must consider the following differences:
+without Kueue. However, you must set the `kueue.x-k8s.io/queue-name` label selecting the LocalQueue you want to submit the Job to.
+You can also skip setting the "queue name" label if you use [LocalQueue defaulting](/docs/tasks/manage/enforce_job_management/setup_default_local_queue).
 
-- You should create the Job in a [suspended state](https://kubernetes.io/docs/concepts/workloads/controllers/job/#suspending-a-job),
-  as Kueue will decide when it's the best time to start the Job.
-- You have to set the Queue you want to submit the Job to. Use the
- `kueue.x-k8s.io/queue-name` label.
-- You should include the resource requests for each Job Pod.
+You should specify [resource requests or limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for each Job Pod.
+If you specify only limits, Kueue will treat the limit values as requests. See [how Kueue uses resource requests](/docs/concepts/workload#resource-requests) for details.
+
+Note that you do not need to create the Job in a [suspended state](https://kubernetes.io/docs/concepts/workloads/controllers/job/#suspending-a-job).
+Kueue automatically manages the Job's suspension via webhook and decides when it's the best time to start the Job.
 
 Here is a sample Job with three Pods that just sleep for a few seconds.
 

--- a/site/content/en/docs/tasks/run/run_cronjobs.md
+++ b/site/content/en/docs/tasks/run/run_cronjobs.md
@@ -43,15 +43,17 @@ Queue.
 ## 1. Define the Job
 
 Running a CronJob in Kueue is similar to [running a CronJob in a Kubernetes cluster](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/)
-without Kueue. However, you must consider the following differences:
+without Kueue. However, you must set the `kueue.x-k8s.io/queue-name` label in `jobTemplate.metadata` selecting the LocalQueue you want to submit the Job to.
+You can also skip setting the "queue name" label if you use [LocalQueue defaulting](/docs/tasks/manage/enforce_job_management/setup_default_local_queue).
 
-- You should set the JobTemplate in CronJob in a [suspended state](https://kubernetes.io/docs/concepts/workloads/controllers/job/#suspending-a-job),
-  as Kueue will decide when it's the best time to start the Job.
-- You have to set the Queue you want to submit the Job to. Use the
- `kueue.x-k8s.io/queue-name` label in `jobTemplate.metadata`
-- You should include the resource requests for each Job Pod.
-- You should set the [`spec.concurrencyPolicy`](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#concurrency-policy) to control the concurrency policy. The default is `Allow`. You can also set it to `Forbid` to prevent concurrent runs.
-- You should set the [`spec.startingDeadlineSeconds`](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#starting-deadline) to control the deadline for starting the Job. The default is no deadline.
+You should also:
+
+- Specify [resource requests or limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for each Job Pod. If you specify only limits, Kueue will treat the limit values as requests. See [how Kueue uses resource requests](/docs/concepts/workload#resource-requests) for details.
+- Set the [`spec.concurrencyPolicy`](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#concurrency-policy) to control the concurrency policy. The default is `Allow`. You can also set it to `Forbid` to prevent concurrent runs.
+- Set the [`spec.startingDeadlineSeconds`](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#starting-deadline) to control the deadline for starting the Job. The default is no deadline.
+
+Note that you do not need to set the JobTemplate in CronJob in a [suspended state](https://kubernetes.io/docs/concepts/workloads/controllers/job/#suspending-a-job).
+Kueue automatically manages the Job's suspension via webhook and decides when it's the best time to start the Job.
 
 Here is a sample CronJob with three Pods that just sleep for 10 seconds. The CronJob runs every minute.
 

--- a/site/static/examples/admission-fs/lq-a-simple-job.yaml
+++ b/site/static/examples/admission-fs/lq-a-simple-job.yaml
@@ -7,7 +7,6 @@ metadata:
     kueue.x-k8s.io/queue-name: lq-a
 spec:
   parallelism: 1
-  suspend: true
   template:
     spec:
       containers:

--- a/site/static/examples/admission-fs/lq-b-simple-job.yaml
+++ b/site/static/examples/admission-fs/lq-b-simple-job.yaml
@@ -7,7 +7,6 @@ metadata:
     kueue.x-k8s.io/queue-name: lq-b
 spec:
   parallelism: 1
-  suspend: true
   template:
     spec:
       containers:

--- a/site/static/examples/appwrapper/deployment-sample.yaml
+++ b/site/static/examples/appwrapper/deployment-sample.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     kueue.x-k8s.io/queue-name: user-queue
 spec:
-  suspend: true
   components:
   - podSets:
     - path: "template.spec.template"

--- a/site/static/examples/jobs/ray-job-sample.yaml
+++ b/site/static/examples/jobs/ray-job-sample.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     kueue.x-k8s.io/queue-name: user-queue
 spec:
-  suspend: true
   shutdownAfterJobFinishes: true
   # submissionMode specifies how RayJob submits the Ray job to the RayCluster.
   # The default value is "K8sJobMode", meaning RayJob will submit the Ray job via a submitter Kubernetes Job.

--- a/site/static/examples/jobs/sample-job-partial-admission.yaml
+++ b/site/static/examples/jobs/sample-job-partial-admission.yaml
@@ -10,7 +10,6 @@ metadata:
 spec:
   parallelism: 20
   completions: 20
-  suspend: true
   template:
     spec:
       containers:

--- a/site/static/examples/jobs/sample-job.yaml
+++ b/site/static/examples/jobs/sample-job.yaml
@@ -8,7 +8,6 @@ metadata:
 spec:
   parallelism: 3
   completions: 3
-  suspend: true
   template:
     spec:
       containers:

--- a/site/static/examples/jobs/sample-scalable-job.yaml
+++ b/site/static/examples/jobs/sample-scalable-job.yaml
@@ -10,7 +10,6 @@ metadata:
 spec:
   parallelism: 3
   completions: 100
-  suspend: true
   template:
     spec:
       containers:

--- a/site/static/examples/multikueue/dev/sample-tas-job.yaml
+++ b/site/static/examples/multikueue/dev/sample-tas-job.yaml
@@ -8,7 +8,6 @@ metadata:
 spec:
   parallelism: 2
   completions: 2
-  suspend: true
   template:
     metadata:
       annotations:
@@ -38,7 +37,6 @@ metadata:
 spec:
   parallelism: 3
   completions: 3
-  suspend: true
   template:
     spec:
       restartPolicy: Never

--- a/site/static/examples/provisioning/sample-job.yaml
+++ b/site/static/examples/provisioning/sample-job.yaml
@@ -10,7 +10,6 @@ metadata:
 spec:
   parallelism: 3
   completions: 3
-  suspend: true
   template:
     spec:
       tolerations:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind documentation

#### What this PR does / why we need it:
Remove outdated suspend: true requirement from docs and examples

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8228 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```