### PR TITLE
Fix StatefulSet MultiKueue adapter selection by creating workload in STS reconciler

### DIFF
--- a/pkg/controller/jobs/statefulset/statefulset_controller.go
+++ b/pkg/controller/jobs/statefulset/statefulset_controller.go
@@ -41,6 +41,7 @@ func init() {
 	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		SetupIndexes:                    SetupIndexes,
 		NewReconciler:                   NewReconciler,
+		NewAdditionalReconcilers:        []jobframework.ReconcilerFactory{NewPodReconciler},
 		SetupWebhook:                    SetupWebhook,
 		JobType:                         &appsv1.StatefulSet{},
 		AddToScheme:                     appsv1.AddToScheme,

--- a/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter_test.go
@@ -87,8 +87,6 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantManagersStatefulSets: []appsv1.StatefulSet{
 				*utiltestingstatefulset.MakeStatefulSet("statefulset1", TestNamespace).
-					StatusReplicas(3).
-					ReadyReplicas(2).
 					Obj(),
 			},
 			wantWorkerStatefulSets: []appsv1.StatefulSet{

--- a/pkg/controller/jobs/statefulset/statefulset_pod_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_pod_reconciler.go
@@ -1,0 +1,193 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statefulset
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/constants"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
+	clientutil "sigs.k8s.io/kueue/pkg/util/client"
+	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
+	"sigs.k8s.io/kueue/pkg/util/roletracker"
+)
+
+type PodReconciler struct {
+	client                     client.Client
+	manageJobsWithoutQueueName bool
+	roleTracker                *roletracker.RoleTracker
+}
+
+const podControllerName = "statefulset_pod"
+
+func NewPodReconciler(_ context.Context, client client.Client, _ client.FieldIndexer, _ record.EventRecorder, opts ...jobframework.Option) (jobframework.JobReconcilerInterface, error) {
+	options := jobframework.ProcessOptions(opts...)
+	return &PodReconciler{
+		client:                     client,
+		manageJobsWithoutQueueName: options.ManageJobsWithoutQueueName,
+		roleTracker:                options.RoleTracker,
+	}, nil
+}
+
+var _ jobframework.JobReconcilerInterface = (*PodReconciler)(nil)
+
+func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	ctrl.Log.V(3).Info("Setting up Pod reconciler for StatefulSet")
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Pod{}).
+		Named(podControllerName).
+		WithEventFilter(r).
+		WithOptions(controller.Options{
+			LogConstructor: roletracker.NewLogConstructor(r.roleTracker, podControllerName),
+		}).
+		Complete(r)
+}
+
+func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	pod := &corev1.Pod{}
+	err := r.client.Get(ctx, req.NamespacedName, pod)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+	log.V(2).Info("Reconcile StatefulSet Pod")
+
+	if utilpod.IsTerminated(pod) || pod.DeletionTimestamp != nil {
+		err = client.IgnoreNotFound(clientutil.Patch(ctx, r.client, pod, func() (bool, error) {
+			removed := controllerutil.RemoveFinalizer(pod, podconstants.PodFinalizer)
+			if removed {
+				log.V(3).Info(
+					"Finalizing statefulset pod in group",
+					"pod", klog.KObj(pod),
+					"group", pod.Labels[podconstants.GroupNameLabel],
+				)
+			}
+			return removed, nil
+		}))
+	} else {
+		err = client.IgnoreNotFound(clientutil.Patch(ctx, r.client, pod, func() (bool, error) {
+			updated, err := r.setDefault(ctx, pod)
+			if err != nil {
+				return false, err
+			}
+			if updated {
+				log.V(3).Info("Updating pod in group", "pod", klog.KObj(pod), "group", pod.Labels[podconstants.GroupNameLabel])
+			}
+			return updated, nil
+		}))
+	}
+
+	return ctrl.Result{}, err
+}
+
+func (r *PodReconciler) setDefault(ctx context.Context, pod *corev1.Pod) (bool, error) {
+	controllerRef := metav1.GetControllerOf(pod)
+	if controllerRef == nil {
+		return false, nil
+	}
+	if controllerRef.Kind != gvk.Kind || controllerRef.APIVersion != gvk.GroupVersion().String() {
+		return false, nil
+	}
+
+	sts := &appsv1.StatefulSet{}
+	err := r.client.Get(ctx, client.ObjectKey{Namespace: pod.Namespace, Name: controllerRef.Name}, sts)
+	if err != nil {
+		return false, client.IgnoreNotFound(err)
+	}
+
+	queueName := jobframework.QueueNameForObject(sts)
+	wlName := GetWorkloadName(sts.Name)
+
+	if pod.Labels[podconstants.GroupNameLabel] == wlName {
+		if queueName != "" && pod.Labels[controllerconstants.QueueLabel] != string(queueName) {
+			pod.Labels[controllerconstants.QueueLabel] = string(queueName)
+			return true, nil
+		}
+		return false, nil
+	}
+
+	if queueName == "" && !r.manageJobsWithoutQueueName {
+		return false, nil
+	}
+
+	if pod.Labels == nil {
+		pod.Labels = make(map[string]string)
+	}
+	pod.Labels[constants.ManagedByKueueLabelKey] = constants.ManagedByKueueLabelValue
+	pod.Labels[podconstants.GroupNameLabel] = wlName
+	pod.Labels[controllerconstants.PrebuiltWorkloadLabel] = wlName
+	if queueName != "" {
+		pod.Labels[controllerconstants.QueueLabel] = string(queueName)
+	}
+
+	if priorityClass := jobframework.WorkloadPriorityClassName(sts); priorityClass != "" {
+		pod.Labels[controllerconstants.WorkloadPriorityClassLabel] = priorityClass
+	}
+
+	pod.Annotations[podconstants.GroupTotalCountAnnotation] = fmt.Sprint(ptr.Deref(sts.Spec.Replicas, 1))
+	pod.Annotations[podconstants.GroupFastAdmissionAnnotationKey] = podconstants.GroupFastAdmissionAnnotationValue
+	pod.Annotations[podconstants.GroupServingAnnotationKey] = podconstants.GroupServingAnnotationValue
+	pod.Annotations[kueue.PodGroupPodIndexLabelAnnotation] = appsv1.PodIndexLabel
+	pod.Annotations[podconstants.RoleHashAnnotation] = string(kueue.DefaultPodSetName)
+
+	return true, nil
+}
+
+var _ predicate.Predicate = (*PodReconciler)(nil)
+
+func (r *PodReconciler) Generic(event.GenericEvent) bool {
+	return false
+}
+
+func (r *PodReconciler) Create(e event.CreateEvent) bool {
+	return r.handle(e.Object)
+}
+
+func (r *PodReconciler) Update(e event.UpdateEvent) bool {
+	return r.handle(e.ObjectNew)
+}
+
+func (r *PodReconciler) Delete(event.DeleteEvent) bool {
+	return false
+}
+
+func (r *PodReconciler) handle(obj client.Object) bool {
+	pod, isPod := obj.(*corev1.Pod)
+	if !isPod {
+		return false
+	}
+	return pod.Annotations[podconstants.SuspendedByParentAnnotation] == FrameworkName
+}

--- a/pkg/controller/jobs/statefulset/statefulset_pod_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_pod_reconciler_test.go
@@ -1,0 +1,265 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statefulset
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	testingjobspod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+	statefulsettesting "sigs.k8s.io/kueue/pkg/util/testingjobs/statefulset"
+)
+
+func TestPodReconciler(t *testing.T) {
+	now := time.Now()
+	cases := map[string]struct {
+		manageJobsWithoutQueueName bool
+		sts                        *appsv1.StatefulSet
+		pod                        *corev1.Pod
+		wantPods                   []corev1.Pod
+		wantErr                    error
+	}{
+		"should finalize succeeded pod": {
+			sts: statefulsettesting.MakeStatefulSet("sts", "ns").Obj(),
+			pod: testingjobspod.MakePod("pod", "ns").
+				OwnerReference("sts", gvk).
+				StatusPhase(corev1.PodSucceeded).
+				KueueFinalizer().
+				Obj(),
+			wantPods: []corev1.Pod{
+				*testingjobspod.MakePod("pod", "ns").
+					OwnerReference("sts", gvk).
+					StatusPhase(corev1.PodSucceeded).
+					Obj(),
+			},
+		},
+		"should finalize failed pod": {
+			sts: statefulsettesting.MakeStatefulSet("sts", "ns").Obj(),
+			pod: testingjobspod.MakePod("pod", "ns").
+				OwnerReference("sts", gvk).
+				StatusPhase(corev1.PodFailed).
+				KueueFinalizer().
+				Obj(),
+			wantPods: []corev1.Pod{
+				*testingjobspod.MakePod("pod", "ns").
+					OwnerReference("sts", gvk).
+					StatusPhase(corev1.PodFailed).
+					Obj(),
+			},
+		},
+		"should finalize deleted pod": {
+			sts: statefulsettesting.MakeStatefulSet("sts", "ns").Obj(),
+			pod: testingjobspod.MakePod("pod", "ns").
+				OwnerReference("sts", gvk).
+				DeletionTimestamp(now).
+				KueueFinalizer().
+				Obj(),
+		},
+		"shouldn't set default values without controller reference": {
+			sts: statefulsettesting.MakeStatefulSet("sts", "ns").Obj(),
+			pod: testingjobspod.MakePod("pod", "ns").
+				Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+				Obj(),
+			wantPods: []corev1.Pod{
+				*testingjobspod.MakePod("pod", "ns").
+					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+					Obj(),
+			},
+		},
+		"shouldn't set default values without queue name": {
+			sts: statefulsettesting.MakeStatefulSet("sts", "ns").Obj(),
+			pod: testingjobspod.MakePod("pod", "ns").
+				OwnerReference("sts", gvk).
+				Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+				Obj(),
+			wantPods: []corev1.Pod{
+				*testingjobspod.MakePod("pod", "ns").
+					OwnerReference("sts", gvk).
+					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+					Obj(),
+			},
+		},
+		"should set default values": {
+			sts: statefulsettesting.MakeStatefulSet("sts", "ns").
+				Queue("queue").
+				Replicas(3).
+				Obj(),
+			pod: testingjobspod.MakePod("pod", "ns").
+				OwnerReference("sts", gvk).
+				Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+				Obj(),
+			wantPods: []corev1.Pod{
+				*testingjobspod.MakePod("pod", "ns").
+					OwnerReference("sts", gvk).
+					Queue("queue").
+					ManagedByKueueLabel().
+					Group(GetWorkloadName("sts")).
+					GroupTotalCount("3").
+					PrebuiltWorkload(GetWorkloadName("sts")).
+					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+					Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
+					Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
+					Annotation(kueue.PodGroupPodIndexLabelAnnotation, appsv1.PodIndexLabel).
+					Annotation(podconstants.RoleHashAnnotation, string(kueue.DefaultPodSetName)).
+					Obj(),
+			},
+		},
+		"should set default values with priority class": {
+			sts: statefulsettesting.MakeStatefulSet("sts", "ns").
+				Queue("queue").
+				Replicas(3).
+				WorkloadPriorityClass("high-priority").
+				Obj(),
+			pod: testingjobspod.MakePod("pod", "ns").
+				OwnerReference("sts", gvk).
+				Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+				Obj(),
+			wantPods: []corev1.Pod{
+				*testingjobspod.MakePod("pod", "ns").
+					OwnerReference("sts", gvk).
+					Queue("queue").
+					ManagedByKueueLabel().
+					Group(GetWorkloadName("sts")).
+					GroupTotalCount("3").
+					Label(controllerconstants.WorkloadPriorityClassLabel, "high-priority").
+					PrebuiltWorkload(GetWorkloadName("sts")).
+					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+					Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
+					Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
+					Annotation(kueue.PodGroupPodIndexLabelAnnotation, appsv1.PodIndexLabel).
+					Annotation(podconstants.RoleHashAnnotation, string(kueue.DefaultPodSetName)).
+					Obj(),
+			},
+		},
+		"shouldn't update pod if already labeled": {
+			sts: statefulsettesting.MakeStatefulSet("sts", "ns").
+				Queue("queue").
+				Replicas(3).
+				Obj(),
+			pod: testingjobspod.MakePod("pod", "ns").
+				OwnerReference("sts", gvk).
+				Queue("queue").
+				ManagedByKueueLabel().
+				Group(GetWorkloadName("sts")).
+				GroupTotalCount("3").
+				Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+				Obj(),
+			wantPods: []corev1.Pod{
+				*testingjobspod.MakePod("pod", "ns").
+					OwnerReference("sts", gvk).
+					Queue("queue").
+					ManagedByKueueLabel().
+					Group(GetWorkloadName("sts")).
+					GroupTotalCount("3").
+					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+					Obj(),
+			},
+		},
+		"should sync queue label on already labeled pod": {
+			sts: statefulsettesting.MakeStatefulSet("sts", "ns").
+				Queue("new-queue").
+				Replicas(3).
+				Obj(),
+			pod: testingjobspod.MakePod("pod", "ns").
+				OwnerReference("sts", gvk).
+				Queue("old-queue").
+				ManagedByKueueLabel().
+				Group(GetWorkloadName("sts")).
+				GroupTotalCount("3").
+				Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+				Obj(),
+			wantPods: []corev1.Pod{
+				*testingjobspod.MakePod("pod", "ns").
+					OwnerReference("sts", gvk).
+					Queue("new-queue").
+					ManagedByKueueLabel().
+					Group(GetWorkloadName("sts")).
+					GroupTotalCount("3").
+					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+					Obj(),
+			},
+		},
+		"should set default values without queue name when manageJobsWithoutQueueName": {
+			manageJobsWithoutQueueName: true,
+			sts: statefulsettesting.MakeStatefulSet("sts", "ns").
+				Replicas(3).
+				Obj(),
+			pod: testingjobspod.MakePod("pod", "ns").
+				OwnerReference("sts", gvk).
+				Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+				Obj(),
+			wantPods: []corev1.Pod{
+				*testingjobspod.MakePod("pod", "ns").
+					OwnerReference("sts", gvk).
+					ManagedByKueueLabel().
+					Group(GetWorkloadName("sts")).
+					GroupTotalCount("3").
+					PrebuiltWorkload(GetWorkloadName("sts")).
+					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+					Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
+					Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
+					Annotation(kueue.PodGroupPodIndexLabelAnnotation, appsv1.PodIndexLabel).
+					Annotation(podconstants.RoleHashAnnotation, string(kueue.DefaultPodSetName)).
+					Obj(),
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			clientBuilder := utiltesting.NewClientBuilder()
+
+			kClient := clientBuilder.WithObjects(tc.sts, tc.pod).Build()
+
+			var opts []jobframework.Option
+			if tc.manageJobsWithoutQueueName {
+				opts = append(opts, jobframework.WithManageJobsWithoutQueueName(true))
+			}
+			reconciler, err := NewPodReconciler(ctx, kClient, nil, nil, opts...)
+			if err != nil {
+				t.Errorf("Error creating the reconciler: %v", err)
+			}
+
+			podKey := client.ObjectKeyFromObject(tc.pod)
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: podKey})
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Reconcile returned error (-want,+got):\n%s", diff)
+			}
+
+			gotPods := &corev1.PodList{}
+			if err := kClient.List(ctx, gotPods, client.InNamespace(tc.pod.Namespace)); err != nil {
+				t.Fatalf("Could not list Pods after reconcile: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.wantPods, gotPods.Items, baseCmpOpts...); diff != "" {
+				t.Errorf("Pods after reconcile (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -18,7 +18,6 @@ package statefulset
 
 import (
 	"context"
-	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
@@ -31,7 +30,6 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
-	"sigs.k8s.io/kueue/pkg/constants"
 	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
@@ -87,26 +85,10 @@ func (wh *Webhook) Default(ctx context.Context, stsObj *appsv1.StatefulSet) erro
 		return err
 	}
 	if suspend {
-		if ss.Spec.Template.Labels == nil {
-			ss.Spec.Template.Labels = make(map[string]string, 4)
-		}
-		ss.Spec.Template.Labels[constants.ManagedByKueueLabelKey] = constants.ManagedByKueueLabelValue
-		ss.Spec.Template.Labels[podconstants.GroupNameLabel] = GetWorkloadName(ss.Name)
-		if queueName := jobframework.QueueNameForObject(ss.Object()); queueName != "" {
-			ss.Spec.Template.Labels[controllerconstants.QueueLabel] = string(queueName)
-		}
-		if priorityClass := jobframework.WorkloadPriorityClassName(ss.Object()); priorityClass != "" {
-			ss.Spec.Template.Labels[controllerconstants.WorkloadPriorityClassLabel] = priorityClass
-		}
-
 		if ss.Spec.Template.Annotations == nil {
-			ss.Spec.Template.Annotations = make(map[string]string, 5)
+			ss.Spec.Template.Annotations = make(map[string]string, 1)
 		}
 		ss.Spec.Template.Annotations[podconstants.SuspendedByParentAnnotation] = FrameworkName
-		ss.Spec.Template.Annotations[podconstants.GroupTotalCountAnnotation] = fmt.Sprint(ptr.Deref(ss.Spec.Replicas, 1))
-		ss.Spec.Template.Annotations[podconstants.GroupFastAdmissionAnnotationKey] = podconstants.GroupFastAdmissionAnnotationValue
-		ss.Spec.Template.Annotations[podconstants.GroupServingAnnotationKey] = podconstants.GroupServingAnnotationValue
-		ss.Spec.Template.Annotations[kueue.PodGroupPodIndexLabelAnnotation] = appsv1.PodIndexLabel
 	}
 
 	return nil

--- a/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
@@ -67,13 +67,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 			want: testingstatefulset.MakeStatefulSet("test-pod", "test-ns").
 				Replicas(10).
-				PodTemplateManagedByKueue().
 				PodTemplateAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
-				PodTemplateSpecPodGroupNameLabel("test-pod", "", gvk).
-				PodTemplateSpecPodGroupTotalCountAnnotation(10).
-				PodTemplateSpecPodGroupFastAdmissionAnnotation().
-				PodTemplateSpecPodGroupServingAnnotation().
-				PodTemplateSpecPodGroupPodIndexLabelAnnotation(appsv1.PodIndexLabel).
 				Obj(),
 		},
 		"statefulset with queue": {
@@ -85,14 +79,7 @@ func TestDefault(t *testing.T) {
 			want: testingstatefulset.MakeStatefulSet("test-pod", "").
 				Replicas(10).
 				Queue("test-queue").
-				PodTemplateSpecQueue("test-queue").
-				PodTemplateManagedByKueue().
 				PodTemplateAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
-				PodTemplateSpecPodGroupNameLabel("test-pod", "", gvk).
-				PodTemplateSpecPodGroupTotalCountAnnotation(10).
-				PodTemplateSpecPodGroupFastAdmissionAnnotation().
-				PodTemplateSpecPodGroupServingAnnotation().
-				PodTemplateSpecPodGroupPodIndexLabelAnnotation(appsv1.PodIndexLabel).
 				Obj(),
 		},
 		"statefulset managed by another framework": {
@@ -119,15 +106,7 @@ func TestDefault(t *testing.T) {
 				Replicas(10).
 				Queue("test-queue").
 				Label(constants.WorkloadPriorityClassLabel, "test").
-				PodTemplateSpecQueue("test-queue").
-				PodTemplateManagedByKueue().
 				PodTemplateAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
-				PodTemplateSpecLabel(constants.WorkloadPriorityClassLabel, "test").
-				PodTemplateSpecPodGroupNameLabel("test-pod", "", gvk).
-				PodTemplateSpecPodGroupTotalCountAnnotation(10).
-				PodTemplateSpecPodGroupFastAdmissionAnnotation().
-				PodTemplateSpecPodGroupServingAnnotation().
-				PodTemplateSpecPodGroupPodIndexLabelAnnotation(appsv1.PodIndexLabel).
 				Obj(),
 		},
 		"statefulset without replicas": {
@@ -137,14 +116,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 			want: testingstatefulset.MakeStatefulSet("test-pod", "").
 				Queue("test-queue").
-				PodTemplateManagedByKueue().
-				PodTemplateSpecPodGroupNameLabel("test-pod", "", gvk).
-				PodTemplateSpecPodGroupTotalCountAnnotation(1).
-				PodTemplateSpecQueue("test-queue").
 				PodTemplateAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
-				PodTemplateSpecPodGroupFastAdmissionAnnotation().
-				PodTemplateSpecPodGroupServingAnnotation().
-				PodTemplateSpecPodGroupPodIndexLabelAnnotation(appsv1.PodIndexLabel).
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label": {
@@ -153,14 +125,7 @@ func TestDefault(t *testing.T) {
 			statefulset:          testingstatefulset.MakeStatefulSet("test-pod", "default").Obj(),
 			want: testingstatefulset.MakeStatefulSet("test-pod", "default").
 				Queue("default").
-				PodTemplateSpecQueue("default").
-				PodTemplateManagedByKueue().
 				PodTemplateAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
-				PodTemplateSpecPodGroupNameLabel("test-pod", "", gvk).
-				PodTemplateSpecPodGroupTotalCountAnnotation(1).
-				PodTemplateSpecPodGroupFastAdmissionAnnotation().
-				PodTemplateSpecPodGroupServingAnnotation().
-				PodTemplateSpecPodGroupPodIndexLabelAnnotation(appsv1.PodIndexLabel).
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, default lq is created, job has queue label": {
@@ -169,14 +134,7 @@ func TestDefault(t *testing.T) {
 			statefulset:          testingstatefulset.MakeStatefulSet("test-pod", "").Queue("test-queue").Obj(),
 			want: testingstatefulset.MakeStatefulSet("test-pod", "").
 				Queue("test-queue").
-				PodTemplateSpecQueue("test-queue").
-				PodTemplateManagedByKueue().
 				PodTemplateAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
-				PodTemplateSpecPodGroupNameLabel("test-pod", "", gvk).
-				PodTemplateSpecPodGroupTotalCountAnnotation(1).
-				PodTemplateSpecPodGroupFastAdmissionAnnotation().
-				PodTemplateSpecPodGroupServingAnnotation().
-				PodTemplateSpecPodGroupPodIndexLabelAnnotation(appsv1.PodIndexLabel).
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, default lq isn't created, job doesn't have queue label": {

--- a/test/e2e/tas/statefulset_test.go
+++ b/test/e2e/tas/statefulset_test.go
@@ -107,7 +107,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for StatefulSet", func() {
 				gomega.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				gotAssignment := make(map[string]string, replicas)
 				for _, pod := range pods.Items {
-					index := pod.Labels[kueue.PodGroupPodIndexLabel]
+					index := pod.Labels[appsv1.PodIndexLabel]
 					gotAssignment[index] = pod.Spec.NodeName
 				}
 				wantAssignment := map[string]string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Currently, the pod framework creates the workload with the pod as the controller owner (and without the `JobOwnerGVKAnnotation`), causing the MK workload controller's `adapter()` function to select the pod adapter instead of the STS adapter.

This PR addresses the issue by having the STS reconciler create the workload (following the LWS pattern) with `JobOwnerGVKAnnotation` set at creation time, ensuring that MK always uses the STS adapter.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MultiKueue: for the StatefulSet integration copy the entire StatefulSet onto the worker clusters. This allows
for proper management (and replacements) of Pods on the worker clusters.
```