### PR TITLE
[TAS] Fix one of unit tests for PodSet groups

### DIFF
--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -4917,13 +4917,14 @@ func TestFindTopologyAssignments(t *testing.T) {
 					requests: resources.Requests{
 						corev1.ResourceCPU: 1000,
 					},
-					count: 1,
+					podSetGroupName: ptr.To("sameGroup"),
+					count:           1,
 					wantAssignment: &tas.TopologyAssignment{
 						Levels: []string{tasBlockLabel},
 						Domains: []tas.TopologyDomainAssignment{
 							{
 								Count:  1,
-								Values: []string{"b1"},
+								Values: []string{"b2"},
 							},
 						},
 					},
@@ -4937,7 +4938,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 						corev1.ResourceCPU: 1000,
 						"example.com/gpu":  2,
 					},
-					count: 4,
+					podSetGroupName: ptr.To("sameGroup"),
+					count:           4,
 					wantAssignment: &tas.TopologyAssignment{
 						Levels: []string{tasBlockLabel},
 						Domains: []tas.TopologyDomainAssignment{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In this refactor PR https://github.com/kubernetes-sigs/kueue/commit/083c7ff7e88cc41fef25756932cf7c239e88962c#diff-85a93b2977c9efa55ca4846fdd219e22733e2b736c4fa3dba06f70739c1bbdfbL3294 we mistakenly removed PodSetGroupName field which resulted in different behavior, than before refactor

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```