### PR TITLE
Optimize cluster_kind_load_image.

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -416,26 +416,24 @@ function kind_load {
 # $1 cluster
 # $2 image
 function cluster_kind_load_image {
-    # check if the command to get worker nodes could succeeded
-    if ! $KIND get nodes --name "$1" > /dev/null 2>&1; then
-        echo "Failed to retrieve nodes for cluster '$1'."
-        return 1
-    fi
     # filter out 'control-plane' node, use only worker nodes to load image
     worker_nodes=$($KIND get nodes --name "$1" | grep -v 'control-plane')
-    if [[ -n "$worker_nodes" ]]; then
-        # Use docker save + ctr import directly to avoid the --all-platforms
-        # issue with multi-arch images in DinD environments.
-        # See: https://github.com/kubernetes-sigs/kind/issues/3795
-        echo "Loading image '$2' to cluster '$1'"
-        while IFS= read -r node; do
-            echo "  Loading image to node: $node"
-            if ! docker save "$2" | docker exec -i "$node" ctr --namespace=k8s.io images import --digests --snapshotter=overlayfs -; then
-                echo "Failed to load image '$2' to node '$node'"
-                return 1
-            fi
-        done <<< "$worker_nodes"
+    if [[ -z "$worker_nodes" ]]; then
+        echo "No worker nodes found for cluster '$1'"
+        return 1
     fi
+
+    # Use docker save + ctr import directly to avoid the --all-platforms
+    # issue with multi-arch images in DinD environments.
+    # See: https://github.com/kubernetes-sigs/kind/issues/3795
+    echo "Loading image '$2' to cluster '$1'"
+    while IFS= read -r node; do
+        echo "  Loading image to node: $node"
+        if ! docker save "$2" | docker exec -i "$node" ctr --namespace=k8s.io images import --digests --snapshotter=overlayfs -; then
+            echo "Failed to load image '$2' to node '$node'"
+            return 1
+        fi
+    done <<< "$worker_nodes"
 }
 
 # $1 kubeconfig


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Optimize cluster_kind_load_image.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
It doesn't _fix #8911 but at least we can see more logs.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```