### PR TITLE
cleanup: improve ExpectWorkloadsToBeAdmittedCount fail message

### DIFF
--- a/test/util/util.go
+++ b/test/util/util.go
@@ -361,32 +361,35 @@ func ExpectWorkloadsToBePending(ctx context.Context, k8sClient client.Client, wl
 	}, Timeout, Interval).Should(gomega.Succeed())
 }
 
+func admittedWorkloadKeys(ctx context.Context, k8sClient client.Client, wlKeys sets.Set[client.ObjectKey]) (sets.Set[client.ObjectKey], error) {
+	admitted := sets.New[client.ObjectKey]()
+	var updatedWorkload kueue.Workload
+	for _, wl := range wlKeys.UnsortedList() {
+		if err := k8sClient.Get(ctx, wl, &updatedWorkload); err != nil {
+			return nil, err
+		}
+		if workload.IsAdmitted(&updatedWorkload) {
+			admitted.Insert(wl)
+		}
+	}
+	return admitted, nil
+}
+
 func ExpectWorkloadsToBeAdmitted(ctx context.Context, k8sClient client.Client, wls ...*kueue.Workload) {
 	wlKeys := workloadKeys(wls...)
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
-		admitted := sets.New[client.ObjectKey]()
-		var updatedWorkload kueue.Workload
-		for _, wl := range wls {
-			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWorkload)).To(gomega.Succeed())
-			if apimeta.IsStatusConditionTrue(updatedWorkload.Status.Conditions, kueue.WorkloadAdmitted) {
-				admitted.Insert(client.ObjectKeyFromObject(wl))
-			}
-		}
+		admitted, err := admittedWorkloadKeys(ctx, k8sClient, wlKeys)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
 		g.Expect(admitted).Should(gomega.Equal(wlKeys), "Unexpected workloads are admitted")
 	}, Timeout, Interval).Should(gomega.Succeed())
 }
 
 func ExpectWorkloadsToBeAdmittedCount(ctx context.Context, k8sClient client.Client, count int, wls ...*kueue.Workload) {
+	wlKeys := workloadKeys(wls...)
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
-		admitted := 0
-		var updatedWorkload kueue.Workload
-		for _, wl := range wls {
-			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWorkload)).To(gomega.Succeed())
-			if apimeta.IsStatusConditionTrue(updatedWorkload.Status.Conditions, kueue.WorkloadAdmitted) {
-				admitted++
-			}
-		}
-		g.Expect(admitted).Should(gomega.Equal(count), "Not enough workloads are admitted")
+		admitted, err := admittedWorkloadKeys(ctx, k8sClient, wlKeys)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(admitted).Should(gomega.HaveLen(count), "Not enough workloads are admitted from the list: %v", wlKeys.UnsortedList())
 	}, Timeout, Interval).Should(gomega.Succeed())
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Improve message information in case of the failure of the ExpectWorkloadsToBeAdmittedCount

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8173 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```