### PR TITLE
Extract kueue-populator targets to a separate Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,8 @@ include Makefile-deps.mk
 
 include Makefile-test.mk
 
+include Makefile-kueue-populator.mk
+
 ##@ Development
 
 .PHONY: manifests
@@ -430,23 +432,6 @@ update-security-insights: yq
 	$(YQ) e '.distribution-points[0] = "https://github.com/kubernetes-sigs/kueue/releases/download/$(GIT_TAG)/manifests.yaml"' -i SECURITY-INSIGHTS.yaml
 	$(YQ) e '.dependencies.sbom[0].sbom-file = "https://github.com/kubernetes-sigs/kueue/releases/download/$(GIT_TAG)/kueue-$(GIT_TAG).spdx.json"' -i SECURITY-INSIGHTS.yaml
 
-##@ Kueue Populator
-
-.PHONY: kueue-populator-test
-kueue-populator-test: ## Run unit tests for kueue-populator.
-	$(MAKE) -C cmd/experimental/kueue-populator test
-
-.PHONY: kueue-populator-test-integration
-kueue-populator-test-integration: ## Run integration tests for kueue-populator.
-	$(MAKE) -C cmd/experimental/kueue-populator test-integration
-
-.PHONY: kueue-populator-test-e2e
-kueue-populator-test-e2e: ## Run e2e tests for kueue-populator.
-	$(MAKE) -C cmd/experimental/kueue-populator test-e2e
-
-.PHONY: kueue-populator-verify
-kueue-populator-verify: ## Run all verification tests for kueue-populator.
-	$(MAKE) -C cmd/experimental/kueue-populator verify
 
 ##@ Debug
 

--- a/Makefile-kueue-populator.mk
+++ b/Makefile-kueue-populator.mk
@@ -1,0 +1,31 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##@ Kueue Populator
+
+.PHONY: kueue-populator-test
+kueue-populator-test: ## Run unit tests for kueue-populator.
+	$(MAKE) -C cmd/experimental/kueue-populator test
+
+.PHONY: kueue-populator-test-integration
+kueue-populator-test-integration: ## Run integration tests for kueue-populator.
+	$(MAKE) -C cmd/experimental/kueue-populator test-integration
+
+.PHONY: kueue-populator-test-e2e
+kueue-populator-test-e2e: ## Run e2e tests for kueue-populator.
+	$(MAKE) -C cmd/experimental/kueue-populator test-e2e
+
+.PHONY: kueue-populator-verify
+kueue-populator-verify: ## Run all verification tests for kueue-populator.
+	$(MAKE) -C cmd/experimental/kueue-populator verify


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

To offload the landing Makefile, as the project is still experimental.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7871

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```