### PR TITLE
Bump kubeadm.k8s.io to v1beta4.

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -383,18 +383,23 @@ function patch_kind_config_for_dra {
     $YQ -i '.featureGates.DRAExtendedResource = true' "$patched_config"
     $YQ -i '.containerdConfigPatches += ["[plugins.\"io.containerd.grpc.v1.cri\"]\n  enable_cdi = true"]' "$patched_config"
     $YQ -i '(.nodes[] | select(.role == "control-plane")).kubeadmConfigPatches[0] = "kind: ClusterConfiguration
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 scheduler:
   extraArgs:
-    v: \"3\"
+  - name: v
+    value: \"3\"
 controllerManager:
   extraArgs:
-    v: \"3\"
+  - name: v
+    value: \"3\"
 apiServer:
   extraArgs:
-    enable-aggregator-routing: \"true\"
-    runtime-config: \"resource.k8s.io/v1=true\"
-    v: \"3\"
+  - name: enable-aggregator-routing
+    value: \"true\"
+  - name: runtime-config
+    value: \"resource.k8s.io/v1=true\"
+  - name: v
+    value: \"3\"
 "' "$patched_config"
 
     echo "$patched_config"
@@ -409,18 +414,23 @@ function patch_kind_config_for_was {
     $YQ -i '.featureGates.GenericWorkload = true' "$patched_config"
     $YQ -i '.featureGates.GangScheduling = true' "$patched_config"
     $YQ -i '(.nodes[] | select(.role == "control-plane")).kubeadmConfigPatches[0] = "kind: ClusterConfiguration
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 scheduler:
   extraArgs:
-    v: \"3\"
+  - name: v
+    value: \"3\"
 controllerManager:
   extraArgs:
-    v: \"3\"
+  - name: v
+    value: \"3\"
 apiServer:
   extraArgs:
-    enable-aggregator-routing: \"true\"
-    runtime-config: \"scheduling.k8s.io/v1alpha3=true\"
-    v: \"3\"
+  - name: enable-aggregator-routing
+    value: \"true\"
+  - name: runtime-config
+    value: \"resource.k8s.io/v1beta1=true\"
+  - name: v
+    value: \"3\"
 "' "$patched_config"
 
     echo "$patched_config"

--- a/hack/testing/kind-cluster-tas.yaml
+++ b/hack/testing/kind-cluster-tas.yaml
@@ -6,22 +6,28 @@ nodes:
     kubeadmConfigPatches:
       - |
         kind: ClusterConfiguration
-        apiVersion: kubeadm.k8s.io/v1beta3
+        apiVersion: kubeadm.k8s.io/v1beta4
         scheduler:
           extraArgs:
-            v: "3"
+          - name: v
+            value: "3"
         controllerManager:
           extraArgs:
-            v: "3"
+          - name: v
+            value: "3"
         apiServer:
           extraArgs:
-            enable-aggregator-routing: "true"
-            v: "3"
+          - name: enable-aggregator-routing
+            value: "true"
+          - name: v
+            value: "3"
       - |
         kind: InitConfiguration
+        apiVersion: kubeadm.k8s.io/v1beta4
         nodeRegistration:
-          kubeletExtraArgs:
-            v: "3"
+          extraArgs:
+          - name: v
+            value: "3"
   - role: worker
     labels:
       cloud.provider.com/node-group: tas-group
@@ -66,6 +72,8 @@ nodes:
 kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"

--- a/hack/testing/kind-cluster.yaml
+++ b/hack/testing/kind-cluster.yaml
@@ -5,22 +5,28 @@ nodes:
   kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration
-    apiVersion: kubeadm.k8s.io/v1beta3
+    apiVersion: kubeadm.k8s.io/v1beta4
     scheduler:
       extraArgs:
-        v: "3"
+      - name: v
+        value: "3"
     controllerManager:
       extraArgs:
-        v: "3"
+      - name: v
+        value: "3"
     apiServer:
       extraArgs:
-        enable-aggregator-routing: "true"
-        v: "3"
+      - name: enable-aggregator-routing
+        value: "true"
+      - name: v
+        value: "3"
   - |
     kind: InitConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"
 - role: worker
   labels:
     instance-type: on-demand
@@ -31,6 +37,8 @@ nodes:
 kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"

--- a/hack/testing/multikueue/manager-cluster.kind.yaml
+++ b/hack/testing/multikueue/manager-cluster.kind.yaml
@@ -5,22 +5,28 @@ nodes:
   kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration
-    apiVersion: kubeadm.k8s.io/v1beta3
+    apiVersion: kubeadm.k8s.io/v1beta4
     scheduler:
       extraArgs:
-        v: "3"
+      - name: v
+        value: "3"
     controllerManager:
       extraArgs:
-        v: "3"
+      - name: v
+        value: "3"
     apiServer:
       extraArgs:
-        enable-aggregator-routing: "true"
-        v: "3"
+      - name: enable-aggregator-routing
+        value: "true"
+      - name: v
+        value: "3"
   - |
     kind: InitConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"
 - role: worker
   labels:
     instance-type: on-demand
@@ -29,6 +35,8 @@ nodes:
 kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"

--- a/hack/testing/multikueue/worker-cluster.kind.yaml
+++ b/hack/testing/multikueue/worker-cluster.kind.yaml
@@ -5,23 +5,30 @@ nodes:
   kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration
-    apiVersion: kubeadm.k8s.io/v1beta3
+    apiVersion: kubeadm.k8s.io/v1beta4
     scheduler:
       extraArgs:
-        v: "3"
+      - name: v
+        value: "3"
     controllerManager:
       extraArgs:
-        v: "3"
+      - name: v
+        value: "3"
     apiServer:
       extraArgs:
-        enable-aggregator-routing: "true"
-        v: "3"
-        service-account-max-token-expiration: "168h"
+      - name: enable-aggregator-routing
+        value: "true"
+      - name: v
+        value: "3"
+      - name: service-account-max-token-expiration
+        value: "168h"
   - |
     kind: InitConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"
 - role: worker
   labels:
     instance-type: on-demand
@@ -30,6 +37,8 @@ nodes:
 kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"

--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -462,12 +462,19 @@ func waitForKueueControllerReadyWithWebhookEndpoints(ctx context.Context, k8sCli
 		endpointIPs := sets.New[string]()
 		for _, slice := range endpointSlices.Items {
 			for _, ep := range slice.Endpoints {
-				if ep.Conditions.Ready == nil || *ep.Conditions.Ready {
+				if ep.Conditions.Ready != nil && *ep.Conditions.Ready {
 					endpointIPs.Insert(ep.Addresses...)
 				}
 			}
 		}
 		g.Expect(endpointIPs).To(gomega.Equal(readyPodIPs))
+
+		// Probe the webhook via a dry-run ResourceFlavor create to confirm the
+		// kube-apiserver can actually reach the new webhook pod. The endpoint
+		// slice being updated is not enough — the apiserver may still be using a
+		// stale connection to the previous pod.
+		rf := &kueue.ResourceFlavor{ObjectMeta: metav1.ObjectMeta{GenerateName: "webhook-probe-"}}
+		g.Expect(k8sClient.Create(ctx, rf, client.DryRunAll)).To(gomega.Succeed())
 	}, LongTimeout, Interval).Should(gomega.Succeed())
 
 	ginkgo.GinkgoLogr.Info("Ready pods and webhook endpoints verified", "deployment", key, "waitingTime", time.Since(waitStart))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Bump kubeadm.k8s.io to v1beta4.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8498

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```