### PR TITLE
Automated cherry pick of #9604: Fix Multikueue E2E script swallowing cluster creation errors and locking kubeconfig

### DIFF
--- a/hack/testing/e2e-multikueue-test.sh
+++ b/hack/testing/e2e-multikueue-test.sh
@@ -39,11 +39,10 @@ function cleanup {
             mkdir -p "$ARTIFACTS"
         fi
 
-        cluster_cleanup "$MANAGER_KIND_CLUSTER_NAME" "$MANAGER_KUBECONFIG" &
-        cluster_cleanup "$WORKER1_KIND_CLUSTER_NAME" "$WORKER1_KUBECONFIG" &
-        cluster_cleanup "$WORKER2_KIND_CLUSTER_NAME" "$WORKER2_KUBECONFIG" &
+        cluster_cleanup "$MANAGER_KIND_CLUSTER_NAME" "$MANAGER_KUBECONFIG" 
+        cluster_cleanup "$WORKER1_KIND_CLUSTER_NAME" "$WORKER1_KUBECONFIG" 
+        cluster_cleanup "$WORKER2_KIND_CLUSTER_NAME" "$WORKER2_KUBECONFIG" 
     fi
-    wait
 }
 
 


### PR DESCRIPTION
Cherry pick of #9604 on release-0.15.

#9604: Fix Multikueue E2E script swallowing cluster creation errors and locking kubeconfig

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug
/kind flake


```release-note
NONE
```