### PR TITLE
docs: Add example ConfigMap for RayJob autoscaling

### DIFF
--- a/site/content/en/docs/tasks/run/rayjobs.md
+++ b/site/content/en/docs/tasks/run/rayjobs.md
@@ -125,4 +125,20 @@ spec:
 
 ### Example RayJob with Autoscaling
 
+In this example, the code is provided to the Ray framework via a ConfigMap.
+
+{{< include "examples/jobs/ray-job-autoscaling-code-sample.yaml" "yaml" >}}
+
+The RayJob looks like the following:
+
 {{< include "examples/jobs/ray-job-autoscaling-sample.yaml" "yaml" >}}
+
+You can run this RayJob with the following commands:
+
+```sh
+# Create the code ConfigMap (once)
+kubectl apply -f ray-job-autoscaling-code-sample.yaml
+# Create a RayJob. You can run this command multiple times
+# to observe the queueing and admission of the jobs.
+kubectl create -f ray-job-autoscaling-sample.yaml
+```

--- a/site/content/zh-CN/docs/tasks/run/rayjobs.md
+++ b/site/content/zh-CN/docs/tasks/run/rayjobs.md
@@ -120,3 +120,22 @@ spec:
   rayClusterSpec:
     enableInTreeAutoscaling: true
 ```
+
+### 带有动态扩容的 RayJob 示例
+
+在本例中，代码通过 ConfigMap 提供给 Ray 框架。
+
+{{< include "examples/jobs/ray-job-autoscaling-code-sample.yaml" "yaml" >}}
+
+RayJob 如下所示：
+
+{{< include "examples/jobs/ray-job-autoscaling-sample.yaml" "yaml" >}}
+
+你可以使用以下命令运行此 RayJob：
+
+```sh
+# 创建代码 ConfigMap（一次）
+kubectl apply -f ray-job-autoscaling-code-sample.yaml
+# 创建 RayJob。你可以多次运行此命令，以观察作业的排队和准入。
+kubectl create -f ray-job-autoscaling-sample.yaml
+```


### PR DESCRIPTION
## Summary

- Add the `ray-job-autoscaling-code-sample.yaml` ConfigMap include to the RayJob autoscaling
  documentation section, along with `kubectl` commands to apply it
- Update both English (`en`) and Chinese (`zh-CN`) docs to match the pattern used in the
  non-autoscaling example section

Fixes #9110

> [!NOTE]
> The Chinese (zh-CN) translation was generated with AI assistance (ChatGPT/Gemini)
> and may need review by a native speaker for accuracy.