### PR TITLE
Document the requirement for `ClusterProfile`s to be in Kueue NS

### DIFF
--- a/site/content/en/docs/tasks/manage/setup_multikueue.md
+++ b/site/content/en/docs/tasks/manage/setup_multikueue.md
@@ -193,6 +193,12 @@ Where:
 * `cluster-url` is the URL of the cluster's control plane.
 * `access-provider-name` is the name of the provider of the cluster's credentials. For example `google`.
 
+{{% alert title="Note" color="primary" %}}
+
+The `ClusterProfile`s have to be provisioned within the Kueue system namespace (`kueue-system` by default).
+
+{{% /alert %}}
+
 #### Manually created cluster inventory
 
 In principle, the `ClusterProfile` objects can be provisioned without the use of a cloud provider.
@@ -222,6 +228,8 @@ status:
 
 The `ClusterProfile` access providers are within the object's `status` subresource and, in principle, should be managed by the cluster manager
 (i.e. the entity provisioning the clusters, like a cloud provider) and not created manually.
+
+They also have to be provisioned within the Kueue system namespace (`kueue-system` by default).
 
 {{% /alert %}}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
The `ClusterProfile`s have to be in the Kueue system namespace. This is documented in the GCP walkthrough ([manual](https://github.com/GoogleCloudPlatform/gke-fleet-management/blob/b9fe08386c48f84617cb8ab7b042f2790741e893/multikueue-clusterprofile/README.md?plain=1#L241) and [Terraform](https://github.com/GoogleCloudPlatform/gke-fleet-management/blob/b9fe08386c48f84617cb8ab7b042f2790741e893/multikueue-clusterprofile/1-infrastructure/main.tf#L54)) but might be overlooked, especially when provisioning the inventory for a real use case and not just following the guide.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```