### PR TITLE
Fix prometheus ServiceMonitor serverName substitution for cert-manager path

### DIFF
--- a/config/components/certmanager/kustomizeconfig.yaml
+++ b/config/components/certmanager/kustomizeconfig.yaml
@@ -14,3 +14,6 @@ varReference:
 - kind: Certificate
   group: cert-manager.io
   path: spec/dnsNames
+- kind: ServiceMonitor
+  group: monitoring.coreos.com
+  path: spec/endpoints/tlsConfig/serverName

--- a/config/components/prometheus/monitor_tls_patch.yaml
+++ b/config/components/prometheus/monitor_tls_patch.yaml
@@ -3,8 +3,8 @@
 - op: replace
   path: /spec/endpoints/0/tlsConfig
   value:
-    # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
-    serverName: SERVICE_NAME.SERVICE_NAMESPACE.svc
+    # METRICS_SERVICE_NAME and METRICS_SERVICE_NAMESPACE will be substituted by kustomize
+    serverName: $(METRICS_SERVICE_NAME).$(METRICS_SERVICE_NAMESPACE).svc
     insecureSkipVerify: false
     ca:
       secret:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Fixes an issue with `serverName` substitution in the kustomize Prometheus TLS patch. The `serverName` was not being substituted because `ServiceMonitor` was not included in `varReference`, and the patch was not updated to use `METRICS_SERVICE_NAME` when it was introduced in #4800.

Helm is not affected, as users provide `tlsConfig` directly in values.yaml.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

To verify the serverName substitution, temporarily uncomment these sections:

1. `config/default/kustomization.yaml`: uncomment `certmanager` resource, `prometheus` resource, and the `vars:` block                                                             
2. `config/components/prometheus/kustomization.yaml`: uncomment the `patches:` block

```bash
kustomize build config/default/ | grep serverName
```

Before: `serverName: SERVICE_NAME.SERVICE_NAMESPACE.svc` (literal)
After: `serverName: kueue-controller-manager-metrics-service.kueue-system.svc` (substituted)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix serverName substitution in kustomize prometheus ServiceMonitor TLS patch for cert-manager deployments.
```