### PR TITLE
Automated cherry pick of #9099: [release-0.15] Fix metrics certificate reload

### DIFF
--- a/test/e2e/certmanager/metrics_test.go
+++ b/test/e2e/certmanager/metrics_test.go
@@ -179,6 +179,57 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Ordered, func() {
 				expectMetricsToBeAvailable(curlPod.Name, curlContainerName, [][]string{expectedMetric})
 			})
 		})
+		ginkgo.It("should continue to expose metrics after the secret is re-created", func() {
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, workload)
+			initialSecret := &corev1.Secret{}
+			ginkgo.By("fetching initial secret", func() {
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKey{
+					Namespace: kueueNS, Name: certSecretName,
+				}, initialSecret)).To(gomega.Succeed())
+			})
+
+			var initialCertContent []byte
+			ginkgo.By("reading initial certificate content from curl-pod", func() {
+				certContent, _, err := util.KExecute(ctx, cfg, restClient, kueueNS, curlPod.Name, curlContainerName,
+					[]string{"/bin/sh", "-c", fmt.Sprintf("cat %s/ca.crt", certMountPath)})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				initialCertContent = certContent
+				gomega.Expect(initialCertContent).NotTo(gomega.BeEmpty())
+			})
+
+			ginkgo.By("deleting the secret", func() {
+				gomega.Expect(k8sClient.Delete(ctx, initialSecret)).To(gomega.Succeed())
+			})
+
+			ginkgo.By("waiting for the secret to be re-created", func() {
+				recreatedSecret := &corev1.Secret{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{
+						Namespace: kueueNS, Name: certSecretName,
+					}, recreatedSecret)).To(gomega.Succeed())
+					g.Expect(recreatedSecret.UID).NotTo(gomega.Equal(initialSecret.UID), "Secret not recreated")
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verifying certificate content changed in curl-pod", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					newCertContent, _, err := util.KExecute(ctx, cfg, restClient, kueueNS, curlPod.Name, curlContainerName,
+						[]string{"/bin/sh", "-c", fmt.Sprintf("cat %s/ca.crt", certMountPath)})
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+					g.Expect(initialCertContent).NotTo(gomega.BeEmpty())
+					g.Expect(newCertContent).NotTo(gomega.BeEmpty())
+					g.Expect(newCertContent).NotTo(gomega.Equal(initialCertContent), "Certificate content should have changed after secret recreation")
+				}, util.VeryLongTimeout, util.LongInterval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("checking that the metrics are still available", func() {
+				expectedMetric := []string{
+					"kueue_quota_reserved_workloads_total",
+					clusterQueue.Name,
+				}
+				expectMetricsToBeAvailable(curlPod.Name, curlContainerName, [][]string{expectedMetric})
+			})
+		})
 	})
 })
 

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -47,6 +47,7 @@ const (
 	ConsistentDuration      = 1 * time.Second
 	ShortInterval           = 10 * time.Millisecond
 	Interval                = time.Millisecond * 250
+	LongInterval            = time.Second * 1
 )
 
 var (


### PR DESCRIPTION
Cherry pick of #9099 on release-0.15.

#9099: [release-0.16] Fix metrics certificate reload

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Metrics certificate is now reloaded when certificate data is updated.
```