### PR TITLE
Improve StatefulSet MultiKueue test assertions and ordering

### DIFF
--- a/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter_test.go
@@ -155,20 +155,18 @@ func TestMultiKueueAdapter(t *testing.T) {
 
 			gotManagersStatefulSets := &appsv1.StatefulSetList{}
 			if err := managerClient.List(ctx, gotManagersStatefulSets); err != nil {
-				t.Errorf("unexpected list manager's statefulsets error %s", err)
-			} else {
-				if diff := cmp.Diff(tc.wantManagersStatefulSets, gotManagersStatefulSets.Items, objCheckOpts...); diff != "" {
-					t.Errorf("unexpected manager's statefulsets (-want/+got):\n%s", diff)
-				}
+				t.Fatalf("unexpected list manager's statefulsets error %s", err)
+			}
+			if diff := cmp.Diff(tc.wantManagersStatefulSets, gotManagersStatefulSets.Items, objCheckOpts...); diff != "" {
+				t.Errorf("unexpected manager's statefulsets (-want/+got):\n%s", diff)
 			}
 
 			gotWorkerStatefulSets := &appsv1.StatefulSetList{}
 			if err := workerClient.List(ctx, gotWorkerStatefulSets); err != nil {
-				t.Errorf("unexpected list worker's statefulsets error %s", err)
-			} else {
-				if diff := cmp.Diff(tc.wantWorkerStatefulSets, gotWorkerStatefulSets.Items, objCheckOpts...); diff != "" {
-					t.Errorf("unexpected worker's statefulsets (-want/+got):\n%s", diff)
-				}
+				t.Fatalf("unexpected list worker's statefulsets error %s", err)
+			}
+			if diff := cmp.Diff(tc.wantWorkerStatefulSets, gotWorkerStatefulSets.Items, objCheckOpts...); diff != "" {
+				t.Errorf("unexpected worker's statefulsets (-want/+got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

Address review nits for StatefulSet MultiKueue support. See https://github.com/kubernetes-sigs/kueue/pull/8611#discussion_r2695210548

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Follow-up to #8611

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```