### PR TITLE
Automated cherry pick of #9493: Increase admission_wait_time_seconds histogram max bucket from ~2.84h to ~11h

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -235,7 +235,7 @@ The label 'underlying_cause' can have the following values:
 			Name:      "admission_wait_time_seconds",
 			Help:      "The time between a workload was created or requeued until admission, per 'cluster_queue'",
 			Buckets:   generateExponentialBuckets(16),
-		}, []string{"cluster_queue", "priority_class", "replica_role"},
+		}, []string{"cluster_queue", "priority_class"},
 	)
 
 	// +metricsdoc:group=optional_wait_for_pods_ready


### PR DESCRIPTION
Cherry pick of #9493 on release-0.15.

#9493: Increase admission_wait_time_seconds histogram max bucket from ~2.84h to ~11h

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind feature


```release-note
Observability: Increased the maximum finite bucket boundary for admission_wait_time_seconds histogram from ~2.84 hours to ~11.3 hours for better observability of long queue times.
```