### PR TITLE
Semi-automated cherry pick of #8768: Add WorkloadSliceNameAnnotation and refactor pod ungating 

### DIFF
--- a/apis/kueue/v1beta1/topology_types.go
+++ b/apis/kueue/v1beta1/topology_types.go
@@ -90,6 +90,12 @@ const (
 	// PodSetGroupName is an annotation indicating the name of the group of PodSets. PodSet Group
 	// is a unit flavor assignment and topology domain fitting.
 	PodSetGroupName = "kueue.x-k8s.io/podset-group-name"
+
+	// WorkloadSliceNameAnnotation identifies the original workload name in a slice chain.
+	// It is set on every Workload created in the chain of the workloads, as well as on the Pods
+	// associated with that Workload.
+	// This annotation is alpha-level for the ElasticJobsViaWorkloadSlices feature gate.
+	WorkloadSliceNameAnnotation = "kueue.x-k8s.io/workload-slice-name"
 )
 
 // TopologySpec defines the desired state of Topology

--- a/apis/kueue/v1beta2/topology_types.go
+++ b/apis/kueue/v1beta2/topology_types.go
@@ -95,6 +95,12 @@ const (
 	// PodSetGroupName is an annotation indicating the name of the group of PodSets. PodSet Group
 	// is a unit flavor assignment and topology domain fitting.
 	PodSetGroupName = "kueue.x-k8s.io/podset-group-name"
+
+	// WorkloadSliceNameAnnotation identifies the original workload name in a slice chain.
+	// It is set on every Workload created in the chain of the workloads, as well as on the Pods
+	// associated with that Workload.
+	// This annotation is alpha-level for the ElasticJobsViaWorkloadSlices feature gate.
+	WorkloadSliceNameAnnotation = "kueue.x-k8s.io/workload-slice-name"
 )
 
 // TopologySpec defines the desired state of Topology

--- a/pkg/controller/core/indexer/indexer.go
+++ b/pkg/controller/core/indexer/indexer.go
@@ -42,6 +42,9 @@ const (
 	OwnerReferenceUID          = "metadata.ownerReferences.uid"
 	WorkloadAdmissionCheckKey  = "status.admissionChecks"
 	WorkloadPriorityClassKey   = "spec.priorityClassRef"
+	// WorkloadSliceNameKey is an index for pods by their workload slice name annotation.
+	// Used to find pods belonging to an elastic workload slice chain.
+	WorkloadSliceNameKey = "metadata.workloadSliceName"
 
 	// OwnerReferenceGroupKindFmt defines the format string used to construct a field path
 	// for indexing or matching against a specific owner Group and Kind in a Kubernetes object's metadata.
@@ -168,6 +171,19 @@ func IndexOwnerUID(obj client.Object) []string {
 	return slices.Map(obj.GetOwnerReferences(), func(o *metav1.OwnerReference) string { return string(o.UID) })
 }
 
+// IndexPodWorkloadSliceName indexes pods by their workload slice name annotation.
+func IndexPodWorkloadSliceName(obj client.Object) []string {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+	value, found := pod.Annotations[kueue.WorkloadSliceNameAnnotation]
+	if !found {
+		return nil
+	}
+	return []string{value}
+}
+
 func IndexWorkloadAdmissionCheck(obj client.Object) []string {
 	wl, ok := obj.(*kueue.Workload)
 	if !ok || len(wl.Status.AdmissionChecks) == 0 {
@@ -219,11 +235,15 @@ func Setup(ctx context.Context, indexer client.FieldIndexer) error {
 	if err := indexer.IndexField(ctx, &kueue.Workload{}, OwnerReferenceUID, IndexOwnerUID); err != nil {
 		return fmt.Errorf("setting index on ownerReferences.uid for Workload: %w", err)
 	}
-	// Add pod index to be able to list pods for elastic-jobs, needed to remove scheduling gate on
-	// admitted workload slices.
+	// Add pod indexes to be able to list pods for elastic-jobs, needed to remove scheduling gate on
+	// admitted workload slices. Uses workload slice name annotation to support JobSet and other
+	// workloads where pods are not immediate children of the job.
 	if features.Enabled(features.ElasticJobsViaWorkloadSlices) {
+		if err := indexer.IndexField(ctx, &corev1.Pod{}, WorkloadSliceNameKey, IndexPodWorkloadSliceName); err != nil {
+			return fmt.Errorf("setting index on workloadSliceName for Pod: %w", err)
+		}
 		if err := indexer.IndexField(ctx, &corev1.Pod{}, OwnerReferenceUID, IndexOwnerUID); err != nil {
-			return err
+			return fmt.Errorf("setting index on ownerReferences.uid for Pod: %w", err)
 		}
 	}
 	return nil

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -130,7 +130,10 @@ func TestReconcileGenericJob(t *testing.T) {
 			podSets: basePodSets,
 			wantWorkloads: []kueue.Workload{
 				*baseWl.Clone().Name("job-test-job-3991b").
-					Annotations(map[string]string{workloadslicing.EnabledAnnotationKey: workloadslicing.EnabledAnnotationValue}).
+					Annotations(map[string]string{
+						workloadslicing.EnabledAnnotationKey: workloadslicing.EnabledAnnotationValue,
+						kueue.WorkloadSliceNameAnnotation:    "job-test-job-3991b",
+					}).
 					Obj(),
 			},
 		},

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -1011,31 +1011,36 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 func Test_StartWorkloadSlicePods(t *testing.T) {
 	clientBuilder := func() *fake.ClientBuilder {
 		return fake.NewClientBuilder().WithScheme(scheme.Scheme).
-			WithIndex(&corev1.Pod{}, indexer.OwnerReferenceUID, indexer.IndexOwnerUID)
+			WithIndex(&corev1.Pod{}, indexer.WorkloadSliceNameKey, indexer.IndexPodWorkloadSliceName)
 	}
-	testPod := func(name, resourceVersion string, owner client.Object, schedulingGates ...corev1.PodSchedulingGate) corev1.Pod {
+	testPod := func(name, resourceVersion, sliceName string, schedulingGates ...corev1.PodSchedulingGate) corev1.Pod {
 		return corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: name,
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: owner.GetObjectKind().GroupVersionKind().GroupVersion().String(),
-						Kind:       owner.GetObjectKind().GroupVersionKind().Kind,
-						Name:       owner.GetName(),
-						UID:        owner.GetUID(),
-					},
-				},
+				Name:            name,
+				Namespace:       "default",
 				ResourceVersion: resourceVersion,
+				Annotations: map[string]string{
+					kueue.WorkloadSliceNameAnnotation: sliceName,
+				},
 			},
 			Spec: corev1.PodSpec{
 				SchedulingGates: schedulingGates,
 			},
 		}
 	}
+	testWorkload := &kueue.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-workload",
+			Namespace: "default",
+			Annotations: map[string]string{
+				kueue.WorkloadSliceNameAnnotation: "test-slice",
+			},
+		},
+	}
 
 	type args struct {
-		clnt   client.Client
-		object client.Object
+		clnt client.Client
+		wl   *kueue.Workload
 	}
 	tests := map[string]struct {
 		args     args
@@ -1049,14 +1054,14 @@ func Test_StartWorkloadSlicePods(t *testing.T) {
 						return errors.New("test-list-pods-error")
 					},
 				}).Build(),
-				object: testJobObject,
+				wl: testWorkload,
 			},
 			wantErr: true,
 		},
 		"NoPods": {
 			args: args{
-				clnt:   clientBuilder().Build(),
-				object: testJobObject,
+				clnt: clientBuilder().Build(),
+				wl:   testWorkload,
 			},
 		},
 		"ProcessPods": {
@@ -1064,34 +1069,26 @@ func Test_StartWorkloadSlicePods(t *testing.T) {
 				clnt: clientBuilder().WithLists(&corev1.PodList{
 					Items: []corev1.Pod{
 						// Un-gated pod should remain un-gated, i.e., no change.
-						testPod("test-one", "100", testJobObject),
+						testPod("test-one", "100", "test-slice"),
 						// Gated pod - gate should be removed.
-						testPod("test-two", "200", testJobObject, corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}),
+						testPod("test-two", "200", "test-slice", corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}),
 						// Gated with some other gate -
-						testPod("test-three", "300", testJobObject, corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}, corev1.PodSchedulingGate{Name: kueue.TopologySchedulingGate}),
-						// Other gated pod (not for this job)
-						testPod("other-pod", "400", &batchv1.Job{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: "other-job",
-							},
-						}, corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}),
+						testPod("test-three", "300", "test-slice", corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}, corev1.PodSchedulingGate{Name: kueue.TopologySchedulingGate}),
+						// Other gated pod (not for this workload slice)
+						testPod("other-pod", "400", "other-slice", corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}),
 					},
 				}).Build(),
-				object: testJobObject,
+				wl: testWorkload,
 			},
 			wantPods: &corev1.PodList{
 				Items: []corev1.Pod{
-					testPod("test-one", "100", testJobObject),
+					testPod("test-one", "100", "test-slice"),
 					// Gated pod - gate removed (resource version increase).
-					testPod("test-two", "201", testJobObject),
+					testPod("test-two", "201", "test-slice"),
 					// Gated with some other gate - other gate remains (resource version increased).
-					testPod("test-three", "301", testJobObject, corev1.PodSchedulingGate{Name: kueue.TopologySchedulingGate}),
-					// Other gated pod (not for this job) - no change.
-					testPod("other-pod", "400", &batchv1.Job{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "other-job",
-						},
-					}, corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}),
+					testPod("test-three", "301", "test-slice", corev1.PodSchedulingGate{Name: kueue.TopologySchedulingGate}),
+					// Other gated pod (not for this workload slice) - no change.
+					testPod("other-pod", "400", "other-slice", corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}),
 				},
 			},
 		},
@@ -1099,7 +1096,7 @@ func Test_StartWorkloadSlicePods(t *testing.T) {
 			args: args{
 				clnt: clientBuilder().WithLists(&corev1.PodList{
 					Items: []corev1.Pod{
-						testPod("test", "100", testJobObject, corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}),
+						testPod("test", "100", "test-slice", corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}),
 					},
 				}).WithInterceptorFuncs(interceptor.Funcs{
 					Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
@@ -1107,15 +1104,72 @@ func Test_StartWorkloadSlicePods(t *testing.T) {
 					},
 				}).
 					Build(),
-				object: testJobObject,
+				wl: testWorkload,
 			},
 			wantErr: true,
+		},
+		"BackwardsCompatibility_FallbackToOwnerReference": {
+			args: args{
+				// Client with both indexes for backwards compatibility
+				clnt: fake.NewClientBuilder().WithScheme(scheme.Scheme).
+					WithIndex(&corev1.Pod{}, indexer.WorkloadSliceNameKey, indexer.IndexPodWorkloadSliceName).
+					WithIndex(&corev1.Pod{}, indexer.OwnerReferenceUID, indexer.IndexOwnerUID).
+					WithLists(&corev1.PodList{
+						Items: []corev1.Pod{
+							// Pod without annotation but with owner reference (old pod)
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:            "old-pod",
+									Namespace:       "default",
+									ResourceVersion: "100",
+									OwnerReferences: []metav1.OwnerReference{
+										{UID: "job-uid-123"},
+									},
+								},
+								Spec: corev1.PodSpec{
+									SchedulingGates: []corev1.PodSchedulingGate{{Name: kueue.ElasticJobSchedulingGate}},
+								},
+							},
+						},
+					}).Build(),
+				// Workload with owner reference to job
+				wl: &kueue.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-workload",
+						Namespace: "default",
+						Annotations: map[string]string{
+							kueue.WorkloadSliceNameAnnotation: "test-slice",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{UID: "job-uid-123"},
+						},
+					},
+				},
+			},
+			wantPods: &corev1.PodList{
+				Items: []corev1.Pod{
+					// Pod should have gate removed (resource version increased)
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            "old-pod",
+							Namespace:       "default",
+							ResourceVersion: "101",
+							OwnerReferences: []metav1.OwnerReference{
+								{UID: "job-uid-123"},
+							},
+						},
+						Spec: corev1.PodSpec{
+							SchedulingGates: nil,
+						},
+					},
+				},
+			},
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
-			if err := StartWorkloadSlicePods(ctx, tt.args.clnt, tt.args.object); (err != nil) != tt.wantErr {
+			if err := StartWorkloadSlicePods(ctx, tt.args.clnt, tt.args.wl); (err != nil) != tt.wantErr {
 				t.Errorf("StartWorkloadSlicePods() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.wantPods == nil {


### PR DESCRIPTION
Cherry pick of #8768 on release-0.15.

#8768: Add WorkloadSliceNameAnnotation and refactor pod ungating 

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```