### PR TITLE
kueueviz: fetch Cohort CRD directly, instead of deriving from ClusterQueue

### DIFF
--- a/cmd/kueueviz/backend/handlers/cohorts.go
+++ b/cmd/kueueviz/backend/handlers/cohorts.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/gin-gonic/gin"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 )
 
@@ -44,54 +45,46 @@ func CohortDetailsWebSocketHandler(dynamicClient dynamic.Interface) gin.HandlerF
 
 // Fetch all cohorts
 func fetchCohorts(ctx context.Context, dynamicClient dynamic.Interface) (any, error) {
-	clusterQueues, err := fetchClusterQueuesList(ctx, dynamicClient)
-
+	// Fetch all Cohort CRD objects directly
+	cohortList, err := dynamicClient.Resource(CohortsGVR()).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error fetching cohorts: %v", err)
 	}
-	cohorts := make(map[string]map[string]any)
 
-	// Iterate through cluster queue items
-	for _, item := range clusterQueues.Items {
-		// Extract spec and metadata
-		spec, specExists := item.Object["spec"].(map[string]any)
-		metadata, metadataExists := item.Object["metadata"].(map[string]any)
-		if !specExists || !metadataExists {
-			continue
-		}
-
-		// Get cohort name from the spec
-		cohortName, cohortExists := spec["cohort"].(string)
-		if !cohortExists || cohortName == "" {
-			continue
-		}
-
-		// Get cluster queue name
-		queueName, queueNameExists := metadata["name"].(string)
-		if !queueNameExists {
-			continue
-		}
-
-		// Initialize the cohort in the map if it doesn't exist
-		if _, exists := cohorts[cohortName]; !exists {
-			cohorts[cohortName] = map[string]any{
-				"name":          cohortName,
-				"clusterQueues": []map[string]any{},
-			}
-		}
-
-		// Add the current cluster queue to the cohort
-		clusterQueuesList := cohorts[cohortName]["clusterQueues"].([]map[string]any)
-		clusterQueuesList = append(clusterQueuesList, map[string]any{
-			"name": queueName,
-		})
-		cohorts[cohortName]["clusterQueues"] = clusterQueuesList
+	// Fetch all ClusterQueues to map them to cohorts
+	clusterQueues, err := fetchClusterQueuesList(ctx, dynamicClient)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching cluster queues: %v", err)
 	}
 
-	// Convert the cohorts map to a list
+	// Build a map of cohort name to ClusterQueues
+	cohortQueues := make(map[string][]map[string]any)
+	for _, item := range clusterQueues.Items {
+		spec, specExists := item.Object["spec"].(map[string]any)
+		if !specExists {
+			continue
+		}
+		cohortName, _ := spec["cohort"].(string)
+		if cohortName == "" {
+			continue
+		}
+		cohortQueues[cohortName] = append(cohortQueues[cohortName], map[string]any{
+			"name": item.GetName(),
+		})
+	}
+
+	// Build result from Cohort CRD objects
 	var result []map[string]any
-	for _, cohort := range cohorts {
-		result = append(result, cohort)
+	for _, cohort := range cohortList.Items {
+		name := cohort.GetName()
+		queues := cohortQueues[name]
+		if queues == nil {
+			queues = []map[string]any{}
+		}
+		result = append(result, map[string]any{
+			"name":          name,
+			"clusterQueues": queues,
+		})
 	}
 
 	return result, nil
@@ -99,31 +92,41 @@ func fetchCohorts(ctx context.Context, dynamicClient dynamic.Interface) (any, er
 
 // Fetch details for a specific cohort
 func fetchCohortDetails(ctx context.Context, dynamicClient dynamic.Interface, cohortName string) (map[string]any, error) {
+	// Fetch the specific Cohort CRD
+	cohort, err := dynamicClient.Resource(CohortsGVR()).Get(ctx, cohortName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error fetching cohort %s: %v", cohortName, err)
+	}
+
 	// Retrieve all cluster queues
 	clusterQueues, err := fetchClusterQueuesList(ctx, dynamicClient)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching cohort details: %v", err)
+		return nil, fmt.Errorf("error fetching cluster queues: %v", err)
 	}
 
-	// Prepare the result
-	cohortDetails := make(map[string]any)
-	cohortDetails["cohort"] = cohortName
-	cohortDetails["clusterQueues"] = []map[string]any{}
-
-	// Iterate through the cluster queues and filter by cohort name
+	// Filter ClusterQueues by cohort name
+	var clusterQueueDetails []map[string]any
 	for _, item := range clusterQueues.Items {
 		queue := item.Object
 		if queueSpec, ok := queue["spec"].(map[string]any); ok {
 			if queueSpec["cohort"] == cohortName {
-				queueDetails := map[string]any{
+				clusterQueueDetails = append(clusterQueueDetails, map[string]any{
 					"name":   item.GetName(),
 					"spec":   queueSpec,
 					"status": queue["status"],
-				}
-				cohortDetails["clusterQueues"] = append(cohortDetails["clusterQueues"].([]map[string]any), queueDetails)
+				})
 			}
 		}
 	}
 
-	return cohortDetails, nil
+	if clusterQueueDetails == nil {
+		clusterQueueDetails = []map[string]any{}
+	}
+
+	return map[string]any{
+		"cohort":        cohortName,
+		"spec":          cohort.Object["spec"],
+		"status":        cohort.Object["status"],
+		"clusterQueues": clusterQueueDetails,
+	}, nil
 }

--- a/cmd/kueueviz/examples/01.5-cohorts.yaml
+++ b/cmd/kueueviz/examples/01.5-cohorts.yaml
@@ -1,0 +1,14 @@
+---
+# Cohort referenced by multiple ClusterQueues
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: Cohort
+metadata:
+  name: ai-for-humanity-foundation
+spec: {}
+---
+# Orphan cohort with no ClusterQueues
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: Cohort
+metadata:
+  name: orphan-cohort-for-testing
+spec: {}

--- a/test/e2e/kueueviz/cypress/e2e/app.cy.js
+++ b/test/e2e/kueueviz/cypress/e2e/app.cy.js
@@ -72,6 +72,22 @@ describe('Kueue Dashboard', () => {
     cy.get('td').contains('llm-cluster-queue')
   })
 
+  it('should display orphan cohort without any cluster queues', { defaultCommandTimeout: 15000 }, () => {
+    // Navigate to cohorts page
+    cy.visit('/cohorts')
+
+    // Verify orphan cohort appears in the list (has no ClusterQueues)
+    cy.get('table').should('exist')
+    cy.get('td').contains('orphan-cohort-for-testing')
+
+    // Navigate to the orphan cohort detail page
+    cy.get('a[href="/cohort/orphan-cohort-for-testing"]').should('exist')
+      .click()
+
+    // Verify the cohort detail page loads correctly
+    cy.contains('orphan-cohort-for-testing').should('exist')
+  })
+
   it('should verify the presence of all main links', () => {
     const links = [
       '/workloads',


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

/kind bug
/kind regression
/area dashboard

#### What this PR does / why we need it:

https://github.com/kubernetes-sigs/kueue/pull/9719#issuecomment-4013082685

Manual backport of #9719 to release-0.15.

Fixes a regression where cohorts without any ClusterQueues assigned were invisible in kueueviz. Previously, cohorts were derived by iterating ClusterQueues — so a cohort with zero ClusterQueues would never appear.

This port re-implements the fix using the `dynamic.Interface` pattern used in release-0.15 (the original commit targets the typed-client architecture in main and cannot be cherry-picked directly due to architectural divergence between the branches).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6346

#### Special notes for your reviewer:

Manual backport of #9719. The automated cherry-pick failed because main and release-0.15 have diverged architecturally (main uses a typed controller-runtime client; release-0.15 uses `dynamic.Interface`). The fix logic is equivalent — fetch Cohort CRDs directly instead of deriving them from ClusterQueues.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kueueviz: fetch Cohort CRD directly, instead of deriving from ClusterQueue
```