### PR TITLE
experiment: loop InTreeAutoscaling test 200 times

### DIFF
--- a/test/e2e/singlecluster/kuberay_test.go
+++ b/test/e2e/singlecluster/kuberay_test.go
@@ -158,17 +158,17 @@ var _ = ginkgo.Describe("Kuberay", ginkgo.Label("area:singlecluster", "feature:k
 	})
 
 	for i := range 200 {
-	ginkgo.FIt(fmt.Sprintf("Should run a rayjob with InTreeAutoscaling %d", i), func() {
-		kuberayTestImage := util.GetKuberayTestImage()
+		ginkgo.FIt(fmt.Sprintf("Should run a rayjob with InTreeAutoscaling %d", i), func() {
+			kuberayTestImage := util.GetKuberayTestImage()
 
-		// Create ConfigMap with Python script
-		configMap := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "rayjob-autoscaling",
-				Namespace: ns.Name,
-			},
-			Data: map[string]string{
-				"sample_code.py": `import ray
+			// Create ConfigMap with Python script
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rayjob-autoscaling",
+					Namespace: ns.Name,
+				},
+				Data: map[string]string{
+					"sample_code.py": `import ray
 import os
 
 ray.init()
@@ -192,175 +192,175 @@ print(ray.get([my_task.remote(i, 8) for i in range(16)]))
 
 # run tasks in sequence to trigger scaling down
 print([ray.get(my_task.remote(i, 1)) for i in range(32)])`,
-			},
-		}
+				},
+			}
 
-		rayJob := testingrayjob.MakeJob("rayjob-autoscaling", ns.Name).
-			Queue(localQueueName).
-			Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-			EnableInTreeAutoscaling().
-			WithSubmissionMode(rayv1.K8sJobMode).
-			Entrypoint("python /home/ray/samples/sample_code.py").
-			RequestAndLimit(rayv1.HeadNode, corev1.ResourceCPU, "200m").
-			RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "200m").
-			WithSubmitterPodTemplate(corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  "rayjob-submitter",
-							Image: kuberayTestImage,
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("200m"),
-								},
-								Limits: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("200m"),
+			rayJob := testingrayjob.MakeJob("rayjob-autoscaling", ns.Name).
+				Queue(localQueueName).
+				Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				EnableInTreeAutoscaling().
+				WithSubmissionMode(rayv1.K8sJobMode).
+				Entrypoint("python /home/ray/samples/sample_code.py").
+				RequestAndLimit(rayv1.HeadNode, corev1.ResourceCPU, "200m").
+				RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "200m").
+				WithSubmitterPodTemplate(corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "rayjob-submitter",
+								Image: kuberayTestImage,
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU: resource.MustParse("200m"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU: resource.MustParse("200m"),
+									},
 								},
 							},
 						},
+						RestartPolicy: corev1.RestartPolicyOnFailure,
 					},
-					RestartPolicy: corev1.RestartPolicyOnFailure,
-				},
-			}).
-			Image(rayv1.HeadNode, kuberayTestImage).
-			Image(rayv1.WorkerNode, kuberayTestImage).Obj()
+				}).
+				Image(rayv1.HeadNode, kuberayTestImage).
+				Image(rayv1.WorkerNode, kuberayTestImage).Obj()
 
-		// Add volume and volumeMount to head node for the ConfigMap
-		rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Volumes = []corev1.Volume{
-			{
-				Name: "script-volume",
-				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "rayjob-autoscaling",
+			// Add volume and volumeMount to head node for the ConfigMap
+			rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Volumes = []corev1.Volume{
+				{
+					Name: "script-volume",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "rayjob-autoscaling",
+							},
 						},
 					},
 				},
-			},
-		}
-		rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
-			{
-				Name:      "script-volume",
-				MountPath: "/home/ray/samples",
-			},
-		}
-		rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.TerminationGracePeriodSeconds = ptr.To(int64(5))
-		for i := range len(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs) {
-			rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.TerminationGracePeriodSeconds = ptr.To(int64(5))
-		}
+			}
+			rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
+				{
+					Name:      "script-volume",
+					MountPath: "/home/ray/samples",
+				},
+			}
+			rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.TerminationGracePeriodSeconds = ptr.To(int64(5))
+			for i := range len(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs) {
+				rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.TerminationGracePeriodSeconds = ptr.To(int64(5))
+			}
 
-		ginkgo.By("Creating the ConfigMap", func() {
-			gomega.Expect(k8sClient.Create(ctx, configMap)).Should(gomega.Succeed())
-		})
+			ginkgo.By("Creating the ConfigMap", func() {
+				gomega.Expect(k8sClient.Create(ctx, configMap)).Should(gomega.Succeed())
+			})
 
-		ginkgo.By("Creating the rayJob", func() {
-			gomega.Expect(k8sClient.Create(ctx, rayJob)).Should(gomega.Succeed())
-		})
+			ginkgo.By("Creating the rayJob", func() {
+				gomega.Expect(k8sClient.Create(ctx, rayJob)).Should(gomega.Succeed())
+			})
 
-		// Variable to store initial pod names for verification during scaling
-		var initialPodNames []string
-		// Variable to store scaled-up pod names for verification during scaling down
-		var scaledUpPodNames []string
+			// Variable to store initial pod names for verification during scaling
+			var initialPodNames []string
+			// Variable to store scaled-up pod names for verification during scaling down
+			var scaledUpPodNames []string
 
-		ginkgo.By("Checking one workload is created", func() {
-			gomega.Eventually(func(g gomega.Gomega) {
-				workloadList := &kueue.WorkloadList{}
-				g.Expect(k8sClient.List(ctx, workloadList, client.InNamespace(ns.Name))).To(gomega.Succeed())
-				g.Expect(workloadList.Items).NotTo(gomega.BeEmpty(), "Expected at least one workload in namespace")
-				hasAdmittedWorkload := false
-				for _, wl := range workloadList.Items {
-					if workload.IsAdmitted(&wl) || workload.IsFinished(&wl) {
-						hasAdmittedWorkload = true
-						break
+			ginkgo.By("Checking one workload is created", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					workloadList := &kueue.WorkloadList{}
+					g.Expect(k8sClient.List(ctx, workloadList, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					g.Expect(workloadList.Items).NotTo(gomega.BeEmpty(), "Expected at least one workload in namespace")
+					hasAdmittedWorkload := false
+					for _, wl := range workloadList.Items {
+						if workload.IsAdmitted(&wl) || workload.IsFinished(&wl) {
+							hasAdmittedWorkload = true
+							break
+						}
 					}
-				}
-				g.Expect(hasAdmittedWorkload).To(gomega.BeTrue(), "Expected admitted workload")
-			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+					g.Expect(hasAdmittedWorkload).To(gomega.BeTrue(), "Expected admitted workload")
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Waiting for the RayJob cluster become ready", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					createdRayJob := &rayv1.RayJob{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayJob), createdRayJob)).To(gomega.Succeed())
+					g.Expect(createdRayJob.Spec.Suspend).To(gomega.BeFalse())
+					g.Expect(createdRayJob.Status.JobDeploymentStatus).To(gomega.Equal(rayv1.JobDeploymentStatusRunning))
+				}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Waiting for 3 pods in rayjob namespace", func() {
+				// 3 rayjob pods: head, worker, submitter job
+				gomega.Eventually(func(g gomega.Gomega) {
+					podList := &corev1.PodList{}
+					g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					g.Expect(podList.Items).To(gomega.HaveLen(3), "Expected exactly 3 pods in rayjob namespace")
+					// Get worker pod names and check count
+					workerPodNames := getRunningWorkerPodNames(podList)
+					g.Expect(workerPodNames).To(gomega.HaveLen(1), "Expected exactly 1 pod with 'workers' in the name")
+
+					// Store initial pod names for later verification
+					initialPodNames = workerPodNames
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			// RayJob is top level job, the submitter job created by RayJob will not create its own workload, there will be only 1 workload
+			ginkgo.By("Waiting for 1 workloads", func() {
+				// 1 workload for the ray cluster
+				gomega.Eventually(func(g gomega.Gomega) {
+					workloadList := &kueue.WorkloadList{}
+					g.Expect(k8sClient.List(ctx, workloadList, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					g.Expect(workloadList.Items).To(gomega.HaveLen(1), "Expected exactly 1 workload")
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Waiting for 5 workers due to scaling up", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					podList := &corev1.PodList{}
+					g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					// Get worker pod names and check count
+					currentPodNames := getRunningWorkerPodNames(podList)
+					g.Expect(currentPodNames).To(gomega.HaveLen(5), "Expected exactly 5 pods with 'workers' in the name")
+
+					// Verify that the current pod names are a superset of the initial pod names
+					g.Expect(currentPodNames).To(gomega.ContainElements(initialPodNames),
+						"Current worker pod names should be a superset of initial pod names")
+
+					// Store scaled-up pod names for later verification during scaling down
+					scaledUpPodNames = currentPodNames
+				}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Waiting for at least 2 total workloads due to scaling up creating another workload", func() {
+				// Use >= 2 since finished slices from intermediate scaling decisions are retained.
+				gomega.Eventually(func(g gomega.Gomega) {
+					workloadList := &kueue.WorkloadList{}
+					g.Expect(k8sClient.List(ctx, workloadList, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					g.Expect(len(workloadList.Items)).To(gomega.BeNumerically(">=", 2), "Expected at least 2 workloads")
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Waiting for workers reduced to 1 due to scaling down", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					podList := &corev1.PodList{}
+					g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					// Get worker pod names and check count
+					currentPodNames := getRunningWorkerPodNames(podList)
+					g.Expect(currentPodNames).To(gomega.HaveLen(1), "Expected exactly 1 pods with 'workers' in the name")
+
+					// Verify that the previous scaled-up pod names are a superset of the current pod names
+					g.Expect(scaledUpPodNames).To(gomega.ContainElements(currentPodNames),
+						"Previous scaled-up worker pod names should be a superset of current pod names")
+				}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Waiting for the RayJob to finish", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					createdRayJob := &rayv1.RayJob{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayJob), createdRayJob)).To(gomega.Succeed())
+					g.Expect(createdRayJob.Status.JobDeploymentStatus).To(gomega.Equal(rayv1.JobDeploymentStatusComplete))
+					g.Expect(createdRayJob.Status.JobStatus).To(gomega.Equal(rayv1.JobStatusSucceeded))
+				}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+			})
 		})
-
-		ginkgo.By("Waiting for the RayJob cluster become ready", func() {
-			gomega.Eventually(func(g gomega.Gomega) {
-				createdRayJob := &rayv1.RayJob{}
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayJob), createdRayJob)).To(gomega.Succeed())
-				g.Expect(createdRayJob.Spec.Suspend).To(gomega.BeFalse())
-				g.Expect(createdRayJob.Status.JobDeploymentStatus).To(gomega.Equal(rayv1.JobDeploymentStatusRunning))
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
-		})
-
-		ginkgo.By("Waiting for 3 pods in rayjob namespace", func() {
-			// 3 rayjob pods: head, worker, submitter job
-			gomega.Eventually(func(g gomega.Gomega) {
-				podList := &corev1.PodList{}
-				g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
-				g.Expect(podList.Items).To(gomega.HaveLen(3), "Expected exactly 3 pods in rayjob namespace")
-				// Get worker pod names and check count
-				workerPodNames := getRunningWorkerPodNames(podList)
-				g.Expect(workerPodNames).To(gomega.HaveLen(1), "Expected exactly 1 pod with 'workers' in the name")
-
-				// Store initial pod names for later verification
-				initialPodNames = workerPodNames
-			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
-		})
-
-		// RayJob is top level job, the submitter job created by RayJob will not create its own workload, there will be only 1 workload
-		ginkgo.By("Waiting for 1 workloads", func() {
-			// 1 workload for the ray cluster
-			gomega.Eventually(func(g gomega.Gomega) {
-				workloadList := &kueue.WorkloadList{}
-				g.Expect(k8sClient.List(ctx, workloadList, client.InNamespace(ns.Name))).To(gomega.Succeed())
-				g.Expect(workloadList.Items).To(gomega.HaveLen(1), "Expected exactly 1 workload")
-			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
-		})
-
-		ginkgo.By("Waiting for 5 workers due to scaling up", func() {
-			gomega.Eventually(func(g gomega.Gomega) {
-				podList := &corev1.PodList{}
-				g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
-				// Get worker pod names and check count
-				currentPodNames := getRunningWorkerPodNames(podList)
-				g.Expect(currentPodNames).To(gomega.HaveLen(5), "Expected exactly 5 pods with 'workers' in the name")
-
-				// Verify that the current pod names are a superset of the initial pod names
-				g.Expect(currentPodNames).To(gomega.ContainElements(initialPodNames),
-					"Current worker pod names should be a superset of initial pod names")
-
-				// Store scaled-up pod names for later verification during scaling down
-				scaledUpPodNames = currentPodNames
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
-		})
-
-		ginkgo.By("Waiting for at least 2 total workloads due to scaling up creating another workload", func() {
-			// Use >= 2 since finished slices from intermediate scaling decisions are retained.
-			gomega.Eventually(func(g gomega.Gomega) {
-				workloadList := &kueue.WorkloadList{}
-				g.Expect(k8sClient.List(ctx, workloadList, client.InNamespace(ns.Name))).To(gomega.Succeed())
-				g.Expect(len(workloadList.Items)).To(gomega.BeNumerically(">=", 2), "Expected at least 2 workloads")
-			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
-		})
-
-		ginkgo.By("Waiting for workers reduced to 1 due to scaling down", func() {
-			gomega.Eventually(func(g gomega.Gomega) {
-				podList := &corev1.PodList{}
-				g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
-				// Get worker pod names and check count
-				currentPodNames := getRunningWorkerPodNames(podList)
-				g.Expect(currentPodNames).To(gomega.HaveLen(1), "Expected exactly 1 pods with 'workers' in the name")
-
-				// Verify that the previous scaled-up pod names are a superset of the current pod names
-				g.Expect(scaledUpPodNames).To(gomega.ContainElements(currentPodNames),
-					"Previous scaled-up worker pod names should be a superset of current pod names")
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
-		})
-
-		ginkgo.By("Waiting for the RayJob to finish", func() {
-			gomega.Eventually(func(g gomega.Gomega) {
-				createdRayJob := &rayv1.RayJob{}
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayJob), createdRayJob)).To(gomega.Succeed())
-				g.Expect(createdRayJob.Status.JobDeploymentStatus).To(gomega.Equal(rayv1.JobDeploymentStatusComplete))
-				g.Expect(createdRayJob.Status.JobStatus).To(gomega.Equal(rayv1.JobStatusSucceeded))
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
-		})
-	})
 	}
 
 	ginkgo.It("Should run a RayCluster on worker if admitted", func() {


### PR DESCRIPTION
## Summary

Experiment PR to verify the fix in #9134 over 200 iterations.

Uses `ginkgo.FIt` loop pattern to run `Should run a rayjob with InTreeAutoscaling` 200 times, as requested in [review comment](https://github.com/kubernetes-sigs/kueue/pull/9134#issuecomment-3890786846).

DO NOT MERGE - experiment only.