### PR TITLE
Introduce a helper for asserting events to reduce code duplication

### DIFF
--- a/test/util/events.go
+++ b/test/util/events.go
@@ -1,0 +1,64 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+)
+
+func ExpectEventsForObjectsWithTimeout(eventWatcher watch.Interface, objs sets.Set[types.NamespacedName], filter func(*corev1.Event) bool, timeout time.Duration) {
+	ginkgo.GinkgoHelper()
+	gotObjs := sets.New[types.NamespacedName]()
+	timeoutCh := time.After(timeout)
+readCh:
+	for !gotObjs.Equal(objs) {
+		select {
+		case evt, ok := <-eventWatcher.ResultChan():
+			gomega.Expect(ok).To(gomega.BeTrue())
+			event, ok := evt.Object.(*corev1.Event)
+			gomega.Expect(ok).To(gomega.BeTrue())
+			if filter(event) {
+				objKey := types.NamespacedName{Namespace: event.InvolvedObject.Namespace, Name: event.InvolvedObject.Name}
+				gotObjs.Insert(objKey)
+			}
+		case <-timeoutCh:
+			break readCh
+		}
+	}
+	gomega.Expect(gotObjs).To(gomega.Equal(objs))
+}
+
+// ExpectEventAppeared asserts that an event matching Reason/Type/Message has been emitted.
+func ExpectEventAppeared(ctx context.Context, k8sClient client.Client, event corev1.Event) {
+	ginkgo.GinkgoHelper()
+	gomega.Eventually(func(g gomega.Gomega) {
+		ok, err := utiltesting.HasEventAppeared(ctx, k8sClient, event)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(ok).Should(gomega.BeTrue())
+	}, Timeout, Interval).Should(gomega.Succeed())
+}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -51,7 +51,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
@@ -1044,41 +1043,6 @@ func ExpectWorkloadsFinalizedOrGone(ctx context.Context, k8sClient client.Client
 			g.Expect(createdWorkload.Finalizers).Should(gomega.BeEmpty(), "Expected workload to be finalized")
 		}, Timeout, Interval).Should(gomega.Succeed())
 	}
-}
-
-func ExpectEventsForObjects(eventWatcher watch.Interface, objs sets.Set[types.NamespacedName], filter func(*corev1.Event) bool) {
-	ExpectEventsForObjectsWithTimeout(eventWatcher, objs, filter, Timeout)
-}
-
-func ExpectEventsForObjectsWithTimeout(eventWatcher watch.Interface, objs sets.Set[types.NamespacedName], filter func(*corev1.Event) bool, timeout time.Duration) {
-	gotObjs := sets.New[types.NamespacedName]()
-	timeoutCh := time.After(timeout)
-readCh:
-	for !gotObjs.Equal(objs) {
-		select {
-		case evt, ok := <-eventWatcher.ResultChan():
-			gomega.ExpectWithOffset(1, ok).To(gomega.BeTrue())
-			event, ok := evt.Object.(*corev1.Event)
-			gomega.ExpectWithOffset(1, ok).To(gomega.BeTrue())
-			if filter(event) {
-				objKey := types.NamespacedName{Namespace: event.InvolvedObject.Namespace, Name: event.InvolvedObject.Name}
-				gotObjs.Insert(objKey)
-			}
-		case <-timeoutCh:
-			break readCh
-		}
-	}
-	gomega.ExpectWithOffset(1, gotObjs).To(gomega.Equal(objs))
-}
-
-// ExpectEventAppeared asserts that an event matching Reason/Type/Message has been emitted.
-func ExpectEventAppeared(ctx context.Context, k8sClient client.Client, event corev1.Event) {
-	ginkgo.GinkgoHelper()
-	gomega.Eventually(func(g gomega.Gomega) {
-		ok, err := utiltesting.HasEventAppeared(ctx, k8sClient, event)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(ok).Should(gomega.BeTrue())
-	}, Timeout, Interval).Should(gomega.Succeed())
 }
 
 func ExpectPreemptedCondition(ctx context.Context, k8sClient client.Client, reason string, status metav1.ConditionStatus, preemptedWl, preempteeWl *kueue.Workload, preemteeWorkloadUID, preempteeJobUID, preemptorPath, preempteePath string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Separate events

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7023

#### Special notes for your reviewer:
https://github.com/kubernetes-sigs/kueue/pull/8549#discussion_r2683298030

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```