### PR TITLE
Handle recommended flags in visibility server

### DIFF
--- a/pkg/visibility/server.go
+++ b/pkg/visibility/server.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"strings"
 
+	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -113,6 +114,7 @@ func applyVisibilityServerOptions(config *genericapiserver.RecommendedConfig, en
 	if err := o.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
 		return fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
+	o.AddFlags(pflag.CommandLine)
 	return o.ApplyTo(config)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

It fixes the problem of visibility server ignoring command-line flags (notably, `--kubeconfg`).

#### Which issue(s) this PR fixes:

Fixes #8606

#### Special notes for your reviewer:

I'm not sure if this deserves a release note.

#### Does this PR introduce a user-facing change?
```release-note
Fix the bug that when running Kueue with the custom `--kubeconfig` flag the visibility server fails to initialize,
because the custom value of flag is not propagated to it. This leads to errors such as "Unable to create and start
visibility server","error":"unable to apply VisibilityServerOptions: failed to get delegated authentication kubeconfig: 
failed to get delegated authentication kubeconfig: ..."
```