### PR TITLE
Add comment prefixes for OrderGroups.

### DIFF
--- a/pkg/util/orderedgroups/ordered_groups.go
+++ b/pkg/util/orderedgroups/ordered_groups.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package orderedgroups
 
-// Represents a mapping of group keys to grouped items and tracks their insertion order for deterministic iteration.
+// OrderedGroups represents a mapping of group keys to grouped items and tracks their insertion order for deterministic iteration.
 type OrderedGroups[K comparable, V any] struct {
 	groups         map[K][]V
 	insertionOrder []K
@@ -29,7 +29,7 @@ func NewOrderedGroups[K comparable, V any]() *OrderedGroups[K, V] {
 	}
 }
 
-// Inserts an element to the group. If the group does not exist yet, tracks it's insertion order.
+// Insert inserts an element to the group. If the group does not exist yet, tracks it's insertion order.
 func (om *OrderedGroups[K, V]) Insert(key K, value V) {
 	if _, ok := om.groups[key]; !ok {
 		om.insertionOrder = append(om.insertionOrder, key)
@@ -37,7 +37,7 @@ func (om *OrderedGroups[K, V]) Insert(key K, value V) {
 	om.groups[key] = append(om.groups[key], value)
 }
 
-// Iterates over the collected groups in order of insertion.
+// InOrder iterates over the collected groups in order of insertion.
 func (om *OrderedGroups[K, V]) InOrder(yield func(K, []V) bool) {
 	for _, k := range om.insertionOrder {
 		if !yield(k, om.groups[k]) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add comment prefixes for OrderGroups.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```