### PR TITLE
[release-0.15] Exclude finished and deactivated workloads from scheduler cache

### DIFF
--- a/pkg/controller/core/clusterqueue_controller_test.go
+++ b/pkg/controller/core/clusterqueue_controller_test.go
@@ -18,13 +18,17 @@ package core
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
@@ -240,6 +244,62 @@ func TestUpdateCqStatusIfChanged(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.wantCqStatus, cq.Status, configCmpOpts...); len(diff) != 0 {
 				t.Errorf("unexpected ClusterQueueStatus (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestReconcileRemovesFinalizerWithFinishedWorkloads(t *testing.T) {
+	testCases := map[string]struct {
+		cqName string
+		wlName string
+	}{
+		"finished workload should not block deletion": {
+			cqName: "cq",
+			wlName: "wl",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx, log := utiltesting.ContextWithLog(t)
+			now := time.Now()
+
+			cq := utiltestingapi.MakeClusterQueue(tc.cqName).Obj()
+			cq.Finalizers = []string{kueue.ResourceInUseFinalizerName}
+
+			cl := utiltesting.NewClientBuilder().WithObjects(cq).Build()
+			cqCache := schdcache.New(cl)
+			qManager := qcache.NewManager(cl, cqCache)
+			if err := cqCache.AddClusterQueue(ctx, cq); err != nil {
+				t.Fatalf("Inserting clusterQueue in cache: %v", err)
+			}
+
+			finishedWl := utiltestingapi.MakeWorkload(tc.wlName, "").ReserveQuotaAt(&kueue.Admission{
+				ClusterQueue: kueue.ClusterQueueReference(tc.cqName),
+			}, now).FinishedAt(now).Obj()
+			cqCache.AddOrUpdateWorkload(log, finishedWl)
+
+			r := &ClusterQueueReconciler{
+				client:   cl,
+				log:      log,
+				cache:    cqCache,
+				qManager: qManager,
+			}
+
+			if err := cl.Delete(ctx, cq); err != nil {
+				t.Fatalf("Failed to delete ClusterQueue: %v", err)
+			}
+
+			_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: tc.cqName}})
+			if err != nil {
+				t.Fatalf("Reconcile failed: %v", err)
+			}
+
+			got := &kueue.ClusterQueue{}
+			err = cl.Get(ctx, types.NamespacedName{Name: tc.cqName}, got)
+			if !apierrors.IsNotFound(err) {
+				t.Fatalf("Expected ClusterQueue to be deleted after finalizer removal, but got: %v", err)
 			}
 		})
 	}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -1135,6 +1135,13 @@ func IsAdmissible(w *kueue.Workload) bool {
 	return !IsFinished(w) && IsActive(w) && !HasQuotaReservation(w)
 }
 
+// HasActiveQuotaReservation returns true if the workload has an active quota
+// reservation that should be tracked for ClusterQueue usage. This requires the
+// workload to be active, not finished, and holding a quota reservation.
+func HasActiveQuotaReservation(w *kueue.Workload) bool {
+	return HasQuotaReservation(w) && !IsFinished(w) && IsActive(w)
+}
+
 // HasDRA returns true if the workload has DRA resources (ResourceClaims or ResourceClaimTemplates).
 func HasDRA(w *kueue.Workload) bool {
 	return HasResourceClaim(w) || HasResourceClaimTemplates(w)

--- a/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
@@ -1036,5 +1036,28 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Label("controller:clus
 			ginkgo.By("Delete clusterQueue")
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
 		})
+
+		ginkgo.It("Should remove finalizer promptly when workload finishes", func() {
+			util.SetAdmissionCheckActive(ctx, k8sClient, check, metav1.ConditionTrue)
+			util.ExpectClusterQueueStatusMetric(cq, metrics.CQStatusActive)
+
+			ginkgo.By("Creating and admitting workload")
+			wl := utiltestingapi.MakeWorkload("workload", ns.Name).Queue(kueue.LocalQueueName(lq.Name)).Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+			key := client.ObjectKeyFromObject(wl)
+			util.SetQuotaReservation(ctx, k8sClient, key, utiltestingapi.MakeAdmission(cq.Name).Obj())
+			util.SetWorkloadsAdmissionCheck(ctx, k8sClient, wl, kueue.AdmissionCheckReference(check.Name), kueue.CheckStateReady, true)
+			gomega.Eventually(func(g gomega.Gomega) {
+				updatedWl := &kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, key, updatedWl)).To(gomega.Succeed())
+				g.Expect(updatedWl.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.WorkloadAdmitted))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Finishing workload")
+			util.FinishWorkloads(ctx, k8sClient, wl)
+
+			ginkgo.By("Deleting clusterQueue - should succeed without waiting")
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		})
 	})
 })


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubernetes-sigs/kueue/pull/8919
/assign @sohankunkerkar 
```release-note
Fix a bug where finished or deactivated workloads blocked ClusterQueue deletion and finalizer removal.
```