### PR TITLE
Group parallel verify output by target

### DIFF
--- a/Makefile-verify.mk
+++ b/Makefile-verify.mk
@@ -18,7 +18,11 @@ GO_FMT ?= gofmt
 VERIFY_NPROCS ?= 8
 # Output sync mode for parallel verification. Set to empty to disable.
 # Requires GNU Make 4.0+. Values: target, line, recurse, or empty.
-VERIFY_OUTPUT_SYNC ?= target
+ifeq ($(shell uname),Darwin)
+    VERIFY_OUTPUT_SYNC ?=
+else
+    VERIFY_OUTPUT_SYNC ?= target
+endif
 # Paths whose content is expected to be fully reproducible from sources.
 # The final step of `make verify` enforces that these paths have:
 # - no unstaged/staged diffs (`git diff --exit-code`)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds `--output-sync=target` to `make verify` so that output from parallel targets is grouped together. When a target fails, its error messages are printed in one block instead of being scattered throughout the log mixed with output from other targets.

This makes it much easier to locate and read actual errors during parallel verify runs.

#### Which issue(s) this PR fixes:

Fixes #9111

#### Special notes for your reviewer:

- Requires GNU Make 4.0+ (available in CI environments)
- Users with older Make can disable with `VERIFY_OUTPUT_SYNC= make verify`
- The `$(if ...)` construct ensures no flag is added when the variable is empty

Example of the expanded command:
```
make -j 8 --output-sync=target verify-checks
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```