### PR TITLE
Do not return assigned counts in the TAS domain helper struct

### DIFF
--- a/pkg/cache/scheduler/tas_balanced_placement.go
+++ b/pkg/cache/scheduler/tas_balanced_placement.go
@@ -325,7 +325,7 @@ func (s *TASFlavorSnapshot) pruneDomainsBelowThreshold(domains []*domain, thresh
 		}
 	}
 	for _, d := range domains {
-		d.state, d.sliceState, d.stateWithLeader, d.sliceStateWithLeader, d.leaderState = s.fillInCountsHelper(d, sliceSize, sliceLevelIdx, level)
+		s.fillInCountsHelper(d, sliceSize, sliceLevelIdx, level)
 		if d.sliceStateWithLeader < threshold {
 			clearState(d)
 		}

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1442,7 +1442,7 @@ func (s *TASFlavorSnapshot) fillInCounts(
 		leaf.stateWithLeader = requests.CountIn(remainingCapacity)
 	}
 	for _, root := range s.roots {
-		root.state, root.sliceState, root.stateWithLeader, root.sliceStateWithLeader, root.leaderState = s.fillInCountsHelper(root, sliceSize, sliceLevelIdx, 0)
+		s.fillInCountsHelper(root, sliceSize, sliceLevelIdx, 0)
 	}
 }
 
@@ -1455,7 +1455,7 @@ func belongsToRequiredDomain(leaf *leafDomain, requiredReplacementDomain utiltas
 	return strings.HasPrefix(string(utiltas.DomainID(leaf.levelValues)), string(requiredReplacementDomain))
 }
 
-func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, sliceLevelIdx int, level int) (int32, int32, int32, int32, int32) {
+func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, sliceLevelIdx int, level int) {
 	// logic for a leaf
 	if len(domain.children) == 0 {
 		if level == sliceLevelIdx {
@@ -1463,7 +1463,7 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 			domain.sliceState = domain.state / sliceSize
 			domain.sliceStateWithLeader = domain.stateWithLeader / sliceSize
 		}
-		return domain.state, domain.sliceState, domain.stateWithLeader, domain.sliceStateWithLeader, domain.leaderState
+		return
 	}
 	// logic for a parent
 	childrenCapacity := int32(0)
@@ -1474,18 +1474,12 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 	leaderState := int32(0)
 
 	for _, child := range domain.children {
-		addChildrenCapacity, addChildrenSliceCapacity, addChildrenCapacityWithLeader, addChildrenSliceCapacityWithLeader, childLeaderState := s.fillInCountsHelper(child, sliceSize, sliceLevelIdx, level+1)
-		childrenCapacity += addChildrenCapacity
-		sliceCapacity += addChildrenSliceCapacity
-		if addChildrenCapacity-addChildrenCapacityWithLeader < minStateWithLeaderDifference {
-			minStateWithLeaderDifference = addChildrenCapacity - addChildrenCapacityWithLeader
-		}
-		if addChildrenSliceCapacity-addChildrenSliceCapacityWithLeader < minSliceStateWithLeaderDifference {
-			minSliceStateWithLeaderDifference = addChildrenSliceCapacity - addChildrenSliceCapacityWithLeader
-		}
-		if childLeaderState > leaderState {
-			leaderState = childLeaderState
-		}
+		s.fillInCountsHelper(child, sliceSize, sliceLevelIdx, level+1)
+		childrenCapacity += child.state
+		sliceCapacity += child.sliceState
+		minStateWithLeaderDifference = min(child.state-child.stateWithLeader, minStateWithLeaderDifference)
+		minSliceStateWithLeaderDifference = min(child.sliceState-child.sliceStateWithLeader, minSliceStateWithLeaderDifference)
+		leaderState = max(child.leaderState, leaderState)
 	}
 	domain.state = childrenCapacity
 	domain.stateWithLeader = childrenCapacity - minStateWithLeaderDifference
@@ -1499,8 +1493,6 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 	}
 	domain.sliceState = sliceCapacity
 	domain.sliceStateWithLeader = sliceStateWithLeader
-
-	return domain.state, domain.sliceState, domain.stateWithLeader, domain.sliceStateWithLeader, domain.leaderState
 }
 
 func (s *TASFlavorSnapshot) notFitMessage(slicesFitCount, totalRequestsSlicesCount, sliceSize int32, stats *ExclusionStats) string {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
The code works in place, while returning values to the caller as well. This introduces some unclarity whether this function works in-place or not.

This function started out with 1 returned value, then 2 and now it's 5. So at this point returning them is slightly confusing, unless I'm missing something.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
Second PR for #8036.

I also changed lines like:
```go
if addChildrenSliceCapacity-addChildrenSliceCapacityWithLeader < minSliceStateWithLeaderDifference
```
to mins:
```go
min(child.state-child.stateWithLeader, minStateWithLeaderDifference)
```
because it seemed cleaner and avoids referencing fields inside `child` multiple times. So it's not a completely unrelated change.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```