### PR TITLE
Update KEP-6757 history to include changes after foreground propagated deletion fix

### DIFF
--- a/keps/6757-failure-recovery/README.md
+++ b/keps/6757-failure-recovery/README.md
@@ -275,7 +275,7 @@ Existing integration tests should prove that this feature does not impact Kueue 
 2026-03-04: The controller is [changed](https://github.com/kubernetes-sigs/kueue/pull/9651) to delete pods in addition to marking them as failed,
 to handle [foreground propagated deletion](https://github.com/kubernetes-sigs/kueue/issues/9649).
 Additionally, the annotation used by the feature was renamed from `kueue.x-k8s.io/safe-to-forcefully-terminate` to `kueue.x-k8s.io/safe-to-forcefully-delete`
-in versions `>=0.15.6`, `>=0.16.3` and `>=0.17.0`. Previous releases retain the old annotation name.
+in versions `>=0.15.6`, `>=0.16.3` and `>=0.17.0`. Previous releases retain the old behaviour and annotation name.
 
 ## Drawbacks
 


### PR DESCRIPTION
#### What type of PR is this?
/kind kep

#### What this PR does / why we need it:
The KEPs history should be updated to match content updates (https://github.com/kubernetes-sigs/kueue/pull/9651).

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```