### PR TITLE
Automated cherry pick of #8308: Remove IsSuspended check from CRD MultiKueue adapters to enable status sync during suspension

### DIFF
--- a/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -42,8 +41,6 @@ type multiKueueAdapter struct{}
 var _ jobframework.MultiKueueAdapter = (*multiKueueAdapter)(nil)
 
 func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) error {
-	log := ctrl.LoggerFrom(ctx)
-
 	localAppWrapper := awv1beta2.AppWrapper{}
 	err := localClient.Get(ctx, key, &localAppWrapper)
 	if err != nil {
@@ -58,11 +55,6 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 
 	// if the remote exists, just copy the status
 	if err == nil {
-		if localAppWrapper.Spec.Suspend {
-			// Ensure the appwrapper is unsuspended before updating its status; otherwise, it will fail when patching the spec.
-			log.V(2).Info("Skipping the sync since the local appwrapper is still suspended")
-			return nil
-		}
 		return clientutil.PatchStatus(ctx, localClient, &localAppWrapper, func() (client.Object, bool, error) {
 			localAppWrapper.Status = remoteAppWrapper.Status
 			return &localAppWrapper, true, nil

--- a/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter_test.go
@@ -112,7 +112,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
-		"status is not synced if local appwrapper is still suspended": {
+		"sync status from remote while local appwrapper is suspended": {
 			managersAppWrappers: []awv1beta2.AppWrapper{
 				*baseAppWrapperManagedByKueueBuilder.DeepCopy().Suspend(true).Obj(),
 			},
@@ -130,7 +130,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			wantManagersAppWrappers: []awv1beta2.AppWrapper{
 				*baseAppWrapperManagedByKueueBuilder.DeepCopy().
 					Suspend(true).
-					SetPhase(awv1beta2.AppWrapperEmpty).
+					SetPhase(awv1beta2.AppWrapperSuspended).
 					Obj(),
 			},
 			wantWorkerAppWrappers: []awv1beta2.AppWrapper{

--- a/pkg/controller/jobs/jobset/jobset_multikueue_adapter.go
+++ b/pkg/controller/jobs/jobset/jobset_multikueue_adapter.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
@@ -42,8 +41,6 @@ type multiKueueAdapter struct{}
 var _ jobframework.MultiKueueAdapter = (*multiKueueAdapter)(nil)
 
 func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) error {
-	log := ctrl.LoggerFrom(ctx)
-
 	localJob := jobset.JobSet{}
 	err := localClient.Get(ctx, key, &localJob)
 	if err != nil {
@@ -58,12 +55,6 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 
 	// if the remote exists, just copy the status
 	if err == nil {
-		if fromObject(&localJob).IsSuspended() {
-			// Ensure the job is unsuspended before updating its status; otherwise, it will fail when patching the spec.
-			log.V(2).Info("Skipping the sync since the local job is still suspended")
-			return nil
-		}
-
 		return clientutil.PatchStatus(ctx, localClient, &localJob, func() (client.Object, bool, error) {
 			localJob.Status = remoteJob.Status
 			return &localJob, true, nil

--- a/pkg/controller/jobs/jobset/jobset_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/jobset/jobset_multikueue_adapter_test.go
@@ -139,7 +139,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
-		"skip to sync status from remote suspended jobset": {
+		"sync status from remote while local jobset is suspended": {
 			managersJobSets: []jobsetapi.JobSet{
 				*baseJobSetManagedByKueueBuilder.Clone().
 					Suspend(true).
@@ -171,6 +171,18 @@ func TestMultiKueueAdapter(t *testing.T) {
 			wantManagersJobSets: []jobsetapi.JobSet{
 				*baseJobSetManagedByKueueBuilder.Clone().
 					Suspend(true).
+					JobsStatus(
+						jobsetapi.ReplicatedJobStatus{
+							Name:      "replicated-job-1",
+							Ready:     1,
+							Succeeded: 1,
+						},
+						jobsetapi.ReplicatedJobStatus{
+							Name:      "replicated-job-2",
+							Ready:     3,
+							Succeeded: 0,
+						},
+					).
 					Obj(),
 			},
 			wantWorkerJobSets: []jobsetapi.JobSet{

--- a/pkg/controller/jobs/kubeflow/jobs/jaxjob/jaxjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/jaxjob/jaxjob_multikueue_adapter_test.go
@@ -108,7 +108,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
-		"skip to sync status from remote suspended jaxjob": {
+		"sync status from remote while local jaxjob is suspended": {
 			managersJAXJobs: []kftraining.JAXJob{
 				*jaxJobBuilder.Clone().
 					Suspend(true).
@@ -128,6 +128,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			wantManagersJAXJobs: []kftraining.JAXJob{
 				*jaxJobBuilder.Clone().
 					Suspend(true).
+					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
 					Obj(),
 			},
 			wantWorkerJAXJobs: []kftraining.JAXJob{

--- a/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_multikueue_adapter_test.go
@@ -109,7 +109,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
-		"skip to sync status from remote suspended PaddleJob": {
+		"sync status from remote while local PaddleJob is suspended": {
 			managersPaddleJobs: []kftraining.PaddleJob{
 				*paddleJobBuilder.Clone().
 					Suspend(true).
@@ -129,6 +129,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			wantManagersPaddleJobs: []kftraining.PaddleJob{
 				*paddleJobBuilder.Clone().
 					Suspend(true).
+					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
 					Obj(),
 			},
 			wantWorkerPaddleJobs: []kftraining.PaddleJob{

--- a/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorch_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorch_multikueue_adapter_test.go
@@ -108,7 +108,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
-		"skip to sync status from remote suspended pytorchjob": {
+		"sync status from remote while local pytorchjob is suspended": {
 			managersPyTorchJobs: []kftraining.PyTorchJob{
 				*pyTorchJobBuilder.Clone().
 					Suspend(true).
@@ -128,6 +128,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			wantManagersPyTorchJobs: []kftraining.PyTorchJob{
 				*pyTorchJobBuilder.Clone().
 					Suspend(true).
+					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
 					Obj(),
 			},
 			wantWorkerPyTorchJobs: []kftraining.PyTorchJob{

--- a/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_multikueue_adapter_test.go
@@ -108,7 +108,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
-		"skip to sync status from remote suspended tfjob": {
+		"sync status from remote while local tfjob is suspended": {
 			managersTFJobs: []kftraining.TFJob{
 				*tfJobBuilder.Clone().
 					Suspend(true).
@@ -128,6 +128,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			wantManagersTFJobs: []kftraining.TFJob{
 				*tfJobBuilder.Clone().
 					Suspend(true).
+					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
 					Obj(),
 			},
 			wantWorkerTFJobs: []kftraining.TFJob{

--- a/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_multikueue_adapter_test.go
@@ -108,7 +108,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
-		"skip to sync status from remote suspended XgBoostJob": {
+		"sync status from remote while local XgBoostJob is suspended": {
 			managersXGBoostJobs: []kftraining.XGBoostJob{
 				*xgboostJobBuilder.Clone().
 					Suspend(true).
@@ -129,6 +129,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			wantManagersXGBoostJobs: []kftraining.XGBoostJob{
 				*xgboostJobBuilder.Clone().
 					Suspend(true).
+					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
 					Obj(),
 			},
 			wantWorkerXGBoostJobs: []kftraining.XGBoostJob{

--- a/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_multikueue_adapter.go
+++ b/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_multikueue_adapter.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -100,8 +99,6 @@ func (a adapter[PtrT, T]) SyncJob(
 	remoteClient client.Client,
 	key types.NamespacedName,
 	workloadName, origin string) error {
-	log := ctrl.LoggerFrom(ctx)
-
 	localJob := PtrT(new(T))
 	err := localClient.Get(ctx, key, localJob)
 	if err != nil {
@@ -115,12 +112,6 @@ func (a adapter[PtrT, T]) SyncJob(
 	}
 
 	if err == nil {
-		if a.fromObject(localJob).IsSuspended() {
-			// Ensure the job is unsuspended before updating its status; otherwise, it will fail when patching the spec.
-			log.V(2).Info("Skipping the sync since the local job is still suspended")
-			return nil
-		}
-
 		return clientutil.PatchStatus(ctx, localClient, localJob, func() (client.Object, bool, error) {
 			// if the remote exists, just copy the status
 			a.copyStatus(localJob, remoteJob)

--- a/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter.go
+++ b/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -42,8 +41,6 @@ type multiKueueAdapter struct{}
 var _ jobframework.MultiKueueAdapter = (*multiKueueAdapter)(nil)
 
 func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) error {
-	log := ctrl.LoggerFrom(ctx)
-
 	localJob := kfmpi.MPIJob{}
 	err := localClient.Get(ctx, key, &localJob)
 	if err != nil {
@@ -58,12 +55,6 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 
 	// if the remote exists, just copy the status
 	if err == nil {
-		if fromObject(&localJob).IsSuspended() {
-			// Ensure the job is unsuspended before updating its status; otherwise, it will fail when patching the spec.
-			log.V(2).Info("Skipping the sync since the local job is still suspended")
-			return nil
-		}
-
 		return clientutil.PatchStatus(ctx, localClient, &localJob, func() (client.Object, bool, error) {
 			localJob.Status = remoteJob.Status
 			return &localJob, true, nil

--- a/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter_test.go
@@ -105,7 +105,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
-		"skip to sync status from remote suspended mpijob": {
+		"sync status from remote while local mpijob is suspended": {
 			managersMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.Clone().
 					Suspend(true).
@@ -125,6 +125,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			wantManagersMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.Clone().
 					Suspend(true).
+					StatusConditions(kfmpi.JobCondition{Type: kfmpi.JobSucceeded, Status: corev1.ConditionTrue}).
 					Obj(),
 			},
 			wantWorkerMpiJobs: []kfmpi.MPIJob{

--- a/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter.go
+++ b/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -42,8 +41,6 @@ type multiKueueAdapter struct{}
 var _ jobframework.MultiKueueAdapter = (*multiKueueAdapter)(nil)
 
 func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) error {
-	log := ctrl.LoggerFrom(ctx)
-
 	localJob := rayv1.RayCluster{}
 	err := localClient.Get(ctx, key, &localJob)
 	if err != nil {
@@ -58,12 +55,6 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 
 	// if the remote exists, just copy the status
 	if err == nil {
-		if fromObject(&localJob).IsSuspended() {
-			// Ensure the job is unsuspended before updating its status; otherwise, it will fail when patching the spec.
-			log.V(2).Info("Skipping the sync since the local job is still suspended")
-			return nil
-		}
-
 		return clientutil.PatchStatus(ctx, localClient, &localJob, func() (client.Object, bool, error) {
 			localJob.Status = remoteJob.Status
 			return &localJob, true, nil

--- a/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
@@ -105,7 +105,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
-		"skip to sync status from remote suspended raycluster": {
+		"sync status from remote while local raycluster is suspended": {
 			managersRayClusters: []rayv1.RayCluster{
 				*rayClusterBuilder.Clone().
 					Suspend(true).
@@ -125,6 +125,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			wantManagersRayClusters: []rayv1.RayCluster{
 				*rayClusterBuilder.Clone().
 					Suspend(true).
+					StatusConditions(metav1.Condition{Type: string(rayv1.HeadPodReady), Status: metav1.ConditionStatus(corev1.ConditionTrue)}).
 					Obj(),
 			},
 			wantWorkerRayClusters: []rayv1.RayCluster{

--- a/pkg/controller/jobs/rayjob/rayjob_multikueue_adapter.go
+++ b/pkg/controller/jobs/rayjob/rayjob_multikueue_adapter.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -42,8 +41,6 @@ type multiKueueAdapter struct{}
 var _ jobframework.MultiKueueAdapter = (*multiKueueAdapter)(nil)
 
 func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) error {
-	log := ctrl.LoggerFrom(ctx)
-
 	localJob := rayv1.RayJob{}
 	err := localClient.Get(ctx, key, &localJob)
 	if err != nil {
@@ -58,11 +55,6 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 
 	// if the remote exists, just copy the status
 	if err == nil {
-		if fromObject(&localJob).IsSuspended() {
-			// Ensure the job is unsuspended before updating its status; otherwise, it will fail when patching the spec.
-			log.V(2).Info("Skipping the sync since the local job is still suspended")
-			return nil
-		}
 		return clientutil.PatchStatus(ctx, localClient, &localJob, func() (client.Object, bool, error) {
 			localJob.Status = remoteJob.Status
 			return &localJob, true, nil

--- a/pkg/controller/jobs/rayjob/rayjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_multikueue_adapter_test.go
@@ -104,7 +104,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
-		"skip to sync status from remote suspended rayjob": {
+		"sync status from remote while local rayjob is suspended": {
 			managersRayJobs: []rayv1.RayJob{
 				*rayJobBuilder.Clone().
 					Suspend(true).
@@ -124,6 +124,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			wantManagersRayJobs: []rayv1.RayJob{
 				*rayJobBuilder.Clone().
 					Suspend(true).
+					JobDeploymentStatus(rayv1.JobDeploymentStatusComplete).
 					Obj(),
 			},
 			wantWorkerRayJobs: []rayv1.RayJob{

--- a/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter.go
+++ b/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -42,8 +41,6 @@ type multiKueueAdapter struct{}
 var _ jobframework.MultiKueueAdapter = (*multiKueueAdapter)(nil)
 
 func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) error {
-	log := ctrl.LoggerFrom(ctx)
-
 	localJob := kftrainerapi.TrainJob{}
 	err := localClient.Get(ctx, key, &localJob)
 	if err != nil {
@@ -58,12 +55,6 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 
 	// if the remote exists, just copy the status
 	if err == nil {
-		if fromObject(&localJob).IsSuspended() {
-			// Ensure the job is unsuspended before updating its status; otherwise, it will fail when patching the spec.
-			log.V(2).Info("Skipping the sync since the local job is still suspended")
-			return nil
-		}
-
 		return clientutil.PatchStatus(ctx, localClient, &localJob, func() (client.Object, bool, error) {
 			localJob.Status = remoteJob.Status
 			return &localJob, true, nil

--- a/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter_test.go
@@ -133,7 +133,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
-		"skip to sync status from remote suspended trainjob": {
+		"sync status from remote while local trainjob is suspended": {
 			managersTrainJobs: []kftrainerapi.TrainJob{
 				*baseTrainJobManagedByKueueBuilder.Clone().
 					Suspend(true).
@@ -163,6 +163,16 @@ func TestMultiKueueAdapter(t *testing.T) {
 			wantManagersTrainJobs: []kftrainerapi.TrainJob{
 				*baseTrainJobManagedByKueueBuilder.Clone().
 					Suspend(true).
+					JobsStatus(
+						testingtrainjob.MakeJobStatusWrapper("replicated-job-1").
+							Ready(1).
+							Succeeded(1).
+							Obj(),
+						testingtrainjob.MakeJobStatusWrapper("replicated-job-2").
+							Ready(3).
+							Succeeded(0).
+							Obj(),
+					).
 					Obj(),
 			},
 			wantWorkerTrainJobs: []kftrainerapi.TrainJob{


### PR DESCRIPTION
Cherry pick of #8308 on release-0.14.

#8308: Remove IsSuspended check from CRD MultiKueue adapters to enable status sync during suspension

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
MultiKueue: Fixed status sync for CRD-based jobs (JobSet, Kubeflow, Ray, etc.) that was blocked while the local job was suspended.
```