### PR TITLE
test(perf): relax baseline threshold for small workload admission

### DIFF
--- a/test/performance/scheduler/configs/baseline/rangespec.yaml
+++ b/test/performance/scheduler/configs/baseline/rangespec.yaml
@@ -19,5 +19,5 @@ wlClassesMaxAvgTimeToAdmissionMs:
   # Average value 76768 (+/- 2%), setting at +20%
   medium: 90_000
 
-  # Average value 215468 (+/- 2%), setting at +5% + 6s accounting for observed failures
-  small: 233_000
+  # Average value 215468 (+/- 2%), setting at +20% accounting for observed failures
+  small: 260_000


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`TestScalability/WorkloadClasses/small` flakes when CI load increases and the average admission time for `small` workloads exceeds the current strict baseline threshold.

This patch minimally adjusts only the baseline threshold for `small` from `233_000` to `260_000` in `test/performance/scheduler/configs/baseline/rangespec.yaml`.

#### Which issue(s) this PR fixes:

Related to #9357

#### Special notes for your reviewer:

- Scope is intentionally minimal (single-file threshold update).
- This does not overlap with TAS rangespec tuning work in #9495 (different config file).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
