### PR TITLE
Speedup make test-integration by avoiding generate-code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ include Makefile-verify.mk
 ##@ Development
 
 .PHONY: manifests
-manifests: controller-gen generate-code ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) \
 		crd:generateEmbeddedObjectMeta=true output:crd:artifacts:config=config/components/crd/bases\
 		paths="./apis/..."

--- a/Makefile-verify.mk
+++ b/Makefile-verify.mk
@@ -79,7 +79,7 @@ verify-docs-prereqs: generate-apiref generate-kueuectl-docs generate-metrics-tab
 
 .PHONY: verify-helm-prereqs
 verify-helm-prereqs: ## Prerequisites for Helm checks.
-verify-helm-prereqs: compile-crd-manifests update-helm generate-helm-docs prepare-release-branch
+verify-helm-prereqs: verify-go-prereqs compile-crd-manifests update-helm generate-helm-docs prepare-release-branch
 
 .PHONY: verify-tree-prereqs
 verify-tree-prereqs: ## Prerequisites to ensure repo is fully regenerated.


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

Reverts the unintended side effect of #8988, which fixed a race condition in make verify -j (#8906) but inadvertently slowed down integration tests. This refines the fix by scoping the ordering constraint to the verify flow only.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```