### PR TITLE
Fix metrics certificate reload

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -189,13 +189,14 @@ func main() {
 
 	config.AddWebhookSettingsTo(&options, &cfg)
 
+	var metricsCertWatcher *certwatcher.CertWatcher
 	if cfg.InternalCertManagement == nil || !*cfg.InternalCertManagement.Enable {
 		metricsCertPath := "/etc/kueue/metrics/certs"
 		setupLog.Info("Initializing metrics certificate watcher using provided certificates",
 			"metrics-cert-path", metricsCertPath)
 
 		var err error
-		metricsCertWatcher, err := certwatcher.New(
+		metricsCertWatcher, err = certwatcher.New(
 			filepath.Join(metricsCertPath, "tls.crt"),
 			filepath.Join(metricsCertPath, "tls.key"),
 		)
@@ -304,6 +305,13 @@ func main() {
 	if err != nil {
 		setupLog.Error(err, "Unable to setup server version fetcher")
 		os.Exit(1)
+	}
+
+	if metricsCertWatcher != nil {
+		if err := mgr.Add(metricsCertWatcher); err != nil {
+			setupLog.Error(err, "Unable to start metrics certificate watcher")
+			os.Exit(1)
+		}
 	}
 
 	if err := setupProbeEndpoints(mgr, certsReady); err != nil {

--- a/test/e2e/certmanager/metrics_test.go
+++ b/test/e2e/certmanager/metrics_test.go
@@ -179,6 +179,57 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Ordered, func() {
 				expectMetricsToBeAvailable(curlPod.Name, curlContainerName, [][]string{expectedMetric})
 			})
 		})
+		ginkgo.It("should continue to expose metrics after the secret is re-created", func() {
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, workload)
+			initialSecret := &corev1.Secret{}
+			ginkgo.By("fetching initial secret", func() {
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKey{
+					Namespace: kueueNS, Name: certSecretName,
+				}, initialSecret)).To(gomega.Succeed())
+			})
+
+			var initialCertContent []byte
+			ginkgo.By("reading initial certificate content from curl-pod", func() {
+				certContent, _, err := util.KExecute(ctx, cfg, restClient, kueueNS, curlPod.Name, curlContainerName,
+					[]string{"/bin/sh", "-c", fmt.Sprintf("cat %s/ca.crt", certMountPath)})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				initialCertContent = certContent
+				gomega.Expect(initialCertContent).NotTo(gomega.BeEmpty())
+			})
+
+			ginkgo.By("deleting the secret", func() {
+				gomega.Expect(k8sClient.Delete(ctx, initialSecret)).To(gomega.Succeed())
+			})
+
+			ginkgo.By("waiting for the secret to be re-created", func() {
+				recreatedSecret := &corev1.Secret{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{
+						Namespace: kueueNS, Name: certSecretName,
+					}, recreatedSecret)).To(gomega.Succeed())
+					g.Expect(recreatedSecret.UID).NotTo(gomega.Equal(initialSecret.UID), "Secret not recreated")
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verifying certificate content changed in curl-pod", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					newCertContent, _, err := util.KExecute(ctx, cfg, restClient, kueueNS, curlPod.Name, curlContainerName,
+						[]string{"/bin/sh", "-c", fmt.Sprintf("cat %s/ca.crt", certMountPath)})
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+					g.Expect(initialCertContent).NotTo(gomega.BeEmpty())
+					g.Expect(newCertContent).NotTo(gomega.BeEmpty())
+					g.Expect(newCertContent).NotTo(gomega.Equal(initialCertContent), "Certificate content should have changed after secret recreation")
+				}, util.VeryLongTimeout, util.LongInterval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("checking that the metrics are still available", func() {
+				expectedMetric := []string{
+					"kueue_quota_reserved_workloads_total",
+					clusterQueue.Name,
+				}
+				expectMetricsToBeAvailable(curlPod.Name, curlContainerName, [][]string{expectedMetric})
+			})
+		})
 	})
 })
 

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -47,6 +47,7 @@ const (
 	ConsistentDuration      = 1 * time.Second
 	ShortInterval           = 10 * time.Millisecond
 	Interval                = time.Millisecond * 250
+	LongInterval            = time.Second * 1
 )
 
 var (


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This commit ensures that the metrics certificate
is reloaded in the server in case the certificate data
is updated.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9005

#### Special notes for your reviewer:
Assisted by Claude Code
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Metrics certificate is now reloaded when certificate data is updated. 
```