### PR TITLE
Automated cherry pick of #8790: Add waitForWebhooks to restartManager for webhook readiness

### DIFF
--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -211,16 +211,14 @@ func (f *Framework) StartManager(ctx context.Context, cfg *rest.Config, managerS
 			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred(), "failed to run manager")
 		}()
 
-		if len(f.WebhookPath) > 0 {
-			// wait for the webhook server to get ready
-			dialer := &net.Dialer{Timeout: time.Second}
-			addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
-			gomega.Eventually(func(g gomega.Gomega) {
-				conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				conn.Close()
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		}
+		// wait for the webhook server to get ready
+		dialer := &net.Dialer{Timeout: time.Second}
+		addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+		gomega.Eventually(func(g gomega.Gomega) {
+			conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			conn.Close()
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 }
 

--- a/test/integration/singlecluster/controller/failurerecovery/suite_test.go
+++ b/test/integration/singlecluster/controller/failurerecovery/suite_test.go
@@ -30,6 +30,7 @@ import (
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/failurerecovery"
+	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
 )
 
@@ -68,4 +69,7 @@ func managerSetup(_ context.Context, mgr manager.Manager) {
 
 	_, err := terminatingPodReconciler.SetupWithManager(mgr, &configapi.Configuration{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	failedWebhook, err := webhooks.Setup(mgr)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
 }


### PR DESCRIPTION
Cherry pick of #8790 on release-0.15.

#8790: Add waitForWebhooks to restartManager for webhook readiness

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```