### PR TITLE
Fix flaky test for sticky workload

### DIFF
--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -880,7 +880,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("Create another admissible workload in queue1")
-			createWorkloadWithPriority("cq1", "2", 9)
+			secondAdmissibleWorkload := createWorkloadWithPriority("cq1", "2", 9)
 
 			ginkgo.By("Validate pending workloads")
 			util.ExpectPendingWorkloadsMetric(cq1, 2, 0)
@@ -904,14 +904,12 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 				g.Expect(cond.Message).To(gomega.ContainSubstring("insufficient quota"))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-			ginkgo.By("Validate pending workloads")
-			util.ExpectPendingWorkloadsMetric(cq1, 1, 1)
-
 			ginkgo.By("Complete preemption")
 			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cq2, 2)
 
 			ginkgo.By("Expected Total Admitted Workloads and Weighted Share")
 			util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 1)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, secondAdmissibleWorkload)
 			util.ExpectClusterQueueWeightedShareMetric(cq1, 1000)
 			util.ExpectClusterQueueWeightedShareMetric(cq2, 0.0)
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
To fix flake discovered why working on #9716. 

#### Special notes for your reviewer:

After reduction of the backoff I got flake more common at the assert `util.ExpectPendingWorkloadsMetric(cq1, 1, 1)`. However, this assert is not correct after the introduction of the asynchrnous requeueing of the workloads, because inadmissible workloads are put on the heap after 1s. The first workload, once it is put on the heap, it stays there behind the new sticky workload, and is not re-evaluated. The stable state is `util.ExpectPendingWorkloadsMetric(cq1, 2, 0)`.

So, I propose to capture the test intention by demonstrating the new  (second) workload gets admitted (after the preemptions complete), despite the first one was sticky originally.

I was running the test looped locally after the adjustment and 100 retries passed.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```