### PR TITLE
Propagate contextual logger to scheduling hash computation via UpdateSchedulingHash

### DIFF
--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -400,17 +400,19 @@ func (m *Manager) AddLocalQueue(ctx context.Context, q *kueue.LocalQueue) error 
 			continue
 		}
 
+		log := ctrl.LoggerFrom(ctx).WithValues("workload", klog.KObj(&w))
 		if features.Enabled(features.DynamicResourceAllocation) && workload.HasDRA(&w) {
 			if m.draReconcileChannel != nil {
 				m.draReconcileChannel <- event.TypedGenericEvent[*kueue.Workload]{Object: &w}
-				log := ctrl.LoggerFrom(ctx).WithValues("workload", klog.KObj(&w))
 				log.V(4).Info("Sent DRA workload to reconcile channel due to LocalQueue creation")
 			}
 			continue
 		}
 
 		workload.AdjustResources(ctx, m.client, &w)
-		qImpl.AddOrUpdate(workload.NewInfo(&w, m.workloadInfoOptions...))
+		wInfo := workload.NewInfo(&w, m.workloadInfoOptions...)
+		wInfo.UpdateSchedulingHash(log)
+		qImpl.AddOrUpdate(wInfo)
 	}
 
 	if cq != nil && cq.AddFromLocalQueue(qImpl, m.roleTracker) {
@@ -532,6 +534,7 @@ func (m *Manager) AddOrUpdateWorkloadWithoutLock(log logr.Logger, w *kueue.Workl
 	}
 	allOptions := append(m.workloadInfoOptions, opts...)
 	wInfo := workload.NewInfo(w, allOptions...)
+	wInfo.UpdateSchedulingHash(log)
 	m.addWorkload(wInfo, q)
 
 	cq := m.hm.ClusterQueue(q.ClusterQueue)
@@ -852,6 +855,7 @@ func (m *Manager) queueSecondPass(ctx context.Context, w *kueue.Workload, iterat
 
 	log := ctrl.LoggerFrom(ctx)
 	wInfo := workload.NewInfo(w, m.workloadInfoOptions...)
+	wInfo.UpdateSchedulingHash(log)
 	wInfo.SecondPassIteration = iteration
 	if m.secondPassQueue.queue(wInfo) {
 		log.V(3).Info("Workload queued for second pass of scheduling", "workload", workload.Key(w))

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -724,7 +724,7 @@ func TestDeleteWorkload(t *testing.T) {
 		q := manager.localQueues[queue.Key(queues[0])]
 		if diff := cmp.Diff(map[workload.Reference]*workload.Info{
 			workload.Key(wl2): workload.NewInfo(wl2),
-		}, q.items); diff != "" {
+		}, q.items, ignoreSchedulingHash); diff != "" {
 			t.Errorf("Unexpected workloads found in local queue (-want,+got):\n%s", diff)
 		}
 
@@ -775,7 +775,7 @@ func TestDeleteAndForgetWorkload(t *testing.T) {
 		q := manager.localQueues[queue.Key(queues[0])]
 		if diff := cmp.Diff(map[workload.Reference]*workload.Info{
 			workload.Key(wl2): workload.NewInfo(wl2),
-		}, q.items); diff != "" {
+		}, q.items, ignoreSchedulingHash); diff != "" {
 			t.Errorf("Unexpected workloads found in local queue (-want,+got):\n%s", diff)
 		}
 

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -457,6 +457,7 @@ func (c *clusterQueue) addOrUpdateWorkload(log logr.Logger, w *kueue.Workload) {
 		c.deleteWorkload(log, k)
 	}
 	wi := workload.NewInfo(w, c.workloadInfoOptions...)
+	wi.UpdateSchedulingHash(log)
 	c.Workloads[k] = wi
 	c.updateWorkloadUsage(log, wi, add)
 	if c.podsReadyTracking && !apimeta.IsStatusConditionTrue(w.Status.Conditions, kueue.WorkloadPodsReady) {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -288,8 +288,13 @@ func NewInfo(w *kueue.Workload, opts ...InfoOption) *Info {
 	} else {
 		info.TotalRequests = totalRequestsFromPodSets(w, &options)
 	}
-	info.SchedulingHash = computeSchedulingHash(log.Log, w, info.TotalRequests)
 	return info
+}
+
+// UpdateSchedulingHash computes and sets the scheduling hash using the
+// provided contextual logger. Call this after NewInfo in production code.
+func (i *Info) UpdateSchedulingHash(log logr.Logger) {
+	i.SchedulingHash = computeSchedulingHash(log, i.Obj, i.TotalRequests)
 }
 
 // Update refreshes the object reference and recomputes the scheduling hash
@@ -297,7 +302,7 @@ func NewInfo(w *kueue.Workload, opts ...InfoOption) *Info {
 func (i *Info) Update(log logr.Logger, wl *kueue.Workload) {
 	log.V(5).Info("Workload info updated", "workload", klog.KObj(wl))
 	i.Obj = wl
-	i.SchedulingHash = computeSchedulingHash(log, wl, i.TotalRequests)
+	i.UpdateSchedulingHash(log)
 }
 
 // computeSchedulingHash returns a deterministic hash of the workload's

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
@@ -2612,7 +2613,9 @@ func TestSchedulingHash(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			info1 := NewInfo(tc.wl1)
+			info1.UpdateSchedulingHash(logr.Discard())
 			info2 := NewInfo(tc.wl2)
+			info2.UpdateSchedulingHash(logr.Discard())
 			if info1.SchedulingHash == "" {
 				t.Error("SchedulingHash should not be empty")
 			}


### PR DESCRIPTION
Add `UpdateSchedulingHash(log)` method to workload.Info so production callers can compute the scheduling hash with a contextual logger after `NewInfo` construction. NewInfo signature stays unchanged.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/pull/9698#discussion_r2897610397

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```