### PR TITLE
Move Grafana queries under observability and align index page format

### DIFF
--- a/site/content/en/docs/tasks/dev/setup_dev_monitoring.md
+++ b/site/content/en/docs/tasks/dev/setup_dev_monitoring.md
@@ -129,5 +129,5 @@ See [Prometheus Metrics](/docs/reference/metrics#optional-metrics) for the full 
 
 ## What's next
 
-- See [Prometheus Metrics](/docs/reference/metrics) for a complete list of available metrics.
+- See [Common Grafana Queries](/docs/tasks/manage/observability/common_grafana_queries) for PromQL queries to monitor Kueue in Grafana.
 - See [Setup Prometheus](/docs/tasks/manage/observability/setup_prometheus) for production setup instructions.

--- a/site/content/en/docs/tasks/manage/observability/_index.md
+++ b/site/content/en/docs/tasks/manage/observability/_index.md
@@ -8,14 +8,3 @@ description: >
 ---
 
 Kueue exposes Prometheus metrics to monitor the health of the system and the status of ClusterQueues and LocalQueues.
-
-## In this section
-
-- [Setup Prometheus](setup_prometheus) - Configure Prometheus to scrape Kueue metrics
-
-## Related
-
-- [Prometheus Metrics Reference](/docs/reference/metrics) - Complete list of available metrics
-- [Monitor pending Workloads](/docs/tasks/manage/monitor_pending_workloads/) - Query pending workloads using the Visibility API
-- [Configure Prometheus with TLS](/docs/tasks/manage/productization/prometheus) - Advanced TLS configuration with cert-manager
-- [Setup Dev Monitoring](/docs/tasks/dev/setup_dev_monitoring) - Developer guide for local monitoring setup

--- a/site/content/en/docs/tasks/manage/observability/common_grafana_queries.md
+++ b/site/content/en/docs/tasks/manage/observability/common_grafana_queries.md
@@ -1,7 +1,7 @@
 ---
 title: "Common Grafana Queries"
 date: 2026-02-03
-weight: 14
+weight: 2
 description: >
   Common PromQL queries for monitoring Kueue in Grafana.
 ---
@@ -18,7 +18,7 @@ Make sure the following conditions are met:
 - The kubectl command-line tool has communication with your cluster.
 - [Kueue is installed](/docs/installation).
 - [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus) is installed.
-- Kueue Prometheus metrics are enabled (see [Configure Prometheus](/docs/tasks/manage/productization/prometheus)).
+- Kueue Prometheus metrics are enabled (see [Setup Prometheus](/docs/tasks/manage/observability/setup_prometheus)).
 
 ## Quota utilization
 

--- a/site/content/en/docs/tasks/manage/observability/setup_prometheus.md
+++ b/site/content/en/docs/tasks/manage/observability/setup_prometheus.md
@@ -101,6 +101,6 @@ See [Prometheus Metrics](/docs/reference/metrics#optional-metrics) for the full 
 
 ## What's next
 
-- See [Prometheus Metrics](/docs/reference/metrics) for a complete list of available metrics.
+- See [Common Grafana Queries](/docs/tasks/manage/observability/common_grafana_queries) for PromQL queries to monitor Kueue in Grafana.
 - See [Configure Prometheus with TLS](/docs/tasks/manage/productization/prometheus) for advanced TLS configuration using cert-manager.
 - See [Setup Dev Monitoring](/docs/tasks/dev/setup_dev_monitoring) for a local development setup with Prometheus.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Moves the Grafana queries page under the Observability section and cleans up the documentation structure

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Follow-up to #8989 and #8968

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```