### PR TITLE
Add LockToDefault for PropagateBatchJobLabelsToWorkload GA feature gate

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -393,7 +393,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	// PropagateBatchJobLabelsToWorkload is enabled from 0.13.10 and 0.14.5.
 	PropagateBatchJobLabelsToWorkload: {
 		{Version: version.MustParse("0.15"), Default: true, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("0.17"), Default: true, PreRelease: featuregate.GA},
+		{Version: version.MustParse("0.17"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 0.19
 	},
 	MultiKueueClusterProfile: {
 		{Version: version.MustParse("0.15"), Default: false, PreRelease: featuregate.Alpha},

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -208,7 +208,7 @@
     preRelease: Beta
     version: "0.15"
   - default: true
-    lockToDefault: false
+    lockToDefault: true
     preRelease: GA
     version: "0.17"
 - name: ReclaimablePods

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -208,7 +208,7 @@
     preRelease: Beta
     version: "0.15"
   - default: true
-    lockToDefault: false
+    lockToDefault: true
     preRelease: GA
     version: "0.17"
 - name: ReclaimablePods


### PR DESCRIPTION
## Summary
- Adds missing `LockToDefault: true` to the `PropagateBatchJobLabelsToWorkload` feature gate GA entry, consistent with all other features promoted to GA in v0.17

Fixes #9632

## Test plan
- [x] Verified the change matches the pattern used by other GA features (LendingLimit, MultiKueueBatchJobWithManagedBy, LocalQueueDefaulting, ObjectRetentionPolicies, SanitizePodSets)

```release-note
NONE
```