### PR TITLE
Extend resource transformation integration tests.

### DIFF
--- a/test/integration/singlecluster/scheduler/resourcetransformations/resource_transformations_test.go
+++ b/test/integration/singlecluster/scheduler/resourcetransformations/resource_transformations_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package resourcetransformations
 
 import (
+	"fmt"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -173,6 +175,157 @@ var _ = ginkgo.Describe("Resource Transformations", ginkgo.Ordered, ginkgo.Conti
 					"nvidia.com/total-gpucores": resource.MustParse("20"),
 				}))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+})
+
+// Tests the "Retain" resource transformation strategy: regular CPU requests are
+// transformed into cpu_credits (1:1 mapping) while preserving the original CPU
+// request for scheduling against on-demand/spot flavors.
+//
+// Goal: verify that transformed capacity (cpu_credits quota) correctly gates
+// admission, while original CPU still participates in flavor selection / fitting.
+//
+// See: https://kueue.sigs.k8s.io/docs/tasks/manage/share_quotas_across_flavors/
+var _ = ginkgo.Describe("Resource Transformation: Retain CPU → cpu_credits (Share Quotas Across Flavors)", ginkgo.Ordered, func() {
+	const cpuCredits = "cpu_credits"
+
+	var (
+		ns       *corev1.Namespace
+		onDemand *kueue.ResourceFlavor
+		spot     *kueue.ResourceFlavor
+		credits  *kueue.ResourceFlavor
+		cq       *kueue.ClusterQueue
+		lq       *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeAll(func() {
+		// Starts the manager with a single retain transformation: 1 CPU → 1 cpu_credits
+		fwk.StartManager(ctx, cfg, managerAndSchedulerSetup([]config.ResourceTransformation{{
+			Input:    corev1.ResourceCPU,
+			Strategy: ptr.To(config.Retain),
+			Outputs:  corev1.ResourceList{cpuCredits: resource.MustParse("1")},
+		}}))
+	})
+
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "tas-")
+
+		onDemand = utiltestingapi.MakeResourceFlavor("on-demand").Obj()
+		util.MustCreate(ctx, k8sClient, onDemand)
+
+		spot = utiltestingapi.MakeResourceFlavor("spot").Obj()
+		util.MustCreate(ctx, k8sClient, spot)
+
+		credits = utiltestingapi.MakeResourceFlavor("credits").Obj()
+		util.MustCreate(ctx, k8sClient, credits)
+
+		// ClusterQueue setup:
+		//   - 9 CPU on on-demand + 9 CPU on spot → total 18 "original" CPU capacity
+		//   - 8 cpu_credits on credits flavor → transformed capacity is the real limit
+		cq = utiltestingapi.MakeClusterQueue("team-cluster-queue").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas(onDemand.Name).Resource(corev1.ResourceCPU, "9").Obj(),
+				*utiltestingapi.MakeFlavorQuotas(spot.Name).Resource(corev1.ResourceCPU, "9").Obj(),
+			).
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(credits.Name).Resource(cpuCredits, "8").Obj()).
+			Preemption(kueue.ClusterQueuePreemption{
+				WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
+			}).
+			Obj()
+		util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+		lq = utiltestingapi.MakeLocalQueue("team-queue", ns.Name).ClusterQueue(cq.Name).Obj()
+		util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemand, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, spot, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, credits, true)
+	})
+
+	ginkgo.When("workloads request regular CPU but are transformed to cpu_credits", func() {
+		const (
+			highPriorityClassName = "high"
+			highPriority          = 1000
+			lowPriorityClassName  = "low"
+			lowPriority           = 100
+
+			podsPerWorkload = 1
+			// each workload requests 3 CPU → 3 cpu_credits after transformation
+			cpuRequestPerPod = "3"
+			// 8 credits available → floor(8/3) = 2 workloads fit initially
+			initialFitCount = 2
+		)
+
+		var (
+			workloadWrapper *utiltestingapi.WorkloadWrapper
+			admitted        []*kueue.Workload
+			pendingWl       *kueue.Workload
+		)
+
+		ginkgo.BeforeEach(func() {
+			workloadWrapper = utiltestingapi.MakeWorkload("tmpl", ns.Name).
+				Queue(kueue.LocalQueueName(lq.Name)).
+				WorkloadPriorityClassRef(highPriorityClassName).
+				Priority(highPriority).
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, podsPerWorkload).
+					Request(corev1.ResourceCPU, cpuRequestPerPod).
+					Obj())
+
+			admitted = make([]*kueue.Workload, 0, initialFitCount)
+
+			ginkgo.By(fmt.Sprintf("Creating %d high-priority workloads (should fit within 8 credits)", initialFitCount), func() {
+				for i := range initialFitCount {
+					wl := workloadWrapper.Clone().Name(fmt.Sprintf("wl-%d", i+1)).Obj()
+					util.MustCreate(ctx, k8sClient, wl)
+					admitted = append(admitted, wl)
+				}
+			})
+
+			ginkgo.By("Verifying initial workloads are admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, admitted...)
+			})
+
+			ginkgo.By("Creating a 3rd workload that should stay pending (not enough credits)", func() {
+				pendingWl = workloadWrapper.Clone().Name("wl").Obj()
+				util.MustCreate(ctx, k8sClient, pendingWl)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, pendingWl)
+			})
+		})
+
+		ginkgo.It("should admit the pending workload after one running workload finishes", func() {
+			ginkgo.By("Marking one admitted workload as finished (frees 3 credits)", func() {
+				util.FinishWorkloads(ctx, k8sClient, admitted[0])
+			})
+
+			ginkgo.By("Waiting for the pending workload to be admitted (credits available again)", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, pendingWl)
+			})
+		})
+
+		ginkgo.It("should admit the pending workload after preempting a lower-priority workload", func() {
+			ginkgo.By("Setting low priority of one admitted workload → making it preemptable", func() {
+				createdWl := &kueue.Workload{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(admitted[0]), createdWl)).To(gomega.Succeed())
+					createdWl.Spec.PriorityClassRef.Name = lowPriorityClassName
+					createdWl.Spec.Priority = ptr.To[int32](lowPriority)
+					g.Expect(k8sClient.Update(ctx, createdWl)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				util.FinishEvictionForWorkloads(ctx, k8sClient, admitted[0])
+			})
+
+			ginkgo.By("Waiting for the pending workload to be admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, pendingWl)
+			})
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Extend resource transformation integration tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```