### PR TITLE
Automated cherry pick of #8592: Add MultiKueueWaitForWorkloadAdmitted feature gate to delay cleanup until admission

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -234,6 +234,12 @@ const (
 	// issue: https://github.com/kubernetes-sigs/kueue/issues/5298
 	// Enabled skip adding finalizers for serving workloads.
 	SkipFinalizersForPodsSuspendedByParent featuregate.Feature = "SkipFinalizersForPodsSuspendedByParent"
+
+	// owner: @IrvingMg
+	//
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/8585
+	// Enable waiting for WorkloadAdmitted before cleaning up non-selected worker workloads.
+	MultiKueueWaitForWorkloadAdmitted featuregate.Feature = "MultiKueueWaitForWorkloadAdmitted"
 )
 
 func init() {
@@ -365,6 +371,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.15"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	SkipFinalizersForPodsSuspendedByParent: {
+		{Version: version.MustParse("0.15"), Default: true, PreRelease: featuregate.Beta}, // GA in 0.18
+	},
+
+	MultiKueueWaitForWorkloadAdmitted: {
 		{Version: version.MustParse("0.15"), Default: true, PreRelease: featuregate.Beta}, // GA in 0.18
 	},
 }

--- a/site/content/en/docs/concepts/multikueue.md
+++ b/site/content/en/docs/concepts/multikueue.md
@@ -63,6 +63,16 @@ The dispatching flow works as follows:
    - The manager performs a final status sync.
    - It then deletes the corresponding objects from the worker cluster.
 
+{{< feature-state state="beta" for_version="v0.15" >}}
+
+{{% alert title="Note" color="primary" %}}
+By default, Workloads are only deleted from non-selected worker clusters after a Workload is
+fully admitted (quota reserved AND all admission checks satisfied). This allows parallel
+ProvisioningRequests across worker clusters. To revert to the previous behavior where Workloads
+are deleted immediately upon quota reservation, disable the `MultiKueueWaitForWorkloadAdmitted`
+feature gate.
+{{% /alert %}}
+
 ## Workload Dispatching
 
 {{% alert title="Note" color="primary" %}}

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -323,6 +323,7 @@ spec:
 | `PropagateBatchJobLabelsToWorkload`           | `true`  | Beta  | 0.15  |       |
 | `FailureRecoveryPolicy`                       | `false` | Alpha | 0.15  |       |
 | `SkipFinalizersForPodsSuspendedByParent`      | `true`  | Beta  | 0.15  |       |
+| `MultiKueueWaitForWorkloadAdmitted`           | `true`  | Beta  | 0.15  |       |
 
 {{% alert title="Note" color="primary" %}}
 The SanitizePodSets and MultiKueueAllowInsecureKubeconfigs features are available starting from versions 0.13.8 and 0.14.3.

--- a/test/integration/multikueue/provisioning_test.go
+++ b/test/integration/multikueue/provisioning_test.go
@@ -45,9 +45,12 @@ var _ = ginkgo.Describe("MultiKueue with ProvisioningRequest", ginkgo.Ordered, g
 	var (
 		managerNs *corev1.Namespace
 		worker1Ns *corev1.Namespace
+		worker2Ns *corev1.Namespace
 
 		managerMultiKueueSecret1 *corev1.Secret
+		managerMultiKueueSecret2 *corev1.Secret
 		workerCluster1           *kueue.MultiKueueCluster
+		workerCluster2           *kueue.MultiKueueCluster
 		managerMultiKueueConfig  *kueue.MultiKueueConfig
 		multiKueueAC             *kueue.AdmissionCheck
 
@@ -60,6 +63,12 @@ var _ = ginkgo.Describe("MultiKueue with ProvisioningRequest", ginkgo.Ordered, g
 		worker1Rf            *kueue.ResourceFlavor
 		worker1Cq            *kueue.ClusterQueue
 		worker1Lq            *kueue.LocalQueue
+
+		worker2ProvReqConfig *kueue.ProvisioningRequestConfig
+		worker2ProvReqAC     *kueue.AdmissionCheck
+		worker2Rf            *kueue.ResourceFlavor
+		worker2Cq            *kueue.ClusterQueue
+		worker2Lq            *kueue.LocalQueue
 	)
 
 	ginkgo.BeforeAll(func() {
@@ -75,18 +84,25 @@ var _ = ginkgo.Describe("MultiKueue with ProvisioningRequest", ginkgo.Ordered, g
 	ginkgo.BeforeEach(func() {
 		managerNs = util.CreateNamespaceFromPrefixWithLog(managerTestCluster.ctx, managerTestCluster.client, "mk-prov-")
 		worker1Ns = util.CreateNamespaceWithLog(worker1TestCluster.ctx, worker1TestCluster.client, managerNs.Name)
+		worker2Ns = util.CreateNamespaceWithLog(worker2TestCluster.ctx, worker2TestCluster.client, managerNs.Name)
 
 		w1Kubeconfig, err := worker1TestCluster.kubeConfigBytes()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		w2Kubeconfig, err := worker2TestCluster.kubeConfigBytes()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Setup MultiKueue resources
-		managerMultiKueueSecret1 = utiltesting.MakeSecret("multikueue-prov-secret", managersConfigNamespace.Name).Data(kueue.MultiKueueConfigSecretKey, w1Kubeconfig).Obj()
+		managerMultiKueueSecret1 = utiltesting.MakeSecret("multikueue-prov-secret1", managersConfigNamespace.Name).Data(kueue.MultiKueueConfigSecretKey, w1Kubeconfig).Obj()
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, managerMultiKueueSecret1)).To(gomega.Succeed())
+		managerMultiKueueSecret2 = utiltesting.MakeSecret("multikueue-prov-secret2", managersConfigNamespace.Name).Data(kueue.MultiKueueConfigSecretKey, w2Kubeconfig).Obj()
+		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, managerMultiKueueSecret2)).To(gomega.Succeed())
 
 		workerCluster1 = utiltestingapi.MakeMultiKueueCluster("worker1-prov").KubeConfig(kueue.SecretLocationType, managerMultiKueueSecret1.Name).Obj()
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, workerCluster1)).To(gomega.Succeed())
+		workerCluster2 = utiltestingapi.MakeMultiKueueCluster("worker2-prov").KubeConfig(kueue.SecretLocationType, managerMultiKueueSecret2.Name).Obj()
+		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, workerCluster2)).To(gomega.Succeed())
 
-		managerMultiKueueConfig = utiltestingapi.MakeMultiKueueConfig("mk-prov-config").Clusters(workerCluster1.Name).Obj()
+		managerMultiKueueConfig = utiltestingapi.MakeMultiKueueConfig("mk-prov-config").Clusters(workerCluster1.Name, workerCluster2.Name).Obj()
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, managerMultiKueueConfig)).Should(gomega.Succeed())
 
 		multiKueueAC = utiltestingapi.MakeAdmissionCheck("mk-ac").
@@ -115,6 +131,7 @@ var _ = ginkgo.Describe("MultiKueue with ProvisioningRequest", ginkgo.Ordered, g
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, managerLq)).Should(gomega.Succeed())
 		util.ExpectLocalQueuesToBeActive(managerTestCluster.ctx, managerTestCluster.client, managerLq)
 
+		// Worker 1 setup
 		worker1ProvReqConfig = utiltestingapi.MakeProvisioningRequestConfig("prov-config").
 			ProvisioningClass("test-provisioning-class").
 			Obj()
@@ -130,7 +147,7 @@ var _ = ginkgo.Describe("MultiKueue with ProvisioningRequest", ginkgo.Ordered, g
 			util.ExpectAdmissionChecksToBeActive(worker1TestCluster.ctx, worker1TestCluster.client, worker1ProvReqAC)
 		})
 
-		worker1Rf = utiltestingapi.MakeResourceFlavor("worker-rf").NodeLabel("instance-type", "worker-node").Obj()
+		worker1Rf = utiltestingapi.MakeResourceFlavor("worker1-rf").NodeLabel("instance-type", "worker-node").Obj()
 		gomega.Expect(worker1TestCluster.client.Create(worker1TestCluster.ctx, worker1Rf)).To(gomega.Succeed())
 
 		worker1Cq = utiltestingapi.MakeClusterQueue("cq-mk-prov").
@@ -145,21 +162,58 @@ var _ = ginkgo.Describe("MultiKueue with ProvisioningRequest", ginkgo.Ordered, g
 		worker1Lq = utiltestingapi.MakeLocalQueue(worker1Cq.Name, worker1Ns.Name).ClusterQueue(worker1Cq.Name).Obj()
 		gomega.Expect(worker1TestCluster.client.Create(worker1TestCluster.ctx, worker1Lq)).Should(gomega.Succeed())
 		util.ExpectLocalQueuesToBeActive(worker1TestCluster.ctx, worker1TestCluster.client, worker1Lq)
+
+		// Worker 2 setup
+		worker2ProvReqConfig = utiltestingapi.MakeProvisioningRequestConfig("prov-config").
+			ProvisioningClass("test-provisioning-class").
+			Obj()
+		gomega.Expect(worker2TestCluster.client.Create(worker2TestCluster.ctx, worker2ProvReqConfig)).Should(gomega.Succeed())
+
+		worker2ProvReqAC = utiltestingapi.MakeAdmissionCheck("prov-ac").
+			ControllerName(kueue.ProvisioningRequestControllerName).
+			Parameters(kueue.GroupVersion.Group, "ProvisioningRequestConfig", worker2ProvReqConfig.Name).
+			Obj()
+		gomega.Expect(worker2TestCluster.client.Create(worker2TestCluster.ctx, worker2ProvReqAC)).Should(gomega.Succeed())
+
+		ginkgo.By("wait for worker provisioning admission check to be active", func() {
+			util.ExpectAdmissionChecksToBeActive(worker2TestCluster.ctx, worker2TestCluster.client, worker2ProvReqAC)
+		})
+
+		worker2Rf = utiltestingapi.MakeResourceFlavor("worker2-rf").NodeLabel("instance-type", "worker-node").Obj()
+		gomega.Expect(worker2TestCluster.client.Create(worker2TestCluster.ctx, worker2Rf)).To(gomega.Succeed())
+
+		worker2Cq = utiltestingapi.MakeClusterQueue("cq-mk-prov").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(worker2Rf.Name).
+				Resource(corev1.ResourceCPU, "5").
+				Obj()).
+			AdmissionChecks(kueue.AdmissionCheckReference(worker2ProvReqAC.Name)).
+			Obj()
+		util.CreateClusterQueuesAndWaitForActive(worker2TestCluster.ctx, worker2TestCluster.client, worker2Cq)
+
+		worker2Lq = utiltestingapi.MakeLocalQueue(worker2Cq.Name, worker2Ns.Name).ClusterQueue(worker2Cq.Name).Obj()
+		util.CreateLocalQueuesAndWaitForActive(worker2TestCluster.ctx, worker2TestCluster.client, worker2Lq)
 	})
 
 	ginkgo.AfterEach(func() {
 		gomega.Expect(util.DeleteNamespace(managerTestCluster.ctx, managerTestCluster.client, managerNs)).To(gomega.Succeed())
 		gomega.Expect(util.DeleteNamespace(worker1TestCluster.ctx, worker1TestCluster.client, worker1Ns)).To(gomega.Succeed())
+		gomega.Expect(util.DeleteNamespace(worker2TestCluster.ctx, worker2TestCluster.client, worker2Ns)).To(gomega.Succeed())
 		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, managerCq, true)
 		util.ExpectObjectToBeDeleted(worker1TestCluster.ctx, worker1TestCluster.client, worker1Cq, true)
+		util.ExpectObjectToBeDeleted(worker2TestCluster.ctx, worker2TestCluster.client, worker2Cq, true)
 		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, managerRf, true)
 		util.ExpectObjectToBeDeleted(worker1TestCluster.ctx, worker1TestCluster.client, worker1Rf, true)
+		util.ExpectObjectToBeDeleted(worker2TestCluster.ctx, worker2TestCluster.client, worker2Rf, true)
 		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, multiKueueAC, true)
 		util.ExpectObjectToBeDeleted(worker1TestCluster.ctx, worker1TestCluster.client, worker1ProvReqAC, true)
+		util.ExpectObjectToBeDeleted(worker2TestCluster.ctx, worker2TestCluster.client, worker2ProvReqAC, true)
 		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, managerMultiKueueConfig, true)
 		util.ExpectObjectToBeDeleted(worker1TestCluster.ctx, worker1TestCluster.client, worker1ProvReqConfig, true)
+		util.ExpectObjectToBeDeleted(worker2TestCluster.ctx, worker2TestCluster.client, worker2ProvReqConfig, true)
 		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, workerCluster1, true)
+		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, workerCluster2, true)
 		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, managerMultiKueueSecret1, true)
+		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, managerMultiKueueSecret2, true)
 	})
 
 	ginkgo.It("Should create workload on worker and provision resources", func() {
@@ -260,6 +314,108 @@ var _ = ginkgo.Describe("MultiKueue with ProvisioningRequest", ginkgo.Ordered, g
 				managerWl := &kueue.Workload{}
 				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, managerWlKey, managerWl)).To(gomega.Succeed())
 				g.Expect(managerWl.Status.Admission).NotTo(gomega.BeNil())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.It("Should wait for admission before deleting non-selected worker workloads", func() {
+		job := testingjob.MakeJob("test-job2", managerNs.Name).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
+			Request(corev1.ResourceCPU, "2").
+			Obj()
+		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, job)).Should(gomega.Succeed())
+
+		managerWlKey := types.NamespacedName{
+			Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+			Namespace: managerNs.Name,
+		}
+		worker1WlKey := types.NamespacedName{
+			Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+			Namespace: worker1Ns.Name,
+		}
+		worker2WlKey := types.NamespacedName{
+			Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+			Namespace: worker2Ns.Name,
+		}
+
+		ginkgo.By("setting quota reservation on manager cluster", func() {
+			admission := utiltestingapi.MakeAdmission(managerCq.Name).
+				PodSets(
+					utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(managerRf.Name), "2").
+						Obj(),
+				).
+				Obj()
+			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, managerWlKey, admission)
+		})
+
+		ginkgo.By("verifying workloads are created on both worker clusters", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				worker1Wl := &kueue.Workload{}
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, worker1WlKey, worker1Wl)).To(gomega.Succeed())
+				worker2Wl := &kueue.Workload{}
+				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, worker2WlKey, worker2Wl)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("setting quota reservation on worker1 (creates ProvisioningRequest)", func() {
+			admission := utiltestingapi.MakeAdmission(worker1Cq.Name).
+				PodSets(
+					utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(worker1Rf.Name), "2").
+						Obj(),
+				).
+				Obj()
+			util.SetQuotaReservation(worker1TestCluster.ctx, worker1TestCluster.client, worker1WlKey, admission)
+		})
+
+		ginkgo.By("verifying worker2 workload still exists while worker1 is not admitted", func() {
+			gomega.Consistently(func(g gomega.Gomega) {
+				worker2Wl := &kueue.Workload{}
+				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, worker2WlKey, worker2Wl)).To(gomega.Succeed())
+			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+		})
+
+		worker1ProvReqKey := types.NamespacedName{
+			Namespace: worker1Ns.Name,
+			Name:      provisioning.ProvisioningRequestName(worker1WlKey.Name, kueue.AdmissionCheckReference(worker1ProvReqAC.Name), 1),
+		}
+
+		ginkgo.By("marking worker1's ProvisioningRequest as provisioned", func() {
+			createdProvReq := &autoscaling.ProvisioningRequest{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, worker1ProvReqKey, createdProvReq)).To(gomega.Succeed())
+				apimeta.SetStatusCondition(&createdProvReq.Status.Conditions, metav1.Condition{
+					Type:   autoscaling.Provisioned,
+					Status: metav1.ConditionTrue,
+					Reason: autoscaling.Provisioned,
+				})
+				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, createdProvReq)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("verifying worker1 workload is admitted", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				worker1Wl := &kueue.Workload{}
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, worker1WlKey, worker1Wl)).To(gomega.Succeed())
+				g.Expect(apimeta.IsStatusConditionTrue(worker1Wl.Status.Conditions, kueue.WorkloadAdmitted)).To(gomega.BeTrue())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("verifying worker2 workload is deleted after worker1 is admitted", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				worker2Wl := &kueue.Workload{}
+				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, worker2WlKey, worker2Wl)).To(utiltesting.BeNotFoundError())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("verifying the multikueue admission check is ready on manager", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				managerWl := &kueue.Workload{}
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, managerWlKey, managerWl)).To(gomega.Succeed())
+				mkCheck := admissioncheck.FindAdmissionCheck(managerWl.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
+				g.Expect(mkCheck).NotTo(gomega.BeNil())
+				g.Expect(mkCheck.State).To(gomega.Equal(kueue.CheckStateReady))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})

--- a/test/integration/multikueue/tas/tas_test.go
+++ b/test/integration/multikueue/tas/tas_test.go
@@ -458,6 +458,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 		ginkgo.It("should admit workload when nodes are provisioned", func() {
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueBatchJobWithManagedBy, true)
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.TopologyAwareScheduling, true)
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueWaitForWorkloadAdmitted, false)
 
 			job := testingjob.MakeJob("job", managerNs.Name).
 				ManagedBy(kueue.MultiKueueControllerName).


### PR DESCRIPTION
Cherry pick of #8592 on release-0.15.

#8592: Add MultiKueueWaitForWorkloadAdmitted feature gate to delay cleanup until admission

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
MultiKueue now waits for WorkloadAdmitted (instead of QuotaReserved) before deleting workloads from non-selected worker clusters. To revert to the previous behavior, disable the `MultiKueueWaitForWorkloadAdmitted` feature gate.
```