### PR TITLE
Add WorkloadSliceNameAnnotation and refactor pod ungating 

### DIFF
--- a/apis/kueue/v1beta1/topology_types.go
+++ b/apis/kueue/v1beta1/topology_types.go
@@ -90,6 +90,12 @@ const (
 	// PodSetGroupName is an annotation indicating the name of the group of PodSets. PodSet Group
 	// is a unit flavor assignment and topology domain fitting.
 	PodSetGroupName = "kueue.x-k8s.io/podset-group-name"
+
+	// WorkloadSliceNameAnnotation identifies the original workload name in a slice chain.
+	// It is set on every Workload created in the chain of the workloads, as well as on the Pods
+	// associated with that Workload.
+	// This annotation is alpha-level for the ElasticJobsViaWorkloadSlices feature gate.
+	WorkloadSliceNameAnnotation = "kueue.x-k8s.io/workload-slice-name"
 )
 
 // TopologySpec defines the desired state of Topology

--- a/apis/kueue/v1beta2/topology_types.go
+++ b/apis/kueue/v1beta2/topology_types.go
@@ -95,6 +95,12 @@ const (
 	// PodSetGroupName is an annotation indicating the name of the group of PodSets. PodSet Group
 	// is a unit flavor assignment and topology domain fitting.
 	PodSetGroupName = "kueue.x-k8s.io/podset-group-name"
+
+	// WorkloadSliceNameAnnotation identifies the original workload name in a slice chain.
+	// It is set on every Workload created in the chain of the workloads, as well as on the Pods
+	// associated with that Workload.
+	// This annotation is alpha-level for the ElasticJobsViaWorkloadSlices feature gate.
+	WorkloadSliceNameAnnotation = "kueue.x-k8s.io/workload-slice-name"
 )
 
 // TopologySpec defines the desired state of Topology

--- a/pkg/controller/core/indexer/indexer.go
+++ b/pkg/controller/core/indexer/indexer.go
@@ -42,6 +42,9 @@ const (
 	OwnerReferenceUID          = "metadata.ownerReferences.uid"
 	WorkloadAdmissionCheckKey  = "status.admissionChecks"
 	WorkloadPriorityClassKey   = "spec.priorityClassRef"
+	// WorkloadSliceNameKey is an index for pods by their workload slice name annotation.
+	// Used to find pods belonging to an elastic workload slice chain.
+	WorkloadSliceNameKey = "metadata.workloadSliceName"
 
 	// OwnerReferenceGroupKindFmt defines the format string used to construct a field path
 	// for indexing or matching against a specific owner Group and Kind in a Kubernetes object's metadata.
@@ -168,6 +171,19 @@ func IndexOwnerUID(obj client.Object) []string {
 	return slices.Map(obj.GetOwnerReferences(), func(o *metav1.OwnerReference) string { return string(o.UID) })
 }
 
+// IndexPodWorkloadSliceName indexes pods by their workload slice name annotation.
+func IndexPodWorkloadSliceName(obj client.Object) []string {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+	value, found := pod.Annotations[kueue.WorkloadSliceNameAnnotation]
+	if !found {
+		return nil
+	}
+	return []string{value}
+}
+
 func IndexWorkloadAdmissionCheck(obj client.Object) []string {
 	wl, ok := obj.(*kueue.Workload)
 	if !ok || len(wl.Status.AdmissionChecks) == 0 {
@@ -219,11 +235,15 @@ func Setup(ctx context.Context, indexer client.FieldIndexer) error {
 	if err := indexer.IndexField(ctx, &kueue.Workload{}, OwnerReferenceUID, IndexOwnerUID); err != nil {
 		return fmt.Errorf("setting index on ownerReferences.uid for Workload: %w", err)
 	}
-	// Add pod index to be able to list pods for elastic-jobs, needed to remove scheduling gate on
-	// admitted workload slices.
+	// Add pod indexes to be able to list pods for elastic-jobs, needed to remove scheduling gate on
+	// admitted workload slices. Uses workload slice name annotation to support JobSet and other
+	// workloads where pods are not immediate children of the job.
 	if features.Enabled(features.ElasticJobsViaWorkloadSlices) {
+		if err := indexer.IndexField(ctx, &corev1.Pod{}, WorkloadSliceNameKey, IndexPodWorkloadSliceName); err != nil {
+			return fmt.Errorf("setting index on workloadSliceName for Pod: %w", err)
+		}
 		if err := indexer.IndexField(ctx, &corev1.Pod{}, OwnerReferenceUID, IndexOwnerUID); err != nil {
-			return err
+			return fmt.Errorf("setting index on ownerReferences.uid for Pod: %w", err)
 		}
 	}
 	return nil

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -652,7 +652,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 	if WorkloadSliceEnabled(job) {
 		// Start workload-slice schedule-gated pods (if any).
 		log.V(3).Info("Job running with admitted workload slice, start pods.")
-		return ctrl.Result{}, workloadslicing.StartWorkloadSlicePods(ctx, r.client, object)
+		return ctrl.Result{}, workloadslicing.StartWorkloadSlicePods(ctx, r.client, wl)
 	}
 
 	// workload is admitted and job is running, nothing to do.
@@ -1308,15 +1308,18 @@ func prepareWorkloadSlice(ctx context.Context, clnt client.Client, job GenericJo
 
 	switch len(workloadSlices) {
 	case 0:
-		// No active workloads found for this job - noop.
+		// First workload - set origin name to itself.
+		metav1.SetMetaDataAnnotation(&wl.ObjectMeta, kueue.WorkloadSliceNameAnnotation, wl.Name)
 		return nil
 	case 1:
-		// One active workload found for this job - typically, we are in a scale-up event, where previous
-		// workload is the "old" slice.
+		// Scale-up event - link to old slice and carry origin name.
 		oldSlice := workloadSlices[0]
-		// Annotate new workload slice with the preemptible (old) workload slice.
 		metav1.SetMetaDataAnnotation(&wl.ObjectMeta, workloadslicing.WorkloadSliceReplacementFor, string(workload.Key(&oldSlice)))
-
+		originName := oldSlice.Annotations[kueue.WorkloadSliceNameAnnotation]
+		if originName == "" {
+			originName = oldSlice.Name
+		}
+		metav1.SetMetaDataAnnotation(&wl.ObjectMeta, kueue.WorkloadSliceNameAnnotation, originName)
 		return nil
 	default:
 		// Any other slices length is invalid. I.E, we expect to have at most 1 "current/old" workload slice.
@@ -1397,6 +1400,12 @@ func getPodSetsInfoFromStatus(ctx context.Context, c client.Client, w *kueue.Wor
 		}
 		if features.Enabled(features.TopologyAwareScheduling) {
 			info.Annotations[kueue.WorkloadAnnotation] = w.Name
+		}
+		// Set workload slice name annotation on pods for elastic workloads.
+		// This enables pod lookup by annotation instead of owner reference,
+		// supporting JobSet and other workloads where pods are not immediate children.
+		if features.Enabled(features.ElasticJobsViaWorkloadSlices) {
+			info.Annotations[kueue.WorkloadSliceNameAnnotation] = workloadslicing.SliceName(w)
 		}
 
 		info.Labels[constants.PodSetLabel] = string(psAssignment.Name)

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -130,7 +130,10 @@ func TestReconcileGenericJob(t *testing.T) {
 			podSets: basePodSets,
 			wantWorkloads: []kueue.Workload{
 				*baseWl.Clone().Name("job-test-job-3991b").
-					Annotations(map[string]string{workloadslicing.EnabledAnnotationKey: workloadslicing.EnabledAnnotationValue}).
+					Annotations(map[string]string{
+						workloadslicing.EnabledAnnotationKey: workloadslicing.EnabledAnnotationValue,
+						kueue.WorkloadSliceNameAnnotation:    "job-test-job-3991b",
+					}).
 					Obj(),
 			},
 		},

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -92,6 +92,17 @@ func ReplacementForKey(wl *kueue.Workload) *workload.Reference {
 	return &ref
 }
 
+// SliceName returns the workload slice name for the given workload.
+// This is the original workload name in the slice chain, used to identify pods
+// across workload slice replacements. If the workload has the WorkloadSliceNameAnnotation,
+// that value is returned; otherwise the workload's own name is returned.
+func SliceName(wl *kueue.Workload) string {
+	if sliceName, found := wl.Annotations[kueue.WorkloadSliceNameAnnotation]; found {
+		return sliceName
+	}
+	return wl.Name
+}
+
 // FindNotFinishedWorkloads returns a sorted list of workloads "owned by" the provided job object/gvk combination and
 // without "Finished" condition with status = "True".
 func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject client.Object, jobObjectGVK schema.GroupVersionKind) ([]kueue.Workload, error) {
@@ -265,24 +276,40 @@ func EnsureWorkloadSlices(
 	}
 }
 
-// StartWorkloadSlicePods identifies pods associated with the provided parent object
+// StartWorkloadSlicePods identifies pods associated with the provided workload
 // that are gated by the ElasticJobSchedulingGate scheduling gate and removes this gate,
 // allowing them to be considered for scheduling.
 //
 // This function performs the following steps:
-// 1. Lists all pods in the same namespace with an OwnerReference UID matching the parent object.
-// 2. For each pod, removes the ElasticJobSchedulingGate scheduling gate if present.
+//  1. Lists all pods in the same namespace with the WorkloadSliceNameAnnotation matching
+//     the workload slice name, falling back to OwnerReference UID for backwards compatibility.
+//  2. For each pod, removes the ElasticJobSchedulingGate scheduling gate if present.
 //
 // Returns:
 // - An error if any of the operations fail; otherwise, nil.
-func StartWorkloadSlicePods(ctx context.Context, clnt client.Client, object client.Object) error {
+func StartWorkloadSlicePods(ctx context.Context, clnt client.Client, wl *kueue.Workload) error {
 	log := ctrl.LoggerFrom(ctx)
 	list := &corev1.PodList{}
-	if err := clnt.List(ctx, list, client.InNamespace(object.GetNamespace()), client.MatchingFields{indexer.OwnerReferenceUID: string(object.GetUID())}); err != nil {
-		return fmt.Errorf("failed to list job pods: %w", err)
+	sliceName := SliceName(wl)
+
+	// First try annotation-based lookup (supports JobSet and other workloads where pods
+	// are not immediate children of the job).
+	if err := clnt.List(ctx, list, client.InNamespace(wl.Namespace), client.MatchingFields{indexer.WorkloadSliceNameKey: sliceName}); err != nil {
+		return fmt.Errorf("failed to list workload slice pods: %w", err)
 	}
+
+	// Fallback to owner reference lookup for backwards compatibility with pods created
+	// before the annotation was introduced.
+	if len(list.Items) == 0 && len(wl.OwnerReferences) > 0 {
+		ownerUID := string(wl.OwnerReferences[0].UID)
+		log.V(4).Info("No pods found with annotation, falling back to owner reference lookup", "ownerUID", ownerUID)
+		if err := clnt.List(ctx, list, client.InNamespace(wl.Namespace), client.MatchingFields{indexer.OwnerReferenceUID: ownerUID}); err != nil {
+			return fmt.Errorf("failed to list job pods by owner reference: %w", err)
+		}
+	}
+
 	for i := range list.Items {
-		log.V(4).Info("Patching pod to remove elastic job scheduling gate", "podName", list.Items[i].Name)
+		log.V(4).Info("Patching pod to remove elastic job scheduling gate", "podName", list.Items[i].Name, "workloadSliceName", sliceName)
 		if err := clientutil.Patch(ctx, clnt, &list.Items[i], func() (bool, error) {
 			return pod.Ungate(&list.Items[i], kueue.ElasticJobSchedulingGate), nil
 		}); err != nil {

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -961,31 +961,36 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 func Test_StartWorkloadSlicePods(t *testing.T) {
 	clientBuilder := func() *fake.ClientBuilder {
 		return fake.NewClientBuilder().WithScheme(scheme.Scheme).
-			WithIndex(&corev1.Pod{}, indexer.OwnerReferenceUID, indexer.IndexOwnerUID)
+			WithIndex(&corev1.Pod{}, indexer.WorkloadSliceNameKey, indexer.IndexPodWorkloadSliceName)
 	}
-	testPod := func(name, resourceVersion string, owner client.Object, schedulingGates ...corev1.PodSchedulingGate) corev1.Pod {
+	testPod := func(name, resourceVersion, sliceName string, schedulingGates ...corev1.PodSchedulingGate) corev1.Pod {
 		return corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: name,
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: owner.GetObjectKind().GroupVersionKind().GroupVersion().String(),
-						Kind:       owner.GetObjectKind().GroupVersionKind().Kind,
-						Name:       owner.GetName(),
-						UID:        owner.GetUID(),
-					},
-				},
+				Name:            name,
+				Namespace:       "default",
 				ResourceVersion: resourceVersion,
+				Annotations: map[string]string{
+					kueue.WorkloadSliceNameAnnotation: sliceName,
+				},
 			},
 			Spec: corev1.PodSpec{
 				SchedulingGates: schedulingGates,
 			},
 		}
 	}
+	testWorkload := &kueue.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-workload",
+			Namespace: "default",
+			Annotations: map[string]string{
+				kueue.WorkloadSliceNameAnnotation: "test-slice",
+			},
+		},
+	}
 
 	type args struct {
-		clnt   client.Client
-		object client.Object
+		clnt client.Client
+		wl   *kueue.Workload
 	}
 	tests := map[string]struct {
 		args     args
@@ -999,14 +1004,14 @@ func Test_StartWorkloadSlicePods(t *testing.T) {
 						return errors.New("test-list-pods-error")
 					},
 				}).Build(),
-				object: testJobObject,
+				wl: testWorkload,
 			},
 			wantErr: true,
 		},
 		"NoPods": {
 			args: args{
-				clnt:   clientBuilder().Build(),
-				object: testJobObject,
+				clnt: clientBuilder().Build(),
+				wl:   testWorkload,
 			},
 		},
 		"ProcessPods": {
@@ -1014,34 +1019,26 @@ func Test_StartWorkloadSlicePods(t *testing.T) {
 				clnt: clientBuilder().WithLists(&corev1.PodList{
 					Items: []corev1.Pod{
 						// Un-gated pod should remain un-gated, i.e., no change.
-						testPod("test-one", "100", testJobObject),
+						testPod("test-one", "100", "test-slice"),
 						// Gated pod - gate should be removed.
-						testPod("test-two", "200", testJobObject, corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}),
+						testPod("test-two", "200", "test-slice", corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}),
 						// Gated with some other gate -
-						testPod("test-three", "300", testJobObject, corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}, corev1.PodSchedulingGate{Name: kueue.TopologySchedulingGate}),
-						// Other gated pod (not for this job)
-						testPod("other-pod", "400", &batchv1.Job{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: "other-job",
-							},
-						}, corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}),
+						testPod("test-three", "300", "test-slice", corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}, corev1.PodSchedulingGate{Name: kueue.TopologySchedulingGate}),
+						// Other gated pod (not for this workload slice)
+						testPod("other-pod", "400", "other-slice", corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}),
 					},
 				}).Build(),
-				object: testJobObject,
+				wl: testWorkload,
 			},
 			wantPods: &corev1.PodList{
 				Items: []corev1.Pod{
-					testPod("test-one", "100", testJobObject),
+					testPod("test-one", "100", "test-slice"),
 					// Gated pod - gate removed (resource version increase).
-					testPod("test-two", "201", testJobObject),
+					testPod("test-two", "201", "test-slice"),
 					// Gated with some other gate - other gate remains (resource version increased).
-					testPod("test-three", "301", testJobObject, corev1.PodSchedulingGate{Name: kueue.TopologySchedulingGate}),
-					// Other gated pod (not for this job) - no change.
-					testPod("other-pod", "400", &batchv1.Job{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "other-job",
-						},
-					}, corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}),
+					testPod("test-three", "301", "test-slice", corev1.PodSchedulingGate{Name: kueue.TopologySchedulingGate}),
+					// Other gated pod (not for this workload slice) - no change.
+					testPod("other-pod", "400", "other-slice", corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}),
 				},
 			},
 		},
@@ -1049,7 +1046,7 @@ func Test_StartWorkloadSlicePods(t *testing.T) {
 			args: args{
 				clnt: clientBuilder().WithLists(&corev1.PodList{
 					Items: []corev1.Pod{
-						testPod("test", "100", testJobObject, corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}),
+						testPod("test", "100", "test-slice", corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}),
 					},
 				}).WithInterceptorFuncs(interceptor.Funcs{
 					Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
@@ -1057,15 +1054,72 @@ func Test_StartWorkloadSlicePods(t *testing.T) {
 					},
 				}).
 					Build(),
-				object: testJobObject,
+				wl: testWorkload,
 			},
 			wantErr: true,
+		},
+		"BackwardsCompatibility_FallbackToOwnerReference": {
+			args: args{
+				// Client with both indexes for backwards compatibility
+				clnt: fake.NewClientBuilder().WithScheme(scheme.Scheme).
+					WithIndex(&corev1.Pod{}, indexer.WorkloadSliceNameKey, indexer.IndexPodWorkloadSliceName).
+					WithIndex(&corev1.Pod{}, indexer.OwnerReferenceUID, indexer.IndexOwnerUID).
+					WithLists(&corev1.PodList{
+						Items: []corev1.Pod{
+							// Pod without annotation but with owner reference (old pod)
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:            "old-pod",
+									Namespace:       "default",
+									ResourceVersion: "100",
+									OwnerReferences: []metav1.OwnerReference{
+										{UID: "job-uid-123"},
+									},
+								},
+								Spec: corev1.PodSpec{
+									SchedulingGates: []corev1.PodSchedulingGate{{Name: kueue.ElasticJobSchedulingGate}},
+								},
+							},
+						},
+					}).Build(),
+				// Workload with owner reference to job
+				wl: &kueue.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-workload",
+						Namespace: "default",
+						Annotations: map[string]string{
+							kueue.WorkloadSliceNameAnnotation: "test-slice",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{UID: "job-uid-123"},
+						},
+					},
+				},
+			},
+			wantPods: &corev1.PodList{
+				Items: []corev1.Pod{
+					// Pod should have gate removed (resource version increased)
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            "old-pod",
+							Namespace:       "default",
+							ResourceVersion: "101",
+							OwnerReferences: []metav1.OwnerReference{
+								{UID: "job-uid-123"},
+							},
+						},
+						Spec: corev1.PodSpec{
+							SchedulingGates: nil,
+						},
+					},
+				},
+			},
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
-			if err := StartWorkloadSlicePods(ctx, tt.args.clnt, tt.args.object); (err != nil) != tt.wantErr {
+			if err := StartWorkloadSlicePods(ctx, tt.args.clnt, tt.args.wl); (err != nil) != tt.wantErr {
 				t.Errorf("StartWorkloadSlicePods() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.wantPods == nil {


### PR DESCRIPTION
This preparatory change adds `WorkloadSliceNameAnnotation` to track workloads across slice replacements and `WorkloadSliceNameKey` index to lookup pods by annotation. It also refactors `StartWorkloadSlicePods` to find pods via the annotation instead of owner reference.

This enables future support for JobSet where pods are not immediate children of the job object, and is required for proper TAS integration with elastic workloads.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes-sigs/kueue/pull/8580#discussion_r2721890685

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```