### PR TITLE
Fix missing replica_role=leader metrics after HA role transition

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -272,6 +272,7 @@ func main() {
 	cacheOptions := []schdcache.Option{
 		schdcache.WithPodsReadyTracking(blockForPodsReady(&cfg)),
 		schdcache.WithRoleTracker(roleTracker),
+		schdcache.WithResourceMetrics(cfg.Metrics.EnableClusterQueueResources),
 	}
 	queueOptions := []qcache.Option{
 		qcache.WithPodsReadyRequeuingTimestamp(podsReadyRequeuingTimestamp(&cfg)),
@@ -332,6 +333,14 @@ func main() {
 	if err := setupProbeEndpoints(mgr, certsReady); err != nil {
 		setupLog.Error(err, "Unable to setup probe endpoints")
 		os.Exit(1)
+	}
+
+	if roleTracker != nil {
+		roleTracker.OnElected(func() {
+			metrics.ClearGaugeMetricsForRole(roletracker.RoleFollower)
+			cCache.ResyncGaugeMetrics()
+			queues.ResyncGaugeMetrics()
+		})
 	}
 
 	preemptionExpectations := preemptexpectations.New()

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -863,6 +863,22 @@ func (m *Manager) queueSecondPass(ctx context.Context, w *kueue.Workload, iterat
 	}
 }
 
+// ResyncGaugeMetrics re-reports pending and finished workload gauge metrics.
+func (m *Manager) ResyncGaugeMetrics() {
+	m.RLock()
+	defer m.RUnlock()
+	for _, cq := range m.hm.ClusterQueues() {
+		reportCQPendingWorkloads(m, cq)
+		reportCQFinishedWorkloads(cq, m.roleTracker)
+	}
+	if features.Enabled(features.LocalQueueMetrics) {
+		for _, lq := range m.localQueues {
+			reportLQPendingWorkloads(m, lq)
+			reportLQFinishedWorkloads(m, lq)
+		}
+	}
+}
+
 type WorkloadUpdateWatcher interface {
 	NotifyWorkloadUpdate(oldWl, newWl *kueue.Workload)
 }

--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -41,6 +42,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/queue"
+	utilresource "sigs.k8s.io/kueue/pkg/util/resource"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -95,6 +97,12 @@ func WithAdmissionFairSharing(afs *config.AdmissionFairSharing) Option {
 	}
 }
 
+func WithResourceMetrics(enabled bool) Option {
+	return func(c *Cache) {
+		c.resourceMetricsEnabled = enabled
+	}
+}
+
 // WithRoleTracker sets the roleTracker for HA metrics.
 func WithRoleTracker(tracker *roletracker.RoleTracker) Option {
 	return func(c *Cache) {
@@ -107,13 +115,14 @@ type Cache struct {
 	sync.RWMutex
 	podsReadyCond sync.Cond
 
-	client               client.Client
-	resourceFlavors      map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor
-	podsReadyTracking    bool
-	admissionChecks      map[kueue.AdmissionCheckReference]AdmissionCheck
-	workloadInfoOptions  []workload.InfoOption
-	fairSharingEnabled   bool
-	admissionFairSharing *config.AdmissionFairSharing
+	client                 client.Client
+	resourceFlavors        map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor
+	podsReadyTracking      bool
+	admissionChecks        map[kueue.AdmissionCheckReference]AdmissionCheck
+	workloadInfoOptions    []workload.InfoOption
+	fairSharingEnabled     bool
+	admissionFairSharing   *config.AdmissionFairSharing
+	resourceMetricsEnabled bool
 	// Tracks Workload's ClusterQueue assignment throughout its presence in the cache, which is when they reserve quota (`QuotaReserved=True`).
 	workloadAssignedQueues map[workload.Reference]kueue.ClusterQueueReference
 
@@ -903,6 +912,36 @@ func (c *Cache) MatchingClusterQueues(nsLabels map[string]string) sets.Set[kueue
 		}
 	}
 	return cqs
+}
+
+// ResyncGaugeMetrics re-reports CQ/LQ status, active workload, resource, and weighted share gauge metrics.
+func (c *Cache) ResyncGaugeMetrics() {
+	c.RLock()
+	defer c.RUnlock()
+	for _, cq := range c.hm.ClusterQueues() {
+		metrics.ReportClusterQueueStatus(cq.Name, cq.Status, c.roleTracker)
+		cq.reportActiveWorkloads()
+		if c.resourceMetricsEnabled {
+			cq.reportResourceMetrics(c.fairSharingEnabled)
+		}
+		if features.Enabled(features.LocalQueueMetrics) {
+			for _, lq := range cq.localQueues {
+				lq.reportActiveWorkloads(c.roleTracker)
+				lq.reportResourceMetrics(cq.resourceNode.Quotas, c.roleTracker)
+			}
+		}
+	}
+	if c.fairSharingEnabled {
+		for _, cohort := range c.hm.Cohorts() {
+			drs := dominantResourceShare(cohort, nil)
+			metrics.ReportCohortWeightedShare(string(cohort.Name), drs.PreciseWeightedShare(), c.roleTracker)
+		}
+	}
+}
+
+func resourceFloat(name corev1.ResourceName, v int64) float64 {
+	q := resources.ResourceQuantity(name, v)
+	return utilresource.QuantityToFloat(&q)
 }
 
 // Key is the key used to index the queue.

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"math"
 	"slices"
 	"strings"
 
@@ -491,6 +492,40 @@ func (c *clusterQueue) reportActiveWorkloads() {
 	role := roletracker.GetRole(c.roleTracker)
 	metrics.AdmittedActiveWorkloads.WithLabelValues(string(c.Name), role).Set(float64(c.admittedWorkloadsCount))
 	metrics.ReservingActiveWorkloads.WithLabelValues(string(c.Name), role).Set(float64(len(c.Workloads)))
+}
+
+func (c *clusterQueue) reportResourceMetrics(fairSharingEnabled bool) {
+	var cohort kueue.CohortReference
+	if c.HasParent() {
+		cohort = c.Parent().GetName()
+	}
+	cqName := string(c.Name)
+	for fr, quota := range c.resourceNode.Quotas {
+		fName, rName := string(fr.Flavor), string(fr.Resource)
+		nominal := resourceFloat(fr.Resource, quota.Nominal)
+		var borrowing, lending float64
+		if quota.BorrowingLimit != nil {
+			borrowing = resourceFloat(fr.Resource, *quota.BorrowingLimit)
+		}
+		if quota.LendingLimit != nil {
+			lending = resourceFloat(fr.Resource, *quota.LendingLimit)
+		}
+		metrics.ReportClusterQueueQuotas(cohort, cqName, fName, rName, nominal, borrowing, lending, c.roleTracker)
+		metrics.ReportClusterQueueResourceReservations(cohort, cqName, fName, rName, resourceFloat(fr.Resource, c.resourceNode.Usage[fr]), c.roleTracker)
+		metrics.ReportClusterQueueResourceUsage(cohort, cqName, fName, rName, resourceFloat(fr.Resource, c.AdmittedUsage[fr]), c.roleTracker)
+	}
+	if fairSharingEnabled {
+		c.reportWeightedShare(cohort)
+	}
+}
+
+func (c *clusterQueue) reportWeightedShare(cohort kueue.CohortReference) {
+	drs := dominantResourceShare(c, nil)
+	weightedShare := drs.PreciseWeightedShare()
+	if weightedShare == math.Inf(1) {
+		weightedShare = math.NaN()
+	}
+	metrics.ReportClusterQueueWeightedShare(string(c.Name), string(cohort), weightedShare, c.roleTracker)
 }
 
 // updateWorkloadUsage updates the usage of the ClusterQueue for the workload

--- a/pkg/cache/scheduler/localqueue.go
+++ b/pkg/cache/scheduler/localqueue.go
@@ -62,3 +62,13 @@ func (q *LocalQueue) reportActiveWorkloads(tracker *roletracker.RoleTracker) {
 	metrics.LocalQueueAdmittedActiveWorkloads.WithLabelValues(string(name), namespace, role).Set(float64(q.admittedWorkloads))
 	metrics.LocalQueueReservingActiveWorkloads.WithLabelValues(string(name), namespace, role).Set(float64(q.reservingWorkloads))
 }
+
+func (q *LocalQueue) reportResourceMetrics(cqQuotas map[resources.FlavorResource]ResourceQuota, tracker *roletracker.RoleTracker) {
+	namespace, name := queue.MustParseLocalQueueReference(q.key)
+	lqRef := metrics.LocalQueueReference{Name: name, Namespace: namespace}
+	for fr := range cqQuotas {
+		fName, rName := string(fr.Flavor), string(fr.Resource)
+		metrics.ReportLocalQueueResourceReservations(lqRef, fName, rName, resourceFloat(fr.Resource, q.totalReserved[fr]), tracker)
+		metrics.ReportLocalQueueResourceUsage(lqRef, fName, rName, resourceFloat(fr.Resource, q.admittedUsage[fr]), tracker)
+	}
+}

--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -100,6 +100,7 @@ func SetupControllers(mgr ctrl.Manager, qManager *qcache.Manager, cc *schdcache.
 	}
 	qManager.AddTopologyUpdateWatcher(cqRec)
 	qManager.AddWorkloadUpdateWatcher(qRec)
+
 	return "", nil
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -879,6 +879,18 @@ func ReportCohortWeightedShare(cohort string, weightedShare float64, tracker *ro
 	CohortWeightedShare.WithLabelValues(cohort, roletracker.GetRole(tracker)).Set(weightedShare)
 }
 
+var allGaugeVecs []*prometheus.GaugeVec
+
+// ClearGaugeMetricsForRole deletes all gauge metric time series matching
+// replica_role=role. Called during HA role transitions to remove stale
+// time series reported under the old role.
+func ClearGaugeMetricsForRole(role string) {
+	lbls := prometheus.Labels{"replica_role": role}
+	for _, g := range allGaugeVecs {
+		g.DeletePartialMatch(lbls)
+	}
+}
+
 func ClearClusterQueueResourceMetrics(cqName string) {
 	lbls := prometheus.Labels{
 		"cluster_queue": cqName,
@@ -940,18 +952,20 @@ func ClearClusterQueueResourceReservations(cqName, flavor, resource string) {
 	ClusterQueueResourceReservations.DeletePartialMatch(lbls)
 }
 
+func registerGaugeVecs(gauges ...*prometheus.GaugeVec) {
+	for _, g := range gauges {
+		metrics.Registry.MustRegister(g)
+		allGaugeVecs = append(allGaugeVecs, g)
+	}
+}
+
 func Register() {
 	metrics.Registry.MustRegister(
 		buildInfo,
 		AdmissionAttemptsTotal,
 		admissionAttemptDuration,
-		AdmissionCyclePreemptionSkips,
-		PendingWorkloads,
-		ReservingActiveWorkloads,
-		AdmittedActiveWorkloads,
 		QuotaReservedWorkloadsTotal,
 		QuotaReservedWaitTime,
-		FinishedWorkloads,
 		FinishedWorkloadsTotal,
 		PodsReadyToEvictedTimeSeconds,
 		AdmittedWorkloadsTotal,
@@ -962,6 +976,13 @@ func Register() {
 		AdmissionChecksWaitTime,
 		QueuedUntilReadyWaitTime,
 		AdmittedUntilReadyWaitTime,
+	)
+	registerGaugeVecs(
+		AdmissionCyclePreemptionSkips,
+		PendingWorkloads,
+		ReservingActiveWorkloads,
+		AdmittedActiveWorkloads,
+		FinishedWorkloads,
 		ClusterQueueResourceUsage,
 		ClusterQueueByStatus,
 		ClusterQueueResourceReservations,
@@ -979,11 +1000,7 @@ func Register() {
 
 func RegisterLQMetrics() {
 	metrics.Registry.MustRegister(
-		LocalQueuePendingWorkloads,
-		LocalQueueReservingActiveWorkloads,
-		LocalQueueAdmittedActiveWorkloads,
 		LocalQueueQuotaReservedWorkloadsTotal,
-		LocalQueueFinishedWorkloads,
 		LocalQueueFinishedWorkloadsTotal,
 		LocalQueueQuotaReservedWaitTime,
 		LocalQueueAdmittedWorkloadsTotal,
@@ -992,6 +1009,12 @@ func RegisterLQMetrics() {
 		LocalQueueQueuedUntilReadyWaitTime,
 		LocalQueueAdmittedUntilReadyWaitTime,
 		LocalQueueEvictedWorkloadsTotal,
+	)
+	registerGaugeVecs(
+		LocalQueuePendingWorkloads,
+		LocalQueueReservingActiveWorkloads,
+		LocalQueueAdmittedActiveWorkloads,
+		LocalQueueFinishedWorkloads,
 		LocalQueueByStatus,
 		LocalQueueResourceReservations,
 		LocalQueueResourceUsage,

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -240,6 +240,29 @@ func TestMetricsWithReplicaRoleLabel(t *testing.T) {
 	ClearLocalQueueMetrics(lq)
 }
 
+func TestStaleMetricsAfterRoleTransition(t *testing.T) {
+	savedGaugeVecs := allGaugeVecs
+	allGaugeVecs = append(allGaugeVecs, ClusterQueueResourceNominalQuota)
+	t.Cleanup(func() {
+		allGaugeVecs = savedGaugeVecs
+	})
+
+	followerTracker := roletracker.NewFakeRoleTracker(roletracker.RoleFollower)
+	leaderTracker := roletracker.NewFakeRoleTracker(roletracker.RoleLeader)
+
+	ReportClusterQueueQuotas("cohort", "stale-test-cq", "flavor", "cpu", 10, 5, 3, followerTracker)
+	expectFilteredMetricsCount(t, ClusterQueueResourceNominalQuota, 1, "cluster_queue", "stale-test-cq", "replica_role", "follower")
+
+	ClearGaugeMetricsForRole(roletracker.RoleFollower)
+
+	expectFilteredMetricsCount(t, ClusterQueueResourceNominalQuota, 0, "cluster_queue", "stale-test-cq", "replica_role", "follower")
+
+	ReportClusterQueueQuotas("cohort", "stale-test-cq", "flavor", "cpu", 10, 5, 3, leaderTracker)
+	expectFilteredMetricsCount(t, ClusterQueueResourceNominalQuota, 1, "cluster_queue", "stale-test-cq", "replica_role", "leader")
+
+	ClearClusterQueueResourceMetrics("stale-test-cq")
+}
+
 func TestMetricsWithDifferentRoles(t *testing.T) {
 	leaderTracker := roletracker.NewFakeRoleTracker(roletracker.RoleLeader)
 	followerTracker := roletracker.NewFakeRoleTracker(roletracker.RoleFollower)

--- a/pkg/util/roletracker/tracker.go
+++ b/pkg/util/roletracker/tracker.go
@@ -33,6 +33,7 @@ const (
 type RoleTracker struct {
 	role        atomic.Value
 	electedChan <-chan struct{}
+	onElected   func()
 }
 
 // NewRoleTracker creates a RoleTracker that starts as follower and becomes leader when electedChan closes.
@@ -51,12 +52,21 @@ func NewFakeRoleTracker(role string) *RoleTracker {
 	return rt
 }
 
+// OnElected registers a callback invoked after the tracker becomes leader.
+// Must be called before Start.
+func (rt *RoleTracker) OnElected(fn func()) {
+	rt.onElected = fn
+}
+
 // Start blocks until leadership is acquired or context is cancelled.
 func (rt *RoleTracker) Start(ctx context.Context, log logr.Logger) {
 	select {
 	case <-rt.electedChan:
 		rt.role.Store(RoleLeader)
 		log.Info("RoleTracker: transitioned to leader")
+		if rt.onElected != nil {
+			rt.onElected()
+		}
 	case <-ctx.Done():
 		return
 	}

--- a/pkg/util/roletracker/tracker_test.go
+++ b/pkg/util/roletracker/tracker_test.go
@@ -89,6 +89,71 @@ func TestRoleTracker_StartLeaderElection(t *testing.T) {
 	}
 }
 
+func TestOnElected(t *testing.T) {
+	tests := []struct {
+		name            string
+		registerCb      bool
+		closeChannel    bool
+		cancelContext   bool
+		expectCalled    bool
+		expectFinalRole string
+	}{
+		{
+			name:            "called on election",
+			registerCb:      true,
+			closeChannel:    true,
+			expectCalled:    true,
+			expectFinalRole: RoleLeader,
+		},
+		{
+			name:            "not called when no callback registered",
+			closeChannel:    true,
+			expectCalled:    false,
+			expectFinalRole: RoleLeader,
+		},
+		{
+			name:            "not called when context cancelled",
+			registerCb:      true,
+			cancelContext:   true,
+			expectCalled:    false,
+			expectFinalRole: RoleFollower,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			electedChan := make(chan struct{})
+			rt := NewRoleTracker(electedChan)
+
+			var called bool
+			if tc.registerCb {
+				rt.OnElected(func() {
+					called = true
+				})
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			if tc.closeChannel {
+				close(electedChan)
+			}
+			if tc.cancelContext {
+				cancel()
+			}
+
+			rt.Start(ctx, logr.Discard())
+
+			if called != tc.expectCalled {
+				t.Errorf("callback called = %v, want %v", called, tc.expectCalled)
+			}
+			if got := rt.GetRole(); got != tc.expectFinalRole {
+				t.Errorf("final role = %q, want %q", got, tc.expectFinalRole)
+			}
+		})
+	}
+}
+
 func TestGetMetricsRole(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package core
 
 import (
+	"context"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"go.uber.org/zap/zapcore"
@@ -25,13 +27,17 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
+	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	testingmetrics "sigs.k8s.io/kueue/pkg/util/testing/metrics"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/test/integration/framework"
 	"sigs.k8s.io/kueue/test/util"
@@ -1131,5 +1137,80 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Label("controller:clus
 					"Log level should be smaller than error")
 			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 		})
+	})
+})
+
+var _ = ginkgo.Describe("ClusterQueue controller with RoleTracker", ginkgo.Label("controller:clusterqueue", "area:core"), ginkgo.Ordered, ginkgo.Serial, func() {
+	var (
+		electedChan   chan struct{}
+		trackerCancel context.CancelFunc
+		rf            *kueue.ResourceFlavor
+		cq            *kueue.ClusterQueue
+	)
+
+	ginkgo.BeforeEach(func() {
+		electedChan = make(chan struct{})
+		tracker := roletracker.NewRoleTracker(electedChan)
+		var trackerCtx context.Context
+		trackerCtx, trackerCancel = context.WithCancel(ctx)
+		go tracker.Start(trackerCtx, ctrl.Log)
+		fwk.StartManager(ctx, cfg, managerAndControllerSetup(nil, withRoleTracker(tracker)))
+
+		rf = utiltestingapi.MakeResourceFlavor("ha-transition-flavor").Obj()
+		util.MustCreate(ctx, k8sClient, rf)
+
+		cq = utiltestingapi.MakeClusterQueue("ha-transition-cq").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("ha-transition-flavor").Resource(corev1.ResourceCPU, "10").Obj()).
+			Obj()
+		util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+	})
+
+	ginkgo.AfterEach(func() {
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, rf, true)
+		select {
+		case <-electedChan:
+		default:
+			close(electedChan)
+		}
+		trackerCancel()
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.It("Should resync metrics after role transition from follower to leader", func() {
+		followerLabels := map[string]string{
+			"cluster_queue": cq.Name,
+			"replica_role":  roletracker.RoleFollower,
+		}
+
+		ginkgo.By("Verifying metrics exist with replica_role=follower")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.ClusterQueueResourceNominalQuota, followerLabels)).NotTo(gomega.BeEmpty())
+			g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.ClusterQueueByStatus, followerLabels)).NotTo(gomega.BeEmpty())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("Triggering role transition by closing electedChan")
+		close(electedChan)
+
+		ginkgo.By("Verifying metrics with replica_role=leader have correct values")
+		gomega.Eventually(func(g gomega.Gomega) {
+			nominalQuota, err := testutil.GetGaugeMetricValue(metrics.ClusterQueueResourceNominalQuota.WithLabelValues(
+				"", cq.Name, "ha-transition-flavor", string(corev1.ResourceCPU), roletracker.RoleLeader,
+			))
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(nominalQuota).To(gomega.Equal(float64(10)))
+
+			activeStatus, err := testutil.GetGaugeMetricValue(metrics.ClusterQueueByStatus.WithLabelValues(
+				cq.Name, string(metrics.CQStatusActive), roletracker.RoleLeader,
+			))
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(activeStatus).To(gomega.Equal(float64(1)))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("Verifying metrics with replica_role=follower are gone")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.ClusterQueueResourceNominalQuota, followerLabels)).To(gomega.BeEmpty())
+			g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.ClusterQueueByStatus, followerLabels)).To(gomega.BeEmpty())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 })

--- a/test/integration/singlecluster/controller/core/suite_test.go
+++ b/test/integration/singlecluster/controller/core/suite_test.go
@@ -27,12 +27,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
+	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
 	"sigs.k8s.io/kueue/test/util"
@@ -59,6 +62,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)
+	metrics.Register()
 })
 
 var _ = ginkgo.AfterSuite(func() {
@@ -67,12 +71,19 @@ var _ = ginkgo.AfterSuite(func() {
 
 type managerSetupOpts struct {
 	runScheduler bool
+	roleTracker  *roletracker.RoleTracker
 }
 
 type managerSetupOption func(*managerSetupOpts)
 
 func runScheduler(opts *managerSetupOpts) {
 	opts.runScheduler = true
+}
+
+func withRoleTracker(rt *roletracker.RoleTracker) managerSetupOption {
+	return func(opts *managerSetupOpts) {
+		opts.roleTracker = rt
+	}
 }
 
 func managerSetup(ctx context.Context, mgr manager.Manager) {
@@ -104,12 +115,28 @@ func managerAndControllerSetup(controllersCfg *config.Configuration, options ...
 
 		controllersCfg.Metrics.EnableClusterQueueResources = true
 
-		cCache := schdcache.New(mgr.GetClient())
-		queues := util.NewManagerForIntegrationTests(ctx, mgr.GetClient(), cCache)
+		cacheOpts := []schdcache.Option{
+			schdcache.WithResourceMetrics(controllersCfg.Metrics.EnableClusterQueueResources),
+			schdcache.WithRoleTracker(opts.roleTracker),
+		}
+		queueOpts := []qcache.Option{
+			qcache.WithRoleTracker(opts.roleTracker),
+		}
+
+		cCache := schdcache.New(mgr.GetClient(), cacheOpts...)
+		queues := util.NewManagerForIntegrationTests(ctx, mgr.GetClient(), cCache, queueOpts...)
 
 		preemptionExpectations := preemptexpectations.New()
-		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, controllersCfg, nil, preemptionExpectations)
+		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, controllersCfg, opts.roleTracker, preemptionExpectations)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
+
+		if opts.roleTracker != nil {
+			opts.roleTracker.OnElected(func() {
+				metrics.ClearGaugeMetricsForRole(roletracker.RoleFollower)
+				cCache.ResyncGaugeMetrics()
+				queues.ResyncGaugeMetrics()
+			})
+		}
 
 		if opts.runScheduler {
 			sched := scheduler.New(queues, cCache, mgr.GetClient(), mgr.GetEventRecorderFor(constants.AdmissionName), scheduler.WithPreemptionExpectations(preemptionExpectations))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

After an HA role transition from `follower` to `leader`, gauge metrics were still tagged with `replica_role` set to `follower` and were never re-reported with `replica_role` set to `leader`.

This change adds an `OnTransition` callback to `RoleTracker` that clears stale follower metrics and resynchronizes all metric-emitting components.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9288 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Observability: Fix missing replica_role=leader gauge metrics after HA role transition.
```