### PR TITLE
Disable revive stdlib package name collision check

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -70,6 +70,10 @@ linters:
         - name: empty-lines
         - name: increment-decrement
         - name: var-naming
+          arguments:
+            - []
+            - []
+            - - skip-package-name-collision-with-go-std: true
         - name: redundant-import-alias
         - name: use-any
         - name: use-waitgroup-go
@@ -110,54 +114,6 @@ linters:
           - revive
         path: 'util/*'
         text: 'var-naming: avoid meaningless package names'
-      - linters:
-          - revive
-        path: 'cmd/kueuectl/app/list/'
-        text: 'var-naming: avoid package names that conflict with Go standard library package names'
-      - linters:
-          - revive
-        path: 'cmd/kueuectl/app/testing/'
-        text: 'var-naming: avoid package names that conflict with Go standard library package names'
-      - linters:
-          - revive
-        path: 'cmd/kueuectl/app/version/'
-        text: 'var-naming: avoid package names that conflict with Go standard library package names'
-      - linters:
-          - revive
-        path: 'pkg/metrics/'
-        text: 'var-naming: avoid package names that conflict with Go standard library package names'
-      - linters:
-          - revive
-        path: 'pkg/util/cmp/'
-        text: 'var-naming: avoid package names that conflict with Go standard library package names'
-      - linters:
-          - revive
-        path: 'pkg/util/heap/'
-        text: 'var-naming: avoid package names that conflict with Go standard library package names'
-      - linters:
-          - revive
-        path: 'pkg/util/maps/'
-        text: 'var-naming: avoid package names that conflict with Go standard library package names'
-      - linters:
-          - revive
-        path: 'pkg/util/slices/'
-        text: 'var-naming: avoid package names that conflict with Go standard library package names'
-      - linters:
-          - revive
-        path: 'pkg/util/strings/'
-        text: 'var-naming: avoid package names that conflict with Go standard library package names'
-      - linters:
-          - revive
-        path: 'pkg/util/testing/'
-        text: 'var-naming: avoid package names that conflict with Go standard library package names'
-      - linters:
-          - revive
-        path: 'pkg/version/'
-        text: 'var-naming: avoid package names that conflict with Go standard library package names'
-      - linters:
-          - revive
-        path: 'test/integration/singlecluster/importer/'
-        text: 'var-naming: avoid package names that conflict with Go standard library package names'
     paths:
       - bin
       - vendor


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Replaces 11 per-package `revive` exclusion rules in `.golangci.yaml` with the `skip-package-name-collision-with-go-std` var-naming option. This disables the stdlib package name collision detection globally rather than maintaining a growing list of individual package exclusions.

#### Which issue(s) this PR fixes:

Fixes #9229

#### Special notes for your reviewer:

The `skip-package-name-collision-with-go-std` option was added in revive v1.9.0 (included in golangci-lint v2). This replaces all existing per-package exclusion rules with a single configuration option.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```