### PR TITLE
Fix typo in `whenCanPreempt` field documentation

### DIFF
--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -412,7 +412,7 @@ type FlavorFungibility struct {
 	// +kubebuilder:default="MayStopSearch"
 	WhenCanBorrow FlavorFungibilityPolicy `json:"whenCanBorrow,omitempty"`
 	// whenCanPreempt determines whether a workload should try the next flavor
-	// before borrowing in current flavor. The possible values are:
+	// before preempting in current flavor. The possible values are:
 	//
 	// - `MayStopSearch`: stop the search for candidate flavors if workload fits or requires
 	//   preemption to fit.

--- a/apis/kueue/v1beta2/clusterqueue_types.go
+++ b/apis/kueue/v1beta2/clusterqueue_types.go
@@ -403,7 +403,7 @@ type FlavorFungibility struct {
 	// +optional
 	WhenCanBorrow FlavorFungibilityPolicy `json:"whenCanBorrow,omitempty"`
 	// whenCanPreempt determines whether a workload should try the next flavor
-	// before borrowing in current flavor. The possible values are:
+	// before preempting in current flavor. The possible values are:
 	//
 	// - `MayStopSearch`: stop the search for candidate flavors if workload fits or requires
 	//   preemption to fit.

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -229,7 +229,7 @@ spec:
                       default: TryNextFlavor
                       description: |-
                         whenCanPreempt determines whether a workload should try the next flavor
-                        before borrowing in current flavor. The possible values are:
+                        before preempting in current flavor. The possible values are:
 
                         - `MayStopSearch`: stop the search for candidate flavors if workload fits or requires
                           preemption to fit.
@@ -995,7 +995,7 @@ spec:
                       default: TryNextFlavor
                       description: |-
                         whenCanPreempt determines whether a workload should try the next flavor
-                        before borrowing in current flavor. The possible values are:
+                        before preempting in current flavor. The possible values are:
 
                         - `MayStopSearch`: stop the search for candidate flavors if workload fits or requires
                           preemption to fit.

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -200,7 +200,7 @@ spec:
                     default: TryNextFlavor
                     description: |-
                       whenCanPreempt determines whether a workload should try the next flavor
-                      before borrowing in current flavor. The possible values are:
+                      before preempting in current flavor. The possible values are:
 
                       - `MayStopSearch`: stop the search for candidate flavors if workload fits or requires
                         preemption to fit.
@@ -986,7 +986,7 @@ spec:
                     default: TryNextFlavor
                     description: |-
                       whenCanPreempt determines whether a workload should try the next flavor
-                      before borrowing in current flavor. The possible values are:
+                      before preempting in current flavor. The possible values are:
 
                       - `MayStopSearch`: stop the search for candidate flavors if workload fits or requires
                         preemption to fit.

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -1507,7 +1507,7 @@ fits or requires borrowing to fit.</li>
 </td>
 <td>
    <p>whenCanPreempt determines whether a workload should try the next flavor
-before borrowing in current flavor. The possible values are:</p>
+before preempting in current flavor. The possible values are:</p>
 <ul>
 <li><code>MayStopSearch</code>: stop the search for candidate flavors if workload fits or requires
 preemption to fit.</li>

--- a/site/content/en/docs/reference/kueue.v1beta2.md
+++ b/site/content/en/docs/reference/kueue.v1beta2.md
@@ -1401,7 +1401,7 @@ fits or requires borrowing to fit.</li>
 </td>
 <td>
    <p>whenCanPreempt determines whether a workload should try the next flavor
-before borrowing in current flavor. The possible values are:</p>
+before preempting in current flavor. The possible values are:</p>
 <ul>
 <li><code>MayStopSearch</code>: stop the search for candidate flavors if workload fits or requires
 preemption to fit.</li>


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

The documentation for whenCanPreempt incorrectly said "before borrowing" when it should say "before preempting" to match the field name and its actual behavior.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```