### PR TITLE
Fix scraper race condition on context cancellation

### DIFF
--- a/test/performance/scheduler/runner/scraper/scraper.go
+++ b/test/performance/scheduler/runner/scraper/scraper.go
@@ -117,6 +117,9 @@ func (s *Scraper) Run(ctx context.Context, output string) error {
 		case <-ticker.C:
 			err := s.doScrape(ctx, tw)
 			if err != nil {
+				if errors.Is(ctx.Err(), context.Canceled) {
+					return nil
+				}
 				return err
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Fixes a race condition in the performance test scraper that causes test failures.

When the context is canceled and the ticker fires simultaneously, Go's `select` may pick the ticker case. This causes `doScrape` to be called with an already-canceled context, resulting in a "context canceled" error that fails the test.

The fix checks if the context is canceled after a scrape error and treats it as a clean exit.

#### Which issue(s) this PR fixes:

Fixes #9007

#### Special notes for your reviewer:

The failing job logs show:
```
INFO  End manager
ERROR Running the scraper {"error": "Get \"http://localhost:41125/metrics\": context canceled"}
make: *** Error 1
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```