### PR TITLE
Adjust waitForPodsReady snippet to use blockAdmission: false and clarify example configuration

### DIFF
--- a/site/content/en/docs/tasks/manage/setup_wait_for_pods_ready.md
+++ b/site/content/en/docs/tasks/manage/setup_wait_for_pods_ready.md
@@ -43,7 +43,7 @@ fields:
     waitForPodsReady:
       timeout: 10m
       recoveryTimeout: 3m
-      blockAdmission: true
+      blockAdmission: false
       requeuingStrategy:
         timestamp: Eviction | Creation
         backoffLimitCount: 5
@@ -122,6 +122,12 @@ In this example we demonstrate the impact of enabling `waitForPodsReady` in Kueu
 We create two jobs which both require all their pods to be running at the same
 time to complete. The cluster has enough resources to support running one of the
 jobs at the same time, but not both.
+
+{{% alert title="Note" color="primary" %}}
+This example uses `blockAdmission: true` to enable sequential admission and
+prevent deadlock situations. Note that [Topology-Aware Scheduling](/docs/concepts/topology_aware_scheduling)
+is an alternative solution to the problems mentioned in this guide.
+{{% /alert %}}
 
 {{% alert title="Note" color="primary" %}}
 In this example we use a cluster with autoscaling disabled in order to simulate


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind documentation

#### What this PR does / why we need it:
Adjust waitForPodsReady snippet to use blockAdmission: false and clarify example configuration

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8289 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```