### PR TITLE
TAS: Fix a bug that MPIJob with runLauncherAsWorker Pod indexes are not correctly evaluated.

### DIFF
--- a/apis/kueue/v1beta2/topology_types.go
+++ b/apis/kueue/v1beta2/topology_types.go
@@ -78,6 +78,11 @@ const (
 	// only kept to support "reading" the label until 0.16.
 	TASLabel = "kueue.x-k8s.io/tas"
 
+	// PodIndexOffsetAnnotation is an annotation on the Pod's metadata
+	// belonging to a Workload. It indicates an offset which represents starting index number
+	// within the same replica.
+	PodIndexOffsetAnnotation = "kueue.x-k8s.io/pod-index-offset"
+
 	// PodGroupPodIndexLabel is a label set on the Pod's metadata belonging
 	// to a Pod group. It indicates the Pod's index within the group.
 	PodGroupPodIndexLabel = "kueue.x-k8s.io/pod-group-pod-index"

--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -13,11 +13,13 @@
     - [Story 4](#story-4)
     - [Story 5](#story-5)
     - [Story 6](#story-6)
+    - [Story 7](#story-7)
   - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
     - [Integration support](#integration-support)
       - [Job](#job)
       - [JobSet](#jobset)
       - [LeaderWorkerSet](#leaderworkerset)
+      - [MPIJob with runLauncherAsWorker](#mpijob-with-runlauncherasworker)
     - [Support for the &quot;auto&quot; mode](#support-for-the-auto-mode)
     - [PodSetAssignment is per lowest-topology level](#podsetassignment-is-per-lowest-topology-level)
     - [Provisioning request and required mode](#provisioning-request-and-required-mode)
@@ -190,6 +192,12 @@ within a "block", but each Job should also run within a "host" within that "bloc
 
 Similar to [Story 1](#story-1), but I want Leader and its Workers within a single replica
 in LeaderWorkerSet to run within a "rack".
+
+#### Story 7
+
+Similar to [Story 1](#story-1), but I want Leader and its Workers across multiple PodSets within a single Workload
+for MPIJob with runLauncherAsWorker (`.spec.runLauncherAsWorker`) which should be scheduled considering
+Pod index order.
 
 ### Notes/Constraints/Caveats (Optional)
 
@@ -475,6 +483,69 @@ spec:
 
 In this example there are 2 replicas with 2 workers and 1 leader each.
 Each group of leader and 2 workers should be placed in a rack.
+
+##### MPIJob with runLauncherAsWorker
+
+According to [Story 7](#story-7) we noticed that Kueue should properly handle MPIJob Pods
+indexes (`training.kubeflow.org/replica-index`) in case of MPIJob with runLauncherAsWorker mode.  
+Because Worker replica indexes occasionally start from `1` when runLauncherAsWorker MPIJob has 
+a separate replica spec for both roles (`Launcher` and `Worker`).
+
+To allow all Pods to be scheduled considering Pod indexes,
+we are adding a new `kueue.x-k8s.io/pod-index-offset` annotation.
+It specifies the starting index for the replica.
+
+**Example**:
+
+```yaml
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: pi
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+  slotsPerWorker: 1
+  runLauncherAsWorker: true  
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+          - image: mpioperator/mpi-pi:openmpi
+            name: mpi-launcher
+            securityContext:
+              runAsUser: 1000
+            command:
+            - mpirun
+            args:
+            - -n
+            - "2"
+            - /home/mpiuser/pi
+    Worker:
+      replicas: 2
+      template:
+        spec:
+          containers:
+          - image: mpioperator/mpi-pi:openmpi
+            name: mpi-worker
+            securityContext:
+              runAsUser: 1000
+            command:
+            - /usr/sbin/sshd
+            args:
+            - -De
+            - -f
+            - /home/mpiuser/.sshd_config
+```
+
+When the above MPIJob is submitted, Kueue MPIJob integration webhook adds
+`kueue.x-k8s.io/pod-index-offset: "1"` annotation to `.spec.mpiReplicas["Worker"].metadata.annotations` 
+because Worker pods will get 1-2 index annotation values in `training.kubeflow.org/replica-index`.
+
+On the other hands, `kueue.x-k8s.io/pod-index-offset` annotation is not added and offset management is delegated to the PodSet Group mechanism
+when `kueue.x-k8s.io/podset-group-name` is specified.
 
 #### Support for the "auto" mode
 

--- a/pkg/controller/jobs/mpijob/mpijob_webhook.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -94,6 +95,22 @@ func (w *MpiJobWebhook) Default(ctx context.Context, obj runtime.Object) error {
 	}
 
 	jobframework.ApplyDefaultForManagedBy(mpiJob, w.queues, w.cache, log)
+
+	if features.Enabled(features.TopologyAwareScheduling) {
+		if replicaSpecs := mpiJob.Spec.MPIReplicaSpecs; ptr.Deref(mpiJob.Spec.RunLauncherAsWorker, false) &&
+			len(replicaSpecs) == 2 && replicaSpecs[v2beta1.MPIReplicaTypeWorker] != nil {
+			// The offset is handled as PodSet group scheduling mechanism separately in topology-unGater
+			// when the MPIJob constructs PodSet group across Launcher and Worker.
+			if _, isPodSetGroup := replicaSpecs[v2beta1.MPIReplicaTypeLauncher].Template.Annotations[kueue.PodSetGroupName]; isPodSetGroup {
+				return nil
+			}
+
+			if mpiJob.Spec.MPIReplicaSpecs[v2beta1.MPIReplicaTypeWorker].Template.Annotations == nil {
+				mpiJob.Spec.MPIReplicaSpecs[v2beta1.MPIReplicaTypeWorker].Template.Annotations = make(map[string]string)
+			}
+			mpiJob.Spec.MPIReplicaSpecs[v2beta1.MPIReplicaTypeWorker].Template.Annotations[kueue.PodIndexOffsetAnnotation] = "1"
+		}
+	}
 
 	return nil
 }

--- a/pkg/controller/tas/topology_ungater.go
+++ b/pkg/controller/tas/topology_ungater.go
@@ -223,6 +223,22 @@ func (r *topologyUngater) Reconcile(ctx context.Context, req reconcile.Request) 
 				log.Error(err, "failed to list Pods for PodSet", "podset", psa.Name, "count", psa.Count)
 				return reconcile.Result{}, err
 			}
+			if len(pods) > 0 {
+				// Assume that same replica all Pods has the same offset value.
+				offsetVal, found := pods[0].Annotations[kueue.PodIndexOffsetAnnotation]
+				if found {
+					if offset, err := strconv.Atoi(offsetVal); err != nil {
+						// If unGater failed to parse offset annotation value, it will fall back to greedy index assignment algorithm.
+						log.Error(err, "failed to parse offset annotation",
+							kueue.PodIndexOffsetAnnotation, offsetVal,
+							"pod", klog.KObj(pods[0]),
+						)
+					} else {
+						rankOffsets[psa.Name] += int32(offset)
+						maxRank[psa.Name] += int32(offset)
+					}
+				}
+			}
 			gatedPodsToDomains := assignGatedPodsToDomains(log, &psa, pods, psNameToTopologyRequest[psa.Name], rankOffsets[psa.Name], maxRank[psa.Name])
 			if len(gatedPodsToDomains) > 0 {
 				toUngate := podsToUngateInfo(&psa, gatedPodsToDomains)

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -1806,6 +1806,280 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		},
+		"ranks: support rank-based ordering for kubeflow with valid offset annotation - for all Pods": {
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("unit-test", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet("launcher", 1).
+							Request(corev1.ResourceCPU, "1").
+							PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+							PodSetGroup("mpijob-group").
+							Obj(),
+						*utiltestingapi.MakePodSet("worker", 3).
+							Request(corev1.ResourceCPU, "1").
+							PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+							PodSetGroup("mpijob-group").
+							Obj(),
+					).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(
+								utiltestingapi.MakePodSetAssignment("launcher").
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
+									TopologyAssignment(utiltestingapi.MakeTopologyAssignment(defaultTestLevels).
+										Domains(utiltestingapi.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+										Obj()).
+									Obj(),
+								utiltestingapi.MakePodSetAssignment("worker").
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "3").
+									Count(3).
+									TopologyAssignment(utiltestingapi.MakeTopologyAssignment(defaultTestLevels).
+										Domains(
+											utiltestingapi.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj(),
+											utiltestingapi.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+											utiltestingapi.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 1).Obj(),
+										).
+										Obj()).
+									Obj(),
+							).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("l0", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(kftraining.JobRoleLabel, "launcher").
+					Label(kftraining.ReplicaIndexLabel, "0").
+					Label(constants.PodSetLabel, "launcher").
+					TopologySchedulingGate().
+					Obj(),
+				*testingpod.MakePod("w1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Annotation(kueue.PodIndexOffsetAnnotation, "1").
+					Label(kftraining.JobRoleLabel, "worker").
+					Label(kftraining.ReplicaIndexLabel, "1").
+					Label(constants.PodSetLabel, "worker").
+					TopologySchedulingGate().
+					Obj(),
+				*testingpod.MakePod("w2", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Annotation(kueue.PodIndexOffsetAnnotation, "1").
+					Label(kftraining.JobRoleLabel, "worker").
+					Label(kftraining.ReplicaIndexLabel, "2").
+					Label(constants.PodSetLabel, "worker").
+					TopologySchedulingGate().
+					Obj(),
+				*testingpod.MakePod("w3", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Annotation(kueue.PodIndexOffsetAnnotation, "1").
+					Label(kftraining.JobRoleLabel, "worker").
+					Label(kftraining.ReplicaIndexLabel, "3").
+					Label(constants.PodSetLabel, "worker").
+					TopologySchedulingGate().
+					Obj(),
+			},
+			cmpNS: true,
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("l0", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(kftraining.JobRoleLabel, "launcher").
+					Label(kftraining.ReplicaIndexLabel, "0").
+					Label(constants.PodSetLabel, "launcher").
+					NodeSelector(tasBlockLabel, "b1").
+					NodeSelector(tasRackLabel, "r1").
+					Obj(),
+				*testingpod.MakePod("w1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Annotation(kueue.PodIndexOffsetAnnotation, "1").
+					Label(kftraining.JobRoleLabel, "worker").
+					Label(kftraining.ReplicaIndexLabel, "1").
+					Label(constants.PodSetLabel, "worker").
+					NodeSelector(tasBlockLabel, "b1").
+					NodeSelector(tasRackLabel, "r1").
+					Obj(),
+				*testingpod.MakePod("w2", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Annotation(kueue.PodIndexOffsetAnnotation, "1").
+					Label(kftraining.JobRoleLabel, "worker").
+					Label(kftraining.ReplicaIndexLabel, "2").
+					Label(constants.PodSetLabel, "worker").
+					NodeSelector(tasBlockLabel, "b1").
+					NodeSelector(tasRackLabel, "r2").
+					Obj(),
+				*testingpod.MakePod("w3", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Annotation(kueue.PodIndexOffsetAnnotation, "1").
+					Label(kftraining.JobRoleLabel, "worker").
+					Label(kftraining.ReplicaIndexLabel, "3").
+					Label(constants.PodSetLabel, "worker").
+					NodeSelector(tasBlockLabel, "b2").
+					NodeSelector(tasRackLabel, "r1").
+					Obj(),
+			},
+			wantCounts: []counts{
+				{
+					NodeSelector: map[string]string{
+						tasBlockLabel: "b1",
+						tasRackLabel:  "r1",
+					},
+					Count: 2,
+				},
+				{
+					NodeSelector: map[string]string{
+						tasBlockLabel: "b1",
+						tasRackLabel:  "r2",
+					},
+					Count: 1,
+				},
+				{
+					NodeSelector: map[string]string{
+						tasBlockLabel: "b2",
+						tasRackLabel:  "r1",
+					},
+					Count: 1,
+				},
+			},
+		},
+		"ranks: support rank-based ordering for kubeflow with invalid offset annotation - for all Pods": {
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("unit-test", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet("launcher", 1).
+							Request(corev1.ResourceCPU, "1").
+							PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+							PodSetGroup("mpijob-group").
+							Obj(),
+						*utiltestingapi.MakePodSet("worker", 3).
+							Request(corev1.ResourceCPU, "1").
+							PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+							PodSetGroup("mpijob-group").
+							Obj(),
+					).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(
+								utiltestingapi.MakePodSetAssignment("launcher").
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
+									TopologyAssignment(utiltestingapi.MakeTopologyAssignment(defaultTestLevels).
+										Domains(utiltestingapi.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+										Obj()).
+									Obj(),
+								utiltestingapi.MakePodSetAssignment("worker").
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "3").
+									Count(3).
+									TopologyAssignment(utiltestingapi.MakeTopologyAssignment(defaultTestLevels).
+										Domains(
+											utiltestingapi.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj(),
+											utiltestingapi.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+											utiltestingapi.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 1).Obj(),
+										).
+										Obj()).
+									Obj(),
+							).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("l0", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(kftraining.JobRoleLabel, "launcher").
+					Label(kftraining.ReplicaIndexLabel, "0").
+					Label(constants.PodSetLabel, "launcher").
+					TopologySchedulingGate().
+					Obj(),
+				*testingpod.MakePod("w0", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Annotation(kueue.PodIndexOffsetAnnotation, "invalid").
+					Label(kftraining.JobRoleLabel, "worker").
+					Label(kftraining.ReplicaIndexLabel, "0").
+					Label(constants.PodSetLabel, "worker").
+					TopologySchedulingGate().
+					Obj(),
+				*testingpod.MakePod("w1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Annotation(kueue.PodIndexOffsetAnnotation, "invalid").
+					Label(kftraining.JobRoleLabel, "worker").
+					Label(kftraining.ReplicaIndexLabel, "1").
+					Label(constants.PodSetLabel, "worker").
+					TopologySchedulingGate().
+					Obj(),
+				*testingpod.MakePod("w2", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Annotation(kueue.PodIndexOffsetAnnotation, "invalid").
+					Label(kftraining.JobRoleLabel, "worker").
+					Label(kftraining.ReplicaIndexLabel, "2").
+					Label(constants.PodSetLabel, "worker").
+					TopologySchedulingGate().
+					Obj(),
+			},
+			cmpNS: true,
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("l0", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(kftraining.JobRoleLabel, "launcher").
+					Label(kftraining.ReplicaIndexLabel, "0").
+					Label(constants.PodSetLabel, "launcher").
+					NodeSelector(tasBlockLabel, "b1").
+					NodeSelector(tasRackLabel, "r1").
+					Obj(),
+				*testingpod.MakePod("w0", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Annotation(kueue.PodIndexOffsetAnnotation, "invalid").
+					Label(kftraining.JobRoleLabel, "worker").
+					Label(kftraining.ReplicaIndexLabel, "0").
+					Label(constants.PodSetLabel, "worker").
+					NodeSelector(tasBlockLabel, "b1").
+					NodeSelector(tasRackLabel, "r1").
+					Obj(),
+				*testingpod.MakePod("w1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Annotation(kueue.PodIndexOffsetAnnotation, "invalid").
+					Label(kftraining.JobRoleLabel, "worker").
+					Label(kftraining.ReplicaIndexLabel, "1").
+					Label(constants.PodSetLabel, "worker").
+					NodeSelector(tasBlockLabel, "b1").
+					NodeSelector(tasRackLabel, "r2").
+					Obj(),
+				*testingpod.MakePod("w2", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Annotation(kueue.PodIndexOffsetAnnotation, "invalid").
+					Label(kftraining.JobRoleLabel, "worker").
+					Label(kftraining.ReplicaIndexLabel, "2").
+					Label(constants.PodSetLabel, "worker").
+					NodeSelector(tasBlockLabel, "b2").
+					NodeSelector(tasRackLabel, "r1").
+					Obj(),
+			},
+			wantCounts: []counts{
+				{
+					NodeSelector: map[string]string{
+						tasBlockLabel: "b1",
+						tasRackLabel:  "r1",
+					},
+					Count: 2,
+				},
+				{
+					NodeSelector: map[string]string{
+						tasBlockLabel: "b1",
+						tasRackLabel:  "r2",
+					},
+					Count: 1,
+				},
+				{
+					NodeSelector: map[string]string{
+						tasBlockLabel: "b2",
+						tasRackLabel:  "r1",
+					},
+					Count: 1,
+				},
+			},
+		},
 		"ranks: support rank-based ordering for kubeflow - for all Pods": {
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).

--- a/pkg/util/testingjobs/mpijob/wrappers_mpijob.go
+++ b/pkg/util/testingjobs/mpijob/wrappers_mpijob.go
@@ -76,27 +76,7 @@ func (j *MPIJobWrapper) MPIJobReplicaSpecs(replicaSpecs ...MPIJobReplicaSpecRequ
 }
 
 func (j *MPIJobWrapper) GenericLauncherAndWorker() *MPIJobWrapper {
-	j.Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher] = &kfmpi.ReplicaSpec{
-		Replicas: ptr.To[int32](1),
-		Template: corev1.PodTemplateSpec{
-			Spec: corev1.PodSpec{
-				RestartPolicy: corev1.RestartPolicyNever,
-				Containers: []corev1.Container{
-					{
-						Name:    "mpijob",
-						Image:   "pause",
-						Command: []string{},
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{},
-							Limits:   corev1.ResourceList{},
-						},
-					},
-				},
-				NodeSelector: map[string]string{},
-			},
-		},
-	}
-
+	j.GenericLauncher()
 	j.Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker] = &kfmpi.ReplicaSpec{
 		Replicas: ptr.To[int32](1),
 		Template: corev1.PodTemplateSpec{
@@ -118,6 +98,30 @@ func (j *MPIJobWrapper) GenericLauncherAndWorker() *MPIJobWrapper {
 		},
 	}
 
+	return j
+}
+
+func (j *MPIJobWrapper) GenericLauncher() *MPIJobWrapper {
+	j.Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher] = &kfmpi.ReplicaSpec{
+		Replicas: ptr.To[int32](1),
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				RestartPolicy: corev1.RestartPolicyNever,
+				Containers: []corev1.Container{
+					{
+						Name:    "mpijob",
+						Image:   "pause",
+						Command: []string{},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{},
+							Limits:   corev1.ResourceList{},
+						},
+					},
+				},
+				NodeSelector: map[string]string{},
+			},
+		},
+	}
 	return j
 }
 
@@ -253,5 +257,11 @@ func (j *MPIJobWrapper) ManagedBy(c string) *MPIJobWrapper {
 func (j *MPIJobWrapper) TerminationGracePeriodSeconds(seconds int64) *MPIJobWrapper {
 	j.Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher].Template.Spec.TerminationGracePeriodSeconds = ptr.To(seconds)
 	j.Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker].Template.Spec.TerminationGracePeriodSeconds = ptr.To(seconds)
+	return j
+}
+
+// RunLauncherAsWorker sets the RunLauncherAsWorker field.
+func (j *MPIJobWrapper) RunLauncherAsWorker(v bool) *MPIJobWrapper {
+	j.Spec.RunLauncherAsWorker = ptr.To(v)
 	return j
 }

--- a/test/integration/singlecluster/controller/jobs/mpijob/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/mpijob/suite_test.go
@@ -61,6 +61,7 @@ func TestAPIs(t *testing.T) {
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
 		DepCRDPaths: []string{util.MpiOperatorCrds},
+		WebhookPath: util.WebhookPath,
 	}
 
 	cfg = fwk.Init()
@@ -73,57 +74,15 @@ var _ = ginkgo.AfterSuite(func() {
 
 func managerSetup(setupJobManager bool, opts ...jobframework.Option) framework.ManagerSetup {
 	return func(ctx context.Context, mgr manager.Manager) {
-		reconciler, err := mpijob.NewReconciler(
-			ctx,
-			mgr.GetClient(),
-			mgr.GetFieldIndexer(),
-			mgr.GetEventRecorderFor(constants.JobControllerName),
-			opts...)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = indexer.Setup(ctx, mgr.GetFieldIndexer())
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = mpijob.SetupIndexes(ctx, mgr.GetFieldIndexer())
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = reconciler.SetupWithManager(mgr)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = mpijob.SetupMPIJobWebhook(mgr, opts...)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		jobframework.EnableIntegration(mpijob.FrameworkName)
-		failedWebhook, err := webhooks.Setup(mgr, nil)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
-
-		if setupJobManager {
-			jobReconciler, _ := job.NewReconciler(
-				ctx,
-				mgr.GetClient(),
-				mgr.GetFieldIndexer(),
-				mgr.GetEventRecorderFor(constants.JobControllerName),
-				opts...)
-			err = job.SetupIndexes(ctx, mgr.GetFieldIndexer())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = jobReconciler.SetupWithManager(mgr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = job.SetupWebhook(mgr, opts...)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		}
+		controllersSetup(ctx, mgr, setupJobManager, opts...)
 	}
 }
 
 func managerAndSchedulerSetup(setupTASControllers bool, opts ...jobframework.Option) framework.ManagerSetup {
 	return func(ctx context.Context, mgr manager.Manager) {
-		managerSetup(true, opts...)(ctx, mgr)
-
-		cCache := schdcache.New(mgr.GetClient())
-		queues := qcache.NewManager(mgr.GetClient(), cCache)
-
-		configuration := &config.Configuration{}
-		mgr.GetScheme().Default(configuration)
-
-		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration, nil)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
-
+		cCache, queues, configuration := controllersSetup(ctx, mgr, true, opts...)
 		if setupTASControllers {
-			failedCtrl, err = tas.SetupControllers(mgr, queues, cCache, configuration, nil)
+			failedCtrl, err := tas.SetupControllers(mgr, queues, cCache, configuration, nil)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "TAS controller", failedCtrl)
 
 			err = tasindexer.SetupIndexes(ctx, mgr.GetFieldIndexer())
@@ -131,7 +90,55 @@ func managerAndSchedulerSetup(setupTASControllers bool, opts ...jobframework.Opt
 		}
 
 		sched := scheduler.New(queues, cCache, mgr.GetClient(), mgr.GetEventRecorderFor(constants.AdmissionName))
-		err = sched.Start(ctx)
+		err := sched.Start(ctx)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
+}
+
+func controllersSetup(
+	ctx context.Context, mgr manager.Manager, setupJobManager bool, opts ...jobframework.Option,
+) (*schdcache.Cache, *qcache.Manager, *config.Configuration) {
+	cCache := schdcache.New(mgr.GetClient())
+	queues := qcache.NewManager(mgr.GetClient(), cCache)
+	opts = append(opts, jobframework.WithCache(cCache), jobframework.WithQueues(queues))
+
+	reconciler, err := mpijob.NewReconciler(
+		ctx,
+		mgr.GetClient(),
+		mgr.GetFieldIndexer(),
+		mgr.GetEventRecorderFor(constants.JobControllerName),
+		opts...)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	err = indexer.Setup(ctx, mgr.GetFieldIndexer())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	err = mpijob.SetupIndexes(ctx, mgr.GetFieldIndexer())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	err = reconciler.SetupWithManager(mgr)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	err = mpijob.SetupMPIJobWebhook(mgr, opts...)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	jobframework.EnableIntegration(mpijob.FrameworkName)
+	configuration := &config.Configuration{}
+	mgr.GetScheme().Default(configuration)
+	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration, nil)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
+	failedWebhook, err := webhooks.Setup(mgr, nil)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
+
+	if setupJobManager {
+		jobReconciler, _ := job.NewReconciler(
+			ctx,
+			mgr.GetClient(),
+			mgr.GetFieldIndexer(),
+			mgr.GetEventRecorderFor(constants.JobControllerName),
+			opts...)
+		err = job.SetupIndexes(ctx, mgr.GetFieldIndexer())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = jobReconciler.SetupWithManager(mgr)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = job.SetupWebhook(mgr, opts...)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+
+	return cCache, queues, configuration
 }

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -142,6 +142,9 @@ func DeleteNamespace(ctx context.Context, c client.Client, ns *corev1.Namespace)
 	if err := DeleteAllTrainingRuntimesInNamespace(ctx, c, ns); err != nil {
 		return err
 	}
+	if err := DeleteAllMPIJobsInNamespace(ctx, c, ns); err != nil {
+		return err
+	}
 	if err := c.DeleteAllOf(ctx, &appsv1.StatefulSet{}, client.InNamespace(ns.Name)); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

I introduced the `kueue.x-k8s.io/pod-index-offset` annotation for TAS, which is used only by MPIJob integration currently.
The MPIJob integration will inject the annotation to the MPIJob Pod template only when MPIJob is run in LauncherAsWorker mode and doesn't have `kueue.x-k8s.io/podset-group-name` annotation because the offset across multiple replicas is handled by the PodSet Group mechanism in that case.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/8471

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Fix a bug that MPIJob with runLauncherAsWorker Pod indexes are not correctly evaluated during rank-based ordering assignments.
```