### PR TITLE
[TAS] Cache non-TAS pod usage

### DIFF
--- a/pkg/cache/scheduler/tas_cache.go
+++ b/pkg/cache/scheduler/tas_cache.go
@@ -21,6 +21,9 @@ import (
 	"slices"
 	"sync"
 
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -33,6 +36,8 @@ type tasCache struct {
 	flavors     map[kueue.ResourceFlavorReference]flavorInformation
 	topologies  map[kueue.TopologyReference]topologyInformation
 	flavorCache map[kueue.ResourceFlavorReference]*TASFlavorCache
+
+	nonTasUsageCache *nonTasUsageCache
 }
 
 func NewTASCache(client client.Client) tasCache {
@@ -41,6 +46,10 @@ func NewTASCache(client client.Client) tasCache {
 		flavors:     make(map[kueue.ResourceFlavorReference]flavorInformation),
 		topologies:  make(map[kueue.TopologyReference]topologyInformation),
 		flavorCache: make(map[kueue.ResourceFlavorReference]*TASFlavorCache),
+		nonTasUsageCache: &nonTasUsageCache{
+			podUsage: make(map[types.NamespacedName]podUsageValue),
+			lock:     sync.RWMutex{},
+		},
 	}
 }
 
@@ -107,4 +116,14 @@ func (t *tasCache) DeleteTopology(name kueue.TopologyReference) {
 			delete(t.flavorCache, flavor)
 		}
 	}
+}
+
+// Update may add a pod to the cache, or
+// delete a terminated pod.
+func (t *tasCache) Update(pod corev1.Pod, log logr.Logger) {
+	t.nonTasUsageCache.update(pod, log)
+}
+
+func (t *tasCache) DeletePodByKey(key client.ObjectKey) {
+	t.nonTasUsageCache.delete(key)
 }

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -19,6 +19,7 @@ package scheduler
 import (
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1730,6 +1731,38 @@ func TestFindTopologyAssignments(t *testing.T) {
 				},
 				count:      1,
 				wantReason: `topology "default" doesn't allow to fit any of 1 pod(s). Total nodes: 1; excluded: resource "cpu": 1`,
+			}},
+		},
+		"include usage from non-TAS pods; pod usage": {
+			// this test case ensures we are counting pods properly
+			// when aggregating non-tas pod usage by node.
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x3").
+					Label(corev1.LabelHostname, "x3").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("running1", "test-ns").NodeName("x3").
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+				*testingpod.MakePod("running2", "test-ns").NodeName("x3").
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+			levels: defaultOneLevel,
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Required: ptr.To(corev1.LabelHostname),
+				},
+				requests: resources.Requests{
+					corev1.ResourceCPU: 0,
+				},
+				count:      9,
+				wantReason: `topology "default" allows to fit only 8 out of 9 pod(s)`,
 			}},
 		},
 		"include usage from running non-TAS pods, found free capacity on another node; BestFit": {
@@ -5979,6 +6012,9 @@ func TestFindTopologyAssignments(t *testing.T) {
 			flavorInformation := flavorInformation{
 				TopologyName: "default",
 				NodeLabels:   tc.nodeLabels,
+			}
+			for _, pod := range tc.pods {
+				tasCache.Update(pod, logr.FromContextOrDiscard(ctx))
 			}
 			tasFlavorCache := tasCache.NewTASFlavorCache(topologyInformation, flavorInformation)
 

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -25,15 +25,12 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	resourcehelpers "k8s.io/component-helpers/resource"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/resources"
-	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -88,15 +85,20 @@ type TASFlavorCache struct {
 
 	// usage maintains the usage per topology domain
 	usage map[utiltas.TopologyDomainID]resources.Requests
+
+	// nonTasUsageCache maintains the usage coming from non-TAS pods,
+	// e.g. static Pods or DaemonSet pods.
+	nonTasUsageCache *nonTasUsageCache
 }
 
 func (t *tasCache) NewTASFlavorCache(topologyInfo topologyInformation,
 	flavorInfo flavorInformation) *TASFlavorCache {
 	return &TASFlavorCache{
-		client:   t.client,
-		topology: topologyInfo,
-		flavor:   flavorInfo,
-		usage:    make(map[utiltas.TopologyDomainID]resources.Requests),
+		client:           t.client,
+		topology:         topologyInfo,
+		flavor:           flavorInfo,
+		usage:            make(map[utiltas.TopologyDomainID]resources.Requests),
+		nonTasUsageCache: t.nonTasUsageCache,
 	}
 }
 
@@ -114,14 +116,7 @@ func (c *TASFlavorCache) snapshot(ctx context.Context) (*TASFlavorSnapshot, erro
 	if err != nil {
 		return nil, fmt.Errorf("failed to list nodes for TAS: %w", err)
 	}
-	podListOpts := &client.ListOptions{}
-	podListOpts.FieldSelector = fields.OneTermEqualSelector(indexer.TASKey, "false")
-	pods := corev1.PodList{}
-	err = c.client.List(ctx, &pods, podListOpts)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list non-TAS pods which are bound to nodes: %w", err)
-	}
-	return c.snapshotForNodes(log, nodes.Items, pods.Items), nil
+	return c.snapshotForNodes(log, nodes.Items), nil
 }
 
 func (c *TASFlavorCache) NodeLabels() map[string]string {
@@ -136,12 +131,12 @@ func (c *TASFlavorCache) TopologyLevels() []string {
 	return c.topology.Levels
 }
 
-func (c *TASFlavorCache) snapshotForNodes(log logr.Logger, nodes []corev1.Node, pods []corev1.Pod) *TASFlavorSnapshot {
+func (c *TASFlavorCache) snapshotForNodes(log logr.Logger, nodes []corev1.Node) *TASFlavorSnapshot {
 	c.RLock()
 	defer c.RUnlock()
 
 	log.V(3).Info("Constructing TAS snapshot", "nodeLabels", c.flavor.NodeLabels,
-		"levels", c.topology.Levels, "nodeCount", len(nodes), "podCount", len(pods))
+		"levels", c.topology.Levels, "nodeCount", len(nodes))
 	snapshot := newTASFlavorSnapshot(log, c.flavor.TopologyName, c.topology.Levels, c.flavor.Tolerations)
 	nodeToDomain := make(map[string]utiltas.TopologyDomainID)
 	for _, node := range nodes {
@@ -151,14 +146,8 @@ func (c *TASFlavorCache) snapshotForNodes(log logr.Logger, nodes []corev1.Node, 
 	for domainID, usage := range c.usage {
 		snapshot.addTASUsage(domainID, usage)
 	}
-	for _, pod := range pods {
-		// skip unscheduled or terminal pods as they don't use any capacity
-		if len(pod.Spec.NodeName) == 0 || utilpod.IsTerminated(&pod) {
-			continue
-		}
-		if domainID, ok := nodeToDomain[pod.Spec.NodeName]; ok {
-			requests := resourcehelpers.PodRequests(&pod, resourcehelpers.PodResourcesOptions{})
-			usage := resources.NewRequests(requests)
+	for nodeName, usage := range c.nonTasUsageCache.usagePerNode() {
+		if domainID, ok := nodeToDomain[nodeName]; ok {
 			snapshot.addNonTASUsage(domainID, usage)
 		}
 	}

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -238,7 +238,6 @@ func (s *TASFlavorSnapshot) addNonTASUsage(domainID utiltas.TopologyDomainID, us
 	// least one TAS pod, and so the addCapacity function to initialize
 	// freeCapacity is already called.
 	s.leaves[domainID].freeCapacity.Sub(usage)
-	s.leaves[domainID].freeCapacity.Sub(resources.Requests{corev1.ResourcePods: 1})
 }
 
 func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests, op usageOp, count int32) {

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache.go
@@ -1,0 +1,84 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"sync"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	resourcehelpers "k8s.io/component-helpers/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/kueue/pkg/resources"
+	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
+)
+
+// nonTasUsageCache caches pod usage, to avoid
+// the hot path documented in kueue#8449.
+type nonTasUsageCache struct {
+	podUsage map[types.NamespacedName]podUsageValue
+	lock     sync.RWMutex
+}
+
+type podUsageValue struct {
+	node  string
+	usage resources.Requests
+}
+
+// update may add a pod to the cache, or
+// delete a terminated pod.
+func (n *nonTasUsageCache) update(pod corev1.Pod, log logr.Logger) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+
+	// delete terminated pods as they no longer use any capacity.
+	if utilpod.IsTerminated(&pod) {
+		log.V(5).Info("Deleting terminated pod from the cache")
+		delete(n.podUsage, client.ObjectKeyFromObject(&pod))
+		return
+	}
+
+	log.V(5).Info("Adding non-TAS pod to the cache")
+	requests := resources.NewRequests(
+		resourcehelpers.PodRequests(&pod, resourcehelpers.PodResourcesOptions{}))
+	n.podUsage[client.ObjectKeyFromObject(&pod)] = podUsageValue{
+		node:  pod.Spec.NodeName,
+		usage: requests,
+	}
+}
+
+func (n *nonTasUsageCache) delete(key client.ObjectKey) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	delete(n.podUsage, key)
+}
+
+func (n *nonTasUsageCache) usagePerNode() map[string]resources.Requests {
+	n.lock.RLock()
+	defer n.lock.RUnlock()
+	usage := make(map[string]resources.Requests)
+	for _, podUsage := range n.podUsage {
+		if _, found := usage[podUsage.node]; !found {
+			usage[podUsage.node] = resources.Requests{}
+		}
+		usage[podUsage.node].Add(podUsage.usage)
+		usage[podUsage.node].Add(resources.Requests{corev1.ResourcePods: 1})
+	}
+	return usage
+}

--- a/pkg/controller/tas/constants.go
+++ b/pkg/controller/tas/constants.go
@@ -23,6 +23,7 @@ const (
 	TASResourceFlavorController = "tas-resource-flavor-controller"
 	TASTopologyUngater          = "tas-topology-ungater"
 	TASNodeFailureController    = "tas-node-failure-controller"
+	TASNonTasUsageController    = "tas-non-tas-usage-controller"
 )
 
 const (

--- a/pkg/controller/tas/controllers.go
+++ b/pkg/controller/tas/controllers.go
@@ -46,5 +46,9 @@ func SetupControllers(mgr ctrl.Manager, queues *qcache.Manager, cache *schdcache
 			return ctrlName, err
 		}
 	}
+	nonTasUsageController := newNonTasUsageReconciler(mgr.GetClient(), cache, queues)
+	if ctrlName, err := nonTasUsageController.SetupWithManager(mgr); err != nil {
+		return ctrlName, err
+	}
 	return "", nil
 }

--- a/pkg/controller/tas/non_tas_usage_controller.go
+++ b/pkg/controller/tas/non_tas_usage_controller.go
@@ -1,0 +1,121 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tas
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/util/roletracker"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
+)
+
+func newNonTasUsageReconciler(client client.Client, cache *schdcache.Cache, qcache *qcache.Manager) *NonTasUsageReconciler {
+	return &NonTasUsageReconciler{
+		Client: client,
+		Cache:  cache,
+		QCache: qcache,
+	}
+}
+
+// NonTasUsageReconciler monitors pods to update
+// the TAS cache with non-TAS usage.
+type NonTasUsageReconciler struct {
+	client.Client
+	Cache       *schdcache.Cache
+	QCache      *qcache.Manager
+	roleTracker *roletracker.RoleTracker
+}
+
+var _ reconcile.Reconciler = (*NonTasUsageReconciler)(nil)
+var _ predicate.TypedPredicate[*corev1.Pod] = (*NonTasUsageReconciler)(nil)
+
+//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+
+func (r *NonTasUsageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := klog.FromContext(ctx).WithValues("pod", req.NamespacedName)
+	log.V(3).Info("Non-TAS usage cache reconciling")
+	var pod corev1.Pod
+	err := r.Get(ctx, req.NamespacedName, &pod)
+	if err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			return ctrl.Result{}, err
+		}
+		log.V(5).Info("Idempotently deleting not found pod")
+		r.Cache.TASCache().DeletePodByKey(req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+
+	r.Cache.TASCache().Update(pod, log)
+	return ctrl.Result{}, nil
+}
+
+func filterPod(pod *corev1.Pod) bool {
+	if utiltas.IsTAS(pod) {
+		return false
+	} else if len(pod.Spec.NodeName) == 0 {
+		// skip unscheduled pods as they don't use any capacity.
+		return false
+	}
+	return true
+}
+
+func (r *NonTasUsageReconciler) Create(e event.TypedCreateEvent[*corev1.Pod]) bool {
+	return filterPod(e.Object)
+}
+
+func (r *NonTasUsageReconciler) Update(e event.TypedUpdateEvent[*corev1.Pod]) bool {
+	return filterPod(e.ObjectNew)
+}
+
+func (r *NonTasUsageReconciler) Delete(e event.TypedDeleteEvent[*corev1.Pod]) bool {
+	return filterPod(e.Object)
+}
+
+func (r *NonTasUsageReconciler) Generic(event.TypedGenericEvent[*corev1.Pod]) bool {
+	return false
+}
+
+func (r *NonTasUsageReconciler) SetupWithManager(mgr ctrl.Manager) (string, error) {
+	return TASNonTasUsageController, ctrl.NewControllerManagedBy(mgr).
+		Named(TASNonTasUsageController).
+		WatchesRawSource(source.TypedKind(
+			mgr.GetCache(),
+			&corev1.Pod{},
+			&handler.TypedEnqueueRequestForObject[*corev1.Pod]{},
+			r,
+		)).
+		WithOptions(controller.Options{
+			NeedLeaderElection:      ptr.To(false),
+			MaxConcurrentReconciles: mgr.GetControllerOptions().GroupKindConcurrency[corev1.SchemeGroupVersion.WithKind("Pod").GroupKind().String()],
+		}).
+		WithLogConstructor(roletracker.NewLogConstructor(r.roleTracker, TASNonTasUsageController)).
+		Complete(r)
+}

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
@@ -1897,62 +1898,6 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 		},
-		"workload gets scheduled as the usage of TAS pods and workloads is not double-counted": {
-			nodes: defaultSingleNode,
-			pods: []corev1.Pod{
-				*testingpod.MakePod("test-running", "test-ns").NodeName("x1").
-					StatusPhase(corev1.PodRunning).
-					Request(corev1.ResourceCPU, "400m").
-					NodeSelector(corev1.LabelHostname, "x1").
-					Label(kueue.TASLabel, "true").
-					Obj(),
-			},
-			topologies:      []kueue.Topology{defaultSingleLevelTopology},
-			resourceFlavors: []kueue.ResourceFlavor{defaultTASFlavor},
-			clusterQueues:   []kueue.ClusterQueue{defaultClusterQueue},
-			workloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("foo", "default").
-					Queue("tas-main").
-					PodSets(*utiltestingapi.MakePodSet("one", 1).
-						RequiredTopologyRequest(corev1.LabelHostname).
-						Request(corev1.ResourceCPU, "500m").
-						Obj()).
-					Obj(),
-				*utiltestingapi.MakeWorkload("bar-admitted", "default").
-					Queue("tas-main").
-					ReserveQuotaAt(
-						utiltestingapi.MakeAdmission("tas-main").
-							PodSets(utiltestingapi.MakePodSetAssignment("one").
-								Assignment(corev1.ResourceCPU, "tas-default", "400m").
-								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-									Obj()).
-								Obj()).
-							Obj(), now,
-					).
-					AdmittedAt(true, now).
-					PodSets(*utiltestingapi.MakePodSet("one", 1).
-						RequiredTopologyRequest(corev1.LabelHostname).
-						Request(corev1.ResourceCPU, "400m").
-						Obj()).
-					Obj(),
-			},
-			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltestingapi.MakeAdmission("tas-main").
-					PodSets(utiltestingapi.MakePodSetAssignment("one").
-						Assignment(corev1.ResourceCPU, "tas-default", "500m").
-						TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-							Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-							Obj()).
-						Obj()).
-					Obj(),
-			},
-			eventCmpOpts: cmp.Options{eventIgnoreMessage},
-			wantEvents: []utiltesting.EventRecord{
-				utiltesting.MakeEventRecord("default", "foo", "QuotaReserved", corev1.EventTypeNormal).Obj(),
-				utiltesting.MakeEventRecord("default", "foo", "Admitted", corev1.EventTypeNormal).Obj(),
-			},
-		},
 		"workload gets admitted next to already admitted workload, multiple resources used": {
 			nodes:           defaultSingleNode,
 			topologies:      []kueue.Topology{defaultSingleLevelTopology},
@@ -2774,6 +2719,9 @@ func TestScheduleForTAS(t *testing.T) {
 					if err := qManager.AddLocalQueue(ctx, &q); err != nil {
 						t.Fatalf("Inserting queue %s/%s in manager: %v", q.Namespace, q.Name, err)
 					}
+				}
+				for _, pod := range tc.pods {
+					cqCache.TASCache().Update(pod, logr.FromContextOrDiscard(ctx))
 				}
 				initiallyAdmittedWorkloads := sets.New[workload.Reference]()
 				for _, w := range testWls {

--- a/test/integration/singlecluster/tas/suite_test.go
+++ b/test/integration/singlecluster/tas/suite_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -36,6 +37,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/tas"
 	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/scheduler"
+	"sigs.k8s.io/kueue/pkg/util/webhook"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
 	"sigs.k8s.io/kueue/test/util"
@@ -46,6 +48,8 @@ var (
 	k8sClient client.Client
 	ctx       context.Context
 	fwk       *framework.Framework
+	// Cleanup after https://github.com/kubernetes-sigs/kueue/issues/8653
+	qManager *qcache.Manager
 )
 
 func TestAPIs(t *testing.T) {
@@ -78,12 +82,16 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 	failedWebhook, err := webhooks.Setup(mgr, nil)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
 
+	err = webhook.SetupNoopWebhook(mgr, &corev1.Pod{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 	controllersCfg := &config.Configuration{}
 	mgr.GetScheme().Default(controllersCfg)
 
 	cacheOptions := []schdcache.Option{}
 	cCache := schdcache.New(mgr.GetClient(), cacheOptions...)
 	queues := qcache.NewManager(mgr.GetClient(), cCache)
+	qManager = queues
 
 	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, controllersCfg, nil)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "Core controller", failedCtrl)

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	autoscaling "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,6 +44,7 @@ import (
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
+	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/test/integration/framework"
 	"sigs.k8s.io/kueue/test/util"
@@ -209,6 +211,219 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				"foo": "bar",
 			}
 			gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.HaveOccurred())
+		})
+	})
+
+	ginkgo.When("non-TAS pod exists", func() {
+		var (
+			nodes        []corev1.Node
+			tasFlavor    *kueue.ResourceFlavor
+			topology     *kueue.Topology
+			localQueue   *kueue.LocalQueue
+			clusterQueue *kueue.ClusterQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			nodes = []corev1.Node{
+				*testingnode.MakeNode("node1").
+					Label("node-group", "tas").
+					Label(utiltesting.DefaultBlockTopologyLevel, "b1").
+					Label(utiltesting.DefaultRackTopologyLevel, "r1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("3"),
+					}).
+					Ready().
+					Obj(),
+			}
+			util.CreateNodesWithStatus(ctx, k8sClient, nodes)
+
+			topology = utiltestingapi.MakeDefaultTwoLevelTopology("default")
+			util.MustCreate(ctx, k8sClient, topology)
+
+			tasFlavor = utiltestingapi.MakeResourceFlavor("tas-flavor").
+				NodeLabel("node-group", "tas").
+				TopologyName("default").Obj()
+			util.MustCreate(ctx, k8sClient, tasFlavor)
+
+			clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas(tasFlavor.Name).Resource(corev1.ResourceCPU, "999").Obj()).
+				Obj()
+			util.MustCreate(ctx, k8sClient, clusterQueue)
+			util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
+
+			localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+			util.MustCreate(ctx, k8sClient, localQueue)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+			for _, node := range nodes {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, &node, true)
+			}
+		})
+
+		ginkgo.It("non-TAS pod terminates, releasing capacity", func() {
+			var wl *kueue.Workload
+			var nonTasPod *corev1.Pod
+
+			ginkgo.By("create a non-TAS pod which consumes the node's capacity", func() {
+				nonTasPod = testingpod.MakePod("pod", ns.Name).
+					Request(corev1.ResourceCPU, "1").
+					NodeName("node1").
+					TerminationGracePeriod(0).
+					Obj()
+				util.MustCreate(ctx, k8sClient, nonTasPod)
+			})
+
+			ginkgo.By("create a workload which requires the node's capacity", func() {
+				wl = utiltestingapi.MakeWorkload("wl", ns.Name).
+					Queue("local-queue").
+					Request(corev1.ResourceCPU, "1").
+					Obj()
+				util.MustCreate(ctx, k8sClient, wl)
+
+				ginkgo.By("verify the workload is not admitted", func() {
+					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
+					util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
+					gomega.Consistently(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+						g.Expect(workload.IsAdmitted(wl)).To(gomega.BeFalse())
+					}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+				})
+			})
+
+			ginkgo.By("terminate the non-TAS pod", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nonTasPod), nonTasPod)).To(gomega.Succeed())
+					util.SetPodsPhase(ctx, k8sClient, corev1.PodSucceeded, nonTasPod)
+					g.Expect(k8sClient.Update(ctx, nonTasPod)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			// https://github.com/kubernetes-sigs/kueue/issues/8653
+			ginkgo.By("hack to requeue workload", func() {
+				cqs := sets.New[kueue.ClusterQueueReference]("cluster-queue")
+				qManager.QueueInadmissibleWorkloads(ctx, cqs)
+			})
+
+			ginkgo.By("expect TAS pod to admit", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+				util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
+			})
+		})
+
+		ginkgo.It("non-TAS pod is deleted, releasing capacity", func() {
+			var wl *kueue.Workload
+			var nonTasPod *corev1.Pod
+
+			ginkgo.By("creating a non-TAS pod which consumes the node's capacity", func() {
+				nonTasPod = testingpod.MakePod("pod", ns.Name).
+					Request(corev1.ResourceCPU, "1").
+					NodeName("node1").
+					TerminationGracePeriod(0).
+					Obj()
+				util.MustCreate(ctx, k8sClient, nonTasPod)
+			})
+
+			ginkgo.By("creating a workload which requires the node's capacity", func() {
+				wl = utiltestingapi.MakeWorkload("wl", ns.Name).
+					Queue("local-queue").
+					Request(corev1.ResourceCPU, "1").
+					Obj()
+				util.MustCreate(ctx, k8sClient, wl)
+			})
+
+			ginkgo.By("verify the workload is not admitted", func() {
+				util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(wl)).To(gomega.BeFalse())
+				}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("delete the non-TAS pod", func() {
+				util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, nonTasPod, true, 60*time.Second)
+			})
+
+			// https://github.com/kubernetes-sigs/kueue/issues/8653
+			ginkgo.By("hack to requeue workload", func() {
+				cqs := sets.New[kueue.ClusterQueueReference]("cluster-queue")
+				qManager.QueueInadmissibleWorkloads(ctx, cqs)
+			})
+
+			ginkgo.By("expect TAS pod to admit", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+				util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
+			})
+		})
+
+		ginkgo.It("Non-TAS pod has no node assignment", func() {
+			var wl *kueue.Workload
+			var nonTasPod *corev1.Pod
+			ginkgo.By("creating a non-TAS pod without assignment", func() {
+				nonTasPod = testingpod.MakePod("pod", ns.Name).
+					Request(corev1.ResourceCPU, "1").
+					Obj()
+				util.MustCreate(ctx, k8sClient, nonTasPod)
+			})
+
+			ginkgo.By("creating a workload which requires the node's capacity", func() {
+				wl = utiltestingapi.MakeWorkload("wl", ns.Name).
+					Queue("local-queue").
+					Request(corev1.ResourceCPU, "1").
+					Obj()
+				util.MustCreate(ctx, k8sClient, wl)
+			})
+
+			ginkgo.By("expect TAS pod to admit", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+				util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
+			})
+		})
+
+		ginkgo.It("workload gets scheduled as the usage of TAS pods and workloads is not double-counted", func() {
+			var wl1, wl2 *kueue.Workload
+
+			ginkgo.By("create a workload which requires the node's capacity", func() {
+				wl1 = utiltestingapi.MakeWorkload("wl1", ns.Name).
+					Queue("local-queue").
+					Request(corev1.ResourceCPU, "400m").
+					Obj()
+				util.MustCreate(ctx, k8sClient, wl1)
+			})
+
+			ginkgo.By("verify the first workload is admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+			})
+
+			ginkgo.By("create a TAS pod belonging to the admitted workload", func() {
+				// We manually create the pod because job controllers don't run in integration tests.
+				// The pod must have a TAS annotation to be identified as such by the controller.
+				tasPod := testingpod.MakePod("tas-pod", ns.Name).
+					NodeName("node1").
+					StatusPhase(corev1.PodRunning).
+					Request(corev1.ResourceCPU, "400m").
+					Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
+					Obj()
+				util.MustCreate(ctx, k8sClient, tasPod)
+			})
+
+			ginkgo.By("create another workload which requires the remaining node's capacity", func() {
+				wl2 = utiltestingapi.MakeWorkload("wl2", ns.Name).
+					Queue("local-queue").
+					Request(corev1.ResourceCPU, "500m").
+					Obj()
+				util.MustCreate(ctx, k8sClient, wl2)
+			})
+
+			ginkgo.By("expect second workload to admit", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl2)
+				util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 2)
+			})
 		})
 	})
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Improve performance of TAS by caching pods used to compute non-TAS usage.

#### Which issue(s) this PR fixes:
Fixes #8449

See https://github.com/kubernetes-sigs/kueue/issues/8449#issuecomment-3725934428 for alternatives considered

#### Special notes for your reviewer:
Considered WIP until I add an integration test (or verify that one already exists)

#### Does this PR introduce a user-facing change?
```release-note
TAS: significantly improves scheduling performance by replacing Pod listing with an event-driven
cache for non-TAS Pods, thereby avoiding expensive DeepCopy operations during each scheduling cycle.
```