### PR TITLE
[release-0.15] Fix inadmissible workload stuck after priority update (#9661)

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -243,10 +243,12 @@ func (c *ClusterQueue) PushOrUpdate(wInfo *workload.Info) {
 		return
 	}
 	if oldInfo := c.inadmissibleWorkloads.get(key); oldInfo != nil {
-		// update in place if the workload was inadmissible and didn't change
-		// to potentially become admissible, unless the Eviction status changed
-		// which can affect the workloads order in the queue.
-		if equality.Semantic.DeepEqual(oldInfo.Obj.Spec, wInfo.Obj.Spec) &&
+		specChangedSinceEval := oldInfo.LastEvaluatedGeneration != 0 &&
+			wInfo.Obj.Generation != oldInfo.LastEvaluatedGeneration
+
+		// Update in place if the workload didn't change to potentially become admissible.
+		if !specChangedSinceEval &&
+			equality.Semantic.DeepEqual(oldInfo.Obj.Spec, wInfo.Obj.Spec) &&
 			equality.Semantic.DeepEqual(oldInfo.Obj.Status.ReclaimablePods, wInfo.Obj.Status.ReclaimablePods) &&
 			equality.Semantic.DeepEqual(apimeta.FindStatusCondition(oldInfo.Obj.Status.Conditions, kueue.WorkloadEvicted),
 				apimeta.FindStatusCondition(wInfo.Obj.Status.Conditions, kueue.WorkloadEvicted)) &&
@@ -450,6 +452,7 @@ func (c *ClusterQueue) Pop() *workload.Info {
 		return nil
 	}
 	c.inflight = c.heap.Pop()
+	c.inflight.LastEvaluatedGeneration = c.inflight.Obj.Generation
 	return c.inflight
 }
 

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -242,6 +242,66 @@ func TestPushOrUpdateSkipsInflightWorkload(t *testing.T) {
 	}
 }
 
+func TestPushOrUpdateGenerationChanged(t *testing.T) {
+	now := time.Now()
+
+	cases := map[string]struct {
+		updatedWorkload           *kueue.Workload
+		wantActiveWorkloads       int
+		wantInadmissibleWorkloads int
+	}{
+		"moves to heap when generation changed": {
+			updatedWorkload: utiltestingapi.MakeWorkload("workload-1", defaultNamespace).
+				Creation(now).Generation(2).ResourceVersion("2").Priority(300).Obj(),
+			wantActiveWorkloads:       1,
+			wantInadmissibleWorkloads: 0,
+		},
+		"stays inadmissible when generation changed but backoff unexpired": {
+			updatedWorkload: utiltestingapi.MakeWorkload("workload-1", defaultNamespace).
+				Creation(now).Generation(2).ResourceVersion("2").Priority(300).
+				RequeueState(ptr.To[int32](1), ptr.To(metav1.NewTime(now.Add(time.Hour)))).
+				Condition(metav1.Condition{
+					Type:   kueue.WorkloadRequeued,
+					Status: metav1.ConditionFalse,
+					Reason: kueue.WorkloadEvictedByPodsReadyTimeout,
+				}).Obj(),
+			wantActiveWorkloads:       0,
+			wantInadmissibleWorkloads: 1,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(now))
+
+			wl := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).
+				Creation(now).Generation(1).Obj()
+			cq.PushOrUpdate(workload.NewInfo(wl))
+
+			head := cq.Pop()
+			if head == nil {
+				t.Fatal("expected to pop workload")
+			}
+
+			// Simulate RequeueWorkload with info.Update: inadmissible entry gets new generation.
+			updatedInfo := workload.NewInfo(tc.updatedWorkload)
+			updatedInfo.LastEvaluatedGeneration = head.LastEvaluatedGeneration
+			cq.requeueIfNotPresent(updatedInfo, false)
+
+			// PushOrUpdate from informer event with the updated workload.
+			cq.PushOrUpdate(workload.NewInfo(tc.updatedWorkload))
+
+			if active, _ := cq.Dump(); len(active) != tc.wantActiveWorkloads {
+				t.Errorf("got %d active workloads, want %d", len(active), tc.wantActiveWorkloads)
+			}
+			if inadmissible, _ := cq.DumpInadmissible(); len(inadmissible) != tc.wantInadmissibleWorkloads {
+				t.Errorf("got %d inadmissible workloads, want %d", len(inadmissible), tc.wantInadmissibleWorkloads)
+			}
+		})
+	}
+}
+
 func Test_Delete(t *testing.T) {
 	ctx, log := utiltesting.ContextWithLog(t)
 	cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(time.Now()))

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -197,6 +197,11 @@ type Info struct {
 
 	// SecondPassIteration indicates the current iteration of the second pass scheduling.
 	SecondPassIteration int
+
+	// LastEvaluatedGeneration stores the Obj.Generation at the time the scheduler
+	// popped this workload for evaluation. Used by PushOrUpdate to detect spec
+	// changes masked by RequeueWorkload's info.Update.
+	LastEvaluatedGeneration int64
 }
 
 type PodSetResources struct {


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubernetes-sigs/kueue/pull/9661

/assign sohankunkerkar
```release-note
Scheduling: Fix a race where updated workload priority could remain stuck in the inadmissible queue and delay rescheduling.
```