### PR TITLE
Fix Multikueue E2E script swallowing cluster creation errors and locking kubeconfig

### DIFF
--- a/hack/testing/e2e-multikueue-test.sh
+++ b/hack/testing/e2e-multikueue-test.sh
@@ -92,12 +92,16 @@ function kueue_deploy {
 trap cleanup EXIT
 startup 
 prepare_docker_images
-for job in $(jobs -p); do wait "$job" || { echo "Cluster creation failed!"; exit 1; } done # wait for clusters creation
+for job in $(jobs -p); do 
+    wait "$job" || { echo "Cluster creation failed!"; exit 1; } 
+done # wait for clusters creation
 
 kind_load "$MANAGER_KIND_CLUSTER_NAME" "$MANAGER_KUBECONFIG" &
 kind_load "$WORKER1_KIND_CLUSTER_NAME" "$WORKER1_KUBECONFIG" &
 kind_load "$WORKER2_KIND_CLUSTER_NAME" "$WORKER2_KUBECONFIG" &
-for job in $(jobs -p); do wait "$job" || { echo "Dependency installation failed!"; exit 1; } done # wait for dependency installation
+for job in $(jobs -p); do 
+    wait "$job" || { echo "Dependency installation failed!"; exit 1; } 
+done # wait for dependency installation
 echo "Add contexts to default kubeconfig"
 $KIND export kubeconfig --name "$MANAGER_KIND_CLUSTER_NAME"
 $KIND export kubeconfig --name "$WORKER1_KIND_CLUSTER_NAME"


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:

If kind create cluster failed (e.g. due to OOM or network timeout), the script swallowed the background process error and continued running the Ginkgo suite against non-existent clusters. Additionally, concurrent kind delete commands in the cleanup phase caused a config.lock: file exists race condition, breaking local dev environments.

Fixes two issues:
1. Added a sequential wait loop after background cluster creation to ensure set -e instantly catches provisioning failures.

2. Made the cluster cleanup sequential to prevent kubeconfig lock collisions.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8983

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```