### PR TITLE
Fix e2e certmanager kustomization missing vars

### DIFF
--- a/test/e2e/config/certmanager/kustomization.yaml
+++ b/test/e2e/config/certmanager/kustomization.yaml
@@ -61,7 +61,16 @@ replacements:
           - spec.dnsNames.1
         options:
           delimiter: "."
-          index: 0  
+          index: 0
+      - select: 
+          kind: ServiceMonitor
+          name: controller-manager-metrics-monitor
+          version: v1
+        fieldPaths:
+          - spec.endpoints.0.tlsConfig.serverName
+        options:
+          delimiter: "."
+          index: 0      
 
   # 2. Replace METRICS_SERVICE_NAMESPACE 
   - source:
@@ -78,7 +87,16 @@ replacements:
           - spec.dnsNames.1
         options:
           delimiter: "."
-          index: 1  
+          index: 1
+      - select: 
+          kind: ServiceMonitor
+          name: controller-manager-metrics-monitor
+          version: v1
+        fieldPaths:
+          - spec.endpoints.0.tlsConfig.serverName
+        options:
+          delimiter: "."
+          index: 1      
 
 
   # 3. Replace $(SERVICE_NAME)
@@ -94,15 +112,6 @@ replacements:
         fieldPaths:
           - spec.dnsNames.0
           - spec.dnsNames.1
-        options:
-          delimiter: "."
-          index: 0
-      - select: 
-          kind: ServiceMonitor
-          name: controller-manager-metrics-monitor
-          version: v1
-        fieldPaths:
-          - spec.endpoints.0.tlsConfig.serverName
         options:
           delimiter: "."
           index: 0              
@@ -124,15 +133,6 @@ replacements:
         options:
           delimiter: "."
           index: 1 
-      - select: 
-          kind: ServiceMonitor
-          name: controller-manager-metrics-monitor
-          version: v1
-        fieldPaths:
-          - spec.endpoints.0.tlsConfig.serverName
-        options:
-          delimiter: "."
-          index: 1
 
   #5.  Replace $(CERTIFICATE_NAME)  
   - source:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it: 
Extracting the e2e certmanager fix from [PR](https://github.com/kubernetes-sigs/kueue/pull/9239#discussion_r2828560057) to allow for easier cherry-picking into 0.15 and 0.16 as requested by @IrvingMg.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:  

needs cherry picking the change to 0.15 and 0.16

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```