### PR TITLE
[release-0.15] Asynchronous Inadmissible Workload Requeueing (#9232)

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -265,7 +265,15 @@ func main() {
 		cacheOptions = append(cacheOptions, schdcache.WithAdmissionFairSharing(cfg.AdmissionFairSharing))
 	}
 	cCache := schdcache.New(mgr.GetClient(), cacheOptions...)
-	queues := qcache.NewManager(mgr.GetClient(), cCache, queueOptions...)
+
+	// setup inadmissible workload requeuer
+	requeuer := qcache.NewRequeuer(qcache.RequeueBatchPeriodProd)
+	if err := mgr.Add(requeuer); err != nil {
+		setupLog.Error(err, "Unable to add workloadRequeuer to manager")
+		os.Exit(1)
+	}
+
+	queues := qcache.NewManager(mgr.GetClient(), cCache, requeuer, queueOptions...)
 
 	if err := setupIndexes(ctx, mgr, &cfg); err != nil {
 		setupLog.Error(err, "Unable to setup indexes")

--- a/pkg/cache/queue/inadmissible_workloads.go
+++ b/pkg/cache/queue/inadmissible_workloads.go
@@ -18,17 +18,23 @@ package queue
 
 import (
 	"context"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/cache/hierarchy"
 	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+const (
+	RequeueBatchPeriodProd = 1 * time.Second
 )
 
 // inadmissibleWorkloads is a thin wrapper around a map to encapsulate
@@ -73,50 +79,57 @@ func (iw *inadmissibleWorkloads) replaceAll(newMap inadmissibleWorkloads) {
 }
 
 // requeueWorkloadsCQ moves all workloads in the same
-// cohort with this ClusterQueue from inadmissibleWorkloads to heap. If the
-// cohort of this ClusterQueue is empty, it just moves all workloads in this
-// ClusterQueue. If at least one workload is moved, returns true, otherwise
-// returns false.
-// The events listed below could make workloads in the same cohort admissible.
-// Then requeueWorkloadsCQ need to be invoked.
-// 1. delete events for any admitted workload in the cohort.
-// 2. add events of any cluster queue in the cohort.
-// 3. update events of any cluster queue in the cohort.
-// 4. update of cohort.
-//
-// WARNING: must hold a read-lock on the manager when calling,
-// or otherwise risk encountering an infinite loop if a Cohort
-// cycle is introduced.
-func requeueWorkloadsCQ(ctx context.Context, m *Manager, cq *ClusterQueue) bool {
-	if cq.HasParent() {
-		return requeueWorkloadsCohort(ctx, m, cq.Parent())
+// cohort with this ClusterQueue from inadmissibleWorkloads to heap.
+// It expects to be passed a ClusterQueue without any Cohort.
+// WARNING: must only be called by the InadmissibleWorkloadRequeuer
+func requeueWorkloadsCQ(ctx context.Context, m *Manager, clusterQueueName kueue.ClusterQueueReference) {
+	m.Lock()
+	defer m.Unlock()
+	cq := m.hm.ClusterQueue(clusterQueueName)
+	if cq == nil {
+		return
 	}
-	return queueInadmissibleWorkloads(ctx, cq, m.client)
+	if queueInadmissibleWorkloads(ctx, cq, m.client) {
+		log := ctrl.LoggerFrom(ctx)
+		log.V(2).Info("Moved workloads", "clusterqueue", cq.name)
+		reportPendingWorkloads(m, cq.name)
+		m.Broadcast()
+	}
 }
 
-// moveWorkloadsCohorts checks for a cycle, the moves all inadmissible
-// workloads in the Cohort tree. If a cycle exists, or no workloads were
-// moved, it returns false.
-//
-// WARNING: must hold a read-lock on the manager when calling,
-// or otherwise risk encountering an infinite loop if a Cohort
-// cycle is introduced.
-func requeueWorkloadsCohort(ctx context.Context, m *Manager, cohort *cohort) bool {
+// requeueWorkloadsCohort moves all inadmissible
+// workloads in the Cohort tree to heap. It expects to be
+// passed a root Cohort. If at least one workload queued,
+// we will broadcast the event.
+// WARNING: must only be called by the InadmissibleWorkloadRequeuer
+func requeueWorkloadsCohort(ctx context.Context, m *Manager, rootCohortName kueue.CohortReference) {
+	m.Lock()
+	defer m.Unlock()
+	cohort := m.hm.Cohort(rootCohortName)
+	if cohort == nil {
+		return
+	}
 	log := ctrl.LoggerFrom(ctx)
 
 	if hierarchy.HasCycle(cohort) {
 		log.V(2).Info("Attempted to move workloads from Cohort which has cycle", "cohort", cohort.GetName())
-		return false
+		return
 	}
-	root := cohort.getRootUnsafe()
-	log.V(2).Info("Attempting to move workloads", "cohort", cohort.Name, "root", root.Name)
-	return requeueWorkloadsCohortSubtree(ctx, m, root)
+	log.V(2).Info("Attempting to move workloads", "rootCohort", cohort.Name)
+	if requeueWorkloadsCohortSubtree(ctx, m, cohort) {
+		log.V(2).Info("Moved all inadmissible workloads in tree", "rootCohort", cohort.Name)
+		m.Broadcast()
+	}
 }
 
+// WARNING: must only be called (indirectly) by InadmissibleWorkloadRequeuer.
 func requeueWorkloadsCohortSubtree(ctx context.Context, m *Manager, cohort *cohort) bool {
 	queued := false
 	for _, clusterQueue := range cohort.ChildCQs() {
-		queued = queueInadmissibleWorkloads(ctx, clusterQueue, m.client) || queued
+		if queueInadmissibleWorkloads(ctx, clusterQueue, m.client) {
+			reportPendingWorkloads(m, clusterQueue.name)
+			queued = true
+		}
 	}
 	for _, childCohort := range cohort.ChildCohorts() {
 		queued = requeueWorkloadsCohortSubtree(ctx, m, childCohort) || queued
@@ -126,6 +139,7 @@ func requeueWorkloadsCohortSubtree(ctx context.Context, m *Manager, cohort *coho
 
 // queueInadmissibleWorkloads moves all workloads from inadmissibleWorkloads to heap.
 // If at least one workload is moved, returns true, otherwise returns false.
+// WARNING: must only be called (indirectly) by InadmissibleWorkloadRequeuer.
 func queueInadmissibleWorkloads(ctx context.Context, c *ClusterQueue, client client.Client) bool {
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
@@ -152,12 +166,17 @@ func queueInadmissibleWorkloads(ctx context.Context, c *ClusterQueue, client cli
 	return moved
 }
 
-// QueueInadmissibleWorkloads moves all inadmissibleWorkloads in
-// corresponding ClusterQueues to heap. If at least one workload queued,
-// we will broadcast the event.
-func QueueInadmissibleWorkloads(ctx context.Context, m *Manager, cqNames sets.Set[kueue.ClusterQueueReference]) {
-	m.Lock()
-	defer m.Unlock()
+// NotifyRetryInadmissible requests that inadmissible workloads
+// from given ClusterQueues, and from all ClusterQueues in these
+// ClusterQueues' Cohort Trees, are moved from
+// inadmissibleQueue to the active workload heap.
+func NotifyRetryInadmissible(m *Manager, cqNames sets.Set[kueue.ClusterQueueReference]) {
+	m.RLock()
+	defer m.RUnlock()
+	notifyRetryInadmissibleWithoutLock(m, cqNames)
+}
+
+func notifyRetryInadmissibleWithoutLock(m *Manager, cqNames sets.Set[kueue.ClusterQueueReference]) {
 	if len(cqNames) == 0 {
 		return
 	}
@@ -165,25 +184,92 @@ func QueueInadmissibleWorkloads(ctx context.Context, m *Manager, cqNames sets.Se
 	// Track processed cohort roots to avoid requeuing the same hierarchy
 	// multiple times when multiple CQs in cqNames share a root.
 	processedRoots := sets.New[kueue.CohortReference]()
-	var queued bool
 	for name := range cqNames {
 		cq := m.hm.ClusterQueue(name)
 		if cq == nil {
 			continue
 		}
-		if cq.HasParent() && !hierarchy.HasCycle(cq.Parent()) {
+		if !cq.HasParent() {
+			m.requeuer.notifyClusterQueue(cq.name)
+		} else if !hierarchy.HasCycle(cq.Parent()) {
 			rootName := cq.Parent().getRootUnsafe().GetName()
 			if processedRoots.Has(rootName) {
 				continue
 			}
+			m.requeuer.notifyCohort(rootName)
 			processedRoots.Insert(rootName)
 		}
-		if requeueWorkloadsCQ(ctx, m, cq) {
-			queued = true
-		}
+		// We silently ignore Cohort trees with cycles.
+		// Once the cycle is removed, we will reconcile
+		// and process the entire tree(s).
 	}
+}
 
-	if queued {
-		m.Broadcast()
+// inadmissibleRequeuer receives notifications
+// that a particular ClusterQueue (without Cohort) or a
+// Root Cohort should have its Inadmissible Workloads requeued.
+type inadmissibleRequeuer interface {
+	// notifyClusterQueue should only be called for ClusterQueues without a Cohort.
+	notifyClusterQueue(cqName kueue.ClusterQueueReference)
+	// notifyCohort should only be called for Root Cohorts.
+	notifyCohort(cohortName kueue.CohortReference)
+	setManager(manager *Manager)
+}
+
+type requeueRequest struct {
+	ClusterQueue kueue.ClusterQueueReference
+	Cohort       kueue.CohortReference
+}
+
+// workqueueRequeuer satisfies the inadmissibleRequeuer
+// interface, implemented via a workqueue.TypedDelayingQueue.
+type workqueueRequeuer struct {
+	manager     *Manager
+	queue       workqueue.TypedDelayingInterface[requeueRequest]
+	batchPeriod time.Duration
+}
+
+func NewRequeuer(batchPeriod time.Duration) *workqueueRequeuer {
+	return &workqueueRequeuer{
+		queue:       workqueue.NewTypedDelayingQueue[requeueRequest](),
+		batchPeriod: batchPeriod,
+	}
+}
+
+func (r *workqueueRequeuer) notifyClusterQueue(cqName kueue.ClusterQueueReference) {
+	r.queue.AddAfter(requeueRequest{ClusterQueue: cqName}, r.batchPeriod)
+}
+
+func (r *workqueueRequeuer) notifyCohort(cohortName kueue.CohortReference) {
+	r.queue.AddAfter(requeueRequest{Cohort: cohortName}, r.batchPeriod)
+}
+
+func (r *workqueueRequeuer) setManager(manager *Manager) {
+	r.manager = manager
+}
+
+func (r *workqueueRequeuer) Start(ctx context.Context) error {
+	log := ctrl.LoggerFrom(ctx).WithName("inadmissible_workload_requeue_worker")
+	ctx = ctrl.LoggerInto(ctx, log)
+	go func() {
+		<-ctx.Done()
+		r.queue.ShutDown()
+	}()
+	for {
+		item, shutdown := r.queue.Get()
+		if shutdown {
+			return nil
+		}
+		r.reconcile(ctx, item)
+		r.queue.Done(item)
+	}
+}
+
+func (r *workqueueRequeuer) reconcile(ctx context.Context, req requeueRequest) {
+	if req.ClusterQueue != "" {
+		requeueWorkloadsCQ(ctx, r.manager, req.ClusterQueue)
+	}
+	if req.Cohort != "" {
+		requeueWorkloadsCohort(ctx, r.manager, req.Cohort)
 	}
 }

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -123,12 +124,14 @@ type Manager struct {
 	workloadUpdateWatchers []WorkloadUpdateWatcher
 
 	draReconcileChannel chan<- event.TypedGenericEvent[*kueue.Workload]
+
+	requeuer inadmissibleRequeuer
 }
 
 // NewManager is a factory for cache.queue.Manager. For tests,
 // NewManagerForUnitTests or NewManagerForIntegrationTests should be
 // used.
-func NewManager(client client.Client, checker StatusChecker, options ...Option) *Manager {
+func NewManager(client client.Client, checker StatusChecker, requeuer inadmissibleRequeuer, options ...Option) *Manager {
 	m := &Manager{
 		clock:         realClock,
 		client:        client,
@@ -144,7 +147,10 @@ func NewManager(client client.Client, checker StatusChecker, options ...Option) 
 		secondPassQueue:        newSecondPassQueue(),
 		AfsEntryPenalties:      queueafs.NewPenaltyMap(),
 		AfsConsumedResources:   queueafs.NewAfsConsumedResources(),
+		requeuer:               requeuer,
 	}
+	m.requeuer.setManager(m)
+
 	for _, option := range options {
 		option(m)
 	}
@@ -169,8 +175,9 @@ func (m *Manager) AddOrUpdateCohort(ctx context.Context, cohort *kueue.Cohort) {
 
 	m.hm.AddCohort(cohortName)
 	m.hm.UpdateCohortEdge(cohortName, cohort.Spec.ParentName)
-	if requeueWorkloadsCohort(ctx, m, m.hm.Cohort(cohortName)) {
-		m.Broadcast()
+	c := m.hm.Cohort(cohortName)
+	if !hierarchy.HasCycle(c) {
+		m.requeuer.notifyCohort(c.getRootUnsafe().GetName())
 	}
 }
 
@@ -217,10 +224,10 @@ func (m *Manager) AddClusterQueue(ctx context.Context, cq *kueue.ClusterQueue) e
 		}
 	}
 
-	queued := requeueWorkloadsCQ(ctx, m, cqImpl)
-	reportPendingWorkloads(m, kueue.ClusterQueueReference(cq.Name))
+	notifyRetryInadmissibleWithoutLock(m, sets.New(cqImpl.name))
+	reportPendingWorkloads(m, cqImpl.name)
 
-	if queued || addedWorkloads {
+	if addedWorkloads {
 		m.Broadcast()
 	}
 	return nil
@@ -245,7 +252,13 @@ func (m *Manager) UpdateClusterQueue(ctx context.Context, cq *kueue.ClusterQueue
 
 	// TODO(#8): Selectively move workloads based on the exact event.
 	// If any workload becomes admissible or the queue becomes active.
-	if (specUpdated && requeueWorkloadsCQ(ctx, m, cqImpl)) || (!oldActive && cqImpl.Active()) {
+	if specUpdated {
+		// Broadcast occurs after inadmissible workloads are requeued.
+		// Immediate broadcast is no-op, as there are no workloads
+		// to process.
+		notifyRetryInadmissibleWithoutLock(m, sets.New(cqName))
+	}
+	if !oldActive && cqImpl.Active() {
 		reportPendingWorkloads(m, cqName)
 		m.Broadcast()
 	}
@@ -524,9 +537,7 @@ func (m *Manager) QueueAssociatedInadmissibleWorkloadsAfter(ctx context.Context,
 		return
 	}
 
-	if requeueWorkloadsCQ(ctx, m, cq) {
-		m.Broadcast()
-	}
+	notifyRetryInadmissibleWithoutLock(m, sets.New(cq.name))
 }
 
 // UpdateWorkload updates the workload to the corresponding queue or adds it if

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -146,7 +146,8 @@ func TestUpdateClusterQueue(t *testing.T) {
 	}
 	// Setup.
 	cl := utiltesting.NewFakeClient(utiltesting.MakeNamespace(defaultNamespace))
-	manager := NewManagerForUnitTests(cl, nil)
+	manager, watcher := NewManagerForUnitTestsWithRequeuer(cl, nil)
+
 	for _, cq := range clusterQueues {
 		if err := manager.AddClusterQueue(ctx, cq); err != nil {
 			t.Fatalf("Failed adding clusterQueue %s: %v", cq.Name, err)
@@ -201,6 +202,8 @@ func TestUpdateClusterQueue(t *testing.T) {
 		t.Errorf("Unexpected ClusterQueues in cohorts (-want,+got):\n%s", diff)
 	}
 
+	watcher.ProcessRequeues(ctx)
+
 	// Verify that all workloads are active after the update.
 	inadmissibleWorkloads = manager.DumpInadmissible()
 	if diff := cmp.Diff(map[kueue.ClusterQueueReference][]workload.Reference(nil), inadmissibleWorkloads); diff != "" {
@@ -228,7 +231,7 @@ func TestRequeueWorkloadsCohortCycle(t *testing.T) {
 	wl := utiltestingapi.MakeWorkload("a", defaultNamespace).Queue("foo").Creation(time.Now()).Obj()
 	// Setup.
 	cl := utiltesting.NewFakeClient(utiltesting.MakeNamespace(defaultNamespace))
-	manager := NewManagerForUnitTests(cl, nil)
+	manager, requeuer := NewManagerForUnitTestsWithRequeuer(cl, nil)
 	for _, cohort := range cohorts {
 		manager.AddOrUpdateCohort(ctx, cohort)
 	}
@@ -247,9 +250,8 @@ func TestRequeueWorkloadsCohortCycle(t *testing.T) {
 
 	// This method is where we do a cycle check. We call it to ensure
 	// it behaves properly when a cycle exists
-	if requeueWorkloadsCohort(ctx, manager, manager.hm.Cohort("cohort-a")) {
-		t.Fatal("Expected moveWorkloadsCohort to return false")
-	}
+	NotifyRetryInadmissible(manager, sets.New[kueue.ClusterQueueReference]("cq1"))
+	requeuer.ProcessRequeues(ctx)
 }
 
 func TestQueueInadmissibleWorkloads(t *testing.T) {
@@ -333,7 +335,7 @@ func TestQueueInadmissibleWorkloads(t *testing.T) {
 			ctx := logr.NewContext(context.Background(), logger)
 
 			cl := utiltesting.NewFakeClient(utiltesting.MakeNamespace(defaultNamespace))
-			manager := NewManagerForUnitTests(cl, nil)
+			manager, watcher := NewManagerForUnitTestsWithRequeuer(cl, nil)
 
 			for _, cohort := range tc.cohorts {
 				manager.AddOrUpdateCohort(ctx, cohort)
@@ -359,8 +361,7 @@ func TestQueueInadmissibleWorkloads(t *testing.T) {
 			// Reset the counter before testing. Setup operations also trigger the log.
 			moveWorkloadsLogCount = 0
 
-			QueueInadmissibleWorkloads(ctx, manager, tc.cqNames)
-
+			watcher.ProcessRequeues(ctx)
 			if diff := cmp.Diff(tc.wantInadmissible, manager.DumpInadmissible()); diff != "" {
 				t.Errorf("Unexpected inadmissible workloads (-want +got):\n%s", diff)
 			}
@@ -760,8 +761,8 @@ func TestRequeueWorkloadStrictFIFO(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.workload.Name, func(t *testing.T) {
 			cl := utiltesting.NewFakeClient()
-			manager := NewManagerForUnitTests(cl, nil)
 			ctx, _ := utiltesting.ContextWithLog(t)
+			manager := NewManagerForUnitTests(cl, nil)
 			if err := manager.AddClusterQueue(ctx, cq); err != nil {
 				t.Fatalf("Failed adding cluster queue %s: %v", cq.Name, err)
 			}

--- a/pkg/cache/queue/test_util.go
+++ b/pkg/cache/queue/test_util.go
@@ -1,25 +1,79 @@
-// Copyright The Kubernetes Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package queue
 
-import "sigs.k8s.io/controller-runtime/pkg/client"
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+)
+
+// testInadmissibleWorkloadRequeuer buffers requeue events
+// to be processed synchronously, for use in unit tests.
+type testInadmissibleWorkloadRequeuer struct {
+	manager *Manager
+	cqs     sets.Set[kueue.ClusterQueueReference]
+	cohorts sets.Set[kueue.CohortReference]
+}
+
+func (r *testInadmissibleWorkloadRequeuer) notifyClusterQueue(cqName kueue.ClusterQueueReference) {
+	r.cqs.Insert(cqName)
+}
+
+func (r *testInadmissibleWorkloadRequeuer) notifyCohort(cohortName kueue.CohortReference) {
+	r.cohorts.Insert(cohortName)
+}
+
+func (r *testInadmissibleWorkloadRequeuer) setManager(manager *Manager) {
+	r.manager = manager
+}
+
+// ProcessRequeues requeues all the inadmissible workloads
+// belonging to Cohorts/Queues which were notified.
+func (w *testInadmissibleWorkloadRequeuer) ProcessRequeues(ctx context.Context) {
+	for cqName := range w.cqs {
+		requeueWorkloadsCQ(ctx, w.manager, cqName)
+	}
+	for cohortName := range w.cohorts {
+		requeueWorkloadsCohort(ctx, w.manager, cohortName)
+	}
+	w.cqs.Clear()
+	w.cohorts.Clear()
+}
 
 // NewManagerForUnitTests creates a new Manager for testing purposes.
 // This test manager, though exported, is not included in Kueue binary.
 // Note that this function is not found when running:
 // make build && go tool nm ./bin/manager | grep "NewManager"
 func NewManagerForUnitTests(client client.Client, checker StatusChecker, options ...Option) *Manager {
-	return NewManager(client, checker, options...)
+	manager, _ := NewManagerForUnitTestsWithRequeuer(client, checker, options...)
+	return manager
+}
+
+// NewManagerForUnitTestsWithRequeuer creates a new Manager for testing purposes, pre-configured with a testInadmissibleWorkloadRequeuer.
+func NewManagerForUnitTestsWithRequeuer(client client.Client, checker StatusChecker, options ...Option) (*Manager, *testInadmissibleWorkloadRequeuer) {
+	requeuer := &testInadmissibleWorkloadRequeuer{
+		cqs:     sets.New[kueue.ClusterQueueReference](),
+		cohorts: sets.New[kueue.CohortReference](),
+	}
+
+	manager := NewManager(client, checker, requeuer, options...)
+	return manager, requeuer
 }

--- a/pkg/controller/core/admissioncheck_controller.go
+++ b/pkg/controller/core/admissioncheck_controller.go
@@ -129,7 +129,7 @@ func (r *AdmissionCheckReconciler) Create(e event.TypedCreateEvent[*kueue.Admiss
 	defer r.notifyWatchers(nil, e.Object)
 	r.log.WithValues("admissionCheck", klog.KObj(e.Object)).V(5).Info("Create event")
 	if cqNames := r.cache.AddOrUpdateAdmissionCheck(r.log, e.Object); len(cqNames) > 0 {
-		qcache.QueueInadmissibleWorkloads(context.Background(), r.qManager, cqNames)
+		qcache.NotifyRetryInadmissible(r.qManager, cqNames)
 	}
 	return true
 }
@@ -141,7 +141,7 @@ func (r *AdmissionCheckReconciler) Update(e event.TypedUpdateEvent[*kueue.Admiss
 		return true
 	}
 	if cqNames := r.cache.AddOrUpdateAdmissionCheck(r.log, e.ObjectNew); len(cqNames) > 0 {
-		qcache.QueueInadmissibleWorkloads(context.Background(), r.qManager, cqNames)
+		qcache.NotifyRetryInadmissible(r.qManager, cqNames)
 	}
 	return false
 }
@@ -151,7 +151,7 @@ func (r *AdmissionCheckReconciler) Delete(e event.TypedDeleteEvent[*kueue.Admiss
 	r.log.WithValues("admissionCheck", klog.KObj(e.Object)).V(5).Info("Delete event")
 
 	if cqNames := r.cache.DeleteAdmissionCheck(r.log, e.Object); len(cqNames) > 0 {
-		qcache.QueueInadmissibleWorkloads(context.Background(), r.qManager, cqNames)
+		qcache.NotifyRetryInadmissible(r.qManager, cqNames)
 	}
 	return true
 }

--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -202,7 +202,7 @@ func (r *ClusterQueueReconciler) NotifyTopologyUpdate(oldTopology, newTopology *
 	// On topology creation, CQs may transition from pending to active.
 	// Broadcast to ensure the scheduler re-evaluates pending workloads.
 	if oldTopology == nil {
-		qcache.QueueInadmissibleWorkloads(context.Background(), r.qManager, sets.New(cqNames...))
+		qcache.NotifyRetryInadmissible(r.qManager, sets.New(cqNames...))
 		r.qManager.Broadcast()
 	}
 }
@@ -487,7 +487,7 @@ func (h *cqNamespaceHandler) Update(ctx context.Context, e event.UpdateEvent, _ 
 			cqs.Insert(cq)
 		}
 	}
-	qcache.QueueInadmissibleWorkloads(ctx, h.qManager, cqs)
+	qcache.NotifyRetryInadmissible(h.qManager, cqs)
 }
 
 func (h *cqNamespaceHandler) Delete(context.Context, event.DeleteEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {

--- a/pkg/controller/core/resourceflavor_controller.go
+++ b/pkg/controller/core/resourceflavor_controller.go
@@ -135,7 +135,7 @@ func (r *ResourceFlavorReconciler) Create(e event.TypedCreateEvent[*kueue.Resour
 	// As long as one clusterQueue becomes active,
 	// we should inform clusterQueue controller to broadcast the event.
 	if cqNames := r.cache.AddOrUpdateResourceFlavor(r.log, e.Object.DeepCopy()); len(cqNames) > 0 {
-		qcache.QueueInadmissibleWorkloads(context.Background(), r.qManager, cqNames)
+		qcache.NotifyRetryInadmissible(r.qManager, cqNames)
 		// If at least one CQ becomes active, then those CQs should now get evaluated by the scheduler;
 		// note that the workloads in those CQs are not necessarily "inadmissible", and hence we trigger a
 		// broadcast here in all cases.
@@ -151,7 +151,7 @@ func (r *ResourceFlavorReconciler) Delete(e event.TypedDeleteEvent[*kueue.Resour
 	log.V(2).Info("ResourceFlavor delete event")
 
 	if cqNames := r.cache.DeleteResourceFlavor(r.log, e.Object); len(cqNames) > 0 {
-		qcache.QueueInadmissibleWorkloads(context.Background(), r.qManager, cqNames)
+		qcache.NotifyRetryInadmissible(r.qManager, cqNames)
 	}
 	return false
 }
@@ -167,7 +167,7 @@ func (r *ResourceFlavorReconciler) Update(e event.TypedUpdateEvent[*kueue.Resour
 	}
 
 	if cqNames := r.cache.AddOrUpdateResourceFlavor(r.log, e.ObjectNew.DeepCopy()); len(cqNames) > 0 {
-		qcache.QueueInadmissibleWorkloads(context.Background(), r.qManager, cqNames)
+		qcache.NotifyRetryInadmissible(r.qManager, cqNames)
 	}
 	return false
 }

--- a/pkg/controller/tas/resource_flavor.go
+++ b/pkg/controller/tas/resource_flavor.go
@@ -160,7 +160,7 @@ func (r *rfReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		// or the set of nodes can allow admitting a workload which was
 		// previously inadmissible.
 		if cqNames := r.cache.ActiveClusterQueues(); len(cqNames) > 0 {
-			qcache.QueueInadmissibleWorkloads(ctx, r.queues, cqNames)
+			qcache.NotifyRetryInadmissible(r.queues, cqNames)
 		}
 	}
 	return reconcile.Result{}, nil

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -8646,7 +8646,7 @@ func TestLastSchedulingContext(t *testing.T) {
 				recorder := broadcaster.NewRecorder(scheme,
 					corev1.EventSource{Component: constants.AdmissionName})
 				cqCache := schdcache.New(cl)
-				qManager := qcache.NewManagerForUnitTests(cl, cqCache)
+				qManager, watcher := qcache.NewManagerForUnitTestsWithRequeuer(cl, cqCache)
 				// Workloads are loaded into queues or clusterQueues as we add them.
 				for _, q := range queues {
 					if err := qManager.AddLocalQueue(ctx, &q); err != nil {
@@ -8711,6 +8711,7 @@ func TestLastSchedulingContext(t *testing.T) {
 					}
 					qManager.QueueAssociatedInadmissibleWorkloadsAfter(ctx, &workload, nil)
 				}
+				watcher.ProcessRequeues(ctx)
 
 				scheduler.schedule(ctx)
 				wg.Wait()

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -934,7 +934,15 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 			util.ExpectAdmittedWorkloadsTotalMetric(cq2, "", 2)
 
 			ginkgo.By("Create admissible workload in queue1")
-			createWorkloadWithPriority("cq1", "3", 99)
+			highPriorityWl := createWorkloadWithPriority("cq1", "3", 99)
+
+			ginkgo.By("Wait until scheduler attempts to schedule priority=99 wl")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(highPriorityWl), highPriorityWl)).To(gomega.Succeed())
+				cond := meta.FindStatusCondition(highPriorityWl.Status.Conditions, kueue.WorkloadQuotaReserved)
+				g.Expect(cond).NotTo(gomega.BeNil())
+				g.Expect(cond.Message).To(gomega.ContainSubstring("insufficient unused quota"))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("Create another admissible workload in queue1")
 			createWorkloadWithPriority("cq1", "2", 9)
@@ -951,6 +959,14 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 					NominalQuota: resource.MustParse("2"),
 				}
 				g.Expect(k8sClient.Update(ctx, updatedCohort)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Wait until schedule considers priority=99 wl as NoFit")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(highPriorityWl), highPriorityWl)).To(gomega.Succeed())
+				cond := meta.FindStatusCondition(highPriorityWl.Status.Conditions, kueue.WorkloadQuotaReserved)
+				g.Expect(cond).NotTo(gomega.BeNil())
+				g.Expect(cond.Message).To(gomega.ContainSubstring("insufficient quota"))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("Validate pending workloads")

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -893,7 +893,13 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectReservingActiveWorkloadsMetric(cq, 0)
 			util.ExpectQuotaReservedWorkloadsTotalMetric(cq, "", 0)
 			util.ExpectAdmittedWorkloadsTotalMetric(cq, "", 0)
-			util.ExpectAdmissionAttemptsMetric(1, 0)
+
+			// we send a requeue request upon CQ creation,
+			// so we may end up processing workload twice
+			// before it settles in inadmissible.
+			util.ExpectPendingAdmissionAttempts(1, ">=")
+			util.ExpectPendingAdmissionAttempts(2, "<=")
+			util.ExpectSuccessfulAdmissionAttempts(0, "==")
 
 			ginkgo.By("updating ClusterQueue")
 			updatedCq := &kueue.ClusterQueue{}
@@ -915,7 +921,8 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectReservingActiveWorkloadsMetric(cq, 1)
 			util.ExpectQuotaReservedWorkloadsTotalMetric(cq, "", 1)
 			util.ExpectAdmittedWorkloadsTotalMetric(cq, "", 1)
-			util.ExpectAdmissionAttemptsMetric(1, 1)
+			util.ExpectPendingAdmissionAttempts(2, "<=")
+			util.ExpectSuccessfulAdmissionAttempts(1, "==")
 		})
 	})
 
@@ -3002,6 +3009,108 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl3), w)).Should(gomega.Succeed())
 				g.Expect(workload.IsAdmitted(w)).Should(gomega.BeFalse())
 			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.When("Requeueing Inadmissible Workloads", func() {
+		var (
+			cq     *kueue.ClusterQueue
+			cohort *kueue.Cohort
+		)
+
+		ginkgo.AfterEach(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cohort, true)
+		})
+
+		ginkgo.It("Should collapse requeue requests to ClusterQueue", func() {
+			metrics.AdmissionAttemptsTotal.Reset()
+			cq = utiltestingapi.MakeClusterQueue("cq").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "1").Obj(),
+				).Obj()
+			util.MustCreate(ctx, k8sClient, cq)
+
+			queue := utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue("cq").Obj()
+			util.MustCreate(ctx, k8sClient, queue)
+
+			ginkgo.By("create a no-fit workload")
+			wl := utiltestingapi.MakeWorkload("wl", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
+				Request(corev1.ResourceCPU, "2").Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+
+			ginkgo.By("validate no-fit")
+			util.ExpectPendingWorkloadsMetric(cq, 0, 1)
+			util.ExpectSuccessfulAdmissionAttempts(0, "==")
+			util.ExpectPendingAdmissionAttempts(1, ">=")
+			util.ExpectPendingAdmissionAttempts(2, "<=")
+
+			ginkgo.By("trigger 10 requeue notifications")
+			metrics.AdmissionAttemptsTotal.Reset()
+			for range 10 {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), cq)).Should(gomega.Succeed())
+
+					cq.Spec.ResourceGroups[0].Flavors[0].Resources[0].NominalQuota.Add(resource.MustParse("1m"))
+
+					g.Expect(k8sClient.Update(ctx, cq)).Should(gomega.Succeed())
+				}, util.Timeout, util.ShortInterval).Should(gomega.Succeed())
+			}
+
+			// schedule attempt is proxy for requeue
+			ginkgo.By("between 1-5 schedule attempts occur")
+			util.ExpectPendingWorkloadsMetric(cq, 0, 1)
+			util.ExpectSuccessfulAdmissionAttempts(0, "==")
+			util.ExpectPendingAdmissionAttempts(1, ">=")
+			util.ExpectPendingAdmissionAttempts(5, "<=")
+		})
+
+		ginkgo.It("Should collapse requeue requests to Cohort", func() {
+			metrics.AdmissionAttemptsTotal.Reset()
+			cq = utiltestingapi.MakeClusterQueue("cq").
+				Cohort("cohort").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "1").Obj(),
+				).Obj()
+			util.MustCreate(ctx, k8sClient, cq)
+			queue := utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue("cq").Obj()
+			util.MustCreate(ctx, k8sClient, queue)
+
+			cohort = utiltestingapi.MakeCohort("cohort").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "0").Obj(),
+				).Obj()
+			util.MustCreate(ctx, k8sClient, cohort)
+
+			ginkgo.By("create a no-fit workload")
+			wl := utiltestingapi.MakeWorkload("wl", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
+				Request(corev1.ResourceCPU, "2").Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+
+			ginkgo.By("validate no-fit")
+			util.ExpectPendingWorkloadsMetric(cq, 0, 1)
+			util.ExpectSuccessfulAdmissionAttempts(0, "==")
+			util.ExpectPendingAdmissionAttempts(1, ">=")
+			util.ExpectPendingAdmissionAttempts(2, "<=")
+
+			ginkgo.By("trigger 10 requeue notifications to root Cohort")
+			metrics.AdmissionAttemptsTotal.Reset()
+			for range 10 {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cohort), cohort)).Should(gomega.Succeed())
+
+					cohort.Spec.ResourceGroups[0].Flavors[0].Resources[0].NominalQuota.Add(resource.MustParse("1m"))
+
+					g.Expect(k8sClient.Update(ctx, cohort)).Should(gomega.Succeed())
+				}, util.Timeout, util.ShortInterval).Should(gomega.Succeed())
+			}
+
+			// schedule attempt is proxy for requeue
+			ginkgo.By("between 1-5 schedule attempts occur")
+			util.ExpectPendingWorkloadsMetric(cq, 0, 1)
+			util.ExpectSuccessfulAdmissionAttempts(0, "==")
+			util.ExpectPendingAdmissionAttempts(1, ">=")
+			util.ExpectPendingAdmissionAttempts(5, "<=")
 		})
 	})
 })

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -311,7 +311,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 			// https://github.com/kubernetes-sigs/kueue/issues/8653
 			ginkgo.By("hack to requeue workload", func() {
 				cqs := sets.New[kueue.ClusterQueueReference]("cluster-queue")
-				qcache.QueueInadmissibleWorkloads(ctx, qManager, cqs)
+				qcache.NotifyRetryInadmissible(qManager, cqs)
 			})
 
 			ginkgo.By("expect TAS pod to admit", func() {
@@ -356,7 +356,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 			// https://github.com/kubernetes-sigs/kueue/issues/8653
 			ginkgo.By("hack to requeue workload", func() {
 				cqs := sets.New[kueue.ClusterQueueReference]("cluster-queue")
-				qcache.QueueInadmissibleWorkloads(ctx, qManager, cqs)
+				qcache.NotifyRetryInadmissible(qManager, cqs)
 			})
 
 			ginkgo.By("expect TAS pod to admit", func() {

--- a/test/performance/scheduler/minimalkueue/main.go
+++ b/test/performance/scheduler/minimalkueue/main.go
@@ -179,7 +179,15 @@ func mainWithExitCode() int {
 	}
 
 	cCache := schdcache.New(mgr.GetClient())
-	queues := qcache.NewManager(mgr.GetClient(), cCache)
+
+	// setup inadmissible workload requeuer
+	requeuer := qcache.NewRequeuer(qcache.RequeueBatchPeriodProd)
+	if err := mgr.Add(requeuer); err != nil {
+		log.Error(err, "Unable to add workloadRequeuer to manager")
+		return 1
+	}
+
+	queues := qcache.NewManager(mgr.GetClient(), cCache, requeuer)
 
 	go queues.CleanUpOnContext(ctx)
 	go cCache.CleanUpOnContext(ctx)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Cherry-pick #9232 to release-0.15.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Scheduling: Fix the bug where inadmissible workloads would be re-queued too frequently at scale.
This resulted in excessive processing, lock contention, and starvation of workloads deeper in the queue.
The fix is to throttle the process with a batch period of 1s per CQ or Cohort.
```