### PR TITLE
MultiKueue + TAS setup script: bump Kueue to 0.16

### DIFF
--- a/site/static/examples/multikueue/dev/setup-kind-multikueue-tas.sh
+++ b/site/static/examples/multikueue/dev/setup-kind-multikueue-tas.sh
@@ -18,7 +18,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUEUE_VERSION="${KUEUE_VERSION:-v0.16.0}"
+DEFAULT_KUEUE_VERSION=v0.16.1
+KUEUE_VERSION="${KUEUE_VERSION:-${DEFAULT_KUEUE_VERSION}}"
 USE_MAIN_BRANCH="${USE_MAIN_BRANCH:-false}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKER_CLUSTERS="worker1 worker2"
@@ -38,7 +39,7 @@ while [[ $# -gt 0 ]]; do
             echo "Unknown option: $1"
             echo "Usage: $0 [--main] [--version VERSION]"
             echo "  --main           Use main branch instead of released version"
-            echo "  --version        Specify Kueue version (default: v0.16.0)"
+            echo "  --version        Specify Kueue version (default: ${DEFAULT_KUEUE_VERSION})"
             exit 1
             ;;
     esac


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

It bumps the Kueue version used in the [MultiKueue + TAS setup script](https://kueue.sigs.k8s.io/docs/tasks/dev/setup_multikueue_development_environment/) from 0.15.0 to 0.16.0.

Kueue 0.16 brings some relevant improvements, e.g. #8151 which fixed #7350.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

I wonder if we have some `latest-stable` tag or so? Then it'd be perfect to use it here.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```