### PR TITLE
Semi-automated cherry pick of #8926: Quick fix for upgrade tests

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -46,7 +46,7 @@ E2E_K8S_FULL_VERSION := $(or $(E2E_K8S_FULL_VERSION),$(E2E_K8S_VERSION).0)
 E2E_KIND_VERSION ?= kindest/node:v$(E2E_K8S_FULL_VERSION)
 E2E_RUN_ONLY_ENV ?= false
 E2E_USE_HELM ?= false
-KUEUE_UPGRADE_FROM_VERSION ?= v0.14.4
+KUEUE_UPGRADE_FROM_VERSION ?= v0.14.8
 
 # For local testing, we should allow user to use different kind cluster name
 # Default will delete default kind cluster


### PR DESCRIPTION
Cherry pick of #8926 on release-0.15.

#8926: Quick fix for upgrade tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```