### PR TITLE
Move utils_test to jobframework package

### DIFF
--- a/pkg/controller/jobframework/utils_test.go
+++ b/pkg/controller/jobframework/utils_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package jobframework_test
+package jobframework
 
 import (
 	"testing"
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -117,7 +116,7 @@ func TestSanitizePodSets(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			_ = features.SetEnable(features.SanitizePodSets, tc.featureEnabled)
 
-			jobframework.SanitizePodSets(tc.podSets)
+			SanitizePodSets(tc.podSets)
 
 			if diff := cmp.Diff(tc.expectedPodSets, tc.podSets); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Follow up from a [previous PR](https://github.com/kubernetes-sigs/kueue/pull/9118#discussion_r2794005578) 

#### Which issue(s) this PR fixes:
Moving utils_test to jobframework package to simplify things

#### Special notes for your reviewer:
NONE
#### Does this PR introduce a user-facing change?
```release-notes
NONE
```