### PR TITLE
Verify if pod placement based on labels is correct

### DIFF
--- a/pkg/controller/tas/topology_ungater.go
+++ b/pkg/controller/tas/topology_ungater.go
@@ -348,28 +348,17 @@ func assignGatedPodsToDomains(
 	psReq *kueue.PodSetTopologyRequest,
 	offset int32,
 	maxRank int32) []podWithDomain {
-	if rankToGatedPod, ok := readRanksIfAvailable(log, psa, pods, psReq, offset, maxRank); ok {
-		return assignGatedPodsToDomainsByRanks(psa, rankToGatedPod)
+	rankToDomainID := rankToDomainID(psa.TopologyAssignment)
+	if rankToPod, ok := readRanksIfAvailable(log, psa, pods, psReq, offset, maxRank, rankToDomainID); ok {
+		return assignGatedPodsToDomainsByRanks(rankToPod, rankToDomainID)
 	}
 	return assignGatedPodsToDomainsGreedy(log, psa, pods)
 }
 
 func assignGatedPodsToDomainsByRanks(
-	psa *kueue.PodSetAssignment,
-	rankToGatedPod map[int]*corev1.Pod) []podWithDomain {
+	rankToGatedPod map[int]*corev1.Pod,
+	rankToDomainID []utiltas.TopologyDomainID) []podWithDomain {
 	toUngate := make([]podWithDomain, 0)
-	totalPodCount := 0
-	for count := range utiltas.PodCounts(psa.TopologyAssignment) {
-		totalPodCount += int(count)
-	}
-	rankToDomainID := make([]utiltas.TopologyDomainID, totalPodCount)
-	index := int32(0)
-	for domain := range utiltas.InternalSeqFrom(psa.TopologyAssignment) {
-		for s := range domain.Count {
-			rankToDomainID[index+s] = utiltas.DomainID(domain.Values)
-		}
-		index += domain.Count
-	}
 	for rank, pod := range rankToGatedPod {
 		toUngate = append(toUngate, podWithDomain{
 			pod:      pod,
@@ -427,7 +416,8 @@ func readRanksIfAvailable(log logr.Logger,
 	pods []*corev1.Pod,
 	psReq *kueue.PodSetTopologyRequest,
 	offset int32,
-	maxRank int32) (map[int]*corev1.Pod, bool) {
+	maxRank int32,
+	rankToDomainID []utiltas.TopologyDomainID) (map[int]*corev1.Pod, bool) {
 	if psReq == nil || psReq.PodIndexLabel == nil {
 		return nil, false
 	}
@@ -440,6 +430,22 @@ func readRanksIfAvailable(log logr.Logger,
 		}
 		return nil, false
 	}
+
+	for rank, pod := range result {
+		if utilpod.HasGate(pod, kueue.TopologySchedulingGate) {
+			continue
+		}
+		expectedDomainID := rankToDomainID[rank]
+		levelKeys := psa.TopologyAssignment.Levels
+		podLevelValues := utiltas.LevelValues(levelKeys, pod.Spec.NodeSelector)
+		podDomainID := utiltas.DomainID(podLevelValues)
+
+		if expectedDomainID != podDomainID {
+			log.V(3).Info("There is a mismatch for a running pod between the domain expected based on the rank-based ordering, and the actual node selectors", "pod", klog.KObj(pod), "rank", rank, "expectedDomainID", expectedDomainID, "actualDomainID", podDomainID)
+			return nil, false
+		}
+	}
+
 	return result, true
 }
 
@@ -499,4 +505,20 @@ func isAdmittedByTAS(w *kueue.Workload) bool {
 			func(psa kueue.PodSetAssignment) bool {
 				return psa.TopologyAssignment != nil
 			})
+}
+
+func rankToDomainID(ta *kueue.TopologyAssignment) []utiltas.TopologyDomainID {
+	totalPodCount := 0
+	for count := range utiltas.PodCounts(ta) {
+		totalPodCount += int(count)
+	}
+	rankToDomainID := make([]utiltas.TopologyDomainID, totalPodCount)
+	index := int32(0)
+	for domain := range utiltas.InternalSeqFrom(ta) {
+		for s := range domain.Count {
+			rankToDomainID[index+s] = utiltas.DomainID(domain.Values)
+		}
+		index += domain.Count
+	}
+	return rankToDomainID
 }

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -723,6 +723,93 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		},
+		// Fixes https://github.com/kubernetes-sigs/kueue/issues/9210
+		"ungate replacement pod for unhealthy node": {
+			// Scenario: A node replacement happens, but a terminating pod is deleted quickly.
+			// The new replacement pod (p0, rank 0) needs to be ungated. But rank 0's expected node mapping
+			// could conflict with where p1 (rank 1) is already running, triggering a fallback to greedy assignment.
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
+						Request(corev1.ResourceCPU, "1").
+						PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
+						SubGroupIndexLabel(ptr.To(jobset.JobIndexKey)).
+						SubGroupCount(ptr.To[int32](1)).
+						Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
+								Count(2).
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(defaultTestLevels).
+									// Expected domains by rank: Rank 0 -> b1/r1, Rank 1 -> b1/r2
+									Domains(
+										utiltestingapi.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj(), // x1
+										utiltestingapi.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(), // x2
+									).
+									Obj()).
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("p1-running", "ns").UID("x").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(batchv1.JobCompletionIndexAnnotation, "1"). // Rank 1
+					Label(jobset.JobIndexKey, "0").
+					Label(jobset.ReplicatedJobReplicas, "1").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
+					NodeSelector(tasBlockLabel, "b1").
+					NodeSelector(tasRackLabel, "r1"). // Occupying Rank 0's expected domain!
+					Obj(),
+				*testingpod.MakePod("p0-replacement", "ns").UID("y").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(batchv1.JobCompletionIndexAnnotation, "0"). // Rank 0
+					Label(jobset.JobIndexKey, "0").
+					Label(jobset.ReplicatedJobReplicas, "1").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
+					TopologySchedulingGate().
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("p0-replacement", "ns").UID("y").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(batchv1.JobCompletionIndexAnnotation, "0").
+					Label(jobset.JobIndexKey, "0").
+					Label(jobset.ReplicatedJobReplicas, "1").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
+					NodeSelector(tasBlockLabel, "b1").
+					NodeSelector(tasRackLabel, "r2"). // Fallback to greedy, correctly picks the remaining domain
+					Obj(),
+				*testingpod.MakePod("p1-running", "ns").UID("x").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(batchv1.JobCompletionIndexAnnotation, "1").
+					Label(jobset.JobIndexKey, "0").
+					Label(jobset.ReplicatedJobReplicas, "1").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
+					NodeSelector(tasBlockLabel, "b1").
+					NodeSelector(tasRackLabel, "r1").
+					Obj(),
+			},
+			wantCounts: []counts{
+				{
+					NodeSelector: map[string]string{
+						tasBlockLabel: "b1",
+						tasRackLabel:  "r1",
+					},
+					Count: 1,
+				},
+				{
+					NodeSelector: map[string]string{
+						tasBlockLabel: "b1",
+						tasRackLabel:  "r2",
+					},
+					Count: 1,
+				},
+			},
+		},
 		"ungate single pod; while there are pending expectations": {
 			expectUIDs: []types.UID{"x"},
 			workloads: []kueue.Workload{

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -34,9 +35,11 @@ import (
 	autoscaling "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/admissionchecks/provisioning"
 	"sigs.k8s.io/kueue/pkg/controller/tas"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -1675,6 +1678,81 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						updatedWl := &kueue.Workload{}
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), updatedWl)).To(gomega.Succeed())
 						g.Expect(updatedWl.Status.UnhealthyNodes).To(gomega.BeEmpty(), "UnhealthyNodes should be cleared after eviction due to multiple node failures")
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+			})
+			// Fixes https://github.com/kubernetes-sigs/kueue/issues/9210
+			ginkgo.It("should fallback to greedy assignment when replacement pod conflicts with already running pod", framework.SlowSpec, func() {
+				// Scenario: This test simulates an edge case during node replacement where a running pod (p1, rank 1)
+				// is occupying a node (x3) that is assigned to a different rank (rank 0) in the TopologyAssignment.
+				// This can happen in practice if a terminating pod is deleted very quickly during a node hotswap,
+				// causing the replacement pod to receive NodeSelectors for the occupied node based on its job labels.
+				// To prevent assigning multiple pods to the same node, the ungater detects this rank mismatch
+				// between the running pod and the topology assignment, and falls back to greedy assignment.
+				// This ensures the new pod (p0) is safely placed on the remaining available node (x1).
+				var wl1 *kueue.Workload
+
+				ginkgo.By("creating a workload", func() {
+					wl1 = utiltestingapi.MakeWorkload("wl-greedy", ns.Name).
+						PodSets(*utiltestingapi.MakePodSet("worker", 2).
+							PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
+							SubGroupIndexLabel(ptr.To(jobset.JobIndexKey)).
+							SubGroupCount(ptr.To[int32](2)).
+							RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+							Obj()).
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
+					util.MustCreate(ctx, k8sClient, wl1)
+				})
+
+				ginkgo.By("verify the workload is admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), wl1)).To(gomega.Succeed())
+					gomega.Expect(wl1.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+						utiltas.V1Beta2From(&utiltas.TopologyAssignment{
+							Levels: []string{corev1.LabelHostname},
+							Domains: []utiltas.TopologyDomainAssignment{
+								{Count: 1, Values: []string{"x3"}},
+								{Count: 1, Values: []string{"x1"}},
+							},
+						}),
+					))
+				})
+
+				var p1 *corev1.Pod
+				ginkgo.By("creating p1 manually assigned to x3 (assigned to rank 0) but given rank 1 to simulate mismatch", func() {
+					p1 = testingpod.MakePod("p1-running", ns.Name).
+						Annotation(kueue.WorkloadAnnotation, wl1.Name).
+						Annotation(kueue.PodSetRequiredTopologyAnnotation, utiltesting.DefaultBlockTopologyLevel).
+						Label(batchv1.JobCompletionIndexAnnotation, "1"). // rank 1
+						Label(jobset.JobIndexKey, "1").
+						Label(jobset.ReplicatedJobReplicas, "1").
+						Label(constants.PodSetLabel, "worker").
+						NodeSelector(corev1.LabelHostname, "x3"). // assigned to rank 0, but this is rank 1
+						Obj()
+					util.MustCreate(ctx, k8sClient, p1)
+				})
+
+				var p0 *corev1.Pod
+				ginkgo.By("creating replacement p0", func() {
+					p0 = testingpod.MakePod("p0-replacement", ns.Name).
+						Annotation(kueue.WorkloadAnnotation, wl1.Name).
+						Annotation(kueue.PodSetRequiredTopologyAnnotation, utiltesting.DefaultBlockTopologyLevel).
+						Label(batchv1.JobCompletionIndexAnnotation, "0"). // rank 0
+						Label(jobset.JobIndexKey, "0").
+						Label(jobset.ReplicatedJobReplicas, "1").
+						Label(constants.PodSetLabel, "worker").
+						TopologySchedulingGate().
+						Obj()
+					util.MustCreate(ctx, k8sClient, p0)
+				})
+
+				ginkgo.By("verify p0 is ungated and assigned to a node other than x3 since x3 is occupied", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						pod := &corev1.Pod{}
+						g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: "p0-replacement"}, pod)).To(gomega.Succeed())
+						g.Expect(pod.Spec.SchedulingGates).To(gomega.BeEmpty())
+						g.Expect(pod.Spec.NodeSelector).Should(gomega.HaveKey(corev1.LabelHostname))
+						g.Expect(pod.Spec.NodeSelector[corev1.LabelHostname]).To(gomega.Equal("x1"))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 			})


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Make pod assignment behave correctly for node replacement

#### Which issue(s) this PR fixes:
Fixes #9210

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: fix a bug where NodeHotSwap may assign a Pod, based on rank-ordering, to a node which is already
occupied by another running Pod.
```