### PR TITLE
Fix discarded ctx from ctrl.LoggerInto causing missing replica-role in logs

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/fswatch_test.go
+++ b/pkg/controller/admissionchecks/multikueue/fswatch_test.go
@@ -147,8 +147,7 @@ func TestFSWatch(t *testing.T) {
 				}
 			}
 			// Using an empty context here to avoid a race condition with the test context when setting the logger.
-			ctx := context.Background()
-			ctrl.LoggerInto(ctx, utiltesting.NewLogger(t))
+			ctx := ctrl.LoggerInto(context.Background(), utiltesting.NewLogger(t))
 			ctx, cancel := context.WithTimeout(ctx, time.Second)
 			defer cancel()
 			watcher := newKubeConfigFSWatcher()
@@ -199,8 +198,7 @@ func TestFSWatch(t *testing.T) {
 
 func TestFSWatchAddRm(t *testing.T) {
 	// Using an empty context here to avoid a race condition with the test context when setting the logger.
-	ctx := context.Background()
-	ctrl.LoggerInto(ctx, utiltesting.NewLogger(t))
+	ctx := ctrl.LoggerInto(context.Background(), utiltesting.NewLogger(t))
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	basePath := t.TempDir()

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -464,7 +464,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		remoteWl := group.remotes[reservingRemote]
 
 		log = log.WithValues("remote", reservingRemote, "remoteWorkload", klog.KObj(remoteWl))
-		ctrl.LoggerInto(ctx, log)
+		ctx = ctrl.LoggerInto(ctx, log)
 
 		evictedCond := apimeta.FindStatusCondition(group.local.Status.Conditions, kueue.WorkloadEvicted)
 		if workload.HasQuotaReservation(group.local) && evictedCond != nil && evictedCond.Status == metav1.ConditionTrue {

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -337,9 +337,8 @@ func (r *Reconciler) handle(obj client.Object) bool {
 		return false
 	}
 
-	ctx := context.Background()
 	log := r.logger().WithValues("leaderworkerset", klog.KObj(lws))
-	ctrl.LoggerInto(ctx, log)
+	ctx := ctrl.LoggerInto(context.Background(), log)
 
 	// Handle only leaderworkerset managed by kueue.
 	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, lws, r.client, r.manageJobsWithoutQueueName, r.managedJobsNamespaceSelector)

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -239,9 +239,8 @@ func (r *Reconciler) handle(obj client.Object) bool {
 		return true
 	}
 
-	ctx := context.Background()
 	log := r.logger().WithValues("statefulset", klog.KObj(sts))
-	ctrl.LoggerInto(ctx, log)
+	ctx := ctrl.LoggerInto(context.Background(), log)
 
 	if frameworkName, managed := managedByAnotherFramework(sts); managed {
 		log.V(3).Info("Skipping reconciliation because the object is managed by another framework", "framework", frameworkName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

`ctrl.LoggerInto(ctx, log)` returns a new context with the logger, but some call sites ignored the returned value. As a result, `ctrl.LoggerFrom(ctx)` later returned a basic logger missing the replica role.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9287 (2.)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
RoleTracker: fix missing replica-role in logs for LWS, StatefulSet, and MultiKueue handlers.
```