### PR TITLE
Use NewPodSetReference() instead if PodSetReference().

### DIFF
--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -5442,7 +5442,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			for _, ps := range tc.podSets {
 				tasInput := TASPodSetRequests{
 					PodSet: &kueue.PodSet{
-						Name:            kueue.PodSetReference(ps.podSetName),
+						Name:            kueue.NewPodSetReference(ps.podSetName),
 						TopologyRequest: ps.topologyRequest,
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
@@ -5469,7 +5469,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				if ps.wantAssignment != nil {
 					wantPodSetResult.TopologyAssignment = ps.wantAssignment
 				}
-				wantResult[kueue.PodSetReference(ps.podSetName)] = wantPodSetResult
+				wantResult[kueue.NewPodSetReference(ps.podSetName)] = wantPodSetResult
 			}
 			gotResult := snapshot.FindTopologyAssignmentsForFlavor(flavorTASRequests)
 			if diff := cmp.Diff(wantResult, gotResult); diff != "" {

--- a/pkg/controller/jobs/jobset/jobset_webhook.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook.go
@@ -172,7 +172,7 @@ func (w *JobSetWebhook) validateTopologyRequest(ctx context.Context, jobSet *Job
 func buildPodSetAnnotationsPathByNameMap(jobSet *JobSet) map[kueue.PodSetReference]*field.Path {
 	podSetAnnotationsPathByName := make(map[kueue.PodSetReference]*field.Path)
 	for i, job := range jobSet.Spec.ReplicatedJobs {
-		podSetAnnotationsPathByName[kueue.PodSetReference(job.Name)] = replicatedJobsPath.Index(i).Child("template", "spec", "template", "metadata", "annotations")
+		podSetAnnotationsPathByName[kueue.NewPodSetReference(job.Name)] = replicatedJobsPath.Index(i).Child("template", "spec", "template", "metadata", "annotations")
 	}
 	return podSetAnnotationsPathByName
 }

--- a/pkg/controller/jobs/raycluster/common.go
+++ b/pkg/controller/jobs/raycluster/common.go
@@ -248,7 +248,7 @@ func BuildPodSetAnnotationsPathByNameMap(rayClusterSpec *rayv1.RayClusterSpec, h
 	podSetAnnotationsPathByName := make(map[kueue.PodSetReference]*field.Path)
 	podSetAnnotationsPathByName[headGroupPodSetName] = headGroupMetaPath.Child("annotations")
 	for i, wgs := range rayClusterSpec.WorkerGroupSpecs {
-		podSetAnnotationsPathByName[kueue.PodSetReference(wgs.GroupName)] = workerGroupSpecsPath.Index(i).Child("template", "metadata", "annotations")
+		podSetAnnotationsPathByName[kueue.NewPodSetReference(wgs.GroupName)] = workerGroupSpecsPath.Index(i).Child("template", "metadata", "annotations")
 	}
 	return podSetAnnotationsPathByName
 }

--- a/pkg/workload/podsetscounts_test.go
+++ b/pkg/workload/podsetscounts_test.go
@@ -26,7 +26,7 @@ import (
 
 func testPodSet(name string, count int32) kueue.PodSet {
 	return kueue.PodSet{
-		Name:  kueue.PodSetReference(name),
+		Name:  kueue.NewPodSetReference(name),
 		Count: count,
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Use NewPodSetReference() instead if PodSetReference().

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```