### PR TITLE
Cherry pick of #9331 for 0.16: Fix ExpectNewWorkloadSlice to retry until workload is found

### DIFF
--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1087,6 +1087,9 @@ func ExpectWorkloadsInNamespace(ctx context.Context, k8sClient client.Client, na
 func ExpectNewWorkloadSlice(ctx context.Context, k8sClient client.Client, oldWorkload *kueue.Workload) (newWorkload *kueue.Workload) {
 	ginkgo.GinkgoHelper()
 	gomega.Eventually(func(g gomega.Gomega) {
+		// Reset newWorkload each iteration to ensure the returned value is from
+		// the current poll, not a stale pointer from a previous retry attempt.
+		newWorkload = nil
 		wlList := &kueue.WorkloadList{}
 		g.Expect(k8sClient.List(ctx, wlList, client.InNamespace(oldWorkload.Namespace))).To(gomega.Succeed())
 		for i := range wlList.Items {
@@ -1096,6 +1099,8 @@ func ExpectNewWorkloadSlice(ctx context.Context, k8sClient client.Client, oldWor
 				break
 			}
 		}
+		g.Expect(newWorkload).ShouldNot(gomega.BeNil(),
+			"replacement workload for %s not found", workload.Key(oldWorkload))
 	}, Timeout, Interval).Should(gomega.Succeed())
 	return newWorkload
 }


### PR DESCRIPTION
Cherry pick of #9331 on release-0.16.

#9331: Fix ExpectNewWorkloadSlice to retry until workload is found

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind flake


```release-note
NONE
```