### PR TITLE
Automated cherry pick of #8324: Make sure the scheduler logs unhealthyNodes when eviction fails

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -22,6 +22,7 @@ import (
 	"maps"
 	"slices"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -239,7 +240,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 		if features.Enabled(features.TASFailedNodeReplacementFailFast) && workload.HasTopologyAssignmentWithUnhealthyNode(e.Obj) && mode != flavorassigner.Fit {
 			// evict workload we couldn't find the replacement for
 			if err := s.evictWorkloadAfterFailedTASReplacement(ctx, log, e.Obj.DeepCopy()); client.IgnoreNotFound(err) != nil {
-				log.V(2).Error(err, "Failed to evict workload after failed try to find a node replacement")
+				log.V(2).Error(err, "Failed to evict workload")
 				continue
 			}
 			e.status = evicted
@@ -576,10 +577,12 @@ func (s *Scheduler) getInitialAssignments(log logr.Logger, wl *workload.Info, sn
 }
 
 func (s *Scheduler) evictWorkloadAfterFailedTASReplacement(ctx context.Context, log logr.Logger, wl *kueue.Workload) error {
-	log.V(3).Info("Evicting workload after failed try to find a node replacement; TASFailedNodeReplacementFailFast enabled")
-	msg := fmt.Sprintf("Workload was evicted as there was no replacement for a failed node: %s", wl.Status.UnhealthyNodes[0].Name)
+	unhealthyNodes := workload.UnhealthyNodeNames(wl)
+	unhealthyNodesCsv := strings.Join(unhealthyNodes, ",")
+	log.V(3).Info("Evicting workload after failed try to find a node replacement; TASFailedNodeReplacementFailFast enabled", "unhealthyNodes", unhealthyNodes)
+	msg := fmt.Sprintf("Workload was evicted as there was no replacement for unhealthy node(s): %s", unhealthyNodesCsv)
 	if err := workload.Evict(ctx, s.client, s.recorder, wl, kueue.WorkloadEvictedDueToNodeFailures, msg, "", s.clock, workload.EvictWithLooseOnApply()); err != nil {
-		return err
+		return fmt.Errorf("failed to evict workload after failed try to find a replacement for unhealthy nodes: %s, %w", unhealthyNodesCsv, err)
 	}
 	return nil
 }

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -588,7 +588,7 @@ func TestScheduleForTAS(t *testing.T) {
 			},
 			wantEvents: []utiltesting.EventRecord{
 				utiltesting.MakeEventRecord("default", "foo", "EvictedDueToNodeFailures", corev1.EventTypeNormal).
-					Message("Workload was evicted as there was no replacement for a failed node: x0").
+					Message("Workload was evicted as there was no replacement for unhealthy node(s): x0").
 					Obj(),
 			},
 		},
@@ -2499,7 +2499,7 @@ func TestScheduleForTAS(t *testing.T) {
 			},
 			wantEvents: []utiltesting.EventRecord{
 				utiltesting.MakeEventRecord("default", "foo", "EvictedDueToNodeFailures", corev1.EventTypeNormal).
-					Message("Workload was evicted as there was no replacement for a failed node: x0").Obj(),
+					Message("Workload was evicted as there was no replacement for unhealthy node(s): x0").Obj(),
 			},
 		},
 		"does not admit workload when node does not match required affinity": {
@@ -5825,7 +5825,7 @@ func TestScheduleForTASWhenWorkloadModifiedConcurrently(t *testing.T) {
 						Type:               kueue.WorkloadEvicted,
 						Status:             metav1.ConditionTrue,
 						Reason:             "NodeFailures",
-						Message:            "Workload was evicted as there was no replacement for a failed node: x0",
+						Message:            "Workload was evicted as there was no replacement for unhealthy node(s): x0",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{
@@ -5836,7 +5836,7 @@ func TestScheduleForTASWhenWorkloadModifiedConcurrently(t *testing.T) {
 			},
 			wantEvents: []utiltesting.EventRecord{
 				utiltesting.MakeEventRecord("default", "wl", "EvictedDueToNodeFailures", corev1.EventTypeNormal).
-					Message("Workload was evicted as there was no replacement for a failed node: x0").
+					Message("Workload was evicted as there was no replacement for unhealthy node(s): x0").
 					Obj(),
 			},
 		},


### PR DESCRIPTION
Cherry pick of #8324 on release-0.14.

#8324: Make sure the scheduler logs unhealthyNodes when eviction fails

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```