### PR TITLE
Report entire objects in ginkgo reports when asserts fail

### DIFF
--- a/test/util/util.go
+++ b/test/util/util.go
@@ -92,6 +92,10 @@ var SetupLoggerGetObservedLogs = sync.OnceValue(func() *observer.ObservedLogs {
 	return observedLogs
 })
 
+func toJSON(obj any) string {
+	return format.Object(obj, 1)
+}
+
 type objAsPtr[T any] interface {
 	client.Object
 	*T
@@ -123,7 +127,7 @@ func expectObjectToBeDeletedWithTimeout[PtrT objAsPtr[T], T any](ctx context.Con
 	}
 	gomega.EventuallyWithOffset(2, func(g gomega.Gomega) {
 		newObj := PtrT(new(T))
-		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(o), newObj)).Should(utiltesting.BeNotFoundError())
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(o), newObj)).Should(utiltesting.BeNotFoundError(), "Object still exists\n%s", toJSON(newObj))
 	}, timeout, Interval).Should(gomega.Succeed())
 }
 
@@ -723,7 +727,7 @@ func ExpectPodsJustFinalized(ctx context.Context, k8sClient client.Client, keys 
 		createdPod := &corev1.Pod{}
 		gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, key, createdPod)).To(gomega.Succeed())
-			g.Expect(createdPod.Finalizers).Should(gomega.BeEmpty(), "Expected pod to be finalized")
+			g.Expect(createdPod.Finalizers).To(gomega.BeEmpty(), "Expected pod to be finalized\n%s", toJSON(createdPod))
 		}, Timeout, Interval).Should(gomega.Succeed())
 	}
 }
@@ -738,7 +742,7 @@ func ExpectPodsFinalizedOrGone(ctx context.Context, k8sClient client.Client, key
 				return
 			}
 			g.Expect(err).To(gomega.Succeed())
-			g.Expect(createdPod.Finalizers).Should(gomega.BeEmpty(), "Expected pod to be finalized")
+			g.Expect(createdPod.Finalizers).To(gomega.BeEmpty(), "Expected pod to be finalized\n%s", toJSON(createdPod))
 		}, Timeout, Interval).Should(gomega.Succeed())
 	}
 }
@@ -753,7 +757,7 @@ func ExpectWorkloadsFinalizedOrGone(ctx context.Context, k8sClient client.Client
 				return
 			}
 			g.Expect(err).To(gomega.Succeed())
-			g.Expect(createdWorkload.Finalizers).Should(gomega.BeEmpty(), "Expected workload to be finalized")
+			g.Expect(createdWorkload.Finalizers).To(gomega.BeEmpty(), "Expected workload to be finalized\n%s", toJSON(createdWorkload))
 		}, Timeout, Interval).Should(gomega.Succeed())
 	}
 }


### PR DESCRIPTION
Include full object state in failure descriptions for test helper functions in test/util/util.go. This uses gomega.HaveField for clear field-level assertions combined with json.MarshalIndent to attach the entire object to the failure report.

Starting with finalizer helpers (ExpectPodsJustFinalized, ExpectPodsFinalizedOrGone, ExpectWorkloadsFinalizedOrGone) to align on the approach before expanding to more helpers.

Ref #9360

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Improves test failure debugging by including the full object state (as JSON) in Ginkgo failure reports when assertions fail in test helper functions.

Currently, when an assertion fails (e.g., a finalizer is still present on a Pod or Workload), the failure report only shows the field value that didn't match. This makes it difficult to understand why the object is in that state. With this change, the entire object is attached to the failure report as JSON, showing all metadata, labels, annotations, finalizers, conditions, status, etc.

The approach uses:
- `gomega.HaveField` for clear field-level assertions
- `json.MarshalIndent` to attach the full object state as a failure description

Starting with finalizer helpers to align on the approach before expanding to more helpers.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  #9360

#### Special notes for your reviewer:

This PR covers 3 helper functions to start with as per @mimowo's suggestion to align on the approach first:
- `ExpectPodsJustFinalized`
- `ExpectPodsFinalizedOrGone`
- `ExpectWorkloadsFinalizedOrGone`

I considered `format.Object` (Gomega's built-in formatter) but chose `json.MarshalIndent` because it produces cleaner output -- nil/empty fields are omitted via `omitempty` tags, and the format is familiar from `kubectl get -o json`.

I also tried using `gomega.HaveField` alone, but it only reports the extracted field value in its failure message, not the entire object. The combined approach (HaveField + JSON description) provides both the field-level clarity and the full object dump.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```