### PR TITLE
feat: graduate localqueuemetrics to beta

### DIFF
--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -37,7 +37,6 @@ import (
 	queueafs "sigs.k8s.io/kueue/pkg/cache/queue/afs"
 	utilindexer "sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/dra"
-	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	afs "sigs.k8s.io/kueue/pkg/util/admissionfairsharing"
 	"sigs.k8s.io/kueue/pkg/util/queue"
@@ -479,7 +478,9 @@ func (m *Manager) DeleteLocalQueue(log logr.Logger, q *kueue.LocalQueue) {
 		cq.DeleteFromLocalQueue(log, qImpl, m.roleTracker, m.customLabels)
 		cq.deleteLocalQueue(key)
 	}
-	clearLQMetrics(key)
+	if m.lqMetrics.IsEnabled() {
+		clearLQMetrics(key)
+	}
 	delete(m.localQueues, key)
 }
 
@@ -876,7 +877,7 @@ func (m *Manager) ResyncGaugeMetrics() {
 		reportCQPendingWorkloads(m, cq)
 		reportCQFinishedWorkloads(cq, m.roleTracker, m.customLabels)
 	}
-	if features.Enabled(features.LocalQueueMetrics) {
+	if m.lqMetrics.IsEnabled() {
 		for _, lq := range m.localQueues {
 			reportLQPendingWorkloads(m, lq)
 			reportLQFinishedWorkloads(m, lq)

--- a/pkg/cache/queue/metrics.go
+++ b/pkg/cache/queue/metrics.go
@@ -18,7 +18,6 @@ package queue
 
 import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/util/queue"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
@@ -33,7 +32,7 @@ func reportPendingWorkloads(m *Manager, cqRef kueue.ClusterQueueReference) {
 	}
 	reportCQPendingWorkloads(m, cq)
 
-	if !features.Enabled(features.LocalQueueMetrics) {
+	if !m.lqMetrics.IsEnabled() {
 		return
 	}
 	for _, lq := range m.localQueues {
@@ -91,9 +90,6 @@ func clearCQMetrics(cqRef kueue.ClusterQueueReference) {
 }
 
 func clearLQMetrics(lqRef queue.LocalQueueReference) {
-	if !features.Enabled(features.LocalQueueMetrics) {
-		return
-	}
 	namespace, lqName := queue.MustParseLocalQueueReference(lqRef)
 	metrics.ClearLocalQueueMetrics(metrics.LocalQueueReference{
 		Name:      lqName,

--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -501,7 +501,7 @@ func (c *Cache) DeleteClusterQueue(cq *kueue.ClusterQueue) {
 	if curCq == nil {
 		return
 	}
-	if features.Enabled(features.LocalQueueMetrics) {
+	if c.lqMetrics.IsEnabled() {
 		for _, q := range curCq.localQueues {
 			namespace, lqName := queue.MustParseLocalQueueReference(q.key)
 			metrics.ClearLocalQueueCacheMetrics(metrics.LocalQueueReference{

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -629,7 +629,7 @@ func (c *clusterQueue) addLocalQueue(q *kueue.LocalQueue, customLabelValues []st
 
 func (c *clusterQueue) deleteLocalQueue(q *kueue.LocalQueue) {
 	qKey := queueKey(q)
-	if features.Enabled(features.LocalQueueMetrics) {
+	if c.lqMetrics.IsEnabled() {
 		namespace, lqName := queue.MustParseLocalQueueReference(qKey)
 		metrics.ClearLocalQueueCacheMetrics(metrics.LocalQueueReference{
 			Name:      lqName,

--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -266,7 +266,7 @@ func (r *LocalQueueReconciler) Create(e event.TypedCreateEvent[*kueue.LocalQueue
 }
 
 func (r *LocalQueueReconciler) Delete(e event.TypedDeleteEvent[*kueue.LocalQueue]) bool {
-	if features.Enabled(features.LocalQueueMetrics) {
+	if r.lqMetrics.IsEnabled() {
 		metrics.ClearLocalQueueResourceMetrics(localQueueReferenceFromLocalQueue(e.Object))
 	}
 	if afs.Enabled(r.admissionFSConfig) {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -388,6 +388,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	LocalQueueMetrics: {
 		{Version: version.MustParse("0.10"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.17"), Default: true, PreRelease: featuregate.Beta},
 	},
 	LocalQueueDefaulting: {
 		{Version: version.MustParse("0.10"), Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/metrics/localqueue.go
+++ b/pkg/metrics/localqueue.go
@@ -63,16 +63,23 @@ func NewLocalQueueMetricsConfig(cfg *configapi.LocalQueueMetrics) *LocalQueueMet
 	return lqMetricsConfig
 }
 
+// IsEnabled reports whether LocalQueue metric reporting is enabled or not,
+// regardless of label configuration.
+func (cfg *LocalQueueMetricsConfig) IsEnabled() bool {
+	return features.Enabled(features.LocalQueueMetrics) && (cfg == nil || cfg.Enabled)
+}
+
 // ShouldExposeLocalQueueMetrics determines if a specific LocalQueue should report metrics
 // based on the global configuration.
 func (cfg *LocalQueueMetricsConfig) ShouldExposeLocalQueueMetrics(lqLabels map[string]string) bool {
-	if cfg == nil {
-		return true
-	}
-	return features.Enabled(features.LocalQueueMetrics) && cfg.Enabled && cfg.QueueSelector.Matches(labels.Set(lqLabels))
+	return cfg.IsEnabled() && (cfg == nil || cfg.QueueSelector.Matches(labels.Set(lqLabels)))
 }
 
+// ShouldExposeLocalQueueMetricsForWorkload detemines if LocalQueue metric reporting should be made for the associated LocalQueue.
 func (cfg *LocalQueueMetricsConfig) ShouldExposeLocalQueueMetricsForWorkload(log logr.Logger, lqLabelStorage LocalQueueLabelStorage, wl *kueue.Workload) bool {
+	if !cfg.IsEnabled() {
+		return false
+	}
 	if wl.Status.Admission == nil {
 		log.V(5).Info("WARNING: cannot expose local queue metrics of workload without status.Admission", "workload", wl)
 		return false

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -121,6 +121,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.10"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.17"
 - name: ManagedJobsNamespaceSelectorAlwaysRespected
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -121,6 +121,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.10"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.17"
 - name: ManagedJobsNamespaceSelectorAlwaysRespected
   versionedSpecs:
   - default: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Graduate LocalQueueMetrics featuregate to beta.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #8830 

#### Special notes for your reviewer:
Related PRs:
LocalQueueMetrics configuration: #9371

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Observability: graduated LocalQueueMetrics to Beta.
```