### PR TITLE
fix: Modified job spec activates deactivated Workload. #6719

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1119,7 +1119,7 @@ func (r *JobReconciler) updateWorkloadToMatchJob(ctx context.Context, job Generi
 	if err != nil {
 		return nil, fmt.Errorf("can't construct workload for update: %w", err)
 	}
-	err = r.prepareWorkload(ctx, job, newWl)
+	err = r.prepareWorkload(ctx, job, newWl, wl.Spec.Active)
 	if err != nil {
 		return nil, fmt.Errorf("can't construct workload for update: %w", err)
 	}
@@ -1342,7 +1342,9 @@ func PrepareWorkloadPriority(ctx context.Context, c client.Client, obj client.Ob
 }
 
 // prepareWorkload adds the priority information for the constructed workload
-func (r *JobReconciler) prepareWorkload(ctx context.Context, job GenericJob, wl *kueue.Workload) error {
+// active is used to set the active field of the workload. If active is nil, the workload will be set to active by default.
+// for the existing workload, the original active status should be retained.
+func (r *JobReconciler) prepareWorkload(ctx context.Context, job GenericJob, wl *kueue.Workload, active *bool) error {
 	if err := PrepareWorkloadPriority(ctx, r.client, job.Object(), wl, getCustomPriorityClassFuncFromJob(job)); err != nil {
 		return err
 	}
@@ -1352,6 +1354,7 @@ func (r *JobReconciler) prepareWorkload(ctx context.Context, job GenericJob, wl 
 	if WorkloadSliceEnabled(job) {
 		return prepareWorkloadSlice(ctx, r.client, job, wl)
 	}
+	wl.Spec.Active = active
 	return nil
 }
 
@@ -1437,7 +1440,7 @@ func (r *JobReconciler) handleJobWithNoWorkload(ctx context.Context, job Generic
 	if err != nil {
 		return err
 	}
-	err = r.prepareWorkload(ctx, job, wl)
+	err = r.prepareWorkload(ctx, job, wl, wl.Spec.Active)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -150,6 +150,58 @@ func TestReconcileGenericJob(t *testing.T) {
 				*baseWl.Clone().Name("job-test-job-1").ResourceVersion("2").Obj(),
 			},
 		},
+		"update workload to match job preserves active=true": {
+			req: baseReq,
+			job: baseJob.Clone().
+				Obj(),
+			podSets: basePodSets,
+			objs: []client.Object{
+				baseWl.Clone().Name("job-test-job-1").
+					PodSets(*utiltestingapi.MakePodSet("old", 2).Obj()).
+					Active(true).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*baseWl.Clone().Name("job-test-job-1").ResourceVersion("2").Active(true).Obj(),
+			},
+		},
+		"update workload to match job preserves active=false": {
+			req: baseReq,
+			job: baseJob.Clone().
+				Obj(),
+			podSets: basePodSets,
+			objs: []client.Object{
+				baseWl.Clone().Name("job-test-job-1").
+					PodSets(*utiltestingapi.MakePodSet("old", 2).Obj()).
+					Active(false).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*baseWl.Clone().Name("job-test-job-1").ResourceVersion("2").Active(false).Obj(),
+			},
+		},
+		"update workload to match job with changed parallelism preserves active=false": {
+			req: baseReq,
+			job: baseJob.Clone().
+				Parallelism(5).
+				Obj(),
+			podSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("main", 5).Obj(),
+			},
+			objs: []client.Object{
+				baseWl.Clone().Name("job-test-job-1").
+					PodSets(*utiltestingapi.MakePodSet("main", 1).Obj()).
+					Active(false).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*baseWl.Clone().Name("job-test-job-1").
+					ResourceVersion("2").
+					PodSets(*utiltestingapi.MakePodSet("main", 5).Obj()).
+					Active(false).
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When updating the workload, we should keep the spec.Active field unchanged, because Active is set to true by default, which does not match the current user's expected behavior.

https://github.com/kubernetes-sigs/kueue/blob/ae75bac9048c9c6dd30c1536b3b39527f92045c1/apis/kueue/v1beta2/workload_types.go#L59-L68

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6719 

#### Special notes for your reviewer:  @mimowo 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
JobFramework: Fixed a bug that allowed a deactivated workload to be activated.
```