### PR TITLE
Fix stale replica-role in scheduler logs after leader election

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -164,7 +164,7 @@ func New(queues *qcache.Manager, cache *schdcache.Cache, cl client.Client, recor
 
 // Start implements the Runnable interface to run scheduler as a controller.
 func (s *Scheduler) Start(ctx context.Context) error {
-	log := roletracker.WithReplicaRole(ctrl.LoggerFrom(ctx).WithName("scheduler"), s.roleTracker)
+	log := ctrl.LoggerFrom(ctx).WithName("scheduler")
 	ctx = ctrl.LoggerInto(ctx, log)
 	go wait.UntilWithBackoff(ctx, s.schedule)
 	return nil
@@ -198,7 +198,7 @@ func (s *Scheduler) reportSkippedPreemptions(p map[kueue.ClusterQueueReference]i
 
 func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 	s.schedulingCycle++
-	log := ctrl.LoggerFrom(ctx).WithValues("schedulingCycle", s.schedulingCycle)
+	log := roletracker.WithReplicaRole(ctrl.LoggerFrom(ctx), s.roleTracker).WithValues("schedulingCycle", s.schedulingCycle)
 	ctx = ctrl.LoggerInto(ctx, log)
 
 	// 1. Get the heads from the queues, including their desired clusterQueue.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Moves role resolution from `Start()` to `schedule()`, resolving it dynamically each cycle.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9314 
Relates to #9287 

#### Special notes for your reviewer:

##### Verification
Running on the attached [e2e.log](https://github.com/user-attachments/files/25495571/e2e.log) 

```bash
grep -m1 '"schedulingCycle": 1,' e2e.log; grep -m1 'transitioned to leader' e2e.log; grep -m1 '"schedulingCycle": 2,' e2e.log
2026-02-23T16:17:18.612895618Z stderr F 2026-02-23T16:17:18.612459534Z  LEVEL(-3)       scheduler       queue/manager.go:683    Obtained ClusterQueue heads     {"replica-role": "follower", "schedulingCycle": 1, "count": 0}
2026-02-23T16:17:18.613480743Z stderr F 2026-02-23T16:17:18.613399034Z  INFO    setup   roletracker/tracker.go:59       RoleTracker: transitioned to leader
2026-02-23T16:17:30.485084013Z stderr F 2026-02-23T16:17:30.483801596Z  LEVEL(-3)       scheduler       queue/manager.go:683    Obtained ClusterQueue heads     {"replica-role": "leader", "schedulingCycle": 2, "count": 0}
```


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Observability: Fix the stale "replica-role" value in scheduler logs after leader election.
```