### PR TITLE
Fix NodeHotSwap for multi-layer TAS topology constraints

### DIFF
--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -5825,13 +5825,15 @@ func TestFindTopologyAssignments(t *testing.T) {
 
 func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 	const (
-		tasBlockLabel = "cloud.com/topology-block"
-		tasRackLabel  = "cloud.com/topology-rack"
+		tasBlockLabel  = "cloud.com/topology-block"
+		tasRackLabel   = "cloud.com/topology-rack"
+		tasSwitchLabel = "cloud.com/topology-switch"
 	)
-	levels := []string{tasBlockLabel, tasRackLabel, corev1.LabelHostname}
+	defaultLevels := []string{tasBlockLabel, tasRackLabel, corev1.LabelHostname}
 	podSetName := kueue.PodSetReference("main")
 
 	cases := map[string]struct {
+		levels          []string
 		nodes           []corev1.Node
 		pods            []corev1.Pod
 		existingTA      *kueue.TopologyAssignment
@@ -5958,6 +5960,214 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 			// x3 is NotReady, x4 is at capacity → no node available in r2 for replacement.
 			wantReason: `topology "default" doesn't allow to fit any of 1 pod(s). Total nodes: 3; excluded: resource "cpu": 1, topologyDomain: 2`,
 		},
+		"3-layer: innermost broken domain confines replacement to correct switch": {
+			// Topology: block → rack → switch → hostname
+			//                    b1
+			//              /            \
+			//            r1              r2
+			//          /    \          /    \
+			//        s1      s2      s3      s4
+			//       / \     / \     / \     / \
+			//      x1 x2  x3 x4  x5  x6  x7  x8
+			//              ^(NotReady)
+			//
+			// Constraints: [{rack: 8}, {switch: 4}, {hostname: 2}], Required: block
+			// Initial: 16 pods (2 per host). x3 dies → tr.Count = 2.
+			//   2 % 8 ≠ 0 → rack constraint broken (outermost)
+			//   2 % 4 ≠ 0 → switch constraint broken (innermost broken)
+			//   2 % 2 = 0 → hostname constraint satisfied
+			//
+			// BUG without fix: requiredReplacementDomain uses outermost constraint
+			// (rack, constraints[0]) → domain = rack r1 ("b1,r1").
+			// belongsToRequiredDomain admits all hosts in r1 (x1, x2, x4).
+			// x1 has tighter fit (allocatable=4, 2 free) than x4
+			// (allocatable=8, 6 free) → BestFit picks x1 (in switch s1!) over x4 (in s2).
+			// Result: x1(4) — replacement lands in WRONG switch. ✗
+			//
+			// With fix: uses innermost broken constraint (switch) → domain = switch s2
+			// ("b1,r1,s2"). Only x4 is eligible. Result: x4(4). ✓
+			levels: []string{tasBlockLabel, tasRackLabel, tasSwitchLabel, corev1.LabelHostname},
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("b1-r1-s1-x1").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r1").Label(tasSwitchLabel, "s1").Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-r1-s1-x2").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r1").Label(tasSwitchLabel, "s1").Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-r1-s2-x3").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r1").Label(tasSwitchLabel, "s2").Label(corev1.LabelHostname, "x3").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourcePods: resource.MustParse("10")}).
+					NotReady().Obj(),
+				*testingnode.MakeNode("b1-r1-s2-x4").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r1").Label(tasSwitchLabel, "s2").Label(corev1.LabelHostname, "x4").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-r2-s3-x5").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r2").Label(tasSwitchLabel, "s3").Label(corev1.LabelHostname, "x5").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-r2-s3-x6").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r2").Label(tasSwitchLabel, "s3").Label(corev1.LabelHostname, "x6").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-r2-s4-x7").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r2").Label(tasSwitchLabel, "s4").Label(corev1.LabelHostname, "x7").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-r2-s4-x8").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r2").Label(tasSwitchLabel, "s4").Label(corev1.LabelHostname, "x8").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("pod-x1-a", "test-ns").NodeName("b1-r1-s1-x1").
+					Request(corev1.ResourceCPU, "1").Obj(),
+				*testingpod.MakePod("pod-x1-b", "test-ns").NodeName("b1-r1-s1-x1").
+					Request(corev1.ResourceCPU, "1").Obj(),
+				*testingpod.MakePod("pod-x2-a", "test-ns").NodeName("b1-r1-s1-x2").
+					Request(corev1.ResourceCPU, "1").Obj(),
+				*testingpod.MakePod("pod-x2-b", "test-ns").NodeName("b1-r1-s1-x2").
+					Request(corev1.ResourceCPU, "1").Obj(),
+				*testingpod.MakePod("pod-x4-a", "test-ns").NodeName("b1-r1-s2-x4").
+					Request(corev1.ResourceCPU, "1").Obj(),
+				*testingpod.MakePod("pod-x4-b", "test-ns").NodeName("b1-r1-s2-x4").
+					Request(corev1.ResourceCPU, "1").Obj(),
+				*testingpod.MakePod("pod-x5-a", "test-ns").NodeName("b1-r2-s3-x5").
+					Request(corev1.ResourceCPU, "1").Obj(),
+				*testingpod.MakePod("pod-x5-b", "test-ns").NodeName("b1-r2-s3-x5").
+					Request(corev1.ResourceCPU, "1").Obj(),
+				*testingpod.MakePod("pod-x6-a", "test-ns").NodeName("b1-r2-s3-x6").
+					Request(corev1.ResourceCPU, "1").Obj(),
+				*testingpod.MakePod("pod-x6-b", "test-ns").NodeName("b1-r2-s3-x6").
+					Request(corev1.ResourceCPU, "1").Obj(),
+				*testingpod.MakePod("pod-x7-a", "test-ns").NodeName("b1-r2-s4-x7").
+					Request(corev1.ResourceCPU, "1").Obj(),
+				*testingpod.MakePod("pod-x7-b", "test-ns").NodeName("b1-r2-s4-x7").
+					Request(corev1.ResourceCPU, "1").Obj(),
+				*testingpod.MakePod("pod-x8-a", "test-ns").NodeName("b1-r2-s4-x8").
+					Request(corev1.ResourceCPU, "1").Obj(),
+				*testingpod.MakePod("pod-x8-b", "test-ns").NodeName("b1-r2-s4-x8").
+					Request(corev1.ResourceCPU, "1").Obj(),
+			},
+			// 16 pods: 2 per host. r1: s1(x1+x2)=4 + s2(x3+x4)=4 = 8.
+			// r2: s3(x5+x6)=4 + s4(x7+x8)=4 = 8. All constraints satisfied.
+			existingTA: utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+				Domain(tas.TopologyDomainAssignment{Count: 2, Values: []string{"x1"}}).
+				Domain(tas.TopologyDomainAssignment{Count: 2, Values: []string{"x2"}}).
+				Domain(tas.TopologyDomainAssignment{Count: 2, Values: []string{"x3"}}).
+				Domain(tas.TopologyDomainAssignment{Count: 2, Values: []string{"x4"}}).
+				Domain(tas.TopologyDomainAssignment{Count: 2, Values: []string{"x5"}}).
+				Domain(tas.TopologyDomainAssignment{Count: 2, Values: []string{"x6"}}).
+				Domain(tas.TopologyDomainAssignment{Count: 2, Values: []string{"x7"}}).
+				Domain(tas.TopologyDomainAssignment{Count: 2, Values: []string{"x8"}}).
+				Obj(),
+			admissionCount: 16,
+			unhealthyNode:  "x3",
+			topologyRequest: &kueue.PodSetTopologyRequest{
+				Required: ptr.To(tasBlockLabel),
+				PodsetSliceRequiredTopologyConstraints: []kueue.PodsetSliceRequiredTopologyConstraint{
+					{Topology: tasRackLabel, Size: 8},
+					{Topology: tasSwitchLabel, Size: 4},
+					{Topology: corev1.LabelHostname, Size: 2},
+				},
+			},
+			count: 16,
+			// With fix: domain = switch s2. Only x4 eligible. x4(4). ✓
+			wantAssignment: &tas.TopologyAssignment{
+				Levels: []string{corev1.LabelHostname},
+				Domains: []tas.TopologyDomainAssignment{
+					{Count: 2, Values: []string{"x1"}},
+					{Count: 2, Values: []string{"x2"}},
+					{Count: 4, Values: []string{"x4"}},
+					{Count: 2, Values: []string{"x5"}},
+					{Count: 2, Values: []string{"x6"}},
+					{Count: 2, Values: []string{"x7"}},
+					{Count: 2, Values: []string{"x8"}},
+				},
+			},
+		},
+		"2-layer: sliceSize=2 prevents scattered single-pod placement across hosts": {
+			// Topology: block → rack → hostname
+			//       b1
+			//   /        \
+			//  r1         r2
+			//  /  \    /  |  \
+			// x1  x2  x3 x4  x5
+			//          ^(NotReady)
+			//
+			// Constraints: [{rack: 4}, {hostname: 2}], Required: block
+			// Initial: 8 pods, 2 per host on x1-x4. After x3 dies → tr.Count = 2.
+			//   2 % 4 ≠ 0 → rack constraint broken → domain = r2
+			//   2 % 2 = 0 → hostname constraint satisfied
+			//
+			// x4 and x5 each have 1 CPU free (can fit 1 pod but not 2).
+			//
+			// BUG without fix: effectiveSliceSize hardcoded to 1.
+			// sliceSize=1 places 2 individual pods. No single host fits 2,
+			// so BestFit goes to rack level and scatters: x4(1), x5(1).
+			// Hostname grouping constraint (size 2) is violated.
+			//
+			// With fix: effectiveSliceSize = 2. sliceSize=2 needs one host
+			// that can fit 2 pods. Neither x4 nor x5 can. Replacement correctly
+			// fails rather than silently violating the topology constraint.
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("b1-r1-x1").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r1").Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-r1-x2").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r1").Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-r2-x3").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r2").Label(corev1.LabelHostname, "x3").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2"), corev1.ResourcePods: resource.MustParse("10")}).
+					NotReady().Obj(),
+				*testingnode.MakeNode("b1-r2-x4").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r2").Label(corev1.LabelHostname, "x4").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("3"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-r2-x5").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r2").Label(corev1.LabelHostname, "x5").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("pod-x1-a", "test-ns").NodeName("b1-r1-x1").
+					Request(corev1.ResourceCPU, "1").Obj(),
+				*testingpod.MakePod("pod-x1-b", "test-ns").NodeName("b1-r1-x1").
+					Request(corev1.ResourceCPU, "1").Obj(),
+				*testingpod.MakePod("pod-x2-a", "test-ns").NodeName("b1-r1-x2").
+					Request(corev1.ResourceCPU, "1").Obj(),
+				*testingpod.MakePod("pod-x2-b", "test-ns").NodeName("b1-r1-x2").
+					Request(corev1.ResourceCPU, "1").Obj(),
+				*testingpod.MakePod("pod-x4-a", "test-ns").NodeName("b1-r2-x4").
+					Request(corev1.ResourceCPU, "1").Obj(),
+				*testingpod.MakePod("pod-x4-b", "test-ns").NodeName("b1-r2-x4").
+					Request(corev1.ResourceCPU, "1").Obj(),
+			},
+			existingTA: utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+				Domain(tas.TopologyDomainAssignment{Count: 2, Values: []string{"x1"}}).
+				Domain(tas.TopologyDomainAssignment{Count: 2, Values: []string{"x2"}}).
+				Domain(tas.TopologyDomainAssignment{Count: 2, Values: []string{"x3"}}).
+				Domain(tas.TopologyDomainAssignment{Count: 2, Values: []string{"x4"}}).
+				Obj(),
+			admissionCount: 8,
+			unhealthyNode:  "x3",
+			topologyRequest: &kueue.PodSetTopologyRequest{
+				Required: ptr.To(tasBlockLabel),
+				PodsetSliceRequiredTopologyConstraints: []kueue.PodsetSliceRequiredTopologyConstraint{
+					{Topology: tasRackLabel, Size: 4},
+					{Topology: corev1.LabelHostname, Size: 2},
+				},
+			},
+			count: 8,
+			// With fix: sliceSize=2, no host in r2 can fit a pair → correctly fails.
+			// Without fix: sliceSize=1, scatters x4(1)+x5(1) → wrongly succeeds.
+			wantReason: `topology "default" doesn't allow to fit any of 1 slice(s). Total nodes: 4; excluded: topologyDomain: 2`,
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -6000,8 +6210,12 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 			for i := range tc.pods {
 				tasCache.Update(&tc.pods[i], log)
 			}
+			tcLevels := tc.levels
+			if tcLevels == nil {
+				tcLevels = defaultLevels
+			}
 			tasFlavorCache := tasCache.NewTASFlavorCache(
-				topologyInformation{Levels: levels},
+				topologyInformation{Levels: tcLevels},
 				flavorInformation{TopologyName: "default"},
 			)
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -573,8 +573,23 @@ func (s *TASFlavorSnapshot) findReplacementAssignment(tr *TASPodSetRequests, exi
 	sliceSize, _ := getSliceSizeWithSinglePodAsDefault(tr.PodSet.TopologyRequest)
 	if slicesRequested(tr.PodSet.TopologyRequest) && requiredReplacementDomain != "" && (tr.Count%sliceSize != 0) {
 		trCopy.PodSet = tr.PodSet.DeepCopy()
+		// Find the innermost constraint whose size divides the number of replacement
+		// pods to preserve leaf-level grouping
+		effectiveSliceSize := int32(1)
+		var effectiveSliceTopology *string
+		constraints := tr.PodSet.TopologyRequest.PodsetSliceRequiredTopologyConstraints
+		for i := len(constraints) - 1; i >= 0; i-- {
+			if tr.Count%constraints[i].Size == 0 {
+				effectiveSliceSize = constraints[i].Size
+				effectiveSliceTopology = ptr.To(constraints[i].Topology)
+				break
+			}
+		}
 		trCopy.PodSet.TopologyRequest.PodsetSliceRequiredTopologyConstraints = nil
-		trCopy.PodSet.TopologyRequest.PodSetSliceSize = ptr.To(int32(1))
+		// PodSetSliceSize is only read when PodSetSliceRequiredTopology is also set,
+		// so both must be configured for the slice grouping to take effect.
+		trCopy.PodSet.TopologyRequest.PodSetSliceRequiredTopology = effectiveSliceTopology
+		trCopy.PodSet.TopologyRequest.PodSetSliceSize = ptr.To(effectiveSliceSize)
 	}
 	replacementAssignment, reason := s.findTopologyAssignment(trCopy, nil, assumedUsage, false, requiredReplacementDomain)
 	if reason != "" {
@@ -627,7 +642,18 @@ func (s *TASFlavorSnapshot) requiredReplacementDomain(tr *TASPodSetRequests, ta 
 
 	sliceSize, _ := getSliceSizeWithSinglePodAsDefault(tr.PodSet.TopologyRequest)
 	if slicesRequested(tr.PodSet.TopologyRequest) && (tr.Count%sliceSize != 0) {
-		return s.findIncompleteSliceDomain(tr, ta, tr.Count, sliceSize)
+		// For multi-layer constraints, find the innermost broken constraint's domain.
+		// This ensures the replacement is confined to the tightest topology level
+		// that needs repair, preserving intermediate grouping invariants.
+		constraints := tr.PodSet.TopologyRequest.PodsetSliceRequiredTopologyConstraints
+		if len(constraints) > 1 {
+			for i := len(constraints) - 1; i >= 0; i-- {
+				if tr.Count%constraints[i].Size != 0 {
+					return s.findIncompleteSliceDomain(tr, ta, tr.Count, constraints[i].Size, constraints[i].Topology)
+				}
+			}
+		}
+		return s.findIncompleteSliceDomain(tr, ta, tr.Count, sliceSize, s.sliceLevelKeyWithDefault(tr.PodSet.TopologyRequest, s.lowestLevel()))
 	}
 
 	if !isRequired(tr.PodSet.TopologyRequest) {
@@ -678,10 +704,9 @@ func deleteDomain(currentTopologyAssignment *utiltas.TopologyAssignment, unhealt
 	return noAffectedPods
 }
 
-func (s *TASFlavorSnapshot) findIncompleteSliceDomain(tr *TASPodSetRequests, ta *utiltas.TopologyAssignment, missingCount int32, sliceSize int32) utiltas.TopologyDomainID {
+func (s *TASFlavorSnapshot) findIncompleteSliceDomain(tr *TASPodSetRequests, ta *utiltas.TopologyAssignment, missingCount int32, sliceSize int32, topologyKey string) utiltas.TopologyDomainID {
 	// this function assumes that all assignments are at the hostname level
-	sliceTopologyKey := s.sliceLevelKeyWithDefault(tr.PodSet.TopologyRequest, s.lowestLevel())
-	sliceLevelIdx, found := s.resolveLevelIdx(sliceTopologyKey)
+	sliceLevelIdx, found := s.resolveLevelIdx(topologyKey)
 	if !found {
 		return ""
 	}


### PR DESCRIPTION
This fixes two issues with NodeHotSwap replacement in multi-layer topology:

1. Domain Selection (requiredReplacementDomain): When multiple slice
   constraints are configured (e.g., [{rack: 8}, {switch: 4}, {hostname: 2}]),
   the code was using only the outermost constraint to find the replacement
   domain. This could place replacements in the wrong sub-domain.

   Fix: Iterate from innermost to outermost constraint and use the first
   (innermost) broken constraint's domain to confine the search.

2. Slice Size (findReplacementAssignment): After clearing
   PodsetSliceRequiredTopologyConstraints, setting PodSetSliceSize alone
   was a dead write because getSliceSizeWithSinglePodAsDefault() requires
   PodSetSliceRequiredTopology to be set. This caused sliceSize=1, scattering
   replacement pods across hosts and violating hostname grouping constraints.

   Fix: Find the innermost satisfied constraint and set both
   PodSetSliceRequiredTopology and PodSetSliceSize to preserve leaf-level
   grouping.

Added test cases:
- 3-layer topology: validates innermost broken domain selection
- 2-layer topology: validates sliceSize prevents scattered placement

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```