### PR TITLE
Automated cherry pick of #8279: TAS: fixed performance issue due to unncessary (empty) request by TopologyUngater

### DIFF
--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -2184,8 +2184,8 @@ func TestReconcile(t *testing.T) {
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
 					Label(kueue.PodGroupPodIndexLabel, "3").
 					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
-					NodeSelector(tasBlockLabel, "b1").
-					NodeSelector(tasRackLabel, "r2").
+					NodeSelector(tasBlockLabel, "b2").
+					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 			},
 			cmpNS: true,


### PR DESCRIPTION
Cherry pick of #8279 on release-0.14.

#8279: TAS: fixed performance issue due to unncessary (empty) request by TopologyUngater

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
TAS: fixed performance issue due to unncessary (empty) request by TopologyUngater
```