### PR TITLE
Fix node scheduling properties change detection logic

### DIFF
--- a/pkg/controller/tas/resource_flavor.go
+++ b/pkg/controller/tas/resource_flavor.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -116,7 +115,7 @@ func (h *nodeHandler) Update(ctx context.Context, e event.UpdateEvent, q workque
 		return
 	}
 
-	if checkNodeSchedulingPropertiesChanged(newNode, oldNode) == None {
+	if checkNodeSchedulingPropertiesChanged(newNode, oldNode) == nodeUnchanged {
 		ctrl.LoggerFrom(ctx).V(5).Info("Skipping node update as scheduling properties are unchanged", "node", newNode.Name)
 		return
 	}
@@ -219,17 +218,17 @@ func nodeBelongsToFlavor(node *corev1.Node, nodeLabels map[string]string, levels
 type eventType int64
 
 const (
-	UpdateNodeAllocatable eventType = 1 << iota
-	UpdateNodeLabel
-	UpdateNodeTaint
-	UpdateNodeCondition
-	UpdateNodeAnnotation
-	UpdateNodeSpecUnschedulable
+	nodeAllocatableChanged eventType = 1 << iota
+	nodeLabelsChanged
+	nodeTaintsChanged
+	nodeConditionsChanged
+	nodeAnnotationsChanged
+	nodeSpecUnschedulableChanged
 
-	None eventType = 0
+	nodeUnchanged eventType = 0
 )
 
-type nodeChangeExtractor func(newNode, oldNode *v1.Node) eventType
+type nodeChangeExtractor func(newNode, oldNode *corev1.Node) eventType
 
 var nodeChangeExtractors = []nodeChangeExtractor{
 	extractNodeSpecUnschedulableChange,
@@ -240,7 +239,7 @@ var nodeChangeExtractors = []nodeChangeExtractor{
 	extractNodeAnnotationsChange,
 }
 
-func checkNodeSchedulingPropertiesChanged(newNode, oldNode *v1.Node) eventType {
+func checkNodeSchedulingPropertiesChanged(newNode, oldNode *corev1.Node) eventType {
 	var et eventType
 	for _, fn := range nodeChangeExtractors {
 		et |= fn(newNode, oldNode)
@@ -248,51 +247,51 @@ func checkNodeSchedulingPropertiesChanged(newNode, oldNode *v1.Node) eventType {
 	return et
 }
 
-func extractNodeAllocatableChange(newNode, oldNode *v1.Node) eventType {
+func extractNodeAllocatableChange(newNode, oldNode *corev1.Node) eventType {
 	if equality.Semantic.DeepEqual(oldNode.Status.Allocatable, newNode.Status.Allocatable) {
-		return None
+		return nodeUnchanged
 	}
-	return UpdateNodeAllocatable
+	return nodeAllocatableChanged
 }
 
-func extractNodeLabelsChange(newNode, oldNode *v1.Node) eventType {
+func extractNodeLabelsChange(newNode, oldNode *corev1.Node) eventType {
 	if equality.Semantic.DeepEqual(newNode.GetLabels(), oldNode.GetLabels()) {
-		return None
+		return nodeUnchanged
 	}
-	return UpdateNodeLabel
+	return nodeLabelsChanged
 }
 
-func extractNodeTaintsChange(newNode, oldNode *v1.Node) eventType {
+func extractNodeTaintsChange(newNode, oldNode *corev1.Node) eventType {
 	if equality.Semantic.DeepEqual(newNode.Spec.Taints, oldNode.Spec.Taints) {
-		return None
+		return nodeUnchanged
 	}
-	return UpdateNodeTaint
+	return nodeTaintsChanged
 }
 
-func extractNodeConditionsChange(newNode, oldNode *v1.Node) eventType {
-	strip := func(conditions []v1.NodeCondition) map[v1.NodeConditionType]v1.ConditionStatus {
-		conditionStatuses := make(map[v1.NodeConditionType]v1.ConditionStatus, len(conditions))
+func extractNodeConditionsChange(newNode, oldNode *corev1.Node) eventType {
+	strip := func(conditions []corev1.NodeCondition) map[corev1.NodeConditionType]corev1.ConditionStatus {
+		conditionStatuses := make(map[corev1.NodeConditionType]corev1.ConditionStatus, len(conditions))
 		for i := range conditions {
 			conditionStatuses[conditions[i].Type] = conditions[i].Status
 		}
 		return conditionStatuses
 	}
 	if equality.Semantic.DeepEqual(strip(oldNode.Status.Conditions), strip(newNode.Status.Conditions)) {
-		return None
+		return nodeUnchanged
 	}
-	return UpdateNodeCondition
+	return nodeConditionsChanged
 }
 
-func extractNodeSpecUnschedulableChange(newNode, oldNode *v1.Node) eventType {
+func extractNodeSpecUnschedulableChange(newNode, oldNode *corev1.Node) eventType {
 	if newNode.Spec.Unschedulable == oldNode.Spec.Unschedulable {
-		return None
+		return nodeUnchanged
 	}
-	return UpdateNodeSpecUnschedulable
+	return nodeSpecUnschedulableChanged
 }
 
-func extractNodeAnnotationsChange(newNode, oldNode *v1.Node) eventType {
+func extractNodeAnnotationsChange(newNode, oldNode *corev1.Node) eventType {
 	if equality.Semantic.DeepEqual(oldNode.GetAnnotations(), newNode.GetAnnotations()) {
-		return None
+		return nodeUnchanged
 	}
-	return UpdateNodeAnnotation
+	return nodeAnnotationsChanged
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

In this PR, instead of filtering out unnecessary events, only extract the required events.
`tas_resource_flavor_controller` already filters out some irrelevant node updates, but some unnecessary status updates still trigger reconciliation. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8400

#### Special notes for your reviewer:

I've included a node annotation change extractor to align with the unit test, though I'm not entirely sure if it's the right trigger to retry for inadmissible workloads.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: fix TAS resource flavor controller to extract only scheduling-relevant node updates to prevent unnecessary reconciliation.
```