### PR TITLE
Simplify workload deletion logic in e2e test by removing unnecessary code.

### DIFF
--- a/test/e2e/certmanager/visibility_test.go
+++ b/test/e2e/certmanager/visibility_test.go
@@ -22,7 +22,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -115,13 +114,10 @@ var _ = ginkgo.Describe("Kueue secure visibility server", func() {
 
 			ginkgo.By("Delete the first job to release the quota", func() {
 				util.ExpectObjectToBeDeleted(ctx, k8sClient, firstJob, true)
-				wlKey := types.NamespacedName{
+				firstWl := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
 					Namespace: firstJob.Namespace,
 					Name:      workloadjob.GetWorkloadNameForJob(firstJob.Name, firstJob.UID),
-				}
-				firstWl := &kueue.Workload{}
-				gomega.Expect(k8sClient.Get(ctx, wlKey, firstWl)).To(gomega.Succeed())
-
+				}}
 				// TODO(#1789): this is no longer needed when we fix the --orphan mode for Jobs
 				util.ExpectObjectToBeDeleted(ctx, k8sClient, firstWl, true)
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Simplify workload deletion logic in e2e test by removing unnecessary code.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```