### PR TITLE
Mention required `interactiveMode` field in MultiKueue docs

### DIFF
--- a/site/content/en/docs/tasks/manage/setup_multikueue.md
+++ b/site/content/en/docs/tasks/manage/setup_multikueue.md
@@ -334,6 +334,7 @@ data:
           execConfig:
             apiVersion: client.authentication.k8s.io/v1beta1
             command: /plugins/<plugin-command>
+            interactiveMode: Never
 kind: ConfigMap
 metadata:
   labels:


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
This field is required and should be listed in the documentation - otherwise it throws:
```sh
"msg":"Unable to load the configuration","error":"multiKueue.clusterProfile.credentialsProviders.execConfig.interactiveMode: Required value: must be specified"
```

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```