### PR TITLE
Graduate LendingLimit feature gate to GA

### DIFF
--- a/keps/1224-lending-limit/kep.yaml
+++ b/keps/1224-lending-limit/kep.yaml
@@ -13,21 +13,21 @@ approvers:
   - "@alculquicondor"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.6"
+latest-milestone: "v0.17"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v0.6"
-  beta: "v0.7"
-  stable: "v0.8"
+  beta: "v0.9"
+  stable: "v0.17"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
   - name: LendingLimit
-disable-supported: true
+disable-supported: false

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -101,12 +101,11 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		return nil
 	}
 	cases := []struct {
-		name                string
-		operation           func(log logr.Logger, cache *Cache) error
-		clientObjects       []client.Object
-		wantClusterQueues   map[kueue.ClusterQueueReference]*clusterQueue
-		wantCohorts         map[kueue.CohortReference]sets.Set[kueue.ClusterQueueReference]
-		disableLendingLimit bool
+		name              string
+		operation         func(log logr.Logger, cache *Cache) error
+		clientObjects     []client.Object
+		wantClusterQueues map[kueue.ClusterQueueReference]*clusterQueue
+		wantCohorts       map[kueue.CohortReference]sets.Set[kueue.ClusterQueueReference]
 	}{
 		{
 			name: "add",
@@ -1011,70 +1010,6 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			},
 		},
 		{
-			name:                "should not populate the fields with lendingLimit when feature disabled",
-			disableLendingLimit: true,
-			operation: func(log logr.Logger, cache *Cache) error {
-				cq := utiltestingapi.MakeClusterQueue("foo").
-					ResourceGroup(
-						kueue.FlavorQuotas{
-							Name: "on-demand",
-							Resources: []kueue.ResourceQuota{
-								{
-									Name:         corev1.ResourceCPU,
-									NominalQuota: resource.MustParse("10"),
-									LendingLimit: ptr.To(resource.MustParse("8")),
-								},
-								{
-									Name:         corev1.ResourceMemory,
-									NominalQuota: resource.MustParse("10Gi"),
-									LendingLimit: ptr.To(resource.MustParse("8Gi")),
-								},
-							},
-						},
-						kueue.FlavorQuotas{
-							Name: "spot",
-							Resources: []kueue.ResourceQuota{
-								{
-									Name:         corev1.ResourceCPU,
-									NominalQuota: resource.MustParse("20"),
-									LendingLimit: ptr.To(resource.MustParse("20")),
-								},
-								{
-									Name:         corev1.ResourceMemory,
-									NominalQuota: resource.MustParse("20Gi"),
-									LendingLimit: ptr.To(resource.MustParse("20Gi")),
-								},
-							},
-						},
-					).
-					ResourceGroup(
-						kueue.FlavorQuotas{
-							Name: "license",
-							Resources: []kueue.ResourceQuota{
-								{
-									Name:         "license",
-									NominalQuota: resource.MustParse("8"),
-									LendingLimit: ptr.To(resource.MustParse("4")),
-								},
-							},
-						},
-					).
-					Obj()
-				return cache.AddClusterQueue(ctx, cq)
-			},
-			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
-				"foo": {
-					Name:                          "foo",
-					NamespaceSelector:             labels.Everything(),
-					Status:                        pending,
-					Preemption:                    defaultPreemption,
-					AllocatableResourceGeneration: 1,
-					FlavorFungibility:             defaultFlavorFungibility,
-					FairWeight:                    defaultWeight,
-				},
-			},
-		},
-		{
 			name: "create cohort",
 			operation: func(log logr.Logger, cache *Cache) error {
 				cohort := utiltestingapi.MakeCohort("cohort").Obj()
@@ -1125,9 +1060,6 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
-			if tc.disableLendingLimit {
-				features.SetFeatureGateDuringTest(t, features.LendingLimit, false)
-			}
 			cache := New(utiltesting.NewFakeClient(tc.clientObjects...))
 			if err := tc.operation(log, cache); err != nil {
 				t.Errorf("Unexpected error during test operation: %s", err)

--- a/pkg/cache/scheduler/resource.go
+++ b/pkg/cache/scheduler/resource.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
 	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
 )
@@ -65,7 +64,7 @@ func createResourceQuotas(kueueRgs []kueue.ResourceGroup) map[resources.FlavorRe
 				if kueueQuota.BorrowingLimit != nil {
 					quota.BorrowingLimit = ptr.To(resources.ResourceValue(kueueQuota.Name, *kueueQuota.BorrowingLimit))
 				}
-				if features.Enabled(features.LendingLimit) && kueueQuota.LendingLimit != nil {
+				if kueueQuota.LendingLimit != nil {
 					quota.LendingLimit = ptr.To(resources.ResourceValue(kueueQuota.Name, *kueueQuota.LendingLimit))
 				}
 				quotas[resources.FlavorResource{Flavor: kueueFlavor.Name, Resource: kueueQuota.Name}] = quota

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -277,6 +277,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	LendingLimit: {
 		{Version: version.MustParse("0.6"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("0.9"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("0.17"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 0.19
 	},
 	MultiKueueBatchJobWithManagedBy: {
 		{Version: version.MustParse("0.8"), Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -820,9 +820,7 @@ func ReportClusterQueueQuotas(cohort kueue.CohortReference, queue, flavor, resou
 	role := roletracker.GetRole(tracker)
 	ClusterQueueResourceNominalQuota.WithLabelValues(string(cohort), queue, flavor, resource, role).Set(nominal)
 	ClusterQueueResourceBorrowingLimit.WithLabelValues(string(cohort), queue, flavor, resource, role).Set(borrowing)
-	if features.Enabled(features.LendingLimit) {
-		ClusterQueueResourceLendingLimit.WithLabelValues(string(cohort), queue, flavor, resource, role).Set(lending)
-	}
+	ClusterQueueResourceLendingLimit.WithLabelValues(string(cohort), queue, flavor, resource, role).Set(lending)
 }
 
 func ReportClusterQueueResourceReservations(cohort kueue.CohortReference, queue, flavor, resource string, usage float64, tracker *roletracker.RoleTracker) {
@@ -855,9 +853,7 @@ func ClearClusterQueueResourceMetrics(cqName string) {
 	}
 	ClusterQueueResourceNominalQuota.DeletePartialMatch(lbls)
 	ClusterQueueResourceBorrowingLimit.DeletePartialMatch(lbls)
-	if features.Enabled(features.LendingLimit) {
-		ClusterQueueResourceLendingLimit.DeletePartialMatch(lbls)
-	}
+	ClusterQueueResourceLendingLimit.DeletePartialMatch(lbls)
 	ClusterQueueResourceUsage.DeletePartialMatch(lbls)
 	ClusterQueueResourceReservations.DeletePartialMatch(lbls)
 }
@@ -883,9 +879,7 @@ func ClearClusterQueueResourceQuotas(cqName, flavor, resource string) {
 
 	ClusterQueueResourceNominalQuota.DeletePartialMatch(lbls)
 	ClusterQueueResourceBorrowingLimit.DeletePartialMatch(lbls)
-	if features.Enabled(features.LendingLimit) {
-		ClusterQueueResourceLendingLimit.DeletePartialMatch(lbls)
-	}
+	ClusterQueueResourceLendingLimit.DeletePartialMatch(lbls)
 }
 
 func ClearClusterQueueResourceUsage(cqName, flavor, resource string) {

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -199,7 +199,6 @@ func TestAssignFlavors(t *testing.T) {
 		secondaryClusterQueueUsage          resources.FlavorResourceQuantities
 		wantRepMode                         FlavorAssignmentMode
 		wantAssignment                      Assignment
-		disableLendingLimit                 bool
 		enableFairSharing                   bool
 		simulationResult                    map[resources.FlavorResource]simulationResultForFlavor
 		elasticJobsViaWorkloadSlicesEnabled bool
@@ -3304,9 +3303,6 @@ func TestAssignFlavors(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ctx, log := utiltesting.ContextWithLog(t)
-			if tc.disableLendingLimit {
-				features.SetFeatureGateDuringTest(t, features.LendingLimit, false)
-			}
 			for fg, enabled := range tc.featureGates {
 				features.SetFeatureGateDuringTest(t, fg, enabled)
 			}

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -279,15 +279,14 @@ func TestPreemption(t *testing.T) {
 		Label(controllerconstants.JobUIDLabel, "job-in")
 
 	cases := map[string]struct {
-		clusterQueues       []*kueue.ClusterQueue
-		cohorts             []*kueue.Cohort
-		admitted            []kueue.Workload
-		incoming            *kueue.Workload
-		targetCQ            kueue.ClusterQueueReference
-		assignment          flavorassigner.Assignment
-		wantPreempted       int
-		wantWorkloads       []kueue.Workload
-		disableLendingLimit bool
+		clusterQueues []*kueue.ClusterQueue
+		cohorts       []*kueue.Cohort
+		admitted      []kueue.Workload
+		incoming      *kueue.Workload
+		targetCQ      kueue.ClusterQueueReference
+		assignment    flavorassigner.Assignment
+		wantPreempted int
+		wantWorkloads []kueue.Workload
 	}{
 		"preempt lowest priority": {
 			clusterQueues: defaultClusterQueues,
@@ -4104,9 +4103,6 @@ func TestPreemption(t *testing.T) {
 			t.Run(fmt.Sprintf("%s when the WorkloadRequestUseMergePatch feature is %t", name, useMergePatch), func(t *testing.T) {
 				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, useMergePatch)
 
-				if tc.disableLendingLimit {
-					features.SetFeatureGateDuringTest(t, features.LendingLimit, false)
-				}
 				ctx, log := utiltesting.ContextWithLog(t)
 				cl := utiltesting.NewClientBuilder().
 					WithLists(&kueue.WorkloadList{Items: tc.admitted}).

--- a/pkg/webhooks/clusterqueue_webhook.go
+++ b/pkg/webhooks/clusterqueue_webhook.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 )
 
@@ -231,7 +230,7 @@ func validateFlavorQuotas(flavorQuotas kueue.FlavorQuotas, coveredResources []co
 			allErrs = append(allErrs, validateLimit(*rq.BorrowingLimit, config, borrowingLimitPath, isCohort)...)
 			allErrs = append(allErrs, validateResourceQuantity(*rq.BorrowingLimit, borrowingLimitPath)...)
 		}
-		if features.Enabled(features.LendingLimit) && rq.LendingLimit != nil {
+		if rq.LendingLimit != nil {
 			lendingLimitPath := path.Child("lendingLimit")
 			allErrs = append(allErrs, validateResourceQuantity(*rq.LendingLimit, lendingLimitPath)...)
 			allErrs = append(allErrs, validateLimit(*rq.LendingLimit, config, lendingLimitPath, isCohort)...)

--- a/pkg/webhooks/cohort_webhook_test.go
+++ b/pkg/webhooks/cohort_webhook_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/features"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 )
 
@@ -33,10 +32,9 @@ func TestValidateCohort(t *testing.T) {
 	resourceGroupsPath := specPath.Child("resourceGroups")
 
 	testcases := []struct {
-		name                string
-		cohort              *kueue.Cohort
-		wantErr             field.ErrorList
-		disableLendingLimit bool
+		name    string
+		cohort  *kueue.Cohort
+		wantErr field.ErrorList
 	}{
 		{
 			name: "flavor quota with lendingLimit and empty parent",
@@ -52,9 +50,6 @@ func TestValidateCohort(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.disableLendingLimit {
-				features.SetFeatureGateDuringTest(t, features.LendingLimit, false)
-			}
 			gotErr := validateCohort(tc.cohort)
 			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.IgnoreFields(field.Error{}, "BadValue")); diff != "" {
 				t.Errorf("ValidateResources() mismatch (-want +got):\n%s", diff)

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -358,13 +358,7 @@ To limit the amount of resources that a ClusterQueue can lend in the cohort,
 you can set the `.spec.resourcesGroup[*].flavors[*].resource[*].lendingLimit`
 [quantity](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/) field.
 
-{{< feature-state state="beta" for_version="v0.9" >}}
-{{% alert title="Note" color="primary" %}}
-
-`LendingLimit` is a Beta feature enabled by default.
-
-You can disable it by setting the `LendingLimit` feature gate. Check the [Installation](/docs/installation/#change-the-feature-gates-configuration) guide for details on feature gate configuration.
-{{% /alert %}}
+{{< feature-state state="stable" for_version="v0.18" >}}
 
 As an example, assume you created the following two ClusterQueues:
 

--- a/site/content/zh-CN/docs/concepts/cluster_queue.md
+++ b/site/content/zh-CN/docs/concepts/cluster_queue.md
@@ -336,13 +336,7 @@ ClusterQueue 可以借用所有名义配额从 cohort 中的所有 ClusterQueues
 `.spec.resourcesGroup[*].flavors[*].resource[*].lendingLimit`
 [quantity](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/) 字段。
 
-{{< feature-state state="beta" for_version="v0.9" >}}
-{{% alert title="注意" color="primary" %}}
-
-`LendingLimit` 是一个 Beta 功能，默认启用。
-
-你可以通过设置 `LendingLimit` feature gate 来禁用它。请参阅 [Installation](/docs/installation/#change-the-feature-gates-configuration) 指南，了解 feature gate 配置的详细信息。
-{{% /alert %}}
+{{< feature-state state="stable" for_version="v0.18" >}}
 
 例如，假设你创建了以下两个 ClusterQueues：
 

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -51,6 +51,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.9"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "0.17"
 - name: LocalQueueDefaulting
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -51,6 +51,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.9"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "0.17"
 - name: LocalQueueDefaulting
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Graduates the `LendingLimit` feature gate to GA at v0.18 with `LockToDefault: true`.

This PR:
- Promotes the feature gate to GA, locked to default true
- Removes all `features.Enabled(features.LendingLimit)` checks from production code (`resource.go`, `clusterqueue_webhook.go`, `metrics.go`)
- Removes unused `features` imports from files that no longer reference feature gates
- Removes `disableLendingLimit` test field and all test cases that verified behavior when the feature was disabled
- Updates site documentation from Beta to Stable for both English and Chinese
- Updates the KEP to reflect stable stage at v0.18
- Regenerates `versioned_feature_list.yaml` files

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes-sigs/kueue/issues/8855

#### Special notes for your reviewer:

The `LendingLimit` feature has been in Beta since v0.9 (enabled by default). This graduation removes the ability to disable it and cleans up all associated feature gate plumbing.

#### Does this PR introduce a user-facing change?

```release-note
Graduated LendingLimit to GA. The feature gate is now locked to true and cannot be disabled.
```