### PR TITLE
TAS: Broadcast scheduler when Topology activates ClusterQueues

### DIFF
--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -209,8 +209,15 @@ func (r *ClusterQueueReconciler) NotifyTopologyUpdate(oldTopology, newTopology *
 	default:
 		return
 	}
+	cqNames := r.cache.ClusterQueuesUsingTopology(kueue.TopologyReference(topology.Name))
 	r.nonCQObjectUpdateCh <- event.TypedGenericEvent[iter.Seq[kueue.ClusterQueueReference]]{
-		Object: slices.Values(r.cache.ClusterQueuesUsingTopology(kueue.TopologyReference(topology.Name))),
+		Object: slices.Values(cqNames),
+	}
+	// On topology creation, CQs may transition from pending to active.
+	// Broadcast to ensure the scheduler re-evaluates pending workloads.
+	if oldTopology == nil {
+		r.qManager.QueueInadmissibleWorkloads(context.Background(), sets.New(cqNames...))
+		r.qManager.Broadcast()
 	}
 }
 


### PR DESCRIPTION
The topology controller was ignoring the return value of AddOrUpdateTopology(), missing the broadcast when CQs transition from pending to active. This caused flaky behavior after controller restart when informer events fire in certain orders.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/9004

#### Special notes for your reviewer:
After controller restart, informer cache repopulation fires Create events for existing resources. The order of these events is non-deterministic. When CQ events fire before Topology events, the CQ initially enters "pending" state (waiting for TAS). When the Topology event fires, the CQ transitions to "active", but the topology controller was not calling Broadcast() to wake up the scheduler.                                                                   

This left pending workloads stuck indefinitely because the scheduler was waiting on cond.Wait() and never notified that CQs became active. The test was flaky because the bug only reproducible when informer events fire in a specific order (ResourceFlavor → ClusterQueue → Topology).

One note here:
When Topology is deleted, CQs become inactive. The scheduler doesn't need to wake up because there's no new capacity to use:                                                                                                                                             
  - Create: CQ pending → active (can admit more) → Broadcast to wake scheduler
  - Delete: CQ active → pending (can't admit) → just requeue inadmissible workloads, no new work possible.
  
Ran the failed test 200 times locally and it works w/o any failure.                                     

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Fixed a bug that pending workloads could be stuck, not being considered by the Kueue's scheduler,
after the restart of Kueue. The workloads would be considered for scheduling again after any update to their 
ClusterQueue.
```