### PR TITLE
promote local queue defaulting to ga

### DIFF
--- a/keps/2936-local-queue-defaulting/kep.yaml
+++ b/keps/2936-local-queue-defaulting/kep.yaml
@@ -17,16 +17,16 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.10"
+latest-milestone: "v0.17"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v0.10"
-  beta:
-  stable:
+  beta: "v0.12"
+  stable: "v0.17"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
   - name: LocalQueueDefaulting
-disable-supported: true
+disable-supported: false

--- a/pkg/controller/constants/constants.go
+++ b/pkg/controller/constants/constants.go
@@ -23,7 +23,7 @@ const (
 	QueueLabel = "kueue.x-k8s.io/queue-name"
 
 	// DefaultLocalQueueName is the name for default LocalQueue that is applied
-	// if the feature LocalQueueDefaulting is enabled and QueueLabel is not specified.
+	// if QueueLabel is not specified.
 	DefaultLocalQueueName kueue.LocalQueueName = "default"
 
 	// PrebuiltWorkloadLabel is the label key of the job holding the name of the pre-built workload to use.

--- a/pkg/controller/jobframework/base_webhook_test.go
+++ b/pkg/controller/jobframework/base_webhook_test.go
@@ -43,7 +43,6 @@ import (
 func TestBaseWebhookDefault(t *testing.T) {
 	testcases := map[string]struct {
 		manageJobsWithoutQueueName bool
-		localQueueDefaulting       bool
 		defaultLqExist             bool
 		enableMultiKueue           bool
 		job                        *batchv1.Job
@@ -58,25 +57,22 @@ func TestBaseWebhookDefault(t *testing.T) {
 			job:                        utiljob.MakeJob("job", metav1.NamespaceDefault).Queue("queue").Obj(),
 			want:                       utiljob.MakeJob("job", metav1.NamespaceDefault).Queue("queue").Suspend(true).Obj(),
 		},
-		"LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			job:                  utiljob.MakeJob("job", metav1.NamespaceDefault).Obj(),
+		"default lq is created, job doesn't have queue label": {
+			defaultLqExist: true,
+			job:            utiljob.MakeJob("job", metav1.NamespaceDefault).Obj(),
 			want: utiljob.MakeJob("job", metav1.NamespaceDefault).
 				Label(constants.QueueLabel, "default").
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, default lq is created, job has queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			job:                  utiljob.MakeJob("job", metav1.NamespaceDefault).Queue("queue").Obj(),
-			want:                 utiljob.MakeJob("job", metav1.NamespaceDefault).Queue("queue").Obj(),
+		"default lq is created, job has queue label": {
+			defaultLqExist: true,
+			job:            utiljob.MakeJob("job", metav1.NamespaceDefault).Queue("queue").Obj(),
+			want:           utiljob.MakeJob("job", metav1.NamespaceDefault).Queue("queue").Obj(),
 		},
-		"LocalQueueDefaulting enabled, default lq isn't created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       false,
-			job:                  utiljob.MakeJob("job", metav1.NamespaceDefault).Obj(),
-			want:                 utiljob.MakeJob("job", metav1.NamespaceDefault).Obj(),
+		"default lq isn't created, job doesn't have queue label": {
+			defaultLqExist: false,
+			job:            utiljob.MakeJob("job", metav1.NamespaceDefault).Obj(),
+			want:           utiljob.MakeJob("job", metav1.NamespaceDefault).Obj(),
 		},
 		"ManagedByDefaulting, targeting multikueue local queue": {
 			job: utiljob.MakeJob("job", metav1.NamespaceDefault).Queue("multikueue").Obj(),
@@ -110,7 +106,6 @@ func TestBaseWebhookDefault(t *testing.T) {
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			ctx, log := utiltesting.ContextWithLog(t)
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
 			features.SetFeatureGateDuringTest(t, features.MultiKueue, tc.enableMultiKueue)
 			clientBuilder := utiltesting.NewClientBuilder().
 				WithObjects(

--- a/pkg/controller/jobframework/defaults.go
+++ b/pkg/controller/jobframework/defaults.go
@@ -30,7 +30,6 @@ import (
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
-	"sigs.k8s.io/kueue/pkg/features"
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 )
 
@@ -79,7 +78,7 @@ func WorkloadShouldBeSuspended(ctx context.Context, jobObj client.Object, k8sCli
 }
 
 func ApplyDefaultLocalQueue(jobObj client.Object, defaultQueueExist func(string) bool) {
-	if !features.Enabled(features.LocalQueueDefaulting) || !defaultQueueExist(jobObj.GetNamespace()) {
+	if !defaultQueueExist(jobObj.GetNamespace()) {
 		return
 	}
 	if QueueNameForObject(jobObj) == "" {

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -38,7 +38,6 @@ import (
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
-	"sigs.k8s.io/kueue/pkg/features"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
@@ -117,10 +116,8 @@ func validateUpdateForQueueName(oldJob, newJob GenericJob, defaultQueueExist fun
 	if !newJob.IsSuspended() {
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(QueueName(newJob), QueueName(oldJob), queueNameLabelPath)...)
 	}
-	if features.Enabled(features.LocalQueueDefaulting) {
-		if QueueName(newJob) == "" && QueueName(oldJob) != "" && defaultQueueExist(oldJob.Object().GetNamespace()) {
-			allErrs = append(allErrs, field.Invalid(queueNameLabelPath, "", "queue-name must not be empty in namespace with default queue"))
-		}
+	if QueueName(newJob) == "" && QueueName(oldJob) != "" && defaultQueueExist(oldJob.Object().GetNamespace()) {
+		allErrs = append(allErrs, field.Invalid(queueNameLabelPath, "", "queue-name must not be empty in namespace with default queue"))
 	}
 
 	return allErrs

--- a/pkg/controller/jobframework/validation_test.go
+++ b/pkg/controller/jobframework/validation_test.go
@@ -262,9 +262,8 @@ func TestValidateJobOnUpdate(t *testing.T) {
 		wantErr           field.ErrorList
 	}{
 		"local queue cannot be changed if job is not suspended": {
-			oldJob:       utiltestingjob.MakeJob("test-job", "ns1").Queue("lq1").Suspend(false).Obj(),
-			newJob:       utiltestingjob.MakeJob("test-job", "ns1").Queue("lq2").Suspend(false).Obj(),
-			featureGates: map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			oldJob: utiltestingjob.MakeJob("test-job", "ns1").Queue("lq1").Suspend(false).Obj(),
+			newJob: utiltestingjob.MakeJob("test-job", "ns1").Queue("lq2").Suspend(false).Obj(),
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
@@ -297,12 +296,6 @@ func TestValidateJobOnUpdate(t *testing.T) {
 			oldJob:            utiltestingjob.MakeJob("test-job", "ns1").Suspend(true).Queue("lq1").Obj(),
 			newJob:            utiltestingjob.MakeJob("test-job", "ns1").Suspend(true).Queue("").Obj(),
 			nsHasDefaultQueue: false,
-		},
-		"local queue can be removed if feature is not enabled": {
-			oldJob:            utiltestingjob.MakeJob("test-job", "ns1").Suspend(true).Queue("lq1").Obj(),
-			newJob:            utiltestingjob.MakeJob("test-job", "ns1").Suspend(true).Queue("").Obj(),
-			nsHasDefaultQueue: true,
-			featureGates:      map[featuregate.Feature]bool{features.LocalQueueDefaulting: false},
 		},
 		"elastic job enabled annotation cannot be removed on update": {
 			oldJob: utiltestingjob.MakeJob("test-job", "ns1").SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).Obj(),

--- a/pkg/controller/jobs/deployment/deployment_webhook_test.go
+++ b/pkg/controller/jobs/deployment/deployment_webhook_test.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
-	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingdeployment "sigs.k8s.io/kueue/pkg/util/testingjobs/deployment"
@@ -38,10 +37,9 @@ import (
 
 func TestDefault(t *testing.T) {
 	testCases := map[string]struct {
-		deployment           *appsv1.Deployment
-		localQueueDefaulting bool
-		defaultLqExist       bool
-		want                 *appsv1.Deployment
+		deployment     *appsv1.Deployment
+		defaultLqExist bool
+		want           *appsv1.Deployment
 	}{
 		"deployment without queue": {
 			deployment: testingdeployment.MakeDeployment("test-pod", "").Obj(),
@@ -74,10 +72,9 @@ func TestDefault(t *testing.T) {
 			deployment: testingdeployment.MakeDeployment("test-pod", "").PodTemplateSpecQueue("test-queue").Obj(),
 			want:       testingdeployment.MakeDeployment("test-pod", "").PodTemplateSpecQueue("test-queue").Obj(),
 		},
-		"LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			deployment:           testingdeployment.MakeDeployment("test-pod", "default").Obj(),
+		"default lq is created, job doesn't have queue label": {
+			defaultLqExist: true,
+			deployment:     testingdeployment.MakeDeployment("test-pod", "default").Obj(),
 			want: testingdeployment.MakeDeployment("test-pod", "default").
 				PodTemplateSpecManagedByKueue().
 				Queue("default").
@@ -85,10 +82,9 @@ func TestDefault(t *testing.T) {
 				PodTemplateAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, default lq is created, job has queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			deployment:           testingdeployment.MakeDeployment("test-pod", "").Queue("test-queue").Obj(),
+		"default lq is created, job has queue label": {
+			defaultLqExist: true,
+			deployment:     testingdeployment.MakeDeployment("test-pod", "").Queue("test-queue").Obj(),
 			want: testingdeployment.MakeDeployment("test-pod", "").
 				PodTemplateSpecManagedByKueue().
 				Queue("test-queue").
@@ -96,10 +92,9 @@ func TestDefault(t *testing.T) {
 				PodTemplateAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, default lq isn't created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       false,
-			deployment:           testingdeployment.MakeDeployment("test-pod", "").Obj(),
+		"default lq isn't created, job doesn't have queue label": {
+			defaultLqExist: false,
+			deployment:     testingdeployment.MakeDeployment("test-pod", "").Obj(),
 			want: testingdeployment.MakeDeployment("test-pod", "").
 				Obj(),
 		},
@@ -148,7 +143,6 @@ func TestDefault(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
 			t.Cleanup(jobframework.EnableIntegrationsForTest(t, "pod"))
 			builder := utiltesting.NewClientBuilder()
 			client := builder.Build()

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -762,7 +762,6 @@ func TestDefault(t *testing.T) {
 		admissionCheck             *kueue.AdmissionCheck
 		manageJobsWithoutQueueName bool
 		multiKueueEnabled          bool
-		localQueueDefaulting       bool
 		defaultLqExist             bool
 		enableIntegrations         []string
 		want                       *batchv1.Job
@@ -843,32 +842,28 @@ func TestDefault(t *testing.T) {
 				Obj(),
 			multiKueueEnabled: true,
 		},
-		"LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			job:                  testingutil.MakeJob("test-job", "default").Obj(),
+		"default lq is created, job doesn't have queue label": {
+			defaultLqExist: true,
+			job:            testingutil.MakeJob("test-job", "default").Obj(),
 			want: testingutil.MakeJob("test-job", "default").
 				Queue("default").
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, default lq is created, job has queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			job:                  testingutil.MakeJob("test-job", "").Queue("test-queue").Obj(),
+		"default lq is created, job has queue label": {
+			defaultLqExist: true,
+			job:            testingutil.MakeJob("test-job", "").Queue("test-queue").Obj(),
 			want: testingutil.MakeJob("test-job", "").
 				Queue("test-queue").
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, default lq isn't created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       false,
-			job:                  testingutil.MakeJob("test-job", "").Obj(),
+		"default lq isn't created, job doesn't have queue label": {
+			defaultLqExist: false,
+			job:            testingutil.MakeJob("test-job", "").Obj(),
 			want: testingutil.MakeJob("test-job", "").
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, job is managed by Kueue managed owner, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
+		"job is managed by Kueue managed owner, job doesn't have queue label": {
+			defaultLqExist: true,
 			// MPIJob callBackFunction is registered as integrations since we initialize MPIJob integration package.
 			enableIntegrations: []string{"kubeflow.org/mpijob"},
 			job: testingutil.MakeJob("test-job", metav1.NamespaceDefault).
@@ -881,9 +876,8 @@ func TestDefault(t *testing.T) {
 				OwnerReference("owner", kfmpi.SchemeGroupVersionKind).
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, job is managed by non Kueue managed owner, job has queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
+		"job is managed by non Kueue managed owner, job has queue label": {
+			defaultLqExist: true,
 			job: testingutil.MakeJob("test-job", metav1.NamespaceDefault).
 				OwnerReference("owner", jobsetapi.SchemeGroupVersion.WithKind("JobSet")).
 				Obj(),
@@ -896,7 +890,6 @@ func TestDefault(t *testing.T) {
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.MultiKueue, tc.multiKueueEnabled)
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
 
 			ctx, log := utiltesting.ContextWithLog(t)
 

--- a/pkg/controller/jobs/jobset/jobset_webhook_test.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook_test.go
@@ -353,17 +353,16 @@ func TestValidateUpdate(t *testing.T) {
 
 func TestDefault(t *testing.T) {
 	testCases := []struct {
-		name                 string
-		jobSet               *jobset.JobSet
-		queues               []kueue.LocalQueue
-		clusterQueues        []kueue.ClusterQueue
-		admissionCheck       *kueue.AdmissionCheck
-		multiKueueEnabled    bool
-		localQueueDefaulting bool
-		defaultLqExist       bool
-		want                 *jobset.JobSet
-		wantManagedBy        *string
-		wantErr              error
+		name              string
+		jobSet            *jobset.JobSet
+		queues            []kueue.LocalQueue
+		clusterQueues     []kueue.ClusterQueue
+		admissionCheck    *kueue.AdmissionCheck
+		multiKueueEnabled bool
+		defaultLqExist    bool
+		want              *jobset.JobSet
+		wantManagedBy     *string
+		wantErr           error
 	}{
 		{
 			name: "TestDefault_JobSetManagedBy_jobsetapi.JobSetControllerName",
@@ -555,32 +554,28 @@ func TestDefault(t *testing.T) {
 			wantManagedBy:     nil,
 		},
 		{
-			name:                 "LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label",
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			jobSet:               testingutil.MakeJobSet("test-js", "default").Obj(),
-			want:                 testingutil.MakeJobSet("test-js", "default").Queue("default").Obj(),
+			name:           "default lq is created, job doesn't have queue label",
+			defaultLqExist: true,
+			jobSet:         testingutil.MakeJobSet("test-js", "default").Obj(),
+			want:           testingutil.MakeJobSet("test-js", "default").Queue("default").Obj(),
 		},
 		{
-			name:                 "LocalQueueDefaulting enabled, default lq is created, job has queue label",
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			jobSet:               testingutil.MakeJobSet("test-js", "default").Queue("queue").Obj(),
-			want:                 testingutil.MakeJobSet("test-js", "default").Queue("queue").Obj(),
+			name:           "default lq is created, job has queue label",
+			defaultLqExist: true,
+			jobSet:         testingutil.MakeJobSet("test-js", "default").Queue("queue").Obj(),
+			want:           testingutil.MakeJobSet("test-js", "default").Queue("queue").Obj(),
 		},
 		{
-			name:                 "LocalQueueDefaulting enabled, default lq isn't created, job doesn't have queue label",
-			localQueueDefaulting: true,
-			defaultLqExist:       false,
-			jobSet:               testingutil.MakeJobSet("test-js", "default").Obj(),
-			want:                 testingutil.MakeJobSet("test-js", "default").Obj(),
+			name:           "default lq isn't created, job doesn't have queue label",
+			defaultLqExist: false,
+			jobSet:         testingutil.MakeJobSet("test-js", "default").Obj(),
+			want:           testingutil.MakeJobSet("test-js", "default").Obj(),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.MultiKueue, tc.multiKueueEnabled)
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
 
 			ctx, log := utiltesting.ContextWithLog(t)
 

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
@@ -65,7 +65,7 @@ func TestDefault(t *testing.T) {
 				WorkerTemplateSpecAnnotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label": {
+		"default lq is created, job doesn't have queue label": {
 			defaultLqExist: true,
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "default").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -79,7 +79,7 @@ func TestDefault(t *testing.T) {
 				WorkerTemplateSpecAnnotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, default lq is created, job has queue label": {
+		"default lq is created, job has queue label": {
 			defaultLqExist: true,
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -94,7 +94,7 @@ func TestDefault(t *testing.T) {
 				WorkerTemplateSpecAnnotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, default lq isn't created, job doesn't have queue label": {
+		"default lq isn't created, job doesn't have queue label": {
 			defaultLqExist: false,
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				LeaderTemplate(corev1.PodTemplateSpec{}).

--- a/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
@@ -324,7 +324,6 @@ func TestDefault(t *testing.T) {
 		clusterQueues           []kueue.ClusterQueue
 		admissionCheck          *kueue.AdmissionCheck
 		multiKueueEnabled       bool
-		localQueueDefaulting    bool
 		topologyAwareScheduling bool
 		defaultLqExist          bool
 		want                    *v2beta1.MPIJob
@@ -525,25 +524,22 @@ func TestDefault(t *testing.T) {
 			wantManagedBy:     nil,
 		},
 		{
-			name:                 "LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label",
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			mpiJob:               testingutil.MakeMPIJob("job", "default").Obj(),
-			want:                 testingutil.MakeMPIJob("job", "default").Queue("default").Obj(),
+			name:           "default lq is created, job doesn't have queue label",
+			defaultLqExist: true,
+			mpiJob:         testingutil.MakeMPIJob("job", "default").Obj(),
+			want:           testingutil.MakeMPIJob("job", "default").Queue("default").Obj(),
 		},
 		{
-			name:                 "LocalQueueDefaulting enabled, default lq is created, job has queue label",
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			mpiJob:               testingutil.MakeMPIJob("job", "default").Queue("queue").Obj(),
-			want:                 testingutil.MakeMPIJob("job", "default").Queue("queue").Obj(),
+			name:           "default lq is created, job has queue label",
+			defaultLqExist: true,
+			mpiJob:         testingutil.MakeMPIJob("job", "default").Queue("queue").Obj(),
+			want:           testingutil.MakeMPIJob("job", "default").Queue("queue").Obj(),
 		},
 		{
-			name:                 "LocalQueueDefaulting enabled, default lq isn't created, job doesn't have queue label",
-			localQueueDefaulting: true,
-			defaultLqExist:       false,
-			mpiJob:               testingutil.MakeMPIJob("job", "default").Obj(),
-			want:                 testingutil.MakeMPIJob("job", "default").Obj(),
+			name:           "default lq isn't created, job doesn't have queue label",
+			defaultLqExist: false,
+			mpiJob:         testingutil.MakeMPIJob("job", "default").Obj(),
+			want:           testingutil.MakeMPIJob("job", "default").Obj(),
 		},
 		{
 			name:                    "TAS enabled, RunLauncherAsWorker true with 2 replica specs",
@@ -760,7 +756,6 @@ func TestDefault(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.MultiKueue, tc.multiKueueEnabled)
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
 			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
 
 			ctx, log := utiltesting.ContextWithLog(t)

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -149,8 +149,7 @@ func (w *PodWebhook) Default(ctx context.Context, obj *corev1.Pod) error {
 		}
 
 		// Local queue defaulting
-		if features.Enabled(features.LocalQueueDefaulting) &&
-			jobframework.QueueNameForObject(pod.Object()) == "" &&
+		if jobframework.QueueNameForObject(pod.Object()) == "" &&
 			w.queues.DefaultLocalQueueExist(pod.pod.GetNamespace()) {
 			if pod.pod.Labels == nil {
 				pod.pod.Labels = make(map[string]string)

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -89,7 +89,6 @@ func TestDefault(t *testing.T) {
 		features                     map[featuregate.Feature]bool
 		initObjects                  []client.Object
 		pod                          *corev1.Pod
-		localQueueDefaulting         bool
 		defaultLqExist               bool
 		manageJobsWithoutQueueName   bool
 		managedJobsNamespaceSelector labels.Selector
@@ -429,12 +428,11 @@ func TestDefault(t *testing.T) {
 				TopologySchedulingGate().
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, default queue is created, pod has no queue label": {
-			initObjects:          []client.Object{defaultNamespace},
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			podSelector:          &metav1.LabelSelector{},
-			namespaceSelector:    defaultNamespaceSelector,
+		"default queue is created, pod has no queue label": {
+			initObjects:       []client.Object{defaultNamespace},
+			defaultLqExist:    true,
+			podSelector:       &metav1.LabelSelector{},
+			namespaceSelector: defaultNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Obj(),
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
@@ -445,23 +443,21 @@ func TestDefault(t *testing.T) {
 				KueueFinalizer().
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, default queue isn't created, pod has no queue label": {
-			initObjects:          []client.Object{defaultNamespace},
-			localQueueDefaulting: true,
-			defaultLqExist:       false,
-			podSelector:          &metav1.LabelSelector{},
-			namespaceSelector:    defaultNamespaceSelector,
+		"default queue isn't created, pod has no queue label": {
+			initObjects:       []client.Object{defaultNamespace},
+			defaultLqExist:    false,
+			podSelector:       &metav1.LabelSelector{},
+			namespaceSelector: defaultNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Obj(),
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, default queue is created, pod has queue label": {
-			initObjects:          []client.Object{defaultNamespace},
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			podSelector:          &metav1.LabelSelector{},
-			namespaceSelector:    defaultNamespaceSelector,
+		"default queue is created, pod has queue label": {
+			initObjects:       []client.Object{defaultNamespace},
+			defaultLqExist:    true,
+			podSelector:       &metav1.LabelSelector{},
+			namespaceSelector: defaultNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("queue").
 				Obj(),
@@ -561,7 +557,6 @@ func TestDefault(t *testing.T) {
 				features.SetFeatureGateDuringTest(t, feature, enabled)
 			}
 			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
 			t.Cleanup(jobframework.EnableIntegrationsForTest(t, tc.enableIntegrations...))
 			builder := utiltesting.NewClientBuilder(rayv1.AddToScheme, kfmpi.AddToScheme, kftraining.AddToScheme, appsv1.AddToScheme)
 			builder = builder.WithObjects(tc.initObjects...)

--- a/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
@@ -40,11 +40,10 @@ import (
 
 func TestValidateDefault(t *testing.T) {
 	testcases := map[string]struct {
-		oldJob               *rayv1.RayCluster
-		newJob               *rayv1.RayCluster
-		manageAll            bool
-		localQueueDefaulting bool
-		defaultLqExist       bool
+		oldJob         *rayv1.RayCluster
+		newJob         *rayv1.RayCluster
+		manageAll      bool
+		defaultLqExist bool
 	}{
 		"unmanaged": {
 			oldJob: testingrayutil.MakeCluster("job", "ns").
@@ -73,26 +72,23 @@ func TestValidateDefault(t *testing.T) {
 				Suspend(true).
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			oldJob:               testingrayutil.MakeCluster("test-job", "default").Obj(),
+		"default lq is created, job doesn't have queue label": {
+			defaultLqExist: true,
+			oldJob:         testingrayutil.MakeCluster("test-job", "default").Obj(),
 			newJob: testingrayutil.MakeCluster("test-job", "default").
 				Queue("default").
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, default lq is created, job has queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			oldJob:               testingrayutil.MakeCluster("test-job", "").Queue("test-queue").Obj(),
+		"default lq is created, job has queue label": {
+			defaultLqExist: true,
+			oldJob:         testingrayutil.MakeCluster("test-job", "").Queue("test-queue").Obj(),
 			newJob: testingrayutil.MakeCluster("test-job", "").
 				Queue("test-queue").
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, default lq isn't created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       false,
-			oldJob:               testingrayutil.MakeCluster("test-job", "").Obj(),
+		"default lq isn't created, job doesn't have queue label": {
+			defaultLqExist: false,
+			oldJob:         testingrayutil.MakeCluster("test-job", "").Obj(),
 			newJob: testingrayutil.MakeCluster("test-job", "").
 				Obj(),
 		},
@@ -100,7 +96,6 @@ func TestValidateDefault(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			builder := utiltesting.NewClientBuilder()
 			cli := builder.Build()

--- a/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
@@ -41,11 +41,10 @@ import (
 
 func TestDefault(t *testing.T) {
 	testcases := map[string]struct {
-		oldJob               *rayv1.RayJob
-		newJob               *rayv1.RayJob
-		manageAll            bool
-		localQueueDefaulting bool
-		defaultLqExist       bool
+		oldJob         *rayv1.RayJob
+		newJob         *rayv1.RayJob
+		manageAll      bool
+		defaultLqExist bool
 	}{
 		"unmanaged": {
 			oldJob: testingrayutil.MakeJob("job", "ns").
@@ -74,26 +73,23 @@ func TestDefault(t *testing.T) {
 				Suspend(true).
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			oldJob:               testingrayutil.MakeJob("test-job", "default").Obj(),
+		"default lq is created, job doesn't have queue label": {
+			defaultLqExist: true,
+			oldJob:         testingrayutil.MakeJob("test-job", "default").Obj(),
 			newJob: testingrayutil.MakeJob("test-job", "default").
 				Queue("default").
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, default lq is created, job has queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			oldJob:               testingrayutil.MakeJob("test-job", "").Queue("test-queue").Obj(),
+		"default lq is created, job has queue label": {
+			defaultLqExist: true,
+			oldJob:         testingrayutil.MakeJob("test-job", "").Queue("test-queue").Obj(),
 			newJob: testingrayutil.MakeJob("test-job", "").
 				Queue("test-queue").
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, default lq isn't created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       false,
-			oldJob:               testingrayutil.MakeJob("test-job", "").Obj(),
+		"default lq isn't created, job doesn't have queue label": {
+			defaultLqExist: false,
+			oldJob:         testingrayutil.MakeJob("test-job", "").Obj(),
 			newJob: testingrayutil.MakeJob("test-job", "").
 				Obj(),
 		},
@@ -101,7 +97,6 @@ func TestDefault(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			builder := utiltesting.NewClientBuilder()
 			cli := builder.Build()
@@ -137,7 +132,6 @@ func TestValidateCreate(t *testing.T) {
 		job                          *rayv1.RayJob
 		manageAll                    bool
 		wantErr                      error
-		localQueueDefaulting         bool
 		topologyAwareScheduling      bool
 		elasticJobsViaWorkloadSlices bool
 	}{
@@ -148,16 +142,6 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: nil,
 		},
 
-		"valid managed - has cluster selector but no RayClusterSpec": {
-			job: testingrayutil.MakeJob("job", "ns").Queue("queue").
-				ClusterSelector(map[string]string{
-					"k1": "v1",
-				}).
-				RayClusterSpec(nil).
-				Obj(),
-			localQueueDefaulting: false,
-			wantErr:              nil,
-		},
 		"invalid managed - no cluster selector and no RayClusterSpec": {
 			job: testingrayutil.MakeJob("job", "ns").Queue("queue").
 				RayClusterSpec(nil).
@@ -170,8 +154,7 @@ func TestValidateCreate(t *testing.T) {
 			job: testingrayutil.MakeJob("job", "ns").
 				ShutdownAfterJobFinishes(false).
 				Obj(),
-			localQueueDefaulting: true,
-			wantErr:              nil,
+			wantErr: nil,
 		},
 		"invalid managed - by config": {
 			job: testingrayutil.MakeJob("job", "ns").
@@ -588,7 +571,6 @@ func TestValidateCreate(t *testing.T) {
 			wh := &RayJobWebhook{
 				manageJobsWithoutQueueName: tc.manageAll,
 			}
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
 			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
 			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, tc.elasticJobsViaWorkloadSlices)
 			ctx, _ := utiltesting.ContextWithLog(t)

--- a/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
@@ -40,7 +40,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobs/appwrapper"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/leaderworkerset"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
-	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingappwrapper "sigs.k8s.io/kueue/pkg/util/testingjobs/appwrapper"
@@ -53,7 +52,6 @@ func TestDefault(t *testing.T) {
 		initObjs                   []client.Object
 		statefulset                *appsv1.StatefulSet
 		manageJobsWithoutQueueName bool
-		localQueueDefaulting       bool
 		defaultLqExist             bool
 		enableIntegrations         []string
 		want                       *appsv1.StatefulSet
@@ -147,10 +145,9 @@ func TestDefault(t *testing.T) {
 				PodTemplateSpecPodGroupPodIndexLabelAnnotation(appsv1.PodIndexLabel).
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			statefulset:          testingstatefulset.MakeStatefulSet("test-pod", "default").Obj(),
+		"default lq is created, job doesn't have queue label": {
+			defaultLqExist: true,
+			statefulset:    testingstatefulset.MakeStatefulSet("test-pod", "default").Obj(),
 			want: testingstatefulset.MakeStatefulSet("test-pod", "default").
 				Queue("default").
 				PodTemplateSpecQueue("default").
@@ -163,10 +160,9 @@ func TestDefault(t *testing.T) {
 				PodTemplateSpecPodGroupPodIndexLabelAnnotation(appsv1.PodIndexLabel).
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, default lq is created, job has queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			statefulset:          testingstatefulset.MakeStatefulSet("test-pod", "").Queue("test-queue").Obj(),
+		"default lq is created, job has queue label": {
+			defaultLqExist: true,
+			statefulset:    testingstatefulset.MakeStatefulSet("test-pod", "").Queue("test-queue").Obj(),
 			want: testingstatefulset.MakeStatefulSet("test-pod", "").
 				Queue("test-queue").
 				PodTemplateSpecQueue("test-queue").
@@ -179,17 +175,15 @@ func TestDefault(t *testing.T) {
 				PodTemplateSpecPodGroupPodIndexLabelAnnotation(appsv1.PodIndexLabel).
 				Obj(),
 		},
-		"LocalQueueDefaulting enabled, default lq isn't created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       false,
-			statefulset:          testingstatefulset.MakeStatefulSet("test-pod", "").Obj(),
-			want:                 testingstatefulset.MakeStatefulSet("test-pod", "").Obj(),
+		"default lq isn't created, job doesn't have queue label": {
+			defaultLqExist: false,
+			statefulset:    testingstatefulset.MakeStatefulSet("test-pod", "").Obj(),
+			want:           testingstatefulset.MakeStatefulSet("test-pod", "").Obj(),
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
 			t.Cleanup(jobframework.EnableIntegrationsForTest(t, tc.enableIntegrations...))
 			ctx, _ := utiltesting.ContextWithLog(t)
 

--- a/pkg/controller/jobs/trainjob/trainjob_webhook_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_webhook_test.go
@@ -205,7 +205,6 @@ func TestDefault(t *testing.T) {
 	testCases := map[string]struct {
 		trainJob                     *kftrainerapi.TrainJob
 		defaultQueue                 *kueue.LocalQueue
-		localQueueDefaultingEnabled  bool
 		manageJobsWithoutQueueName   bool
 		withMultiKueueAdmissionCheck bool
 		withDefaultLocalQueue        bool
@@ -238,14 +237,12 @@ func TestDefault(t *testing.T) {
 				Queue(string(controllerconstants.DefaultLocalQueueName)).
 				JobSetLabel(controllerconstants.QueueLabel, string(controllerconstants.DefaultLocalQueueName)).
 				Obj(),
-			localQueueDefaultingEnabled: true,
-			withDefaultLocalQueue:       true,
+			withDefaultLocalQueue: true,
 		},
 		"should not set the default local queue if doesn't exists": {
-			trainJob:                    testTrainJob.Clone().Obj(),
-			wantTrainJob:                testTrainJob.Clone().Obj(),
-			localQueueDefaultingEnabled: true,
-			withDefaultLocalQueue:       false,
+			trainJob:              testTrainJob.Clone().Obj(),
+			wantTrainJob:          testTrainJob.Clone().Obj(),
+			withDefaultLocalQueue: false,
 		},
 		"should set managedBy to multiKueue if the user didn't specify any": {
 			trainJob: testTrainJob.Clone().Queue(testLocalQueue.Name).Obj(),
@@ -281,7 +278,6 @@ func TestDefault(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.MultiKueue, tc.multiKueueEnabled)
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaultingEnabled)
 
 			ctx, log := utiltesting.ContextWithLog(t)
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -301,6 +301,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	LocalQueueDefaulting: {
 		{Version: version.MustParse("0.10"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("0.12"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("0.17"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 0.19
 	},
 	TASProfileLeastFreeCapacity: {
 		{Version: version.MustParse("0.10"), Default: false, PreRelease: featuregate.Alpha},

--- a/site/content/en/docs/tasks/manage/enforce_job_management/setup_default_local_queue.md
+++ b/site/content/en/docs/tasks/manage/enforce_job_management/setup_default_local_queue.md
@@ -6,23 +6,17 @@ description: >
   Setup default LocalQueue to fullfil a queue label on jobs that submited without queue label.
 ---
 
-{{< feature-state state="beta" for_version="v0.12" >}}
-
-{{% alert title="Note" color="primary" %}}
-
-`LocalQueueDefaulting` is a Beta feature that is enabled by default.
-
-You can disable it by setting the `LocalQueueDefaulting` feature gate. Check the [Installation](/docs/installation/#change-the-feature-gates-configuration) guide for details on feature gate configuration.
-{{% /alert %}}
+{{< feature-state state="stable" for_version="v0.17" >}}
 
 This page describes how to setup default LocalQueue to ensure that all Workloads submitted to a specific namespace are managed by Kueue,
 even if the `kueue.x-k8s.io/queue-name` label is not specified explicitly.
 
 ## Setup default LocalQueue
 
-LocalQueueDefaulting is an Beta feature that allows the use of a LocalQueue with name `default` as the default LocalQueue
+LocalQueueDefaulting is a feature that allows the use of a LocalQueue with name `default` as the default LocalQueue
 for workloads in the same namespace that do not have the `kueue.x-k8s.io/queue-name` label.
-The feature is gated by the `LocalQueueDefaulting` feature gate, and is enabled by default. To use this feature:
+
+To use this feature:
 
 - create a LocalQueue with the name `default` in a namespace.
 

--- a/site/content/zh-CN/docs/tasks/manage/enforce_job_management/setup_default_local_queue.md
+++ b/site/content/zh-CN/docs/tasks/manage/enforce_job_management/setup_default_local_queue.md
@@ -6,24 +6,17 @@ description: >
   配置默认的 LocalQueue，以满足未指定队列标签的作业的队列标签需求。
 ---
 
-{{< feature-state state="beta" for_version="v0.12" >}}
-
-{{% alert title="Note" color="primary" %}}
-
-`LocalQueueDefaulting` 是一个默认启用的 Beta 特性。
-
-你可以通过设置 `LocalQueueDefaulting` 特性门控来禁用它。
-查看[安装](/zh-CN/docs/installation/#change-the-feature-gates-configuration)指南以获取关于特性门控配置的详细信息。
-{{% /alert %}}
+{{< feature-state state="stable" for_version="v0.17" >}}
 
 此页面描述了如何设置默认 LocalQueue，以确保所有提交到特定命名空间的工作负载由 Kueue 管理，
 即使未明确指定 `kueue.x-k8s.io/queue-name` 标签。
 
 ## 设置默认 LocalQueue
 
-LocalQueueDefaulting 作为一个Beta 特性，允许使用一个名为 `default` 的 LocalQueue
+LocalQueueDefaulting 是一个特性，允许使用一个名为 `default` 的 LocalQueue
 作为同命名空间下没有 `kueue.x-k8s.io/queue-name` 标签的工作负载的默认 LocalQueue。
-此特性由 `LocalQueueDefaulting` 特性门控控制，并且默认启用。要使用此特性：
+
+要使用此特性：
 
 - 在命名空间中创建一个名称为 `default` 的 LocalQueue。
 

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -71,6 +71,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.12"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "0.17"
 - name: LocalQueueMetrics
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -71,6 +71,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.12"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "0.17"
 - name: LocalQueueMetrics
   versionedSpecs:
   - default: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- Promote LocalQueueDefaulting to GA
- Remove all references to the feature Gate
- Remove test code that sets the feature gate
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #8855 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Graduated LocalQueueDefaulting to GA.
```