### PR TITLE
[release-0.15] Propagate contextual logger to workload.Info.Update

### DIFF
--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -478,7 +478,8 @@ func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reas
 	if q == nil {
 		return false
 	}
-	info.Update(&w)
+	log := ctrl.LoggerFrom(ctx)
+	info.Update(log, &w)
 	q.AddOrUpdate(info)
 	cq := m.hm.ClusterQueue(q.ClusterQueue)
 	if cq == nil {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -278,7 +278,8 @@ func NewInfo(w *kueue.Workload, opts ...InfoOption) *Info {
 	return info
 }
 
-func (i *Info) Update(wl *kueue.Workload) {
+func (i *Info) Update(log logr.Logger, wl *kueue.Workload) {
+	log.V(5).Info("Workload info updated", "workload", klog.KObj(wl))
 	i.Obj = wl
 }
 


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubernetes-sigs/kueue/pull/9723
/assign sohankunkerkar
```release-note
NONE
```