### PR TITLE
Terminate Workloads Sequentially in Integration Test

### DIFF
--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -174,13 +174,30 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 			util.ExpectClusterQueueWeightedShareMetric(cqB, 0.0)
 			util.ExpectClusterQueueWeightedShareMetric(cqShared, 0.0)
 
-			ginkgo.By("Terminating 4 running workloads in cqA: shared quota is fair-shared")
-			util.FinishRunningWorkloadsInCQ(ctx, k8sClient, cqA, 4)
-
 			// Admits 1 from cqA and 3 from cqB.
-			util.ExpectReservingActiveWorkloadsMetric(cqA, 5)
-			util.ExpectPendingWorkloadsMetric(cqA, 0, 1)
+			ginkgo.By("Terminating 4 running workloads in cqA: shared quota is fair-shared")
+
+			// Admit cqB workload.
+			util.FinishRunningWorkloadsInCQ(ctx, k8sClient, cqA, 1)
+			util.ExpectReservingActiveWorkloadsMetric(cqB, 1)
+			util.ExpectReservingActiveWorkloadsMetric(cqA, 7)
+
+			// Admit cqB workload.
+			util.FinishRunningWorkloadsInCQ(ctx, k8sClient, cqA, 1)
+			util.ExpectReservingActiveWorkloadsMetric(cqB, 2)
+			util.ExpectReservingActiveWorkloadsMetric(cqA, 6)
+
+			// Admit cqB workload.
+			util.FinishRunningWorkloadsInCQ(ctx, k8sClient, cqA, 1)
 			util.ExpectReservingActiveWorkloadsMetric(cqB, 3)
+			util.ExpectReservingActiveWorkloadsMetric(cqA, 5)
+
+			// Admit cqA workload.
+			util.FinishRunningWorkloadsInCQ(ctx, k8sClient, cqA, 1)
+			util.ExpectReservingActiveWorkloadsMetric(cqB, 3)
+			util.ExpectReservingActiveWorkloadsMetric(cqA, 5)
+
+			util.ExpectPendingWorkloadsMetric(cqA, 0, 1)
 			util.ExpectPendingWorkloadsMetric(cqB, 0, 2)
 			util.ExpectClusterQueueWeightedShareMetric(cqA, 250.0)
 			util.ExpectClusterQueueWeightedShareMetric(cqB, 250.0)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Prep for #9232

Works around issue described in https://github.com/kubernetes-sigs/kueue/issues/9345, as after we batch the requeues in #9232, we schedule too many workloads to `cqA`. By finishing one workload at a time, we choose the queue (`cqB`) with the lowest DRS in the first 3 scheduling cycles.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```