### PR TITLE
Fix certs e2e test for k8s 1.35

### DIFF
--- a/test/e2e/singlecluster/certs_test.go
+++ b/test/e2e/singlecluster/certs_test.go
@@ -162,7 +162,7 @@ var _ = ginkgo.Describe("Kueue Certs", ginkgo.Serial, func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, key, deployment)).To(gomega.Succeed())
 				g.Expect(deployment.Status.Replicas).To(gomega.Equal(int32(0)))
-				g.Expect(deployment.Status.TerminatingReplicas).To(gomega.BeNil())
+				g.Expect(ptr.Deref(deployment.Status.TerminatingReplicas, 0)).To(gomega.Equal(int32(0)))
 			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 		})
 


### PR DESCRIPTION
In k8s 1.35, Deployment.Status.TerminatingReplicas returns *int32(0) instead of nil when there are no terminating replicas. Use ptr.Deref to handle both cases.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://gcsweb.k8s.io/gcs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_kueue/8500/pull-kueue-test-e2e-main-1-35/2009664144264925184/

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```