### PR TITLE
Fix race in KubeConfigFSWatcher tests by making Start() blocking

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/fswatch_test.go
+++ b/pkg/controller/admissionchecks/multikueue/fswatch_test.go
@@ -149,12 +149,15 @@ func TestFSWatch(t *testing.T) {
 			// Using an empty context here to avoid a race condition with the test context when setting the logger.
 			ctx := ctrl.LoggerInto(context.Background(), utiltesting.NewLogger(t))
 			ctx, cancel := context.WithTimeout(ctx, time.Second)
-			defer cancel()
+			wg := sync.WaitGroup{}
+			defer func() {
+				cancel()
+				wg.Wait()
+			}()
 			watcher := newKubeConfigFSWatcher()
 
-			// start the recorder
+			// start the recorder and the watcher
 			gotEventsForClusters := set.New[string]()
-			wg := sync.WaitGroup{}
 			wg.Go(func() {
 				for {
 					select {
@@ -168,7 +171,10 @@ func TestFSWatch(t *testing.T) {
 					}
 				}
 			})
-			_ = watcher.Start(ctx)
+			wg.Go(func() {
+				_ = watcher.Start(ctx)
+			})
+			<-watcher.ready
 
 			gotAddErrors := map[string]error{}
 			for c, p := range tc.clusters {
@@ -200,7 +206,11 @@ func TestFSWatchAddRm(t *testing.T) {
 	// Using an empty context here to avoid a race condition with the test context when setting the logger.
 	ctx := ctrl.LoggerInto(context.Background(), utiltesting.NewLogger(t))
 	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	wg := sync.WaitGroup{}
+	defer func() {
+		cancel()
+		wg.Wait()
+	}()
 	basePath := t.TempDir()
 	f1Path := filepath.Join(basePath, "file.one")
 	f2Path := filepath.Join(basePath, "file.two")
@@ -225,7 +235,11 @@ func TestFSWatchAddRm(t *testing.T) {
 		{
 			name: "start",
 			opFnc: func(kcf *KubeConfigFSWatcher) error {
-				return kcf.Start(ctx)
+				wg.Go(func() {
+					_ = kcf.Start(ctx)
+				})
+				<-kcf.ready
+				return nil
 			},
 			wantClustersToFile: map[string]string{},
 			wantFileToClusters: map[string]set.Set[string]{},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
/kind flake

#### What this PR does / why we need it:

Fixes a test race in `KubeConfigFSWatcher` where the goroutine spawned by `Start()` could log to `testing.T` after the test returned. The root cause was `Start()` being non-blocking, it spawned a goroutine and returned immediately, violating the controller-runtime `Runnable` contract. Making `Start()` blocking fixes both the race and the contract compliance.

In production, no changes are required as `mgr.Add()` registers the watcher with the controller-runtime manager, which calls `Start()` internally.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9454

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```