### PR TITLE
chore: Introduce PodSet wrapper in LWS reconciler UTs

### DIFF
--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -74,18 +74,10 @@ func TestReconciler(t *testing.T) {
 					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						kueue.PodSet{
-							Name: kueue.DefaultPodSetName,
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{Name: "c", Image: "pause"},
-									},
-								},
-							},
-							Count:           1,
-							TopologyRequest: nil,
-						}).
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							RestartPolicy("").
+							Image("pause").
+							Obj()).
 					Priority(0).
 					Obj(),
 			},
@@ -132,30 +124,14 @@ func TestReconciler(t *testing.T) {
 					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						kueue.PodSet{
-							Name: leaderPodSetName,
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{Name: "c", Image: "pause"},
-									},
-								},
-							},
-							Count:           1,
-							TopologyRequest: nil,
-						},
-						kueue.PodSet{
-							Name: workerPodSetName,
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{Name: "c", Image: "pause"},
-									},
-								},
-							},
-							Count:           2,
-							TopologyRequest: nil,
-						},
+						*utiltestingapi.MakePodSet(leaderPodSetName, 1).
+							RestartPolicy("").
+							Image("pause").
+							Obj(),
+						*utiltestingapi.MakePodSet(workerPodSetName, 2).
+							RestartPolicy("").
+							Image("pause").
+							Obj(),
 					).
 					Priority(0).
 					Obj(),
@@ -205,30 +181,14 @@ func TestReconciler(t *testing.T) {
 					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						kueue.PodSet{
-							Name: leaderPodSetName,
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{Name: "c", Image: "pause"},
-									},
-								},
-							},
-							Count:           1,
-							TopologyRequest: nil,
-						},
-						kueue.PodSet{
-							Name: workerPodSetName,
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{Name: "c", Image: "pause"},
-									},
-								},
-							},
-							Count:           2,
-							TopologyRequest: nil,
-						},
+						*utiltestingapi.MakePodSet(leaderPodSetName, 1).
+							RestartPolicy("").
+							Image("pause").
+							Obj(),
+						*utiltestingapi.MakePodSet(workerPodSetName, 2).
+							RestartPolicy("").
+							Image("pause").
+							Obj(),
 					).
 					Priority(0).
 					Obj(),
@@ -237,30 +197,14 @@ func TestReconciler(t *testing.T) {
 					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						kueue.PodSet{
-							Name: leaderPodSetName,
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{Name: "c", Image: "pause"},
-									},
-								},
-							},
-							Count:           1,
-							TopologyRequest: nil,
-						},
-						kueue.PodSet{
-							Name: workerPodSetName,
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{Name: "c", Image: "pause"},
-									},
-								},
-							},
-							Count:           2,
-							TopologyRequest: nil,
-						},
+						*utiltestingapi.MakePodSet(leaderPodSetName, 1).
+							RestartPolicy("").
+							Image("pause").
+							Obj(),
+						*utiltestingapi.MakePodSet(workerPodSetName, 2).
+							RestartPolicy("").
+							Image("pause").
+							Obj(),
 					).
 					Priority(0).
 					Obj(),
@@ -352,35 +296,17 @@ func TestReconciler(t *testing.T) {
 					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						kueue.PodSet{
-							Name: leaderPodSetName,
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{Name: "c", Image: "pause"},
-									},
-								},
-							},
-							Count: 1,
-							TopologyRequest: &kueue.PodSetTopologyRequest{
-								Required: ptr.To("cloud.com/block"),
-							},
-						},
-						kueue.PodSet{
-							Name: workerPodSetName,
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{Name: "c", Image: "pause"},
-									},
-								},
-							},
-							Count: 2,
-							TopologyRequest: &kueue.PodSetTopologyRequest{
-								Required:      ptr.To("cloud.com/block"),
-								PodIndexLabel: ptr.To(leaderworkersetv1.WorkerIndexLabelKey),
-							},
-						},
+						*utiltestingapi.MakePodSet(leaderPodSetName, 1).
+							RestartPolicy("").
+							Image("pause").
+							RequiredTopologyRequest("cloud.com/block").
+							Obj(),
+						*utiltestingapi.MakePodSet(workerPodSetName, 2).
+							RestartPolicy("").
+							Image("pause").
+							RequiredTopologyRequest("cloud.com/block").
+							PodIndexLabel(ptr.To(leaderworkersetv1.WorkerIndexLabelKey)).
+							Obj(),
 					).
 					Priority(0).
 					Obj(),
@@ -462,28 +388,14 @@ func TestReconciler(t *testing.T) {
 					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						kueue.PodSet{
-							Name: leaderPodSetName,
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{Name: "c", Image: "pause"},
-									},
-								},
-							},
-							Count: 1,
-						},
-						kueue.PodSet{
-							Name: workerPodSetName,
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{Name: "c", Image: "pause"},
-									},
-								},
-							},
-							Count: 2,
-						},
+						*utiltestingapi.MakePodSet(leaderPodSetName, 1).
+							RestartPolicy("").
+							Image("pause").
+							Obj(),
+						*utiltestingapi.MakePodSet(workerPodSetName, 2).
+							RestartPolicy("").
+							Image("pause").
+							Obj(),
 					).
 					Priority(0).
 					Obj(),
@@ -520,18 +432,10 @@ func TestReconciler(t *testing.T) {
 					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						kueue.PodSet{
-							Name: kueue.DefaultPodSetName,
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{Name: "c", Image: "pause"},
-									},
-								},
-							},
-							Count:           1,
-							TopologyRequest: nil,
-						}).
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							RestartPolicy("").
+							Image("pause").
+							Obj()).
 					WorkloadPriorityClassRef("high-priority").
 					Priority(5000).
 					Obj(),
@@ -560,17 +464,10 @@ func TestReconciler(t *testing.T) {
 					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						kueue.PodSet{
-							Name: kueue.DefaultPodSetName,
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{Name: "c", Image: "pause"},
-									},
-								},
-							},
-							Count: 1,
-						}).
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							RestartPolicy("").
+							Image("pause").
+							Obj()).
 					Priority(0).
 					Obj(),
 				*utiltestingapi.MakeWorkload(GetWorkloadName(types.UID(testUID), testLWS, "1"), testNS).
@@ -579,17 +476,10 @@ func TestReconciler(t *testing.T) {
 					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						kueue.PodSet{
-							Name: kueue.DefaultPodSetName,
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{Name: "c", Image: "pause"},
-									},
-								},
-							},
-							Count: 1,
-						}).
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							RestartPolicy("").
+							Image("pause").
+							Obj()).
 					Priority(0).
 					Obj(),
 			},
@@ -600,17 +490,10 @@ func TestReconciler(t *testing.T) {
 					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						kueue.PodSet{
-							Name: kueue.DefaultPodSetName,
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{Name: "c", Image: "pause"},
-									},
-								},
-							},
-							Count: 1,
-						}).
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							RestartPolicy("").
+							Image("pause").
+							Obj()).
 					Priority(0).
 					Obj(),
 				*utiltestingapi.MakeWorkload(GetWorkloadName(types.UID(testUID), testLWS, "1"), testNS).
@@ -618,17 +501,10 @@ func TestReconciler(t *testing.T) {
 					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						kueue.PodSet{
-							Name: kueue.DefaultPodSetName,
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{Name: "c", Image: "pause"},
-									},
-								},
-							},
-							Count: 1,
-						}).
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							RestartPolicy("").
+							Image("pause").
+							Obj()).
 					Priority(0).
 					Obj(),
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

I replaced directly defining PodSet with wrappers in LWS reconciler UTs.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```