### PR TITLE
Add E2E test suite for MultiKueue with TAS

### DIFF
--- a/test/e2e/multikueue/tas_test.go
+++ b/test/e2e/multikueue/tas_test.go
@@ -61,8 +61,8 @@ func waitForTopologyAssignment(workerClient client.Client, wlLookupKey types.Nam
 
 func waitForDelayedTopologyRequestReady(wlLookupKey types.NamespacedName) {
 	ginkgo.GinkgoHelper()
+	managerWl := &kueue.Workload{}
 	gomega.Eventually(func(g gomega.Gomega) {
-		managerWl := &kueue.Workload{}
 		g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
 		g.Expect(managerWl.Status.Admission).NotTo(gomega.BeNil())
 		g.Expect(managerWl.Status.Admission.PodSetAssignments).To(gomega.HaveLen(1))


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a dedicated E2E test suite that checks TAS works through MultiKueue's multi-cluster dispatch. Without this, TAS behaviour across manager and worker clusters goes untested in CI.

The suite runs two tests against a three-cluster Kind setup (one manager, two workers with asymmetric CPU quotas):

1. **Preferred hostname topology** — a 1.5 CPU job routes to the only worker that can fit it, gets a topology assignment there, and the manager's `DelayedTopologyRequest` reaches `Ready` before pods run.

2. **Required hostname topology** — a 500m job lands on either worker, and the test verifies the same worker-side assignment and manager-side `DelayedTopologyRequest` reconciliation.

#### Which issue(s) this PR fixes:

Fixes #9380

#### Special notes for your reviewer:

The test follows the same patterns as the existing MultiKueue+TAS tests in `test/e2e/multikueue/tas_test.go`. The key design choice: topology assignment is verified on the **worker** workload, while the manager workload is checked for `DelayedTopologyRequest=Ready`; To match how MultiKueue defers topology resolution to workers.

The kustomize overlay mirrors `test/e2e/config/dra/`, enabling only `batch/job` integration with two controller replicas.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```