### PR TITLE
Fix/yaml processor insert text tests

### DIFF
--- a/hack/tools/yaml-processor/yamlproc/processor_test.go
+++ b/hack/tools/yaml-processor/yamlproc/processor_test.go
@@ -228,18 +228,21 @@ root:
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, errs := fp.ProcessFileOperations([]byte(tt.data), FileOperations{
-				Operations: []Operation{
-					{
-						Type:            tt.opType,
-						Key:             tt.key,
-						Value:           tt.value,
-						AddKeyIfMissing: tt.addKeyIfMissing,
-						OnFileCondition: tt.onCondition,
-						Indentation:     tt.indentation,
-					},
-				},
-			})
+			op := Operation{
+				Type:            tt.opType,
+				Key:             tt.key,
+				Value:           tt.value,
+				AddKeyIfMissing: tt.addKeyIfMissing,
+				OnFileCondition: tt.onCondition,
+				Indentation:     tt.indentation,
+			}
+			fileOps := FileOperations{}
+			if tt.opType == InsertText {
+				fileOps.PostOperations = []Operation{op}
+			} else {
+				fileOps.Operations = []Operation{op}
+			}
+			got, errs := fp.ProcessFileOperations([]byte(tt.data), fileOps)
 			var gotErrs []string
 			for _, err := range errs {
 				gotErrs = append(gotErrs, err.Error())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

The `yaml-processor` tests were running all operations in the regular phase, but some (such as `InsertText`) run only in the post phase. Adds a `postOperation` field to the test struct to route operations to the correct phase.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Depends on #9408.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```