### PR TITLE
Fix ExpectNewWorkloadSlice to retry until workload is found

### DIFF
--- a/test/e2e/singlecluster/tas_test.go
+++ b/test/e2e/singlecluster/tas_test.go
@@ -596,9 +596,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", ginkgo.Label("area:singleclus
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
 		})
 
-		ginkgo.XIt("should preserve topology assignment during scale-up", func() {
-			// TODO(#9316): the test is temporarily disabled, because it was failing too often.
-			// re-enable when the issue is resolved.
+		ginkgo.It("should preserve topology assignment during scale-up", func() {
 			sampleJob := testingjob.MakeJob("test-job", ns.Name).
 				Queue(kueue.LocalQueueName(localQueue.Name)).
 				SetAnnotation("kueue.x-k8s.io/elastic-job", "true").

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1112,6 +1112,9 @@ func ExpectWorkloadsInNamespace(ctx context.Context, k8sClient client.Client, na
 func ExpectNewWorkloadSlice(ctx context.Context, k8sClient client.Client, oldWorkload *kueue.Workload) (newWorkload *kueue.Workload) {
 	ginkgo.GinkgoHelper()
 	gomega.Eventually(func(g gomega.Gomega) {
+		// Reset newWorkload each iteration to ensure the returned value is from
+		// the current poll, not a stale pointer from a previous retry attempt.
+		newWorkload = nil
 		wlList := &kueue.WorkloadList{}
 		g.Expect(k8sClient.List(ctx, wlList, client.InNamespace(oldWorkload.Namespace))).To(gomega.Succeed())
 		for i := range wlList.Items {
@@ -1121,6 +1124,8 @@ func ExpectNewWorkloadSlice(ctx context.Context, k8sClient client.Client, oldWor
 				break
 			}
 		}
+		g.Expect(newWorkload).ShouldNot(gomega.BeNil(),
+			"replacement workload for %s not found", workload.Key(oldWorkload))
 	}, Timeout, Interval).Should(gomega.Succeed())
 	return newWorkload
 }


### PR DESCRIPTION
The function was supposed to wait until a new workload appeared, but it returned immediately after checking the list even if nothing was found yet. This caused the test to fail randomly when the controller was slower than expected. Keep retrying until the workload is actually found, and clear the result before each retry to avoid returning stale data.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/9316 and https://github.com/kubernetes-sigs/kueue/issues/9341

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```