### PR TITLE
Use List to verify object state in LWS reconciler tests

### DIFF
--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_pod_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_pod_reconciler_test.go
@@ -38,10 +38,10 @@ import (
 func TestPodReconciler(t *testing.T) {
 	now := time.Now()
 	cases := map[string]struct {
-		lws     *leaderworkersetv1.LeaderWorkerSet
-		pod     *corev1.Pod
-		wantPod *corev1.Pod
-		wantErr error
+		lws      *leaderworkersetv1.LeaderWorkerSet
+		pod      *corev1.Pod
+		wantPods []corev1.Pod
+		wantErr  error
 	}{
 		"should finalize succeeded pod": {
 			lws: leaderworkerset.MakeLeaderWorkerSet("lws", "ns").Obj(),
@@ -50,10 +50,12 @@ func TestPodReconciler(t *testing.T) {
 				StatusPhase(corev1.PodSucceeded).
 				KueueFinalizer().
 				Obj(),
-			wantPod: testingjobspod.MakePod("pod", "ns").
-				Label(leaderworkersetv1.SetNameLabelKey, "lws").
-				StatusPhase(corev1.PodSucceeded).
-				Obj(),
+			wantPods: []corev1.Pod{
+				*testingjobspod.MakePod("pod", "ns").
+					Label(leaderworkersetv1.SetNameLabelKey, "lws").
+					StatusPhase(corev1.PodSucceeded).
+					Obj(),
+			},
 		},
 		"should finalize failed pod": {
 			lws: leaderworkerset.MakeLeaderWorkerSet("lws", "ns").Obj(),
@@ -62,10 +64,12 @@ func TestPodReconciler(t *testing.T) {
 				StatusPhase(corev1.PodFailed).
 				KueueFinalizer().
 				Obj(),
-			wantPod: testingjobspod.MakePod("pod", "ns").
-				Label(leaderworkersetv1.SetNameLabelKey, "lws").
-				StatusPhase(corev1.PodFailed).
-				Obj(),
+			wantPods: []corev1.Pod{
+				*testingjobspod.MakePod("pod", "ns").
+					Label(leaderworkersetv1.SetNameLabelKey, "lws").
+					StatusPhase(corev1.PodFailed).
+					Obj(),
+			},
 		},
 		"shouldn't set default values without group index label": {
 			lws: leaderworkerset.MakeLeaderWorkerSet("lws", "ns").Obj(),
@@ -74,11 +78,13 @@ func TestPodReconciler(t *testing.T) {
 				Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 				Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
 				Obj(),
-			wantPod: testingjobspod.MakePod("pod", "ns").
-				Label(leaderworkersetv1.SetNameLabelKey, "lws").
-				Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
-				Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
-				Obj(),
+			wantPods: []corev1.Pod{
+				*testingjobspod.MakePod("pod", "ns").
+					Label(leaderworkersetv1.SetNameLabelKey, "lws").
+					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+					Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
+					Obj(),
+			},
 		},
 		"shouldn't set default values without queue name": {
 			lws: leaderworkerset.MakeLeaderWorkerSet("lws", "ns").
@@ -89,12 +95,14 @@ func TestPodReconciler(t *testing.T) {
 				Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 				Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
 				Obj(),
-			wantPod: testingjobspod.MakePod("pod", "ns").
-				Label(leaderworkersetv1.SetNameLabelKey, "lws").
-				Label(leaderworkersetv1.GroupIndexLabelKey, "0").
-				Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
-				Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
-				Obj(),
+			wantPods: []corev1.Pod{
+				*testingjobspod.MakePod("pod", "ns").
+					Label(leaderworkersetv1.SetNameLabelKey, "lws").
+					Label(leaderworkersetv1.GroupIndexLabelKey, "0").
+					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+					Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
+					Obj(),
+			},
 		},
 		"should set default values": {
 			lws: leaderworkerset.MakeLeaderWorkerSet("lws", "ns").
@@ -107,18 +115,20 @@ func TestPodReconciler(t *testing.T) {
 				Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 				Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
 				Obj(),
-			wantPod: testingjobspod.MakePod("pod", "ns").
-				Label(leaderworkersetv1.SetNameLabelKey, "lws").
-				Label(leaderworkersetv1.GroupIndexLabelKey, "0").
-				Queue("queue").
-				ManagedByKueueLabel().
-				Group(GetWorkloadName(types.UID(testUID), "lws", "0")).
-				GroupTotalCount("1").
-				PrebuiltWorkload(GetWorkloadName(types.UID(testUID), "lws", "0")).
-				Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
-				Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
-				Annotation(podconstants.RoleHashAnnotation, string(kueue.DefaultPodSetName)).
-				Obj(),
+			wantPods: []corev1.Pod{
+				*testingjobspod.MakePod("pod", "ns").
+					Label(leaderworkersetv1.SetNameLabelKey, "lws").
+					Label(leaderworkersetv1.GroupIndexLabelKey, "0").
+					Queue("queue").
+					ManagedByKueueLabel().
+					Group(GetWorkloadName(types.UID(testUID), "lws", "0")).
+					GroupTotalCount("1").
+					PrebuiltWorkload(GetWorkloadName(types.UID(testUID), "lws", "0")).
+					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+					Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
+					Annotation(podconstants.RoleHashAnnotation, string(kueue.DefaultPodSetName)).
+					Obj(),
+			},
 		},
 		"should finalize deleted pod": {
 			lws: leaderworkerset.MakeLeaderWorkerSet("lws", "ns").Obj(),
@@ -127,7 +137,6 @@ func TestPodReconciler(t *testing.T) {
 				DeletionTimestamp(now).
 				KueueFinalizer().
 				Obj(),
-			wantPod: nil,
 		},
 	}
 	for name, tc := range cases {
@@ -153,12 +162,7 @@ func TestPodReconciler(t *testing.T) {
 				t.Fatalf("Could not list Pods after reconcile: %v", err)
 			}
 
-			var wantPods []corev1.Pod
-			if tc.wantPod != nil {
-				wantPods = []corev1.Pod{*tc.wantPod}
-			}
-
-			if diff := cmp.Diff(wantPods, gotPods.Items, baseCmpOpts...); diff != "" {
+			if diff := cmp.Diff(tc.wantPods, gotPods.Items, baseCmpOpts...); diff != "" {
 				t.Errorf("Pods after reconcile (-want,+got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Replace the error bypass pattern using Get with NotFound checks
with explicit List operations that properly verify object existence.

This ensures tests correctly validate that:
- When wantPod/wantLeaderWorkerSet is nil, no objects exist
- When objects are expected, exactly one exists

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8521

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```