### PR TITLE
Align the Kueue KEP template with the K8s KEP template

### DIFF
--- a/keps/NNNN-template/README.md
+++ b/keps/NNNN-template/README.md
@@ -23,15 +23,16 @@ tags, and then generate with `hack/update-toc.sh`.
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
   - [User Stories (Optional)](#user-stories-optional)
-    - [Story 1](#story-1)
-    - [Story 2](#story-2)
+    - [Story 1 (Optional)](#story-1-optional)
+    - [Story 2 (Optional)](#story-2-optional)
   - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
   - [Test Plan](#test-plan)
-      - [Prerequisite testing updates](#prerequisite-testing-updates)
-    - [Unit Tests](#unit-tests)
+    - [Prerequisite testing updates](#prerequisite-testing-updates)
+    - [Unit tests](#unit-tests)
     - [Integration tests](#integration-tests)
+    - [e2e tests](#e2e-tests)
   - [Graduation Criteria](#graduation-criteria)
 - [Implementation History](#implementation-history)
 - [Drawbacks](#drawbacks)
@@ -104,9 +105,9 @@ the system. The goal here is to make this feel real for users without getting
 bogged down.
 -->
 
-#### Story 1
+#### Story 1 (Optional)
 
-#### Story 2
+#### Story 2 (Optional)
 
 ### Notes/Constraints/Caveats (Optional)
 
@@ -157,14 +158,14 @@ when drafting this test plan.
 existing tests to make this code solid enough prior to committing the changes necessary
 to implement this enhancement.
 
-##### Prerequisite testing updates
+#### Prerequisite testing updates
 
 <!--
 Based on reviewers feedback describe what additional tests need to be added prior
 implementing this enhancement to ensure the enhancements have also solid foundations.
 -->
 
-#### Unit Tests
+#### Unit tests
 
 <!--
 In principle every added code should have complete unit test coverage, so providing
@@ -191,6 +192,21 @@ extending the production code to implement this enhancement.
 Describe what tests will be added to ensure proper quality of the enhancement.
 
 After the implementation PR is merged, add the names of the tests here.
+-->
+
+#### e2e tests
+
+<!--
+This question should be filled when targeting a release.
+For Alpha, describe what tests will be added to ensure proper quality of the enhancement.
+
+For Beta and GA, document that tests have been written,
+have been executed regularly, and have been stable.
+This can be done with:
+- permalinks to the GitHub source code
+- links to the periodic job (typically a job owned by the SIG responsible for the feature), filtered by the test name
+
+If e2e tests are not necessary or useful, explain why.
 -->
 
 ### Graduation Criteria


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
For consistency, the KEP template should be as close to the K8s one as possible.

#### Which issue(s) this PR fixes:
Fixes #7315

#### Special notes for your reviewer:
I got pinged about the issues staleness so I figured I'll pick it up. It's a quick one.

The ToC diff before this PR: https://www.diffchecker.com/XZmyhevi/
The ToC diff after this PR: https://www.diffchecker.com/zkfNI3Eb/

Pretty much only the test plan is changed. 

Here's what I didn't add any why:
1. **Release Signoff Checklist** - could actually be useful, but I see it more as a process change than a simple template change. Do we need this?
2. **Upgrade / Downgrade Strategy** - this was in the k8s template for a [long time](https://github.com/kubernetes/enhancements/commit/400931940a25a8a6ca001f4fd9f8735bdd79edee#diff-3df430c68270e73ed3fdb8880e18ca3b3a519c544bee244361db12ad014e0775R94-R95) so I assume this wasn't included in the Kueue one intentionally.
3. **Version Skew Strategy** - ditto.
4. **Production Readiness Review Questionnaire** - @mimowo mentioned that Kueue never held a PRR.
5. **Infrastructure Needed** - I think it's rare for Kueue to require any infrastructure outside of the project.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```