### PR TITLE
Allow configuring KueueViz resources via Helm values

### DIFF
--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -136,6 +136,7 @@ The following table lists the configurable parameters of the kueue chart and the
 | kueueViz.backend.ingress.tlsSecretName | string | `"kueueviz-backend-tls"` | KueueViz dashboard backend ingress tls secret name |
 | kueueViz.backend.nodeSelector | object | `{}` | KueueViz backend nodeSelector |
 | kueueViz.backend.priorityClassName | string | `nil` | Enable PriorityClass for KueueViz dashboard backend deployments |
+| kueueViz.backend.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"500m","memory":"512Mi"}}` | KueueViz backend pod resources |
 | kueueViz.backend.tolerations | list | `[]` | KueueViz backend tolerations |
 | kueueViz.frontend.env | list | `[{"name":"REACT_APP_WEBSOCKET_URL","value":"wss://backend.kueueviz.local"}]` | Environment variables for KueueViz frontend deployment |
 | kueueViz.frontend.image.pullPolicy | string | `"Always"` | KueueViz dashboard frontend image pullPolicy. This should be set to 'IfNotPresent' for released version |
@@ -148,6 +149,7 @@ The following table lists the configurable parameters of the kueue chart and the
 | kueueViz.frontend.ingress.tlsSecretName | string | `"kueueviz-frontend-tls"` | KueueViz dashboard frontend ingress tls secret name |
 | kueueViz.frontend.nodeSelector | object | `{}` | KueueViz frontend nodeSelector |
 | kueueViz.frontend.priorityClassName | string | `nil` | Enable PriorityClass for KueueViz dashboard frontend deployments |
+| kueueViz.frontend.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"500m","memory":"512Mi"}}` | KueueViz frontend pod resources |
 | kueueViz.frontend.tolerations | list | `[]` | KueueViz frontend tolerations |
 | managerConfig.controllerManagerConfigYaml | string | controllerManagerConfigYaml | controller_manager_config.yaml. ControllerManager utilizes this yaml via manager-config Configmap. |
 | metrics.prometheusNamespace | string | `"monitoring"` | Prometheus namespace |

--- a/charts/kueue/templates/kueueviz/backend-deployment.yaml
+++ b/charts/kueue/templates/kueueviz/backend-deployment.yaml
@@ -55,13 +55,8 @@ spec:
           {{- end }}
           image: '{{ .Values.kueueViz.backend.image.repository }}:{{ .Values.kueueViz.backend.image.tag | default .Chart.AppVersion }}'
           imagePullPolicy: '{{ .Values.kueueViz.backend.image.pullPolicy }}'
+          resources:
+            {{- toYaml .Values.kueueViz.backend.resources | nindent 12 }}
           ports:
             - containerPort: 8080
-          resources:
-            limits:
-              cpu: 500m
-              memory: 512Mi
-            requests:
-              cpu: 500m
-              memory: 512Mi
 {{- end }}

--- a/charts/kueue/templates/kueueviz/frontend-deployment.yaml
+++ b/charts/kueue/templates/kueueviz/frontend-deployment.yaml
@@ -55,13 +55,8 @@ spec:
           {{- end }}
           image: '{{ .Values.kueueViz.frontend.image.repository }}:{{ .Values.kueueViz.frontend.image.tag | default .Chart.AppVersion }}'
           imagePullPolicy: '{{ .Values.kueueViz.frontend.image.pullPolicy }}'
+          resources:
+            {{- toYaml .Values.kueueViz.frontend.resources | nindent 12 }}
           ports:
             - containerPort: 8080
-          resources:
-            limits:
-              cpu: 500m
-              memory: 512Mi
-            requests:
-              cpu: 500m
-              memory: 512Mi
 {{- end }}

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -221,6 +221,14 @@ kueueViz:
     imagePullSecrets: []
     # -- Enable PriorityClass for KueueViz dashboard backend deployments
     priorityClassName:
+    # -- KueueViz backend pod resources
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 500m
+        memory: 512Mi
     # -- Environment variables for KueueViz backend deployment
     env:
       - name: KUEUEVIZ_ALLOWED_ORIGINS
@@ -254,6 +262,14 @@ kueueViz:
     imagePullSecrets: []
     # -- Enable PriorityClass for KueueViz dashboard frontend deployments
     priorityClassName:
+    # -- KueueViz frontend pod resources
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 500m
+        memory: 512Mi
     # -- Environment variables for KueueViz frontend deployment
     env:
       - name: REACT_APP_WEBSOCKET_URL

--- a/hack/processing-plan.yaml
+++ b/hack/processing-plan.yaml
@@ -660,6 +660,12 @@ files:
         value: '"wss://{{ .Values.kueueViz.backend.ingress.host | default \"backend.kueueviz.local\" }}"'
         onFileCondition: '.kind == "Deployment" and .metadata.name | contains("kueueviz-frontend")'
         onItemCondition: '.spec.template.spec.containers.[].env.[].name == "REACT_APP_WEBSOCKET_URL"'
+      - type: DELETE
+        key: .spec.template.spec.containers.[].resources
+        onFileCondition: '.kind == "Deployment" and .metadata.name | contains("kueueviz-backend")'
+      - type: DELETE
+        key: .spec.template.spec.containers.[].resources
+        onFileCondition: '.kind == "Deployment" and .metadata.name | contains("kueueviz-frontend")'
     postOperations:
       - type: INSERT_TEXT
         key: .spec
@@ -755,6 +761,20 @@ files:
           {{- end }}
         indentation: 2
         onFileCondition: '.kind == "Deployment" and  .metadata.name | contains("backend")'
+      - type: INSERT_TEXT
+        key: .spec.template.spec.containers.[].imagePullPolicy
+        value: |
+          resources:
+            {{- toYaml .Values.kueueViz.backend.resources | nindent 12 }}
+        indentation: 0
+        onFileCondition: '.kind == "Deployment" and  .metadata.name | contains("backend")'
+      - type: INSERT_TEXT
+        key: .spec.template.spec.containers.[].imagePullPolicy
+        value: |
+          resources:
+            {{- toYaml .Values.kueueViz.frontend.resources | nindent 12 }}
+        indentation: 0
+        onFileCondition: '.kind == "Deployment" and  .metadata.name | contains("frontend")'
       - type: INSERT_TEXT
         key: .spec.template.spec
         value: |


### PR DESCRIPTION
Fixes #8969                                                                                                                                                                                
   
  This change makes KueueViz backend and frontend resource requests/limits configurable via Helm values, using the current hardcoded values as defaults.                                     
                                                                                                                                                                                           
  ## Implementation approach

  The yaml-processor's INSERT_TEXT operation inserts content AFTER a specified key's line. Since `ports` is an array, inserting after it places content inside the array structure rather
  than as a sibling field.

  To work around this limitation, we:
  1. DELETE the hardcoded `resources` from the source during processing
  2. INSERT_TEXT the templated `resources` after `imagePullPolicy` (a scalar field)

  This results in `resources` appearing BEFORE `ports` in the generated templates, which is a minor ordering change but functionally equivalent.

  ## Alternative solutions considered

  1. **INSERT_TEXT after `ports` array** - Doesn't work because content gets inserted inside the array, not as a sibling field.

  2. **DELETE both `ports` and `resources`, then INSERT_TEXT both** - Works but is overly invasive, modifying sections that don't need to change.

  3. **Extend yaml-processor to support inserting before a key** - Would be the cleanest solution but requires changes to the yaml-processor tool itself.

  4. **Use UPDATE on individual resource values** - Not possible because UPDATE uses yq which can't handle Helm template syntax.

  #### What type of PR is this?

  /kind feature

  #### What this PR does / why we need it:

  Allows users to configure KueueViz backend and frontend resource requests/limits via Helm values instead of using hardcoded values.

  #### Which issue(s) this PR fixes:

  Fixes #8969

  #### Special notes for your reviewer:

  The `resources` field now appears before `ports` in the generated templates due to yaml-processor limitations (see implementation approach above). This is functionally equivalent.

  #### Does this PR introduce a user-facing change?

  ```release-note
  KueueViz backend and frontend resource requests/limits are now configurable via Helm values (kueueViz.backend.resources and kueueViz.frontend.resources).
```