### PR TITLE
test(e2e): stop cleanup retries when kind cluster is already deleted

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -168,7 +168,15 @@ function cluster_cleanup {
     local retry_delay=1
 
     for attempt in $(seq 1 "$max_retries"); do
-        if $KIND delete cluster --name "$cluster_name"; then
+        local output
+        if output=$($KIND delete cluster --name "$cluster_name" 2>&1); then
+            echo "$output"
+            return 0
+        fi
+        echo "$output"
+
+        if [[ "$output" == *"unknown cluster"* ]]; then
+            echo "Cluster '$cluster_name' is already deleted (unknown cluster)."
             return 0
         fi
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

In `cluster_cleanup`, `kind delete cluster` can return `ERROR: unknown cluster "kind"` after a prior delete already removed the cluster.

Today we retry this case up to 5 times and then fail cleanup, which can turn a successful test run into a false-negative CI failure.

This change captures `kind delete cluster` output and treats `unknown cluster` as success, ending cleanup immediately.

#### Which issue(s) this PR fixes:

Related to #9352

#### Special notes for your reviewer:

Scope is intentionally minimal: one shell helper in `hack/testing/e2e-common.sh`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
