### PR TITLE
Disable testing for mutating WPC for LWS on Kueue 0.14 and K8s 1.35+

### DIFF
--- a/test/e2e/singlecluster/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/leaderworkerset_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
@@ -802,6 +803,17 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 		})
 
 		ginkgo.It("should allow to update the workload priority in LeaderWorkerSet", func() {
+			ginkgo.By("check if the functionality can be tested", func() {
+				discoveryClient := discovery.NewDiscoveryClientForConfigOrDie(cfg)
+				version, err := discoveryClient.ServerVersion()
+				if err != nil {
+					ginkgo.Fail("Failed to get server version")
+				}
+				if version.Major == "1" && version.Minor >= "35" {
+					ginkgo.Skip("Skipping test: the tested functionality is broken on 1.35+ on 0.14")
+				}
+			})
+
 			lowPriorityLWS := leaderworkersettesting.MakeLeaderWorkerSet("low-priority", ns.Name).
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				Size(3).


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

temporary disabling of test waiting for decision about cherrypicking https://github.com/kubernetes-sigs/kueue/pull/8516

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8523

#### Special notes for your reviewer:

PR to skip testing to unblock other cherrypicks. I'm still ok to cherrypick the actual bugfix.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
LWS: disable testing the mutating of the `kueue.x-k8s.io/workloadpriorityclass` label as the functionality is broken on
Kueue 0.14 with Kubernetes 1.35+. 

ACTION REQUIRED: If you are using this functionality, please migrate to use Kueue 0.15+.
```