### PR TITLE
Automated cherry pick of #9605: Add a missing backslash in the helm upgrade command for kueueviz

### DIFF
--- a/cmd/kueueviz/INSTALL.md
+++ b/cmd/kueueviz/INSTALL.md
@@ -23,7 +23,7 @@ by ensuring that `enableKueueViz` is set to `true`:
 
 ```
 helm upgrade --install kueue oci://registry.k8s.io/kueue/charts/kueue \
-  --version="0.15.5"
+  --version="0.15.5" \
   --namespace kueue-system \
   --set enableKueueViz=true \
   --create-namespace


### PR DESCRIPTION
Cherry pick of #9605 on release-0.15.

#9605: Add a missing backslash in the helm upgrade command for kueueviz

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind documentation


```release-note
NONE
```