### PR TITLE
🍒 [Cherry-Pick] Bug fix: MultiKueue v1/Job with ElasticJob worker sync. (#9044)

### DIFF
--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -68,6 +69,12 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 				log.V(2).Info("Skipping the sync since the local job is still suspended")
 				return nil
 			}
+			// Elastic workload sync takes precedence over status updates.
+			if needElasticJobSync(log, workloadName, &localJob, &remoteJob) {
+				if err := syncElasticJob(ctx, remoteClient, log, workloadName, &localJob, &remoteJob); err != nil {
+					return err
+				}
+			}
 			return clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
 				localJob.Status = remoteJob.Status
 				return true, nil
@@ -81,50 +88,9 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 			})
 		}
 
-		if workloadslicing.Enabled(&localJob) {
-			oldParallelism := ptr.Deref(remoteJob.Spec.Parallelism, 0)
-			newParallelism := ptr.Deref(localJob.Spec.Parallelism, 0)
-			newWorkloadName := jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(localJob.GetName(), localJob.GetUID(), gvk, localJob.GetGeneration())
-
-			// Detect and skip stale local Workload updates caused by a Job scale-up event.
-			//
-			// During scale-up, a race condition may occur between the GenericJobReconciler
-			// and this controller. The GenericJobReconciler is responsible for creating a
-			// new Workload slice that reflects the updated Job spec. Once admitted, that
-			// new slice finalizes (Finishes) the old slice.
-			//
-			// If the current reconciliation observes the old Workload slice while the Job’s
-			// parallelism has already increased, the slice is considered stale. In this case,
-			// we skip syncing to avoid propagating outdated state to the remote clusters.
-			if oldParallelism < newParallelism && workloadName != newWorkloadName {
-				log.V(2).Info("Skipping stale ElasticWorkload sync",
-					"old.parallelism", oldParallelism,
-					"new.parallelism", newParallelism,
-					"workloadName", workloadName,
-					"newWorkloadName", newWorkloadName)
-				return nil
-			}
-
-			// Update remote job's workload slice name and parallelism if needed.
-			if err := clientutil.Patch(ctx, remoteClient, &remoteJob, func() (bool, error) {
-				// Update workload name label.
-				labelsChanged := false
-				if remoteJob.Labels == nil {
-					remoteJob.Labels = map[string]string{constants.PrebuiltWorkloadLabel: workloadName}
-					labelsChanged = true
-				} else {
-					if cur, ok := remoteJob.Labels[constants.PrebuiltWorkloadLabel]; !ok || cur != workloadName {
-						remoteJob.Labels[constants.PrebuiltWorkloadLabel] = workloadName
-						labelsChanged = true
-					}
-				}
-
-				// Update parallelism.
-				remoteJob.Spec.Parallelism = localJob.Spec.Parallelism
-				return oldParallelism != newParallelism || labelsChanged, nil
-			}); err != nil {
-				return fmt.Errorf("failed to patch remote job: %w", err)
-			}
+		// Sync elastic workload if needed.
+		if needElasticJobSync(log, workloadName, &localJob, &remoteJob) {
+			return syncElasticJob(ctx, remoteClient, log, workloadName, &localJob, &remoteJob)
 		}
 
 		return nil
@@ -208,4 +174,70 @@ func (*multiKueueAdapter) WorkloadKeyFor(o runtime.Object) (types.NamespacedName
 	}
 
 	return types.NamespacedName{Name: prebuiltWl, Namespace: job.Namespace}, nil
+}
+
+// needElasticJobSync determines if a remote Job requires synchronization due to elastic job features.
+// Returns true when elastic jobs via workload slices are enabled and workload slicing is enabled for the job,
+// and either the parallelism differs between local and remote Jobs, or the remote Job lacks the workload label.
+// Skips sync when detecting stale workload updates during scale-up by comparing workload names and parallelism.
+func needElasticJobSync(log logr.Logger, workloadName string, localJob, remoteJob *batchv1.Job) bool {
+	if !features.Enabled(features.ElasticJobsViaWorkloadSlices) || !workloadslicing.Enabled(localJob) {
+		return false
+	}
+	oldParallelism := ptr.Deref(remoteJob.Spec.Parallelism, 0)
+	newParallelism := ptr.Deref(localJob.Spec.Parallelism, 0)
+	newWorkloadName := jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(localJob.GetName(), localJob.GetUID(), gvk, localJob.GetGeneration())
+
+	// Detect and skip stale local Workload updates caused by a Job scale-up event.
+	//
+	// During scale-up, a race condition may occur between the GenericJobReconciler
+	// and this controller. The GenericJobReconciler is responsible for creating a
+	// new Workload slice that reflects the updated Job spec. Once admitted, that
+	// new slice finalizes (Finishes) the old slice.
+	//
+	// If the current reconciliation observes the old Workload slice while the Job’s
+	// parallelism has already increased, the slice is considered stale. In this case,
+	// we return as if the sync is not needed to avoid propagating outdated state to the remote clusters.
+	if oldParallelism < newParallelism && workloadName != newWorkloadName {
+		log.V(2).Info("Skipping stale ElasticWorkload sync",
+			"old.parallelism", oldParallelism,
+			"new.parallelism", newParallelism,
+			"workloadName", workloadName,
+			"newWorkloadName", newWorkloadName)
+		return false
+	}
+	return oldParallelism != newParallelism || remoteJob.Labels == nil || remoteJob.Labels[constants.PrebuiltWorkloadLabel] != workloadName
+}
+
+// syncElasticJob updates the remote job's workload label and parallelism to match the local job configuration.
+// It patches the remote job only if the parallelism value or workload name label has changed.
+//
+// Note: this call should be gated by needElasticJobSync to ensure it's only executed when necessary,
+// and to perform check for stale workload updates during scale-up.
+func syncElasticJob(ctx context.Context, remoteClient client.Client, log logr.Logger, workloadName string, localJob, remoteJob *batchv1.Job) error {
+	oldParallelism := ptr.Deref(remoteJob.Spec.Parallelism, 0)
+	newParallelism := ptr.Deref(localJob.Spec.Parallelism, 0)
+
+	// Update a remote job's workload slice name and parallelism if needed.
+	if err := clientutil.Patch(ctx, remoteClient, remoteJob, func() (bool, error) {
+		// Update the workload name label.
+		labelsChanged := false
+		if remoteJob.Labels == nil {
+			remoteJob.Labels = map[string]string{constants.PrebuiltWorkloadLabel: workloadName}
+			labelsChanged = true
+		} else {
+			if cur, ok := remoteJob.Labels[constants.PrebuiltWorkloadLabel]; !ok || cur != workloadName {
+				remoteJob.Labels[constants.PrebuiltWorkloadLabel] = workloadName
+				labelsChanged = true
+			}
+		}
+
+		// Update parallelism.
+		remoteJob.Spec.Parallelism = localJob.Spec.Parallelism
+		return oldParallelism != newParallelism || labelsChanged, nil
+	}); err != nil {
+		return fmt.Errorf("failed to patch remote job: %w", err)
+	}
+
+	return nil
 }

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -71,6 +71,7 @@ import (
 	testingtfjob "sigs.k8s.io/kueue/pkg/util/testingjobs/tfjob"
 	testingtrainjob "sigs.k8s.io/kueue/pkg/util/testingjobs/trainjob"
 	testingxgboostjob "sigs.k8s.io/kueue/pkg/util/testingjobs/xgboostjob"
+	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 	"sigs.k8s.io/kueue/test/integration/framework"
 	"sigs.k8s.io/kueue/test/util"
@@ -1795,7 +1796,292 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				remoteJob := job.DeepCopy()
 				getJob(worker1.ctx, worker1.client, remoteJob)
 				g.Expect(remoteJob.Spec.Suspend).To(gomega.Equal(ptr.To(false)))
+				g.Expect(remoteJob.Spec.Parallelism).To(gomega.BeEquivalentTo(ptr.To(int32(2))))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		/*
+			Scale-down Section.
+			Note: Scaling down does not create a new workload slice, so we continue using the previously generated `newWorkloadKey`.
+		*/
+		ginkgo.By("scale-down the job", func() {
+			getJob(manager.ctx, manager.client, job)
+			job.Spec.Parallelism = ptr.To(int32(1))
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(manager.client.Update(manager.ctx, job)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+		ginkgo.By("observe: workload changed in the manager cluster", func() {
+			getJob(manager.ctx, manager.client, job)
+			gomega.Eventually(func(g gomega.Gomega) {
+				workload := getWorkload(g, manager.ctx, manager.client, newWorkloadKey)
+				g.Expect(workload.Spec.PodSets[0].Count).To(gomega.BeEquivalentTo(int32(1)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+		ginkgo.By("observe: there are no new workloads created in response to scale-down even in the manager cluster", func() {
+			list := &kueue.WorkloadList{}
+			gomega.Expect(manager.client.List(manager.ctx, list, client.InNamespace(job.Namespace))).To(gomega.Succeed())
+			gomega.Expect(list.Items).To(gomega.HaveLen(2))
+		})
+		ginkgo.By("observe: job changed in the worker1 cluster", func() {
+			remoteJob := job.DeepCopy()
+			gomega.Eventually(func(g gomega.Gomega) {
+				getJob(worker1.ctx, worker1.client, remoteJob)
 				g.Expect(remoteJob.Spec.Parallelism).To(gomega.BeEquivalentTo(ptr.To(int32(1))))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+		ginkgo.By("observe: there are no new workloads created in response to scale-down even in the worker1 cluster", func() {
+			list := &kueue.WorkloadList{}
+			gomega.Expect(worker1.client.List(worker1.ctx, list, client.InNamespace(job.Namespace))).To(gomega.Succeed())
+			gomega.Expect(list.Items).To(gomega.HaveLen(2))
+		})
+		ginkgo.By("observe: there are still no workloads or jobs in the worker2 cluster", func() {
+			workloads := &kueue.WorkloadList{}
+			gomega.Expect(worker2.client.List(worker2.ctx, workloads, client.InNamespace(job.Namespace))).To(gomega.Succeed())
+			gomega.Expect(workloads.Items).To(gomega.BeEmpty())
+			jobs := &batchv1.JobList{}
+			gomega.Expect(worker2.client.List(worker2.ctx, jobs, client.InNamespace(job.Namespace))).To(gomega.Succeed())
+			gomega.Expect(jobs.Items).To(gomega.BeEmpty())
+		})
+
+		/*
+			Finish Job Section.
+		*/
+		ginkgo.By("finishing the job in the worker1 cluster", func() {
+			now := metav1.Now()
+			completedJobCondition := batchv1.JobCondition{
+				Type:               batchv1.JobComplete,
+				Status:             corev1.ConditionTrue,
+				LastProbeTime:      now,
+				LastTransitionTime: now,
+				Message:            "Job finished successfully",
+			}
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				remoteJob := job.DeepCopy()
+				getJob(worker1.ctx, worker1.client, remoteJob)
+				remoteJob.Status.Conditions = append(remoteJob.Status.Conditions,
+					completedJobCondition,
+					batchv1.JobCondition{
+						Type:               batchv1.JobSuccessCriteriaMet,
+						Status:             corev1.ConditionTrue,
+						LastProbeTime:      now,
+						LastTransitionTime: now,
+						Message:            "Reached expected number of succeeded pods",
+					})
+				remoteJob.Status.Succeeded = 1
+				remoteJob.Status.StartTime = ptr.To(now)
+				remoteJob.Status.CompletionTime = ptr.To(now)
+				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, remoteJob)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			waitForWorkloadToFinishAndRemoteWorkloadToBeDeleted(newWorkloadKey, completedJobCondition.Message)
+
+			getJob(manager.ctx, manager.client, job)
+			gomega.Expect(job.Status.Conditions).Should(gomega.ContainElement(gomega.WithTransform(func(condition batchv1.JobCondition) batchv1.JobCondition {
+				condition.LastProbeTime = now
+				condition.LastTransitionTime = now
+				return condition
+			}, gomega.Equal(completedJobCondition))))
+		})
+	})
+
+	ginkgo.It("Should run an ElasticJob on worker if admitted when features.MultiKueueBatchJobWithManagedBy is disabled", func() {
+		manager := managerTestCluster
+		worker1 := worker1TestCluster
+		worker2 := worker2TestCluster
+
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlices, true)
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueBatchJobWithManagedBy, false)
+
+		jobGVK := batchv1.SchemeGroupVersion.WithKind("Job")
+
+		getJob := func(ctx context.Context, clnt client.Client, job *batchv1.Job) {
+			ginkgo.GinkgoHelper()
+			gomega.Expect(clnt.Get(ctx, client.ObjectKeyFromObject(job), job)).To(gomega.Succeed())
+		}
+		getWorkloadKey := func(job *batchv1.Job) types.NamespacedName {
+			ginkgo.GinkgoHelper()
+			getJob(manager.ctx, manager.client, job)
+			return types.NamespacedName{Name: jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.Name, job.UID, jobGVK, job.GetGeneration()), Namespace: job.Namespace}
+		}
+		getWorkload := func(g gomega.Gomega, ctx context.Context, clnt client.Client, key types.NamespacedName) *kueue.Workload {
+			ginkgo.GinkgoHelper()
+			workload := &kueue.Workload{}
+			g.Expect(clnt.Get(ctx, key, workload)).To(gomega.Succeed())
+			return workload
+		}
+
+		job := testingjob.MakeJob("job", managerNs.Name).
+			Parallelism(1).
+			Completions(2).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
+			Obj()
+		util.MustCreate(manager.ctx, manager.client, job)
+
+		ginkgo.By("observe: the job is created in the manager cluster", func() {
+			getJob(manager.ctx, manager.client, job)
+			gomega.Expect(job.Spec.Suspend).To(gomega.Equal(ptr.To(true)))
+		})
+
+		ginkgo.By("observe: a new workload is created in the manager cluster")
+		workloadKey := getWorkloadKey(job)
+		gomega.Eventually(func(g gomega.Gomega) {
+			getWorkload(g, manager.ctx, manager.client, workloadKey)
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("admit workload on the manager cluster")
+		util.SetQuotaReservation(manager.ctx, manager.client, workloadKey, utiltestingapi.MakeAdmission(managerCq.Name).Obj())
+
+		ginkgo.By("observe: workload is created on all worker clusters", func() {
+			localWorkload := getWorkload(gomega.Default, manager.ctx, manager.client, workloadKey)
+			gomega.Eventually(func(g gomega.Gomega) {
+				workload := getWorkload(g, worker1.ctx, worker1.client, workloadKey)
+				g.Expect(workload.Spec).To(gomega.BeComparableTo(localWorkload.Spec))
+				workload = getWorkload(g, worker2.ctx, worker2.client, workloadKey)
+				g.Expect(workload.Spec).To(gomega.BeComparableTo(localWorkload.Spec))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("admit the workload on the worker1 cluster")
+		util.SetQuotaReservation(worker1.ctx, worker1.client, workloadKey, utiltestingapi.MakeAdmission(managerCq.Name).Obj())
+
+		ginkgo.By("observe: the local workload admission check and local events reflect reservation on the worker1 cluster")
+		gomega.Eventually(func(g gomega.Gomega) {
+			localWorkload := getWorkload(g, manager.ctx, manager.client, workloadKey)
+			acs := admissioncheck.FindAdmissionCheck(localWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
+			g.Expect(acs).NotTo(gomega.BeNil())
+			g.Expect(acs.State).To(gomega.Equal(kueue.CheckStateReady))
+			g.Expect(acs.Message).To(gomega.Equal(`The workload got reservation on "worker1"`))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		util.ExpectEventAppeared(manager.ctx, manager.client, corev1.Event{
+			Reason:  "MultiKueue",
+			Type:    corev1.EventTypeNormal,
+			Message: `The workload got reservation on "worker1"`,
+		})
+
+		ginkgo.By("observe: job is synced to the worker1 cluster and is active", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				remoteJob := job.DeepCopy()
+				getJob(worker1.ctx, worker1.client, remoteJob)
+				g.Expect(remoteJob.Spec.Suspend).To(gomega.Equal(ptr.To(false)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("observe: the workload is removed from the worker2 cluster")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(worker2.client.Get(worker2.ctx, workloadKey, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("observe: there are no jobs in the worker2 cluster", func() {
+			list := &batchv1.JobList{}
+			gomega.Expect(worker2.client.List(worker2.ctx, list, client.InNamespace(job.Namespace))).To(gomega.Succeed())
+			gomega.Expect(list.Items).To(gomega.BeEmpty())
+		})
+
+		ginkgo.By("observe: job is still suspended in the manager cluster", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				getJob(manager.ctx, manager.client, job)
+				g.Expect(job.Spec.Suspend).To(gomega.Equal(ptr.To(true)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		/*
+			Scale-up Section
+		*/
+
+		ginkgo.By("scale-up the job", func() {
+			getJob(manager.ctx, manager.client, job)
+			job.Spec.Parallelism = ptr.To(int32(2))
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(manager.client.Update(manager.ctx, job)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("observe: a new workload slice is created")
+		newWorkloadKey := getWorkloadKey(job)
+		gomega.Eventually(func(g gomega.Gomega) {
+			getWorkload(g, manager.ctx, manager.client, newWorkloadKey)
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("copy clusterName from the old workload to the new workload", func() {
+			oldWorkload := getWorkload(gomega.Default, manager.ctx, manager.client, workloadKey)
+			newWorkload := getWorkload(gomega.Default, manager.ctx, manager.client, newWorkloadKey)
+			// This step is done by the scheduler during the new slice admission and the old slice replacement.
+			// Since we are not "running" scheduler for this test suit, we need to "emulate" this step.
+			newWorkload.Status.ClusterName = oldWorkload.Status.ClusterName
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(manager.client.Status().Update(manager.ctx, newWorkload)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			newWorkload = getWorkload(gomega.Default, manager.ctx, manager.client, newWorkloadKey)
+			gomega.Expect(newWorkload.Status.ClusterName).Should(gomega.BeEquivalentTo(oldWorkload.Status.ClusterName))
+		})
+
+		ginkgo.By("admit the new workload and finish the old workload in the manager cluster", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				oldWorkload := getWorkload(g, manager.ctx, manager.client, workloadKey)
+				g.Expect(workload.Finish(manager.ctx, manager.client, oldWorkload, kueue.WorkloadSliceReplaced, "Replaced to accommodate a new slice", util.RealClock)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.SetQuotaReservation(manager.ctx, manager.client, newWorkloadKey, utiltestingapi.MakeAdmission(managerCq.Name).Obj())
+		})
+
+		ginkgo.By("observe: the new workload is created in the worker1 cluster")
+		gomega.Eventually(func(g gomega.Gomega) {
+			local := getWorkload(g, manager.ctx, manager.client, newWorkloadKey)
+			remote := getWorkload(g, worker1.ctx, worker1.client, newWorkloadKey)
+			g.Expect(remote.Spec).To(gomega.BeComparableTo(local.Spec))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("observe: there are no workloads or jobs in the worker2 cluster", func() {
+			workloads := &kueue.WorkloadList{}
+			gomega.Expect(worker2.client.List(worker2.ctx, workloads, client.InNamespace(job.Namespace))).To(gomega.Succeed())
+			gomega.Expect(workloads.Items).To(gomega.BeEmpty())
+			jobs := &batchv1.JobList{}
+			gomega.Expect(worker2.client.List(worker2.ctx, jobs, client.InNamespace(job.Namespace))).To(gomega.Succeed())
+			gomega.Expect(jobs.Items).To(gomega.BeEmpty())
+		})
+
+		ginkgo.By("observe: the old workload is still admitted in the worker1 cluster", func() {
+			workload := getWorkload(gomega.Default, worker1.ctx, worker1.client, workloadKey)
+			util.ExpectWorkloadsToBeAdmitted(worker1.ctx, worker1.client, workload)
+		})
+
+		ginkgo.By("observe: the remote job is still active and has old parallelism count", func() {
+			remoteJob := job.DeepCopy()
+			getJob(worker1.ctx, worker1.client, remoteJob)
+			gomega.Expect(remoteJob.Spec.Suspend).To(gomega.Equal(ptr.To(false)))
+			gomega.Expect(remoteJob.Spec.Parallelism).To(gomega.BeEquivalentTo(ptr.To(int32(1))))
+		})
+
+		ginkgo.By("admit the new workload replacing the old workload in the worker1 cluster", func() {
+			util.SetQuotaReservation(worker1.ctx, worker1.client, newWorkloadKey, utiltestingapi.MakeAdmission(managerCq.Name).Obj())
+			gomega.Eventually(func(g gomega.Gomega) {
+				wl := getWorkload(g, worker1.ctx, worker1.client, workloadKey)
+				g.Expect(workload.Finish(worker1.ctx, worker1.client, wl, kueue.WorkloadSliceReplaced, "Replaced to accommodate a new slice", util.RealClock)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("observe: the new local workload admission check and local events reflect reservation in the worker1 cluster")
+		gomega.Eventually(func(g gomega.Gomega) {
+			workload := getWorkload(g, manager.ctx, manager.client, newWorkloadKey)
+			acs := admissioncheck.FindAdmissionCheck(workload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
+			g.Expect(acs).NotTo(gomega.BeNil())
+			g.Expect(acs.State).To(gomega.Equal(kueue.CheckStateReady))
+			g.Expect(acs.Message).To(gomega.Equal(`The workload got reservation on "worker1"`))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		util.ExpectEventAppeared(manager.ctx, manager.client, corev1.Event{
+			Reason:  "MultiKueue",
+			Type:    corev1.EventTypeNormal,
+			Message: `The workload got reservation on "worker1"`,
+		})
+
+		ginkgo.By("observe: job changes are synced to the worker1 cluster", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				remoteJob := job.DeepCopy()
+				getJob(worker1.ctx, worker1.client, remoteJob)
+				g.Expect(remoteJob.Spec.Suspend).To(gomega.Equal(ptr.To(false)))
+				g.Expect(remoteJob.Spec.Parallelism).To(gomega.BeEquivalentTo(ptr.To(int32(2))))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This is a cherry-pick of #9044 into `release-0.15`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9043

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MultiKueue & ElasticJobs: fix the bug that the new size of a Job was not reflected on the worker cluster.
```