### PR TITLE
Skip PushOrUpdate for inflight workloads to prevent spurious scheduling cycles

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -252,7 +252,11 @@ func (c *ClusterQueue) PushOrUpdate(wInfo *workload.Info) {
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
 	key := workload.Key(wInfo.Obj)
-	c.forgetInflightByKey(key)
+	// Skip if the scheduler is actively processing this workload.
+	// RequeueWorkload will handle placement with the latest version.
+	if c.inflight != nil && workload.Key(c.inflight.Obj) == key {
+		return
+	}
 	if oldInfo := c.inadmissibleWorkloads.get(key); oldInfo != nil {
 		// update in place if the workload was inadmissible and didn't change
 		// to potentially become admissible, unless the Eviction status changed

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -212,6 +212,37 @@ func Test_Pop(t *testing.T) {
 	}
 }
 
+func TestPushOrUpdateSkipsInflightWorkload(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	now := time.Now()
+	cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(now))
+
+	wl := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).Creation(now).Obj()
+	cq.PushOrUpdate(workload.NewInfo(wl))
+
+	// Pop makes the workload inflight.
+	head := cq.Pop()
+	if head == nil {
+		t.Fatal("expected to pop workload")
+	}
+
+	// Simulate a concurrent PushOrUpdate while the workload is inflight.
+	updatedWl := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).
+		Creation(now).ResourceVersion("1").Obj()
+	cq.PushOrUpdate(workload.NewInfo(updatedWl))
+
+	// The workload should not be on the heap or in inadmissible.
+	activeWorkloads, _ := cq.Dump()
+	if len(activeWorkloads) != 0 {
+		t.Errorf("expected empty heap while workload is inflight, got %v", activeWorkloads)
+	}
+
+	inadmissibleWorkloads, _ := cq.DumpInadmissible()
+	if len(inadmissibleWorkloads) != 0 {
+		t.Errorf("expected no inadmissible workloads while workload is inflight, got %v", inadmissibleWorkloads)
+	}
+}
+
 func Test_Delete(t *testing.T) {
 	ctx, log := utiltesting.ContextWithLog(t)
 	cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(time.Now()))


### PR DESCRIPTION
When a workload is popped by the scheduler (inflight), a concurrent PushOrUpdate from the workload controller can push it onto the heap while the scheduler also places it in the inadmissible set. This causes an extra scheduling cycle.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/9591

#### Special notes for your reviewer:

I ran the failed test 100 times in a loop and it looks fine.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Scheduling: Fixed a race condition where a workload could simultaneously exist in the scheduler's heap
and the "inadmissible workloads" list. This fix prevents unnecessary scheduler cycles and prevents temporary 
double counting for the metric of pending workloads.
```