### PR TITLE
Small clarifications in scheduling code

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -558,12 +558,10 @@ func (c *ClusterQueue) Active() bool {
 }
 
 // RequeueIfNotPresent inserts a workload that was not
-// admitted back into the ClusterQueue. If the boolean is true,
-// the workloads should be put back in the queue immediately,
-// because we couldn't determine if the workload was admissible
-// in the last cycle. If the boolean is false, the implementation might
-// choose to keep it in temporary placeholder stage where it doesn't
-// compete with other workloads, until cluster events free up quota.
+// admitted back into the ClusterQueue.
+// This may be done either "immediately" or "non-immediately";
+// in the latter case the implementation may choose to keep the workload in "inadmissible workloads"
+// where it doesn't compete with other workloads, until cluster events free up quota.
 // The workload should not be reinserted if it's already in the ClusterQueue.
 // Returns true if the workload was inserted.
 func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.Info, reason RequeueReason) bool {
@@ -578,13 +576,15 @@ func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.
 		c.sw.set(workload.Key(wInfo.Obj))
 	}
 
+	var immediate bool
 	if c.queueingStrategy == kueue.StrictFIFO {
-		return c.requeueIfNotPresent(log, wInfo, reason != RequeueReasonNamespaceMismatch)
-	}
-	return c.requeueIfNotPresent(log, wInfo,
-		reason == RequeueReasonFailedAfterNomination ||
+		immediate = reason != RequeueReasonNamespaceMismatch
+	} else {
+		immediate = reason == RequeueReasonFailedAfterNomination ||
 			reason == RequeueReasonPendingPreemption ||
-			reason == RequeueReasonPreemptionFailed)
+			reason == RequeueReasonPreemptionFailed
+	}
+	return c.requeueIfNotPresent(log, wInfo, immediate)
 }
 
 // queueOrderingFunc returns a comparison function used to sort workloads.

--- a/pkg/cache/queue/inadmissible_workloads.go
+++ b/pkg/cache/queue/inadmissible_workloads.go
@@ -78,8 +78,8 @@ func (iw *inadmissibleWorkloads) replaceAll(newMap inadmissibleWorkloads) {
 	*iw = newMap
 }
 
-// requeueWorkloadsCQ moves all workloads in the same
-// cohort with this ClusterQueue from inadmissibleWorkloads to heap.
+// requeueWorkloadsCQ moves all workloads in this ClusterQueue
+// from inadmissibleWorkloads to heap.
 // It expects to be passed a ClusterQueue without any Cohort.
 // WARNING: must only be called by the InadmissibleWorkloadRequeuer
 func requeueWorkloadsCQ(ctx context.Context, m *Manager, clusterQueueName kueue.ClusterQueueReference) int {
@@ -141,7 +141,7 @@ func requeueWorkloadsCohortSubtree(ctx context.Context, m *Manager, cohort *coho
 	return total
 }
 
-// queueInadmissibleWorkloads moves all workloads from inadmissibleWorkloads to heap.
+// queueInadmissibleWorkloads moves all (eligible) workloads from inadmissibleWorkloads to heap.
 // Returns the number of workloads moved.
 // WARNING: must only be called (indirectly) by InadmissibleWorkloadRequeuer.
 func queueInadmissibleWorkloads(ctx context.Context, c *ClusterQueue, client client.Client) int {
@@ -166,7 +166,7 @@ func queueInadmissibleWorkloads(ctx context.Context, c *ClusterQueue, client cli
 	}
 
 	c.inadmissibleWorkloads.replaceAll(newInadmissibleWorkloads)
-	log.V(5).Info("Moved all workloads from inadmissibleWorkloads back to heap", "clusterQueue", c.name)
+	log.V(5).Info("Moved workloads from inadmissibleWorkloads back to heap", "clusterQueue", c.name, "workloadsMoved", moved, "workloadsNotMoved", len(c.inadmissibleWorkloads))
 	return moved
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -639,6 +639,7 @@ func updateAssignmentForTAS(snapshot *schdcache.Snapshot, cq *schdcache.ClusterQ
 // admit sets the admitting clusterQueue and flavors into the workload of
 // the entry, and asynchronously updates the object in the apiserver after
 // assuming it in the cache.
+// Note: this does not necessarily make the workload "admitted".
 func (s *Scheduler) admit(ctx context.Context, e *entry, cq *schdcache.ClusterQueueSnapshot) error {
 	log := ctrl.LoggerFrom(ctx)
 	admission := &kueue.Admission{

--- a/pkg/workload/admissionchecks.go
+++ b/pkg/workload/admissionchecks.go
@@ -159,6 +159,7 @@ func HasAllChecksReady(wl *kueue.Workload) bool {
 }
 
 // HasAllChecks returns true if all the mustHaveChecks are present in the workload.
+// (They don't have to be in the Ready state; for that, see HasAllChecksReady).
 func HasAllChecks(wl *kueue.Workload, mustHaveChecks sets.Set[kueue.AdmissionCheckReference]) bool {
 	if mustHaveChecks.Len() == 0 {
 		return true


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

It's a random set of small clarifications following my recent reading of the code (partially with @Singularity23x0 ).

This includes:

- A few changes to the comments which were previously misleading.
- In [`RequeueIfNotPresent`](https://github.com/kubernetes-sigs/kueue/blob/48a2c7d3dca3f347268566c76608f712ebe41a7d/pkg/cache/queue/cluster_queue.go#L564-L592), a refactor to indicate more clearly what is "the boolean" mentioned in the comment. (Which otherwise feels highly confusing, as "the boolean" is neither the argument to the function nor its return value).
- In `queueInadmissibleWorkloads`, a fix to the log, which in its current form can be misleading in some cases.

#### Which issue(s) this PR fixes:

(none)

#### Special notes for your reviewer:

The log fix is, strictly speaking, user-facing. So I drafted a release note. Though it's such a minor thing that maybe `NONE` would fit better? I'm not sure about this.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```