### PR TITLE
Fix stale replica-role in event handler logs

### DIFF
--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -63,7 +63,7 @@ type ClusterQueueUpdateWatcher interface {
 // ClusterQueueReconciler reconciles a ClusterQueue object
 type ClusterQueueReconciler struct {
 	client                client.Client
-	log                   logr.Logger
+	logName               string
 	qManager              *qcache.Manager
 	cache                 *schdcache.Cache
 	nonCQObjectUpdateCh   chan event.TypedGenericEvent[iter.Seq[kueue.ClusterQueueReference]]
@@ -128,7 +128,7 @@ func NewClusterQueueReconciler(
 	}
 	return &ClusterQueueReconciler{
 		client:                client,
-		log:                   roletracker.WithReplicaRole(ctrl.Log.WithName("cluster-queue-reconciler"), options.roleTracker),
+		logName:               "cluster-queue-reconciler",
 		qManager:              qMgr,
 		cache:                 cache,
 		nonCQObjectUpdateCh:   make(chan event.TypedGenericEvent[iter.Seq[kueue.ClusterQueueReference]], updateChBuffer),
@@ -138,6 +138,10 @@ func NewClusterQueueReconciler(
 		clock:                 options.clock,
 		roleTracker:           options.roleTracker,
 	}
+}
+
+func (r *ClusterQueueReconciler) logger() logr.Logger {
+	return roletracker.WithReplicaRole(ctrl.Log.WithName(r.logName), r.roleTracker)
 }
 
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
@@ -298,7 +302,7 @@ func (r *ClusterQueueReconciler) NotifyAdmissionCheckUpdate(oldAc, newAc *kueue.
 func (r *ClusterQueueReconciler) Create(e event.TypedCreateEvent[*kueue.ClusterQueue]) bool {
 	defer r.notifyWatchers(nil, e.Object)
 
-	log := r.log.WithValues("clusterQueue", klog.KObj(e.Object))
+	log := r.logger().WithValues("clusterQueue", klog.KObj(e.Object))
 	log.V(2).Info("ClusterQueue create event")
 	ctx := ctrl.LoggerInto(context.Background(), log)
 	if err := r.cache.AddClusterQueue(ctx, e.Object); err != nil {
@@ -319,18 +323,19 @@ func (r *ClusterQueueReconciler) Create(e event.TypedCreateEvent[*kueue.ClusterQ
 func (r *ClusterQueueReconciler) Delete(e event.TypedDeleteEvent[*kueue.ClusterQueue]) bool {
 	defer r.notifyWatchers(e.Object, nil)
 
-	r.log.V(2).Info("ClusterQueue delete event", "clusterQueue", klog.KObj(e.Object))
+	log := r.logger()
+	log.V(2).Info("ClusterQueue delete event", "clusterQueue", klog.KObj(e.Object))
 	r.cache.DeleteClusterQueue(e.Object)
 	r.qManager.DeleteClusterQueue(e.Object)
 
 	metrics.ClearClusterQueueResourceMetrics(e.Object.Name)
-	r.log.V(2).Info("Cleared resource metrics for deleted ClusterQueue.", "clusterQueue", klog.KObj(e.Object))
+	log.V(2).Info("Cleared resource metrics for deleted ClusterQueue.", "clusterQueue", klog.KObj(e.Object))
 
 	return true
 }
 
 func (r *ClusterQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.ClusterQueue]) bool {
-	log := r.log.WithValues("clusterQueue", klog.KObj(e.ObjectNew))
+	log := r.logger().WithValues("clusterQueue", klog.KObj(e.ObjectNew))
 	log.V(2).Info("ClusterQueue update event")
 
 	if !e.ObjectNew.DeletionTimestamp.IsZero() {
@@ -339,7 +344,7 @@ func (r *ClusterQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.ClusterQ
 	defer r.notifyWatchers(e.ObjectOld, e.ObjectNew)
 	specUpdated := !equality.Semantic.DeepEqual(e.ObjectOld.Spec, e.ObjectNew.Spec)
 
-	if err := r.cache.UpdateClusterQueue(r.log, e.ObjectNew); err != nil {
+	if err := r.cache.UpdateClusterQueue(log, e.ObjectNew); err != nil {
 		log.Error(err, "Failed to update clusterQueue in cache")
 	}
 	if err := r.qManager.UpdateClusterQueue(context.Background(), e.ObjectNew, specUpdated); err != nil {
@@ -353,7 +358,7 @@ func (r *ClusterQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.ClusterQ
 }
 
 func (r *ClusterQueueReconciler) Generic(e event.TypedGenericEvent[*kueue.ClusterQueue]) bool {
-	r.log.V(3).Info("Got ClusterQueue generic event", "clusterQueue", klog.KObj(e.Object))
+	r.logger().V(3).Info("Got ClusterQueue generic event", "clusterQueue", klog.KObj(e.Object))
 	return true
 }
 
@@ -547,15 +552,16 @@ func (r *ClusterQueueReconciler) updateCqStatusIfChanged(
 	conditionStatus metav1.ConditionStatus,
 	reason, msg string,
 ) error {
+	log := r.logger()
 	oldStatus := cq.Status.DeepCopy()
 	pendingWorkloads, err := r.qManager.Pending(cq)
 	if err != nil {
-		r.log.Error(err, "Failed getting pending workloads from queue manager")
+		log.Error(err, "Failed getting pending workloads from queue manager")
 		return err
 	}
 	stats, err := r.cache.Usage(cq)
 	if err != nil {
-		r.log.Error(err, "Failed getting usage from cache")
+		log.Error(err, "Failed getting usage from cache")
 		// This is likely because the cluster queue was recently removed,
 		// but we didn't process that event yet.
 		return err

--- a/pkg/controller/core/clusterqueue_controller_test.go
+++ b/pkg/controller/core/clusterqueue_controller_test.go
@@ -222,7 +222,7 @@ func TestUpdateCqStatusIfChanged(t *testing.T) {
 			}
 			r := &ClusterQueueReconciler{
 				client:   cl,
-				log:      log,
+				logName:  "cluster-queue-reconciler",
 				cache:    cqCache,
 				qManager: qManager,
 			}

--- a/pkg/controller/core/workloadpriorityclass_controller.go
+++ b/pkg/controller/core/workloadpriorityclass_controller.go
@@ -42,7 +42,7 @@ import (
 
 // WorkloadPriorityClassReconciler reconciles a WorkloadPriorityClass object
 type WorkloadPriorityClassReconciler struct {
-	log         logr.Logger
+	logName     string
 	client      client.Client
 	roleTracker *roletracker.RoleTracker
 }
@@ -55,10 +55,14 @@ func NewWorkloadPriorityClassReconciler(
 	roleTracker *roletracker.RoleTracker,
 ) *WorkloadPriorityClassReconciler {
 	return &WorkloadPriorityClassReconciler{
-		log:         roletracker.WithReplicaRole(ctrl.Log.WithName("workloadpriorityclass-reconciler"), roleTracker),
+		logName:     "workloadpriorityclass-reconciler",
 		client:      client,
 		roleTracker: roleTracker,
 	}
+}
+
+func (r *WorkloadPriorityClassReconciler) logger() logr.Logger {
+	return roletracker.WithReplicaRole(ctrl.Log.WithName(r.logName), r.roleTracker)
 }
 
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloadpriorityclasses,verbs=get;list;watch
@@ -115,7 +119,7 @@ func (r *WorkloadPriorityClassReconciler) Reconcile(ctx context.Context, req ctr
 }
 
 func (r *WorkloadPriorityClassReconciler) Create(e event.TypedCreateEvent[*kueue.WorkloadPriorityClass]) bool {
-	log := r.log.WithValues("workloadPriorityClass", klog.KObj(e.Object))
+	log := r.logger().WithValues("workloadPriorityClass", klog.KObj(e.Object))
 	log.V(2).Info("WorkloadPriorityClass create event")
 
 	// Covering the case when the WorkloadPriorityClass was re-created with a different priority,
@@ -128,7 +132,7 @@ func (r *WorkloadPriorityClassReconciler) Delete(e event.TypedDeleteEvent[*kueue
 }
 
 func (r *WorkloadPriorityClassReconciler) Update(e event.TypedUpdateEvent[*kueue.WorkloadPriorityClass]) bool {
-	log := r.log.WithValues("workloadPriorityClass", klog.KObj(e.ObjectNew))
+	log := r.logger().WithValues("workloadPriorityClass", klog.KObj(e.ObjectNew))
 	log.V(2).Info("WorkloadPriorityClass update event")
 
 	// Only reconcile if the priority value changed


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Event handler logs showed stale "follower" role because loggers were stored at initialization (before leader election). This PR replaces stored loggers with a `logger()` factory method that evaluates the role at log time.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8713 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```