### PR TITLE
Deduplicate cohort hierarchy processing in QueueInadmissibleWorkloads

### DIFF
--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -608,11 +608,21 @@ func (m *Manager) QueueInadmissibleWorkloads(ctx context.Context, cqNames sets.S
 		return
 	}
 
+	// Track processed cohort roots to avoid requeuing the same hierarchy
+	// multiple times when multiple CQs in cqNames share a root.
+	processedRoots := sets.New[kueue.CohortReference]()
 	var queued bool
 	for name := range cqNames {
 		cq := m.hm.ClusterQueue(name)
 		if cq == nil {
 			continue
+		}
+		if cq.HasParent() && !hierarchy.HasCycle(cq.Parent()) {
+			rootName := cq.Parent().getRootUnsafe().GetName()
+			if processedRoots.Has(rootName) {
+				continue
+			}
+			processedRoots.Insert(rootName)
 		}
 		if m.requeueWorkloadsCQ(ctx, cq) {
 			queued = true

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
@@ -260,6 +261,128 @@ func TestRequeueWorkloadsCohortCycle(t *testing.T) {
 	}
 	if diff := cmp.Diff(expectedAssigned, manager.assignedWorkloads); diff != "" {
 		t.Errorf("Unexpected assigned workloads (-want,+got):\n%s", diff)
+	}
+}
+
+func TestQueueInadmissibleWorkloads(t *testing.T) {
+	now := time.Now()
+	cases := map[string]struct {
+		cohorts                   []*kueue.Cohort
+		clusterQueues             []*kueue.ClusterQueue
+		localQueues               []*kueue.LocalQueue
+		workloads                 []*kueue.Workload
+		cqNames                   sets.Set[kueue.ClusterQueueReference]
+		wantInadmissible          map[kueue.ClusterQueueReference][]workload.Reference
+		wantActive                map[kueue.ClusterQueueReference][]workload.Reference
+		wantMoveWorkloadsLogCount int
+	}{
+		"deduplication with shared root": {
+			// Tree structure:
+			//   root
+			//   ├── child1
+			//   │   └── cq1
+			//   └── child2
+			//       └── cq2
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root").Obj(),
+				utiltestingapi.MakeCohort("child1").Parent("root").Obj(),
+				utiltestingapi.MakeCohort("child2").Parent("root").Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq1").Cohort("child1").Obj(),
+				utiltestingapi.MakeClusterQueue("cq2").Cohort("child2").Obj(),
+			},
+			localQueues: []*kueue.LocalQueue{
+				utiltestingapi.MakeLocalQueue("foo", defaultNamespace).ClusterQueue("cq1").Obj(),
+				utiltestingapi.MakeLocalQueue("bar", defaultNamespace).ClusterQueue("cq2").Obj(),
+			},
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("a", defaultNamespace).Queue("foo").Creation(now).Obj(),
+				utiltestingapi.MakeWorkload("b", defaultNamespace).Queue("bar").Creation(now.Add(time.Second)).Obj(),
+			},
+			cqNames:          sets.New[kueue.ClusterQueueReference]("cq1", "cq2"),
+			wantInadmissible: nil,
+			wantActive: map[kueue.ClusterQueueReference][]workload.Reference{
+				"cq1": {"default/a"},
+				"cq2": {"default/b"},
+			},
+			// Verify deduplication: although cq1 and cq2 share the same root, the
+			// "Attempting to move workloads" log should appear only once.
+			wantMoveWorkloadsLogCount: 1,
+		},
+		"cohort cycle": {
+			// cohort-a -> cohort-b -> cohort-c -> cohort-a
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
+				utiltestingapi.MakeCohort("cohort-c").Parent("cohort-a").Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq1").Cohort("cohort-a").Obj(),
+			},
+			localQueues: []*kueue.LocalQueue{
+				utiltestingapi.MakeLocalQueue("foo", defaultNamespace).ClusterQueue("cq1").Obj(),
+			},
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("a", defaultNamespace).Queue("foo").Creation(now).Obj(),
+			},
+			cqNames: sets.New[kueue.ClusterQueueReference]("cq1"),
+			wantInadmissible: map[kueue.ClusterQueueReference][]workload.Reference{
+				"cq1": {"default/a"},
+			},
+			wantActive: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var moveWorkloadsLogCount int
+			logger := funcr.New(func(prefix, args string) {
+				if strings.Contains(args, "Attempting to move workloads") {
+					moveWorkloadsLogCount++
+				}
+			}, funcr.Options{Verbosity: 2})
+			ctx := logr.NewContext(context.Background(), logger)
+
+			cl := utiltesting.NewFakeClient(utiltesting.MakeNamespace(defaultNamespace))
+			manager := NewManager(cl, nil)
+
+			for _, cohort := range tc.cohorts {
+				manager.AddOrUpdateCohort(ctx, cohort)
+			}
+			for _, cq := range tc.clusterQueues {
+				if err := manager.AddClusterQueue(ctx, cq); err != nil {
+					t.Fatalf("Failed adding clusterQueue %s: %v", cq.Name, err)
+				}
+				manager.getClusterQueue(kueue.ClusterQueueReference(cq.Name)).popCycle++
+			}
+			for _, lq := range tc.localQueues {
+				if err := manager.AddLocalQueue(ctx, lq); err != nil {
+					t.Fatalf("Failed adding queue %s: %v", lq.Name, err)
+				}
+			}
+			for _, wl := range tc.workloads {
+				if err := cl.Create(ctx, wl); err != nil {
+					t.Fatalf("Failed adding workload to client: %v", err)
+				}
+				manager.RequeueWorkload(ctx, workload.NewInfo(wl), RequeueReasonGeneric)
+			}
+
+			// Reset the counter before testing. Setup operations also trigger the log.
+			moveWorkloadsLogCount = 0
+
+			manager.QueueInadmissibleWorkloads(ctx, tc.cqNames)
+
+			if diff := cmp.Diff(tc.wantInadmissible, manager.DumpInadmissible()); diff != "" {
+				t.Errorf("Unexpected inadmissible workloads (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantActive, manager.Dump(), cmpDump...); diff != "" {
+				t.Errorf("Unexpected active workloads (-want +got):\n%s", diff)
+			}
+			if moveWorkloadsLogCount != tc.wantMoveWorkloadsLogCount {
+				t.Errorf("Expected %d 'Attempting to move workloads' log call(s), got %d", tc.wantMoveWorkloadsLogCount, moveWorkloadsLogCount)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
The change tracks which cohort roots have already been processed within a single `QueueInadmissibleWorkloads` call and skip CQs whose root was already handled. This ensures each hierarchy is processed exactly once regardless of how many CQs from that hierarchy are in the input.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8339 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
HC: Avoid redundant requeuing of inadmissible workloads when multiple ClusterQueues in the same cohort hierarchy are processed.
```