### PR TITLE
Automated cherry pick of #8647: Remove unused BaseSSAWorkload.
#8648: Commonize UpdateKueueConfiguration logic.
#8649: Avoid double calls to WaitForKueueAvailability.
#9275: Optimize UpdateKueueConfiguration.

### DIFF
--- a/test/e2e/customconfigs/managejobswithoutqueuename_test.go
+++ b/test/e2e/customconfigs/managejobswithoutqueuename_test.go
@@ -64,7 +64,7 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 	)
 
 	ginkgo.BeforeAll(func() {
-		util.UpdateKueueConfiguration(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
+		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
 			cfg.ManageJobsWithoutQueueName = true
 		})
 	})
@@ -91,7 +91,7 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 
 	ginkgo.When("manageJobsWithoutQueueName=true and ManagedJobsNamespaceSelectorAlwaysRespected=false", func() {
 		ginkgo.BeforeEach(func() {
-			util.UpdateKueueConfiguration(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
+			util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
 				cfg.ManageJobsWithoutQueueName = true
 				cfg.FeatureGates = map[string]bool{string(features.ManagedJobsNamespaceSelectorAlwaysRespected): false}
 				cfg.ManagedJobsNamespaceSelector = &metav1.LabelSelector{
@@ -106,7 +106,7 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 			})
 		})
 		ginkgo.AfterEach(func() {
-			util.UpdateKueueConfiguration(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
+			util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
 				cfg.ManageJobsWithoutQueueName = true
 			})
 		})
@@ -177,7 +177,7 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 			var jobLookupKey types.NamespacedName
 
 			ginkgo.By("setting local queue defulting as false", func() {
-				util.UpdateKueueConfiguration(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
+				util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
 					cfg.FeatureGates = map[string]bool{string(features.LocalQueueDefaulting): false}
 					cfg.ManageJobsWithoutQueueName = true
 				})
@@ -213,7 +213,7 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 			ginkgo.By("setting feature gates back to its original state", func() {
-				util.UpdateKueueConfiguration(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
+				util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
 					cfg.ManageJobsWithoutQueueName = true
 				})
 			})
@@ -990,7 +990,7 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName without JobSet integration",
 	)
 
 	ginkgo.BeforeAll(func() {
-		util.UpdateKueueConfiguration(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
+		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
 			cfg.ManageJobsWithoutQueueName = true
 			cfg.Integrations.Frameworks = slices.Filter(nil, cfg.Integrations.Frameworks, func(framework string) bool {
 				return framework != jobset.FrameworkName

--- a/test/e2e/customconfigs/objectretentionpolicies_test.go
+++ b/test/e2e/customconfigs/objectretentionpolicies_test.go
@@ -77,7 +77,7 @@ var _ = ginkgo.Describe("ObjectRetentionPolicies", ginkgo.Ordered, ginkgo.Contin
 			},
 		}
 
-		util.UpdateKueueConfiguration(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
+		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
 			cfg.FeatureGates = nil
 			cfg.ObjectRetentionPolicies = nil
 			cfg.WaitForPodsReady = waitForPodsReady.DeepCopy()
@@ -106,7 +106,7 @@ var _ = ginkgo.Describe("ObjectRetentionPolicies", ginkgo.Ordered, ginkgo.Contin
 		})
 
 		ginkgo.By("Enable ObjectRetentionPolicies feature gate", func() {
-			util.UpdateKueueConfiguration(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
+			util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
 				cfg.FeatureGates = map[string]bool{string(features.ObjectRetentionPolicies): true}
 				cfg.ObjectRetentionPolicies = &configapi.ObjectRetentionPolicies{
 					Workloads: &configapi.WorkloadRetentionPolicy{
@@ -141,7 +141,7 @@ var _ = ginkgo.Describe("ObjectRetentionPolicies with TinyTimeout", ginkgo.Order
 	)
 
 	ginkgo.BeforeAll(func() {
-		util.UpdateKueueConfiguration(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
+		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
 			cfg.FeatureGates = map[string]bool{string(features.ObjectRetentionPolicies): true}
 			cfg.ObjectRetentionPolicies = &configapi.ObjectRetentionPolicies{
 				Workloads: &configapi.WorkloadRetentionPolicy{
@@ -273,7 +273,7 @@ var _ = ginkgo.Describe("ObjectRetentionPolicies with TinyTimeout and RequeuingL
 	)
 
 	ginkgo.BeforeAll(func() {
-		util.UpdateKueueConfiguration(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
+		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
 			cfg.FeatureGates = map[string]bool{string(features.ObjectRetentionPolicies): true}
 			cfg.ObjectRetentionPolicies = &configapi.ObjectRetentionPolicies{
 				Workloads: &configapi.WorkloadRetentionPolicy{

--- a/test/e2e/customconfigs/podintegrationautoenablement_test.go
+++ b/test/e2e/customconfigs/podintegrationautoenablement_test.go
@@ -44,7 +44,7 @@ var _ = ginkgo.Describe("Auto-Enablement of Pod Integration for Pod-Dependent Fr
 	)
 
 	ginkgo.BeforeAll(func() {
-		util.UpdateKueueConfiguration(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
+		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
 			cfg.Integrations.Frameworks = []string{"statefulset"}
 		})
 

--- a/test/e2e/customconfigs/reconcile_test.go
+++ b/test/e2e/customconfigs/reconcile_test.go
@@ -48,7 +48,7 @@ var _ = ginkgo.Describe("Job reconciliation with ManagedJobsNamespaceSelectorAlw
 	)
 
 	ginkgo.BeforeAll(func() {
-		util.UpdateKueueConfiguration(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
+		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
 			cfg.FeatureGates = map[string]bool{string(features.ManagedJobsNamespaceSelectorAlwaysRespected): true}
 			cfg.ManagedJobsNamespaceSelector = &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{

--- a/test/e2e/customconfigs/suite_test.go
+++ b/test/e2e/customconfigs/suite_test.go
@@ -75,5 +75,5 @@ var _ = ginkgo.BeforeSuite(func() {
 })
 
 var _ = ginkgo.AfterSuite(func() {
-	util.UpdateKueueConfiguration(ctx, k8sClient, defaultKueueCfg, kindClusterName)
+	util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
 })

--- a/test/e2e/customconfigs/waitforpodsready_test.go
+++ b/test/e2e/customconfigs/waitforpodsready_test.go
@@ -78,7 +78,7 @@ var _ = ginkgo.Describe("WaitForPodsReady with tiny Timeout and no RecoveryTimeo
 		}
 		util.MustCreate(ctx, k8sClient, metricsReaderClusterRoleBinding)
 
-		util.UpdateKueueConfiguration(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
+		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
 			cfg.WaitForPodsReady = &configapi.WaitForPodsReady{
 				BlockAdmission:  ptr.To(true),
 				Timeout:         metav1.Duration{Duration: util.TinyTimeout},
@@ -234,7 +234,7 @@ var _ = ginkgo.Describe("WaitForPodsReady with default Timeout and a tiny Recove
 		}
 		util.MustCreate(ctx, k8sClient, metricsReaderClusterRoleBinding)
 
-		util.UpdateKueueConfiguration(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
+		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
 			cfg.WaitForPodsReady = &configapi.WaitForPodsReady{
 				Timeout:         metav1.Duration{Duration: 5 * time.Minute},
 				BlockAdmission:  ptr.To(true),
@@ -379,7 +379,7 @@ var _ = ginkgo.Describe("WaitForPodsReady with default Timeout and a long Recove
 		}
 		util.MustCreate(ctx, k8sClient, metricsReaderClusterRoleBinding)
 
-		util.UpdateKueueConfiguration(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
+		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
 			cfg.WaitForPodsReady = &configapi.WaitForPodsReady{
 				Timeout:         metav1.Duration{Duration: 5 * time.Minute},
 				BlockAdmission:  ptr.To(true),

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -1259,7 +1259,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			ginkgo.By("setting MultiKueue Dispatcher to Incremental", func() {
 				defaultManagerKueueCfg = util.GetKueueConfiguration(ctx, k8sManagerClient)
 				newCfg := defaultManagerKueueCfg.DeepCopy()
-				util.UpdateKueueConfiguration(ctx, k8sManagerClient, newCfg, managerClusterName, func(cfg *kueueconfig.Configuration) {
+				util.UpdateKueueConfigurationAndRestart(ctx, k8sManagerClient, newCfg, managerClusterName, func(cfg *kueueconfig.Configuration) {
 					if cfg.MultiKueue == nil {
 						cfg.MultiKueue = &kueueconfig.MultiKueue{}
 					}
@@ -1269,7 +1269,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 		})
 		ginkgo.AfterAll(func() {
 			ginkgo.By("setting MultiKueue Dispatcher back to AllAtOnce", func() {
-				util.UpdateKueueConfiguration(ctx, k8sManagerClient, defaultManagerKueueCfg, managerClusterName)
+				util.UpdateKueueConfigurationAndRestart(ctx, k8sManagerClient, defaultManagerKueueCfg, managerClusterName)
 			})
 		})
 		ginkgo.It("Should run a job on worker if admitted", func() {
@@ -1496,14 +1496,14 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			ginkgo.By("setting MultiKueueClusterProfile feature gate", func() {
 				defaultManagerKueueCfg = util.GetKueueConfiguration(ctx, k8sManagerClient)
 				newCfg := defaultManagerKueueCfg.DeepCopy()
-				util.UpdateKueueConfiguration(ctx, k8sManagerClient, newCfg, managerClusterName, func(cfg *kueueconfig.Configuration) {
+				util.UpdateKueueConfigurationAndRestart(ctx, k8sManagerClient, newCfg, managerClusterName, func(cfg *kueueconfig.Configuration) {
 					cfg.FeatureGates[string(features.MultiKueueClusterProfile)] = true
 				})
 			})
 		})
 		ginkgo.AfterAll(func() {
 			ginkgo.By("reverting the configuration", func() {
-				util.UpdateKueueConfiguration(ctx, k8sManagerClient, defaultManagerKueueCfg, managerClusterName)
+				util.UpdateKueueConfigurationAndRestart(ctx, k8sManagerClient, defaultManagerKueueCfg, managerClusterName)
 			})
 		})
 
@@ -1675,7 +1675,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 
 			ginkgo.By("Updating MultiKueue configuration with CredentialsProviders", func() {
 				defaultManagerKueueCfg = util.GetKueueConfiguration(ctx, k8sManagerClient)
-				util.UpdateKueueConfiguration(ctx, k8sManagerClient, defaultManagerKueueCfg, managerClusterName, func(cfg *kueueconfig.Configuration) {
+				util.UpdateKueueConfigurationAndRestart(ctx, k8sManagerClient, defaultManagerKueueCfg, managerClusterName, func(cfg *kueueconfig.Configuration) {
 					cfg.FeatureGates[string(features.MultiKueueClusterProfile)] = true
 					if cfg.MultiKueue == nil {
 						cfg.MultiKueue = &kueueconfig.MultiKueue{}
@@ -1697,17 +1697,21 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			})
 		})
 		ginkgo.AfterAll(func() {
-			ginkgo.By("setting back the deployment", func() {
-				updatedDeployment := &appsv1.Deployment{}
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sManagerClient.Get(ctx, deploymentKey, updatedDeployment)).Should(gomega.Succeed())
-					updatedDeployment.Spec = *defaultManagerDeployment.Spec.DeepCopy()
-					g.Expect(k8sManagerClient.Update(ctx, updatedDeployment)).Should(gomega.Succeed())
-				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
-				// We will wait for Kueue after setting back the configuration
-			})
 			ginkgo.By("setting back the configuration", func() {
-				util.UpdateKueueConfiguration(ctx, k8sManagerClient, defaultManagerKueueCfg, managerClusterName)
+				// Just update Kueue configuration. We will restart Kueue later.
+				util.UpdateKueueConfiguration(ctx, k8sManagerClient, defaultManagerKueueCfg)
+			})
+
+			ginkgo.By("setting back the deployment", func() {
+				util.UpdateDeploymentAndWaitForProgressing(ctx, k8sManagerClient, deploymentKey, managerClusterName, func(deployment *appsv1.Deployment) {
+					deployment.Spec = *defaultManagerDeployment.Spec.DeepCopy()
+				})
+			})
+
+			ginkgo.By("wait for Kueue availability", func() {
+				// We are using NoRestartCountCheck because we expect one fails in MultiKueue tests.
+				// This happens on "The connection to a worker cluster is unreliable" test case.
+				util.WaitForKueueAvailabilityNoRestartCountCheck(ctx, k8sManagerClient)
 			})
 
 			for _, s := range clusterProfileSecrets {

--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -221,14 +221,17 @@ func CreateVisibilityClient(user string) visibilityv1beta2.VisibilityV1beta2Inte
 	return kueueClientset.VisibilityV1beta2()
 }
 
-func rolloutOperatorDeployment(ctx context.Context, k8sClient client.Client, key types.NamespacedName, kindClusterName string) {
-	// Export logs before the rollout to preserve logs from the previous version.
+func UpdateDeploymentAndWaitForProgressing(ctx context.Context, k8sClient client.Client, key types.NamespacedName, kindClusterName string, applyChanges func(deployment *appsv1.Deployment)) {
+	ginkgo.GinkgoHelper()
+
+	// Export logs before the update to preserve logs from the previous version.
 	exportKindLogs(ctx, kindClusterName)
 
 	deployment := &appsv1.Deployment{}
 	var deploymentCondition *appsv1.DeploymentCondition
 
-	gomega.EventuallyWithOffset(2, func(g gomega.Gomega) {
+	// Make sure that we don't have progressing status before update Deployment.
+	gomega.Eventually(func(g gomega.Gomega) {
 		g.Expect(k8sClient.Get(ctx, key, deployment)).To(gomega.Succeed())
 		deploymentCondition = FindDeploymentCondition(deployment, appsv1.DeploymentProgressing)
 		g.Expect(deploymentCondition).NotTo(gomega.BeNil())
@@ -236,22 +239,23 @@ func rolloutOperatorDeployment(ctx context.Context, k8sClient client.Client, key
 		g.Expect(deploymentCondition.Reason).To(gomega.BeElementOf("NewReplicaSetCreated", "NewReplicaSetAvailable", "ReplicaSetUpdated"))
 		ginkgo.GinkgoLogr.Info("Deployment status condition before the restart", "type", deploymentCondition.Type, "status", deploymentCondition.Status, "reason", deploymentCondition.Reason)
 	}, Timeout, Interval).Should(gomega.Succeed())
+
 	beforeUpdateTime := deploymentCondition.LastUpdateTime
 
-	gomega.EventuallyWithOffset(2, func(g gomega.Gomega) {
-		deployment.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+	// Apply changes and update Deployment.
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(k8sClient.Get(ctx, key, deployment)).To(gomega.Succeed())
+		applyChanges(deployment)
 		g.Expect(k8sClient.Update(ctx, deployment)).To(gomega.Succeed())
 	}, Timeout, Interval).Should(gomega.Succeed())
 
-	gomega.EventuallyWithOffset(2, func(g gomega.Gomega) {
+	// Wait for the Deployment update to be in progress.
+	gomega.Eventually(func(g gomega.Gomega) {
 		g.Expect(k8sClient.Get(ctx, key, deployment)).To(gomega.Succeed())
 		deploymentCondition := FindDeploymentCondition(deployment, appsv1.DeploymentProgressing)
 		g.Expect(deploymentCondition).NotTo(gomega.BeNil())
-		g.Expect(deploymentCondition.Status).To(gomega.Equal(corev1.ConditionTrue))
-		g.Expect(deploymentCondition.Reason).To(gomega.Equal("NewReplicaSetAvailable"))
-		afterUpdateTime := deploymentCondition.LastUpdateTime
-		g.Expect(afterUpdateTime).NotTo(gomega.Equal(beforeUpdateTime))
-	}, StartUpTimeout, Interval).Should(gomega.Succeed())
+		g.Expect(deploymentCondition.LastUpdateTime).NotTo(gomega.Equal(beforeUpdateTime))
+	}, Timeout, Interval).Should(gomega.Succeed())
 }
 
 func exportKindLogs(ctx context.Context, kindClusterName string) {
@@ -311,9 +315,8 @@ func waitForDeploymentAvailability(ctx context.Context, k8sClient client.Client,
 }
 
 func WaitForKueueAvailability(ctx context.Context, k8sClient client.Client) {
-	kueueNS := GetKueueNamespace()
-	kcmKey := types.NamespacedName{Namespace: kueueNS, Name: "kueue-controller-manager"}
-	waitForDeploymentAvailability(ctx, k8sClient, kcmKey, true)
+	ginkgo.GinkgoHelper()
+	waitForKueueAvailability(ctx, k8sClient, true)
 }
 
 func WaitForAppWrapperAvailability(ctx context.Context, k8sClient client.Client) {
@@ -379,12 +382,18 @@ func applyKueueConfiguration(ctx context.Context, k8sClient client.Client, kueue
 }
 
 func RestartKueueController(ctx context.Context, k8sClient client.Client, kindClusterName string) {
+	ginkgo.GinkgoHelper()
 	kueueNS := GetKueueNamespace()
 	kcmKey := types.NamespacedName{Namespace: kueueNS, Name: "kueue-controller-manager"}
-	restartStartTime := time.Now()
-	rolloutOperatorDeployment(ctx, k8sClient, kcmKey, kindClusterName)
-	waitForKueueControllerReadyWithWebhookEndpoints(ctx, k8sClient, kcmKey)
-	WaitForLeaderElection(ctx, k8sClient, restartStartTime)
+	startTime := time.Now()
+	UpdateDeploymentAndWaitForProgressing(ctx, k8sClient, kcmKey, kindClusterName, func(deployment *appsv1.Deployment) {
+		if deployment.Spec.Template.Annotations == nil {
+			deployment.Spec.Template.Annotations = make(map[string]string, 1)
+		}
+		deployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+	})
+	WaitForKueueAvailabilityNoRestartCountCheck(ctx, k8sClient)
+	ginkgo.GinkgoLogr.Info("Kueue restarted", "took", time.Since(startTime))
 }
 
 func isPodReady(pod *corev1.Pod) bool {
@@ -483,19 +492,27 @@ func WaitForActivePodsAndTerminate(ctx context.Context, k8sClient client.Client,
 }
 
 func WaitForKueueAvailabilityNoRestartCountCheck(ctx context.Context, k8sClient client.Client) {
-	kueueNS := GetKueueNamespace()
-	kcmKey := types.NamespacedName{Namespace: kueueNS, Name: "kueue-controller-manager"}
-	waitForDeploymentAvailability(ctx, k8sClient, kcmKey, false)
+	ginkgo.GinkgoHelper()
+	waitForKueueAvailability(ctx, k8sClient, false)
 }
 
-// WaitForLeaderElection waits for the kueue controller to acquire the leader lease
-// after the given startTime to ensure the new controller has the lease.
-func WaitForLeaderElection(ctx context.Context, k8sClient client.Client, startTime time.Time) {
+func waitForKueueAvailability(ctx context.Context, k8sClient client.Client, checkNoRestarts bool) {
+	ginkgo.GinkgoHelper()
+	kcmKey := types.NamespacedName{Namespace: GetKueueNamespace(), Name: "kueue-controller-manager"}
+	waitForDeploymentAvailability(ctx, k8sClient, kcmKey, checkNoRestarts)
+	waitForKueueControllerReadyWithWebhookEndpoints(ctx, k8sClient, kcmKey)
+	waitForLeaderElection(ctx, k8sClient)
+}
+
+// waitForLeaderElection waits for the kueue controller to acquire the leader lease
+func waitForLeaderElection(ctx context.Context, k8sClient client.Client) {
+	ginkgo.GinkgoHelper()
 	kueueNS := GetKueueNamespace()
 	leaseKey := types.NamespacedName{Namespace: kueueNS, Name: configapi.DefaultLeaderElectionID}
 	lease := &coordinationv1.Lease{}
+	startTime := time.Now()
 	ginkgo.By(fmt.Sprintf("Waiting for leader election lease %q", leaseKey))
-	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
+	gomega.Eventually(func(g gomega.Gomega) {
 		g.Expect(k8sClient.Get(ctx, leaseKey, lease)).To(gomega.Succeed())
 		g.Expect(lease.Spec.RenewTime).NotTo(gomega.BeNil())
 		g.Expect(lease.Spec.RenewTime.After(startTime)).To(gomega.BeTrue())
@@ -606,15 +623,21 @@ func WaitForPodRunning(ctx context.Context, k8sClient client.Client, pod *corev1
 	}, LongTimeout, Interval).Should(gomega.Succeed())
 }
 
-func UpdateKueueConfiguration(ctx context.Context, k8sClient client.Client, config *configapi.Configuration, kindClusterName string, applyChanges ...func(cfg *configapi.Configuration)) {
+func UpdateKueueConfiguration(ctx context.Context, k8sClient client.Client, config *configapi.Configuration, applyChanges ...func(cfg *configapi.Configuration)) {
+	ginkgo.GinkgoHelper()
 	startTime := time.Now()
 	config = config.DeepCopy()
 	for _, applyChange := range applyChanges {
 		applyChange(config)
 	}
 	applyKueueConfiguration(ctx, k8sClient, config)
-	RestartKueueController(ctx, k8sClient, kindClusterName)
 	ginkgo.GinkgoLogr.Info("Kueue configuration updated", "took", time.Since(startTime))
+}
+
+func UpdateKueueConfigurationAndRestart(ctx context.Context, k8sClient client.Client, config *configapi.Configuration, kindClusterName string, applyChanges ...func(cfg *configapi.Configuration)) {
+	ginkgo.GinkgoHelper()
+	UpdateKueueConfiguration(ctx, k8sClient, config, applyChanges...)
+	RestartKueueController(ctx, k8sClient, kindClusterName)
 }
 
 func GetClusterServerAddress(clusterName string) string {


### PR DESCRIPTION
Cherry pick of #8647 #8648 #8649 #9275 on release-0.15.

#8647: Remove unused BaseSSAWorkload.
#8648: Commonize UpdateKueueConfiguration logic.
#8649: Avoid double calls to WaitForKueueAvailability.
#9275: Optimize UpdateKueueConfiguration.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```