### PR TITLE
kueueviz: add topology visualization to kueueviz dashboard

### DIFF
--- a/cmd/kueueviz/backend/handlers/api_handlers.go
+++ b/cmd/kueueviz/backend/handlers/api_handlers.go
@@ -41,6 +41,7 @@ var resourceGVRMap = map[string]schema.GroupVersionResource{
 	"localqueue":     LocalQueuesGVR(),
 	"resourceflavor": ResourceFlavorsGVR(),
 	"cohort":         CohortsGVR(),
+	"topology":       TopologiesGVR(),
 }
 
 func GetResource(dynamicClient dynamic.Interface) gin.HandlerFunc {

--- a/cmd/kueueviz/backend/handlers/gvr.go
+++ b/cmd/kueueviz/backend/handlers/gvr.go
@@ -91,3 +91,12 @@ func ResourceFlavorsGVR() schema.GroupVersionResource {
 	}
 	return resourceFlavorsGVR
 }
+
+// TopologiesGVR defines the GroupVersionResource for Topologies
+func TopologiesGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    "kueue.x-k8s.io",
+		Version:  "v1beta2",
+		Resource: "topologies",
+	}
+}

--- a/cmd/kueueviz/backend/handlers/handlers.go
+++ b/cmd/kueueviz/backend/handlers/handlers.go
@@ -60,6 +60,10 @@ func (h *Handlers) InitializeWebSocketRoutes(router gin.IRoutes) {
 	// Resource Flavors
 	router.GET("/ws/resource-flavors", h.ResourceFlavorsWebSocketHandler())
 	router.GET("/ws/resource-flavor/:flavor_name", h.ResourceFlavorDetailsWebSocketHandler())
+
+	// Topologies
+	router.GET("/ws/topologies", h.TopologiesWebSocketHandler())
+	router.GET("/ws/topology/:topology_name", h.TopologyDetailsWebSocketHandler())
 }
 
 func (h *Handlers) InitializeAPIRoutes(router gin.IRoutes, dynamicClient dynamic.Interface) {

--- a/cmd/kueueviz/backend/handlers/resource_flavors.go
+++ b/cmd/kueueviz/backend/handlers/resource_flavors.go
@@ -127,6 +127,9 @@ func (h *Handlers) fetchResourceFlavorDetails(ctx context.Context, flavorName st
 		"tolerations": flavor.Spec.Tolerations,
 		"taints":      flavor.Spec.NodeTaints,
 	}
+	if flavor.Spec.TopologyName != nil {
+		details["topologyName"] = string(*flavor.Spec.TopologyName)
+	}
 
 	// Construct the result
 	result := map[string]any{

--- a/cmd/kueueviz/backend/handlers/topologies.go
+++ b/cmd/kueueviz/backend/handlers/topologies.go
@@ -1,0 +1,228 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+	corev1 "k8s.io/api/core/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueueapi "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+)
+
+// TopologiesWebSocketHandler streams all topologies
+func (h *Handlers) TopologiesWebSocketHandler() gin.HandlerFunc {
+	return h.GenericWebSocketHandler(func(ctx context.Context) (any, error) {
+		return h.fetchTopologies(ctx)
+	})
+}
+
+// TopologyDetailsWebSocketHandler streams details for a specific topology
+func (h *Handlers) TopologyDetailsWebSocketHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		topologyName := c.Param("topology_name")
+		h.GenericWebSocketHandler(func(ctx context.Context) (any, error) {
+			return h.fetchTopologyDetails(ctx, topologyName)
+		})(c)
+	}
+}
+
+func (h *Handlers) fetchTopologies(ctx context.Context) (any, error) {
+	tl := &kueueapi.TopologyList{}
+	if err := h.client.List(ctx, tl); err != nil {
+		return nil, fmt.Errorf("error fetching topologies: %v", err)
+	}
+
+	rfl := &kueueapi.ResourceFlavorList{}
+	if err := h.client.List(ctx, rfl); err != nil {
+		return nil, fmt.Errorf("error fetching resource flavors: %v", err)
+	}
+
+	topologyFlavors := make(map[string][]string)
+	for _, rf := range rfl.Items {
+		if rf.Spec.TopologyName != nil {
+			name := string(*rf.Spec.TopologyName)
+			topologyFlavors[name] = append(topologyFlavors[name], rf.Name)
+		}
+	}
+
+	result := make([]map[string]any, 0, len(tl.Items))
+	for _, t := range tl.Items {
+		flavors := topologyFlavors[t.Name]
+		if flavors == nil {
+			flavors = []string{}
+		}
+		result = append(result, map[string]any{
+			"name":            t.Name,
+			"levelCount":      len(t.Spec.Levels),
+			"levels":          t.Spec.Levels,
+			"resourceFlavors": flavors,
+		})
+	}
+
+	return result, nil
+}
+
+func (h *Handlers) fetchTopologyDetails(ctx context.Context, topologyName string) (map[string]any, error) {
+	topology := &kueueapi.Topology{}
+	if err := h.client.Get(ctx, ctrlclient.ObjectKey{Name: topologyName}, topology); err != nil {
+		return nil, fmt.Errorf("error fetching topology %s: %v", topologyName, err)
+	}
+
+	rfl := &kueueapi.ResourceFlavorList{}
+	if err := h.client.List(ctx, rfl); err != nil {
+		return nil, fmt.Errorf("error fetching resource flavors: %v", err)
+	}
+
+	var referencingFlavors []map[string]any
+	var matchingFlavors []kueueapi.ResourceFlavor
+	for _, rf := range rfl.Items {
+		if rf.Spec.TopologyName != nil && string(*rf.Spec.TopologyName) == topologyName {
+			referencingFlavors = append(referencingFlavors, map[string]any{
+				"name": rf.Name,
+			})
+			matchingFlavors = append(matchingFlavors, rf)
+		}
+	}
+	if referencingFlavors == nil {
+		referencingFlavors = []map[string]any{}
+	}
+
+	levelKeys := make([]string, 0, len(topology.Spec.Levels))
+	for _, level := range topology.Spec.Levels {
+		levelKeys = append(levelKeys, level.NodeLabel)
+	}
+
+	domainTree, err := h.buildDomainTree(ctx, topologyName, levelKeys, matchingFlavors)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]any{
+		"name":            topologyName,
+		"levels":          topology.Spec.Levels,
+		"levelKeys":       levelKeys,
+		"resourceFlavors": referencingFlavors,
+		"domainTree":      domainTree,
+	}, nil
+}
+
+// buildDomainTree constructs a nested tree from live nodes grouped by topology level labels.
+func (h *Handlers) buildDomainTree(ctx context.Context, topologyName string, levelKeys []string, flavors []kueueapi.ResourceFlavor) (map[string]any, error) {
+	if len(levelKeys) == 0 || len(flavors) == 0 {
+		return nil, nil
+	}
+
+	nl := &corev1.NodeList{}
+	if err := h.client.List(ctx, nl); err != nil {
+		return nil, fmt.Errorf("error fetching nodes: %v", err)
+	}
+
+	// Collect nodes that match any referencing flavor and have all level labels
+	seen := make(map[string]bool)
+	var entries []nodeEntry
+
+	for _, flavor := range flavors {
+		for _, node := range nl.Items {
+			if seen[node.Name] {
+				continue
+			}
+			if !hasMatchingLabels(node.Labels, flavor.Spec.NodeLabels) {
+				continue
+			}
+			values := make([]string, 0, len(levelKeys))
+			valid := true
+			for _, key := range levelKeys {
+				v, ok := node.Labels[key]
+				if !ok {
+					valid = false
+					break
+				}
+				values = append(values, v)
+			}
+			if !valid {
+				continue
+			}
+			seen[node.Name] = true
+			entries = append(entries, nodeEntry{name: node.Name, levelValues: values})
+		}
+	}
+
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	// Build nested tree: root → level0 domains → level1 domains → ... → leaf nodes
+	root := map[string]any{
+		"name":  topologyName,
+		"level": "root",
+	}
+	insertNode(root, entries, levelKeys, 0)
+	return root, nil
+}
+
+// insertNode recursively groups nodeEntries by level values and builds children.
+func insertNode(parent map[string]any, entries []nodeEntry, levelKeys []string, depth int) {
+	if depth >= len(levelKeys) {
+		return
+	}
+
+	groups := make(map[string][]nodeEntry)
+	var order []string
+	for _, e := range entries {
+		key := e.levelValues[depth]
+		if _, exists := groups[key]; !exists {
+			order = append(order, key)
+		}
+		groups[key] = append(groups[key], e)
+	}
+
+	isLeafLevel := depth == len(levelKeys)-1
+	var children []map[string]any
+
+	for _, key := range order {
+		group := groups[key]
+		child := map[string]any{
+			"name":  key,
+			"level": levelKeys[depth],
+		}
+		if isLeafLevel {
+			var leafChildren []map[string]any
+			for _, e := range group {
+				leafChildren = append(leafChildren, map[string]any{
+					"name":  e.name,
+					"level": levelKeys[depth],
+					"value": 1,
+				})
+			}
+			child["children"] = leafChildren
+		} else {
+			insertNode(child, group, levelKeys, depth+1)
+		}
+		children = append(children, child)
+	}
+
+	parent["children"] = children
+}
+
+type nodeEntry struct {
+	name        string
+	levelValues []string
+}

--- a/cmd/kueueviz/examples/00.5-topology.yaml
+++ b/cmd/kueueviz/examples/00.5-topology.yaml
@@ -1,0 +1,161 @@
+---
+# Topology defines the hierarchy of node labels used for Topology Aware Scheduling (TAS).
+# This example models a three-level topology: block -> rack -> host.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: Topology
+metadata:
+  name: "block-rack-topology"
+spec:
+  levels:
+  - nodeLabel: "cloud.provider.com/topology-block"
+  - nodeLabel: "cloud.provider.com/topology-rack"
+  - nodeLabel: "kubernetes.io/hostname"
+
+---
+# A ResourceFlavor that references the topology above.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: "tas-flavor"
+spec:
+  nodeLabels:
+    node.kubernetes.io/instance-type: tas-node
+  topologyName: "block-rack-topology"
+
+---
+# Fake nodes to demonstrate Treemap visualization.
+# block-1/rack-1: 3 nodes (dense)
+apiVersion: v1
+kind: Node
+metadata:
+  name: "fake-node-b1-r1-h1"
+  labels:
+    node.kubernetes.io/instance-type: tas-node
+    cloud.provider.com/topology-block: block-1
+    cloud.provider.com/topology-rack: rack-1
+    kubernetes.io/hostname: fake-node-b1-r1-h1
+spec: {}
+
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: "fake-node-b1-r1-h2"
+  labels:
+    node.kubernetes.io/instance-type: tas-node
+    cloud.provider.com/topology-block: block-1
+    cloud.provider.com/topology-rack: rack-1
+    kubernetes.io/hostname: fake-node-b1-r1-h2
+spec: {}
+
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: "fake-node-b1-r1-h3"
+  labels:
+    node.kubernetes.io/instance-type: tas-node
+    cloud.provider.com/topology-block: block-1
+    cloud.provider.com/topology-rack: rack-1
+    kubernetes.io/hostname: fake-node-b1-r1-h3
+spec: {}
+
+---
+# block-1/rack-2: 2 nodes
+apiVersion: v1
+kind: Node
+metadata:
+  name: "fake-node-b1-r2-h1"
+  labels:
+    node.kubernetes.io/instance-type: tas-node
+    cloud.provider.com/topology-block: block-1
+    cloud.provider.com/topology-rack: rack-2
+    kubernetes.io/hostname: fake-node-b1-r2-h1
+spec: {}
+
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: "fake-node-b1-r2-h2"
+  labels:
+    node.kubernetes.io/instance-type: tas-node
+    cloud.provider.com/topology-block: block-1
+    cloud.provider.com/topology-rack: rack-2
+    kubernetes.io/hostname: fake-node-b1-r2-h2
+spec: {}
+
+---
+# block-2/rack-1: 2 nodes
+apiVersion: v1
+kind: Node
+metadata:
+  name: "fake-node-b2-r1-h1"
+  labels:
+    node.kubernetes.io/instance-type: tas-node
+    cloud.provider.com/topology-block: block-2
+    cloud.provider.com/topology-rack: rack-1
+    kubernetes.io/hostname: fake-node-b2-r1-h1
+spec: {}
+
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: "fake-node-b2-r1-h2"
+  labels:
+    node.kubernetes.io/instance-type: tas-node
+    cloud.provider.com/topology-block: block-2
+    cloud.provider.com/topology-rack: rack-1
+    kubernetes.io/hostname: fake-node-b2-r1-h2
+spec: {}
+
+---
+# block-2/rack-2: 1 node (sparse — shows imbalance)
+apiVersion: v1
+kind: Node
+metadata:
+  name: "fake-node-b2-r2-h1"
+  labels:
+    node.kubernetes.io/instance-type: tas-node
+    cloud.provider.com/topology-block: block-2
+    cloud.provider.com/topology-rack: rack-2
+    kubernetes.io/hostname: fake-node-b2-r2-h1
+spec: {}
+
+---
+# block-2/rack-3: 3 nodes (shows third rack only in block-2)
+apiVersion: v1
+kind: Node
+metadata:
+  name: "fake-node-b2-r3-h1"
+  labels:
+    node.kubernetes.io/instance-type: tas-node
+    cloud.provider.com/topology-block: block-2
+    cloud.provider.com/topology-rack: rack-3
+    kubernetes.io/hostname: fake-node-b2-r3-h1
+spec: {}
+
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: "fake-node-b2-r3-h2"
+  labels:
+    node.kubernetes.io/instance-type: tas-node
+    cloud.provider.com/topology-block: block-2
+    cloud.provider.com/topology-rack: rack-3
+    kubernetes.io/hostname: fake-node-b2-r3-h2
+spec: {}
+
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: "fake-node-b2-r3-h3"
+  labels:
+    node.kubernetes.io/instance-type: tas-node
+    cloud.provider.com/topology-block: block-2
+    cloud.provider.com/topology-rack: rack-3
+    kubernetes.io/hostname: fake-node-b2-r3-h3
+spec: {}

--- a/cmd/kueueviz/examples/06-tas-jobs.yaml
+++ b/cmd/kueueviz/examples/06-tas-jobs.yaml
@@ -1,0 +1,83 @@
+---
+# ClusterQueue that uses the TAS-enabled flavor.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: "tas-cluster-queue"
+spec:
+  namespaceSelector: {}
+  resourceGroups:
+  - coveredResources: ["cpu", "memory"]
+    flavors:
+    - name: "tas-flavor"
+      resources:
+      - name: "cpu"
+        nominalQuota: "4"
+      - name: "memory"
+        nominalQuota: 4Gi
+
+---
+# LocalQueue pointing to the TAS ClusterQueue.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: "tas-queue"
+  namespace: default
+spec:
+  clusterQueue: "tas-cluster-queue"
+
+---
+# Job 1: multi-pod TAS job requesting block-level affinity.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: tas-training-
+  namespace: default
+  labels:
+    kueue.x-k8s.io/queue-name: tas-queue
+spec:
+  parallelism: 3
+  completions: 3
+  suspend: true
+  template:
+    metadata:
+      annotations:
+        kueue.x-k8s.io/podset-preferred-topology: "cloud.provider.com/topology-block"
+    spec:
+      containers:
+      - name: trainer
+        image: gcr.io/google-containers/busybox:latest
+        command: ['sh', '-c', 'echo "TAS training pod running" && sleep 600']
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      restartPolicy: Never
+
+---
+# Job 2: single-pod TAS job requesting rack-level affinity.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: tas-inference-
+  namespace: default
+  labels:
+    kueue.x-k8s.io/queue-name: tas-queue
+spec:
+  parallelism: 2
+  completions: 2
+  suspend: true
+  template:
+    metadata:
+      annotations:
+        kueue.x-k8s.io/podset-required-topology: "cloud.provider.com/topology-rack"
+    spec:
+      containers:
+      - name: inference
+        image: gcr.io/google-containers/busybox:latest
+        command: ['sh', '-c', 'echo "TAS inference pod running" && sleep 600']
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+      restartPolicy: Never

--- a/cmd/kueueviz/frontend/package-lock.json
+++ b/cmd/kueueviz/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^7.3.9",
         "@mui/material": "^7.3.1",
+        "@nivo/treemap": "^0.99.0",
         "ace-builds": "^1.43.6",
         "react": "^19.2.4",
         "react-ace": "^14.0.1",
@@ -1174,6 +1175,116 @@
         }
       }
     },
+    "node_modules/@nivo/colors": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.99.0.tgz",
+      "integrity": "sha512-hyYt4lEFIfXOUmQ6k3HXm3KwhcgoJpocmoGzLUqzk7DzuhQYJo+4d5jIGGU0N/a70+9XbHIdpKNSblHAIASD3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@types/d3-color": "^3.0.0",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-scale-chromatic": "^3.0.0",
+        "d3-color": "^3.1.0",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/core": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.99.0.tgz",
+      "integrity": "sha512-olCItqhPG3xHL5ei+vg52aB6o+6S+xR2idpkd9RormTTUniZb8U2rOdcQojOojPY5i9kVeQyLFBpV4YfM7OZ9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-shape": "^3.1.6",
+        "d3-color": "^3.1.0",
+        "d3-format": "^1.4.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "d3-shape": "^3.2.0",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21",
+        "react-virtualized-auto-sizer": "^1.0.26",
+        "use-debounce": "^10.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nivo/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/text": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/text/-/text-0.99.0.tgz",
+      "integrity": "sha512-ho3oZpAZApsJNjsIL5WJSAdg/wjzTBcwo1KiHBlRGUmD+yUWO8qp7V+mnYRhJchwygtRVALlPgZ/rlcW2Xr/MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/theming": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/theming/-/theming-0.99.0.tgz",
+      "integrity": "sha512-KvXlf0nqBzh/g2hAIV9bzscYvpq1uuO3TnFN3RDXGI72CrbbZFTGzprPju3sy/myVsauv+Bb+V4f5TZ0jkYKRg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/tooltip": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.99.0.tgz",
+      "integrity": "sha512-weoEGR3xAetV4k2P6k96cdamGzKQ5F2Pq+uyDaHr1P3HYArM879Pl+x+TkU0aWjP6wgUZPx/GOBiV1Hb1JxIqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/treemap": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/treemap/-/treemap-0.99.0.tgz",
+      "integrity": "sha512-zGVQyR+e38UqUsMrsnio8Ulz7IYDZ4HpUv+iVKSYX29Fa8TS39yHGyaGXTXt6PvL6owjvdwhJ/7TQAeO/qcWaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@react-spring/core": "9.4.5 || ^9.7.2 || ^10.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-hierarchy": "^3.1.7",
+        "d3-hierarchy": "^3.1.2",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -1182,6 +1293,78 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@react-spring/animated": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-10.0.3.tgz",
+      "integrity": "sha512-7MrxADV3vaUADn2V9iYhaIL6iOWRx9nCJjYrsk2AHD2kwPr6fg7Pt0v+deX5RnCDmCKNnD6W5fasiyM8D+wzJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/shared": "~10.0.3",
+        "@react-spring/types": "~10.0.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/core": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-10.0.3.tgz",
+      "integrity": "sha512-D4DwNO68oohDf/0HG2G0Uragzb9IA1oXblxrd6MZAcBcUQG2EHUWXewjdECMPLNmQvlYVyyBRH6gPxXM5DX7DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~10.0.3",
+        "@react-spring/shared": "~10.0.3",
+        "@react-spring/types": "~10.0.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-10.0.3.tgz",
+      "integrity": "sha512-Ri2/xqt8OnQ2iFKkxKMSF4Nqv0LSWnxXT4jXFzBDsHgeeH/cHxTLupAWUwmV9hAGgmEhBmh5aONtj3J6R/18wg==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/shared": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-10.0.3.tgz",
+      "integrity": "sha512-geCal66nrkaQzUVhPkGomylo+Jpd5VPK8tPMEDevQEfNSWAQP15swHm+MCRG4wVQrQlTi9lOzKzpRoTL3CA84Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/rafz": "~10.0.3",
+        "@react-spring/types": "~10.0.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-10.0.3.tgz",
+      "integrity": "sha512-H5Ixkd2OuSIgHtxuHLTt7aJYfhMXKXT/rK32HPD/kSrOB6q6ooeiWAXkBy7L8F3ZxdkBb9ini9zP9UwnEFzWgQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/web": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.0.3.tgz",
+      "integrity": "sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~10.0.3",
+        "@react-spring/core": "~10.0.3",
+        "@react-spring/shared": "~10.0.3",
+        "@react-spring/types": "~10.0.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1585,6 +1768,54 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2337,6 +2568,149 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-time": "1 - 2"
+      }
+    },
+    "node_modules/d3-time-format/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-time-format/node_modules/d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "2"
+      }
+    },
+    "node_modules/d3-time-format/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -2866,6 +3240,15 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -3063,7 +3446,6 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.get": {
@@ -3621,6 +4003,16 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/react-virtualized-auto-sizer": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
+      "integrity": "sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -4129,6 +4521,18 @@
       "dependencies": {
         "registry-auth-token": "3.3.2",
         "registry-url": "3.1.0"
+      }
+    },
+    "node_modules/use-debounce": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.1.0.tgz",
+      "integrity": "sha512-lu87Za35V3n/MyMoEpD5zJv0k7hCn0p+V/fK2kWD+3k2u3kOCwO593UArbczg1fhfs2rqPEnHpULJ3KmGdDzvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/vary": {

--- a/cmd/kueueviz/frontend/package.json
+++ b/cmd/kueueviz/frontend/package.json
@@ -18,6 +18,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.3.9",
     "@mui/material": "^7.3.1",
+    "@nivo/treemap": "^0.99.0",
     "ace-builds": "^1.43.6",
     "react": "^19.2.4",
     "react-ace": "^14.0.1",

--- a/cmd/kueueviz/frontend/src/App.jsx
+++ b/cmd/kueueviz/frontend/src/App.jsx
@@ -27,6 +27,8 @@ import Login from './Login';
 import Navbar from './Navbar';
 import ResourceFlavorDetail from './ResourceFlavorDetail';
 import ResourceFlavors from './ResourceFlavors';
+import TopologyDetail from './TopologyDetail';
+import Topologies from './Topologies';
 import WorkloadDetail from './WorkloadDetail';
 import Workloads from './Workloads';
 import ClusterQueueDetail from './ClusterQueueDetail';
@@ -44,12 +46,14 @@ const App = () => {
           <Route path="/cluster-queues" element={<RequireAuth><ClusterQueues /></RequireAuth>} />
           <Route path="/resource-flavors" element={<RequireAuth><ResourceFlavors /></RequireAuth>} />
           <Route path="/cohorts" element={<RequireAuth><Cohorts /></RequireAuth>} />
+          <Route path="/topologies" element={<RequireAuth><Topologies /></RequireAuth>} />
 
           <Route path="/workload/:namespace/:workloadName" element={<RequireAuth><WorkloadDetail /></RequireAuth>} />
           <Route path="/local-queue/:namespace/:queueName" element={<RequireAuth><LocalQueueDetail /></RequireAuth>} />
           <Route path="/cluster-queue/:clusterQueueName" element={<RequireAuth><ClusterQueueDetail /></RequireAuth>} />
           <Route path="/resource-flavor/:flavorName" element={<RequireAuth><ResourceFlavorDetail /></RequireAuth>} />
           <Route path="/cohort/:cohortName" element={<RequireAuth><CohortDetail /></RequireAuth>} />
+          <Route path="/topology/:topologyName" element={<RequireAuth><TopologyDetail /></RequireAuth>} />
         </Routes>
       </AuthProvider>
     </Router>

--- a/cmd/kueueviz/frontend/src/Navbar.jsx
+++ b/cmd/kueueviz/frontend/src/Navbar.jsx
@@ -33,6 +33,7 @@ const Navbar = () => {
         <Button color="inherit" component={Link} to="/cluster-queues">Cluster Queues</Button>
         <Button color="inherit" component={Link} to="/cohorts">Cohorts</Button>
         <Button color="inherit" component={Link} to="/resource-flavors">Resource Flavors</Button>
+        <Button color="inherit" component={Link} to="/topologies">Topologies</Button>
         {authMode !== 'Disabled' && token && (
           <Box sx={{ ml: 'auto' }}>
             <Button color="inherit" onClick={logout}>Logout</Button>

--- a/cmd/kueueviz/frontend/src/ResourceFlavorDetail.jsx
+++ b/cmd/kueueviz/frontend/src/ResourceFlavorDetail.jsx
@@ -90,6 +90,15 @@ const ResourceFlavorDetail = () => {
         ) : (
           <Typography variant="body2">No specific tolerations.</Typography>
         )}
+
+        {details.topologyName && (
+          <>
+            <Typography variant="body1" mt={2}><strong>Topology:</strong></Typography>
+            <Typography variant="body2">
+              <Link to={`/topology/${details.topologyName}`}>{details.topologyName}</Link>
+            </Typography>
+          </>
+        )}
       </Box>
 
       {/* Display Queues Using This Flavor */}

--- a/cmd/kueueviz/frontend/src/Topologies.jsx
+++ b/cmd/kueueviz/frontend/src/Topologies.jsx
@@ -1,0 +1,100 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { Typography, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Box } from '@mui/material';
+import useWebSocket from './useWebSocket';
+import './App.css';
+import ErrorMessage from './ErrorMessage';
+import ViewYamlButton from './ViewYamlButton';
+
+const Topologies = () => {
+  const { data: topologies, error } = useWebSocket('/ws/topologies');
+  const [topologyList, setTopologyList] = useState([]);
+
+  useEffect(() => {
+    if (topologies && Array.isArray(topologies)) {
+      setTopologyList(topologies);
+    }
+  }, [topologies]);
+
+  if (error) return <ErrorMessage error={error} />;
+
+  return (
+    <Paper className="parentContainer">
+      <Typography variant="h4" gutterBottom>Topologies</Typography>
+      {topologyList.length === 0 ? (
+        <Typography>No Topologies found.</Typography>
+      ) : (
+        <TableContainer component={Paper} className="tableContainerWithBorder">
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Topology Name</TableCell>
+                <TableCell>Levels</TableCell>
+                <TableCell>Resource Flavors</TableCell>
+                <TableCell align="right">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {topologyList.map((topology) => (
+                <TableRow key={topology.name}>
+                  <TableCell>
+                    <Link to={`/topology/${topology.name}`}>{topology.name}</Link>
+                  </TableCell>
+                  <TableCell>
+                    {topology.levels && topology.levels.length > 0 ? (
+                      topology.levels.map((level, index) => (
+                        <span key={index}>
+                          {level.nodeLabel}{index < topology.levels.length - 1 ? ' → ' : ''}
+                        </span>
+                      ))
+                    ) : (
+                      'No levels'
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {topology.resourceFlavors && topology.resourceFlavors.length > 0 ? (
+                      topology.resourceFlavors.map((name, index) => (
+                        <span key={name}>
+                          <Link to={`/resource-flavor/${name}`}>{name}</Link>
+                          {index < topology.resourceFlavors.length - 1 ? ', ' : ''}
+                        </span>
+                      ))
+                    ) : (
+                      'None'
+                    )}
+                  </TableCell>
+                  <TableCell align="right">
+                    <Box display="flex" justifyContent="flex-end">
+                      <ViewYamlButton
+                        resourceType="topology"
+                        resourceName={topology.name}
+                      />
+                    </Box>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Paper>
+  );
+};
+
+export default Topologies;

--- a/cmd/kueueviz/frontend/src/TopologyDetail.jsx
+++ b/cmd/kueueviz/frontend/src/TopologyDetail.jsx
@@ -1,0 +1,137 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { useState, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { Typography, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, CircularProgress, Box } from '@mui/material';
+import { ResponsiveTreeMap } from '@nivo/treemap';
+import useWebSocket from './useWebSocket';
+import './App.css';
+import ErrorMessage from './ErrorMessage';
+
+const TopologyDetail = () => {
+  const { topologyName } = useParams();
+  const url = `/ws/topology/${topologyName}`;
+  const { data: topologyData, error } = useWebSocket(url);
+
+  const [topology, setTopology] = useState(null);
+
+  useEffect(() => {
+    if (topologyData && topologyData.name) {
+      setTopology(topologyData);
+    }
+  }, [topologyData]);
+
+  if (error) return <ErrorMessage error={error} />;
+
+  if (!topology) {
+    return (
+      <Paper className="parentContainer">
+        <Typography variant="h6">Loading...</Typography>
+        <CircularProgress />
+      </Paper>
+    );
+  }
+
+  const hasDomainTree = topology.domainTree && topology.domainTree.children && topology.domainTree.children.length > 0;
+
+  return (
+    <Paper className="parentContainer">
+      <Typography variant="h4" gutterBottom>Topology Detail: {topologyName}</Typography>
+
+      <Box mt={3} width="100%">
+        <Typography variant="h5" gutterBottom>Topology Map</Typography>
+        {hasDomainTree ? (
+          <Box sx={{ height: 400, width: '100%' }}>
+            <ResponsiveTreeMap
+              data={topology.domainTree}
+              identity="name"
+              value="value"
+              tile="squarify"
+              leavesOnly={false}
+              innerPadding={3}
+              outerPadding={6}
+              label={node => node.data.name}
+              colorBy="treeDepth"
+              borderWidth={2}
+              tooltip={({ node }) => (
+                <span style={{ padding: '4px 8px', background: 'white', border: '1px solid #ccc', borderRadius: 4 }}>
+                  {node.data.level}: {node.data.name} ({node.value} {node.value === 1 ? 'node' : 'nodes'})
+                </span>
+              )}
+            />
+          </Box>
+        ) : (
+          <Typography>No nodes found matching this topology.</Typography>
+        )}
+      </Box>
+
+      <Box mt={5} width="100%">
+        <Typography variant="h5" gutterBottom>Levels</Typography>
+        {topology.levels && topology.levels.length > 0 ? (
+          <TableContainer component={Paper} className="tableContainerWithBorder">
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Level</TableCell>
+                  <TableCell>Node Label</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {topology.levels.map((level, index) => (
+                  <TableRow key={index}>
+                    <TableCell>{index + 1}</TableCell>
+                    <TableCell>{level.nodeLabel}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        ) : (
+          <Typography>No levels defined.</Typography>
+        )}
+      </Box>
+
+      <Box mt={5} width="100%">
+        <Typography variant="h5" gutterBottom>Resource Flavors Using This Topology</Typography>
+        {topology.resourceFlavors && topology.resourceFlavors.length === 0 ? (
+          <Typography>No resource flavors reference this topology.</Typography>
+        ) : (
+          <TableContainer component={Paper} className="tableContainerWithBorder">
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Resource Flavor Name</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {topology.resourceFlavors && topology.resourceFlavors.map((rf) => (
+                  <TableRow key={rf.name}>
+                    <TableCell>
+                      <Link to={`/resource-flavor/${rf.name}`}>{rf.name}</Link>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </Box>
+    </Paper>
+  );
+};
+
+export default TopologyDetail;

--- a/cmd/kueueviz/frontend/src/WorkloadDetail.jsx
+++ b/cmd/kueueviz/frontend/src/WorkloadDetail.jsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 import React, { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom'; 
-import { Typography,  Paper, CircularProgress, Grid, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
+import { Typography,  Paper, CircularProgress, Grid, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Box } from '@mui/material';
 import useWebSocket from './useWebSocket';
 import './App.css';
 import ErrorMessage from './ErrorMessage';
@@ -98,6 +98,86 @@ const WorkloadDetail = () => {
             </TableBody>
           </Table>
         </TableContainer>
+      )}
+
+      {workload.status?.admission?.podSetAssignments?.some(ps => ps.topologyAssignment) && (
+        <Box mt={4}>
+          <Typography variant="h5" gutterBottom>Topology Assignments</Typography>
+          {workload.status.admission.podSetAssignments.map((ps) => {
+            const specPodSet = workload.spec?.podSets?.find(s => s.name === ps.name);
+            const tr = specPodSet?.topologyRequest;
+            return ps.topologyAssignment ? (
+              <Box key={ps.name} mt={2}>
+                <Typography variant="h6" gutterBottom>PodSet: {ps.name}</Typography>
+                {tr && (
+                  <Box mb={1}>
+                    {tr.required && (
+                      <Typography variant="body2">
+                        <strong>Required topology level:</strong> {tr.required}
+                      </Typography>
+                    )}
+                    {tr.preferred && (
+                      <Typography variant="body2">
+                        <strong>Preferred topology level:</strong> {tr.preferred}
+                      </Typography>
+                    )}
+                    {tr.unconstrained && (
+                      <Typography variant="body2">
+                        <strong>Topology constraint:</strong> unconstrained
+                      </Typography>
+                    )}
+                    {tr.podIndexLabel && (
+                      <Typography variant="body2">
+                        <strong>Pod index label:</strong> {tr.podIndexLabel}
+                      </Typography>
+                    )}
+                  </Box>
+                )}
+                <Typography variant="body2" gutterBottom>
+                  <strong>Assigned levels:</strong> {ps.topologyAssignment.levels?.join(' → ') || 'N/A'}
+                </Typography>
+                {ps.topologyAssignment.slices && ps.topologyAssignment.slices.length > 0 && (
+                  <TableContainer component={Paper} className="tableContainerWithBorder">
+                    <Table size="small">
+                      <TableHead>
+                        <TableRow>
+                          {ps.topologyAssignment.levels?.map((level, i) => (
+                            <TableCell key={i}>{level}</TableCell>
+                          ))}
+                          <TableCell>Pod Count</TableCell>
+                        </TableRow>
+                      </TableHead>
+                      <TableBody>
+                        {ps.topologyAssignment.slices.map((slice, si) => {
+                          const podCount = slice.podCounts?.universal != null
+                            ? `${slice.podCounts.universal} × ${slice.domainCount} domain(s)`
+                            : slice.podCounts?.individual?.join(', ') || 'N/A';
+                          const levelValues = (slice.valuesPerLevel || []).map(vpl => {
+                            if (vpl.universal != null) return vpl.universal;
+                            if (vpl.individual) {
+                              const prefix = vpl.individual.prefix || '';
+                              const suffix = vpl.individual.suffix || '';
+                              return (vpl.individual.roots || []).map(r => `${prefix}${r}${suffix}`).join(', ');
+                            }
+                            return 'N/A';
+                          });
+                          return (
+                            <TableRow key={si}>
+                              {levelValues.map((v, i) => (
+                                <TableCell key={i}>{v}</TableCell>
+                              ))}
+                              <TableCell>{podCount}</TableCell>
+                            </TableRow>
+                          );
+                        })}
+                      </TableBody>
+                    </Table>
+                  </TableContainer>
+                )}
+              </Box>
+            ) : null;
+          })}
+        </Box>
       )}
     </Paper>
   );

--- a/test/e2e/kueueviz/cypress/e2e/app.cy.js
+++ b/test/e2e/kueueviz/cypress/e2e/app.cy.js
@@ -3,7 +3,7 @@ describe('Kueue Dashboard', () => {
     cy.visit('/')
   })
 
-  
+
   it('should have the correct title', () => {
     cy.title().should('contain', 'Kueue Dashboard')
   })
@@ -35,7 +35,7 @@ describe('Kueue Dashboard', () => {
     cy.get('th').contains('Queue Name')
 
     // Navigate to the first link in the table
-      cy.get('table').find('a').first().click()
+    cy.get('table').find('a').first().click()
   })
 
   it('should navigate to cluster-queue unused-cluster-queue', { defaultCommandTimeout: 15000 }, () => {
@@ -49,7 +49,7 @@ describe('Kueue Dashboard', () => {
     cy.get('th').contains('Queue Name')
     // the table has one empty row
     cy.get('table').find('td').should('have.text', 'No local queues using this cluster queue')
- 
+
   })
 
 
@@ -94,7 +94,8 @@ describe('Kueue Dashboard', () => {
       '/local-queues',
       '/cluster-queues',
       '/cohorts',
-      '/resource-flavors'
+      '/resource-flavors',
+      '/topologies'
     ];
 
     links.forEach(link => {
@@ -104,24 +105,53 @@ describe('Kueue Dashboard', () => {
 
   it('should open and close YAML viewer modal on resource-flavors page', { defaultCommandTimeout: 15000 }, () => {
     cy.visit('/resource-flavors')
-    
+
     cy.get('table').should('exist')
-    
+
     cy.contains('button', 'View YAML').first().click()
-    
+
     cy.get('[role="dialog"]').should('be.visible')
-    
+
     cy.get('[role="dialog"]').within(() => {
-      cy.get('h6').should('exist') 
+      cy.get('h6').should('exist')
       cy.get('button').find('svg').should('exist')
     })
-    
+
     cy.get('[role="dialog"]').within(() => {
       cy.get('button').find('svg').click()
     })
-    
+
     cy.get('[role="dialog"]').should('not.exist')
   })
 
   // Add more test cases here as needed
-}) 
+
+  it('should navigate to topologies and verify table content', { defaultCommandTimeout: 15000 }, () => {
+    cy.get('a[href="/topologies"]').should('exist')
+      .click()
+
+    cy.get('table').should('exist')
+    cy.get('th').contains('Topology Name')
+    cy.get('th').contains('Levels')
+    cy.get('th').contains('Resource Flavors')
+
+    cy.get('td').contains('block-rack-topology')
+    cy.get('td').contains('tas-flavor')
+  })
+
+  it('should navigate to topology detail and verify levels and resource flavors', { defaultCommandTimeout: 15000 }, () => {
+    cy.visit('/topology/block-rack-topology')
+
+    cy.contains('Topology Detail: block-rack-topology').should('exist')
+
+    cy.contains('Levels').should('exist')
+    cy.get('td').contains('cloud.provider.com/topology-block')
+    cy.get('td').contains('cloud.provider.com/topology-rack')
+    cy.get('td').contains('kubernetes.io/hostname')
+
+    cy.contains('Resource Flavors Using This Topology').should('exist')
+    cy.get('a[href="/resource-flavor/tas-flavor"]').should('exist')
+
+    cy.get('svg').find('rect').should('have.length.greaterThan', 0)
+  })
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

/kind feature
/area dashboard
/area tas

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5147

#### Special notes for your reviewer:

What this PR does: Adds Topology visualization to the kueueviz dashboard, include list view, detail view with interactive treemap, topology assignments on workload detail, and cross-links from ResourceFlavor detail.

Backend (topologies.go):
- fetchTopologies joins Topology ↔ ResourceFlavor to show which flavors reference each topology
- fetchTopologyDetails returns levels, referencing flavors, and a domainTree for treemap rendering
- buildDomainTree lists nodes from the controller-runtime cache (not direct API calls), filters by flavor labels + level labels, and builds a nested tree grouped by topology level values
- resource_flavors.go: exposes topologyName in flavor detail response when present

Frontend:
- Topologies.jsx — list page with levels display and flavor cross-links
- TopologyDetail.jsx — detail page with nivo ResponsiveTreeMap for domain tree visualization, levels table, and referencing flavors table
- WorkloadDetail.jsx — shows topology assignments (levels, slices, pod counts) for admitted workloads with TAS
- ResourceFlavorDetail.jsx — links to topology detail when flavor has topologyName

Key design decisions:
- The client.List for nodes goes through the controller-runtime informer cache, not direct API Server calls. No performance concern for polling.
- Treemap leaf structure is uniform: leaf-level domain nodes always produce children with individual node entries, regardless of whether one or multiple nodes share the same label value. This ensures consistent
  tree shape for nivo.
- fetchTopologies returns [] (not null) when no topologies exist, so the frontend doesn't need null-guarding on the array.

E2E tests:
- Topology list: verifies table headers, topology name, and linked flavor
- Topology detail: verifies levels, resource flavor links, and treemap SVG rendering (asserts <rect> elements exist inside <svg>, which proves the full data pipeline worked — if domainTree were null or
malformed, nivo wouldn't render any rects)

Test data: examples/00.5-topology.yaml — a 3-level topology (block → rack → hostname) with 11 fake nodes across 2 blocks and 5 racks, showing balanced and imbalanced distributions.

See the video demo below for the full UI walkthrough.

https://github.com/user-attachments/assets/f7e89436-0709-412d-b5b7-debbb20b4285

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kueueviz: add topology visualization to kueueviz dashboard
```