### PR TITLE
Add support for TAS + Elasticworkloads

### DIFF
--- a/pkg/cache/scheduler/tas_elastic_workloads.go
+++ b/pkg/cache/scheduler/tas_elastic_workloads.go
@@ -1,0 +1,126 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/resources"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
+)
+
+// elasticPlacementResult holds the result of elastic workload placement.
+type elasticPlacementResult struct {
+	// applied indicates delta placement was used; false means use standard placement.
+	applied     bool
+	assignments map[kueue.PodSetReference]tasPodSetAssignmentResult
+}
+
+// handleElasticWorkload processes delta-only placement for elastic workloads.
+// It keeps previous pods fixed and places only new pods during scale-up,
+// or truncates the assignment during scale-down.
+func (s *TASFlavorSnapshot) handleElasticWorkload(
+	workers TASPodSetRequests,
+	leader *TASPodSetRequests,
+	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
+	opts *findTopologyAssignmentsOption,
+) elasticPlacementResult {
+	if workers.PreviousAssignment == nil {
+		return elasticPlacementResult{applied: false}
+	}
+
+	prevAssignment := utiltas.InternalFrom(workers.PreviousAssignment)
+
+	if isStale, staleDomain := s.IsTopologyAssignmentStale(prevAssignment); isStale {
+		s.log.V(3).Info("previous TAS assignment is stale, doing fresh placement",
+			"staleDomain", staleDomain)
+		return elasticPlacementResult{applied: false}
+	}
+
+	previousCount := utiltas.CountPodsInAssignment(prevAssignment)
+	result := make(map[kueue.PodSetReference]tasPodSetAssignmentResult)
+
+	switch {
+	case workers.Count > previousCount:
+		return s.handleScaleUp(workers, leader, prevAssignment, previousCount, assumedUsage, opts)
+	case workers.Count < previousCount:
+		return s.handleScaleDown(workers, prevAssignment, assumedUsage)
+	default:
+		// Same count: reuse previous assignment
+		result[workers.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: prevAssignment}
+		addAssumedUsage(assumedUsage, prevAssignment, &workers)
+		return elasticPlacementResult{applied: true, assignments: result}
+	}
+}
+
+// handleScaleUp places only delta pods while keeping previous pods fixed.
+func (s *TASFlavorSnapshot) handleScaleUp(
+	workers TASPodSetRequests,
+	leader *TASPodSetRequests,
+	prevAssignment *utiltas.TopologyAssignment,
+	previousCount int32,
+	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
+	opts *findTopologyAssignmentsOption,
+) elasticPlacementResult {
+	result := make(map[kueue.PodSetReference]tasPodSetAssignmentResult)
+
+	deltaCount := workers.Count - previousCount
+	deltaRequest := workers
+	deltaRequest.Count = deltaCount
+	deltaRequest.PreviousAssignment = nil
+
+	// Previous pods consume capacity
+	prevAssumedUsage := utiltas.ComputeUsagePerDomain(prevAssignment, workers.SinglePodRequests)
+	for domainID, usage := range prevAssumedUsage {
+		if assumedUsage[domainID] == nil {
+			assumedUsage[domainID] = resources.Requests{}
+		}
+		assumedUsage[domainID].Add(usage)
+	}
+
+	deltaAssignments, reason := s.findTopologyAssignment(deltaRequest, leader, assumedUsage, opts.simulateEmpty, "")
+	if reason != "" {
+		result[workers.PodSet.Name] = tasPodSetAssignmentResult{FailureReason: reason}
+		return elasticPlacementResult{applied: true, assignments: result}
+	}
+
+	deltaAssignment := deltaAssignments[workers.PodSet.Name]
+	finalAssignment := s.mergeTopologyAssignments(deltaAssignment, prevAssignment)
+	result[workers.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: finalAssignment}
+
+	if leader != nil {
+		result[leader.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: deltaAssignments[leader.PodSet.Name]}
+		addAssumedUsage(assumedUsage, deltaAssignments[leader.PodSet.Name], leader)
+	}
+
+	// Add only delta to avoid double-counting previous pods.
+	addAssumedUsage(assumedUsage, deltaAssignment, &workers)
+	return elasticPlacementResult{applied: true, assignments: result}
+}
+
+// handleScaleDown truncates the previous assignment to fit fewer pods.
+func (s *TASFlavorSnapshot) handleScaleDown(
+	workers TASPodSetRequests,
+	prevAssignment *utiltas.TopologyAssignment,
+	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
+) elasticPlacementResult {
+	result := make(map[kueue.PodSetReference]tasPodSetAssignmentResult)
+
+	truncatedAssignment := utiltas.TruncateAssignment(prevAssignment, workers.Count)
+	result[workers.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: truncatedAssignment}
+	addAssumedUsage(assumedUsage, truncatedAssignment, &workers)
+	return elasticPlacementResult{applied: true, assignments: result}
+}

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -347,6 +347,9 @@ type TASPodSetRequests struct {
 	Flavor            kueue.ResourceFlavorReference
 	Implied           bool
 	PodSetGroupName   *string
+	// PreviousAssignment holds the topology assignment from a workload slice
+	// that this workload is replacing.
+	PreviousAssignment *kueue.TopologyAssignment
 }
 
 func (t *TASPodSetRequests) TotalRequests() resources.Requests {
@@ -511,6 +514,19 @@ func (s *TASFlavorSnapshot) FindTopologyAssignmentsForFlavor(flavorTASRequests F
 		} else {
 			leader, workers := findLeaderAndWorkers(trs)
 
+			// Handle elastic workloads with delta-only placement
+			if features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
+				elasticResult := s.handleElasticWorkload(workers, leader, assumedUsage, opts)
+				if elasticResult.applied {
+					maps.Copy(result, elasticResult.assignments)
+					if elasticResult.assignments[workers.PodSet.Name].FailureReason != "" {
+						return result
+					}
+					continue
+				}
+			}
+
+			// Normal path: no previous assignment or stale assignment
 			assignments, reason := s.findTopologyAssignment(workers, leader, assumedUsage, opts.simulateEmpty, "")
 			for _, tr := range trs {
 				podSetName := tr.PodSet.Name
@@ -616,9 +632,15 @@ func (s *TASFlavorSnapshot) requiredReplacementDomain(tr *TASPodSetRequests, ta 
 	}
 
 	nodeLevel := len(s.levelKeys) - 1
-	// We know at this point that values contains only hostname
-	nodeDomain := ta.Domains[0].Values[0]
-	domain := s.domainsPerLevel[nodeLevel][utiltas.TopologyDomainID(nodeDomain)]
+	domainValues := ta.Domains[0].Values
+	if len(domainValues) == 0 {
+		return ""
+	}
+	// Look up domain using full DomainID path (e.g., "b2,r1,b2-r1")
+	domain, found := s.domainsPerLevel[nodeLevel][utiltas.DomainID(domainValues)]
+	if !found {
+		return ""
+	}
 	// Find a domain that complies with the required policy
 	for i := nodeLevel; i > levelIdx; i-- {
 		domain = domain.parent
@@ -873,39 +895,6 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	assignments[workersTasPodSetRequests.PodSet.Name] = s.buildAssignment(currFitDomain)
 
 	return assignments, ""
-}
-
-// Merges two topology assignments keeping the lexicographical order of levelValues
-func (s *TASFlavorSnapshot) mergeTopologyAssignments(a, b *utiltas.TopologyAssignment) *utiltas.TopologyAssignment {
-	nodeLevel := len(s.levelKeys) - 1
-	sortedDomains := make([]utiltas.TopologyDomainAssignment, 0, len(a.Domains)+len(b.Domains))
-	sortedDomains = append(sortedDomains, a.Domains...)
-	sortedDomains = append(sortedDomains, b.Domains...)
-	slices.SortFunc(sortedDomains, func(a, b utiltas.TopologyDomainAssignment) int {
-		aDomain := s.domainsPerLevel[nodeLevel][utiltas.DomainID(a.Values)]
-		bDomain := s.domainsPerLevel[nodeLevel][utiltas.DomainID(b.Values)]
-		return cmp.Compare(utiltas.DomainID(aDomain.levelValues), utiltas.DomainID(bDomain.levelValues))
-	})
-	mergedDomains := make([]utiltas.TopologyDomainAssignment, 0, len(sortedDomains))
-	for _, domain := range sortedDomains {
-		if canMerge(mergedDomains, domain) {
-			mergedDomains[len(mergedDomains)-1].Count += domain.Count
-		} else {
-			mergedDomains = append(mergedDomains, domain)
-		}
-	}
-	return &utiltas.TopologyAssignment{
-		Levels:  a.Levels,
-		Domains: mergedDomains,
-	}
-}
-
-func canMerge(mergedDomains []utiltas.TopologyDomainAssignment, domain utiltas.TopologyDomainAssignment) bool {
-	if len(mergedDomains) == 0 {
-		return false
-	}
-	lastDomain := mergedDomains[len(mergedDomains)-1]
-	return utiltas.DomainID(domain.Values) == utiltas.DomainID(lastDomain.Values)
 }
 
 func (s *TASFlavorSnapshot) HasLevel(r *kueue.PodSetTopologyRequest) bool {
@@ -1518,4 +1507,37 @@ func (s *TASFlavorSnapshot) notFitMessage(slicesFitCount, totalRequestsSlicesCou
 	}
 
 	return builder.String()
+}
+
+// mergeTopologyAssignments merges two topology assignments keeping the lexicographical order of levelValues.
+func (s *TASFlavorSnapshot) mergeTopologyAssignments(a, b *utiltas.TopologyAssignment) *utiltas.TopologyAssignment {
+	nodeLevel := len(s.levelKeys) - 1
+	sortedDomains := make([]utiltas.TopologyDomainAssignment, 0, len(a.Domains)+len(b.Domains))
+	sortedDomains = append(sortedDomains, a.Domains...)
+	sortedDomains = append(sortedDomains, b.Domains...)
+	slices.SortFunc(sortedDomains, func(a, b utiltas.TopologyDomainAssignment) int {
+		aDomain := s.domainsPerLevel[nodeLevel][utiltas.DomainID(a.Values)]
+		bDomain := s.domainsPerLevel[nodeLevel][utiltas.DomainID(b.Values)]
+		return cmp.Compare(utiltas.DomainID(aDomain.levelValues), utiltas.DomainID(bDomain.levelValues))
+	})
+	mergedDomains := make([]utiltas.TopologyDomainAssignment, 0, len(sortedDomains))
+	for _, domain := range sortedDomains {
+		if canMergeDomains(mergedDomains, domain) {
+			mergedDomains[len(mergedDomains)-1].Count += domain.Count
+		} else {
+			mergedDomains = append(mergedDomains, domain)
+		}
+	}
+	return &utiltas.TopologyAssignment{
+		Levels:  a.Levels,
+		Domains: mergedDomains,
+	}
+}
+
+func canMergeDomains(mergedDomains []utiltas.TopologyDomainAssignment, domain utiltas.TopologyDomainAssignment) bool {
+	if len(mergedDomains) == 0 {
+		return false
+	}
+	lastDomain := mergedDomains[len(mergedDomains)-1]
+	return utiltas.DomainID(domain.Values) == utiltas.DomainID(lastDomain.Values)
 }

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -512,6 +512,15 @@ func ValidateFeatureGates(featureGateCLI string, featureGateMap map[string]bool)
 		return errors.New("cannot use a TAS profile with TAS disabled")
 	}
 
+	if features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
+		if !features.Enabled(features.ElasticJobsViaWorkloadSlices) {
+			return errors.New("ElasticJobsViaWorkloadSlicesWithTAS requires ElasticJobsViaWorkloadSlices to be enabled")
+		}
+		if !features.Enabled(features.TopologyAwareScheduling) {
+			return errors.New("ElasticJobsViaWorkloadSlicesWithTAS requires TopologyAwareScheduling to be enabled")
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -30,9 +30,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 )
 
 func TestValidate(t *testing.T) {
@@ -972,9 +974,10 @@ func TestValidate(t *testing.T) {
 
 func TestValidateFeatureGates(t *testing.T) {
 	cases := map[string]struct {
-		featureGatesCLI string
-		featureGateMap  map[string]bool
-		errorStr        string
+		featureGatesCLI   string
+		featureGateMap    map[string]bool
+		setupFeatureGates map[featuregate.Feature]bool
+		errorStr          string
 	}{
 		"no feature gates is null": {
 			featureGatesCLI: "",
@@ -989,28 +992,74 @@ func TestValidateFeatureGates(t *testing.T) {
 		"cannot specify both feature gates": {
 			featureGatesCLI: "test:true",
 			featureGateMap:  map[string]bool{"test": true},
-
-			errorStr: "feature gates for CLI and configuration cannot both specified",
+			errorStr:        "feature gates for CLI and configuration cannot both specified",
 		},
 		"cannot specify more than one TAS profile using GateMap": {
-			featureGateMap: map[string]bool{"TASProfileMixed": true,
-				"TASProfileLeastFreeCapacity": true},
-			errorStr: "Cannot use more than one TAS profiles",
+			setupFeatureGates: map[featuregate.Feature]bool{
+				features.TASProfileMixed:             true,
+				features.TASProfileLeastFreeCapacity: true,
+			},
+			errorStr: "cannot use more than one TAS profiles",
 		},
 		"cannot specify more than one TAS profile using GatesCLI": {
-			featureGatesCLI: "TASProfileLeastFreeCapacity:true,TASProfileMixed:true",
-			errorStr:        "Cannot use more than one TAS profiles",
+			setupFeatureGates: map[featuregate.Feature]bool{
+				features.TASProfileMixed:             true,
+				features.TASProfileLeastFreeCapacity: true,
+			},
+			errorStr: "cannot use more than one TAS profiles",
 		},
 		"cannot set TAS profile with TAS disabled": {
-			featureGateMap: map[string]bool{"TASProfileLeastFreeCapacity": true},
-			errorStr:       "Cannot use a TAS profile with TAS disabled",
+			setupFeatureGates: map[featuregate.Feature]bool{
+				features.TASProfileLeastFreeCapacity: true,
+				features.TASProfileMixed:             false,
+				features.TopologyAwareScheduling:     false,
+			},
+			errorStr: "cannot use a TAS profile with TAS disabled",
+		},
+		"ElasticJobsViaWorkloadSlicesWithTAS requires ElasticJobsViaWorkloadSlices": {
+			setupFeatureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
+				features.TopologyAwareScheduling:             true,
+				features.ElasticJobsViaWorkloadSlices:        false,
+				features.TASProfileLeastFreeCapacity:         false,
+				features.TASProfileMixed:                     false,
+			},
+			errorStr: "ElasticJobsViaWorkloadSlicesWithTAS requires ElasticJobsViaWorkloadSlices to be enabled",
+		},
+		"ElasticJobsViaWorkloadSlicesWithTAS requires TopologyAwareScheduling": {
+			setupFeatureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
+				features.ElasticJobsViaWorkloadSlices:        true,
+				features.TopologyAwareScheduling:             false,
+				features.TASProfileLeastFreeCapacity:         false,
+				features.TASProfileMixed:                     false,
+			},
+			errorStr: "ElasticJobsViaWorkloadSlicesWithTAS requires TopologyAwareScheduling to be enabled",
+		},
+		"ElasticJobsViaWorkloadSlicesWithTAS valid when all dependencies enabled": {
+			setupFeatureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
+				features.ElasticJobsViaWorkloadSlices:        true,
+				features.TopologyAwareScheduling:             true,
+				features.TASProfileLeastFreeCapacity:         false,
+				features.TASProfileMixed:                     false,
+			},
+			errorStr: "",
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			// Set up feature gates for this test
+			for fg, enabled := range tc.setupFeatureGates {
+				features.SetFeatureGateDuringTest(t, fg, enabled)
+			}
 			got := ValidateFeatureGates(tc.featureGatesCLI, tc.featureGateMap)
-			if got != nil && tc.errorStr != got.Error() {
-				t.Errorf("Unexpected result from ValidateFeatureGates\nwant:\n%v\ngot:%v\n", tc.errorStr, got.Error())
+			gotErr := ""
+			if got != nil {
+				gotErr = got.Error()
+			}
+			if gotErr != tc.errorStr {
+				t.Errorf("Unexpected result from ValidateFeatureGates\nwant: %q\ngot: %q\n", tc.errorStr, gotErr)
 			}
 		})
 	}

--- a/pkg/controller/tas/node_failure_controller_test.go
+++ b/pkg/controller/tas/node_failure_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	coreindexer "sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	"sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -285,6 +286,10 @@ func TestNodeFailureReconciler(t *testing.T) {
 			err := indexer.SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder))
 			if err != nil {
 				t.Fatalf("Failed to setup indexes: %v", err)
+			}
+			// Register WorkloadSliceNameKey index used by ListPodsForWorkloadSlice.
+			if err := utiltesting.AsIndexer(clientBuilder).IndexField(ctx, &corev1.Pod{}, coreindexer.WorkloadSliceNameKey, coreindexer.IndexPodWorkloadSliceName); err != nil {
+				t.Fatalf("Could not setup WorkloadSliceNameKey index: %v", err)
 			}
 			cl := clientBuilder.Build()
 			recorder := &utiltesting.EventRecorder{}

--- a/pkg/controller/tas/pods.go
+++ b/pkg/controller/tas/pods.go
@@ -1,0 +1,45 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tas
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+)
+
+// ListPodsForWorkloadSlice lists pods belonging to a workload slice by querying
+// the WorkloadSliceNameKey index. Additional list options (e.g., label selectors)
+// can be passed for filtering. Returns pointers to avoid copying large Pod structs.
+func ListPodsForWorkloadSlice(ctx context.Context, c client.Client, namespace, workloadSliceName string, opts ...client.ListOption) ([]*corev1.Pod, error) {
+	var podList corev1.PodList
+	listOpts := append([]client.ListOption{
+		client.InNamespace(namespace),
+		client.MatchingFields{indexer.WorkloadSliceNameKey: workloadSliceName},
+	}, opts...)
+	if err := c.List(ctx, &podList, listOpts...); err != nil {
+		return nil, err
+	}
+	result := make([]*corev1.Pod, len(podList.Items))
+	for i := range podList.Items {
+		result[i] = &podList.Items[i]
+	}
+	return result, nil
+}

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -39,6 +39,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/constants"
+	coreindexer "sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	"sigs.k8s.io/kueue/pkg/util/tas"
@@ -2589,6 +2590,10 @@ func TestReconcile(t *testing.T) {
 			clientBuilder := utiltesting.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 			if err := indexer.SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder)); err != nil {
 				t.Fatalf("Could not setup indexes: %v", err)
+			}
+			// Register WorkloadSliceNameKey index used by ListPodsForWorkloadSlice.
+			if err := utiltesting.AsIndexer(clientBuilder).IndexField(ctx, &corev1.Pod{}, coreindexer.WorkloadSliceNameKey, coreindexer.IndexPodWorkloadSliceName); err != nil {
+				t.Fatalf("Could not setup WorkloadSliceNameKey index: %v", err)
 			}
 
 			kcBuilder := clientBuilder.WithObjects()

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -131,6 +131,13 @@ const (
 	// ElasticJobsViaWorkloadSlices enables workload-slices support.
 	ElasticJobsViaWorkloadSlices featuregate.Feature = "ElasticJobsViaWorkloadSlices"
 
+	// owner: @sohankunkerkar
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/77-dynamically-sized-jobs
+	//
+	// ElasticJobsViaWorkloadSlicesWithTAS enables TAS integration with elastic workload slices.
+	// Requires both ElasticJobsViaWorkloadSlices and TopologyAwareScheduling to be enabled.
+	ElasticJobsViaWorkloadSlicesWithTAS featuregate.Feature = "ElasticJobsViaWorkloadSlicesWithTAS"
+
 	// owner: @pbundyra
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-scheduling
 	//
@@ -320,6 +327,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	ElasticJobsViaWorkloadSlices: {
 		{Version: version.MustParse("0.13"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	ElasticJobsViaWorkloadSlicesWithTAS: {
+		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	TASFailedNodeReplacementFailFast: {
 		{Version: version.MustParse("0.13"), Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4056,6 +4056,147 @@ func TestWorkloadsTopologyRequests_ErrorBranches(t *testing.T) {
 	}
 }
 
+func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
+	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlicesWithTAS, true)
+
+	// Create a mock TAS flavor snapshot
+	tasFlavor := &schdcache.TASFlavorSnapshot{}
+
+	cases := map[string]struct {
+		cq         schdcache.ClusterQueueSnapshot
+		assignment Assignment
+		workload   workload.Info
+		wantErr    string
+	}{
+		"required topology is rejected with ElasticJobsViaWorkloadSlices": {
+			cq: schdcache.ClusterQueueSnapshot{
+				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{"tas": tasFlavor},
+			},
+			assignment: Assignment{
+				PodSets: []PodSetAssignment{{
+					Name: kueue.DefaultPodSetName,
+					Flavors: ResourceAssignment{
+						corev1.ResourceCPU: {Name: "tas", Mode: Fit, TriedFlavorIdx: -1},
+					},
+					Count:  2,
+					Status: *NewStatus(),
+				}},
+				replaceWorkloadSlice: workload.NewInfo(&kueue.Workload{
+					Status: kueue.WorkloadStatus{
+						Admission: &kueue.Admission{
+							PodSetAssignments: []kueue.PodSetAssignment{{
+								Name:               kueue.DefaultPodSetName,
+								TopologyAssignment: &kueue.TopologyAssignment{},
+							}},
+						},
+					},
+				}),
+			},
+			workload: *workload.NewInfo(&kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
+							Request(corev1.ResourceCPU, "1").
+							RequiredTopologyRequest(corev1.LabelHostname).
+							Obj(),
+					},
+				},
+			}),
+			wantErr: "required topology is not supported with ElasticJobsViaWorkloadSlices",
+		},
+		"preferred topology is rejected with ElasticJobsViaWorkloadSlices": {
+			cq: schdcache.ClusterQueueSnapshot{
+				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{"tas": tasFlavor},
+			},
+			assignment: Assignment{
+				PodSets: []PodSetAssignment{{
+					Name: kueue.DefaultPodSetName,
+					Flavors: ResourceAssignment{
+						corev1.ResourceCPU: {Name: "tas", Mode: Fit, TriedFlavorIdx: -1},
+					},
+					Count:  2,
+					Status: *NewStatus(),
+				}},
+				replaceWorkloadSlice: workload.NewInfo(&kueue.Workload{
+					Status: kueue.WorkloadStatus{
+						Admission: &kueue.Admission{
+							PodSetAssignments: []kueue.PodSetAssignment{{
+								Name:               kueue.DefaultPodSetName,
+								TopologyAssignment: &kueue.TopologyAssignment{},
+							}},
+						},
+					},
+				}),
+			},
+			workload: *workload.NewInfo(&kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
+							Request(corev1.ResourceCPU, "1").
+							PreferredTopologyRequest(corev1.LabelHostname).
+							Obj(),
+					},
+				},
+			}),
+			wantErr: "preferred topology is not supported with ElasticJobsViaWorkloadSlices",
+		},
+		"unconstrained topology is accepted with ElasticJobsViaWorkloadSlices": {
+			cq: schdcache.ClusterQueueSnapshot{
+				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{"tas": tasFlavor},
+			},
+			assignment: Assignment{
+				PodSets: []PodSetAssignment{{
+					Name: kueue.DefaultPodSetName,
+					Flavors: ResourceAssignment{
+						corev1.ResourceCPU: {Name: "tas", Mode: Fit, TriedFlavorIdx: -1},
+					},
+					Count:  2,
+					Status: *NewStatus(),
+				}},
+				replaceWorkloadSlice: workload.NewInfo(&kueue.Workload{
+					Status: kueue.WorkloadStatus{
+						Admission: &kueue.Admission{
+							PodSetAssignments: []kueue.PodSetAssignment{{
+								Name:               kueue.DefaultPodSetName,
+								TopologyAssignment: &kueue.TopologyAssignment{},
+							}},
+						},
+					},
+				}),
+			},
+			workload: *workload.NewInfo(&kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
+							Request(corev1.ResourceCPU, "1").
+							UnconstrainedTopologyRequest().
+							Obj(),
+					},
+				},
+			}),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tasReqs := tc.assignment.WorkloadsTopologyRequests(&tc.workload, &tc.cq)
+			if tc.wantErr != "" {
+				if len(tasReqs) != 0 {
+					t.Errorf("expected no TAS requests, got: %+v", tasReqs)
+				}
+				if tc.assignment.PodSets[0].Status.err == nil {
+					t.Errorf("expected error %q, got nil", tc.wantErr)
+				} else if diff := cmp.Diff(tc.wantErr, tc.assignment.PodSets[0].Status.err.Error()); diff != "" {
+					t.Errorf("Error mismatch (-want +got):\n%s", diff)
+				}
+			} else if tc.assignment.PodSets[0].Status.err != nil {
+				t.Errorf("expected no error, got: %v", tc.assignment.PodSets[0].Status.err)
+			}
+		})
+	}
+}
+
 func TestAssignment_TotalRequestsFor(t *testing.T) {
 	type fields struct {
 		PodSets              []PodSetAssignment

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -137,6 +137,20 @@ func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject
 	}), nil
 }
 
+// FindLatestActiveWorkload returns the newest non-finished workload from the list of workloads
+// owned by the provided job. Returns nil if no active workload exists.
+func FindLatestActiveWorkload(ctx context.Context, clnt client.Client, jobObject client.Object, jobObjectGVK schema.GroupVersionKind) (*kueue.Workload, error) {
+	workloads, err := FindNotFinishedWorkloads(ctx, clnt, jobObject, jobObjectGVK)
+	if err != nil {
+		return nil, err
+	}
+	if len(workloads) == 0 {
+		return nil, nil
+	}
+	// FindNotFinishedWorkloads returns oldest first, so the latest is at the end
+	return &workloads[len(workloads)-1], nil
+}
+
 // ScaledDown returns true if the new pod sets represent a scale-down operation.
 // This is determined by checking whether at least one new pod set has fewer replicas
 // than its corresponding old pod set, and none of the old pod sets have fewer replicas

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -23,6 +23,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.13"
+- name: ElasticJobsViaWorkloadSlicesWithTAS
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.17"
 - name: FailureRecoveryPolicy
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -23,6 +23,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.13"
+- name: ElasticJobsViaWorkloadSlicesWithTAS
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.17"
 - name: FailureRecoveryPolicy
   versionedSpecs:
   - default: false

--- a/test/e2e/config/default/values.yaml
+++ b/test/e2e/config/default/values.yaml
@@ -67,3 +67,4 @@ managerConfig:
     featureGates:
       LocalQueueMetrics: true
       ElasticJobsViaWorkloadSlices: true
+      ElasticJobsViaWorkloadSlicesWithTAS: true

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -3558,6 +3558,145 @@ var _ = ginkgo.Describe("Job controller with TopologyAwareScheduling", ginkgo.Or
 	})
 })
 
+var _ = ginkgo.Describe("Job controller with TAS and ElasticJobsViaWorkloadSlices", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+	const (
+		nodeGroupLabel = "node-group"
+		tasBlockLabel  = "cloud.com/topology-block"
+	)
+
+	var (
+		ns           *corev1.Namespace
+		nodes        []corev1.Node
+		topology     *kueue.Topology
+		tasFlavor    *kueue.ResourceFlavor
+		clusterQueue *kueue.ClusterQueue
+		localQueue   *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeAll(func() {
+		gomega.Expect(utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
+			string(features.ElasticJobsViaWorkloadSlices): true,
+		})).Should(gomega.Succeed())
+		fwk.StartManager(ctx, cfg, managerAndControllersSetup(true, true, nil))
+	})
+
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "tas-elastic-")
+
+		nodes = []corev1.Node{
+			*testingnode.MakeNode("b1").
+				Label(nodeGroupLabel, "tas").
+				Label(tasBlockLabel, "b1").
+				StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+					corev1.ResourcePods:   resource.MustParse("10"),
+				}).
+				Ready().
+				Obj(),
+			*testingnode.MakeNode("b2").
+				Label(nodeGroupLabel, "tas").
+				Label(tasBlockLabel, "b2").
+				StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+					corev1.ResourcePods:   resource.MustParse("10"),
+				}).
+				Ready().
+				Obj(),
+		}
+		for i := range nodes {
+			util.MustCreate(ctx, k8sClient, &nodes[i])
+		}
+
+		topology = utiltestingapi.MakeTopology("default").Levels(tasBlockLabel).Obj()
+		util.MustCreate(ctx, k8sClient, topology)
+
+		tasFlavor = utiltestingapi.MakeResourceFlavor("tas-flavor").
+			NodeLabel(nodeGroupLabel, "tas").
+			TopologyName(topology.Name).Obj()
+		util.MustCreate(ctx, k8sClient, tasFlavor)
+
+		clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas(tasFlavor.Name).
+					Resource(corev1.ResourceCPU, "5").
+					Resource(corev1.ResourceMemory, "5Gi").
+					Obj(),
+			).Obj()
+		util.MustCreate(ctx, k8sClient, clusterQueue)
+
+		localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+		util.MustCreate(ctx, k8sClient, localQueue)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+		for i := range nodes {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, &nodes[i], true)
+		}
+	})
+
+	ginkgo.It("should scale up an elastic job with TAS unconstrained topology", func() {
+		job := testingjob.MakeJob("elastic-job", ns.Name).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			PodAnnotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Parallelism(1).
+			Completions(10).
+			Request(corev1.ResourceCPU, "100m").
+			Obj()
+
+		ginkgo.By("creating an elastic job with unconstrained topology", func() {
+			util.MustCreate(ctx, k8sClient, job)
+		})
+
+		var originalWorkload *kueue.Workload
+		ginkgo.By("verify the workload is created and admitted with topology assignment", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				workloads := &kueue.WorkloadList{}
+				g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+				g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+				originalWorkload = &workloads.Items[0]
+				g.Expect(originalWorkload.Spec.PodSets).Should(gomega.HaveLen(1))
+				g.Expect(originalWorkload.Spec.PodSets[0].TopologyRequest).ShouldNot(gomega.BeNil())
+				g.Expect(originalWorkload.Spec.PodSets[0].TopologyRequest.Unconstrained).Should(gomega.Equal(ptr.To(true)))
+				g.Expect(originalWorkload.Status.Admission).ShouldNot(gomega.BeNil())
+				g.Expect(originalWorkload.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(1))
+				g.Expect(originalWorkload.Status.Admission.PodSetAssignments[0].TopologyAssignment).ShouldNot(gomega.BeNil())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("scale up the job by increasing parallelism", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), job)).Should(gomega.Succeed())
+				job.Spec.Parallelism = ptr.To(int32(2))
+				g.Expect(k8sClient.Update(ctx, job)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("verify a new workload slice is created and admitted with topology assignment", func() {
+			newWorkload := util.ExpectNewWorkloadSlice(ctx, k8sClient, originalWorkload)
+			gomega.Expect(newWorkload).ShouldNot(gomega.BeNil(), "Expected a new workload slice to be created")
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(newWorkload), newWorkload)).To(gomega.Succeed())
+				g.Expect(newWorkload.Status.Admission).ShouldNot(gomega.BeNil(), "New workload should be admitted")
+				g.Expect(newWorkload.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(1))
+				g.Expect(newWorkload.Status.Admission.PodSetAssignments[0].TopologyAssignment).ShouldNot(gomega.BeNil(),
+					"New workload slice should have topology assignment")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+})
+
 var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		enableWaitForPodsReady  bool

--- a/test/integration/singlecluster/tas/suite_test.go
+++ b/test/integration/singlecluster/tas/suite_test.go
@@ -34,6 +34,8 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/admissionchecks/provisioning"
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	"sigs.k8s.io/kueue/pkg/controller/tas"
 	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/scheduler"
@@ -98,6 +100,9 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 
 	failedCtrl, err = tas.SetupControllers(mgr, queues, cCache, controllersCfg, nil)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "TAS controller", failedCtrl)
+
+	err = pod.SetupWebhook(mgr, jobframework.WithQueues(queues))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = tasindexer.SetupIndexes(ctx, mgr.GetFieldIndexer())
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/8160

#### Special notes for your reviewer:
When both TopologyAwareScheduling and ElasticJobsViaWorkloadSlices feature gates are enabled, Kueue now preserves topology locality across workload slice transitions during job scaling.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
ElasticWorkloads & TAS: enable the integration with the ElasticJobsViaWorkloadSlicesWithTAS feature gate (alpha)
```