### PR TITLE
[WIP] Handle `--kubeconfig` flag in visibility server

### DIFF
--- a/pkg/visibility/server.go
+++ b/pkg/visibility/server.go
@@ -18,10 +18,12 @@ package visibility
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"net"
 	"strings"
 
+	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -112,6 +114,13 @@ func applyVisibilityServerOptions(config *genericapiserver.RecommendedConfig, en
 	o.Admission.DisablePlugins = disabledPlugins
 	if err := o.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
 		return fmt.Errorf("error creating self-signed certificates: %v", err)
+	}
+	o.AddFlags(pflag.CommandLine)
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
+	if kubeconfigPath := o.CoreAPI.CoreAPIKubeconfigPath; kubeconfigPath != "" {
+		o.Authentication.RemoteKubeConfigFile = kubeconfigPath
+		o.Authorization.RemoteKubeConfigFile = kubeconfigPath
 	}
 	return o.ApplyTo(config)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

It makes the `--kubeconfig` flag, when passed into the Kueue manager binary, respected by the visibility server.

This addresses at least a part of #8606.
(I'm not sure at this point if there's more to do for that bug).

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
OnDemandVisibility: Fix the bug that when running Kueue with the custom `--kubeconfig` flag the visibility server
fails to initialize, because the custom value of the flag is not propagated to it, leading to errors such as:
"Unable to create and start visibility server","error":"unable to apply VisibilityServerOptions: failed to get delegated authentication kubeconfig:  failed to get delegated authentication kubeconfig: ..."
```