### PR TITLE
[flake] fix Admission Fair Sharing test2

### DIFF
--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -1075,10 +1075,8 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 
 		ginkgo.It("admits workloads from less active LocalQueues after quota is released", framework.SlowSpec, func() {
 			ginkgo.By("Saturating the cq with lq-a")
-			initialWls := []*kueue.Workload{
-				createWorkload("lq-a", "4"),
-				createWorkload("lq-a", "4"),
-			}
+			wl1 := createWorkload("lq-a", "4")
+			wl2 := createWorkload("lq-a", "4")
 			util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 2)
 			util.ExpectReservingActiveWorkloadsMetric(cq1, 2)
 
@@ -1098,8 +1096,17 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 			util.ExpectLocalQueueFairSharingUsageToBe(ctx, k8sClient, client.ObjectKeyFromObject(lqB), "==", 0)
 			util.ExpectLocalQueueFairSharingUsageToBe(ctx, k8sClient, client.ObjectKeyFromObject(lqC), "==", 0)
 
-			ginkgo.By("Releasing quota")
-			util.FinishWorkloads(ctx, k8sClient, initialWls...)
+			ginkgo.By("Release wl1 quota")
+			util.FinishWorkloads(ctx, k8sClient, wl1)
+
+			ginkgo.By("Workload admits")
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 3)
+
+			ginkgo.By("Release wl2 quota")
+			util.FinishWorkloads(ctx, k8sClient, wl2)
+
+			ginkgo.By("Workload admits")
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 4)
 
 			ginkgo.By("Verifying one workload from lq-b and one from lq-c to be admitted")
 			util.ExpectWorkloadsToBeAdmittedCount(ctx, k8sClient, 1, lqBWls...)


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
Another flake discovered when stress testing #9232. There is a race where
2nd scheduling cycle starts before 2nd workload quota is available, and we mark
a workload as inadmissible. Then, two workloads from same lq queue are admitted.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```