### PR TITLE
fix: handle Workload creation in LWS controller to prevent race conditions during fast scaling

### DIFF
--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -360,7 +360,8 @@ type lwsWorkloadHandler struct{}
 
 var _ handler.EventHandler = (*lwsWorkloadHandler)(nil)
 
-func (h *lwsWorkloadHandler) Create(_ context.Context, _ event.CreateEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (h *lwsWorkloadHandler) Create(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	h.enqueue(ctx, e.Object, q)
 }
 
 func (h *lwsWorkloadHandler) Update(_ context.Context, _ event.UpdateEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
@@ -370,7 +371,12 @@ func (h *lwsWorkloadHandler) Generic(_ context.Context, _ event.GenericEvent, _ 
 }
 
 func (h *lwsWorkloadHandler) Delete(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	wl, ok := e.Object.(*kueue.Workload)
+	h.enqueue(ctx, e.Object, q)
+}
+
+// enqueue is a helper function to add the owning LeaderWorkerSet to the reconcile queue.
+func (h *lwsWorkloadHandler) enqueue(ctx context.Context, obj client.Object, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	wl, ok := obj.(*kueue.Workload)
 	if !ok {
 		return
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind flake
/kind integrations
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
This PR fixes a race condition in the LeaderWorkerSet (LWS) controller that occurs during rapid scale-up and scale-down operations. 

**Problem:**
When an LWS is scaled up and then immediately scaled down, the reconciler may perform an out-of-sync check because the newly created Workload hasn't reached the local informer cache yet (stale cache). Since the `Create` event handler for Workloads was missing, the controller would not be re-triggered once the Workload finally arrived in the cache, leading to orphaned "zombie" Workloads and E2E test failures (timeouts).

**Solution:**
Implemented the `Create` event handler in `lwsWorkloadHandler`. I refactored the handler to use a common `enqueue` helper function for both `Create` and `Delete` events. This ensures that the controller re-evaluates the state as soon as a new Workload is observed in the cache, maintaining eventual consistency even in high-frequency scaling scenarios.

#### Which issue(s) this PR fixes:

Fixes #9473

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```