### PR TITLE
Add option to require ready admission checks when selecting worker cluster in MultiKueue

### DIFF
--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -277,6 +277,12 @@ type MultiKueue struct {
 	// ClusterProfile defines configuration for using the ClusterProfile API.
 	// +optional
 	ClusterProfile *ClusterProfile `json:"clusterProfile,omitempty"`
+
+	// RequireAllAdmissionChecksReady determines whether all admission checks must be
+	// in Ready state for a workload to be considered when selecting which remote cluster
+	// reserved quota first. Defaults to false.
+	// +optional
+	RequireAllAdmissionChecksReady *bool `json:"requireAllAdmissionChecksReady,omitempty"`
 }
 
 // MultiKueueExternalFramework defines a framework that is not built-in.

--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -409,6 +409,7 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, cCache *schdcache.C
 			multikueue.WithDispatcherName(ptr.Deref(cfg.MultiKueue.DispatcherName, configapi.MultiKueueDispatcherModeAllAtOnce)),
 			multikueue.WithClusterProfiles(cfg.MultiKueue.ClusterProfile),
 			multikueue.WithRoleTracker(roleTracker),
+			multikueue.WithRequireAllAdmissionChecksReady(ptr.Deref(cfg.MultiKueue.RequireAllAdmissionChecksReady, false)),
 		); err != nil {
 			return fmt.Errorf("could not setup MultiKueue controller: %w", err)
 		}

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -103,6 +103,8 @@ func TestWlReconcile(t *testing.T) {
 		// second worker
 		wantWorker2Workloads []kueue.Workload
 		wantWorker2Jobs      []batchv1.Job
+
+		requireAllAdmissionChecksReady bool
 	}{
 		"deleted regular workload is removed from the cache": {
 			reconcileFor: "wl1",
@@ -114,7 +116,8 @@ func TestWlReconcile(t *testing.T) {
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					Obj(),
 			},
-			wantManagersJobs: []batchv1.Job{*baseJobBuilder.Clone().Obj()},
+			wantManagersJobs:               []batchv1.Job{*baseJobBuilder.Clone().Obj()},
+			requireAllAdmissionChecksReady: false,
 		},
 		"deleted MultiKueue workload is deleted from cache - the worker will be deleted by GC": {
 			reconcileFor: "wl1",
@@ -138,9 +141,11 @@ func TestWlReconcile(t *testing.T) {
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"missing workload": {
-			reconcileFor: "missing workload",
+			reconcileFor:                   "missing workload",
+			requireAllAdmissionChecksReady: false,
 		},
 		"missing workload (in deleted workload cache)": {
 			reconcileFor: "wl1",
@@ -163,6 +168,7 @@ func TestWlReconcile(t *testing.T) {
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"missing workload (in deleted workload cache), no remote objects": {
 			reconcileFor: "wl1",
@@ -173,6 +179,7 @@ func TestWlReconcile(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
 					Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"unmanaged wl (no ac) is ignored": {
 			reconcileFor: "wl1",
@@ -182,6 +189,7 @@ func TestWlReconcile(t *testing.T) {
 			wantManagersWorkloads: []kueue.Workload{
 				*baseWorkloadBuilder.Clone().Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"unmanaged wl (no parent) is rejected": {
 			reconcileFor: "wl1",
@@ -195,6 +203,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStateRejected, Message: "No multikueue adapter found"}).
 					Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"unmanaged wl (owned by pod) is rejected": {
 			reconcileFor: "wl1",
@@ -210,6 +219,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStateRejected, Message: `No multikueue adapter found for owner kind "/v1, Kind=Pod"`}).
 					Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"unmanaged wl (job not managed by multikueue) is rejected": {
 			features:     map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
@@ -232,6 +242,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStateRejected, Message: `The owner is not managed by Kueue: Expecting spec.managedBy to be "kueue.x-k8s.io/multikueue" not ""`}).
 					Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"failing to read from a worker": {
 			reconcileFor: "wl1",
@@ -252,7 +263,8 @@ func TestWlReconcile(t *testing.T) {
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					Obj(),
 			},
-			wantError: errFake,
+			wantError:                      errFake,
+			requireAllAdmissionChecksReady: false,
 		},
 		"reconnecting clients are skipped": {
 			reconcileFor: "wl1",
@@ -274,7 +286,8 @@ func TestWlReconcile(t *testing.T) {
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					Obj(),
 			},
-			wantError: nil,
+			wantError:                      nil,
+			requireAllAdmissionChecksReady: false,
 		},
 		"wl without reservation, clears the workload objects": {
 			reconcileFor: "wl1",
@@ -297,6 +310,7 @@ func TestWlReconcile(t *testing.T) {
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"wl without reservation, clears the workload objects (withoutJobManagedBy)": {
 			features:     map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: false},
@@ -320,6 +334,7 @@ func TestWlReconcile(t *testing.T) {
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"wl with reservation, creates remote workloads, worker2 fails": {
 			reconcileFor: "wl1",
@@ -348,7 +363,8 @@ func TestWlReconcile(t *testing.T) {
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Obj(),
 			},
-			wantError: errFake,
+			wantError:                      errFake,
+			requireAllAdmissionChecksReady: false,
 		},
 		"wl with reservation, creates missing workloads": {
 			reconcileFor: "wl1",
@@ -387,6 +403,7 @@ func TestWlReconcile(t *testing.T) {
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"remote wl with reservation, unable to delete the second worker's workload": {
 			reconcileFor: "wl1",
@@ -434,7 +451,8 @@ func TestWlReconcile(t *testing.T) {
 				*baseWorkloadBuilder.Clone().
 					Obj(),
 			},
-			wantError: errFake,
+			wantError:                      errFake,
+			requireAllAdmissionChecksReady: false,
 		},
 		"remote wl with reservation": {
 			features:     map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
@@ -500,6 +518,7 @@ func TestWlReconcile(t *testing.T) {
 					Message:   `The workload got reservation on "worker1"`,
 				},
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"remote wl evicted": {
 			features:     map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
@@ -570,6 +589,7 @@ func TestWlReconcile(t *testing.T) {
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"handle workload evicted on manager cluster": {
 			features:     map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
@@ -650,6 +670,7 @@ func TestWlReconcile(t *testing.T) {
 			wantWorker2Workloads: []kueue.Workload{
 				*baseWorkloadBuilder.DeepCopy(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"remote wl with reservation (withoutJobManagedBy)": {
 			features:     map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: false},
@@ -715,6 +736,7 @@ func TestWlReconcile(t *testing.T) {
 					Message:   `The workload got reservation on "worker1"`,
 				},
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"remote wl with reservation (withoutJobManagedBy, MultiKueueDispatcherModeIncremental)": {
 			features:       map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: false},
@@ -781,6 +803,7 @@ func TestWlReconcile(t *testing.T) {
 					Message:   `The workload got reservation on "worker1"`,
 				},
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"remote job is changing status the local Job is updated ": {
 			features:     map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
@@ -853,6 +876,7 @@ func TestWlReconcile(t *testing.T) {
 					Message:   `The workload got reservation on "worker1"`,
 				},
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"remote job is changing status, the local job is not updated (withoutJobManagedBy)": {
 			features:     map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: false},
@@ -923,6 +947,7 @@ func TestWlReconcile(t *testing.T) {
 					Message:   `The workload got reservation on "worker1"`,
 				},
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"remote wl is finished, the local workload and Job are marked completed ": {
 			reconcileFor: "wl1",
@@ -988,6 +1013,7 @@ func TestWlReconcile(t *testing.T) {
 					Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
 					Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"remote wl is finished, the local workload and Job are marked completed (withoutJobManagedBy)": {
 			features:     map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: false},
@@ -1054,6 +1080,7 @@ func TestWlReconcile(t *testing.T) {
 					Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
 					Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"the local Job is marked finished, the remote objects are removed": {
 			reconcileFor: "wl1",
@@ -1107,6 +1134,7 @@ func TestWlReconcile(t *testing.T) {
 					Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
 					Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"the local workload admission check Ready if the remote WorkerLostTimeout is not exceeded": {
 			reconcileFor: "wl1",
@@ -1135,6 +1163,7 @@ func TestWlReconcile(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
 					Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"the local workload's admission check is set to Retry if the WorkerLostTimeout is exceeded": {
 			reconcileFor: "wl1",
@@ -1163,6 +1192,7 @@ func TestWlReconcile(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
 					Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"worker reconnects after the local workload is requeued, remote objects are deleted": {
 			reconcileFor: "wl1",
@@ -1201,6 +1231,7 @@ func TestWlReconcile(t *testing.T) {
 					Label(constants.PrebuiltWorkloadLabel, "wl1").
 					Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"worker reconnects after the local workload is requeued and got reservation on a second worker": {
 			features: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
@@ -1280,6 +1311,7 @@ func TestWlReconcile(t *testing.T) {
 					Message:   `The workload got reservation on "worker1"`,
 				},
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"elastic job finished local workload via replacement is ignored": {
 			features:     map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
@@ -1352,6 +1384,7 @@ func TestWlReconcile(t *testing.T) {
 					Label(constants.PrebuiltWorkloadLabel, "wl1").
 					Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"elastic job local workload without quota reservation": {
 			features:     map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
@@ -1401,6 +1434,7 @@ func TestWlReconcile(t *testing.T) {
 			wantManagersJobs: []batchv1.Job{
 				*baseJobManagedByKueueBuilder.Clone().Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"elastic job local scaled-up workload slice without quota reservation": {
 			features: map[featuregate.Feature]bool{
@@ -1466,6 +1500,7 @@ func TestWlReconcile(t *testing.T) {
 					Label(constants.PrebuiltWorkloadLabel, "wl1").
 					Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"elastic job local workload out-of-sync other than scaled-down": {
 			features: map[featuregate.Feature]bool{
@@ -1522,6 +1557,7 @@ func TestWlReconcile(t *testing.T) {
 			wantManagersJobs: []batchv1.Job{
 				*baseJobManagedByKueueBuilder.Clone().Obj(),
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 		"elastic job local workload out-of-sync scaled-down": {
 			features: map[featuregate.Feature]bool{
@@ -1596,6 +1632,7 @@ func TestWlReconcile(t *testing.T) {
 					Message:   `The workload got reservation on "worker1"`,
 				},
 			},
+			requireAllAdmissionChecksReady: false,
 		},
 	}
 
@@ -1678,7 +1715,7 @@ func TestWlReconcile(t *testing.T) {
 				helper, _ := admissioncheck.NewMultiKueueStoreHelper(managerClient)
 				recorder := &utiltesting.EventRecorder{}
 				mkDispatcherName := ptr.Deref(tc.dispatcherName, config.MultiKueueDispatcherModeAllAtOnce)
-				reconciler := newWlReconciler(managerClient, helper, cRec, defaultOrigin, recorder, defaultWorkerLostTimeout, time.Second, adapters, mkDispatcherName, nil, WithClock(t, fakeClock))
+				reconciler := newWlReconciler(managerClient, helper, cRec, defaultOrigin, recorder, defaultWorkerLostTimeout, time.Second, adapters, mkDispatcherName, nil, tc.requireAllAdmissionChecksReady, WithClock(t, fakeClock))
 
 				for _, val := range tc.managersDeletedWorkloads {
 					reconciler.Delete(event.DeleteEvent{


### PR DESCRIPTION
#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:

Multi-kueue currently only considers quota reservations but not admission checks when selecting a worker cluster.

When using Kueue with the `kueue.x-k8s.io/provisioning-request` admission check, one typically sets very high quotas as only the provisioning request determines whether a workload can be scheduled, see e.g. [here](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/provisioningrequest#kueue-resources):

```yaml
apiVersion: kueue.x-k8s.io/v1beta1
kind: ClusterQueue
metadata:
  name: "dws-cluster-queue"
spec:
    ...
          resources:
            ...
            - name: "nvidia.com/gpu"
              nominalQuota: 1000000000 # "Infinite" quota 
  admissionChecks:
    - dws-prov
```

When using such a `ClusterQueue` with "infinite" resource quota but with an admission check in the worker clusters of MultiKueue, the current behaviour is that all worker clusters immediately grant a quota reservation and the first one to do so is picked as the one running the workload. The provisioning request is immediately deleted in all other worker clusters.


This behaviour can be undesirable because the picked cluster might not be the one that would have granted the provisioning request first.

In this PR I'm introducing a new MultiKueue config flag that enables exactly this behaviour:

```yaml
In a mu
multiKueue:
  requireAllAdmissionChecksReady: true
```

By default, the new feature is disabled, hence fully backwards compatible. If enabled, not only the quota reservation but also the admission checks are evaluated when picking a worker cluster. This way, with the `AllAtOnce` strategy, the provisioning request is kept in all worker clusters until one of them provisions the provisioning request.


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

Yes, there is a new feature flag `multiKueue.requireAllAdmissionChecksReady` users can enable. By default, there is no change in behaviour.

-->
```release-note
MultiKueue can now consider admission checks (e.g. for the provisioning request api integration) when determining which worker cluster to run the workload on. Set `multiKueue.requireAllAdmissionChecksReady: true` to activate this behaviour.
```