### PR TITLE
LeaderWorkerSet integration when LeaderWorkerSet created with RestartPolicy should only recreate the deleted pod when policy is set to NoneRestartPolicy

### DIFF
--- a/test/e2e/singlecluster/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/leaderworkerset_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
@@ -1037,7 +1038,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 			})
 
 			var podToDelete *corev1.Pod
-			originalPodUIDs := make(map[string]types.UID)
+			originalPodUIDSet := sets.New[types.UID]()
 			ginkgo.By("Select a worker pod to delete", func() {
 				pods := &corev1.PodList{}
 				gomega.Expect(k8sClient.List(ctx, pods, client.MatchingLabels{
@@ -1046,7 +1047,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 				gomega.Expect(pods.Items).To(gomega.HaveLen(3))
 
 				for i, pod := range pods.Items {
-					originalPodUIDs[pod.Name] = pod.UID
+					originalPodUIDSet.Insert(pod.UID)
 					if pod.Labels[leaderworkersetv1.WorkerIndexLabelKey] != "0" {
 						podToDelete = &pods.Items[i]
 					}
@@ -1054,8 +1055,18 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 				gomega.Expect(podToDelete).NotTo(gomega.BeNil(), "Couldn't find a worker pod to delete")
 			})
 
+			deletedPodUID := podToDelete.UID
+			deletedPodKey := client.ObjectKeyFromObject(podToDelete)
 			ginkgo.By("Delete the worker pod", func() {
 				gomega.Expect(k8sClient.Delete(ctx, podToDelete)).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Wait for the deleted pod to be recreated with a new UID", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					pod := &corev1.Pod{}
+					g.Expect(k8sClient.Get(ctx, deletedPodKey, pod)).To(gomega.Succeed())
+					g.Expect(pod.UID).NotTo(gomega.Equal(deletedPodUID), "pod should be recreated with a new UID")
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Wait for all pods to be recreated with new UIDs", func() {
@@ -1065,14 +1076,12 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 						leaderworkersetv1.SetNameLabelKey: lws.Name,
 					}, client.InNamespace(lws.Namespace))).Should(gomega.Succeed())
 
-					recreatedCount := 0
+					currentUIDs := sets.New[types.UID]()
 					for _, pod := range pods.Items {
-						originalUID, existed := originalPodUIDs[pod.Name]
-						if existed && pod.UID != originalUID {
-							recreatedCount++
-						}
+						currentUIDs.Insert(pod.UID)
 					}
-					g.Expect(recreatedCount).To(gomega.Equal(3), "all pods should be recreated with new UIDs due to RecreateGroupOnPodRestart policy")
+					survived := originalPodUIDSet.Intersection(currentUIDs)
+					g.Expect(survived).To(gomega.BeEmpty(), "all pods should be recreated with new UIDs due to RecreateGroupOnPodRestart policy")
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -1120,7 +1129,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 			})
 
 			var podToDelete *corev1.Pod
-			originalPodUIDs := make(map[string]types.UID)
+			originalPodUIDSet := sets.New[types.UID]()
 			ginkgo.By("Select a worker pod to delete", func() {
 				pods := &corev1.PodList{}
 				gomega.Expect(k8sClient.List(ctx, pods, client.MatchingLabels{
@@ -1129,7 +1138,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 				gomega.Expect(pods.Items).To(gomega.HaveLen(3))
 
 				for i, pod := range pods.Items {
-					originalPodUIDs[pod.Name] = pod.UID
+					originalPodUIDSet.Insert(pod.UID)
 					if pod.Labels[leaderworkersetv1.WorkerIndexLabelKey] != "0" {
 						podToDelete = &pods.Items[i]
 					}
@@ -1137,9 +1146,18 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 				gomega.Expect(podToDelete).NotTo(gomega.BeNil(), "Couldn't find a worker pod to delete")
 			})
 
-			deletedPodName := podToDelete.Name
+			deletedPodUID := podToDelete.UID
+			deletedPodKey := client.ObjectKeyFromObject(podToDelete)
 			ginkgo.By("Delete the worker pod", func() {
 				gomega.Expect(k8sClient.Delete(ctx, podToDelete)).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Wait for the deleted pod to be recreated with a new UID", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					pod := &corev1.Pod{}
+					g.Expect(k8sClient.Get(ctx, deletedPodKey, pod)).To(gomega.Succeed())
+					g.Expect(pod.UID).NotTo(gomega.Equal(deletedPodUID), "pod should be recreated with a new UID")
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Verify if only the deleted pod was recreated", func() {
@@ -1148,22 +1166,19 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 					g.Expect(k8sClient.List(ctx, pods, client.MatchingLabels{
 						leaderworkersetv1.SetNameLabelKey: lws.Name,
 					}, client.InNamespace(lws.Namespace))).Should(gomega.Succeed())
+					g.Expect(pods.Items).To(gomega.HaveLen(3))
 
-					recreatedCount := 0
-					unchangedCount := 0
+					currentUIDs := sets.New[types.UID]()
 					for _, pod := range pods.Items {
-						originalUID, existed := originalPodUIDs[pod.Name]
-						if existed {
-							if pod.UID != originalUID {
-								recreatedCount++
-								g.Expect(pod.Name).To(gomega.Equal(deletedPodName), "only the deleted pod should be recreated")
-							} else {
-								unchangedCount++
-							}
-						}
+						currentUIDs.Insert(pod.UID)
 					}
-					g.Expect(recreatedCount).To(gomega.Equal(1), "only the deleted pod should be recreated with NoneRestartPolicy")
-					g.Expect(unchangedCount).To(gomega.Equal(2), "other pods should NOT be recreated with NoneRestartPolicy")
+
+					survived := originalPodUIDSet.Intersection(currentUIDs)
+					newUIDs := currentUIDs.Difference(originalPodUIDSet)
+
+					g.Expect(survived).To(gomega.HaveLen(2), "2 original pods should survive")
+					g.Expect(survived.Has(deletedPodUID)).To(gomega.BeFalse(), "deleted pod should not survive")
+					g.Expect(newUIDs).To(gomega.HaveLen(1), "exactly 1 replacement pod")
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
The old assertion identified the recreated pod by comparing current pods against the original map keyed by pod name. That is brittle because after deletion/recreation, the replacement can be observed in a different way than the test assumes, so the check can temporarily see no “same-name, new-UID” pod and incorrectly conclude that nothing was recreated.

I changed the test to assert the actual behavior more directly:
exactly 3 pods exist again,
exactly 1 pod has a new UID,
2 original pod UIDs are still present,
the newly created pod corresponds to the deleted worker index.
So the problem was: the test was using an unstable way to detect pod replacement, which made it report 0 recreated pods even when the system behavior was valid.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9750

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```