### PR TITLE
Increase MultiKueueConfig clusters limit from 10 to 20

### DIFF
--- a/apis/kueue/v1beta1/multikueue_types.go
+++ b/apis/kueue/v1beta1/multikueue_types.go
@@ -126,7 +126,7 @@ type MultiKueueConfigSpec struct {
 	//
 	// +listType=set
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=10
+	// +kubebuilder:validation:MaxItems=20
 	Clusters []string `json:"clusters"`
 }
 

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -427,7 +427,7 @@ type WorkloadStatus struct {
 	// This field is optional.
 	//
 	// +listType=atomic
-	// +kubebuilder:validation:MaxItems=10
+	// +kubebuilder:validation:MaxItems=20
 	// +optional
 	NominatedClusterNames []string `json:"nominatedClusterNames,omitempty"`
 

--- a/apis/kueue/v1beta2/multikueue_types.go
+++ b/apis/kueue/v1beta2/multikueue_types.go
@@ -140,7 +140,7 @@ type MultiKueueConfigSpec struct {
 	//
 	// +listType=set
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=10
+	// +kubebuilder:validation:MaxItems=20
 	// +kubebuilder:validation:items:MaxLength=256
 	// +required
 	Clusters []string `json:"clusters,omitempty,omitzero"`

--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -642,7 +642,7 @@ type WorkloadStatus struct {
 	// This field is optional.
 	//
 	// +listType=atomic
-	// +kubebuilder:validation:MaxItems=10
+	// +kubebuilder:validation:MaxItems=20
 	// +kubebuilder:validation:items:MaxLength=256
 	// +optional
 	NominatedClusterNames []string `json:"nominatedClusterNames,omitempty"`

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueconfigs.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueconfigs.yaml
@@ -65,7 +65,7 @@ spec:
                   description: clusters is a list of MultiKueueClusters names where the workloads from the ClusterQueue should be distributed.
                   items:
                     type: string
-                  maxItems: 10
+                  maxItems: 20
                   minItems: 1
                   type: array
                   x-kubernetes-list-type: set
@@ -105,7 +105,7 @@ spec:
                   items:
                     maxLength: 256
                     type: string
-                  maxItems: 10
+                  maxItems: 20
                   minItems: 1
                   type: array
                   x-kubernetes-list-type: set

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -8803,7 +8803,7 @@ spec:
                     This field is optional.
                   items:
                     type: string
-                  maxItems: 10
+                  maxItems: 20
                   type: array
                   x-kubernetes-list-type: atomic
                 reclaimablePods:
@@ -17766,7 +17766,7 @@ spec:
                   items:
                     maxLength: 256
                     type: string
-                  maxItems: 10
+                  maxItems: 20
                   type: array
                   x-kubernetes-list-type: atomic
                 reclaimablePods:

--- a/config/components/crd/bases/kueue.x-k8s.io_multikueueconfigs.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_multikueueconfigs.yaml
@@ -44,7 +44,7 @@ spec:
                   the workloads from the ClusterQueue should be distributed.
                 items:
                   type: string
-                maxItems: 10
+                maxItems: 20
                 minItems: 1
                 type: array
                 x-kubernetes-list-type: set
@@ -85,7 +85,7 @@ spec:
                 items:
                   maxLength: 256
                   type: string
-                maxItems: 10
+                maxItems: 20
                 minItems: 1
                 type: array
                 x-kubernetes-list-type: set

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -9273,7 +9273,7 @@ spec:
                   This field is optional.
                 items:
                   type: string
-                maxItems: 10
+                maxItems: 20
                 type: array
                 x-kubernetes-list-type: atomic
               reclaimablePods:
@@ -18857,7 +18857,7 @@ spec:
                 items:
                   maxLength: 256
                   type: string
-                maxItems: 10
+                maxItems: 20
                 type: array
                 x-kubernetes-list-type: atomic
               reclaimablePods:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
/kind api-change

#### What this PR does / why we need it:
Increases the maximum number of clusters allowed per MultiKueueConfig from 10 to 20.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8561

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MultiKueue: Allow up to 20 clusters per MultiKueueConfig.
```