### PR TITLE
fix: Add a TASBalancedPlacement FG to the number of TAS profile validation

### DIFF
--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -498,6 +498,7 @@ func ValidateFeatureGates(featureGateCLI string, featureGateMap map[string]bool)
 	}
 	TASProfilesEnabled := []bool{features.Enabled(features.TASProfileMixed),
 		features.Enabled(features.TASProfileLeastFreeCapacity),
+		features.Enabled(features.TASBalancedPlacement),
 	}
 	enabledProfilesCount := 0
 	for _, enabled := range TASProfilesEnabled {

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -998,6 +998,7 @@ func TestValidateFeatureGates(t *testing.T) {
 			setupFeatureGates: map[featuregate.Feature]bool{
 				features.TASProfileMixed:             true,
 				features.TASProfileLeastFreeCapacity: true,
+				features.TASBalancedPlacement:        true,
 			},
 			errorStr: "cannot use more than one TAS profiles",
 		},
@@ -1005,6 +1006,7 @@ func TestValidateFeatureGates(t *testing.T) {
 			setupFeatureGates: map[featuregate.Feature]bool{
 				features.TASProfileMixed:             true,
 				features.TASProfileLeastFreeCapacity: true,
+				features.TASBalancedPlacement:        true,
 			},
 			errorStr: "cannot use more than one TAS profiles",
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
As we discussed in https://github.com/kubernetes-sigs/kueue/pull/9298#discussion_r2826002663, we forgot to validate TASBalancedPlacement FG.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Add a TASBalancedPlacement FG to the validation for the number of TAS profiles
```