### PR TITLE
chore: Fix MPIJob TAS E2E test nests

### DIFF
--- a/test/e2e/tas/mpijob_test.go
+++ b/test/e2e/tas/mpijob_test.go
@@ -233,85 +233,85 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for MPIJob", func() {
 				gomega.Expect(wantAssignment).Should(gomega.BeComparableTo(gotAssignment))
 			})
 		})
+	})
 
-		ginkgo.When("Creating a MPIJob with runLauncherAsWorker", func() {
-			ginkgo.It("Should place MPIJob launcher and workers grouped pods based on the ranks-ordering (kueue.x-k8s.io/podset-group-name Pods annotation)", func() {
-				const (
-					launcherReplicas = 1
-					workerReplicas   = 3
-				)
+	ginkgo.When("Creating a launcher and workers grouped MPIJob with runLauncherAsWorker", func() {
+		ginkgo.It("Should place MPIJob launcher and workers grouped pods based on the ranks-ordering (kueue.x-k8s.io/podset-group-name Pods annotation)", func() {
+			const (
+				launcherReplicas = 1
+				workerReplicas   = 3
+			)
 
-				numPods := launcherReplicas + workerReplicas
+			numPods := launcherReplicas + workerReplicas
 
-				mpijob := testingmpijob.MakeMPIJob("ranks-mpi-podsetgroup", ns.Name).
-					Queue(localQueue.Name).
-					RunLauncherAsWorker(true).
-					MPIJobReplicaSpecs(
-						testingmpijob.MPIJobReplicaSpecRequirement{
-							ReplicaType:   kfmpi.MPIReplicaTypeLauncher,
-							ReplicaCount:  launcherReplicas,
-							RestartPolicy: corev1.RestartPolicyOnFailure,
-							Annotations: map[string]string{
-								kueue.PodSetRequiredTopologyAnnotation: utiltesting.DefaultBlockTopologyLevel,
-								kueue.PodSetGroupName:                  "same-group",
-							},
+			mpiJob := testingmpijob.MakeMPIJob("ranks-mpi-podsetgroup", ns.Name).
+				Queue(localQueue.Name).
+				RunLauncherAsWorker(true).
+				MPIJobReplicaSpecs(
+					testingmpijob.MPIJobReplicaSpecRequirement{
+						ReplicaType:   kfmpi.MPIReplicaTypeLauncher,
+						ReplicaCount:  launcherReplicas,
+						RestartPolicy: corev1.RestartPolicyOnFailure,
+						Annotations: map[string]string{
+							kueue.PodSetRequiredTopologyAnnotation: utiltesting.DefaultBlockTopologyLevel,
+							kueue.PodSetGroupName:                  "same-group",
 						},
-						testingmpijob.MPIJobReplicaSpecRequirement{
-							ReplicaType:   kfmpi.MPIReplicaTypeWorker,
-							ReplicaCount:  workerReplicas,
-							RestartPolicy: corev1.RestartPolicyOnFailure,
-							Annotations: map[string]string{
-								kueue.PodSetRequiredTopologyAnnotation: utiltesting.DefaultBlockTopologyLevel,
-								kueue.PodSetGroupName:                  "same-group",
-							},
+					},
+					testingmpijob.MPIJobReplicaSpecRequirement{
+						ReplicaType:   kfmpi.MPIReplicaTypeWorker,
+						ReplicaCount:  workerReplicas,
+						RestartPolicy: corev1.RestartPolicyOnFailure,
+						Annotations: map[string]string{
+							kueue.PodSetRequiredTopologyAnnotation: utiltesting.DefaultBlockTopologyLevel,
+							kueue.PodSetGroupName:                  "same-group",
 						},
-					).
-					Image(kfmpi.MPIReplicaTypeLauncher, util.GetAgnHostImage(), util.BehaviorExitFast).
-					Image(kfmpi.MPIReplicaTypeWorker, util.GetAgnHostImage(), util.BehaviorExitFast).
-					RequestAndLimit(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "200m").
-					RequestAndLimit(kfmpi.MPIReplicaTypeWorker, extraResource, "1").
-					Obj()
-				util.MustCreate(ctx, k8sClient, mpijob)
+					},
+				).
+				Image(kfmpi.MPIReplicaTypeLauncher, util.GetAgnHostImage(), util.BehaviorExitFast).
+				Image(kfmpi.MPIReplicaTypeWorker, util.GetAgnHostImage(), util.BehaviorExitFast).
+				RequestAndLimit(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "200m").
+				RequestAndLimit(kfmpi.MPIReplicaTypeWorker, extraResource, "1").
+				Obj()
+			util.MustCreate(ctx, k8sClient, mpiJob)
 
-				ginkgo.By("MPIJob is unsuspended", func() {
-					gomega.Eventually(func(g gomega.Gomega) {
-						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(mpijob), mpijob)).To(gomega.Succeed())
-						g.Expect(mpijob.Spec.RunPolicy.Suspend).Should(gomega.Equal(ptr.To(false)))
-					}, util.Timeout, util.Interval).Should(gomega.Succeed())
-				})
-
-				pods := &corev1.PodList{}
-				ginkgo.By("ensure all pods are created", func() {
-					gomega.Eventually(func(g gomega.Gomega) {
-						g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
-						g.Expect(pods.Items).Should(gomega.HaveLen(numPods))
-					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
-				})
-
-				ginkgo.By("ensure all pods are scheduled", func() {
-					listOpts := &client.ListOptions{
-						FieldSelector: fields.OneTermNotEqualSelector("spec.nodeName", ""),
-					}
-					gomega.Eventually(func(g gomega.Gomega) {
-						g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name), listOpts)).To(gomega.Succeed())
-						g.Expect(pods.Items).Should(gomega.HaveLen(numPods))
-					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
-				})
-
-				// TODO: Once we resolve this bug https://github.com/kubernetes-sigs/kueue/issues/8635,
-				// we can verify the following Pods node assignments.
-				// ginkgo.By("verify the assignment of all pods (launcher + workers) with rank-based ordering within the same block", func() {
-				//	 gomega.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
-				//	 gotAssignment := readRankAssignmentsFromMPIJobPods(pods.Items, true)
-				//	 wantAssignment := map[string]string{
-				//		 "launcher/0": "kind-worker",
-				//		 "worker/1":   "kind-worker2",
-				//		 "worker/2":   "kind-worker3",
-				//		 "worker/3":   "kind-worker4",
-				//	 }
-				//	 gomega.Expect(wantAssignment).Should(gomega.BeComparableTo(gotAssignment))
-				// })
+			ginkgo.By("MPIJob is unsuspended", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(mpiJob), mpiJob)).To(gomega.Succeed())
+					g.Expect(mpiJob.Spec.RunPolicy.Suspend).Should(gomega.Equal(ptr.To(false)))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
+
+			pods := &corev1.PodList{}
+			ginkgo.By("ensure all pods are created", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					g.Expect(pods.Items).Should(gomega.HaveLen(numPods))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("ensure all pods are scheduled", func() {
+				listOpts := &client.ListOptions{
+					FieldSelector: fields.OneTermNotEqualSelector("spec.nodeName", ""),
+				}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name), listOpts)).To(gomega.Succeed())
+					g.Expect(pods.Items).Should(gomega.HaveLen(numPods))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			// TODO: Once we resolve this bug https://github.com/kubernetes-sigs/kueue/issues/8635,
+			// we can verify the following Pods node assignments.
+			// ginkgo.By("verify the assignment of all pods (launcher + workers) with rank-based ordering within the same block", func() {
+			//	 gomega.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
+			//	 gotAssignment := readRankAssignmentsFromMPIJobPods(pods.Items, true)
+			//	 wantAssignment := map[string]string{
+			//		 "launcher/0": "kind-worker",
+			//		 "worker/1":   "kind-worker2",
+			//		 "worker/2":   "kind-worker3",
+			//		 "worker/3":   "kind-worker4",
+			//	 }
+			//	 gomega.Expect(wantAssignment).Should(gomega.BeComparableTo(gotAssignment))
+			// })
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Previously, I accidentally nested the same Gomega container twice. So, I decoupled those correctly.
Hence, I moved https://github.com/kubernetes-sigs/kueue/blob/9c069eab72732d108916b88ba07f401e9daba766/test/e2e/tas/mpijob_test.go#L237 container out of https://github.com/kubernetes-sigs/kueue/blob/9c069eab72732d108916b88ba07f401e9daba766/test/e2e/tas/mpijob_test.go#L155 container.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Inaccurately, https://github.com/kubernetes-sigs/kueue/blob/9c069eab72732d108916b88ba07f401e9daba766/test/e2e/tas/mpijob_test.go#L237 container exists inside of https://github.com/kubernetes-sigs/kueue/blob/9c069eab72732d108916b88ba07f401e9daba766/test/e2e/tas/mpijob_test.go#L155 container.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```