### PR TITLE
TAS: topology ungater should return early in case of invalid offset annotation

### DIFF
--- a/pkg/controller/tas/topology_ungater.go
+++ b/pkg/controller/tas/topology_ungater.go
@@ -56,7 +56,8 @@ import (
 )
 
 var (
-	errPendingUngateOps = errors.New("pending ungate operations")
+	errPendingUngateOps      = errors.New("pending ungate operations")
+	errParseOffsetAnnotation = errors.New("failed to parse offset annotation")
 )
 
 type topologyUngater struct {
@@ -227,16 +228,16 @@ func (r *topologyUngater) Reconcile(ctx context.Context, req reconcile.Request) 
 				// Assume that same replica all Pods has the same offset value.
 				offsetVal, found := pods[0].Annotations[kueue.PodIndexOffsetAnnotation]
 				if found {
-					if offset, err := strconv.Atoi(offsetVal); err != nil {
-						// If unGater failed to parse offset annotation value, it will fall back to greedy index assignment algorithm.
-						log.Error(err, "failed to parse offset annotation",
+					var offset int
+					if offset, err = strconv.Atoi(offsetVal); err != nil {
+						log.Error(err, errParseOffsetAnnotation.Error(),
 							kueue.PodIndexOffsetAnnotation, offsetVal,
 							"pod", klog.KObj(pods[0]),
 						)
-					} else {
-						rankOffsets[psa.Name] += int32(offset)
-						maxRank[psa.Name] += int32(offset)
+						return reconcile.Result{}, errors.Join(err, errParseOffsetAnnotation)
 					}
+					rankOffsets[psa.Name] += int32(offset)
+					maxRank[psa.Name] += int32(offset)
 				}
 			}
 			gatedPodsToDomains := assignGatedPodsToDomains(log, &psa, pods, psNameToTopologyRequest[psa.Name], rankOffsets[psa.Name], maxRank[psa.Name])

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -2025,8 +2025,7 @@ func TestReconcile(t *testing.T) {
 					Label(kftraining.JobRoleLabel, "launcher").
 					Label(kftraining.ReplicaIndexLabel, "0").
 					Label(constants.PodSetLabel, "launcher").
-					NodeSelector(tasBlockLabel, "b1").
-					NodeSelector(tasRackLabel, "r1").
+					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
@@ -2034,8 +2033,7 @@ func TestReconcile(t *testing.T) {
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "0").
 					Label(constants.PodSetLabel, "worker").
-					NodeSelector(tasBlockLabel, "b1").
-					NodeSelector(tasRackLabel, "r1").
+					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
@@ -2043,8 +2041,7 @@ func TestReconcile(t *testing.T) {
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "1").
 					Label(constants.PodSetLabel, "worker").
-					NodeSelector(tasBlockLabel, "b1").
-					NodeSelector(tasRackLabel, "r2").
+					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "unit-test").
@@ -2052,33 +2049,10 @@ func TestReconcile(t *testing.T) {
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "2").
 					Label(constants.PodSetLabel, "worker").
-					NodeSelector(tasBlockLabel, "b2").
-					NodeSelector(tasRackLabel, "r1").
+					TopologySchedulingGate().
 					Obj(),
 			},
-			wantCounts: []counts{
-				{
-					NodeSelector: map[string]string{
-						tasBlockLabel: "b1",
-						tasRackLabel:  "r1",
-					},
-					Count: 2,
-				},
-				{
-					NodeSelector: map[string]string{
-						tasBlockLabel: "b1",
-						tasRackLabel:  "r2",
-					},
-					Count: 1,
-				},
-				{
-					NodeSelector: map[string]string{
-						tasBlockLabel: "b2",
-						tasRackLabel:  "r1",
-					},
-					Count: 1,
-				},
-			},
+			wantErr: errParseOffsetAnnotation,
 		},
 		"ranks: support rank-based ordering for kubeflow - for all Pods": {
 			workloads: []kueue.Workload{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is a follow-up PR to address the comment: https://github.com/kubernetes-sigs/kueue/pull/8618#discussion_r2704347851

The invalid offset annotation (`kueue.x-k8s.io/pod-index-offset`) value should be rejected during ungating.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```