### PR TITLE
KEP-2724 - Update handling of pending pods for node replacement feature

### DIFF
--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -1406,27 +1406,25 @@ We introduce the `TASReplaceNodeOnNodeTaints` feature gate from v0.17 as Beta, a
 When enabled, Kueue treats tainted nodes as unhealthy. This applies to nodes with `NoExecute` taint,
 or nodes with `NoSchedule` taint where all pods of the workload running on that node are failing, terminating, or in unscheduled state.
 
-- **NoExecute**: Nodes with the `NoExecute` effect taint, that is not tolerated by the workload, are considered unhealthy.
+- **NoExecute**: Nodes with the `NoExecute` taint, that is not tolerated by the workload, are considered unhealthy.
 The pods on such nodes are expected to be terminated by the node controller. Once terminated, Kueue will attempt
 to replace the node if `TASFailedNodeReplacement` is enabled, and evict the workload if no replacement is possible.
 If `tolerationSeconds` is specified, Kueue waits for the duration before treating the node as unhealthy.
-- **NoSchedule**: Nodes with the `NoSchedule` effect taint, that is not tolerated by the workload, are considered unhealthy
+- **NoSchedule**: Nodes with the `NoSchedule` taint, that is not tolerated by the workload, are considered unhealthy
 only if all pods of the workload that have topology assignment to that node are terminating, in the failed state,
 or if they are unscheduled. In this case, Kueue can trigger node replacement.
 
-While `NoSchedule` taint does not evict running pods (unlike `NoExecute`), Kueue triggers recovery for unscheduled or failed pods.
-Kueue also performs node replacement if pods fail or terminate after `NoSchedule` is assigned, ensuring the workload is not blocked by unschedulable Pods which are assigned to a tainted node.
+While the `NoSchedule` taint does not evict running pods (unlike `NoExecute`), Kueue triggers recovery for unscheduled or failed pods.
+Kueue also performs node replacement if pods fail or terminate after the `NoSchedule` taint is assigned, ensuring the workload is not blocked by unschedulable Pods which are assigned to a tainted node.
 
-Notably the analogous problem exists not just for Pods assigned to nodes tainted with  `NoSchedule` , but also nodes with the untolerated `NoExecute` taint, or with `NotReady` state. 
+Notably the analogous problem exists not just for Pods assigned to nodes tainted with the `NoSchedule` taint, but also nodes with the untolerated `NoExecute` taint, or in the `NotReady` state. 
 
-In order to remediate the problem, for workloads where single Node replacement is possible, the node failure controller transitions these `Pending` Pods to the `Failed` phase so that replacement Pods are created.
-
-Kueue will not terminate the Pods if there is more than one node requiring replacement, because this scenario is handled by full workload eviction.
+In order to remediate the problem, for workloads where a single Node replacement is possible, the node failure controller transitions these `Pending` Pods to the `Failed` phase so that replacement Pods are created.
 
 This ensures that the pods are re-created by the Job controller for placement on other nodes, while keeping the original
-pods in Failed state for debuggability. Without this step, the pending pods would block the creation of replacement pods.
+pods in the `Failed` state for debuggability. Without this step, the pending pods would block the creation of replacement pods.
 
-When transitioning these Pods, the controller appends the following condition:
+When transitioning the `Pending` Pods, the controller appends the following condition:
 ```yaml
 type: TerminatedByKueue
 status: True
@@ -1434,9 +1432,11 @@ reason: UnschedulableOnAssignedNode
 message: "..."
 ```
 
-In addition, Kueue emits a Normal event with reason `PodTerminated` on the Pod to inform about the termination.
+In addition, Kueue emits a Normal event with the reason `PodTerminated` on Pod termination.
 
-Nodes with `.spec.unschedulable` set to true are treated as having `NoSchedule` taint.
+Kueue will not terminate a `Pending` Pod if there is more than one node requiring replacement, because this scenario is handled by a full workload eviction.
+
+Nodes with `.spec.unschedulable` set to true are treated as having the `NoSchedule` taint.
 
 ##### User stories
 


### PR DESCRIPTION
#### What this PR does / why we need it:
The current implementation of the node replacement feature in TAS contains several bugs and race conditions that might cause problems with node replacement:

- Stuck Pending Pods: When a workload is assigned a specific topology, and a node within that topology becomes tainted or enters a NotReady state, the resulting pods are still created with node selectors pointing to that node. Consequently, the Kubernetes scheduler rightfully refuses to schedule them. This leaves the pods stuck in a `Pending` state indefinitely unless manually intervened.

- Race Conditions in Node Failure Detection: The node failure controller currently reacts to node taints or `NotReady` condition without ensuring all of a workload's pods have actually been created. Evaluating early against an empty pod list leads to falsely concluding that all pods are terminated, prematurely marking the node as unhealthy. To act predictably, the controller must first wait for a stable state where all pods have been created and settled (accounting for aspects like `tolerationSeconds`).

- Event-Driven Correctness over Polling: While establishing an initial stable state is necessary, relying on polling to manage that state is fundamentally flawed because underlying controllers act instantaneously. For example: suppose a stable state is reached where one pod is stuck in `Pending` due to a taint. The controller transitions that pod to `Failed` and proceeds to mark the node as unhealthy. Immediately, the Job controller creates a new replacement pod. Before the node replacement is fully completed, this new pod can also get stuck in `Pending` on the same tainted node. A polling-based approach will likely miss this newly created pod, leaving it orphaned and permanently "out of watch". By transitioning to an event-driven model, the controller reacts continuously to Pod events, instantly catching and handling these fast-arriving replacement pods.

- Expanded Condition Support: The original design heavily assumed these edge-cases only occurred with `NoSchedule` taints. In reality, these issues persist equally with NoExecute taints and `NotReady` states. The event-driven implementation unifies the handling of all three node conditions.
    
#### Which issue(s) this PR fixes:
Fixes #9616
    
#### Special notes for your reviewer:
    
#### Does this PR introduce a user-facing change?
```release-note
NONE
```