### PR TITLE
cherry-pick #8484 to release-0.14

### DIFF
--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -19,6 +19,7 @@ package scheduler
 import (
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1742,6 +1743,38 @@ func TestFindTopologyAssignments(t *testing.T) {
 				},
 				count:      1,
 				wantReason: `topology "default" doesn't allow to fit any of 1 pod(s). Total nodes: 1; excluded: resource "cpu": 1`,
+			}},
+		},
+		"include usage from non-TAS pods; pod usage": {
+			// this test case ensures we are counting pods properly
+			// when aggregating non-tas pod usage by node.
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x3").
+					Label(corev1.LabelHostname, "x3").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("running1", "test-ns").NodeName("x3").
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+				*testingpod.MakePod("running2", "test-ns").NodeName("x3").
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+			levels: defaultOneLevel,
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Required: ptr.To(corev1.LabelHostname),
+				},
+				requests: resources.Requests{
+					corev1.ResourceCPU: 0,
+				},
+				count:      9,
+				wantReason: `topology "default" allows to fit only 8 out of 9 pod(s)`,
 			}},
 		},
 		"include usage from running non-TAS pods, found free capacity on another node; BestFit": {
@@ -4256,6 +4289,9 @@ func TestFindTopologyAssignments(t *testing.T) {
 			flavorInformation := flavorInformation{
 				TopologyName: "default",
 				NodeLabels:   tc.nodeLabels,
+			}
+			for _, pod := range tc.pods {
+				tasCache.Update(pod, logr.FromContextOrDiscard(ctx))
 			}
 			tasFlavorCache := tasCache.NewTASFlavorCache(topologyInformation, flavorInformation)
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -238,7 +238,6 @@ func (s *TASFlavorSnapshot) addNonTASUsage(domainID utiltas.TopologyDomainID, us
 	// least one TAS pod, and so the addCapacity function to initialize
 	// freeCapacity is already called.
 	s.leaves[domainID].freeCapacity.Sub(usage)
-	s.leaves[domainID].freeCapacity.Sub(resources.Requests{corev1.ResourcePods: 1})
 }
 
 func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests, op usageOp, count int32) {

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache.go
@@ -1,0 +1,84 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"sync"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	resourcehelpers "k8s.io/component-helpers/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/kueue/pkg/resources"
+	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
+)
+
+// nonTasUsageCache caches pod usage, to avoid
+// the hot path documented in kueue#8449.
+type nonTasUsageCache struct {
+	podUsage map[types.NamespacedName]podUsageValue
+	lock     sync.RWMutex
+}
+
+type podUsageValue struct {
+	node  string
+	usage resources.Requests
+}
+
+// update may add a pod to the cache, or
+// delete a terminated pod.
+func (n *nonTasUsageCache) update(pod corev1.Pod, log logr.Logger) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+
+	// delete terminated pods as they no longer use any capacity.
+	if utilpod.IsTerminated(&pod) {
+		log.V(5).Info("Deleting terminated pod from the cache")
+		delete(n.podUsage, client.ObjectKeyFromObject(&pod))
+		return
+	}
+
+	log.V(5).Info("Adding non-TAS pod to the cache")
+	requests := resources.NewRequests(
+		resourcehelpers.PodRequests(&pod, resourcehelpers.PodResourcesOptions{}))
+	n.podUsage[client.ObjectKeyFromObject(&pod)] = podUsageValue{
+		node:  pod.Spec.NodeName,
+		usage: requests,
+	}
+}
+
+func (n *nonTasUsageCache) delete(key client.ObjectKey) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	delete(n.podUsage, key)
+}
+
+func (n *nonTasUsageCache) usagePerNode() map[string]resources.Requests {
+	n.lock.RLock()
+	defer n.lock.RUnlock()
+	usage := make(map[string]resources.Requests)
+	for _, podUsage := range n.podUsage {
+		if _, found := usage[podUsage.node]; !found {
+			usage[podUsage.node] = resources.Requests{}
+		}
+		usage[podUsage.node].Add(podUsage.usage)
+		usage[podUsage.node].Add(resources.Requests{corev1.ResourcePods: 1})
+	}
+	return usage
+}

--- a/pkg/controller/tas/constants.go
+++ b/pkg/controller/tas/constants.go
@@ -23,6 +23,7 @@ const (
 	TASResourceFlavorController = "tas-resource-flavor-controller"
 	TASTopologyUngater          = "tas-topology-ungater"
 	TASNodeFailureController    = "tas-node-failure-controller"
+	TASNonTasUsageController    = "tas-non-tas-usage-controller"
 )
 
 const (

--- a/pkg/controller/tas/controllers.go
+++ b/pkg/controller/tas/controllers.go
@@ -45,5 +45,9 @@ func SetupControllers(mgr ctrl.Manager, queues *qcache.Manager, cache *schdcache
 			return ctrlName, err
 		}
 	}
+	nonTasUsageController := newNonTasUsageReconciler(mgr.GetClient(), cache, queues)
+	if ctrlName, err := nonTasUsageController.SetupWithManager(mgr); err != nil {
+		return ctrlName, err
+	}
 	return "", nil
 }

--- a/pkg/controller/tas/non_tas_usage_controller.go
+++ b/pkg/controller/tas/non_tas_usage_controller.go
@@ -1,0 +1,118 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tas
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
+)
+
+func newNonTasUsageReconciler(client client.Client, cache *schdcache.Cache, qcache *qcache.Manager) *NonTasUsageReconciler {
+	return &NonTasUsageReconciler{
+		Client: client,
+		Cache:  cache,
+		QCache: qcache,
+	}
+}
+
+// NonTasUsageReconciler monitors pods to update
+// the TAS cache with non-TAS usage.
+type NonTasUsageReconciler struct {
+	client.Client
+	Cache  *schdcache.Cache
+	QCache *qcache.Manager
+}
+
+var _ reconcile.Reconciler = (*NonTasUsageReconciler)(nil)
+var _ predicate.TypedPredicate[*corev1.Pod] = (*NonTasUsageReconciler)(nil)
+
+//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+
+func (r *NonTasUsageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := klog.FromContext(ctx).WithValues("pod", req.NamespacedName)
+	log.V(3).Info("Non-TAS usage cache reconciling")
+	var pod corev1.Pod
+	err := r.Get(ctx, req.NamespacedName, &pod)
+	if err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			return ctrl.Result{}, err
+		}
+		log.V(5).Info("Idempotently deleting not found pod")
+		r.Cache.TASCache().DeletePodByKey(req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+
+	r.Cache.TASCache().Update(pod, log)
+	return ctrl.Result{}, nil
+}
+
+func filterPod(pod *corev1.Pod) bool {
+	if utiltas.IsTAS(pod) {
+		return false
+	} else if len(pod.Spec.NodeName) == 0 {
+		// skip unscheduled pods as they don't use any capacity.
+		return false
+	}
+	return true
+}
+
+func (r *NonTasUsageReconciler) Create(e event.TypedCreateEvent[*corev1.Pod]) bool {
+	return filterPod(e.Object)
+}
+
+func (r *NonTasUsageReconciler) Update(e event.TypedUpdateEvent[*corev1.Pod]) bool {
+	return filterPod(e.ObjectNew)
+}
+
+func (r *NonTasUsageReconciler) Delete(e event.TypedDeleteEvent[*corev1.Pod]) bool {
+	return filterPod(e.Object)
+}
+
+func (r *NonTasUsageReconciler) Generic(event.TypedGenericEvent[*corev1.Pod]) bool {
+	return false
+}
+
+func (r *NonTasUsageReconciler) SetupWithManager(mgr ctrl.Manager) (string, error) {
+	return TASNonTasUsageController, ctrl.NewControllerManagedBy(mgr).
+		Named(TASNonTasUsageController).
+		WatchesRawSource(source.TypedKind(
+			mgr.GetCache(),
+			&corev1.Pod{},
+			&handler.TypedEnqueueRequestForObject[*corev1.Pod]{},
+			r,
+		)).
+		WithOptions(controller.Options{
+			NeedLeaderElection:      ptr.To(false),
+			MaxConcurrentReconciles: mgr.GetControllerOptions().GroupKindConcurrency[corev1.SchemeGroupVersion.WithKind("Pod").GroupKind().String()],
+		}).
+		Complete(r)
+}


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
Cherry-pick #8484 to release-0.14

#### Special notes for your reviewer:
Manual resolutions:
- delete test (also deleted in main) in scheduler_tas_test
- remove role tracker from non_tas_usage_controller (this is new in 0.16)
- manually resolve TestScheduleForTAS fixture
- manually resolve integration test
- resolve package in integration test for `DefaultBlockTopologyLevel` and `DefaultRackTopologyLevel`

#### Does this PR introduce a user-facing change?

```release-note
TAS: significantly improves scheduling performance by replacing Pod listing with an event-driven
cache for non-TAS Pods, thereby avoiding expensive DeepCopy operations during each scheduling cycle.
```