### PR TITLE
Automated cherry pick of #8671: LeaderWorkerSet: remove workload instead of finalize.

### DIFF
--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -106,7 +106,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return ctrl.Result{}, err
 	}
 
-	toCreate, toUpdate, toFinalize := r.filterWorkloads(lws, wlList.Items)
+	toCreate, toUpdate, toDelete := r.filterWorkloads(lws, wlList.Items)
 
 	eg, ctx := errgroup.WithContext(ctx)
 
@@ -123,8 +123,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	})
 
 	eg.Go(func() error {
-		return parallelize.Until(ctx, len(toFinalize), func(i int) error {
-			return r.removeOwnerReference(ctx, lws, toFinalize[i])
+		return parallelize.Until(ctx, len(toDelete), func(i int) error {
+			return r.client.Delete(ctx, toDelete[i])
 		})
 	})
 
@@ -137,17 +137,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 }
 
 // filterWorkloads compares the desired state of a LeaderWorkerSet with existing workloads,
-// determining which workloads need to be created, updated, or finalized.
+// determining which workloads need to be created, updated, or deleted.
 //
 // It accepts a LeaderWorkerSet and a slice of existing Workload objects as input and returns:
 // 1. A slice of workload names to be created
 // 2. A slice of workloads that may require updates
-// 3. A slice of Workload pointers to be finalized
+// 3. A slice of Workload pointers to be deleted
 func (r *Reconciler) filterWorkloads(lws *leaderworkersetv1.LeaderWorkerSet, existingWorkloads []kueue.Workload) ([]string, []*kueue.Workload, []*kueue.Workload) {
 	var (
-		toCreate   []string
-		toUpdate   []*kueue.Workload
-		toFinalize = utilslices.ToRefMap(existingWorkloads, func(e *kueue.Workload) string {
+		toCreate []string
+		toUpdate []*kueue.Workload
+		toDelete = utilslices.ToRefMap(existingWorkloads, func(e *kueue.Workload) string {
 			return e.Name
 		})
 		replicas = ptr.Deref(lws.Spec.Replicas, 1)
@@ -155,15 +155,15 @@ func (r *Reconciler) filterWorkloads(lws *leaderworkersetv1.LeaderWorkerSet, exi
 
 	for i := range replicas {
 		workloadName := GetWorkloadName(lws.UID, lws.Name, fmt.Sprint(i))
-		if wl, ok := toFinalize[workloadName]; ok {
+		if wl, ok := toDelete[workloadName]; ok {
 			toUpdate = append(toUpdate, wl)
-			delete(toFinalize, workloadName)
+			delete(toDelete, workloadName)
 		} else {
 			toCreate = append(toCreate, workloadName)
 		}
 	}
 
-	return toCreate, toUpdate, slices.Collect(maps.Values(toFinalize))
+	return toCreate, toUpdate, slices.Collect(maps.Values(toDelete))
 }
 
 func (r *Reconciler) createPrebuiltWorkload(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, workloadName string) error {
@@ -252,14 +252,6 @@ func podSets(lws *leaderworkersetv1.LeaderWorkerSet) ([]kueue.PodSet, error) {
 	podSets = append(podSets, podSet)
 
 	return podSets, nil
-}
-
-func (r *Reconciler) removeOwnerReference(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, wl *kueue.Workload) error {
-	err := controllerutil.RemoveOwnerReference(lws, wl, r.client.Scheme())
-	if err != nil {
-		return err
-	}
-	return r.client.Update(ctx, wl)
 }
 
 var _ predicate.Predicate = (*Reconciler)(nil)

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -577,7 +577,6 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(gvk, testLWS, testUID).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "test-pod2", "test-pod2-uid").
 					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
-					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
 						kueue.PodSet{
 							Name: kueue.DefaultPodSetName,
@@ -597,24 +596,6 @@ func TestReconciler(t *testing.T) {
 				*utiltestingapi.MakeWorkload(GetWorkloadName(types.UID(testUID), testLWS, "0"), testNS).
 					OwnerReference(gvk, testLWS, testUID).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "test-pod1", "test-pod1-uid").
-					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
-					Finalizers(kueue.ResourceInUseFinalizerName).
-					PodSets(
-						kueue.PodSet{
-							Name: kueue.DefaultPodSetName,
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{Name: "c", Image: "pause"},
-									},
-								},
-							},
-							Count: 1,
-						}).
-					Priority(0).
-					Obj(),
-				*utiltestingapi.MakeWorkload(GetWorkloadName(types.UID(testUID), testLWS, "1"), testNS).
-					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "test-pod2", "test-pod2-uid").
 					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(


### PR DESCRIPTION
Cherry pick of #8671 on release-0.15.

#8671: LeaderWorkerSet: remove workload instead of finalize.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

Fixed https://github.com/kubernetes-sigs/kueue/issues/8550

```release-note
LeaderWorkerSet: Fixed a bug that prevented deleting the workload when the LeaderWorkerSet was scaled down.
```