### PR TITLE
Implement Pod Integration Fast Quota Release

### DIFF
--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -404,12 +404,21 @@ func (p *Pod) PodSets(ctx context.Context) ([]kueue.PodSet, error) {
 // elapsed, it is treated as inactive. This prevents workloads from being
 // blocked by Pods that are stuck terminating, ensuring quota can be released
 // and new Pods admitted.
+//
+// When the FastQuotaReleaseInPodIntegration feature gate is enabled, any pod
+// with a DeletionTimestamp is treated as inactive immediately, regardless of
+// its grace period status. This allows quota to be released as soon as
+// preempted pods begin terminating.
 func (p *Pod) IsActive() bool {
 	for i := range p.list.Items {
 		pod := p.list.Items[i]
 
 		// Pods that are not in the Running phase are never considered Active.
 		if pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+
+		if features.Enabled(features.FastQuotaReleaseInPodIntegration) && pod.DeletionTimestamp != nil {
 			continue
 		}
 

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -6058,8 +6058,9 @@ func TestPod_IsActive(t *testing.T) {
 		list corev1.PodList
 	}
 	tests := map[string]struct {
-		fields fields
-		want   bool
+		fields                 fields
+		enableFastQuotaRelease bool
+		want                   bool
 	}{
 		"RegularPod": {
 			want: false,
@@ -6121,9 +6122,94 @@ func TestPod_IsActive(t *testing.T) {
 			},
 			want: true,
 		},
+		"FastQuotaRelease_PodWithDeletionTimestamp_Inactive": {
+			enableFastQuotaRelease: true,
+			fields: fields{
+				list: corev1.PodList{
+					Items: []corev1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:                       "terminating-within-grace",
+								DeletionTimestamp:          ptr.To(metav1.NewTime(now.Add(-10 * time.Second))),
+								DeletionGracePeriodSeconds: ptr.To(int64(90)),
+							},
+							Status: corev1.PodStatus{Phase: corev1.PodRunning},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		"FastQuotaRelease_Disabled_PodWithDeletionTimestampWithinGrace_Active": {
+			enableFastQuotaRelease: false,
+			fields: fields{
+				list: corev1.PodList{
+					Items: []corev1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:                       "terminating-within-grace",
+								DeletionTimestamp:          ptr.To(metav1.NewTime(now.Add(-10 * time.Second))),
+								DeletionGracePeriodSeconds: ptr.To(int64(90)),
+							},
+							Status: corev1.PodStatus{Phase: corev1.PodRunning},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		"FastQuotaRelease_MixedGroup_SomeTerminating_SomeRunning": {
+			enableFastQuotaRelease: true,
+			fields: fields{
+				list: corev1.PodList{
+					Items: []corev1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:                       "terminating-pod",
+								DeletionTimestamp:          ptr.To(metav1.NewTime(now.Add(-10 * time.Second))),
+								DeletionGracePeriodSeconds: ptr.To(int64(90)),
+							},
+							Status: corev1.PodStatus{Phase: corev1.PodRunning},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "running-pod"},
+							Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		"FastQuotaRelease_AllTerminating": {
+			enableFastQuotaRelease: true,
+			fields: fields{
+				list: corev1.PodList{
+					Items: []corev1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:                       "terminating-pod-1",
+								DeletionTimestamp:          ptr.To(metav1.NewTime(now.Add(-10 * time.Second))),
+								DeletionGracePeriodSeconds: ptr.To(int64(90)),
+							},
+							Status: corev1.PodStatus{Phase: corev1.PodRunning},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:                       "terminating-pod-2",
+								DeletionTimestamp:          ptr.To(metav1.NewTime(now.Add(-5 * time.Second))),
+								DeletionGracePeriodSeconds: ptr.To(int64(300)),
+							},
+							Status: corev1.PodStatus{Phase: corev1.PodRunning},
+						},
+					},
+				},
+			},
+			want: false,
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.FastQuotaReleaseInPodIntegration, tt.enableFastQuotaRelease)
 			p := &Pod{
 				pod:   tt.fields.pod,
 				list:  tt.fields.list,

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -328,6 +328,14 @@ const (
 	//
 	// Enables gating the admission of workloads based on annotations.
 	AdmissionGatedBy featuregate.Feature = "AdmissionGatedBy"
+
+	// owner: @tkillian
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/6143-quota-release-strategy
+	//
+	// When enabled, pods with a DeletionTimestamp are treated as inactive in the
+	// Pod integration's IsActive() check, allowing quota to be released immediately
+	// when preempted pods begin terminating rather than waiting for the grace period.
+	FastQuotaReleaseInPodIntegration featuregate.Feature = "FastQuotaReleaseInPodIntegration"
 )
 
 func init() {
@@ -507,6 +515,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	AdmissionGatedBy: {
+		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
+	FastQuotaReleaseInPodIntegration: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -65,6 +65,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.17"
+- name: FastQuotaReleaseInPodIntegration
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.17"
 - name: FlavorFungibility
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -65,6 +65,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.17"
+- name: FastQuotaReleaseInPodIntegration
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.17"
 - name: FlavorFungibility
   versionedSpecs:
   - default: true


### PR DESCRIPTION
This PR implements the initial steps outlined in the [quota release strategy KEP](https://github.com/kubernetes-sigs/kueue/tree/main/keps/6143-quota-release-strategy). It adds a feature flag specific to the pod integration that will cause pods to be considered inactive in the same way that other integrations do (when termination is initiated, not completed)

#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:
Fixes https://github.com/kubernetes-sigs/kueue/issues/6143



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Pod integration: introduce the FastQuotaReleaseInPodIntegration feature gate (alpha, disabled by default)
which allows to release quota as soon as all Pods in a group are terminating.
```