### PR TITLE
fix: ResourceFlavor should be cleaned up after tests

### DIFF
--- a/test/performance/scheduler/runner/generator/generator.go
+++ b/test/performance/scheduler/runner/generator/generator.go
@@ -202,7 +202,7 @@ func Generate(ctx context.Context, c client.Client, cSets []CohortSet) error {
 	log := ctrl.LoggerFrom(ctx).WithName("generate cohort sets").WithValues("numSets", len(cSets))
 	log.Info("Start generation")
 	defer log.Info("End generation")
-	rf := utiltestingapi.MakeResourceFlavor(resourceFlavorName).NodeLabel(CleanupLabel, "true").Obj()
+	rf := utiltestingapi.MakeResourceFlavor(resourceFlavorName).Label(CleanupLabel, "true").Obj()
 	err := c.Create(ctx, rf)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind failing-test
/kind flake
-->

#### What this PR does / why we need it:

Performance tests are not repeatable because ResourceFlavor ```rf``` isn't cleaned up.
Correctly adds CleanupLabel to ResourceFlavor's ```.metadata.Labels```, and not ```.spec.nodeLabels```.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8429 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```