### PR TITLE
Fix Pod Termination Controller's MaxConcurrentReconciles

### DIFF
--- a/pkg/controller/failurerecovery/pod_termination_controller.go
+++ b/pkg/controller/failurerecovery/pod_termination_controller.go
@@ -34,7 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
-	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	utilclient "sigs.k8s.io/kueue/pkg/util/client"
@@ -225,7 +224,7 @@ func (r *TerminatingPodReconciler) SetupWithManager(mgr ctrl.Manager, cfg *confi
 		)).
 		WithOptions(controller.Options{
 			NeedLeaderElection:      ptr.To(false),
-			MaxConcurrentReconciles: mgr.GetControllerOptions().GroupKindConcurrency[kueue.GroupVersion.WithKind("Pod").GroupKind().String()],
+			MaxConcurrentReconciles: mgr.GetControllerOptions().GroupKindConcurrency[corev1.SchemeGroupVersion.WithKind("Pod").GroupKind().String()],
 		}).
 		WithLogConstructor(roletracker.NewLogConstructor(r.roleTracker, ControllerName)).
 		Complete(core.WithLeadingManager(mgr, r, &corev1.Pod{}, cfg))


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
We were using the wrong SchemeGroupVersion for pod: Kueue's rather than corev1.

Compare with https://github.com/kubernetes-sigs/kueue/blob/41c74539c8e9a6035f30bddd49d6202840ce8832/pkg/controller/jobs/pod/pod_controller.go#L85

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
FailureRecovery: Fix Pod Termination Controller's MaxConcurrentReconciles
```