### PR TITLE
Fix Prometheus ServiceMonitor selector and add EndpointSlice RBAC

### DIFF
--- a/charts/kueue/templates/prometheus/role.yaml
+++ b/charts/kueue/templates/prometheus/role.yaml
@@ -51,6 +51,14 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
 {{- end }}
 ---
 {{- if .Values.enablePrometheus }}

--- a/config/components/prometheus/monitor.yaml
+++ b/config/components/prometheus/monitor.yaml
@@ -14,5 +14,5 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      app.kubernetes.io/component: controller
+      app.kubernetes.io/component: metrics-service
       app.kubernetes.io/name: kueue

--- a/config/components/prometheus/role.yaml
+++ b/config/components/prometheus/role.yaml
@@ -30,6 +30,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Fixes the Prometheus ServiceMonitor configuration so Kueue metrics can be scraped:

1. Updates the ServiceMonitor selector to match the metrics service label (`metrics-service` instead of `controller`)
2. Adds EndpointSlice RBAC permissions required by Prometheus for target discovery

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

- After #7371, the ServiceMonitor selector needs to be updated to match the metrics-service label.
- The EndpointSlice RBAC issue was identified during manual testing.

**Steps to reproduce:**                                                                                                                                                                  

```bash                                                                                                                                                                                  
# With kube-prometheus installed, apply Kueue prometheus config                                                                                                                          
make prometheus                                                                                                                                                                          
                                                                                                                                                                                         
# Check Prometheus targets - kueue target is missing                                                                                                                                     
kubectl -n monitoring port-forward svc/prometheus-k8s 9090:9090                                                                                                                    
curl -s 'http://localhost:9090/api/v1/targets' | jq '.data.activeTargets[] | select(.labels.job | contains("kueue"))'                                                                    
# Returns empty
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Observability: Fix Prometheus ServiceMonitor selector and RBAC to enable metrics scraping.
```