### PR TITLE
Automated cherry pick of #8324: Make sure the scheduler logs unhealthyNodes when eviction fails

### DIFF
--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -589,7 +589,7 @@ func TestScheduleForTAS(t *testing.T) {
 			},
 			wantEvents: []utiltesting.EventRecord{
 				utiltesting.MakeEventRecord("default", "foo", "EvictedDueToNodeFailures", corev1.EventTypeNormal).
-					Message("Workload was evicted as there was no replacement for a failed node: x0").
+					Message("Workload was evicted as there was no replacement for unhealthy node(s): x0").
 					Obj(),
 			},
 		},
@@ -2498,7 +2498,7 @@ func TestScheduleForTAS(t *testing.T) {
 			},
 			wantEvents: []utiltesting.EventRecord{
 				utiltesting.MakeEventRecord("default", "foo", "EvictedDueToNodeFailures", corev1.EventTypeNormal).
-					Message("Workload was evicted as there was no replacement for a failed node: x0").Obj(),
+					Message("Workload was evicted as there was no replacement for unhealthy node(s): x0").Obj(),
 			},
 		},
 		"does not admit workload when node does not match required affinity": {
@@ -5844,7 +5844,7 @@ func TestScheduleForTASWhenWorkloadModifiedConcurrently(t *testing.T) {
 						Type:               kueue.WorkloadEvicted,
 						Status:             metav1.ConditionTrue,
 						Reason:             "NodeFailures",
-						Message:            "Workload was evicted as there was no replacement for a failed node: x0",
+						Message:            "Workload was evicted as there was no replacement for unhealthy node(s): x0",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{
@@ -5855,7 +5855,7 @@ func TestScheduleForTASWhenWorkloadModifiedConcurrently(t *testing.T) {
 			},
 			wantEvents: []utiltesting.EventRecord{
 				utiltesting.MakeEventRecord("default", "wl", "EvictedDueToNodeFailures", corev1.EventTypeNormal).
-					Message("Workload was evicted as there was no replacement for a failed node: x0").
+					Message("Workload was evicted as there was no replacement for unhealthy node(s): x0").
 					Obj(),
 			},
 		},


### PR DESCRIPTION
Cherry pick of #8324 on release-0.15.

#8324: Make sure the scheduler logs unhealthyNodes when eviction fails

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```