### PR TITLE
Manual cherry pick 8269 release 0.14

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -44,4 +44,9 @@ const (
 	// ManagedByKueueLabelKey label that signalize that an object is managed by Kueue
 	ManagedByKueueLabelKey   = "kueue.x-k8s.io/managed"
 	ManagedByKueueLabelValue = "true"
+
+	// PodSetLabel is a label set on the Job's PodTemplate to indicate the name
+	// of the PodSet of the admitted Workload corresponding to the PodTemplate.
+	// The label is set when starting the Job, and removed on stopping the Job.
+	PodSetLabel = "kueue.x-k8s.io/podset"
 )

--- a/pkg/controller/jobs/trainjob/trainjob_controller_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller_test.go
@@ -32,6 +32,7 @@ import (
 	jobsetapi "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/podset"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -202,6 +203,79 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 		"should return an error if the trainjob references an unknown training runtime": {
 			trainJob: testTrainJob.Clone().Obj(),
 			wantErr:  true,
+		},
+		"should replace existing Kueue overrides (idempotency)": {
+			trainJob: testTrainJob.Clone().
+				PodTemplateOverrides([]kftrainerapi.PodTemplateOverride{
+					{
+						TargetJobs: []kftrainerapi.PodTemplateOverrideTargetJob{
+							{Name: "user-provided"},
+						},
+						Spec: &kftrainerapi.PodTemplateSpecOverride{
+							NodeSelector: map[string]string{"disktype": "sdd"},
+						},
+					},
+					{
+						TargetJobs: []kftrainerapi.PodTemplateOverrideTargetJob{
+							{Name: "node"},
+						},
+						Metadata: &metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"test-annotation": "old-value",
+							},
+							Labels: map[string]string{
+								constants.PodSetLabel: "node",
+							},
+						},
+						Spec: &kftrainerapi.PodTemplateSpecOverride{
+							NodeSelector: map[string]string{"old-selector": "value"},
+						},
+					},
+				}).
+				Obj(),
+			podsetsInfo: []podset.PodSetInfo{
+				{
+					Name: "node",
+					Annotations: map[string]string{
+						"test-annotation": "new-value",
+					},
+					Labels: map[string]string{
+						constants.PodSetLabel: "node",
+					},
+					NodeSelector: map[string]string{"new-selector": "value"},
+				},
+			},
+			wantTrainJob: testTrainJob.Clone().
+				Annotation(firstOverrideIdx, "1").
+				PodTemplateOverrides([]kftrainerapi.PodTemplateOverride{
+					{
+						TargetJobs: []kftrainerapi.PodTemplateOverrideTargetJob{
+							{Name: "user-provided"},
+						},
+						Spec: &kftrainerapi.PodTemplateSpecOverride{
+							NodeSelector: map[string]string{"disktype": "sdd"},
+						},
+					},
+					{
+						TargetJobs: []kftrainerapi.PodTemplateOverrideTargetJob{
+							{Name: "node"},
+						},
+						Metadata: &metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"test-annotation": "new-value",
+							},
+							Labels: map[string]string{
+								constants.PodSetLabel: "node",
+							},
+						},
+						Spec: &kftrainerapi.PodTemplateSpecOverride{
+							NodeSelector: map[string]string{"new-selector": "value"},
+						},
+					},
+				}).
+				Suspend(false).
+				Obj(),
+			wantErr: false,
 		},
 	}
 


### PR DESCRIPTION
This is a manual cherrypick of #8269
```release-note
Kubeflow TrainJob v2: fix the bug to prevent duplicate pod template overrides when starting the Job is retried.
```