### PR TITLE
Automated cherry pick of #8963: TAS: support ResourceTransformations

### DIFF
--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -41,6 +41,10 @@ func NewRequests(rl corev1.ResourceList) Requests {
 	return r
 }
 
+func NewRequestsFromPodSpec(podSpec *corev1.PodSpec) Requests {
+	return NewRequests(resourcehelpers.PodRequests(&corev1.Pod{Spec: *podSpec}, resourcehelpers.PodResourcesOptions{}))
+}
+
 // NewRequestsFromPodTemplate computes resource requests directly from a PodTemplateSpec,
 // bypassing quota filtering. Use for physical placement calculations.
 func NewRequestsFromPodTemplate(template *corev1.PodTemplateSpec) Requests {

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -74,7 +74,7 @@ type Assignment struct {
 }
 
 // UpdateForTASResult updates the Assignment with the TAS result
-func (a *Assignment) UpdateForTASResult(result schdcache.TASAssignmentsResult) {
+func (a *Assignment) UpdateForTASResult(cq *schdcache.ClusterQueueSnapshot, result schdcache.TASAssignmentsResult) {
 	for psName, psResult := range result {
 		psAssignment := a.podSetAssignmentByName(psName)
 		psAssignment.TopologyAssignment = psResult.TopologyAssignment
@@ -82,19 +82,32 @@ func (a *Assignment) UpdateForTASResult(result schdcache.TASAssignmentsResult) {
 			psAssignment.DelayedTopologyRequest = ptr.To(kueue.DelayedTopologyRequestStateReady)
 		}
 	}
-	a.Usage.TAS = a.ComputeTASNetUsage(nil)
+	a.Usage.TAS = a.ComputeTASNetUsage(cq, nil)
 }
 
 // ComputeTASNetUsage computes the net TAS usage for the assignment
-func (a *Assignment) ComputeTASNetUsage(prevAdmission *kueue.Admission) workload.TASUsage {
+func (a *Assignment) ComputeTASNetUsage(cq *schdcache.ClusterQueueSnapshot, prevAdmission *kueue.Admission) workload.TASUsage {
 	result := make(workload.TASUsage)
 	for i, psa := range a.PodSets {
 		if psa.TopologyAssignment != nil {
 			if prevAdmission != nil && prevAdmission.PodSetAssignments[i].TopologyAssignment != nil {
 				continue
 			}
-			singlePodRequests := resources.NewRequests(psa.Requests).ScaledDown(int64(psa.Count))
+			tasRequests := make(corev1.ResourceList, len(psa.Requests))
+			for resourceName, quantity := range psa.Requests {
+				flv := psa.Flavors[resourceName]
+				if flv == nil || cq.TASFlavors[flv.Name] == nil {
+					// This is the quota-only resources, skip when computing TAS usage.
+					continue
+				}
+				tasRequests[resourceName] = quantity
+			}
+			singlePodRequests := resources.NewRequests(tasRequests).ScaledDown(int64(psa.Count))
 			for _, flv := range psa.Flavors {
+				if cq.TASFlavors[flv.Name] == nil {
+					// This is a quota-only flavor, skip when computing TAS usage.
+					continue
+				}
 				if _, ok := result[flv.Name]; !ok {
 					result[flv.Name] = make(workload.TASFlavorUsage, 0)
 				}
@@ -678,7 +691,7 @@ func (a *FlavorAssigner) assignFlavors(log logr.Logger, counts []int32) Assignme
 				assignment.representativeMode = ptr.To(Preempt)
 			} else {
 				// All PodSets fit, we just update the TopologyAssignments
-				assignment.UpdateForTASResult(result)
+				assignment.UpdateForTASResult(a.cq, result)
 			}
 		}
 		if assignment.RepresentativeMode() == Preempt && !workload.HasUnhealthyNodes(a.wl.Obj) {
@@ -778,7 +791,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 		attemptedFlavorIdx = idx
 		fName := resourceGroup.Flavors[idx]
 
-		if flavorStatus := a.checkFlavorForPodSets(log, fName, psIDs, podSets, selectors); !flavorStatus.IsFit() {
+		if flavorStatus := a.checkFlavorForPodSets(log, fName, psIDs, podSets, selectors, resourceGroup); !flavorStatus.IsFit() {
 			status.reasons = append(status.reasons, flavorStatus.reasons...)
 			consideredFlavors.AddNoFitFlavorAttempt(fName, flavorStatus)
 			if flavorStatus.err != nil {
@@ -885,6 +898,7 @@ func (a *FlavorAssigner) checkFlavorForPodSets(
 	psIDs []int,
 	podSets []*kueue.PodSet,
 	selectors []nodeaffinity.RequiredNodeAffinity,
+	rg *schdcache.ResourceGroup,
 ) *Status {
 	status := NewStatus()
 
@@ -898,7 +912,7 @@ func (a *FlavorAssigner) checkFlavorForPodSets(
 	for psIdx, psID := range psIDs {
 		if features.Enabled(features.TopologyAwareScheduling) {
 			ps := &a.wl.Obj.Spec.PodSets[psID]
-			if message := checkPodSetAndFlavorMatchForTAS(a.cq, ps, flavor); message != nil {
+			if message := checkPodSetAndFlavorMatchForTAS(a.cq, ps, flavor, rg); message != nil {
 				log.Error(nil, *message)
 				status.appendf("%s", *message)
 				return status

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -3980,7 +3980,7 @@ func TestWorkloadsTopologyRequests_ErrorBranches(t *testing.T) {
 			}),
 			wantErr: "workload requires Topology, but there is no TAS cache information",
 		},
-		"workload requires Topology, but there is no TAS cache information for the assigned flavor": {
+		"workload requires Topology, but there is no TAS flavor assigned": {
 			cq: schdcache.ClusterQueueSnapshot{
 				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{"tas": nil},
 			},
@@ -4004,7 +4004,7 @@ func TestWorkloadsTopologyRequests_ErrorBranches(t *testing.T) {
 					},
 				},
 			}),
-			wantErr: "workload requires Topology, but there is no TAS cache information for the assigned flavor",
+			wantErr: "no TAS flavor assigned",
 		},
 	}
 

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -19,8 +19,12 @@ package flavorassigner
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
+	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -73,7 +77,7 @@ func podSetTopologyRequest(psAssignment *PodSetAssignment,
 		return nil, errors.New("workload requires Topology, but there is no TAS cache information")
 	}
 	podCount := psAssignment.Count
-	tasFlvr, err := onlyFlavor(psAssignment.Flavors)
+	tasFlvr, err := onlyTASFlavor(psAssignment.Flavors, cq.TASFlavors)
 	if err != nil {
 		return nil, err
 	}
@@ -82,9 +86,6 @@ func podSetTopologyRequest(psAssignment *PodSetAssignment,
 		// For ProvisioningRequest, delay TAS on first scheduling pass only (topology assigned after provisioning).
 		psAssignment.DelayedTopologyRequest = ptr.To(kueue.DelayedTopologyRequestStatePending)
 		return nil, nil
-	}
-	if cq.TASFlavors[*tasFlvr] == nil {
-		return nil, errors.New("workload requires Topology, but there is no TAS cache information for the assigned flavor")
 	}
 	podSet := &wl.Obj.Spec.PodSets[podSetIndex]
 	// Use PodSpec directly for TAS placement, not quota-filtered admission values.
@@ -115,22 +116,35 @@ func podSetTopologyRequest(psAssignment *PodSetAssignment,
 	}, nil
 }
 
-func onlyFlavor(ra ResourceAssignment) (*kueue.ResourceFlavorReference, error) {
-	var result *kueue.ResourceFlavorReference
-	for _, v := range ra {
-		if result == nil {
-			result = &v.Name
-		} else if *result != v.Name {
-			return nil, fmt.Errorf("more than one flavor assigned: %s, %s", v.Name, *result)
+func onlyTASFlavor(
+	resourceAssignment ResourceAssignment,
+	tasFlavors map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot,
+) (*kueue.ResourceFlavorReference, error) {
+	flavors := sets.New[kueue.ResourceFlavorReference]()
+
+	for _, flavorAssignment := range resourceAssignment {
+		if tasFlavors[flavorAssignment.Name] != nil {
+			flavors.Insert(flavorAssignment.Name)
 		}
 	}
-	if result != nil {
-		return result, nil
+
+	if flavors.Len() == 0 {
+		return nil, errors.New("no TAS flavor assigned")
 	}
-	return nil, errors.New("no flavor assigned")
+
+	if flavors.Len() == 1 {
+		return ptr.To(sets.List(flavors)[0]), nil
+	}
+
+	list := sets.List(flavors)
+	names := make([]string, len(list))
+	for i, n := range list {
+		names[i] = string(n)
+	}
+	return nil, fmt.Errorf("more than one TAS flavor assigned: %s", strings.Join(names, ", "))
 }
 
-func checkPodSetAndFlavorMatchForTAS(cq *schdcache.ClusterQueueSnapshot, ps *kueue.PodSet, flavor *kueue.ResourceFlavor) *string {
+func checkPodSetAndFlavorMatchForTAS(cq *schdcache.ClusterQueueSnapshot, ps *kueue.PodSet, flavor *kueue.ResourceFlavor, rg *schdcache.ResourceGroup) *string {
 	if isTASRequested(ps, cq) {
 		if isTASImplied(ps, cq) {
 			// If this is a TAS-only CQ, then we don't need to check the flavor because
@@ -140,6 +154,12 @@ func checkPodSetAndFlavorMatchForTAS(cq *schdcache.ClusterQueueSnapshot, ps *kue
 		}
 		// PodSet explicitly requires TAS, so we need to check if the flavor supports it.
 		if flavor.Spec.TopologyName == nil {
+			if !hasOverlapWithPodRequestedResources(ps, rg.CoveredResources) {
+				// We only accept the flavor if it does not have any intersection with
+				// the resources which are going to be provided by the TAS flavor.
+				// This flavor may still provide quota-only resources using ResourceTransformations.
+				return nil
+			}
 			return ptr.To(fmt.Sprintf("Flavor %q does not support TopologyAwareScheduling", flavor.Name))
 		}
 		s := cq.TASFlavors[kueue.ResourceFlavorReference(flavor.Name)]
@@ -162,6 +182,12 @@ func checkPodSetAndFlavorMatchForTAS(cq *schdcache.ClusterQueueSnapshot, ps *kue
 	}
 	// PodSet doesn't require TAS and the flavor doesn't support it, so it's a match.
 	return nil
+}
+
+// hasOverlapWithPodRequestedResources checks if the PodSet's resource requests overlap with the specified flavor resources.
+func hasOverlapWithPodRequestedResources(ps *kueue.PodSet, flavorResources sets.Set[corev1.ResourceName]) bool {
+	requests := resources.NewRequestsFromPodSpec(&ps.Template.Spec)
+	return flavorResources.HasAny(slices.Collect(maps.Keys(requests))...)
 }
 
 // isTASImplied returns true if TAS is requested implicitly.

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -491,7 +491,7 @@ func resourcesToReserve(e *entry, cq *schdcache.ClusterQueueSnapshot) workload.U
 func netUsage(e *entry, netQuota resources.FlavorResourceQuantities) workload.Usage {
 	result := workload.Usage{}
 	if features.Enabled(features.TopologyAwareScheduling) {
-		result.TAS = e.assignment.ComputeTASNetUsage(e.Obj.Status.Admission)
+		result.TAS = e.assignment.ComputeTASNetUsage(e.clusterQueueSnapshot, e.Obj.Status.Admission)
 	}
 	if !workload.HasQuotaReservation(e.Obj) {
 		result.Quota = netQuota
@@ -632,7 +632,7 @@ func updateAssignmentForTAS(snapshot *schdcache.Snapshot, cq *schdcache.ClusterQ
 			// assuming the cluster is empty.
 			tasResult = cq.FindTopologyAssignmentsForWorkload(tasRequests, schdcache.WithSimulateEmpty(true))
 		}
-		assignment.UpdateForTASResult(tasResult)
+		assignment.UpdateForTASResult(cq, tasResult)
 	}
 }
 

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -34,9 +34,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
+	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
@@ -56,6 +58,8 @@ import (
 func TestScheduleForTAS(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	const (
+		cpuCredits = "cpu_credits"
+
 		tasBlockLabel = "cloud.com/topology-block"
 		tasRackLabel  = "cloud.provider.com/rack"
 	)
@@ -196,6 +200,7 @@ func TestScheduleForTAS(t *testing.T) {
 		Levels(tasBlockLabel, tasRackLabel, corev1.LabelHostname).
 		Obj()
 	defaultFlavor := *utiltestingapi.MakeResourceFlavor("default").Obj()
+	creditsFlavor := *utiltestingapi.MakeResourceFlavor("credits").Obj()
 	defaultTASFlavor := *utiltestingapi.MakeResourceFlavor("tas-default").
 		NodeLabel("tas-node", "true").
 		TopologyName("tas-single-level").
@@ -244,14 +249,15 @@ func TestScheduleForTAS(t *testing.T) {
 	}
 	eventIgnoreMessage := cmpopts.IgnoreFields(utiltesting.EventRecord{}, "Message")
 	cases := map[string]struct {
-		nodes           []corev1.Node
-		pods            []corev1.Pod
-		topologies      []kueue.Topology
-		admissionChecks []kueue.AdmissionCheck
-		resourceFlavors []kueue.ResourceFlavor
-		clusterQueues   []kueue.ClusterQueue
-		workloads       []kueue.Workload
-		patchStatusErr  error
+		resourceTransformations []config.ResourceTransformation
+		nodes                   []corev1.Node
+		pods                    []corev1.Pod
+		topologies              []kueue.Topology
+		admissionChecks         []kueue.AdmissionCheck
+		resourceFlavors         []kueue.ResourceFlavor
+		clusterQueues           []kueue.ClusterQueue
+		workloads               []kueue.Workload
+		patchStatusErr          error
 
 		// wantNewAssignments is a summary of all new admissions in the cache after this cycle.
 		wantNewAssignments map[workload.Reference]kueue.Admission
@@ -2783,6 +2789,92 @@ func TestScheduleForTAS(t *testing.T) {
 				utiltesting.MakeEventRecord("default", "foo", "Admitted", corev1.EventTypeNormal).Obj(),
 			},
 		},
+		"workload with Resource Transformation (Retain CPU → cpu_credits)": {
+			resourceTransformations: []config.ResourceTransformation{{
+				Input:    corev1.ResourceCPU,
+				Strategy: ptr.To(config.Retain),
+				Outputs:  corev1.ResourceList{cpuCredits: resource.MustParse("1")},
+			}},
+			nodes:           defaultSingleNode,
+			topologies:      []kueue.Topology{defaultSingleLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{defaultTASFlavor, creditsFlavor},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("tas-main").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(defaultTASFlavor.Name).
+							Resource(corev1.ResourceCPU, "1").Obj(),
+					).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(creditsFlavor.Name).
+							Resource("cpu_credits", "1").Obj(),
+					).
+					Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("foo", "default").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					Obj(),
+			},
+			wantNewAssignments: map[workload.Reference]kueue.Admission{
+				"default/foo": *utiltestingapi.MakeAdmission("tas-main").
+					PodSets(utiltestingapi.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(defaultTASFlavor.Name), "1000m").
+						Assignment(cpuCredits, kueue.ResourceFlavorReference(creditsFlavor.Name), "1000m").
+						TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
+						Obj()).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "foo", "QuotaReserved", corev1.EventTypeNormal).
+					Message("Quota reserved in ClusterQueue tas-main, wait time since queued was 9223372037s").Obj(),
+				utiltesting.MakeEventRecord("default", "foo", "Admitted", corev1.EventTypeNormal).
+					Message("Admitted by ClusterQueue tas-main, wait time since reservation was 0s").Obj(),
+			},
+		},
+		"workload with Resource Transformation (Retain CPU → cpu_credits, not enough credits)": {
+			resourceTransformations: []config.ResourceTransformation{{
+				Input:    corev1.ResourceCPU,
+				Strategy: ptr.To(config.Retain),
+				Outputs:  corev1.ResourceList{cpuCredits: resource.MustParse("1")},
+			}},
+			nodes:           defaultSingleNode,
+			topologies:      []kueue.Topology{defaultSingleLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{defaultTASFlavor, creditsFlavor},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("tas-main").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(defaultTASFlavor.Name).
+							Resource(corev1.ResourceCPU, "2").Obj(),
+					).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(creditsFlavor.Name).
+							Resource("cpu_credits", "1").Obj(),
+					).
+					Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("foo", "default").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "2").
+						Obj()).
+					Obj(),
+			},
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"tas-main": {"default/foo"},
+			},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "foo", "Pending", corev1.EventTypeWarning).
+					Message("couldn't assign flavors to pod set one: insufficient quota for cpu_credits in flavor credits, previously considered podsets requests (0) + current podset request (2) > maximum capacity (1)").Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		for _, enabled := range []bool{false, true} {
@@ -2822,9 +2914,10 @@ func TestScheduleForTAS(t *testing.T) {
 				_ = tasindexer.SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder))
 				cl := clientBuilder.Build()
 				recorder := &utiltesting.EventRecorder{}
-				cqCache := schdcache.New(cl)
+				cqCache := schdcache.New(cl, schdcache.WithResourceTransformations(tc.resourceTransformations))
 				fakeClock := testingclock.NewFakeClock(now)
-				qManager := qcache.NewManagerForUnitTests(cl, cqCache, qcache.WithClock(fakeClock))
+				qManager := qcache.NewManagerForUnitTests(cl, cqCache,
+					qcache.WithClock(fakeClock), qcache.WithResourceTransformations(tc.resourceTransformations))
 				topologyByName := slices.ToMap(tc.topologies, func(i int) (kueue.TopologyReference, kueue.Topology) {
 					return kueue.TopologyReference(tc.topologies[i].Name), tc.topologies[i]
 				})

--- a/test/integration/singlecluster/tas/suite_test.go
+++ b/test/integration/singlecluster/tas/suite_test.go
@@ -76,7 +76,7 @@ var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
 })
 
-func managerSetup(resourceTransformations []config.ResourceTransformation) func(ctx context.Context, mgr manager.Manager) {
+func managerSetup(resourceTransformations ...config.ResourceTransformation) func(ctx context.Context, mgr manager.Manager) {
 	return func(ctx context.Context, mgr manager.Manager) {
 		err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -61,7 +61,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 	)
 
 	ginkgo.BeforeAll(func() {
-		fwk.StartManager(ctx, cfg, managerSetup(nil))
+		fwk.StartManager(ctx, cfg, managerSetup())
 	})
 
 	ginkgo.AfterAll(func() {
@@ -783,7 +783,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("restart controllers", func() {
 					fwk.StopManager(ctx)
-					fwk.StartManager(ctx, cfg, managerSetup(nil))
+					fwk.StartManager(ctx, cfg, managerSetup())
 				})
 
 				ginkgo.By("verify wl2 is still not admitted", func() {
@@ -3565,7 +3565,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("restart Kueue manager", func() {
 					fwk.StopManager(ctx)
-					fwk.StartManager(ctx, cfg, managerSetup(nil))
+					fwk.StartManager(ctx, cfg, managerSetup())
 				})
 
 				ginkgo.By("verify admission for the workload", func() {
@@ -4628,11 +4628,11 @@ var _ = ginkgo.Describe("Topology Aware Scheduling – Resource Transformation: 
 
 	ginkgo.BeforeAll(func() {
 		// Starts the manager with a single retain transformation: 1 CPU → 1 cpu_credits
-		fwk.StartManager(ctx, cfg, managerSetup([]config.ResourceTransformation{{
+		fwk.StartManager(ctx, cfg, managerSetup(config.ResourceTransformation{
 			Input:    corev1.ResourceCPU,
 			Strategy: ptr.To(config.Retain),
 			Outputs:  corev1.ResourceList{cpuCredits: resource.MustParse("1")},
-		}}))
+		}))
 	})
 
 	ginkgo.AfterAll(func() {


### PR DESCRIPTION
Cherry pick of #8963 on release-0.16.

#8963: TAS: support ResourceTransformations

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
TAS: support ResourceTransformations to define "virtual" resources which allow putting a cap on
some "virtual" credits across multiple-flavors, see [sharing quotas](https://kueue.sigs.k8s.io/docs/tasks/manage/share_quotas_across_flavors/) for quota-only resources.
This is considered a bug since there was no validation preventing such configuration before.
```