### PR TITLE
Upgrade TASReplaceNodeOnNodeTaints to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -398,7 +398,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.17"), Default: true, PreRelease: featuregate.Beta},
 	},
 	TASReplaceNodeOnNodeTaints: {
-		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.17"), Default: true, PreRelease: featuregate.Beta},
 	},
 	AssignQueueLabelsForPods: {
 		{Version: version.MustParse("0.17"), Default: true, PreRelease: featuregate.Beta},

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -265,9 +265,9 @@
     version: "0.15"
 - name: TASReplaceNodeOnNodeTaints
   versionedSpecs:
-  - default: false
+  - default: true
     lockToDefault: false
-    preRelease: Alpha
+    preRelease: Beta
     version: "0.17"
 - name: TASReplaceNodeOnPodTermination
   versionedSpecs:

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -265,9 +265,9 @@
     version: "0.15"
 - name: TASReplaceNodeOnNodeTaints
   versionedSpecs:
-  - default: false
+  - default: true
     lockToDefault: false
-    preRelease: Alpha
+    preRelease: Beta
     version: "0.17"
 - name: TASReplaceNodeOnPodTermination
   versionedSpecs:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Enable TASReplaceNodeOnNodeTaints feature gate as described in KEP - https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-scheduling#tainted-nodes-treatment

#### Which issue(s) this PR fixes:
Part of #8828

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Introduce the TASReplaceNodeOnNodeTaints feature gate (enabled by default) which allows 
TAS workloads to be evicted or replaced when a node is tainted with NoExecute.
```