### PR TITLE
Automated cherry pick of #8530: Skip adding pod finalizer for suspended by parent workloads.

### DIFF
--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_pod_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_pod_reconciler.go
@@ -71,6 +71,8 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	log := ctrl.LoggerFrom(ctx)
 	log.V(2).Info("Reconcile LeaderWorkerSet Pod")
 
+	// TODO (#8530): As discussed in https://github.com/kubernetes-sigs/kueue/pull/8530#discussion_r2681240298,
+	// this check should be removed in v0.18.
 	if utilpod.IsTerminated(pod) {
 		err = client.IgnoreNotFound(clientutil.Patch(ctx, r.client, pod, func() (bool, error) {
 			removed := controllerutil.RemoveFinalizer(pod, podconstants.PodFinalizer)

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -123,6 +123,8 @@ func ungateAndFinalize(sts *appsv1.StatefulSet, pod *corev1.Pod) bool {
 		updated = true
 	}
 
+	// TODO (#8530): As discussed in https://github.com/kubernetes-sigs/kueue/pull/8530#discussion_r2681240298,
+	// this check should be removed in v0.18.
 	if shouldFinalize(sts, pod) && controllerutil.RemoveFinalizer(pod, podcontroller.PodFinalizer) {
 		updated = true
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -228,6 +228,12 @@ const (
 	// issue: https://github.com/kubernetes-sigs/kueue/issues/6757
 	// Enabled failure recovery of pods stuck in terminating state.
 	FailureRecoveryPolicy featuregate.Feature = "FailureRecoveryPolicy"
+
+	// owner: @mbobrovskyi
+	//
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/5298
+	// Enabled skip adding finalizers for serving workloads.
+	SkipFinalizersForPodsSuspendedByParent featuregate.Feature = "SkipFinalizersForPodsSuspendedByParent"
 )
 
 func init() {
@@ -357,6 +363,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	FailureRecoveryPolicy: {
 		{Version: version.MustParse("0.15"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	SkipFinalizersForPodsSuspendedByParent: {
+		{Version: version.MustParse("0.16"), Default: true, PreRelease: featuregate.Beta},
 	},
 }
 

--- a/pkg/util/testingjobs/pod/wrappers.go
+++ b/pkg/util/testingjobs/pod/wrappers.go
@@ -112,6 +112,10 @@ func (p *PodWrapper) Queue(q string) *PodWrapper {
 	return p.Label(controllerconsts.QueueLabel, q)
 }
 
+func (p *PodWrapper) SuspendedByParent(controller string) *PodWrapper {
+	return p.Annotation(podconstants.SuspendedByParentAnnotation, controller)
+}
+
 func (p *PodWrapper) PrebuiltWorkload(name string) *PodWrapper {
 	return p.Label(controllerconsts.PrebuiltWorkloadLabel, name)
 }

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -281,7 +281,7 @@ spec:
 ### Feature gates for alpha and beta features
 
 | Feature                                       | Default | Stage | Since | Until |
-| --------------------------------------------- | ------- | ----- | ----- | ----- |
+| --------------------------------------------- |---------|-------|-------| ----- |
 | `FlavorFungibility`                           | `true`  | Beta  | 0.5   |       |
 | `MultiKueue`                                  | `false` | Alpha | 0.6   | 0.8   |
 | `MultiKueue`                                  | `true`  | Beta  | 0.9   |       |
@@ -322,6 +322,7 @@ spec:
 | `MultiKueueAdaptersForCustomJobs`             | `true`  | Beta  | 0.15  |       |
 | `PropagateBatchJobLabelsToWorkload`           | `true`  | Beta  | 0.15  |       |
 | `FailureRecoveryPolicy`                       | `false` | Alpha | 0.15  |       |
+| `SkipFinalizersForServingWorkloads`           | `true`  | Beta  | 0.16  |       |
 
 {{% alert title="Note" color="primary" %}}
 The SanitizePodSets and MultiKueueAllowInsecureKubeconfigs features are available starting from versions 0.13.8 and 0.14.3.

--- a/site/content/zh-CN/docs/installation/_index.md
+++ b/site/content/zh-CN/docs/installation/_index.md
@@ -297,6 +297,7 @@ spec:
 | `WorkloadRequestUseMergePatch`                | `false` | Alpha | 0.14 |      |
 | `SanitizePodSets`                             | `true`  | Beta  | 0.13 |      |
 | `MultiKueueAllowInsecureKubeconfigs`          | `false` | Alpha | 0.13 |      |
+| `SkipFinalizersForServingWorkloads`           | `true`  | Beta  | 0.16 |      |
 
 ### 已毕业或已弃用特性的特性门控 {#feature-gates-for-graduated-or-deprecated-features}
 

--- a/test/e2e/customconfigs/managejobswithoutqueuename_test.go
+++ b/test/e2e/customconfigs/managejobswithoutqueuename_test.go
@@ -569,7 +569,6 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 					g.Expect(k8sClient.Get(ctx, podLookupKey, createdPod)).Should(gomega.Succeed())
 					g.Expect(createdPod.Spec.SchedulingGates).ShouldNot(gomega.BeEmpty())
 					g.Expect(createdPod.Labels).Should(gomega.HaveKeyWithValue(constants.ManagedByKueueLabelKey, constants.ManagedByKueueLabelValue))
-					g.Expect(createdPod.Finalizers).Should(gomega.ContainElement(podcontroller.PodFinalizer))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
@@ -625,7 +624,6 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 					for _, pod := range pods.Items {
 						g.Expect(pod.Spec.SchedulingGates).ShouldNot(gomega.BeEmpty())
 						g.Expect(pod.Labels).Should(gomega.HaveKeyWithValue(constants.ManagedByKueueLabelKey, constants.ManagedByKueueLabelValue))
-						g.Expect(pod.Finalizers).Should(gomega.ContainElement(podcontroller.PodFinalizer))
 					}
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})


### PR DESCRIPTION
Cherry pick of #8530 on website.

#8530: Skip adding pod finalizer for suspended by parent workloads.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Integrations based on Pods: skip using finalizers on the Pods created and managed by integrations. 

In particular we skip setting finalizers for Pods managed by the built in Serving Workloads  Deployments,
StatefulSets, and LeaderWorkerSets.

This improves performance of suspending the workloads, and fixes occasional race conditions when a StatefulSet
could get stuck when deactivating and re-activating in a short interval.
```