### PR TITLE
Automated cherry pick of #9067: Skip kind_cluster_exists in kind_load.

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -286,9 +286,8 @@ function cluster_kind_load {
 function kind_load {
     kubectl config --kubeconfig="$2" use-context "kind-$1"
 
-    if kind_cluster_exists "$1"; then
-        cluster_kind_load "$1"
-    fi
+    cluster_kind_load "$1"
+
     if [[ -n ${APPWRAPPER_VERSION:-} && ("$GINKGO_ARGS" =~ feature:appwrapper || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         install_appwrapper "$1" "$2"
     fi


### PR DESCRIPTION
Cherry pick of https://github.com/kubernetes-sigs/kueue/pull/9067 on release-0.16.

https://github.com/kubernetes-sigs/kueue/pull/9067: Add TAS performance test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

/kind cleanup

```release-note
NONE
```