### PR TITLE
Fix typo in preemption.md regarding workload preemption

### DIFF
--- a/site/content/en/docs/concepts/preemption.md
+++ b/site/content/en/docs/concepts/preemption.md
@@ -60,7 +60,7 @@ already above the nominal quota. The algorithms are:
   - Preemption while borrowing is enabled for the workload's ClusterQueue
   - All candidates for preemption belong to the same ClusterQueue as the preempting Workload
 
-  In the above scenarios, a workload can only be considered for preemption, in favor a workload from another ClusterQueue, 
+  In the above scenarios, a workload can only be considered for preemption, in favor of a workload from another ClusterQueue, 
   if it belongs to a ClusterQueue which is running over its nominal quota. 
   ClusterQueues in a cohort borrow resources in a first-come first-served fashion.
   


### PR DESCRIPTION
Corrected a typo in the preemption.md file regarding workload preemption conditions.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:



#### Which issue(s) this PR fixes:

I want to corrects a typo in the preemption documentation. 

* :ok_hand: "in favor of a workload"
* :no_good: "in favor a workload"

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```