### PR TITLE
LeaderWorkerSet: create multiple PodSets Workload.

### DIFF
--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_pod_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_pod_reconciler.go
@@ -146,12 +146,10 @@ func (r *PodReconciler) setDefault(ctx context.Context, pod *corev1.Pod) (bool, 
 	pod.Annotations[podconstants.GroupTotalCountAnnotation] = fmt.Sprint(ptr.Deref(lws.Spec.LeaderWorkerTemplate.Size, 1))
 	pod.Annotations[podconstants.RoleHashAnnotation] = string(kueue.DefaultPodSetName)
 
-	if lws.Spec.LeaderWorkerTemplate.LeaderTemplate != nil {
-		if _, ok := pod.Annotations[leaderworkersetv1.LeaderPodNameAnnotationKey]; !ok {
-			pod.Annotations[podconstants.RoleHashAnnotation] = leaderPodSetName
-		} else {
-			pod.Annotations[podconstants.RoleHashAnnotation] = workerPodSetName
-		}
+	if _, ok := pod.Annotations[leaderworkersetv1.LeaderPodNameAnnotationKey]; !ok {
+		pod.Annotations[podconstants.RoleHashAnnotation] = leaderPodSetName
+	} else {
+		pod.Annotations[podconstants.RoleHashAnnotation] = workerPodSetName
 	}
 
 	return true, nil

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_pod_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_pod_reconciler_test.go
@@ -127,7 +127,7 @@ func TestPodReconciler(t *testing.T) {
 					PrebuiltWorkload(GetWorkloadName(types.UID(testUID), "lws", "0")).
 					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 					Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
-					Annotation(podconstants.RoleHashAnnotation, string(kueue.DefaultPodSetName)).
+					Annotation(podconstants.RoleHashAnnotation, leaderPodSetName).
 					Obj(),
 			},
 		},
@@ -156,7 +156,7 @@ func TestPodReconciler(t *testing.T) {
 					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 					Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
 					Annotation(leaderworkersetv1.LeaderPodNameAnnotationKey, "lws-0").
-					Annotation(podconstants.RoleHashAnnotation, string(kueue.DefaultPodSetName)).
+					Annotation(podconstants.RoleHashAnnotation, workerPodSetName).
 					Obj(),
 			},
 		},
@@ -250,7 +250,7 @@ func TestPodReconciler(t *testing.T) {
 					PrebuiltWorkload(GetWorkloadName("origin-uid", "lws", "0")).
 					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 					Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
-					Annotation(podconstants.RoleHashAnnotation, string(kueue.DefaultPodSetName)).
+					Annotation(podconstants.RoleHashAnnotation, leaderPodSetName).
 					Obj(),
 			},
 		},

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -281,26 +281,19 @@ func newPodSet(name kueue.PodSetReference, count int32, template *corev1.PodTemp
 }
 
 func podSets(lws *leaderworkersetv1.LeaderWorkerSet) ([]kueue.PodSet, error) {
-	podSets := make([]kueue.PodSet, 0, 2)
-
-	defaultPodSetName := kueue.DefaultPodSetName
-	defaultPodSetCount := ptr.Deref(lws.Spec.LeaderWorkerTemplate.Size, 1)
-
+	leaderTemplate := &lws.Spec.LeaderWorkerTemplate.WorkerTemplate
 	if lws.Spec.LeaderWorkerTemplate.LeaderTemplate != nil {
-		defaultPodSetName = workerPodSetName
-		defaultPodSetCount--
+		leaderTemplate = lws.Spec.LeaderWorkerTemplate.LeaderTemplate
+	}
 
-		leaderPodSet, err := newPodSet(leaderPodSetName, 1, lws.Spec.LeaderWorkerTemplate.LeaderTemplate, nil)
-		if err != nil {
-			return nil, err
-		}
-
-		podSets = append(podSets, *leaderPodSet)
+	leaderPodSet, err := newPodSet(leaderPodSetName, 1, leaderTemplate, nil)
+	if err != nil {
+		return nil, err
 	}
 
 	workerPodSet, err := newPodSet(
-		defaultPodSetName,
-		defaultPodSetCount,
+		workerPodSetName,
+		ptr.Deref(lws.Spec.LeaderWorkerTemplate.Size, 1)-1,
 		&lws.Spec.LeaderWorkerTemplate.WorkerTemplate,
 		ptr.To(leaderworkersetv1.WorkerIndexLabelKey),
 	)
@@ -308,9 +301,7 @@ func podSets(lws *leaderworkersetv1.LeaderWorkerSet) ([]kueue.PodSet, error) {
 		return nil, err
 	}
 
-	podSets = append(podSets, *workerPodSet)
-
-	return podSets, nil
+	return []kueue.PodSet{*leaderPodSet, *workerPodSet}, nil
 }
 
 var _ predicate.Predicate = (*Reconciler)(nil)

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -83,10 +83,15 @@ func TestReconciler(t *testing.T) {
 					Annotation(constants.ComponentWorkloadIndexAnnotation, "0").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+						*utiltestingapi.MakePodSet(leaderPodSetName, 1).
 							RestartPolicy("").
 							Image("pause").
-							Obj()).
+							Obj(),
+						*utiltestingapi.MakePodSet(workerPodSetName, 0).
+							RestartPolicy("").
+							Image("pause").
+							Obj(),
+					).
 					Priority(0).
 					Obj(),
 			},
@@ -466,10 +471,15 @@ func TestReconciler(t *testing.T) {
 					Annotation(constants.ComponentWorkloadIndexAnnotation, "0").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+						*utiltestingapi.MakePodSet(leaderPodSetName, 1).
 							RestartPolicy("").
 							Image("pause").
-							Obj()).
+							Obj(),
+						*utiltestingapi.MakePodSet(workerPodSetName, 0).
+							RestartPolicy("").
+							Image("pause").
+							Obj(),
+					).
 					WorkloadPriorityClassRef("high-priority").
 					Priority(5000).
 					Obj(),

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
@@ -126,15 +126,9 @@ var (
 	specPath                      = field.NewPath("spec")
 	leaderWorkerTemplatePath      = specPath.Child("leaderWorkerTemplate")
 	leaderTemplatePath            = leaderWorkerTemplatePath.Child("leaderTemplate")
-	leaderTemplateMetaPath        = leaderTemplatePath.Child("metadata")
 	workerTemplatePath            = leaderWorkerTemplatePath.Child("workerTemplate")
 	workerTemplateMetaPath        = workerTemplatePath.Child("metadata")
 	workerTemplateAnnotationsPath = workerTemplateMetaPath.Child("annotations")
-	podSetAnnotationsPathByName   = map[kueue.PodSetReference]*field.Path{
-		"leader": leaderTemplateMetaPath.Child("annotations"),
-		"worker": workerTemplateAnnotationsPath,
-		"main":   workerTemplateAnnotationsPath,
-	}
 )
 
 func (wh *Webhook) ValidateCreate(ctx context.Context, obj *leaderworkersetv1.LeaderWorkerSet) (warnings admission.Warnings, err error) {
@@ -224,26 +218,42 @@ func validateTopologyRequest(lws *LeaderWorkerSet) (field.ErrorList, error) {
 	lwsv1 := leaderworkersetv1.LeaderWorkerSet(*lws)
 	podSets, podSetsErr := podSets(&lwsv1)
 
-	defaultPodSetName := kueue.DefaultPodSetName
-
+	leaderTemplateMetaPath := workerTemplateMetaPath
+	leaderObjectMeta := lws.Spec.LeaderWorkerTemplate.WorkerTemplate.ObjectMeta
 	if lws.Spec.LeaderWorkerTemplate.LeaderTemplate != nil {
-		defaultPodSetName = workerPodSetName
+		leaderTemplateMetaPath = leaderTemplatePath.Child("metadata")
+		leaderObjectMeta = lws.Spec.LeaderWorkerTemplate.LeaderTemplate.ObjectMeta
 
-		allErrs = append(allErrs, jobframework.ValidateTASPodSetRequest(leaderTemplateMetaPath, &lws.Spec.LeaderWorkerTemplate.LeaderTemplate.ObjectMeta)...)
-
-		if podSetsErr == nil {
-			leaderPodSet := podset.FindPodSetByName(podSets, leaderPodSetName)
-			allErrs = append(allErrs, jobframework.ValidateSliceSizeAnnotationUpperBound(leaderTemplateMetaPath,
-				&lws.Spec.LeaderWorkerTemplate.LeaderTemplate.ObjectMeta, leaderPodSet)...)
-		}
+		allErrs = append(allErrs, jobframework.ValidateTASPodSetRequest(
+			leaderTemplateMetaPath,
+			&lws.Spec.LeaderWorkerTemplate.LeaderTemplate.ObjectMeta,
+		)...)
 	}
 
-	allErrs = append(allErrs, jobframework.ValidateTASPodSetRequest(workerTemplateMetaPath, &lws.Spec.LeaderWorkerTemplate.WorkerTemplate.ObjectMeta)...)
+	allErrs = append(allErrs, jobframework.ValidateTASPodSetRequest(
+		workerTemplateMetaPath,
+		&lws.Spec.LeaderWorkerTemplate.WorkerTemplate.ObjectMeta,
+	)...)
 
 	if podSetsErr == nil {
-		workerPodSet := podset.FindPodSetByName(podSets, defaultPodSetName)
-		allErrs = append(allErrs, jobframework.ValidateSliceSizeAnnotationUpperBound(workerTemplateMetaPath,
-			&lws.Spec.LeaderWorkerTemplate.WorkerTemplate.ObjectMeta, workerPodSet)...)
+		leaderPodSet := podset.FindPodSetByName(podSets, leaderPodSetName)
+		allErrs = append(allErrs, jobframework.ValidateSliceSizeAnnotationUpperBound(
+			leaderTemplateMetaPath,
+			&leaderObjectMeta,
+			leaderPodSet,
+		)...)
+
+		workerPodSet := podset.FindPodSetByName(podSets, workerPodSetName)
+		allErrs = append(allErrs, jobframework.ValidateSliceSizeAnnotationUpperBound(
+			workerTemplateMetaPath,
+			&lws.Spec.LeaderWorkerTemplate.WorkerTemplate.ObjectMeta,
+			workerPodSet,
+		)...)
+
+		podSetAnnotationsPathByName := map[kueue.PodSetReference]*field.Path{
+			"leader": leaderTemplateMetaPath.Child("annotations"),
+			"worker": workerTemplateAnnotationsPath,
+		}
 		allErrs = append(allErrs, jobframework.ValidatePodSetGroupingTopology(podSets, podSetAnnotationsPathByName)...)
 	}
 

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
@@ -576,22 +576,6 @@ func TestValidateCreate(t *testing.T) {
 					Key("kueue.x-k8s.io/podset-group-name"), "may not be set when neither 'kueue.x-k8s.io/podset-preferred-topology' nor 'kueue.x-k8s.io/podset-required-topology' is specified"),
 			}.ToAggregate(),
 		},
-		"invalid PodSet grouping request - grouping requested without leader template": {
-			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
-				Queue("test-queue").
-				WorkerTemplate(corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							kueue.PodSetGroupName:                   "groupname",
-							kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block",
-						},
-					},
-				}).
-				Obj(),
-			wantErr: field.ErrorList{
-				field.Invalid(field.NewPath("spec.leaderWorkerTemplate.workerTemplate.metadata.annotations[kueue.x-k8s.io/podset-group-name]"), "groupname", "can only define groups of exactly 2 pod sets, got: 1 pod set(s)"),
-			}.ToAggregate(),
-		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
LeaderWorkerSet: create multiple PodSets Workload.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8666

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
LeaderWorkerSet: fixed a bug where only the worker PodSet was created when LeaderTemplate was not set.
```