### PR TITLE
introduce short name kwl for kueue workloads

### DIFF
--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -783,7 +783,7 @@ const (
 // +kubebuilder:printcolumn:name="Admitted",JSONPath=".status.conditions[?(@.type=='Admitted')].status",type="string",description="Admission status"
 // +kubebuilder:printcolumn:name="Finished",JSONPath=".status.conditions[?(@.type=='Finished')].status",type="string",description="Workload finished"
 // +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type="date",description="Time this workload was created"
-// +kubebuilder:resource:shortName={wl}
+// +kubebuilder:resource:shortName={wl,kwl,kueueworkload}
 
 // Workload is the Schema for the workloads API
 // +kubebuilder:validation:XValidation:rule="has(self.status) && has(self.status.conditions) && self.status.conditions.exists(c, c.type == 'QuotaReserved' && c.status == 'True') && has(self.status.admission) ? size(self.spec.podSets) == size(self.status.admission.podSetAssignments) : true", message="podSetAssignments must have the same number of podSets as the spec"

--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -999,7 +999,7 @@ const (
 // +kubebuilder:printcolumn:name="Admitted",JSONPath=".status.conditions[?(@.type=='Admitted')].status",type="string",description="Admission status"
 // +kubebuilder:printcolumn:name="Finished",JSONPath=".status.conditions[?(@.type=='Finished')].status",type="string",description="Workload finished"
 // +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type="date",description="Time this workload was created"
-// +kubebuilder:resource:shortName={wl}
+// +kubebuilder:resource:shortName={wl,kwl,kueueworkload}
 
 // Workload is the Schema for the workloads API
 // +kubebuilder:validation:XValidation:rule="has(self.status) && has(self.status.conditions) && self.status.conditions.exists(c, c.type == 'QuotaReserved' && c.status == 'True') && has(self.status.admission) ? size(self.spec.podSets) == size(self.status.admission.podSetAssignments) : true", message="podSetAssignments must have the same number of podSets as the spec"

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -45,6 +45,8 @@ spec:
     plural: workloads
     shortNames:
       - wl
+      - kwl
+      - kueueworkload
     singular: workload
   scope: Namespaced
   versions:

--- a/cmd/kueuectl/app/delete/delete_workload.go
+++ b/cmd/kueuectl/app/delete/delete_workload.go
@@ -44,7 +44,7 @@ import (
 var (
 	wlExample = templates.Examples(`  
 		# Delete the Workload
-  		kueuectl delete workload my-workload
+  		kueuectl delete kueueworkload my-workload
 	`)
 	wlLong = templates.LongDesc(`
 		If the Workload has associated Jobs, the command will prompt for deletion approval
@@ -87,7 +87,7 @@ func NewWorkloadCmd(clientGetter util.ClientGetter, streams genericiooptions.IOS
 	cmd := &cobra.Command{
 		Use:                   "workload NAME [--yes] [--all] [--dry-run STRATEGY]",
 		DisableFlagsInUseLine: true,
-		Aliases:               []string{"wl"},
+		Aliases:               []string{"wl", "kwl", "kueueworkload"},
 		Short:                 "Delete the given Workload and its corresponding Job",
 		Long:                  wlLong,
 		Example:               wlExample,

--- a/cmd/kueuectl/app/list/list_workload.go
+++ b/cmd/kueuectl/app/list/list_workload.go
@@ -49,7 +49,7 @@ var (
 	wlLong    = templates.LongDesc(`Lists Workloads that match the provided criteria.`)
 	wlExample = templates.Examples(`
 		# List Workload 
-  		kueuectl list workload
+  		kueuectl list kueueworkload
 	`)
 )
 
@@ -99,7 +99,7 @@ func NewWorkloadCmd(clientGetter util.ClientGetter, streams genericiooptions.IOS
 		Use: "workload [--clusterqueue CLUSTER_QUEUE_NAME] [--localqueue LOCAL_QUEUE_NAME] [--status STATUS] [--selector key1=value1] [--field-selector key1=value1] [--all-namespaces] [--for TYPE[.API-GROUP]/NAME]",
 		// To do not add "[flags]" suffix on the end of usage line
 		DisableFlagsInUseLine: true,
-		Aliases:               []string{"wl"},
+		Aliases:               []string{"wl", "kwl", "kueueworkload"},
 		Short:                 "List Workload",
 		Long:                  wlLong,
 		Example:               wlExample,

--- a/cmd/kueuectl/app/passthrough/passthrough.go
+++ b/cmd/kueuectl/app/passthrough/passthrough.go
@@ -49,7 +49,7 @@ var (
 	}
 
 	passThroughTypes = []passThroughType{
-		{name: "workload", aliases: []string{"wl"}},
+		{name: "workload", aliases: []string{"wl", "kwl", "kueueworkload"}},
 		{name: "clusterqueue", aliases: []string{"cq"}},
 		{name: "localqueue", aliases: []string{"lq"}},
 		{name: "resourceflavor", aliases: []string{"rf"}},

--- a/cmd/kueuectl/app/resume/resume_workload.go
+++ b/cmd/kueuectl/app/resume/resume_workload.go
@@ -31,7 +31,7 @@ var (
 	wlLong    = templates.LongDesc(`Resumes the Workload, allowing its admission according to regular ClusterQueue rules.`)
 	wlExample = templates.Examples(`
 		# Resume the workload 
-  		kueuectl resume workload my-workload
+  		kueuectl resume kueueworkload my-workload
 	`)
 )
 
@@ -42,7 +42,7 @@ func NewWorkloadCmd(clientGetter util.ClientGetter, streams genericiooptions.IOS
 		Use: "workload NAME [--namespace NAMESPACE] [--dry-run STRATEGY]",
 		// To do not add "[flags]" suffix on the end of usage line
 		DisableFlagsInUseLine: true,
-		Aliases:               []string{"wl"},
+		Aliases:               []string{"wl", "kwl", "kueueworkload"},
 		Short:                 "Resume the Workload",
 		Long:                  wlLong,
 		Example:               wlExample,

--- a/cmd/kueuectl/app/stop/stop_workload.go
+++ b/cmd/kueuectl/app/stop/stop_workload.go
@@ -46,7 +46,7 @@ func NewWorkloadCmd(clientGetter util.ClientGetter, streams genericiooptions.IOS
 		Use: "workload NAME [--namespace NAMESPACE] [--dry-run STRATEGY]",
 		// To do not add "[flags]" suffix on the end of usage line
 		DisableFlagsInUseLine: true,
-		Aliases:               []string{"wl"},
+		Aliases:               []string{"wl", "kueueworkload", "kwl"},
 		Short:                 "Stop the Workload",
 		Long:                  wlLong,
 		Example:               wlExample,

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -13,6 +13,8 @@ spec:
     plural: workloads
     shortNames:
     - wl
+    - kwl
+    - kueueworkload
     singular: workload
   scope: Namespaced
   versions:

--- a/site/content/en/docs/reference/kubectl-kueue/commands/kueuectl_delete/kueuectl_delete_workload.md
+++ b/site/content/en/docs/reference/kubectl-kueue/commands/kueuectl_delete/kueuectl_delete_workload.md
@@ -24,7 +24,7 @@ kueuectl delete workload NAME [--yes] [--all] [--dry-run STRATEGY]
 
 ```
   # Delete the Workload
-  kueuectl delete workload my-workload
+  kueuectl delete kueueworkload my-workload
 ```
 
 

--- a/site/content/en/docs/reference/kubectl-kueue/commands/kueuectl_list/kueuectl_list_workload.md
+++ b/site/content/en/docs/reference/kubectl-kueue/commands/kueuectl_list/kueuectl_list_workload.md
@@ -24,7 +24,7 @@ kueuectl list workload [--clusterqueue CLUSTER_QUEUE_NAME] [--localqueue LOCAL_Q
 
 ```
   # List Workload
-  kueuectl list workload
+  kueuectl list kueueworkload
 ```
 
 

--- a/site/content/en/docs/reference/kubectl-kueue/commands/kueuectl_resume/kueuectl_resume_workload.md
+++ b/site/content/en/docs/reference/kubectl-kueue/commands/kueuectl_resume/kueuectl_resume_workload.md
@@ -24,7 +24,7 @@ kueuectl resume workload NAME [--namespace NAMESPACE] [--dry-run STRATEGY]
 
 ```
   # Resume the workload
-  kueuectl resume workload my-workload
+  kueuectl resume kueueworkload my-workload
 ```
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When in-tree workload object, kueue may conflict if workloads use wl shortname.

We want to at least provide a way to use `kubectl get kwl` and not conflict with workloads.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8113 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
CLI: Support "kwl" and "kueueworkload" as a shortname for Kueue Workloads.
```