### PR TITLE
Automated cherry pick of #8570: Fix SkipFinalizersForPodsSuspendedByParent feature gate.

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -358,7 +358,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.14"), Default: true, PreRelease: featuregate.Beta},
 	},
 	SkipFinalizersForPodsSuspendedByParent: {
-		{Version: version.MustParse("0.16"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("0.14"), Default: true, PreRelease: featuregate.Beta},
 	},
 }
 

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -298,7 +298,7 @@ spec:
 | `SanitizePodSets`                             | `true`  | Beta  | 0.13  |       |
 | `MultiKueueAllowInsecureKubeconfigs`          | `false` | Alpha | 0.14  |       |
 | `ReclaimablePods`                             | `true`  | Beta  | 0.14  |       |
-| `SkipFinalizersForServingWorkloads`           | `true`  | Beta  | 0.16  |       |
+| `SkipFinalizersForPodsSuspendedByParent`      | `true`  | Beta  | 0.14  |       |
 
 ### Feature gates for graduated or deprecated features
 

--- a/site/content/zh-CN/docs/installation/_index.md
+++ b/site/content/zh-CN/docs/installation/_index.md
@@ -293,7 +293,7 @@ spec:
 | `WorkloadRequestUseMergePatch`                | `false` | Alpha | 0.14     |          |
 | `SanitizePodSets`                             | `true`  | Beta  | 0.13     |          |
 | `MultiKueueAllowInsecureKubeconfigs`          | `false` | Alpha | 0.14     |          |
-| `SkipFinalizersForServingWorkloads`           | `true`  | Beta  | 0.16     |          |
+| `SkipFinalizersForPodsSuspendedByParent`      | `true`  | Beta  | 0.14     |          |
 
 ### 已毕业或已弃用特性的特性门控 {#feature-gates-for-graduated-or-deprecated-features}
 


### PR DESCRIPTION
Cherry pick of #8570 on release-0.14.

#8570: Fix SkipFinalizersForPodsSuspendedByParent feature gate.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```