### PR TITLE
Execute all FG validations at once

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -145,7 +145,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := config.ValidateFeatureGates(featureGates, cfg.FeatureGates); err != nil {
+	if err := config.ValidateFeatureGates(featureGates, cfg.FeatureGates).ToAggregate(); err != nil {
 		setupLog.Error(err, "conflicting feature gates detected")
 		os.Exit(1)
 	}

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -64,6 +63,7 @@ var (
 	objectRetentionPoliciesPath                  = field.NewPath("objectRetentionPolicies")
 	objectRetentionPoliciesWorkloadsPath         = objectRetentionPoliciesPath.Child("workloads")
 	tlsPath                                      = field.NewPath("tls")
+	featureGatesPath                             = field.NewPath("featureGates")
 )
 
 func validate(c *configapi.Configuration, scheme *runtime.Scheme) field.ErrorList {
@@ -492,9 +492,10 @@ func validateManagedJobsNamespaceSelector(c *configapi.Configuration) field.Erro
 	return allErrs
 }
 
-func ValidateFeatureGates(featureGateCLI string, featureGateMap map[string]bool) error {
+func ValidateFeatureGates(featureGateCLI string, featureGateMap map[string]bool) field.ErrorList {
+	var allErrs field.ErrorList
 	if featureGateCLI != "" && featureGateMap != nil {
-		return errors.New("feature gates for CLI and configuration cannot both specified")
+		allErrs = append(allErrs, field.Invalid(featureGatesPath, featureGateMap, "feature gates for CLI and configuration cannot both specified"))
 	}
 	TASProfilesEnabled := []bool{features.Enabled(features.TASProfileMixed)}
 	enabledProfilesCount := 0
@@ -505,22 +506,22 @@ func ValidateFeatureGates(featureGateCLI string, featureGateMap map[string]bool)
 	}
 	// Currently dead code but leaving in if more TASProfiles are added
 	if enabledProfilesCount > 1 {
-		return errors.New("cannot use more than one TAS profiles")
+		allErrs = append(allErrs, field.Invalid(featureGatesPath, TASProfilesEnabled, "cannot use more than one TAS profiles"))
 	}
 	if !features.Enabled(features.TopologyAwareScheduling) && enabledProfilesCount > 0 {
-		return errors.New("cannot use a TAS profile with TAS disabled")
+		allErrs = append(allErrs, field.Invalid(featureGatesPath, enabledProfilesCount, "cannot use a TAS profile with TAS disabled"))
 	}
 
 	if features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
 		if !features.Enabled(features.ElasticJobsViaWorkloadSlices) {
-			return errors.New("ElasticJobsViaWorkloadSlicesWithTAS requires ElasticJobsViaWorkloadSlices to be enabled")
+			allErrs = append(allErrs, field.Invalid(featureGatesPath, "ElasticJobsViaWorkloadSlicesWithTAS", "ElasticJobsViaWorkloadSlicesWithTAS requires ElasticJobsViaWorkloadSlices to be enabled"))
 		}
 		if !features.Enabled(features.TopologyAwareScheduling) {
-			return errors.New("ElasticJobsViaWorkloadSlicesWithTAS requires TopologyAwareScheduling to be enabled")
+			allErrs = append(allErrs, field.Invalid(featureGatesPath, "ElasticJobsViaWorkloadSlicesWithTAS", "ElasticJobsViaWorkloadSlicesWithTAS requires TopologyAwareScheduling to be enabled"))
 		}
 	}
 
-	return nil
+	return allErrs
 }
 
 func validateObjectRetentionPolicies(c *configapi.Configuration) field.ErrorList {

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -977,29 +977,37 @@ func TestValidateFeatureGates(t *testing.T) {
 		featureGatesCLI   string
 		featureGateMap    map[string]bool
 		setupFeatureGates map[featuregate.Feature]bool
-		errorStr          string
+		wantErr           field.ErrorList
 	}{
 		"no feature gates is null": {
 			featureGatesCLI: "",
-			featureGateMap:  nil,
-			errorStr:        "",
 		},
 		"feature gate cli": {
 			featureGatesCLI: "test:true",
-			featureGateMap:  nil,
-			errorStr:        "",
 		},
 		"cannot specify both feature gates": {
 			featureGatesCLI: "test:true",
 			featureGateMap:  map[string]bool{"test": true},
-			errorStr:        "feature gates for CLI and configuration cannot both specified",
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "featureGates",
+					Detail: "feature gates for CLI and configuration cannot both specified",
+				},
+			},
 		},
 		"cannot set TAS profile with TAS disabled": {
 			setupFeatureGates: map[featuregate.Feature]bool{
 				features.TASProfileMixed:         true,
 				features.TopologyAwareScheduling: false,
 			},
-			errorStr: "cannot use a TAS profile with TAS disabled",
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "featureGates",
+					Detail: "cannot use a TAS profile with TAS disabled",
+				},
+			},
 		},
 		"ElasticJobsViaWorkloadSlicesWithTAS requires ElasticJobsViaWorkloadSlices": {
 			setupFeatureGates: map[featuregate.Feature]bool{
@@ -1008,7 +1016,13 @@ func TestValidateFeatureGates(t *testing.T) {
 				features.ElasticJobsViaWorkloadSlices:        false,
 				features.TASProfileMixed:                     false,
 			},
-			errorStr: "ElasticJobsViaWorkloadSlicesWithTAS requires ElasticJobsViaWorkloadSlices to be enabled",
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "featureGates",
+					Detail: "ElasticJobsViaWorkloadSlicesWithTAS requires ElasticJobsViaWorkloadSlices to be enabled",
+				},
+			},
 		},
 		"ElasticJobsViaWorkloadSlicesWithTAS requires TopologyAwareScheduling": {
 			setupFeatureGates: map[featuregate.Feature]bool{
@@ -1017,7 +1031,13 @@ func TestValidateFeatureGates(t *testing.T) {
 				features.TopologyAwareScheduling:             false,
 				features.TASProfileMixed:                     false,
 			},
-			errorStr: "ElasticJobsViaWorkloadSlicesWithTAS requires TopologyAwareScheduling to be enabled",
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "featureGates",
+					Detail: "ElasticJobsViaWorkloadSlicesWithTAS requires TopologyAwareScheduling to be enabled",
+				},
+			},
 		},
 		"ElasticJobsViaWorkloadSlicesWithTAS valid when all dependencies enabled": {
 			setupFeatureGates: map[featuregate.Feature]bool{
@@ -1026,7 +1046,31 @@ func TestValidateFeatureGates(t *testing.T) {
 				features.TopologyAwareScheduling:             true,
 				features.TASProfileMixed:                     false,
 			},
-			errorStr: "",
+		},
+		"multiple FG validation errors at once": {
+			setupFeatureGates: map[featuregate.Feature]bool{
+				features.TASProfileMixed:                     true,
+				features.TopologyAwareScheduling:             false,
+				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
+				features.ElasticJobsViaWorkloadSlices:        false,
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "featureGates",
+					Detail: "cannot use a TAS profile with TAS disabled",
+				},
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "featureGates",
+					Detail: "ElasticJobsViaWorkloadSlicesWithTAS requires ElasticJobsViaWorkloadSlices to be enabled",
+				},
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "featureGates",
+					Detail: "ElasticJobsViaWorkloadSlicesWithTAS requires TopologyAwareScheduling to be enabled",
+				},
+			},
 		},
 	}
 	for name, tc := range cases {
@@ -1036,12 +1080,8 @@ func TestValidateFeatureGates(t *testing.T) {
 				features.SetFeatureGateDuringTest(t, fg, enabled)
 			}
 			got := ValidateFeatureGates(tc.featureGatesCLI, tc.featureGateMap)
-			gotErr := ""
-			if got != nil {
-				gotErr = got.Error()
-			}
-			if gotErr != tc.errorStr {
-				t.Errorf("Unexpected result from ValidateFeatureGates\nwant: %q\ngot: %q\n", tc.errorStr, gotErr)
+			if diff := cmp.Diff(tc.wantErr, got, cmpopts.IgnoreFields(field.Error{}, "BadValue")); diff != "" {
+				t.Errorf("Unexpected result from ValidateFeatureGates (-want,+got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9355

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```