### PR TITLE
test(populator): reuse shared cluster cleanup helper in run-e2e script

### DIFF
--- a/cmd/experimental/kueue-populator/run-e2e.sh
+++ b/cmd/experimental/kueue-populator/run-e2e.sh
@@ -27,7 +27,6 @@ GIT_TAG=$(git describe --tags --dirty --always)
 # Ensure tools are built
 cd "$REPO_ROOT"
 make kustomize ginkgo kind yq
-cd "$SCRIPT_DIR"
 
 # Reuse common e2e helpers (including kind cluster cleanup retry logic).
 ROOT_DIR="$REPO_ROOT"
@@ -36,6 +35,7 @@ GINKGO_ARGS="${GINKGO_ARGS:-}"
 E2E_KIND_VERSION="${E2E_KIND_VERSION:-}"
 # shellcheck source=hack/testing/e2e-common.sh
 source "$SOURCE_DIR/e2e-common.sh"
+cd "$SCRIPT_DIR"
 
 function cleanup {
   cluster_cleanup "$KIND_CLUSTER_NAME"


### PR DESCRIPTION
## Summary
This updates `cmd/experimental/kueue-populator/run-e2e.sh` to reuse the shared e2e cleanup helper instead of maintaining a local one-off cluster delete path.

### What changed
- source `hack/testing/e2e-common.sh`
- call shared `cluster_cleanup "$KIND_CLUSTER_NAME"` in `cleanup()`
- build `yq` before sourcing common helper (`make kustomize ginkgo kind yq`), because common helper initialization references it

## Why
`#9582` tracks intermittent cleanup failures in populator e2e (`kind delete cluster` / Docker exit-event race). The shared helper already implements retry/backoff behavior used elsewhere, and maintainer guidance asked to commonize this logic.

## Verification
- `bash -n cmd/experimental/kueue-populator/run-e2e.sh`
- Reproduced one-shot cleanup failure case in prior evidence bundle
- Verified helper-based cleanup path retries and succeeds in mocked failure/then-success scenario

## Risk
Low-to-medium. The script now depends on shared helper initialization and fails fast when cleanup cannot be completed after retries (instead of single-shot delete).

Related to #9582

```release-note
NONE
```
