### PR TITLE
Cleanup e2e test clusterprofile texts

### DIFF
--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -1282,7 +1282,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 		)
 
 		ginkgo.BeforeAll(func() {
-			ginkgo.By("setting MultiKueue Dispatcher to Incremental", func() {
+			ginkgo.By("setting MultiKueueClusterProfile feature gate", func() {
 				defaultManagerKueueCfg = util.GetKueueConfiguration(ctx, k8sManagerClient)
 				newCfg := defaultManagerKueueCfg.DeepCopy()
 				util.UpdateKueueConfiguration(ctx, k8sManagerClient, newCfg, managerClusterName, func(cfg *kueueconfig.Configuration) {
@@ -1291,7 +1291,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			})
 		})
 		ginkgo.AfterAll(func() {
-			ginkgo.By("setting MultiKueue Dispatcher back to AllAtOnce", func() {
+			ginkgo.By("reverting the configuration", func() {
 				util.ApplyKueueConfiguration(ctx, k8sManagerClient, defaultManagerKueueCfg)
 				util.RestartKueueController(ctx, k8sManagerClient, managerClusterName)
 			})
@@ -1308,8 +1308,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			}
 		})
 
-		ginkgo.It("Should be able to use ClusterProfile as way to connect worker cluster", func() {
-			ginkgo.By("Update MultiKueueConfig to include worker that use ClusterProfile", func() {
+		ginkgo.It("uses ClusterProfile as way to connect worker cluster", func() {
+			ginkgo.By("updating MultiKueueConfig to include worker that use ClusterProfile", func() {
 				createdMkConfig := &kueue.MultiKueueConfig{}
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(multiKueueConfig), createdMkConfig)).To(gomega.Succeed())
@@ -1320,7 +1320,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 			worker3MkClusterKey := client.ObjectKeyFromObject(workerCluster3)
-			ginkgo.By("Check MultiKueueCluster status", func() {
+			ginkgo.By("checking MultiKueueCluster status", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdCluster := &kueue.MultiKueueCluster{}
 					g.Expect(k8sManagerClient.Get(ctx, worker3MkClusterKey, createdCluster)).To(gomega.Succeed())
@@ -1336,20 +1336,20 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			})
 
 			var cp *inventoryv1alpha1.ClusterProfile
-			ginkgo.By("Create missing ClusterProfile", func() {
+			ginkgo.By("creating missing ClusterProfile", func() {
 				cp = utiltestingapi.MakeClusterProfile("clusterprofile3", kueueNS).
 					ClusterManager("clustermanager3").
 					Obj()
 				util.MustCreate(ctx, k8sManagerClient, cp)
 			})
-			ginkgo.By("Check ClusterProfile exists", func() {
+			ginkgo.By("checking ClusterProfile exists", func() {
 				clusterProfileKey := client.ObjectKeyFromObject(cp)
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdClusterProfile := &inventoryv1alpha1.ClusterProfile{}
 					g.Expect(k8sManagerClient.Get(ctx, clusterProfileKey, createdClusterProfile)).To(gomega.Succeed())
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
-			ginkgo.By("Trigger MultiKueueCluster reconciliation", func() {
+			ginkgo.By("triggering MultiKueueCluster reconciliation", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdCluster := &kueue.MultiKueueCluster{}
 					g.Expect(k8sManagerClient.Get(ctx, worker3MkClusterKey, createdCluster)).To(gomega.Succeed())
@@ -1358,7 +1358,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 			worker3MkClusterKey = client.ObjectKeyFromObject(workerCluster3)
-			ginkgo.By("Check MultiKueueCluster status again", func() {
+			ginkgo.By("checking MultiKueueCluster status again", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdCluster := &kueue.MultiKueueCluster{}
 					g.Expect(k8sManagerClient.Get(ctx, worker3MkClusterKey, createdCluster)).To(gomega.Succeed())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
As requested [here](https://github.com/kubernetes-sigs/kueue/pull/8318#discussion_r2675266126) and [here](https://github.com/kubernetes-sigs/kueue/pull/8318#discussion_r2682969510)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```