### PR TITLE
Automate adding kind/* labels to cherry-pick PRs

### DIFF
--- a/hack/cherry_pick_pull.sh
+++ b/hack/cherry_pick_pull.sh
@@ -134,6 +134,7 @@ trap return_to_kansas EXIT
 
 SUBJECTS=()
 RELEASE_NOTES=()
+KIND_LABELS=()
 function make-a-pr() {
   local rel
   rel="$(basename "${BRANCH}")"
@@ -142,12 +143,39 @@ function make-a-pr() {
 
   local numandtitle
   numandtitle=$(printf '%s\n' "${SUBJECTS[@]}")
+
+  local kind_commands=""
+  if [[ ${#KIND_LABELS[@]} -gt 0 ]]; then
+    while IFS= read -r label; do
+      if [[ -n "${label}" ]]; then
+        kind_commands+="/kind ${label#kind/}"$'\n'
+      fi
+    done < <(printf '%s\n' "${KIND_LABELS[@]}" | sort -u)
+  fi
+
   prtext=$(cat <<EOF
 Cherry pick of ${PULLSUBJ} on ${rel}.
 
 ${numandtitle}
 
 For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
+
+#### What type of PR is this?
+${kind_commands}
+<!--
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind documentation
+/kind feature
+
+Optionally add one or more of the following kinds if applicable:
+/kind api-change
+/kind deprecation
+/kind failing-test
+/kind flake
+/kind regression
+-->
 
 \`\`\`release-note
 $(printf '%s\n' "${RELEASE_NOTES[@]}")
@@ -202,6 +230,13 @@ for pull in "${PULLS[@]}"; do
   # set the release note
   release_note=$(gh pr view "$pull" --json body --jq '.["body"]' | awk '/```release-note/{f=1;next} /```/{f=0} f')
   RELEASE_NOTES+=("${release_note}")
+
+  # collect kind/* labels from the original PR
+  while IFS= read -r label; do
+    if [[ -n "${label}" ]]; then
+      KIND_LABELS+=("${label}")
+    fi
+  done < <(gh pr view "$pull" --json labels --jq '.labels[].name | select(startswith("kind/"))')
 
   # remove the patch file from /tmp
   rm -f "/tmp/${pull}.patch"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Copies kind labels from original PR

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #9222

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```