### PR TITLE
separate BoolCompare and LazyOr to separate packages to not conflict with stdlib

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -128,10 +128,6 @@ linters:
         text: 'var-naming: avoid package names that conflict with Go standard library package names'
       - linters:
           - revive
-        path: 'pkg/util/cmp/'
-        text: 'var-naming: avoid package names that conflict with Go standard library package names'
-      - linters:
-          - revive
         path: 'pkg/util/heap/'
         text: 'var-naming: avoid package names that conflict with Go standard library package names'
       - linters:

--- a/pkg/scheduler/preemption/common/ordering.go
+++ b/pkg/scheduler/preemption/common/ordering.go
@@ -26,7 +26,8 @@ import (
 	"k8s.io/klog/v2"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	cmputil "sigs.k8s.io/kueue/pkg/util/cmp"
+	"sigs.k8s.io/kueue/pkg/util/boolcmp"
+	"sigs.k8s.io/kueue/pkg/util/lazyor"
 	"sigs.k8s.io/kueue/pkg/util/priority"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -39,15 +40,15 @@ import (
 // 3. Workloads with lower priority first.
 // 4. Workloads admitted more recently first.
 func CandidatesOrdering(log logr.Logger, afsEnabled bool, a, b *workload.Info, cq kueue.ClusterQueueReference, now time.Time) int {
-	return cmputil.LazyOr(
+	return lazyor.Eval(
 		func() int {
-			return cmputil.CompareBool(
+			return boolcmp.Compare(
 				workload.IsEvicted(a.Obj),
 				workload.IsEvicted(b.Obj),
 			)
 		},
 		func() int {
-			return cmputil.CompareBool(
+			return boolcmp.Compare(
 				b.ClusterQueue == cq,
 				a.ClusterQueue == cq,
 			)

--- a/pkg/util/boolcmp/boolcmp.go
+++ b/pkg/util/boolcmp/boolcmp.go
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmp
+package boolcmp
 
-// CompareBool compares two boolean values and returns:
+// Compare compares two boolean values and returns:
 // - 0 if they are equal
 // - -1 if a is true and b is false
 // - 1 if a is false and b is true
-func CompareBool(a, b bool) int {
+func Compare(a, b bool) int {
 	if a == b {
 		return 0
 	}
@@ -30,18 +30,4 @@ func CompareBool(a, b bool) int {
 	}
 
 	return 1
-}
-
-// LazyOr evaluates the provided functions in order and returns the first non-zero value.
-// It returns the zero value if all functions return zero values.
-// This is useful for implementing short-circuit evaluation in comparison functions.
-func LazyOr[T comparable](funcs ...func() T) T {
-	var zero T
-	for _, fn := range funcs {
-		n := fn()
-		if n != zero {
-			return n
-		}
-	}
-	return zero
 }

--- a/pkg/util/boolcmp/boolcmp_test.go
+++ b/pkg/util/boolcmp/boolcmp_test.go
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmp
+package boolcmp
 
 import (
 	"testing"
 )
 
-func TestCompareBool(t *testing.T) {
+func TestCompare(t *testing.T) {
 	cases := map[string]struct {
 		a   bool
 		b   bool
@@ -50,9 +50,9 @@ func TestCompareBool(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			result := CompareBool(tc.a, tc.b)
+			result := Compare(tc.a, tc.b)
 			if result != tc.exp {
-				t.Errorf("CompareBool(%t, %t) = %d; want %d", tc.a, tc.b, result, tc.exp)
+				t.Errorf("Compare(%t, %t) = %d; want %d", tc.a, tc.b, result, tc.exp)
 			}
 		})
 	}

--- a/pkg/util/lazyor/lazyor.go
+++ b/pkg/util/lazyor/lazyor.go
@@ -1,0 +1,31 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lazyor
+
+// Eval evaluates the provided functions in order and returns the first non-zero value.
+// It returns the zero value if all functions return zero values.
+// This is useful for implementing short-circuit evaluation in comparison functions.
+func Eval[T comparable](funcs ...func() T) T {
+	var zero T
+	for _, fn := range funcs {
+		n := fn()
+		if n != zero {
+			return n
+		}
+	}
+	return zero
+}

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/scheduler/preemption"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
-	cmputil "sigs.k8s.io/kueue/pkg/util/cmp"
+	"sigs.k8s.io/kueue/pkg/util/lazyor"
 	"sigs.k8s.io/kueue/pkg/util/pod"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -118,7 +118,7 @@ func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject
 	// integration or e2e tests where the original and scaled-up workloads are created
 	// in rapid succession.
 	slices.SortFunc(list.Items, func(a, b kueue.Workload) int {
-		return cmputil.LazyOr(
+		return lazyor.Eval(
 			func() int {
 				return a.CreationTimestamp.Compare(b.CreationTimestamp.Time)
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Part of #9229.

cmp conflicts with stdlib but there were two functions so I just separate them into separate folders and renamed.

We should not get any conflicts now.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```