### PR TITLE
WIP: Fix upgrade tests by using released version

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -273,7 +273,7 @@ function cluster_kind_load {
     cluster_kind_load_image "$1" "${E2E_TEST_AGNHOST_IMAGE}"
     cluster_kind_load_image "$1" "$IMAGE_TAG"
     if [[ -n ${KUEUE_UPGRADE_FROM_VERSION:-} ]]; then
-        local old_image="${IMAGE_TAG%:*}:${KUEUE_UPGRADE_FROM_VERSION}"
+        local old_image="registry.k8s.io/kueue/kueue:${KUEUE_UPGRADE_FROM_VERSION}"
         cluster_kind_load_image "$1" "${old_image}"
     fi
     if [[ -n "${CLUSTERPROFILE_VERSION:-}" ]]; then


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8925

Currently upgrade jobs fail with:

```
application/vnd.oci.image.manifest.v1+json sha256:f605cf0694c5bda65a9794dd8b612f3a00a7d15ac4b9c946ba42eed7190f4a0e
Importing	elapsed: 4.4 s	total:   0.0 B	(0.0 B/s)	
Loading image 'us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue:v0.14.4' to cluster 'kind'
  Loading image to node: kind-worker2
Error response from daemon: reference does not exist
ctr: unrecognized image format
Failed to load image 'us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue:v0.14.4' to node 'kind-worker2'
Set the current-context in a kubeconfig file.
```

#### Special notes for your reviewer:

Attempt to fix #8925

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```