### PR TITLE
test: fix flaky perf test by distinguishing context cancellation from timeout

### DIFF
--- a/test/performance/scheduler/runner/main.go
+++ b/test/performance/scheduler/runner/main.go
@@ -112,6 +112,16 @@ func main() {
 			ErrorIfCRDPathMissing: true,
 		}
 
+		// Increase API server request limits to handle high load from performance tests.
+		// The default generator config creates ~15,000 workloads (5 cohorts × 6 queues × 500 workloads).
+		// Under heavy reconciliation, the default kube-apiserver limits (max-requests-inflight=400,
+		// max-mutating-requests-inflight=200) can cause the API server to become overwhelmed,
+		// resulting in "http2: client connection lost" errors when pending requests queue up
+		// and connections time out.
+		testEnv.ControlPlane.GetAPIServer().Configure().
+			Append("max-requests-inflight", "800").
+			Append("max-mutating-requests-inflight", "400")
+
 		var err error
 		cfg, err = testEnv.Start()
 		if err != nil {


### PR DESCRIPTION
The performance test creates ~15,000 workloads (5 cohorts × 6 queues × 500 workloads). Under heavy reconciliation, the default kube-apiserver limits (max-requests-inflight=400, max-mutating-requests-inflight=200) cause the envtest API server to become overwhelmed, resulting in "http2: client connection lost" errors when pending requests queue up
and connections time out.
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8437

#### Special notes for your reviewer:
I was referring to https://e-whisper.com/posts/51187/

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```