### PR TITLE
KEP-2941: Add extended resources design for DRA integration

### DIFF
--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -1,4 +1,4 @@
-# KEP-2941: Structured Parameters
+# KEP-2941: DRA Support in Kueue
 
 <!--
 This is the title of your KEP. Keep it short, simple, and descriptive. A good
@@ -32,6 +32,7 @@ tags, and then generate with `hack/update-toc.sh`.
     - [Story 1](#story-1)
     - [Story 2](#story-2)
     - [Story 3](#story-3)
+    - [Story 4](#story-4)
   - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
@@ -42,6 +43,14 @@ tags, and then generate with `hack/update-toc.sh`.
   - [Workloads](#workloads)
     - [DRA-Specific Workload Processing](#dra-specific-workload-processing)
     - [Workload Processing Flow](#workload-processing-flow)
+  - [Extended Resources](#extended-resources)
+    - [Configuration](#configuration)
+    - [Path Separation](#path-separation)
+    - [Processing Flow](#processing-flow)
+    - [Same Hardware with Both Paths](#same-hardware-with-both-paths)
+    - [DeviceClass Resolution via Field Indexer](#deviceclass-resolution-via-field-indexer)
+    - [DeviceClass Lifecycle Scenarios](#deviceclass-lifecycle-scenarios)
+    - [Late DeviceClass Creation](#late-deviceclass-creation)
   - [Architecture Details](#architecture-details)
     - [Queue Manager Extensions](#queue-manager-extensions)
   - [MultiKueue Integration](#multikueue-integration)
@@ -57,6 +66,7 @@ tags, and then generate with `hack/update-toc.sh`.
 - [Implementation History](#implementation-history)
 - [Drawbacks](#drawbacks)
 - [Alternatives](#alternatives)
+  - [Webhook Rewriting Extended Resources to ResourceClaimTemplates](#webhook-rewriting-extended-resources-to-resourceclaimtemplates)
   - [ResourceClaim By Count](#resourceclaim-by-count)
   - [Using devices in ResourceSlice to Count](#using-devices-in-resourceslice-to-count)
   - [Using a CEL expression](#using-a-cel-expression)
@@ -69,6 +79,10 @@ tags, and then generate with `hack/update-toc.sh`.
 
 [Dynamic Resource Allocation (DRA)](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/)
 is a major effort to improve device support in Kubernetes. It changes how one can request resources in a myriad of ways.
+
+This KEP supports two approaches for DRA integration with Kueue:
+1. **ResourceClaimTemplates**: Pods explicitly reference ResourceClaimTemplates that specify device requests.
+2. **Extended Resources**: Pods request DRA devices via standard `resources.requests` (e.g., `example.com/gpu: 1`), and kube-scheduler automatically creates ResourceClaims when the DeviceClass has an `extendedResourceName` field set.
 
 ## Motivation
 
@@ -106,7 +120,7 @@ An example workload that uses DRA:
 ```yaml
 ---
 
-apiVersion: resource.k8s.io/v1alpha3
+apiVersion: resource.k8s.io/v1
 kind: ResourceClaimTemplate
 metadata:
   namespace: gpu-test1
@@ -116,7 +130,8 @@ spec:
     devices:
       requests:
       - name: gpu
-        deviceClassName: gpu.example.com
+        exactly:
+          deviceClassName: gpu.example.com
 ---
 apiVersion: batch/v1
 kind: Job
@@ -163,17 +178,19 @@ a simple device class named `gpu.example.com`. This will be the way to enforce q
 
 ### Goals
 
-- Users can submit workloads using resource claims and Kueue can monitor the usage.
+- Users can submit workloads using ResourceClaimTemplates and Kueue can monitor the usage.
+- Users can submit workloads using extended resource requests (e.g., `example.com/gpu: 1`) and
+  Kueue can account for quota when the DeviceClass has `extendedResourceName` set.
 - Admins can enforce the quota for number of devices for a given DeviceClass.
-
 
 ### Non-Goals
 
-- We are limiting scope for DRA to structured parameters (beta in 1.32 and 1.33)
-    - Support for alpha features like DRADeviceTaints, DRAAdminAccess, DRAPrioritizedLists and DRAPartitionableDevices
-      will not be included.
-- This design does not work with Topology Aware Scheduling feature of Kueue. It is a significant amount of work, will be
-  addressed in the future with a separate body of work
+- Quota-aware handling of DRAAdminAccess and DRAPrioritizedLists (beta, default enabled in K8s 1.35)
+  is not included in Kueue's alpha. See [Risks and Mitigations](#risks-and-mitigations) for the
+  planned approach.
+- Support for alpha DRA features like DRADeviceTaints and DRAPartitionableDevices will not be included.
+- This design does not work with Topology Aware Scheduling feature of Kueue. It is a significant
+  amount of work, will be addressed in the future with a separate body of work.
 
 ## Proposal
 
@@ -183,9 +200,11 @@ scheduling. This includes:
 1. Extending the existing Kueue Configuration API with `DeviceClassMappings` to map device classes to logical resource
    names
 2. Supporting workloads that use ResourceClaimTemplates (ResourceClaims are not supported in alpha)
-3. Allowing admins to define quota for DRA resources in ClusterQueues using the logical resource names from device class
+3. Supporting workloads that use extended resource requests backed by DRA DeviceClasses with
+   `extendedResourceName` set (requires Kubernetes `DRAExtendedResource` feature gate, alpha in k8s 1.35)
+4. Allowing admins to define quota for DRA resources in ClusterQueues using the logical resource names from device class
    mappings
-4. Implementing validation to prevent device class conflicts and ensure predictable quota behavior
+5. Implementing validation to prevent device class conflicts and ensure predictable quota behavior
 
 More details are documented in [Design Details](#design-details)
 
@@ -205,6 +224,12 @@ queuing, quota management and preemptable workloads for cluster users.
 As a cluster administrator, I want clear validation feedback when I misconfigure device class mappings so I can quickly
 identify and fix configuration conflicts before they affect workload scheduling.
 
+#### Story 4
+
+As a Kueue user, I want to request DRA devices using standard resource requests (e.g., `resources.requests: {"example.com/gpu": 1}`)
+instead of ResourceClaimTemplates, so my existing workloads can benefit from DRA without modification when the cluster
+administrator configures DeviceClasses with `extendedResourceName`.
+
 ### Notes/Constraints/Caveats (Optional)
 
 - The `ResourceClaims` and `ResourceClaimTemplates` APIs for DRA in k8s are immutable.
@@ -213,13 +238,38 @@ identify and fix configuration conflicts before they affect workload scheduling.
 - Device class uniqueness is enforced - each device class can only map to one resource name to prevent quota ambiguity.
 - Configuration-based approach - device class mappings are configured through the Kueue Configuration API
 - This design does not work with Kueue's Topology Aware Scheduling feature and will be addressed in future work.
-- This implementation focuses on structured parameters (GA in 1.34) and does not support alpha DRA features
-  like DRADeviceTaints, DRAAdminAccess, DRAPrioritizedLists, and DRAPartitionableDevices.
+- Quota-aware handling of DRAAdminAccess and DRAPrioritizedLists (beta in K8s 1.35) is deferred
+  to beta graduation. Alpha DRA features like DRADeviceTaints and DRAPartitionableDevices are
+  not supported.
+- **Extended Resources** requires DeviceClasses to have `spec.extendedResourceName` set.
+  This depends on the Kubernetes `DRAExtendedResource` feature gate (alpha in k8s 1.35).
+  When enabled, kube-scheduler automatically creates ResourceClaims for pods requesting extended resources.
+  Extended resources support in Kueue is gated behind the `DRAExtendedResources` feature gate.
+- **GPU time-slicing and MPS via extended resources are not supported in Alpha.**
+  Time-slicing and MPS sharing modes require opaque parameters on the DeviceClass
+  (e.g., `GpuConfig` with `sharing.strategy: TimeSlicing`). When kube-scheduler creates
+  ResourceClaims from extended resource requests, correct quota accounting for shared
+  devices requires [consumable capacity](https://github.com/kubernetes/enhancements/issues/5075)
+  integration with both the DRA driver and Kueue. MPS additionally requires
+  [KEP-5691 (Restricted Sharing)](https://github.com/kubernetes/enhancements/issues/5691)
+  to restrict sharing to the same namespace. These will be evaluated for Beta once the
+  upstream dependencies are available.
+  With structured parameters, GPU sharing is supported via ResourceClaimTemplates where
+  containers within the same pod share a GPU. Cross-pod sharing via direct ResourceClaims
+  is not supported.
+
+- **Kueue does not validate DeviceClass existence at config load time.** Admins should
+  create DeviceClasses before submitting workloads but strict ordering is not enforced.
+
+- **When a DeviceClass is referenced by both `deviceClassMappings` and has an
+  `extendedResourceName`, Kueue unifies quota** using the `deviceClassMappings` logical
+  name as the quota key for both paths, preventing over-allocation.
 
 ### Risks and Mitigations
 
-With newer DRA features like DRAAdminAccess and DRAPrioritizedLists, there is a risk that
-effective tallying of resources will not be available until after allocation of these resources by kube-scheduler.
+With DRAAdminAccess and DRAPrioritizedLists (both beta, default enabled in K8s 1.35), there is a
+risk that effective tallying of resources will not be available until after allocation of these
+resources by kube-scheduler.
 
 In order to mitigate this risk, Kueue can take the following approach:
 1. For DRAPrioritizedLists: all the mentioned device classes in the request will be counted against the quota
@@ -230,12 +280,38 @@ In order to mitigate this risk, Kueue can take the following approach:
    devices in admin namespace if counted against quota, will eat up quota meant for user workloads.
 3. For ResourceClaims with allocation mode `All`: worst-case scenario of the max number of devices that could be
    allocated to a single claim will be used against quota.
-
+4. For Extended Resources: if a DeviceClass is created or updated between Kueue admitting a
+   workload and kube-scheduler scheduling it, the two components may pick different DeviceClasses
+   for the same `extendedResourceName` (a TOCTOU gap). This can happen during valid operational
+   scenarios. KEP-5004 documents a transition pattern where two DeviceClasses temporarily
+   coexist (create new class, then clear old mapping), and the scheduler picks the newer one.
+   There are two failure modes:
+   - **Scheduling failure**: the scheduler cannot allocate devices. `waitForPodsReady` catches
+     this by timing out the Pending pod and evicting/re-queuing the workload.
+     Users deploying DRA with Kueue should enable `waitForPodsReady`.
+   - **Quota drift**: the scheduler allocates from a different DeviceClass than Kueue charged
+     quota against, but the pod runs successfully. `waitForPodsReady` does not catch this.
+     Since the extended resources path uses `extendedResourceName` directly as the quota key,
+     quota accounting remains correct at the resource name level, though not at the physical
+     DeviceClass level.
+   To mitigate:
+   - Kueue uses a controller-runtime field indexer on `DeviceClass` by `spec.extendedResourceName`
+     to resolve DeviceClasses deterministically.
+   - Per KEP-5004, admins should ensure one `extendedResourceName` maps to at most one
+     DeviceClass.
+   - Post-scheduling quota reconciliation will be evaluated for Beta.
+   - TAS + DRA is the longer-term path to closing this admission-scheduling gap.
 
 ## Design Details
 
-A new feature gate DynamicResourceAllocation will be introduced, allowing users to test it in dev environments while
-making the changes dormant for production users. The following sections will explain the design in detail.
+Two feature gates control DRA support in Kueue:
+- `DynamicResourceAllocation`: gates ResourceClaimTemplate-based DRA quota accounting.
+  Uses `deviceClassMappings` for DeviceClass-to-quota-resource mapping.
+- `DRAExtendedResources`: gates extended resources support, including DeviceClass
+  auto-discovery via `extendedResourceName`. Does not use `deviceClassMappings`.
+  Requires `DynamicResourceAllocation` to also be enabled.
+
+The following sections will explain the design in detail.
 
 ### Configuration API Extension for DRA
 
@@ -361,7 +437,7 @@ data:
       - name: fast-gpus
         deviceClassNames:
         - gpus.example.com          # ERROR: Duplicate device class name
-``
+```
 
 Example of valid configuration:
 ```yaml
@@ -405,11 +481,15 @@ rules:
 - apiGroups: ["resource.k8s.io"]
   resources: ["resourceclaimtemplates"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["resource.k8s.io"]
+  resources: ["deviceclasses"]
+  verbs: ["get", "list", "watch"]
 ```
 
 **Required Permissions:**
 - `resourceclaims`: Read access to validate ResourceClaim references (though not supported for quota)
 - `resourceclaimtemplates`: Read access to process ResourceClaimTemplates and extract device class information
+- `deviceclasses`: Read access to look up `extendedResourceName` for Extended Resources
 
 **Security Considerations:**
 - Kueue only requires read permissions - no create, update, or delete access to DRA resources
@@ -457,6 +537,12 @@ When a user submits a workload and DynamicResourceAllocation feature gate is ena
 6. Queue Admission: Add the workload to the queue with preprocessed DRA resources.
 7. Status Update: Once admitted, the workload status reflects the assigned flavors and resource usage including DRA resources.
 
+Note: The flow above applies to the ResourceClaimTemplate path (`DynamicResourceAllocation` gate).
+When the `DRAExtendedResources` gate is also enabled, workloads with extended resources in
+`resources.requests` follow a separate resolution path through the ExtendedResourceCache.
+See [Extended Resources](#extended-resources) for details. Both paths can be active simultaneously
+for workloads that use both ResourceClaimTemplates and extended resources.
+
 The steps above are reflected in the complete configuration and workload example below:
 
 ```yaml
@@ -496,7 +582,7 @@ spec:
         nominalQuota: 2
 ---
 # Step 3: Create ResourceClaimTemplate (only templates are supported)
-apiVersion: resource.k8s.io/v1alpha3
+apiVersion: resource.k8s.io/v1
 kind: ResourceClaimTemplate
 metadata:
   namespace: gpu-test1
@@ -506,7 +592,8 @@ spec:
     devices:
       requests:
       - name: gpu
-        deviceClassName: gpu.example.com # Device class from the mapping
+        exactly:
+          deviceClassName: gpu.example.com # Device class from the mapping
 ---
 # Step 4: Submit workload using ResourceClaimTemplate
 apiVersion: batch/v1
@@ -559,6 +646,160 @@ status:
         whole-gpus: "1" # DRA device count reflected in status
 ```
 
+### Extended Resources
+
+This section is gated behind the `DRAExtendedResources` Kueue feature gate.
+
+Kueue also supports workloads requesting DRA devices via `resources.requests` (e.g., `example.com/gpu: 1`).
+When a DeviceClass has `spec.extendedResourceName` set, kube-scheduler automatically creates ResourceClaims.
+This requires the Kubernetes `DRAExtendedResource` feature gate (alpha in k8s 1.35).
+
+An extended resource can be identified by verifying that qualified resource names containing `/` are not in the `kubernetes.io/` or `requests.` namespaces and are not standard resources like `cpu`, `memory`, `ephemeral-storage`, or `hugepages-*`.
+
+#### Configuration
+
+The extended resources path does not require `deviceClassMappings`. Kueue auto-discovers
+DeviceClasses via a field indexer on `spec.extendedResourceName` and uses the
+`extendedResourceName` directly as the quota key in ClusterQueue.
+
+DeviceClass with `extendedResourceName` (DeviceClass API is v1/GA, but the `extendedResourceName`
+field requires the Kubernetes `DRAExtendedResource` feature gate):
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: gpu.example.com
+spec:
+  extendedResourceName: example.com/gpu
+```
+
+ClusterQueue uses the `extendedResourceName` directly as the quota resource:
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: gpu-queue
+spec:
+  resourceGroups:
+  - coveredResources: ["example.com/gpu"]
+    flavors:
+    - name: default
+      resources:
+      - name: example.com/gpu
+        nominalQuota: 8
+```
+
+No Kueue configuration changes are needed. No `deviceClassMappings` entry is required for
+extended resources. This is a clean separation from the ResourceClaimTemplate path, which
+continues to use `deviceClassMappings`.
+
+#### Path Separation
+
+The two DRA paths have independent quota resolution:
+1. **Extended resources** (`DRAExtendedResources` gate): auto-discovers DeviceClass via
+   field indexer, uses `extendedResourceName` as quota key. No `deviceClassMappings` needed.
+2. **ResourceClaimTemplates** (`DynamicResourceAllocation` gate): uses `deviceClassMappings`
+   to map DeviceClass names to logical resource names. No auto-discovery.
+
+There is no precedence or fallback between the two paths. Each path has exactly one resolution
+mechanism.
+
+#### Processing Flow
+
+1. Kueue detects extended resources in `resources.requests`
+2. Looks up DeviceClass by `extendedResourceName` by field indexer
+3. If no matching DeviceClass is found, the resource is not DRA-backed and Kueue
+   processes it through the standard resource quota path (counted via `node.Status.Allocatable`)
+4. If a matching DeviceClass is found, uses the `extendedResourceName` as the quota key
+5. Removes original extended resource from the workload's effective resource requests
+   (tracked internally per PodSet) to avoid double-counting
+6. Admits workload against the quota for the `extendedResourceName`
+
+The extended resource translation reads directly from the workload spec before
+`excludeResourcePrefixes` filtering is applied. The processing order:
+1. Extended resource translation runs first, reading the original spec
+2. `excludeResourcePrefixes` filters the pod's `resources.requests`
+3. Original extended resource is removed from the workload's effective resource requests
+4. Translated resource is added through `preprocessedDRAResources`
+
+This ensures no overlap or double-counting between the two mechanisms.
+
+#### Same Hardware with Both Paths
+
+When the same hardware needs to serve both ResourceClaimTemplate users and extended resource
+users, admins configure separate flavors under the same ClusterQueue. Assuming a cluster
+with 1 node and 8 GPU devices available:
+
+```yaml
+# DeviceClass
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: gpu.example.com
+spec:
+  extendedResourceName: example.com/gpu
+---
+# Kueue config: deviceClassMappings only needed for ResourceClaimTemplate path
+apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+resources:
+  deviceClassMappings:
+  - name: gpu-claims
+    deviceClassNames:
+    - gpu.example.com
+---
+# ClusterQueue with quota for both paths
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: gpu-queue
+spec:
+  resourceGroups:
+  - coveredResources: ["example.com/gpu", "gpu-claims"]
+    flavors:
+    - name: default
+      resources:
+      - name: example.com/gpu    # for extended resource users
+        nominalQuota: 4
+      - name: gpu-claims          # for ResourceClaimTemplate users
+        nominalQuota: 4
+```
+
+Both quota buckets draw from the same physical hardware. The admin controls how capacity is
+split between the two user populations. Since these are different resource names, the split
+is fixed at configuration time.
+
+#### DeviceClass Resolution via Field Indexer
+
+Kueue resolves `extendedResourceName` to DeviceClasses using a controller-runtime field indexer
+on `DeviceClass` by `spec.extendedResourceName`. This provides fast lookups without adding
+dependencies on non-staging k8s repos.
+
+Even when multiple DeviceClasses share the same `extendedResourceName` (which K8s
+[permits with deterministic tiebreaking](https://github.com/kubernetes/kubernetes/blob/v1.35.0/staging/src/k8s.io/api/resource/v1/types.go#L1816-L1820)),
+Kueue still treats the resource as DRA-backed. The quota key is the `extendedResourceName`
+itself, not the DeviceClass name, so multiple matching DeviceClasses do not affect quota accounting.
+
+#### DeviceClass Lifecycle Scenarios
+
+1. Two DeviceClasses with the same `extendedResourceName`: per KEP-5004, admins should ensure
+   one `extendedResourceName` maps to at most one DeviceClass.
+
+2. New DeviceClass created after Kueue admits a workload: a TOCTOU gap exists where Kueue
+   and the scheduler may resolve differently. `waitForPodsReady` handles scheduling failures.
+   See [Risks and Mitigations](#risks-and-mitigations) for the full breakdown.
+
+3. DeviceClass `extendedResourceName` updated: the field indexer reflects the updated mapping
+   on the next reconciliation cycle. The same TOCTOU considerations as scenario 2 apply.
+
+#### Late DeviceClass Creation
+
+For Alpha, if a DeviceClass does not exist when a workload is created, the extended resource
+is treated as a normal (non-DRA) extended resource. A subsequent reconciliation cycle
+(e.g., triggered by other workload or queue events) re-evaluates the workload after the
+DeviceClass is created. Event-driven re-reconciliation on DeviceClass creation will be
+evaluated as a Beta graduation criterion.
+
 ### Architecture Details
 
 #### Queue Manager Extensions
@@ -571,7 +812,10 @@ func (m *Manager) AddOrUpdateWorkload(wl *kueue.Workload, opts ...workload.InfoO
 func (m *Manager) UpdateWorkload(oldWl, newWl *kueue.Workload, opts ...workload.InfoOption) error
 
 // DRA-specific InfoOption
-func WithPreprocessedDRAResources(resources map[kueue.PodSetReference]corev1.ResourceList) workload.InfoOption
+func WithPreprocessedDRAResources(
+	draResources map[kueue.PodSetReference]corev1.ResourceList,
+	replacedExtendedResources map[kueue.PodSetReference]sets.Set[corev1.ResourceName],
+) workload.InfoOption
 ```
 
 Processing Flow:
@@ -621,6 +865,7 @@ extending the production code to implement this enhancement.
 - pkg/config/validation.go: 09/17/2025 - 97.3%
 - pkg/controller/core/workload_controller.go: 09/17/2025 - 55.8%
 - pkg/dra/claims.go: 09/17/2025 - 83.3%
+- pkg/dra/extended_resources.go: TODO (pkg/dra overall: 89.6%)
 - pkg/workload/workload.go: 09/17/2025 - 72.3%
 
 #### Integration tests
@@ -643,6 +888,8 @@ using mock ResourceClaimTemplates and DeviceClasses to simulate DRA workloads. K
 - Workload inadmissibility: Testing various error conditions and proper WorkloadInadmissible condition setting
 - Resource preprocessing: Verifying correct device count calculation from ResourceClaimTemplates
 - Queue integration: Testing workload admission with preprocessed DRA resources
+- Extended Resources: Testing extended resource detection, DeviceClass lookup, and resource translation
+- Late DeviceClass creation: Testing workload inadmissibility when DeviceClass does not exist
 
 #### E2E Test
 
@@ -653,16 +900,19 @@ Use existing dra-example-driver or Kubernetes test driver for e2e testing.
 #### Alpha
 
 - the implementation behind the feature gate flag in alpha
-- support Beta API of the core k8s
+- support v1 API of DRA in core k8s
 - initial e2e tests for baseline scenario
+- support for Extended Resources (alpha in k8s 1.35)
 
 #### Beta
 
 - the feature gate in Beta
 - all known bugs are fixed
-- support integration with v1 API of DRA in core k8s
 - support integration with MultiKueue
 - e2e tests
+- TAS + DRA testing and support as a graduation requirement
+- re-evaluate event-driven DeviceClass tracking for late DeviceClass creation
+- re-evaluate post-scheduling quota reconciliation for DeviceClass drift
 - re-evaluate the support for TopologyAwareScheduling (might be moved to GA)
 
 #### GA
@@ -677,12 +927,15 @@ Use existing dra-example-driver or Kubernetes test driver for e2e testing.
 - Design evolution from standalone CRD to Configuration API approach: October 2024
 - Alpha implementation completed: December 2024
 - KEP updated to reflect actual implementation: September 2025 by @alaypatel07
+- Extended Resources implementation: January 2026
 
 **Key Design Evolution:**
 - **Original Design**: Standalone DynamicResourceAllocationConfig CRD with runtime ambiguity resolution
 - **Final Implementation**: Configuration API extension with strict validation and conflict prevention
 - **Architecture Decision**: DRA processing moved to Reconcile loop for proper error handling
 - **Scope Refinement**: ResourceClaims support removed, focus on ResourceClaimTemplates only
+- **Extended Resources**: Added support for workloads requesting DRA devices via `resources.requests`
+  using DeviceClass `extendedResourceName` field (alpha in k8s 1.35)
 
 ## Drawbacks
 
@@ -693,6 +946,27 @@ Use existing dra-example-driver or Kubernetes test driver for e2e testing.
 **Limited Dynamic Reconfiguration**: Unlike some other Kueue features, DRA configuration cannot be changed dynamically and requires controller restart.
 
 ## Alternatives
+
+### Webhook Rewriting Extended Resources to ResourceClaimTemplates
+
+For extended resources support, an alternative approach was considered: use Kueue's existing
+mutating webhook to rewrite extended resource requests (e.g., `example.com/gpu: 1`) into
+ResourceClaimTemplate references at admission time. This would eliminate the need for a
+separate DeviceClass resolution path in Kueue, since the existing ResourceClaimTemplate
+processing would handle quota accounting.
+
+This approach was rejected for several reasons:
+1. Creating a ResourceClaimTemplate from a webhook is a side effect, violating the
+   `sideEffects: None` declaration on Kueue webhooks.
+2. Late DeviceClass creation cannot be handled. If the DeviceClass does not exist when the
+   webhook fires, the webhook must either reject the workload (creating an ordering
+   dependency on admin configuration) or pass it through unchanged (requiring a controller
+   fallback that duplicates the logic).
+3. Webhook ordering and reinvocation issues with external frameworks that modify pod specs
+   after Kueue's webhook runs.
+4. DRA processing in Kueue follows the pattern of handling logic in the Reconcile loop
+   rather than event handlers or webhooks, enabling proper error handling and retry.
+5. It goes against the architectural direction of reducing webhook surface area in Kueue.
 
 ### ResourceClaim By Count
 
@@ -725,12 +999,14 @@ users who have resourceclaims with the deviceclass and selector like this:
 kind: ResourceClaim
 name: one-large-gpu
 spec:
-requests:
-- name: gpu-large
-  deviceClassName: gpu.example.com
-  selectors:
-    - cel:
-      expression: device.attributes["memory"] >= 80g
+  devices:
+    requests:
+    - name: gpu-large
+      exactly:
+        deviceClassName: gpu.example.com
+        selectors:
+        - cel:
+            expression: device.attributes["memory"] >= 80g
 ```
 
 Now, if Kueue admin wants to set quota for gpu.example.com devices with device.attribute["memory"]>=80g, Kueue admin
@@ -776,12 +1052,14 @@ the allocation result).
 kind: ResourceClaim
 name: one-mid-or-large-gpu
 spec:
-  requests:
-  - name: middle-or-large-gpu
-    deviceClassName: gpu.example.com
-    selectors:
-    - cel:
-        expression: 50g < device.attributes["memory"] and device.attributes["memory"] <= 100g
+  devices:
+    requests:
+    - name: middle-or-large-gpu
+      exactly:
+        deviceClassName: gpu.example.com
+        selectors:
+        - cel:
+            expression: 50g < device.attributes["memory"] and device.attributes["memory"] <= 100g
 ---
 kind: Device
 devices:

--- a/keps/2941-DRA/kep.yaml
+++ b/keps/2941-DRA/kep.yaml
@@ -2,7 +2,8 @@ title: DRA Support in Kueue
 kep-number: 2941
 authors:
   - "@alaypatel07"
-status: provisional
+  - "@sohankunkerkar"
+status: implementable
 creation-date: 2025-05-02
 reviewers:
   - "@kannon92"
@@ -13,6 +14,7 @@ approvers:
 
 see-also:
   - "https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/4381-dra-structured-parameters/README.md"
+  - "https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5004-dra-extended-resource"
 replaces:
   - "https://github.com/kubernetes-sigs/kueue/pull/3071"
 
@@ -22,7 +24,7 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.13"
+latest-milestone: "v0.17"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
@@ -34,6 +36,7 @@ milestone:
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
   - name: DynamicResourceAllocation
+  - name: DRAExtendedResources
 disable-supported: true
 
 # The following PRR answers are required at beta release


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of  https://github.com/kubernetes-sigs/kueue/issues/9868

#### Special notes for your reviewer:

Please review https://github.com/kubernetes-sigs/kueue/pull/8597 for implementation.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```