### PR TITLE
[TAS] Requeue inadmissible workloads after non-TAS pod finishes

### DIFF
--- a/pkg/cache/scheduler/tas_cache.go
+++ b/pkg/cache/scheduler/tas_cache.go
@@ -135,13 +135,15 @@ func (t *tasCache) DeleteTopology(name kueue.TopologyReference) {
 }
 
 // UpdateNonTASUsage updates the non-TAS resource usage cache for the pod.
-func (t *tasCache) UpdateNonTASUsage(pod *corev1.Pod, log logr.Logger) {
-	t.nonTasUsageCache.update(pod, log)
+// Returns the node name when a terminated pod is removed from the cache.
+func (t *tasCache) UpdateNonTASUsage(pod *corev1.Pod, log logr.Logger) string {
+	return t.nonTasUsageCache.update(pod, log)
 }
 
 // DeleteNonTASUsageByKey removes the pod from the non-TAS resource usage cache.
-func (t *tasCache) DeleteNonTASUsageByKey(key client.ObjectKey, log logr.Logger) {
-	t.nonTasUsageCache.delete(key, log)
+// Returns the node name when an entry is removed.
+func (t *tasCache) DeleteNonTASUsageByKey(key client.ObjectKey, log logr.Logger) string {
+	return t.nonTasUsageCache.delete(key, log)
 }
 
 // TrackPod notifies the scheduling simulator that a pod is running on a node.

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache.go
@@ -41,29 +41,42 @@ type podUsageValue struct {
 	usage resources.Requests
 }
 
-// update may add a pod to the cache, or
-// delete a terminated pod.
-func (n *nonTasUsageCache) update(pod *corev1.Pod, log logr.Logger) {
+// removePodUsage removes a pod entry and its node usage from the cache.
+// Returns the node name if the pod was found, empty string otherwise.
+// Must be called under write lock.
+func (n *nonTasUsageCache) removePodUsage(key client.ObjectKey, log logr.Logger) string {
+	if old, found := n.podUsage[key]; found {
+		n.removeNodeUsage(old.node, old.usage, log)
+		delete(n.podUsage, key)
+		return old.node
+	}
+	delete(n.podUsage, key)
+	return ""
+}
+
+// update may add a pod to the cache, or delete a terminated pod.
+// Returns the node name when a terminated pod is removed from the cache.
+func (n *nonTasUsageCache) update(pod *corev1.Pod, log logr.Logger) string {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 
 	key := client.ObjectKeyFromObject(pod)
 
-	// delete terminated pods as they no longer use any capacity.
 	if utilpod.IsTerminated(pod) {
 		log.V(5).Info("Deleting terminated pod from the cache")
-		if old, found := n.podUsage[key]; found {
-			n.removeNodeUsage(old.node, old.usage, log)
-		}
-		delete(n.podUsage, key)
-		return
+		return n.removePodUsage(key, log)
 	}
 
-	// Remove old entry if pod already exists (handles node migration, resource resize).
+	n.updatePodUsage(key, pod, log)
+	return ""
+}
+
+// updatePodUsage replaces or inserts a pod's usage entry and adjusts node totals.
+// Must be called under write lock.
+func (n *nonTasUsageCache) updatePodUsage(key client.ObjectKey, pod *corev1.Pod, log logr.Logger) {
 	if old, found := n.podUsage[key]; found {
 		n.removeNodeUsage(old.node, old.usage, log)
 	}
-
 	log.V(5).Info("Adding non-TAS pod to the cache")
 	requests := resources.NewRequestsFromPodSpec(&pod.Spec)
 	n.podUsage[key] = podUsageValue{
@@ -73,13 +86,12 @@ func (n *nonTasUsageCache) update(pod *corev1.Pod, log logr.Logger) {
 	n.addNodeUsage(pod.Spec.NodeName, requests)
 }
 
-func (n *nonTasUsageCache) delete(key client.ObjectKey, log logr.Logger) {
+// delete removes a pod from the cache.
+// Returns the node name when an entry is removed.
+func (n *nonTasUsageCache) delete(key client.ObjectKey, log logr.Logger) string {
 	n.lock.Lock()
 	defer n.lock.Unlock()
-	if old, found := n.podUsage[key]; found {
-		n.removeNodeUsage(old.node, old.usage, log)
-	}
-	delete(n.podUsage, key)
+	return n.removePodUsage(key, log)
 }
 
 // forEachNodeUsage invokes fn for each node's usage while holding the read lock.

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
@@ -19,15 +19,91 @@ package scheduler
 import (
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/kueue/pkg/resources"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
+
+func TestNonTasUsageCacheRemovedNode(t *testing.T) {
+	testCases := map[string]struct {
+		setup    func(cache *nonTasUsageCache, log logr.Logger)
+		action   func(cache *nonTasUsageCache, log logr.Logger) string
+		wantNode string
+	}{
+		"update with succeeded pod returns node": {
+			setup: func(cache *nonTasUsageCache, log logr.Logger) {
+				cache.update(makePod("pod1", "ns", "node-a", "2"), log)
+			},
+			action: func(cache *nonTasUsageCache, log logr.Logger) string {
+				pod := makePod("pod1", "ns", "node-a", "2")
+				pod.Status.Phase = corev1.PodSucceeded
+				return cache.update(pod, log)
+			},
+			wantNode: "node-a",
+		},
+		"update with failed pod returns node": {
+			setup: func(cache *nonTasUsageCache, log logr.Logger) {
+				cache.update(makePod("pod1", "ns", "node-a", "2"), log)
+			},
+			action: func(cache *nonTasUsageCache, log logr.Logger) string {
+				pod := makePod("pod1", "ns", "node-a", "2")
+				pod.Status.Phase = corev1.PodFailed
+				return cache.update(pod, log)
+			},
+			wantNode: "node-a",
+		},
+		"update with terminated pod not in cache returns empty": {
+			action: func(cache *nonTasUsageCache, log logr.Logger) string {
+				pod := makePod("pod1", "ns", "node-a", "2")
+				pod.Status.Phase = corev1.PodSucceeded
+				return cache.update(pod, log)
+			},
+		},
+		"update with running pod returns empty": {
+			action: func(cache *nonTasUsageCache, log logr.Logger) string {
+				return cache.update(makePod("pod1", "ns", "node-a", "2"), log)
+			},
+		},
+		"delete existing pod returns node": {
+			setup: func(cache *nonTasUsageCache, log logr.Logger) {
+				cache.update(makePod("pod1", "ns", "node-a", "2"), log)
+			},
+			action: func(cache *nonTasUsageCache, log logr.Logger) string {
+				return cache.delete(types.NamespacedName{Namespace: "ns", Name: "pod1"}, log)
+			},
+			wantNode: "node-a",
+		},
+		"delete non-existent pod returns empty": {
+			action: func(cache *nonTasUsageCache, log logr.Logger) string {
+				return cache.delete(types.NamespacedName{Namespace: "ns", Name: "ghost"}, log)
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
+			cache := &nonTasUsageCache{
+				podUsage:  make(map[types.NamespacedName]podUsageValue),
+				nodeUsage: make(map[string]resources.Requests),
+			}
+			if tc.setup != nil {
+				tc.setup(cache, log)
+			}
+			got := tc.action(cache, log)
+			if got != tc.wantNode {
+				t.Errorf("got removedNode=%q, want %q", got, tc.wantNode)
+			}
+		})
+	}
+}
 
 // verifyNodeUsageConsistency recomputes usage from podUsage (old O(pods) algorithm)
 // and verifies it matches the incremental nodeUsage.

--- a/pkg/controller/tas/controllers.go
+++ b/pkg/controller/tas/controllers.go
@@ -17,6 +17,9 @@ limitations under the License.
 package tas
 
 import (
+	"fmt"
+	"time"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -25,7 +28,34 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 )
 
-func SetupControllers(mgr ctrl.Manager, queues *qcache.Manager, cache *schdcache.Cache, cfg *configapi.Configuration, roleTracker *roletracker.RoleTracker) (string, error) {
+// SetupControllersOption configures TAS controller setup.
+type SetupControllersOption func(*setupControllersOptions)
+
+type setupControllersOptions struct {
+	podUsageOpts []podUsageOption
+}
+
+// WithRequeueBatchInterval overrides the interval at which freed non-TAS
+// capacity triggers requeue of inadmissible workloads. Defaults to 10s.
+func WithRequeueBatchInterval(d time.Duration) SetupControllersOption {
+	return func(o *setupControllersOptions) {
+		o.podUsageOpts = append(o.podUsageOpts, withRequeueBatchInterval(d))
+	}
+}
+
+func SetupControllers(
+	mgr ctrl.Manager,
+	queues *qcache.Manager,
+	cache *schdcache.Cache,
+	cfg *configapi.Configuration,
+	roleTracker *roletracker.RoleTracker,
+	opts ...SetupControllersOption,
+) (string, error) {
+	var options setupControllersOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	recorder := mgr.GetEventRecorder(TASResourceFlavorController)
 	topologyRec := newTopologyReconciler(mgr.GetClient(), queues, cache, roleTracker)
 	if ctrlName, err := topologyRec.setupWithManager(mgr, cfg); err != nil {
@@ -43,9 +73,15 @@ func SetupControllers(mgr ctrl.Manager, queues *qcache.Manager, cache *schdcache
 	if ctrlName, err := nodeRec.SetupWithManager(mgr, cfg); err != nil {
 		return ctrlName, err
 	}
-	podUsageController := newPodUsageReconciler(mgr.GetClient(), cache, roleTracker)
+	podUsageController := newPodUsageReconciler(mgr.GetClient(), queues, cache, roleTracker, options.podUsageOpts...)
 	if ctrlName, err := podUsageController.SetupWithManager(mgr); err != nil {
 		return ctrlName, err
+	}
+	if err := mgr.Add(podUsageController); err != nil {
+		return TASPodUsageController, fmt.Errorf(
+			"unable to add pod usage requeue drainer: %w",
+			err,
+		)
 	}
 	return "", nil
 }

--- a/pkg/controller/tas/pod_usage_controller.go
+++ b/pkg/controller/tas/pod_usage_controller.go
@@ -18,43 +18,101 @@ package tas
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 )
 
-func newPodUsageReconciler(k8sClient client.Client, cache *schdcache.Cache, roleTracker *roletracker.RoleTracker) *PodUsageReconciler {
-	return &PodUsageReconciler{
-		k8sClient:   k8sClient,
-		cache:       cache,
-		roleTracker: roleTracker,
+const defaultRequeueBatchInterval = 10 * time.Second
+
+type podUsageOption func(*PodUsageReconciler)
+
+func withRequeueBatchInterval(d time.Duration) podUsageOption {
+	return func(r *PodUsageReconciler) {
+		if d > 0 {
+			r.requeueBatchInterval = d
+		}
 	}
 }
 
+func newPodUsageReconciler(k8sClient client.Client, queues *qcache.Manager, cache *schdcache.Cache, roleTracker *roletracker.RoleTracker, opts ...podUsageOption) *PodUsageReconciler {
+	r := &PodUsageReconciler{
+		k8sClient:            k8sClient,
+		queues:               queues,
+		cache:                cache,
+		roleTracker:          roleTracker,
+		requeueBatchInterval: defaultRequeueBatchInterval,
+		pending:              pendingRequeue{nodes: sets.New[string]()},
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// pendingRequeue collects freed node names under a mutex and
+// swaps the set atomically on drain.
+type pendingRequeue struct {
+	mu    sync.Mutex
+	nodes sets.Set[string]
+}
+
+func (p *pendingRequeue) notify(nodeName string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.nodes.Insert(nodeName)
+}
+
+func (p *pendingRequeue) drain() sets.Set[string] {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	nodes := p.nodes
+	p.nodes = sets.New[string]()
+	return nodes
+}
+
 // PodUsageReconciler monitors all scheduled pods to update the TAS cache
-// with non-TAS resource usage and to feed the scheduling simulator with
-// pod state for feasibility checks.
+// with non-TAS resource usage, to feed the scheduling simulator with pod
+// state for feasibility checks, and to requeue inadmissible workloads when
+// capacity is freed.
 type PodUsageReconciler struct {
 	k8sClient   client.Client
 	cache       *schdcache.Cache
+	queues      *qcache.Manager
 	roleTracker *roletracker.RoleTracker
+
+	requeueBatchInterval time.Duration
+	pending              pendingRequeue
 }
 
 var _ reconcile.Reconciler = (*PodUsageReconciler)(nil)
 var _ predicate.TypedPredicate[*corev1.Pod] = (*PodUsageReconciler)(nil)
+var _ manager.Runnable = (*PodUsageReconciler)(nil)
+var _ manager.LeaderElectionRunnable = (*PodUsageReconciler)(nil)
+
+func (r *PodUsageReconciler) NeedLeaderElection() bool {
+	return false
+}
 
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 
@@ -68,7 +126,9 @@ func (r *PodUsageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return ctrl.Result{}, err
 		}
 		log.V(5).Info("Idempotently deleting not found pod")
-		r.cache.TASCache().DeleteNonTASUsageByKey(req.NamespacedName, log)
+		if removedNode := r.cache.TASCache().DeleteNonTASUsageByKey(req.NamespacedName, log); removedNode != "" {
+			r.notifyFreedNode(removedNode)
+		}
 		r.cache.TASCache().UntrackPod(req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
@@ -80,9 +140,13 @@ func (r *PodUsageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	if belongsToNonTASCache(&pod) {
+		// UpdateNonTASUsage only returns a node name for terminated pods,
+		// which are already filtered out by belongsToNonTASCache.
 		r.cache.TASCache().UpdateNonTASUsage(&pod, log)
 	} else {
-		r.cache.TASCache().DeleteNonTASUsageByKey(req.NamespacedName, log)
+		if removedNode := r.cache.TASCache().DeleteNonTASUsageByKey(req.NamespacedName, log); removedNode != "" {
+			r.notifyFreedNode(removedNode)
+		}
 	}
 	return ctrl.Result{}, nil
 }
@@ -105,6 +169,71 @@ func belongsToNonTASCache(pod *corev1.Pod) bool {
 		return false
 	}
 	return true
+}
+
+func (r *PodUsageReconciler) notifyFreedNode(nodeName string) {
+	r.pending.notify(nodeName)
+}
+
+// Start implements the Runnable interface. It drains accumulated freed node
+// names at a slow interval to avoid clearing equivalence hashes on every pod
+// event during sustained non-TAS pod churn.
+func (r *PodUsageReconciler) Start(ctx context.Context) error {
+	log := ctrl.LoggerFrom(ctx).WithName("pod-usage-requeue-drainer")
+	ctx = ctrl.LoggerInto(ctx, log)
+	ticker := time.NewTicker(r.requeueBatchInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			r.drainPendingNodes(ctx)
+		}
+	}
+}
+
+func (r *PodUsageReconciler) drainPendingNodes(ctx context.Context) {
+	nodes := r.pending.drain()
+
+	if nodes.Len() == 0 {
+		return
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+	cqNames := sets.New[kueue.ClusterQueueReference]()
+	flavorCache := r.cache.CloneTASCache()
+	for nodeName := range nodes {
+		var node corev1.Node
+		if err := r.k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, &node); err != nil {
+			if client.IgnoreNotFound(err) == nil {
+				log.V(3).
+					Info("Node deleted, skipping requeue (RF controller handles this)", "node", nodeName)
+				continue
+			}
+			log.Error(
+				err,
+				"Failed to get node for requeue, will retry next cycle",
+				"node",
+				nodeName,
+			)
+			r.notifyFreedNode(nodeName)
+			continue
+		}
+		for name, fc := range flavorCache {
+			if utiltas.NodeMatchesFlavor(node.Labels, fc.NodeLabels(), fc.TopologyLevels()) {
+				for _, cq := range r.cache.ClusterQueuesUsingFlavor(name) {
+					cqNames.Insert(cq)
+				}
+			}
+		}
+	}
+	if cqNames.Len() > 0 {
+		log.V(3).
+			Info("Requeueing inadmissible workloads after non-TAS pod freed capacity",
+				"nodes", sets.List(nodes), "clusterQueues", sets.List(cqNames))
+		qcache.NotifyRetryInadmissible(r.queues, cqNames)
+	}
 }
 
 func (r *PodUsageReconciler) Create(e event.TypedCreateEvent[*corev1.Pod]) bool {

--- a/pkg/controller/tas/pod_usage_controller_test.go
+++ b/pkg/controller/tas/pod_usage_controller_test.go
@@ -17,12 +17,20 @@ limitations under the License.
 package tas
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 )
 
@@ -264,5 +272,73 @@ func TestPodUsageReconcilerUpdate(t *testing.T) {
 	})
 	if !got {
 		t.Errorf("Update() = %v, want %v", got, true)
+	}
+}
+
+func TestDrainPendingNodes(t *testing.T) {
+	tests := map[string]struct {
+		initialNodes    []string
+		objects         []corev1.Node
+		interceptGet    bool
+		wantPendingLen  int
+		wantPendingKeys sets.Set[string]
+	}{
+		"empty set is a no-op": {
+			wantPendingLen: 0,
+		},
+		"NotFound node is skipped without re-insert": {
+			initialNodes:   []string{"deleted-node"},
+			wantPendingLen: 0,
+		},
+		"existing node is drained": {
+			initialNodes:   []string{"node-a"},
+			objects:        []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}}},
+			wantPendingLen: 0,
+		},
+		"duplicate nodes are deduplicated": {
+			initialNodes: []string{"node-a", "node-a", "node-b"},
+			objects: []corev1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-b"}},
+			},
+			wantPendingLen: 0,
+		},
+		"transient error re-inserts node for next cycle": {
+			initialNodes:    []string{"flaky-node"},
+			interceptGet:    true,
+			wantPendingLen:  1,
+			wantPendingKeys: sets.New[string]("flaky-node"),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			builder := fake.NewClientBuilder()
+			for i := range tc.objects {
+				builder = builder.WithObjects(&tc.objects[i])
+			}
+			if tc.interceptGet {
+				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+						return errors.New("transient error")
+					},
+				})
+			}
+			cl := builder.Build()
+			cache := schdcache.New(cl)
+			r := newPodUsageReconciler(cl, nil, cache, nil)
+
+			for _, n := range tc.initialNodes {
+				r.notifyFreedNode(n)
+			}
+			r.drainPendingNodes(t.Context())
+
+			if r.pending.nodes.Len() != tc.wantPendingLen {
+				t.Errorf("pendingRequeueNodes has %d items, want %d", r.pending.nodes.Len(), tc.wantPendingLen)
+			}
+			if tc.wantPendingKeys != nil && !r.pending.nodes.Equal(tc.wantPendingKeys) {
+				t.Errorf("pendingRequeueNodes = %v, want %v", r.pending.nodes, tc.wantPendingKeys)
+			}
+		})
 	}
 }

--- a/test/integration/singlecluster/tas/suite_test.go
+++ b/test/integration/singlecluster/tas/suite_test.go
@@ -19,6 +19,7 @@ package tas
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -51,8 +52,6 @@ var (
 	k8sClient client.Client
 	ctx       context.Context
 	fwk       *framework.Framework
-	// Cleanup after https://github.com/kubernetes-sigs/kueue/issues/8653
-	qManager *qcache.Manager
 )
 
 func TestAPIs(t *testing.T) {
@@ -100,7 +99,6 @@ func managerSetupWithConfig(
 			qcache.WithPreemptionExpectations(preemptionExpectations),
 		}
 		queues := util.NewManagerForIntegrationTests(ctx, mgr.GetClient(), cCache, queueOptions...)
-		qManager = queues
 
 		failedCtrl, err := core.SetupControllers(
 			mgr,
@@ -111,7 +109,7 @@ func managerSetupWithConfig(
 		)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "Core controller", failedCtrl)
 
-		failedCtrl, err = tas.SetupControllers(mgr, queues, cCache, controllersCfg, nil)
+		failedCtrl, err = tas.SetupControllers(mgr, queues, cCache, controllersCfg, nil, tas.WithRequeueBatchInterval(time.Second))
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "TAS controller", failedCtrl)
 
 		err = pod.SetupWebhook(mgr, jobframework.WithQueues(queues))

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	autoscaling "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,7 +41,6 @@ import (
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/admissionchecks/provisioning"
 	"sigs.k8s.io/kueue/pkg/controller/tas"
@@ -632,12 +630,6 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			// https://github.com/kubernetes-sigs/kueue/issues/8653
-			ginkgo.By("hack to requeue workload", func() {
-				cqs := sets.New[kueue.ClusterQueueReference]("cluster-queue")
-				qcache.NotifyRetryInadmissible(qManager, cqs)
-			})
-
 			ginkgo.By("expect TAS pod to admit", func() {
 				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
 				util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
@@ -675,12 +667,6 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 			ginkgo.By("delete the non-TAS pod", func() {
 				util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, nonTasPod, true, 60*time.Second)
-			})
-
-			// https://github.com/kubernetes-sigs/kueue/issues/8653
-			ginkgo.By("hack to requeue workload", func() {
-				cqs := sets.New[kueue.ClusterQueueReference]("cluster-queue")
-				qcache.NotifyRetryInadmissible(qManager, cqs)
 			})
 
 			ginkgo.By("expect TAS pod to admit", func() {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/area tas

#### What this PR does / why we need it:
When a non-TAS pod terminates or is deleted, capacity is freed on the node. Previously, inadmissible TAS workloads were not automatically requeued to reconsider the freed capacity, requiring a manual workaround in tests. This fix makes the `NonTasUsageReconciler` detect when a pod is removed from the cache and requeue inadmissible workloads  for the affected ClusterQueues using the existing batched requeue infrastructure.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/8653

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Fixed a bug where inadmissible TAS workloads were not automatically requeued when non-TAS pods terminated, potentially leaving workloads stuck pending despite available capacity.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Automatically retries previously inadmissible workloads when capacity is freed after pod termination or deletion.
  * Batches node requeue processing for more efficient workload recovery.
  * Retries node lookups when necessary and safely skips deleted nodes.
* **Configuration**
  * Added an option to configure the node requeue batch interval.
* **Tests**
  * Expanded coverage for cache removal and node tracking scenarios.
  * Simplified integration tests by removing manual retry notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->