### PR TITLE
Update method signatures of scheduler cache used in workload controller

### DIFF
--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -622,10 +622,9 @@ func (c *Cache) deleteFromQueueIfPresent(log logr.Logger, wlKey workload.Referen
 	}
 }
 
-func (c *Cache) DeleteWorkload(log logr.Logger, w *kueue.Workload) error {
+func (c *Cache) DeleteWorkload(log logr.Logger, wlKey workload.Reference) error {
 	c.Lock()
 	defer c.Unlock()
-	wlKey := workload.Key(w)
 
 	cqName, assigned := c.workloadAssignedQueues[wlKey]
 	if !assigned {

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -1471,7 +1471,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				w := utiltestingapi.MakeWorkload("a", "").ReserveQuotaAt(&kueue.Admission{
 					ClusterQueue: "one",
 				}, now).Obj()
-				return cache.DeleteWorkload(log, w)
+				return cache.DeleteWorkload(log, workload.Key(w))
 			},
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
@@ -1490,7 +1490,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			name: "delete workload with cancelled admission",
 			operation: func(log logr.Logger, cache *Cache) error {
 				w := utiltestingapi.MakeWorkload("a", "").Obj()
-				return cache.DeleteWorkload(log, w)
+				return cache.DeleteWorkload(log, workload.Key(w))
 			},
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
@@ -1509,7 +1509,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			name: "delete non-existing workload with cancelled admission",
 			operation: func(log logr.Logger, cache *Cache) error {
 				w := utiltestingapi.MakeWorkload("d", "").Obj()
-				return cache.DeleteWorkload(log, w)
+				return cache.DeleteWorkload(log, workload.Key(w))
 			},
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
@@ -1546,7 +1546,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				}
 				cache.DeleteClusterQueue(cq)
 
-				return cache.DeleteWorkload(log, w)
+				return cache.DeleteWorkload(log, workload.Key(w))
 			},
 			wantError: "cluster queue not found",
 			wantResults: map[kueue.ClusterQueueReference]result{
@@ -1574,7 +1574,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				w := utiltestingapi.MakeWorkload("d", "").ReserveQuotaAt(&kueue.Admission{
 					ClusterQueue: "one",
 				}, now).Obj()
-				return cache.DeleteWorkload(log, w)
+				return cache.DeleteWorkload(log, workload.Key(w))
 			},
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
@@ -2592,7 +2592,7 @@ func TestCacheQueueOperations(t *testing.T) {
 				insertAllWorkloads,
 				func(ctx context.Context, cl client.Client, cache *Cache) error {
 					log := ctrl.LoggerFrom(ctx)
-					return cache.DeleteWorkload(log, workloads[0])
+					return cache.DeleteWorkload(log, workload.Key(workloads[0]))
 				},
 			},
 			wantLocalQueues: map[queue.LocalQueueReference]*LocalQueue{
@@ -3000,7 +3000,7 @@ func TestCachePodsReadyForAllAdmittedWorkloads(t *testing.T) {
 			},
 			operation: func(log logr.Logger, cache *Cache) error {
 				wl := cache.hm.ClusterQueue("one").Workloads["/a"].Obj
-				return cache.DeleteWorkload(log, wl)
+				return cache.DeleteWorkload(log, workload.Key(wl))
 			},
 			wantReady: true,
 		},

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -850,7 +850,7 @@ func (r *WorkloadReconciler) Delete(e event.TypedDeleteEvent[*kueue.Workload]) b
 	// by the scheduler, and leaving them blocks ClusterQueue finalizer removal.
 	// The operation is idempotent if the workload was never in the cache.
 	r.queues.QueueAssociatedInadmissibleWorkloadsAfter(ctx, wlKey, func() {
-		if err := r.cache.DeleteWorkload(log, e.Object); err != nil {
+		if err := r.cache.DeleteWorkload(log, wlKey); err != nil {
 			log.Error(err, "Failed to delete workload from cache")
 		}
 	})
@@ -904,7 +904,7 @@ func (r *WorkloadReconciler) Update(e event.TypedUpdateEvent[*kueue.Workload]) b
 			// Delete the workload from cache while holding the queues lock
 			// to guarantee that requeued workloads are taken into account before
 			// the next scheduling cycle.
-			if err := r.cache.DeleteWorkload(log, e.ObjectOld); err != nil && prevStatus == workload.StatusAdmitted {
+			if err := r.cache.DeleteWorkload(log, wlKey); err != nil && prevStatus == workload.StatusAdmitted {
 				log.Error(err, "Failed to delete workload from cache")
 			}
 		})
@@ -939,7 +939,7 @@ func (r *WorkloadReconciler) Update(e event.TypedUpdateEvent[*kueue.Workload]) b
 			// Delete the workload from cache while holding the queues lock
 			// to guarantee that requeued workloads are taken into account before
 			// the next scheduling cycle.
-			if err := r.cache.DeleteWorkload(log, e.ObjectNew); err != nil {
+			if err := r.cache.DeleteWorkload(log, wlKey); err != nil {
 				log.Error(err, "Failed to delete workload from cache")
 			}
 			// Here we don't take the lock as it is already taken by the wrapping function.

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -662,7 +662,7 @@ func (s *Scheduler) admit(ctx context.Context, e *entry, cq *schdcache.ClusterQu
 		}
 		// Ignore errors because the workload or clusterQueue could have been deleted
 		// by an event.
-		_ = s.cache.DeleteWorkload(log, cacheWl)
+		_ = s.cache.DeleteWorkload(log, workload.Key(cacheWl))
 		if afs.Enabled(s.admissionFairSharing) {
 			s.updateEntryPenalty(log, e, subtract)
 		}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -8637,7 +8637,7 @@ func TestLastSchedulingContext(t *testing.T) {
 					if err != nil {
 						t.Errorf("Delete workload failed: %v", err)
 					}
-					err = cqCache.DeleteWorkload(log, &wl)
+					err = cqCache.DeleteWorkload(log, workload.Key(&wl))
 					if err != nil {
 						t.Errorf("Delete workload failed: %v", err)
 					}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Cleans up after the refactor of scheduler cache. Removes the need to pass full workloads to the delete method.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part 2.2 of addressing: https://github.com/kubernetes-sigs/kueue/issues/5310

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```