### PR TITLE
Decoupled deletion in queue cache from full workload objects.

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -285,15 +285,14 @@ func (c *ClusterQueue) backoffWaitingTimeExpired(wInfo *workload.Info) bool {
 }
 
 // Delete removes the workload from ClusterQueue.
-func (c *ClusterQueue) Delete(log logr.Logger, w *kueue.Workload) {
+func (c *ClusterQueue) Delete(log logr.Logger, key workload.Reference) {
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
-	c.delete(log, w)
+	c.delete(log, key)
 }
 
 // delete removes the workload from ClusterQueue without lock.
-func (c *ClusterQueue) delete(log logr.Logger, w *kueue.Workload) {
-	key := workload.Key(w)
+func (c *ClusterQueue) delete(log logr.Logger, key workload.Reference) {
 	c.inadmissibleWorkloads.delete(key)
 	c.heap.Delete(key)
 	c.forgetInflightByKey(key)
@@ -311,7 +310,7 @@ func (c *ClusterQueue) DeleteFromLocalQueue(log logr.Logger, q *LocalQueue) {
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
 	for _, w := range q.items {
-		c.delete(log, w.Obj)
+		c.delete(log, workload.Key(w.Obj))
 	}
 }
 

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -221,13 +221,13 @@ func Test_Delete(t *testing.T) {
 	if cq.PendingTotal() != 2 {
 		t.Error("ClusterQueue should have two workload")
 	}
-	cq.Delete(log, wl1)
+	cq.Delete(log, workload.Key(wl1))
 	if cq.PendingTotal() != 1 {
 		t.Error("ClusterQueue should have only one workload")
 	}
 	// Change workload item, ClusterQueue.Delete should only care about the namespace and name.
 	wl2.Spec = kueue.WorkloadSpec{QueueName: "default"}
-	cq.Delete(log, wl2)
+	cq.Delete(log, workload.Key(wl2))
 	if cq.PendingTotal() != 0 {
 		t.Error("ClusterQueue should have be empty")
 	}
@@ -259,7 +259,7 @@ func Test_AddFromLocalQueue(t *testing.T) {
 	if added := cq.AddFromLocalQueue(queue); added {
 		t.Error("expected workload not to be added")
 	}
-	cq.Delete(log, wl)
+	cq.Delete(log, workload.Key(wl))
 	if added := cq.AddFromLocalQueue(queue); !added {
 		t.Error("workload should be added to the ClusterQueue")
 	}
@@ -454,7 +454,7 @@ func TestClusterQueueImpl(t *testing.T) {
 			}
 
 			for _, w := range test.workloadsToDelete {
-				cq.Delete(log, w)
+				cq.Delete(log, workload.Key(w))
 			}
 
 			if test.queueInadmissibleWorkloads {
@@ -706,9 +706,7 @@ func TestFIFOClusterQueue(t *testing.T) {
 		t.Errorf("Popped workload %q want %q", got.Obj.Name, "after")
 	}
 
-	q.Delete(log, &kueue.Workload{
-		ObjectMeta: metav1.ObjectMeta{Name: "now"},
-	})
+	q.Delete(log, workload.NewReference("", "now"))
 	got = q.Pop()
 	if got != nil {
 		t.Errorf("Queue is not empty, popped workload %q", got.Obj.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Simplifying the queue cache integration with the workload controller.
The PR cleans up the use of full workloads where just their keys suffice.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part 1.4 of addressing: #5310 

#### Special notes for your reviewer:
Followup to https://github.com/kubernetes-sigs/kueue/pull/7915

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```