### PR TITLE
Add a missing backslash in the helm upgrade command for kueueviz

### DIFF
--- a/cmd/kueueviz/INSTALL.md
+++ b/cmd/kueueviz/INSTALL.md
@@ -23,7 +23,7 @@ by ensuring that `enableKueueViz` is set to `true`:
 
 ```
 helm upgrade --install kueue oci://registry.k8s.io/kueue/charts/kueue \
-  --version="0.16.2"
+  --version="0.16.2" \
   --namespace kueue-system \
   --set enableKueueViz=true \
   --create-namespace


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

A missing backslash in the installation docs for kueueviz resulted in a failure to install kueueviz with a helm chart.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```