### PR TITLE
Automated cherry pick of #8394: Provisioning: Fix event recording in syncCheckStates.

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -19,6 +19,7 @@ package provisioning
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -32,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	autoscaling "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
-	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -91,8 +91,9 @@ func requestWithConditions(r *autoscaling.ProvisioningRequest, conditions []meta
 func requestWithCondition(r *autoscaling.ProvisioningRequest, conditionType string, status metav1.ConditionStatus) *autoscaling.ProvisioningRequest {
 	r = r.DeepCopy()
 	apimeta.SetStatusCondition(&r.Status.Conditions, metav1.Condition{
-		Type:   conditionType,
-		Status: status,
+		Type:    conditionType,
+		Status:  status,
+		Message: "By test",
 	})
 	return r
 }
@@ -307,7 +308,6 @@ func TestReconcile(t *testing.T) {
 		templates            []corev1.PodTemplate
 		checks               []kueue.AdmissionCheck
 		configs              []kueue.ProvisioningRequestConfig
-		enableGates          []featuregate.Feature
 		flavors              []kueue.ResourceFlavor
 		workload             *kueue.Workload
 		wantReconcileError   error
@@ -570,13 +570,21 @@ func TestReconcile(t *testing.T) {
 					AdmissionChecks(kueue.AdmissionCheckState{
 						Name:                "check1",
 						State:               kueue.CheckStateRetry,
-						Message:             "Retrying after failure: ",
+						Message:             "Retrying after failure: By test",
 						RequeueAfterSeconds: ptr.To(backoffBaseSeconds),
 					}, kueue.AdmissionCheckState{
 						Name:  "not-provisioning",
 						State: kueue.CheckStatePending,
 					}).
 					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkload),
+					EventType: corev1.EventTypeNormal,
+					Reason:    "AdmissionCheckUpdated",
+					Message:   `Admission check check1 updated state from Pending to Retry with message: Retrying after failure: By test`,
+				},
 			},
 		},
 		"when request fails, and there is no retry": {
@@ -591,13 +599,22 @@ func TestReconcile(t *testing.T) {
 			wantWorkloads: map[string]*kueue.Workload{
 				baseWorkload.GetName(): (&utiltestingapi.WorkloadWrapper{Workload: *baseWorkload.DeepCopy()}).
 					AdmissionChecks(kueue.AdmissionCheckState{
-						Name:  "check1",
-						State: kueue.CheckStateRejected,
+						Name:    "check1",
+						State:   kueue.CheckStateRejected,
+						Message: "By test",
 					}, kueue.AdmissionCheckState{
 						Name:  "not-provisioning",
 						State: kueue.CheckStatePending,
 					}).
 					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkload),
+					EventType: corev1.EventTypeNormal,
+					Reason:    "AdmissionCheckUpdated",
+					Message:   `Admission check check1 updated state from Pending to Rejected with message: By test`,
+				},
 			},
 		},
 		"when request is provisioned": {
@@ -612,8 +629,9 @@ func TestReconcile(t *testing.T) {
 			wantWorkloads: map[string]*kueue.Workload{
 				baseWorkload.GetName(): (&utiltestingapi.WorkloadWrapper{Workload: *baseWorkload.DeepCopy()}).
 					AdmissionChecks(kueue.AdmissionCheckState{
-						Name:  "check1",
-						State: kueue.CheckStateReady,
+						Name:    "check1",
+						Message: "By test",
+						State:   kueue.CheckStateReady,
 						PodSetUpdates: []kueue.PodSetUpdate{
 							{
 								Name: "ps1",
@@ -636,6 +654,14 @@ func TestReconcile(t *testing.T) {
 					}).
 					Obj(),
 			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkload),
+					EventType: corev1.EventTypeNormal,
+					Reason:    "AdmissionCheckUpdated",
+					Message:   `Admission check check1 updated state from Pending to Ready with message: By test`,
+				},
+			},
 		},
 		"when no request is needed": {
 			workload: baseWorkload.DeepCopy(),
@@ -653,6 +679,14 @@ func TestReconcile(t *testing.T) {
 						State: kueue.CheckStatePending,
 					}).
 					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkload),
+					EventType: corev1.EventTypeNormal,
+					Reason:    "AdmissionCheckUpdated",
+					Message:   `Admission check check1 updated state from Pending to Ready with message: the provisioning request is not needed`,
+				},
 			},
 		},
 		"when request is needed for one PodSet (resource request)": {
@@ -847,6 +881,14 @@ func TestReconcile(t *testing.T) {
 					Admitted(true).
 					Obj(),
 			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkload),
+					EventType: corev1.EventTypeNormal,
+					Reason:    "AdmissionCheckUpdated",
+					Message:   `Admission check check1 updated state from Pending to Rejected`,
+				},
+			},
 		},
 		"workload sets AdmissionCheck status to Rejected when it is not admitted and receives the provisioning request's CapacityRevoked condition": {
 			workload: (&utiltestingapi.WorkloadWrapper{Workload: *baseWorkload.DeepCopy()}).
@@ -887,6 +929,14 @@ func TestReconcile(t *testing.T) {
 					}).
 					Admitted(false).
 					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkload),
+					EventType: corev1.EventTypeNormal,
+					Reason:    "AdmissionCheckUpdated",
+					Message:   `Admission check check1 updated state from Pending to Rejected`,
+				},
 			},
 		},
 		"workloads doesnt set AdmissionCheck status to Rejected when it is finished and receives the provisioning request's CapacityRevoked condition": {
@@ -992,8 +1042,9 @@ func TestReconcile(t *testing.T) {
 							Status: metav1.ConditionTrue,
 						},
 						{
-							Type:   autoscaling.BookingExpired,
-							Status: metav1.ConditionTrue,
+							Type:    autoscaling.BookingExpired,
+							Status:  metav1.ConditionTrue,
+							Message: "Expired By test",
 						},
 					}),
 			},
@@ -1002,7 +1053,7 @@ func TestReconcile(t *testing.T) {
 					AdmissionChecks(kueue.AdmissionCheckState{
 						Name:                "check1",
 						State:               kueue.CheckStateRetry,
-						Message:             "Retrying after booking expired: ",
+						Message:             "Retrying after booking expired: Expired By test",
 						RequeueAfterSeconds: ptr.To(backoffBaseSeconds),
 					}, kueue.AdmissionCheckState{
 						Name:  "not-provisioning",
@@ -1010,6 +1061,14 @@ func TestReconcile(t *testing.T) {
 					}).
 					Admitted(false).
 					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkload),
+					EventType: corev1.EventTypeNormal,
+					Reason:    "AdmissionCheckUpdated",
+					Message:   `Admission check check1 updated state from Pending to Retry with message: Retrying after booking expired: Expired By test`,
+				},
 			},
 		},
 		"workload rejects the admission check when is not admitted and receives the provisioning request's BookingExpired condition": {
@@ -1051,6 +1110,14 @@ func TestReconcile(t *testing.T) {
 					}).
 					Admitted(false).
 					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkload),
+					EventType: corev1.EventTypeNormal,
+					Reason:    "AdmissionCheckUpdated",
+					Message:   `Admission check check1 updated state from Pending to Rejected`,
+				},
 			},
 		},
 		"when pod template creation error": {
@@ -1173,8 +1240,9 @@ func TestReconcile(t *testing.T) {
 			wantWorkloads: map[string]*kueue.Workload{
 				baseWorkload.GetName(): (&utiltestingapi.WorkloadWrapper{Workload: *baseWorkload.DeepCopy()}).
 					AdmissionChecks(kueue.AdmissionCheckState{
-						Name:  "check1",
-						State: kueue.CheckStateReady,
+						Name:    "check1",
+						Message: "By test",
+						State:   kueue.CheckStateReady,
 						PodSetUpdates: []kueue.PodSetUpdate{
 							{
 								Name: "ps1",
@@ -1202,6 +1270,14 @@ func TestReconcile(t *testing.T) {
 						State: kueue.CheckStatePending,
 					}).
 					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkload),
+					EventType: corev1.EventTypeNormal,
+					Reason:    "AdmissionCheckUpdated",
+					Message:   `Admission check check1 updated state from Pending to Ready with message: By test`,
+				},
 			},
 		},
 		"when request is provisioned and has NodeSelector missing in the ProvisioningClassDetail": {
@@ -1222,8 +1298,9 @@ func TestReconcile(t *testing.T) {
 			wantWorkloads: map[string]*kueue.Workload{
 				baseWorkload.GetName(): (&utiltestingapi.WorkloadWrapper{Workload: *baseWorkload.DeepCopy()}).
 					AdmissionChecks(kueue.AdmissionCheckState{
-						Name:  "check1",
-						State: kueue.CheckStateReady,
+						Name:    "check1",
+						State:   kueue.CheckStateReady,
+						Message: "By test",
 						PodSetUpdates: []kueue.PodSetUpdate{
 							{
 								Name: "ps1",
@@ -1245,6 +1322,14 @@ func TestReconcile(t *testing.T) {
 						State: kueue.CheckStatePending,
 					}).
 					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkload),
+					EventType: corev1.EventTypeNormal,
+					Reason:    "AdmissionCheckUpdated",
+					Message:   `Admission check check1 updated state from Pending to Ready with message: By test`,
+				},
 			},
 		},
 		"with podSetMergePolicy IdenticalPodTemplates": {
@@ -1577,100 +1662,100 @@ func TestReconcile(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			for _, gate := range tc.enableGates {
-				features.SetFeatureGateDuringTest(t, gate, true)
-			}
+		for _, useMergePatch := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", name, useMergePatch), func(t *testing.T) {
+				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, true)
 
-			interceptorFuncs := interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}
-			if tc.interceptorFuncsCreate != nil {
-				interceptorFuncs.Create = tc.interceptorFuncsCreate
-			}
-
-			ctx, _ := utiltesting.ContextWithLog(t)
-			builder, ctx := getClientBuilder(ctx)
-			builder = builder.WithInterceptorFuncs(interceptorFuncs)
-			builder = builder.WithObjects(tc.workload)
-			builder = builder.WithStatusSubresource(tc.workload)
-			builder = builder.WithLists(
-				&autoscaling.ProvisioningRequestList{Items: tc.requests},
-				&corev1.PodTemplateList{Items: tc.templates},
-				&kueue.ProvisioningRequestConfigList{Items: tc.configs},
-				&kueue.AdmissionCheckList{Items: tc.checks},
-				&kueue.ResourceFlavorList{Items: tc.flavors},
-			)
-
-			k8sclient := builder.Build()
-			recorder := &utiltesting.EventRecorder{}
-			controller, err := NewController(
-				k8sclient,
-				recorder,
-			)
-			if err != nil {
-				t.Fatalf("Setting up the provisioning request controller: %v", err)
-			}
-
-			req := reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: TestNamespace,
-					Name:      tc.workload.Name,
-				},
-			}
-			_, gotReconcileError := controller.Reconcile(ctx, req)
-			if diff := cmp.Diff(tc.wantReconcileError, gotReconcileError, cmpopts.EquateErrors()); diff != "" {
-				t.Errorf("unexpected reconcile error (-want/+got):\n%s", diff)
-			}
-
-			for name, wantWl := range tc.wantWorkloads {
-				gotWl := &kueue.Workload{}
-				if err := k8sclient.Get(ctx, types.NamespacedName{Namespace: TestNamespace, Name: name}, gotWl); err != nil {
-					t.Errorf("unexpected error getting workload %q", name)
+				interceptorFuncs := interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}
+				if tc.interceptorFuncsCreate != nil {
+					interceptorFuncs.Create = tc.interceptorFuncsCreate
 				}
 
-				if diff := cmp.Diff(wantWl, gotWl, wlCmpOptions...); diff != "" {
-					t.Errorf("unexpected workload %q (-want/+got):\n%s", name, diff)
-				}
-			}
+				ctx, _ := utiltesting.ContextWithLog(t)
+				builder, ctx := getClientBuilder(ctx)
+				builder = builder.WithInterceptorFuncs(interceptorFuncs)
+				builder = builder.WithObjects(tc.workload)
+				builder = builder.WithStatusSubresource(tc.workload)
+				builder = builder.WithLists(
+					&autoscaling.ProvisioningRequestList{Items: tc.requests},
+					&corev1.PodTemplateList{Items: tc.templates},
+					&kueue.ProvisioningRequestConfigList{Items: tc.configs},
+					&kueue.AdmissionCheckList{Items: tc.checks},
+					&kueue.ResourceFlavorList{Items: tc.flavors},
+				)
 
-			for name, wantRequest := range tc.wantRequests {
-				gotRequest := &autoscaling.ProvisioningRequest{}
-				if err := k8sclient.Get(ctx, types.NamespacedName{Namespace: TestNamespace, Name: name}, gotRequest); client.IgnoreNotFound(err) != nil {
-					t.Errorf("unexpected error getting request %q: %s", name, err)
-				}
-
-				if diff := cmp.Diff(wantRequest, gotRequest, reqCmpOptions...); diff != "" {
-					t.Errorf("unexpected request %q (-want/+got):\n%s", name, diff)
-				}
-				if diff := cmp.Diff(wantRequest.GetLabels(), gotRequest.GetLabels()); diff != "" {
-					t.Errorf("unexpected request labels %q (-want/+got):\n%s", name, diff)
-				}
-			}
-
-			for name, wantTemplate := range tc.wantTemplates {
-				gotTemplate := &corev1.PodTemplate{}
-				if err := k8sclient.Get(ctx, types.NamespacedName{Namespace: TestNamespace, Name: name}, gotTemplate); err != nil {
-					t.Errorf("unexpected error getting template %q", name)
+				k8sclient := builder.Build()
+				recorder := &utiltesting.EventRecorder{}
+				controller, err := NewController(
+					k8sclient,
+					recorder,
+				)
+				if err != nil {
+					t.Fatalf("Setting up the provisioning request controller: %v", err)
 				}
 
-				if diff := cmp.Diff(wantTemplate, gotTemplate, tmplCmpOptions...); diff != "" {
-					t.Errorf("unexpected template %q (-want/+got):\n%s", name, diff)
+				req := reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: TestNamespace,
+						Name:      tc.workload.Name,
+					},
 				}
-				if diff := cmp.Diff(wantTemplate.GetLabels(), gotTemplate.GetLabels()); diff != "" {
-					t.Errorf("unexpected template labels %q (-want/+got):\n%s", name, diff)
+				_, gotReconcileError := controller.Reconcile(ctx, req)
+				if diff := cmp.Diff(tc.wantReconcileError, gotReconcileError, cmpopts.EquateErrors()); diff != "" {
+					t.Errorf("unexpected reconcile error (-want/+got):\n%s", diff)
 				}
-			}
 
-			for _, name := range tc.wantRequestsNotFound {
-				gotRequest := &autoscaling.ProvisioningRequest{}
-				if err := k8sclient.Get(ctx, types.NamespacedName{Namespace: TestNamespace, Name: name}, gotRequest); !apierrors.IsNotFound(err) {
-					t.Errorf("request %q should no longer be found", name)
-				}
-			}
+				for name, wantWl := range tc.wantWorkloads {
+					gotWl := &kueue.Workload{}
+					if err := k8sclient.Get(ctx, types.NamespacedName{Namespace: TestNamespace, Name: name}, gotWl); err != nil {
+						t.Errorf("unexpected error getting workload %q", name)
+					}
 
-			if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents); diff != "" {
-				t.Errorf("unexpected events (-want/+got):\n%s", diff)
-			}
-		})
+					if diff := cmp.Diff(wantWl, gotWl, wlCmpOptions...); diff != "" {
+						t.Errorf("unexpected workload %q (-want/+got):\n%s", name, diff)
+					}
+				}
+
+				for name, wantRequest := range tc.wantRequests {
+					gotRequest := &autoscaling.ProvisioningRequest{}
+					if err := k8sclient.Get(ctx, types.NamespacedName{Namespace: TestNamespace, Name: name}, gotRequest); client.IgnoreNotFound(err) != nil {
+						t.Errorf("unexpected error getting request %q: %s", name, err)
+					}
+
+					if diff := cmp.Diff(wantRequest, gotRequest, reqCmpOptions...); diff != "" {
+						t.Errorf("unexpected request %q (-want/+got):\n%s", name, diff)
+					}
+					if diff := cmp.Diff(wantRequest.GetLabels(), gotRequest.GetLabels()); diff != "" {
+						t.Errorf("unexpected request labels %q (-want/+got):\n%s", name, diff)
+					}
+				}
+
+				for name, wantTemplate := range tc.wantTemplates {
+					gotTemplate := &corev1.PodTemplate{}
+					if err := k8sclient.Get(ctx, types.NamespacedName{Namespace: TestNamespace, Name: name}, gotTemplate); err != nil {
+						t.Errorf("unexpected error getting template %q", name)
+					}
+
+					if diff := cmp.Diff(wantTemplate, gotTemplate, tmplCmpOptions...); diff != "" {
+						t.Errorf("unexpected template %q (-want/+got):\n%s", name, diff)
+					}
+					if diff := cmp.Diff(wantTemplate.GetLabels(), gotTemplate.GetLabels()); diff != "" {
+						t.Errorf("unexpected template labels %q (-want/+got):\n%s", name, diff)
+					}
+				}
+
+				for _, name := range tc.wantRequestsNotFound {
+					gotRequest := &autoscaling.ProvisioningRequest{}
+					if err := k8sclient.Get(ctx, types.NamespacedName{Namespace: TestNamespace, Name: name}, gotRequest); !apierrors.IsNotFound(err) {
+						t.Errorf("request %q should no longer be found", name)
+					}
+				}
+
+				if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents); diff != "" {
+					t.Errorf("unexpected events (-want/+got):\n%s", diff)
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #8394 on release-0.15.

#8394: Provisioning: Fix event recording in syncCheckStates.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
ProvisioningRequest: Fixed a bug that prevented events from being updated when the AdmissionCheck state changed.
```