### PR TITLE
Self-nominate kshalot as reviewer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -12,6 +12,7 @@ aliases:
     - kannon92
     - pajakd
     - olekzabl
+    - kshalot
   dependency-approvers:
     - mbobrovskyi
     - pbundyra


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
- [x] Member for at least 3 months https://github.com/kubernetes/org/issues/6023:
    * Technically, I'm a few days short, but I was told to self-nominate anyway.
- [x] Primary reviewer for at least 5 PRs to the codebase. "Assigned" to [8 PRs](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+reviewed-by%3Akshalot+-author%3Akshalot+assignee%3Akshalot), including:
    * https://github.com/kubernetes-sigs/kueue/pull/8246
    * https://github.com/kubernetes-sigs/kueue/pull/8563
    * https://github.com/kubernetes-sigs/kueue/pull/9340
    * https://github.com/kubernetes-sigs/kueue/pull/9619
- [x]  Reviewed or merged at least 20 substantial PRs to the codebase:
    * [35 merged PRs in total](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+author%3Akshalot+is%3Aclosed+is%3Amerged).
        * [23 of which were >=`size/M`](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+author%3Akshalot+is%3Aclosed+is%3Amerged+-label%3Asize%2FXS+-label%3Asize%2FS).
        * Including two KEPs ([1](https://github.com/kubernetes-sigs/kueue/pull/7311), [2](https://github.com/kubernetes-sigs/kueue/pull/8985))
    * [40 reviewed PRs in total](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+reviewed-by%3Akshalot+-author%3Akshalot).
        * [36 of which were >=`size/M`](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+reviewed-by%3Akshalot+-author%3Akshalot+-label%3Asize%2FXS+-label%3Asize%2FS).
        * [26 of which were >=`size/L`](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+reviewed-by%3Akshalot+-author%3Akshalot+-label%3Asize%2FXS+-label%3Asize%2FS+-label%3Asize%2FM)
    
#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```