### PR TITLE
Graduate SanitizePodSets feature gate to GA

### DIFF
--- a/pkg/controller/jobframework/utils.go
+++ b/pkg/controller/jobframework/utils.go
@@ -22,12 +22,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/orderedgroups"
 )
 
 // JobPodSets retrieves the pod sets from a GenericJob and applies environment variable
-// deduplication if the SanitizePodSets feature gate is enabled.
+// deduplication.
 func JobPodSets(ctx context.Context, job GenericJob) ([]kueue.PodSet, error) {
 	podSets, err := job.PodSets(ctx)
 	if err != nil {
@@ -38,8 +37,7 @@ func JobPodSets(ctx context.Context, job GenericJob) ([]kueue.PodSet, error) {
 }
 
 // SanitizePodSets sanitizes all PodSets in the given slice by removing duplicate
-// environment variables from each container when the SanitizePodSets
-// feature is enabled. This function modifies the podSets slice in place.
+// environment variables from each container. This function modifies the podSets slice in place.
 func SanitizePodSets(podSets []kueue.PodSet) {
 	for podSetIndex := range podSets {
 		SanitizePodSet(&podSets[podSetIndex])
@@ -47,13 +45,8 @@ func SanitizePodSets(podSets []kueue.PodSet) {
 }
 
 // SanitizePodSet sanitizes a single PodSet by removing duplicate environment
-// variables from all containers and initContainers in its pod template, but only if the
-// SanitizePodSets feature gate is enabled.
+// variables from all containers and initContainers in its pod template.
 func SanitizePodSet(podSet *kueue.PodSet) {
-	if !features.Enabled(features.SanitizePodSets) {
-		return
-	}
-
 	for containerIndex := range podSet.Template.Spec.Containers {
 		sanitizeContainer(&podSet.Template.Spec.Containers[containerIndex])
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -347,6 +347,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	SanitizePodSets: {
 		{Version: version.MustParse("0.13"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("0.17"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 0.19
 	},
 	MultiKueueAllowInsecureKubeconfigs: {
 		{Version: version.MustParse("0.15"), Default: false, PreRelease: featuregate.Alpha},

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -285,7 +285,7 @@ spec:
 {{< feature-gates-table stage="alpha-beta" >}}
 
 {{% alert title="Note" color="primary" %}}
-The SanitizePodSets and MultiKueueAllowInsecureKubeconfigs features are available starting from versions 0.13.8 and 0.14.3.
+The MultiKueueAllowInsecureKubeconfigs feature is available starting from versions 0.13.8 and 0.14.3.
 {{% /alert %}}
 
 ### Feature gates for graduated or deprecated features

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -189,6 +189,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.13"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "0.17"
 - name: SkipFinalizersForPodsSuspendedByParent
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -189,6 +189,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.13"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "0.17"
 - name: SkipFinalizersForPodsSuspendedByParent
   versionedSpecs:
   - default: true


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Graduates the `SanitizePodSets` feature gate to GA in v0.17 with `LockToDefault: true`.

Changes:
- Set `SanitizePodSets` feature gate to GA with `LockToDefault: true`
- Removed the `features.Enabled(features.SanitizePodSets)` guard from `SanitizePodSet()`
- Removed the `"disabled feature gate"` test case and `featureEnabled` test struct field
- Updated documentation to remove `SanitizePodSets` from the beta features note
- Regenerated YAML metadata files

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes-sigs/kueue/issues/8855

#### Special notes for your reviewer:

The feature has been Beta and enabled by default since v0.13. This follows the same graduation pattern used for `MultiKueueBatchJobWithManagedBy` and `PropagateBatchJobLabelsToWorkload` in v0.17.

#### Does this PR introduce a user-facing change?

```release-note
Graduated SanitizePodSets feature gate to GA.
```