### PR TITLE
Add subpage in observability about resource usage monitoring

### DIFF
--- a/site/content/en/docs/tasks/manage/observability/monitor_resource_usage.md
+++ b/site/content/en/docs/tasks/manage/observability/monitor_resource_usage.md
@@ -71,7 +71,17 @@ done
 watch -n 15  'kubectl top pod --sum -l kueue.x-k8s.io/local-queue-name=user-queue'
 ```
 You will see a list of pods currently running on the local queue named "user-queue" with their current cpu and memory measurements and the sum of the usage at the bottom. The list will be automatically refreshed every 15 seconds.
+The outcome should look like this:
+```text
+Every 15.0s: kubectl top pod --sum -l kueue.x-k8s.io/local-queue-name=user-queue
 
+NAME                     CPU(cores)   MEMORY(bytes)
+sample-job-jd2vm-9hpnr   661m         3Mi
+sample-job-p8mxr-cld27   684m         2Mi
+sample-job-wccrt-h4684   654m         0Mi
+                         ________     ________
+                         1998m        6Mi
+```
 4. Similarly, you can monitor the usage of the resources by jobs admitted to a cluster queue:
 ```sh
 watch -n 15  'kubectl top pod --sum -l kueue.x-k8s.io/cluster-queue-name=cluster-queue'


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Adds description to the website how to use the new pod labels to monitor real resource usage of the queues.

#### Which issue(s) this PR fixes:
Fixes #9435

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

Result of the commands execution in my local cluster:

<img width="2541" height="1048" alt="image" src="https://github.com/user-attachments/assets/a6816ec8-a654-4594-833e-73a2804c498a" />
<img width="896" height="206" alt="image" src="https://github.com/user-attachments/assets/0938785b-4284-4689-8fc2-88fdf79da578" />

