### PR TITLE
docs: document suspend behavior for raycluster/rayservice/rayjob

### DIFF
--- a/site/content/en/docs/tasks/run/rayclusters.md
+++ b/site/content/en/docs/tasks/run/rayclusters.md
@@ -63,7 +63,11 @@ spec:
 
 Note that a RayCluster will hold resource quotas while it exists. For optimal resource management, you should delete a RayCluster that is no longer in use.
 
-### c. Limitations
+### c. Suspend control
+
+Kueue controls the `spec.suspend` field of the RayCluster. When a RayCluster is admitted by Kueue, Kueue will unsuspend it by setting `spec.suspend` to `false`, regardless of its previous value.
+
+### d. Limitations
 - Limited Worker Groups: Because a Kueue workload can have a maximum of 8 PodSets, the maximum number of `spec.workerGroupSpecs` is 7
 - In-Tree Autoscaling Constraints: Autoscaling is only supported for [elastic](/docs/concepts/elastic_workload) RayCluster objects. To enable in-tree autoscaling:
 

--- a/site/content/en/docs/tasks/run/rayjobs.md
+++ b/site/content/en/docs/tasks/run/rayjobs.md
@@ -63,7 +63,11 @@ spec:
                     cpu: "1"
 ```
 
-### c. Limitations
+### c. Suspend control
+
+Kueue controls the `spec.suspend` field of the RayJob. When a RayJob is admitted by Kueue, Kueue will unsuspend it by setting `spec.suspend` to `false`, regardless of its previous value.
+
+### d. Limitations
 
 - A Kueue managed RayJob cannot use an existing RayCluster.
 - The RayCluster should be deleted at the end of the job execution, `spec.ShutdownAfterJobFinishes` should be `true`.

--- a/site/content/en/docs/tasks/run/rayservices.md
+++ b/site/content/en/docs/tasks/run/rayservices.md
@@ -63,7 +63,11 @@ spec:
                   cpu: "1"
 ```
 
-### c. Limitations
+### c. Suspend control
+
+Kueue controls the `spec.suspend` field of the RayCluster created by RayService. When the RayCluster is admitted by Kueue, Kueue will unsuspend it by setting `spec.suspend` to `false`, regardless of its previous value.
+
+### d. Limitations
 - Limited Worker Groups: Because a Kueue workload can have a maximum of 8 PodSets, the maximum number of `spec.rayClusterConfig.workerGroupSpecs` is 7
 - In-Tree Autoscaling Disabled: Kueue manages resource allocation for the RayService; therefore, the internal autoscaling mechanisms need to be disabled
 

--- a/site/content/zh-CN/docs/tasks/run/rayclusters.md
+++ b/site/content/zh-CN/docs/tasks/run/rayclusters.md
@@ -63,7 +63,11 @@ spec:
 
 请注意，RayCluster 在存在期间会占用资源配额。为了优化资源管理，你应该删除不再使用的 RayCluster。
 
-### c. 限制 {#c-limitations}
+### c. Suspend 控制 {#c-suspend-control}
+
+Kueue 控制 RayCluster 的 `spec.suspend` 字段。当 RayCluster 被 Kueue 接纳时，Kueue 会通过将 `spec.suspend` 设置为 `false` 来取消暂停，无论其之前的值是什么。
+
+### d. 限制 {#d-limitations}
 - 有限的 Worker Groups：由于 Kueue 工作负载最多可以有 8 个 PodSets，`spec.workerGroupSpecs` 的最大数量为 7
 - 内建自动扩缩禁用：Kueue 管理 RayCluster 的资源分配；因此，集群的内部自动扩缩机制需要禁用
 

--- a/site/content/zh-CN/docs/tasks/run/rayjobs.md
+++ b/site/content/zh-CN/docs/tasks/run/rayjobs.md
@@ -62,7 +62,11 @@ spec:
                     cpu: "1"
 ```
 
-### c. 限制 {#c-limitations}
+### c. Suspend 控制 {#c-suspend-control}
+
+Kueue 控制 RayJob 的 `spec.suspend` 字段。当 RayJob 被 Kueue 接纳时，Kueue 会通过将 `spec.suspend` 设置为 `false` 来取消暂停，无论其之前的值是什么。
+
+### d. 限制 {#d-limitations}
 
 - 一个 Kueue 管理的 RayJob 不能使用现有的 RayCluster。
 - RayCluster 应在作业执行结束后删除，`spec.ShutdownAfterJobFinishes` 应为 `true`。

--- a/site/content/zh-CN/docs/tasks/run/rayservices.md
+++ b/site/content/zh-CN/docs/tasks/run/rayservices.md
@@ -69,7 +69,11 @@ spec:
                   cpu: "1"
 ```
 
-### c. 限制事项 {#c-limitations}
+### c. Suspend 控制 {#c-suspend-control}
+
+Kueue 控制由 RayService 创建的 RayCluster 的 `spec.suspend` 字段。当 RayCluster 被 Kueue 接纳时，Kueue 会通过将 `spec.suspend` 设置为 `false` 来取消暂停，无论其之前的值是什么。
+
+### d. 限制事项 {#c-limitations}
 - 有限的 Worker Group：由于 Kueue 工作负载最多可以有 8 个 PodSet,
   所以`spec.rayClusterConfig.workerGroupSpecs` 的最大数量为 7。
 - 内建自动扩缩禁用：Kueue 管理 RayService 的资源分配，因此，集群的内部自动扩缩机制需要禁用。


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Updated documentation for RayCluster, RayJob, and RayService to clarify that Kueue manages the `suspend` field and overrides it upon admission.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```