### PR TITLE
feat(kueueviz/backend): drop polling and switch to informers

### DIFF
--- a/cmd/kueueviz/backend/go.mod
+++ b/cmd/kueueviz/backend/go.mod
@@ -15,6 +15,7 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bep/debounce v1.2.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect

--- a/cmd/kueueviz/backend/go.sum
+++ b/cmd/kueueviz/backend/go.sum
@@ -2,6 +2,8 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
+github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
 github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=

--- a/cmd/kueueviz/backend/handlers/api_handlers.go
+++ b/cmd/kueueviz/backend/handlers/api_handlers.go
@@ -41,6 +41,9 @@ var resourceGVRMap = map[string]schema.GroupVersionResource{
 	"localqueue":     LocalQueuesGVR(),
 	"resourceflavor": ResourceFlavorsGVR(),
 	"cohort":         CohortsGVR(),
+	"event":          EventsGVR(),
+	"node":           NodesGVR(),
+	"pod":            PodsGVR(),
 }
 
 func GetResource(dynamicClient dynamic.Interface) gin.HandlerFunc {

--- a/cmd/kueueviz/backend/handlers/cluster_queues.go
+++ b/cmd/kueueviz/backend/handlers/cluster_queues.go
@@ -30,31 +30,32 @@ import (
 func (h *Handlers) ClusterQueuesWebSocketHandler() gin.HandlerFunc {
 	return h.GenericWebSocketHandler(func(ctx context.Context) (any, error) {
 		return h.fetchClusterQueues(ctx)
-	})
+	}, ClusterQueuesGVK())
 }
 
 // ClusterQueueDetailsWebSocketHandler streams details for a specific cluster queue
 func (h *Handlers) ClusterQueueDetailsWebSocketHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		clusterQueueName := c.Param("cluster_queue_name")
+
 		h.GenericWebSocketHandler(func(ctx context.Context) (any, error) {
 			return h.fetchClusterQueueDetails(ctx, clusterQueueName)
-		})(c)
+		}, ClusterQueuesGVK(), LocalQueuesGVK())(c)
 	}
 }
 
 // Fetch all cluster queues
 func (h *Handlers) fetchClusterQueues(ctx context.Context) ([]map[string]any, error) {
 	// Fetch the list of ClusterQueue objects
-	l := &kueueapi.ClusterQueueList{}
-	err := h.client.List(ctx, l)
+	cql := &kueueapi.ClusterQueueList{}
+	err := h.client.List(ctx, cql)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching cluster queues: %v", err)
 	}
 
 	// Process the ClusterQueue objects
 	var result []map[string]any
-	for _, item := range l.Items {
+	for _, item := range cql.Items {
 		// Extract relevant fields
 		name := item.GetName()
 

--- a/cmd/kueueviz/backend/handlers/cohorts.go
+++ b/cmd/kueueviz/backend/handlers/cohorts.go
@@ -28,9 +28,10 @@ import (
 
 // CohortsWebSocketHandler streams all cohorts
 func (h *Handlers) CohortsWebSocketHandler() gin.HandlerFunc {
+	// Cohorts are derived from ClusterQueues, so use ClusterQueue informer
 	return h.GenericWebSocketHandler(func(ctx context.Context) (any, error) {
 		return h.fetchCohorts(ctx)
-	})
+	}, ClusterQueuesGVK())
 }
 
 // CohortDetailsWebSocketHandler streams details for a specific cohort
@@ -40,7 +41,7 @@ func (h *Handlers) CohortDetailsWebSocketHandler() gin.HandlerFunc {
 
 		h.GenericWebSocketHandler(func(ctx context.Context) (any, error) {
 			return h.fetchCohortDetails(ctx, cohortName)
-		})(c)
+		}, ClusterQueuesGVK())(c)
 	}
 }
 

--- a/cmd/kueueviz/backend/handlers/gvr.go
+++ b/cmd/kueueviz/backend/handlers/gvr.go
@@ -43,6 +43,73 @@ func NewClientFromManager(manager ctrlmanager.Manager) Client {
 	}
 }
 
+// GVK helper functions for informers
+
+// ClusterQueuesGVK returns the GroupVersionKind for ClusterQueues
+func ClusterQueuesGVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   "kueue.x-k8s.io",
+		Version: "v1beta2",
+		Kind:    "ClusterQueue",
+	}
+}
+
+// WorkloadsGVK returns the GroupVersionKind for Workloads
+func WorkloadsGVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   "kueue.x-k8s.io",
+		Version: "v1beta2",
+		Kind:    "Workload",
+	}
+}
+
+// LocalQueuesGVK returns the GroupVersionKind for LocalQueues
+func LocalQueuesGVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   "kueue.x-k8s.io",
+		Version: "v1beta2",
+		Kind:    "LocalQueue",
+	}
+}
+
+// ResourceFlavorsGVK returns the GroupVersionKind for ResourceFlavors
+func ResourceFlavorsGVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   "kueue.x-k8s.io",
+		Version: "v1beta2",
+		Kind:    "ResourceFlavor",
+	}
+}
+
+// PodsGVK returns the GroupVersionKind for Pods
+func PodsGVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Pod",
+	}
+}
+
+// EventsGVK returns the GroupVersionKind for Events
+func EventsGVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Event",
+	}
+}
+
+// NodesGVK returns the GroupVersionKind for Nodes
+func NodesGVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Node",
+	}
+}
+
+// GVR helper functions for dynamic client operations
+
 // ClusterQueuesGVR defines the GroupVersionResource for ClusterQueues
 func ClusterQueuesGVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
@@ -90,4 +157,31 @@ func ResourceFlavorsGVR() schema.GroupVersionResource {
 		Resource: "resourceflavors",
 	}
 	return resourceFlavorsGVR
+}
+
+// EventsGVR defines the GroupVersionResource for Events
+func EventsGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "events",
+	}
+}
+
+// NodesGVR defines the GroupVersionResource for Nodes
+func NodesGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "nodes",
+	}
+}
+
+// PodsGVR defines the GroupVersionResource for Pods
+func PodsGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "pods",
+	}
 }

--- a/cmd/kueueviz/backend/handlers/local_queue_workloads.go
+++ b/cmd/kueueviz/backend/handlers/local_queue_workloads.go
@@ -30,9 +30,10 @@ func (h *Handlers) LocalQueueWorkloadsWebSocketHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		namespace := c.Param("namespace")
 		queueName := c.Param("queue_name")
+
 		h.GenericWebSocketHandler(func(ctx context.Context) (any, error) {
 			return h.fetchLocalQueueWorkloads(ctx, namespace, queueName)
-		})(c)
+		}, WorkloadsGVK())(c)
 	}
 }
 

--- a/cmd/kueueviz/backend/handlers/local_queues.go
+++ b/cmd/kueueviz/backend/handlers/local_queues.go
@@ -30,7 +30,7 @@ import (
 func (h *Handlers) LocalQueuesWebSocketHandler() gin.HandlerFunc {
 	return h.GenericWebSocketHandler(func(ctx context.Context) (any, error) {
 		return h.fetchLocalQueues(ctx)
-	})
+	}, LocalQueuesGVK())
 }
 
 // LocalQueueDetailsWebSocketHandler streams details for a specific local queue
@@ -38,9 +38,10 @@ func (h *Handlers) LocalQueueDetailsWebSocketHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		namespace := c.Param("namespace")
 		queueName := c.Param("queue_name")
+
 		h.GenericWebSocketHandler(func(ctx context.Context) (any, error) {
 			return h.fetchLocalQueueDetails(ctx, namespace, queueName)
-		})(c)
+		}, LocalQueuesGVK())(c)
 	}
 }
 

--- a/cmd/kueueviz/backend/handlers/namespaces.go
+++ b/cmd/kueueviz/backend/handlers/namespaces.go
@@ -27,24 +27,25 @@ import (
 
 // NamespacesWebSocketHandler streams namespaces that are related to Kueue
 func (h *Handlers) NamespacesWebSocketHandler() gin.HandlerFunc {
+	// Use LocalQueue informer since namespaces are derived from LocalQueues
 	return h.GenericWebSocketHandler(func(ctx context.Context) (any, error) {
 		return h.fetchNamespaces(ctx)
-	})
+	}, LocalQueuesGVK())
 }
 
 // Fetch namespaces that have LocalQueues (Kueue-related namespaces)
 func (h *Handlers) fetchNamespaces(ctx context.Context) (any, error) {
-	l := &kueueapi.LocalQueueList{}
+	lql := &kueueapi.LocalQueueList{}
 
 	// First, get all LocalQueues to find namespaces that have them
-	err := h.client.List(ctx, l)
+	err := h.client.List(ctx, lql)
 	if err != nil {
 		return nil, err
 	}
 
 	// Extract unique namespaces from LocalQueues
 	namespaceSet := make(map[string]struct{})
-	for _, lq := range l.Items {
+	for _, lq := range lql.Items {
 		namespaceSet[lq.GetNamespace()] = struct{}{}
 	}
 

--- a/cmd/kueueviz/backend/handlers/websocket_handler.go
+++ b/cmd/kueueviz/backend/handlers/websocket_handler.go
@@ -23,8 +23,11 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/bep/debounce"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
 	"kueueviz/middleware"
 )
 
@@ -36,8 +39,9 @@ var upgrader = websocket.Upgrader{
 	Subprotocols: []string{middleware.WebSocketBaseProtocol},
 }
 
-// GenericWebSocketHandler creates a WebSocket endpoint with periodic data updates
-func (h *Handlers) GenericWebSocketHandler(dataFetcher func(ctx context.Context) (any, error)) gin.HandlerFunc {
+// GenericWebSocketHandler creates a WebSocket endpoint with informer-based real-time updates
+// Accepts one or more GroupVersionKinds to watch for changes
+func (h *Handlers) GenericWebSocketHandler(dataFetcher func(ctx context.Context) (any, error), gvks ...schema.GroupVersionKind) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		startTime := time.Now()
 		slog.Debug("WebSocket handler started")
@@ -46,88 +50,145 @@ func (h *Handlers) GenericWebSocketHandler(dataFetcher func(ctx context.Context)
 		connStart := time.Now()
 		conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
 		if err != nil {
-			slog.Debug("Failed to upgrade to WebSocket: %v", "error", err)
+			slog.Debug("Failed to upgrade to WebSocket", "error", err)
 			return
 		}
 		defer conn.Close()
-		slog.Debug("WebSocket connection established took %v", "duration", time.Since(connStart))
+		slog.Debug("WebSocket connection established", "duration", time.Since(connStart))
 
-		// Fetch the initial data to send it immediately
-		fetchStart := time.Now()
-		data, err := dataFetcher(c.Request.Context())
+		ctx, cancel := context.WithCancel(c.Request.Context())
+		defer cancel()
+
+		// Read pump: gorilla/websocket requires an active reader to process control
+		// frames and detect client disconnects. On any read error, cancel the context
+		// to unblock handleInformerUpdates and trigger informer cleanup.
+		go func() {
+			defer cancel()
+			for {
+				if _, _, err := conn.ReadMessage(); err != nil {
+					return
+				}
+			}
+		}()
+
+		// Send initial data
+		if err := h.sendData(ctx, conn, dataFetcher); err != nil {
+			slog.Error("Error sending initial data", "error", err)
+			return
+		}
+
+		// Use informer-based updates for real-time streaming
+		h.handleInformerUpdates(ctx, conn, dataFetcher, gvks...)
+
+		slog.Debug("WebSocket handler completed", "duration", time.Since(startTime))
+	}
+}
+
+// sendData fetches and sends data through the WebSocket connection
+func (h *Handlers) sendData(ctx context.Context, conn *websocket.Conn, dataFetcher func(ctx context.Context) (any, error)) error {
+	fetchStart := time.Now()
+	data, err := dataFetcher(ctx)
+	if err != nil {
+		return err
+	}
+	slog.Debug("Data fetched", "duration", time.Since(fetchStart))
+
+	marshalStart := time.Now()
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	slog.Debug("Data marshaled into JSON", "duration", time.Since(marshalStart))
+
+	if err := conn.SetWriteDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return err
+	}
+
+	writeStart := time.Now()
+	err = conn.WriteMessage(websocket.TextMessage, jsonData)
+	if err != nil {
+		return err
+	}
+	slog.Debug("Message sent to client", "duration", time.Since(writeStart))
+
+	return nil
+}
+
+// handleInformerUpdates uses Kubernetes informers to stream real-time changes
+// Supports watching multiple resource types by registering handlers for all provided GVKs
+func (h *Handlers) handleInformerUpdates(ctx context.Context, conn *websocket.Conn, dataFetcher func(ctx context.Context) (any, error), gvks ...schema.GroupVersionKind) {
+	// Channel to signal when debounced update should be sent
+	updateChan := make(chan struct{}, 1)
+
+	// Debounce rapid informer events (e.g. pod churn) into a single update
+	debounced := debounce.New(200 * time.Millisecond)
+	triggerUpdate := func() {
+		debounced(func() {
+			select {
+			case updateChan <- struct{}{}:
+			default:
+				// Channel already has a pending update
+			}
+		})
+	}
+
+	type registrationInfo struct {
+		gvk schema.GroupVersionKind
+		reg cache.ResourceEventHandlerRegistration
+	}
+
+	// Track all registrations for cleanup
+	var registrations []registrationInfo
+	defer func() {
+		for _, r := range registrations {
+			informer, err := h.client.GetInformerForKind(context.Background(), r.gvk)
+			if err == nil {
+				if err := informer.RemoveEventHandler(r.reg); err != nil {
+					slog.Error("Error removing event handler", "gvk", r.gvk, "error", err)
+				}
+			}
+		}
+	}()
+
+	// Register event handlers for all provided GVKs
+	for _, gvk := range gvks {
+		informer, err := h.client.GetInformerForKind(ctx, gvk)
 		if err != nil {
-			slog.Error("Error fetching data %v", "error", err)
-			return
+			slog.Error("Error getting informer", "gvk", gvk, "error", err)
+			continue
 		}
-		slog.Debug("Data fetched took %v", "duration", time.Since(fetchStart))
 
-		// Marshal the fetched data into JSON
-		marshalStart := time.Now()
-		jsonData, err := json.Marshal(data)
+		registration, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj any) {
+				slog.Debug("Informer: object added", "gvk", gvk)
+				triggerUpdate()
+			},
+			UpdateFunc: func(oldObj, newObj any) {
+				slog.Debug("Informer: object updated", "gvk", gvk)
+				triggerUpdate()
+			},
+			DeleteFunc: func(obj any) {
+				slog.Debug("Informer: object deleted", "gvk", gvk)
+				triggerUpdate()
+			},
+		})
 		if err != nil {
-			slog.Error("Error marshaling data : %v", "error", err)
+			slog.Error("Error adding event handler", "gvk", gvk, "error", err)
+			continue
+		}
+		registrations = append(registrations, registrationInfo{gvk: gvk, reg: registration})
+	}
+
+	// Handle updates from the informers
+	for {
+		select {
+		case <-ctx.Done():
 			return
-		}
-		slog.Debug("Data marshaled into JSON at took %v", "duration", time.Since(marshalStart))
-
-		// Set write deadline to avoid blocking indefinitely
-		if err := conn.SetWriteDeadline(time.Now().Add(5 * time.Second)); err != nil {
-			slog.Error("Error setting write deadline: %v", "error", err)
-			return
-		}
-
-		// Send the initial data to the WebSocket client immediately
-		writeStart := time.Now()
-		err = conn.WriteMessage(websocket.TextMessage, jsonData)
-		if err != nil {
-			slog.Error("Error writing message : %v", "error", err)
-			// If writing fails, break the loop and close the connection
-			return
-		}
-		slog.Debug("Initial message sent to client took %v", "duration", time.Since(writeStart))
-
-		// Start a ticker for periodic updates (every 5 seconds)
-		// TODO use SharedInformers and TTL to only send updates if they happen
-		ticker := time.NewTicker(5 * time.Second)
-		defer ticker.Stop()
-
-		// Continue sending updates every 5 seconds
-		for range ticker.C {
-			// Fetch the latest data
-			fetchStart := time.Now()
-			data, err := dataFetcher(c.Request.Context())
-			if err != nil {
-				slog.Error("Error fetching data %v", "error", err)
-				continue
+		case <-updateChan:
+			if err := h.sendData(ctx, conn, dataFetcher); err != nil {
+				slog.Error("Error sending update", "error", err)
+				return
 			}
-			slog.Debug("Data fetched at  took %v", "duration", time.Since(fetchStart))
-
-			// Marshal the fetched data into JSON
-			marshalStart := time.Now()
-			jsonData, err := json.Marshal(data)
-			if err != nil {
-				slog.Error("Error marshaling data at %v", "error", err)
-				continue
-			}
-			slog.Debug("Data marshaled into JSON took %v", "duration", time.Since(marshalStart))
-
-			// Set write deadline to avoid blocking indefinitely
-			if err := conn.SetWriteDeadline(time.Now().Add(5 * time.Second)); err != nil {
-				slog.Error("Error writing deadline to client: %v", "error", err)
-				continue
-			}
-
-			// Send the JSON data to the WebSocket client
-			writeStart := time.Now()
-			err = conn.WriteMessage(websocket.TextMessage, jsonData)
-			if err != nil {
-				slog.Error("Error writing message: ", "error", err)
-				// If writing fails, break the loop and close the connection
-				break
-			}
-			slog.Debug("Message sent to client  took %v", "duration", time.Since(writeStart))
 		}
-
-		slog.Debug("WebSocket handler completed  total time: %v", "duration", time.Since(startTime))
 	}
 }

--- a/cmd/kueueviz/backend/handlers/websocket_handler_test.go
+++ b/cmd/kueueviz/backend/handlers/websocket_handler_test.go
@@ -1,0 +1,367 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	toolscache "k8s.io/client-go/tools/cache"
+	"kueueviz/middleware"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type mockResourceEventHandlerRegistration struct{}
+
+func (m *mockResourceEventHandlerRegistration) HasSynced() bool { return true }
+
+type mockInformer struct {
+	mu sync.Mutex
+
+	handlers       []toolscache.ResourceEventHandler
+	registrations  map[toolscache.ResourceEventHandlerRegistration]struct{}
+	addHandlerCall int
+	removeCall     int
+}
+
+func newMockInformer() *mockInformer {
+	return &mockInformer{
+		registrations: make(map[toolscache.ResourceEventHandlerRegistration]struct{}),
+	}
+}
+
+func (m *mockInformer) AddEventHandler(handler toolscache.ResourceEventHandler) (toolscache.ResourceEventHandlerRegistration, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.addHandlerCall++
+	m.handlers = append(m.handlers, handler)
+	registration := &mockResourceEventHandlerRegistration{}
+	m.registrations[registration] = struct{}{}
+
+	return registration, nil
+}
+
+func (m *mockInformer) AddEventHandlerWithResyncPeriod(handler toolscache.ResourceEventHandler, _ time.Duration) (toolscache.ResourceEventHandlerRegistration, error) {
+	return m.AddEventHandler(handler)
+}
+
+func (m *mockInformer) AddEventHandlerWithOptions(handler toolscache.ResourceEventHandler, _ toolscache.HandlerOptions) (toolscache.ResourceEventHandlerRegistration, error) {
+	return m.AddEventHandler(handler)
+}
+
+func (m *mockInformer) RemoveEventHandler(handle toolscache.ResourceEventHandlerRegistration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.registrations[handle]; !ok {
+		return errors.New("unknown registration")
+	}
+
+	delete(m.registrations, handle)
+	m.removeCall++
+
+	return nil
+}
+
+func (m *mockInformer) AddIndexers(_ toolscache.Indexers) error { return nil }
+
+func (m *mockInformer) HasSynced() bool { return true }
+
+func (m *mockInformer) IsStopped() bool { return false }
+
+func (m *mockInformer) AddEventHandlerCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.addHandlerCall
+}
+
+func (m *mockInformer) RemoveEventHandlerCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.removeCall
+}
+
+func (m *mockInformer) triggerAdd(obj any) {
+	m.mu.Lock()
+	handlers := append([]toolscache.ResourceEventHandler(nil), m.handlers...)
+	m.mu.Unlock()
+
+	for _, handler := range handlers {
+		handler.OnAdd(obj, false)
+	}
+}
+
+type mockClient struct {
+	mu sync.Mutex
+
+	informersByGVK map[schema.GroupVersionKind]*mockInformer
+	getCalls       []schema.GroupVersionKind
+}
+
+func newMockClient(informersByGVK map[schema.GroupVersionKind]*mockInformer) *mockClient {
+	return &mockClient{informersByGVK: informersByGVK}
+}
+
+func (m *mockClient) Get(_ context.Context, _ ctrlclient.ObjectKey, _ ctrlclient.Object, _ ...ctrlclient.GetOption) error {
+	return nil
+}
+
+func (m *mockClient) List(_ context.Context, _ ctrlclient.ObjectList, _ ...ctrlclient.ListOption) error {
+	return nil
+}
+
+func (m *mockClient) GetInformerForKind(_ context.Context, gvk schema.GroupVersionKind, _ ...ctrlcache.InformerGetOption) (ctrlcache.Informer, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.getCalls = append(m.getCalls, gvk)
+
+	informer, ok := m.informersByGVK[gvk]
+	if !ok {
+		return nil, fmt.Errorf("informer not found for GVK %v", gvk)
+	}
+
+	return informer, nil
+}
+
+func (m *mockClient) GetInformerCallCount(gvk schema.GroupVersionKind) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	count := 0
+	for _, calledGVK := range m.getCalls {
+		if calledGVK == gvk {
+			count++
+		}
+	}
+
+	return count
+}
+
+func TestWebSocketHandleInformerUpdates(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"registers event handlers for all provided GVKs": {
+			run: func(t *testing.T) {
+				gvkA := schema.GroupVersionKind{Group: "group-a", Version: "v1", Kind: "KindA"}
+				gvkB := schema.GroupVersionKind{Group: "group-b", Version: "v1", Kind: "KindB"}
+
+				informerA := newMockInformer()
+				informerB := newMockInformer()
+				client := newMockClient(map[schema.GroupVersionKind]*mockInformer{
+					gvkA: informerA,
+					gvkB: informerB,
+				})
+
+				var fetchCalls atomic.Int64
+				dataFetcher := func(_ context.Context) (any, error) {
+					return map[string]int64{"call": fetchCalls.Add(1)}, nil
+				}
+
+				conn, closeServer := newTestWebSocketConnection(t, &Handlers{client: client}, dataFetcher, gvkA, gvkB)
+				defer closeServer()
+				defer conn.Close()
+
+				readMessage(t, conn)
+
+				waitUntil(t, 2*time.Second, 10*time.Millisecond, func() bool {
+					return informerA.AddEventHandlerCallCount() == 1 && informerB.AddEventHandlerCallCount() == 1
+				}, "expected AddEventHandler to be called exactly once for each informer")
+
+				if got := client.GetInformerCallCount(gvkA); got < 1 {
+					t.Fatalf("GetInformerForKind calls for gvkA = %d, want >= 1", got)
+				}
+				if got := client.GetInformerCallCount(gvkB); got < 1 {
+					t.Fatalf("GetInformerForKind calls for gvkB = %d, want >= 1", got)
+				}
+			},
+		},
+		"removes event handlers on context cancellation": {
+			run: func(t *testing.T) {
+				gvkA := schema.GroupVersionKind{Group: "group-a", Version: "v1", Kind: "KindA"}
+				gvkB := schema.GroupVersionKind{Group: "group-b", Version: "v1", Kind: "KindB"}
+
+				informerA := newMockInformer()
+				informerB := newMockInformer()
+				client := newMockClient(map[schema.GroupVersionKind]*mockInformer{
+					gvkA: informerA,
+					gvkB: informerB,
+				})
+
+				dataFetcher := func(_ context.Context) (any, error) {
+					return map[string]string{"status": "ok"}, nil
+				}
+
+				conn, closeServer := newTestWebSocketConnection(t, &Handlers{client: client}, dataFetcher, gvkA, gvkB)
+				defer closeServer()
+
+				readMessage(t, conn)
+
+				waitUntil(t, 2*time.Second, 10*time.Millisecond, func() bool {
+					return informerA.AddEventHandlerCallCount() == 1 && informerB.AddEventHandlerCallCount() == 1
+				}, "expected handlers to be registered before cancellation")
+
+				if err := conn.Close(); err != nil {
+					t.Fatalf("close websocket connection: %v", err)
+				}
+
+				waitUntil(t, 2*time.Second, 10*time.Millisecond, func() bool {
+					return informerA.RemoveEventHandlerCallCount() == 1 && informerB.RemoveEventHandlerCallCount() == 1
+				}, "expected RemoveEventHandler to be called once per informer after context cancellation")
+			},
+		},
+		"debounces rapid informer events into fewer sendData calls": {
+			run: func(t *testing.T) {
+				gvk := schema.GroupVersionKind{Group: "group", Version: "v1", Kind: "Kind"}
+
+				informer := newMockInformer()
+				client := newMockClient(map[schema.GroupVersionKind]*mockInformer{gvk: informer})
+
+				var fetchCalls atomic.Int64
+				dataFetcher := func(_ context.Context) (any, error) {
+					return map[string]int64{"call": fetchCalls.Add(1)}, nil
+				}
+
+				conn, closeServer := newTestWebSocketConnection(t, &Handlers{client: client}, dataFetcher, gvk)
+				defer closeServer()
+				defer conn.Close()
+
+				readMessage(t, conn)
+
+				drainDone := make(chan struct{})
+				go func() {
+					defer close(drainDone)
+					for {
+						if _, _, err := conn.ReadMessage(); err != nil {
+							return
+						}
+					}
+				}()
+
+				waitUntil(t, 2*time.Second, 10*time.Millisecond, func() bool {
+					return informer.AddEventHandlerCallCount() == 1
+				}, "expected handler registration before firing informer events")
+
+				const events = 20
+				for range events {
+					informer.triggerAdd(struct{}{})
+				}
+
+				waitUntil(t, 2*time.Second, 10*time.Millisecond, func() bool {
+					return fetchCalls.Load() > 1
+				}, "expected at least one update after burst of informer events")
+
+				time.Sleep(700 * time.Millisecond)
+
+				calls := fetchCalls.Load()
+				if calls >= events+1 {
+					t.Fatalf("data fetch calls = %d, want less than %d due to debounce", calls, events+1)
+				}
+				if calls > 4 {
+					t.Fatalf("data fetch calls = %d, want <= 4 for debounced burst", calls)
+				}
+
+				if err := conn.Close(); err != nil {
+					t.Fatalf("close websocket connection: %v", err)
+				}
+				select {
+				case <-drainDone:
+				case <-time.After(2 * time.Second):
+					t.Fatalf("reader goroutine did not exit after connection close")
+				}
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			tc.run(t)
+		})
+	}
+}
+
+func newTestWebSocketConnection(
+	t *testing.T,
+	handlers *Handlers,
+	dataFetcher func(ctx context.Context) (any, error),
+	gvks ...schema.GroupVersionKind,
+) (*websocket.Conn, func()) {
+	t.Helper()
+
+	router := gin.New()
+	router.GET("/ws/test", handlers.GenericWebSocketHandler(dataFetcher, gvks...))
+
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws/test"
+	dialer := websocket.Dialer{Subprotocols: []string{middleware.WebSocketBaseProtocol}}
+	conn, _, err := dialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+
+	closeServer := func() {
+		server.Close()
+	}
+
+	return conn, closeServer
+}
+
+func readMessage(t *testing.T, conn *websocket.Conn) {
+	t.Helper()
+
+	if err := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	if _, _, err := conn.ReadMessage(); err != nil {
+		t.Fatalf("read websocket message: %v", err)
+	}
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		t.Fatalf("reset read deadline: %v", err)
+	}
+}
+
+func waitUntil(t *testing.T, timeout, interval time.Duration, condition func() bool, failMessage string) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(interval)
+	}
+
+	t.Fatalf("timeout after %v: %s", timeout, failMessage)
+}

--- a/cmd/kueueviz/backend/handlers/workloads.go
+++ b/cmd/kueueviz/backend/handlers/workloads.go
@@ -40,15 +40,15 @@ type workloadResult struct {
 
 func (h *Handlers) WorkloadsWebSocketHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// Extract namespace query parameter if provided
 		namespace := c.Query("namespace")
+
 		h.GenericWebSocketHandler(func(ctx context.Context) (any, error) {
 			workloads, err := h.fetchWorkloads(ctx, namespace)
 			result := map[string]any{
 				"workloads": workloads,
 			}
 			return result, err
-		})(c)
+		}, WorkloadsGVK())(c)
 	}
 }
 
@@ -56,9 +56,10 @@ func (h *Handlers) WorkloadDetailsWebSocketHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		namespace := c.Param("namespace")
 		workloadName := c.Param("workload_name")
+
 		h.GenericWebSocketHandler(func(ctx context.Context) (any, error) {
 			return h.fetchWorkloadDetails(ctx, namespace, workloadName)
-		})(c)
+		}, WorkloadsGVK())(c)
 	}
 }
 
@@ -123,15 +124,14 @@ func (h *Handlers) WorkloadEventsWebSocketHandler() gin.HandlerFunc {
 
 		h.GenericWebSocketHandler(func(ctx context.Context) (any, error) {
 			return h.fetchWorkloadEvents(ctx, namespace, workloadName)
-		})(c)
+		}, EventsGVK())(c)
 	}
 }
 
 func (h *Handlers) fetchWorkloadEvents(ctx context.Context, namespace, workloadName string) (any, error) {
 	el := &corev1.EventList{}
 	err := h.client.List(ctx, el, &ctrlclient.ListOptions{
-		Namespace: namespace,
-		// TODO: needed index here
+		Namespace:     namespace,
 		FieldSelector: fields.OneTermEqualSelector("involvedObject.name", workloadName),
 	})
 	if err != nil {

--- a/cmd/kueueviz/backend/handlers/workloads_dashboard.go
+++ b/cmd/kueueviz/backend/handlers/workloads_dashboard.go
@@ -31,6 +31,7 @@ import (
 )
 
 // WorkloadsDashboardWebSocketHandler streams workloads along with attached pod details
+// Watches Workloads, Pods, ClusterQueues, LocalQueues, and ResourceFlavors for comprehensive updates
 func (h *Handlers) WorkloadsDashboardWebSocketHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Extract namespace query parameter if provided
@@ -41,7 +42,13 @@ func (h *Handlers) WorkloadsDashboardWebSocketHandler() gin.HandlerFunc {
 			return h.fetchDashboardData(ctx, namespace)
 		}
 
-		h.GenericWebSocketHandler(dataFetcher)(c)
+		h.GenericWebSocketHandler(dataFetcher,
+			WorkloadsGVK(),
+			PodsGVK(),
+			ClusterQueuesGVK(),
+			LocalQueuesGVK(),
+			ResourceFlavorsGVK(),
+		)(c)
 	}
 }
 
@@ -60,7 +67,6 @@ func (h *Handlers) fetchDashboardData(ctx context.Context, namespace string) (ma
 }
 
 func (h *Handlers) fetchWorkloadsDashboardData(ctx context.Context, namespace string) any {
-	// Filter workloads by namespace if provided, otherwise fetch all
 	wql := &kueueapi.WorkloadList{}
 	err := h.client.List(ctx, wql, ctrlclient.InNamespace(namespace))
 

--- a/cmd/kueueviz/backend/main.go
+++ b/cmd/kueueviz/backend/main.go
@@ -103,6 +103,7 @@ func main() {
 	// Shutdown the server gracefully
 	if err := srv.Shutdown(context.Background()); err != nil {
 		slog.Error("Server forced to shutdown", "error", err)
+		cancel()
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind cleanup

#### What this PR does / why we need it:

Replace polling with informers in kueueviz backend WebSocket handlers.

- Drop polling, use informers for real-time updates
- Support multi-resource watching (variadic GVKs in GenericWebSocketHandler)
- Addressed nits from #7663

#### Special notes for your reviewer:

No polling fallback. WebSocket protocol unchanged.

#### Does this PR introduce a user-facing change?

```release-note
kueueviz: use informers instead of polling for WebSocket updates
```

