### PR TITLE
Automated cherry pick of #9081: Make sure worker nodes are ready before reporting cluster created

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -272,6 +272,8 @@ function cluster_create {
     ||  { echo "unable to start the $1 cluster "; cat "$ARTIFACTS/$1-create.log" ; }
 
     kubectl config --kubeconfig="$3" use-context "kind-$1"
+    # wait for nodes to become ready before loading images or deploying components
+    kubectl wait --kubeconfig="$3" --for=condition=Ready node --all --timeout=300s
     kubectl get nodes --kubeconfig="$3" > "$ARTIFACTS/$1-nodes.log" || true
     kubectl describe pods --kubeconfig="$3" -n kube-system > "$ARTIFACTS/$1-system-pods.log" || true
 }


### PR DESCRIPTION
Cherry pick of #9081 on release-0.16.

#9081: Make sure worker nodes are ready before reporting cluster created

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```