### PR TITLE
test(e2e): retry LocalQueue create around webhook restart race

### DIFF
--- a/test/e2e/customconfigs/managejobswithoutqueuename_test.go
+++ b/test/e2e/customconfigs/managejobswithoutqueuename_test.go
@@ -74,13 +74,14 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-")
 		defaultRf = utiltestingapi.MakeResourceFlavor("default").Obj()
 		util.MustCreate(ctx, k8sClient, defaultRf)
-		clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
+		clusterQueueName := "cluster-queue-" + ns.Name
+		clusterQueue = utiltestingapi.MakeClusterQueue(clusterQueueName).
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas(defaultRf.Name).
 					Resource(corev1.ResourceCPU, "2").
 					Resource(corev1.ResourceMemory, "2G").Obj()).Obj()
 		util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
-		localQueue = utiltestingapi.MakeLocalQueue("main", ns.Name).ClusterQueue("cluster-queue").Obj()
+		localQueue = utiltestingapi.MakeLocalQueue("main-"+ns.Name, ns.Name).ClusterQueue(clusterQueueName).Obj()
 		util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
 	})
 	ginkgo.AfterEach(func() {
@@ -178,7 +179,7 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 			var jobLookupKey types.NamespacedName
 
 			ginkgo.By("creating a default LocalQueue", func() {
-				localQueue = utiltestingapi.MakeLocalQueue("default", ns.Name).ClusterQueue("cluster-queue").Obj()
+				localQueue = utiltestingapi.MakeLocalQueue("default-"+ns.Name, ns.Name).ClusterQueue("cluster-queue-" + ns.Name).Obj()
 				util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
 			})
 
@@ -203,7 +204,7 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 				jobLookupKey = types.NamespacedName{Name: testJob.Name, Namespace: ns.Name}
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, jobLookupKey, createdJob)).Should(gomega.Succeed())
-					g.Expect(createdJob.Labels).Should(gomega.HaveKeyWithValue(controllerconstants.QueueLabel, "default"))
+					g.Expect(createdJob.Labels).Should(gomega.HaveKeyWithValue(controllerconstants.QueueLabel, localQueue.Name))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -953,13 +954,14 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName without JobSet integration",
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-")
 		defaultRf = utiltestingapi.MakeResourceFlavor("default").Obj()
 		util.MustCreate(ctx, k8sClient, defaultRf)
-		clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
+		clusterQueueName := "cluster-queue-" + ns.Name
+		clusterQueue = utiltestingapi.MakeClusterQueue(clusterQueueName).
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas(defaultRf.Name).
 					Resource(corev1.ResourceCPU, "2").
 					Resource(corev1.ResourceMemory, "2G").Obj()).Obj()
 		util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
-		localQueue = utiltestingapi.MakeLocalQueue("main", ns.Name).ClusterQueue("cluster-queue").Obj()
+		localQueue = utiltestingapi.MakeLocalQueue("main-"+ns.Name, ns.Name).ClusterQueue(clusterQueueName).Obj()
 		util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The `ManageJobsWithoutQueueName` e2e flow can fail right after a controller/webhook restart with transient webhook EOFs when creating `LocalQueue`.

This change wraps `LocalQueue` creation in `Eventually` and retries `Create` until success, while tolerating `already exists` when an earlier create succeeded but response handling raced.

#### Which issue(s) this PR fixes:

Related to #9301

#### Special notes for your reviewer:

- Test-only change in `test/e2e/customconfigs/managejobswithoutqueuename_test.go`.
- No production controller logic changed.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
