### PR TITLE
Automated cherry pick of #3912: Add RemoveFinalizersWithStrictPatch feature gate

### DIFF
--- a/keps/3899-remove-finalizers-with-strict-patch/kep.yaml
+++ b/keps/3899-remove-finalizers-with-strict-patch/kep.yaml
@@ -17,10 +17,10 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.11"
+latest-milestone: "v0.17"
 
 milestone:
-    beta: "v0.11"
+    beta: "v0.17"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -553,10 +553,8 @@ func (p *Pod) Finalize(ctx context.Context, c client.Client) error {
 	}
 
 	return parallelize.Until(ctx, len(podsInGroup.Items), func(i int) error {
-		pod := &podsInGroup.Items[i]
-		return clientutil.Patch(ctx, c, pod, func() (bool, error) {
-			return controllerutil.RemoveFinalizer(pod, podconstants.PodFinalizer), nil
-		}, clientutil.WithLoose())
+		_, err := removePodFinalizers(ctx, c, &podsInGroup.Items[i])
+		return err
 	})
 }
 
@@ -906,6 +904,24 @@ func sortActivePods(activePods []corev1.Pod) {
 	})
 }
 
+func removePodFinalizers(ctx context.Context, c client.Client, pod *corev1.Pod) (bool, error) {
+	var removed bool
+	patchOptions := make([]clientutil.PatchOption, 0, 1)
+
+	if features.Enabled(features.RemoveFinalizersWithStrictPatch) {
+		patchOptions = append(patchOptions, clientutil.WithRetryOnConflict())
+	} else {
+		patchOptions = append(patchOptions, clientutil.WithLoose())
+	}
+
+	err := clientutil.Patch(ctx, c, pod, func() (bool, error) {
+		removed = controllerutil.RemoveFinalizer(pod, podconstants.PodFinalizer)
+		return removed, nil
+	}, patchOptions...)
+
+	return removed, err
+}
+
 func (p *Pod) removeExcessPods(ctx context.Context, c client.Client, r record.EventRecorder, extraPods []corev1.Pod) error {
 	if len(extraPods) == 0 {
 		return nil
@@ -919,26 +935,26 @@ func (p *Pod) removeExcessPods(ctx context.Context, c client.Client, r record.Ev
 
 	// Finalize and delete the active pods created last
 	err := parallelize.Until(ctx, len(extraPods), func(i int) error {
-		pod := extraPods[i]
-		if err := clientutil.Patch(ctx, c, &pod, func() (bool, error) {
-			removed := controllerutil.RemoveFinalizer(&pod, podconstants.PodFinalizer)
-			if removed {
-				log.V(3).Info("Finalizing excess pod in group", "excessPod", klog.KObj(&pod))
-			}
-			return removed, nil
-		}, clientutil.WithLoose()); err != nil {
+		pod := &extraPods[i]
+
+		removed, err := removePodFinalizers(ctx, c, pod)
+		if err != nil {
 			// We won't observe this cleanup in the event handler.
 			p.excessPodExpectations.ObservedUID(log, p.key, pod.UID)
 			return err
 		}
+		if removed {
+			log.V(3).Info("Finalized excess pod in group", "excessPod", klog.KObj(pod))
+		}
+
 		if pod.DeletionTimestamp.IsZero() {
-			log.V(3).Info("Deleting excess pod in group", "excessPod", klog.KObj(&pod))
-			if err := c.Delete(ctx, &pod); err != nil {
+			log.V(3).Info("Deleting excess pod in group", "excessPod", klog.KObj(pod))
+			if err := c.Delete(ctx, pod); err != nil {
 				// We won't observe this cleanup in the event handler.
 				p.excessPodExpectations.ObservedUID(log, p.key, pod.UID)
 				return err
 			}
-			r.Event(&pod, corev1.EventTypeNormal, ReasonExcessPodDeleted, "Excess pod deleted")
+			r.Event(pod, corev1.EventTypeNormal, ReasonExcessPodDeleted, "Excess pod deleted")
 		}
 		return nil
 	})
@@ -960,23 +976,15 @@ func (p *Pod) finalizePods(ctx context.Context, c client.Client, extraPods []cor
 	p.excessPodExpectations.ExpectUIDs(log, p.key, extraPodsUIDs)
 
 	err := parallelize.Until(ctx, len(extraPods), func(i int) error {
-		pod := extraPods[i]
-		var removed bool
-		if err := clientutil.Patch(ctx, c, &pod, func() (bool, error) {
-			removed = controllerutil.RemoveFinalizer(&pod, podconstants.PodFinalizer)
-			if removed {
-				log.V(3).Info("Finalizing pod in group", "Pod", klog.KObj(&pod))
-			}
-			return removed, nil
-		}, clientutil.WithLoose()); err != nil {
+		pod := &extraPods[i]
+
+		removed, err := removePodFinalizers(ctx, c, pod)
+		if err != nil || !removed {
 			// We won't observe this cleanup in the event handler.
 			p.excessPodExpectations.ObservedUID(log, p.key, pod.UID)
 			return err
 		}
-		if !removed {
-			// We don't expect an event in this case.
-			p.excessPodExpectations.ObservedUID(log, p.key, pod.UID)
-		}
+		log.V(3).Info("Finalized pod in group", "pod", klog.KObj(pod))
 		return nil
 	})
 	if err != nil {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -240,6 +240,12 @@ const (
 	// issue: https://github.com/kubernetes-sigs/kueue/issues/8585
 	// Enable waiting for WorkloadAdmitted before cleaning up non-selected worker workloads.
 	MultiKueueWaitForWorkloadAdmitted featuregate.Feature = "MultiKueueWaitForWorkloadAdmitted"
+
+	// owner: @mykysha
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/3899-remove-finalizers-with-strict-patch
+	//
+	// Finalizers are removed using a strict patch not to cause race conditions.
+	RemoveFinalizersWithStrictPatch featuregate.Feature = "RemoveFinalizersWithStrictPatch"
 )
 
 func init() {
@@ -376,6 +382,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 
 	MultiKueueWaitForWorkloadAdmitted: {
 		{Version: version.MustParse("0.15"), Default: true, PreRelease: featuregate.Beta}, // GA in 0.18
+	},
+	RemoveFinalizersWithStrictPatch: {
+		{Version: version.MustParse("0.15"), Default: true, PreRelease: featuregate.Beta},
 	},
 }
 

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -324,6 +324,7 @@ spec:
 | `FailureRecoveryPolicy`                       | `false` | Alpha | 0.15  |       |
 | `SkipFinalizersForPodsSuspendedByParent`      | `true`  | Beta  | 0.15  |       |
 | `MultiKueueWaitForWorkloadAdmitted`           | `true`  | Beta  | 0.15  |       |
+| `RemoveFinalizersWithStrictPatch`             | `true`  | Beta  | 0.15  |       |
 
 {{% alert title="Note" color="primary" %}}
 The SanitizePodSets and MultiKueueAllowInsecureKubeconfigs features are available starting from versions 0.13.8 and 0.14.3.

--- a/site/content/zh-CN/docs/installation/_index.md
+++ b/site/content/zh-CN/docs/installation/_index.md
@@ -298,6 +298,7 @@ spec:
 | `SanitizePodSets`                             | `true`  | Beta  | 0.13 |      |
 | `MultiKueueAllowInsecureKubeconfigs`          | `false` | Alpha | 0.13 |      |
 | `SkipFinalizersForPodsSuspendedByParent`      | `true`  | Beta  | 0.15 |      |
+| `RemoveFinalizersWithStrictPatch`             | `true`  | Beta  | 0.15 |       |
 
 ### 已毕业或已弃用特性的特性门控 {#feature-gates-for-graduated-or-deprecated-features}
 


### PR DESCRIPTION
Cherry pick of #3912 on release-0.15.

#3912: Add RemoveFinalizersWithStrictPatch feature gate

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
PodIntegration: Fix the bug that Kueue would occasionally remove the custom finalizers when
removing the `kueue.x-k8s.io/managed` finalizer.
```