### PR TITLE
Fix flaky "infinite preemption cycle" test with unique CQ names

### DIFF
--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -71,17 +71,17 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 		return cq
 	}
 
-	var createWorkloadWithPriority = func(queue kueue.LocalQueueName, cpuRequests string, priority int32) *kueue.Workload {
+	var createWorkloadWithPriority = func(queue string, cpuRequests string, priority int32) *kueue.Workload {
 		wl := utiltestingapi.MakeWorkloadWithGeneratedName("workload-", ns.Name).
 			Priority(priority).
-			Queue(queue).
+			Queue(kueue.LocalQueueName(queue)).
 			Request(corev1.ResourceCPU, cpuRequests).Obj()
 		wls = append(wls, wl)
 		util.MustCreate(ctx, k8sClient, wl)
 		return wl
 	}
 
-	var createWorkload = func(queue kueue.LocalQueueName, cpuRequests string) *kueue.Workload {
+	var createWorkload = func(queue string, cpuRequests string) *kueue.Workload {
 		return createWorkloadWithPriority(queue, cpuRequests, 0)
 	}
 
@@ -348,8 +348,8 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 
 		ginkgo.It("should not cause an infinite preemption cycle", func() {
 			ginkgo.By("Creating two workloads in cqA")
-			wlA1 := createWorkloadWithPriority(kueue.LocalQueueName(cqA.Name), "4", 9001)
-			wlA2 := createWorkloadWithPriority(kueue.LocalQueueName(cqA.Name), "4", 100)
+			wlA1 := createWorkloadWithPriority(cqA.Name, "4", 9001)
+			wlA2 := createWorkloadWithPriority(cqA.Name, "4", 100)
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlA1, wlA2)
 			util.ExpectAdmittedWorkloadsTotalMetric(cqA, "", 2)
 			// Sanity check asserting reserving_active_workloads to verify metric correctness after update
@@ -358,7 +358,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 			util.ExpectReservingActiveWorkloadsMetric(cqB, 0)
 
 			ginkgo.By("Creating a workload in cqB that should preempt one from cqA")
-			wlB1 := createWorkloadWithPriority(kueue.LocalQueueName(cqB.Name), "4", 100)
+			wlB1 := createWorkloadWithPriority(cqB.Name, "4", 100)
 
 			ginkgo.By("Check Preemptions")
 			util.ExpectPreemptedWorkloadsTotalMetric(cqA.Name, "InCohortFairSharing", 0)
@@ -386,7 +386,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 
 		ginkgo.It("should have NaN weighted share metric", func() {
 			ginkgo.By("Creating a workload in cqA")
-			wlA1 := createWorkloadWithPriority(kueue.LocalQueueName(cqA.Name), "4", 100)
+			wlA1 := createWorkloadWithPriority(cqA.Name, "4", 100)
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlA1)
 			util.ExpectAdmittedWorkloadsTotalMetric(cqA, "", 1)
 			util.ExpectReservingActiveWorkloadsMetric(cqA, 1)
@@ -480,8 +480,8 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 
 			ginkgo.By("all capacity used")
 			for range 6 {
-				createWorkloadWithPriority(kueue.LocalQueueName(bestEffortQueue.GetName()), "1", -1)
-				createWorkloadWithPriority(kueue.LocalQueueName(physicsQueue.GetName()), "1", -1)
+				createWorkloadWithPriority(bestEffortQueue.GetName(), "1", -1)
+				createWorkloadWithPriority(physicsQueue.GetName(), "1", -1)
 			}
 			expectCohortWeightedShare("best-effort", 1000.0)
 			expectCohortWeightedShare("physics", 500.0)
@@ -493,7 +493,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 			ginkgo.By("create high priority workloads")
 			for range 6 {
 				for _, cq := range cqs {
-					createWorkloadWithPriority(kueue.LocalQueueName(cq.GetName()), "1", 100)
+					createWorkloadWithPriority(cq.GetName(), "1", 100)
 				}
 			}
 
@@ -1205,17 +1205,17 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing", "featur
 		wls     []*kueue.Workload
 	)
 
-	var createWorkloadWithPriority = func(queue kueue.LocalQueueName, cpuRequests string, priority int32) *kueue.Workload {
+	var createWorkloadWithPriority = func(queue string, cpuRequests string, priority int32) *kueue.Workload {
 		wl := utiltestingapi.MakeWorkloadWithGeneratedName("workload-", ns.Name).
 			Priority(priority).
-			Queue(queue).
+			Queue(kueue.LocalQueueName(queue)).
 			Request(corev1.ResourceCPU, cpuRequests).Obj()
 		wls = append(wls, wl)
 		util.MustCreate(ctx, k8sClient, wl)
 		return wl
 	}
 
-	var createWorkload = func(queue kueue.LocalQueueName, cpuRequests string) *kueue.Workload {
+	var createWorkload = func(queue string, cpuRequests string) *kueue.Workload {
 		return createWorkloadWithPriority(queue, cpuRequests, 0)
 	}
 
@@ -1360,17 +1360,17 @@ var _ = ginkgo.Describe("Scheduler with AdmissionFairSharing = nil", ginkgo.Labe
 		wls     []*kueue.Workload
 	)
 
-	var createWorkloadWithPriority = func(queue kueue.LocalQueueName, cpuRequests string, priority int32) *kueue.Workload {
+	var createWorkloadWithPriority = func(queue string, cpuRequests string, priority int32) *kueue.Workload {
 		wl := utiltestingapi.MakeWorkloadWithGeneratedName("workload-", ns.Name).
 			Priority(priority).
-			Queue(queue).
+			Queue(kueue.LocalQueueName(queue)).
 			Request(corev1.ResourceCPU, cpuRequests).Obj()
 		wls = append(wls, wl)
 		util.MustCreate(ctx, k8sClient, wl)
 		return wl
 	}
 
-	var createWorkload = func(queue kueue.LocalQueueName, cpuRequests string) *kueue.Workload {
+	var createWorkload = func(queue string, cpuRequests string) *kueue.Workload {
 		return createWorkloadWithPriority(queue, cpuRequests, 0)
 	}
 
@@ -1428,7 +1428,7 @@ var _ = ginkgo.Describe("Scheduler with AdmissionFairSharing = nil", ginkgo.Labe
 
 		ginkgo.It("should ignore FairSharing", framework.SlowSpec, func() {
 			ginkgo.By("Creating a workload")
-			wl := createWorkload(kueue.LocalQueueName(lqA.Name), "32")
+			wl := createWorkload(lqA.Name, "32")
 
 			ginkgo.By("Admitting the workload")
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)


### PR DESCRIPTION
Avoid Prometheus metric collision by using ns.Name in ClusterQueue names (best-effort-cq-a/b) so each spec has its own metric series.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/8975

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```