### PR TITLE
test: fix flaky MPIJob test and generalize MustCreateWithRetry

### DIFF
--- a/test/e2e/tas/trainjob_test.go
+++ b/test/e2e/tas/trainjob_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tase2e
 
 import (
-	"context"
 	"fmt"
 
 	kftrainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
@@ -116,7 +115,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for TrainJob", func() {
 				Obj()
 
 			util.MustCreate(ctx, k8sClient, trainingRuntime)
-			createTrainJobWithRetry(ctx, k8sClient, trainjob)
+			util.MustCreateWithRetry(ctx, k8sClient, trainjob)
 
 			ginkgo.By("TrainJob is unsuspended", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -188,7 +187,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for TrainJob", func() {
 				Obj()
 
 			util.MustCreate(ctx, k8sClient, trainingRuntime)
-			createTrainJobWithRetry(ctx, k8sClient, trainjob)
+			util.MustCreateWithRetry(ctx, k8sClient, trainjob)
 
 			ginkgo.By("TrainJob is unsuspended", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -259,7 +258,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for TrainJob", func() {
 				Obj()
 
 			util.MustCreate(ctx, k8sClient, trainingRuntime)
-			createTrainJobWithRetry(ctx, k8sClient, trainjob)
+			util.MustCreateWithRetry(ctx, k8sClient, trainjob)
 
 			ginkgo.By("TrainJob is unsuspended", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -312,12 +311,4 @@ func readRankAssignmentsFromTrainJobPods(pods []corev1.Pod) map[string]string {
 		assignment[key] = pod.Spec.NodeName
 	}
 	return assignment
-}
-
-func createTrainJobWithRetry(ctx context.Context, c client.Client, trainJob *kftrainer.TrainJob) {
-	gomega.Eventually(func(g gomega.Gomega) {
-		err := c.Create(ctx, trainJob)
-		// Ignore transient webhook errors (e.g., TrainingRuntime not yet visible)
-		g.Expect(client.IgnoreAlreadyExists(err)).ToNot(gomega.HaveOccurred())
-	}, util.Timeout, util.Interval).Should(gomega.Succeed())
 }

--- a/test/integration/singlecluster/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/mpijob/mpijob_controller_test.go
@@ -524,7 +524,7 @@ var _ = ginkgo.Describe("Job controller for workloads when only jobs with queue 
 			Suspend(false).
 			Obj()
 		gomega.Expect(ctrl.SetControllerReference(parentJob, childJob, k8sClient.Scheme())).To(gomega.Succeed())
-		util.MustCreate(ctx, k8sClient, childJob)
+		util.MustCreateWithRetry(ctx, k8sClient, childJob)
 
 		ginkgo.By("checking that the child job is suspended")
 		gomega.Eventually(func(g gomega.Gomega) {
@@ -547,7 +547,7 @@ var _ = ginkgo.Describe("Job controller for workloads when only jobs with queue 
 			Suspend(false).
 			Obj()
 		gomega.Expect(ctrl.SetControllerReference(parentJob, childJob, k8sClient.Scheme())).To(gomega.Succeed())
-		util.MustCreate(ctx, k8sClient, childJob)
+		util.MustCreateWithRetry(ctx, k8sClient, childJob)
 
 		ginkgo.By("Checking that the child job isn't suspended")
 		gomega.Eventually(func(g gomega.Gomega) {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -987,6 +987,13 @@ func MustCreate(ctx context.Context, c client.Client, obj client.Object) {
 	gomega.Expect(c.Create(ctx, obj)).Should(gomega.Succeed())
 }
 
+func MustCreateWithRetry(ctx context.Context, c client.Client, obj client.Object) {
+	ginkgo.GinkgoHelper()
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(client.IgnoreAlreadyExists(c.Create(ctx, obj))).ToNot(gomega.HaveOccurred())
+	}, Timeout, Interval).Should(gomega.Succeed())
+}
+
 func CreateClusterQueuesAndWaitForActive(ctx context.Context, c client.Client, cqs ...*kueue.ClusterQueue) {
 	ginkgo.GinkgoHelper()
 	for _, cq := range cqs {


### PR DESCRIPTION
#### What type of PR is this?

/kind flake
/kind cleanup
/area testing

#### What this PR does / why we need it:
This PR fixes the flaky MPIJob integration test (parent workload not found error). 
Additionally, following the suggestion from @mimowo in #9571, I generalized the retry logic into a common utility function so it can be shared across different tests.

**Changes:**
- **`test/util/util.go`**: Added a generic `MustCreateWithRetry` function that accepts `client.Object` to handle transient webhook errors.
- **`mpijob_controller_test.go`**: Replaced `MustCreate` with `MustCreateWithRetry` when creating child jobs to prevent the flaky error.
- **`trainjob_test.go`**: Refactored the test by removing the specific `createTrainJobWithRetry` function and migrating it to use the new generic `util.MustCreateWithRetry`.

#### Which issue(s) this PR fixes:
Related to #9609

#### Special notes for your reviewer:
As discussed in #9571, the `createTrainJobWithRetry` function has been successfully generalized and applied to fix the analogous issue in MPIJob tests. 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```