### PR TITLE
Automated cherry pick of #9756: Cleanup Consistently.

### DIFF
--- a/cmd/experimental/kueue-populator/test/e2e/populator_test.go
+++ b/cmd/experimental/kueue-populator/test/e2e/populator_test.go
@@ -95,9 +95,9 @@ var _ = ginkgo.Describe("KueuePopulator", func() {
 
 			ginkgo.By("verifying no localqueue is created initially")
 			createdLQ := &kueue.LocalQueue{}
-			gomega.Consistently(func() error {
-				return k8sClient.Get(ctx, types.NamespacedName{Name: "default", Namespace: ns.Name}, createdLQ)
-			}, util.Timeout, util.Interval).Should(gomega.Not(gomega.Succeed()))
+			gomega.Consistently(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default", Namespace: ns.Name}, createdLQ)).ToNot(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("updating the ClusterQueue to match the namespace")
 			gomega.Eventually(func() error {
@@ -146,14 +146,11 @@ var _ = ginkgo.Describe("KueuePopulator", func() {
 			gomega.Expect(k8sClient.Update(ctx, ns)).To(gomega.Succeed())
 
 			ginkgo.By("waiting to ensure controller doesn't modify it")
-			gomega.Consistently(func() string {
-				var lq kueue.LocalQueue
-				err := k8sClient.Get(ctx, types.NamespacedName{Name: "default", Namespace: ns.Name}, &lq)
-				if err != nil {
-					return ""
-				}
-				return string(lq.Spec.ClusterQueue)
-			}, util.Timeout, util.Interval).Should(gomega.Equal("some-other-queue"))
+			createdLQ := &kueue.LocalQueue{}
+			gomega.Consistently(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default", Namespace: ns.Name}, createdLQ)).Should(gomega.Succeed())
+				g.Expect(string(createdLQ.Spec.ClusterQueue)).Should(gomega.Equal("some-other-queue"))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
 		ginkgo.It("Should not delete LocalQueue when namespace no longer matches", func() {
@@ -183,8 +180,8 @@ var _ = ginkgo.Describe("KueuePopulator", func() {
 			gomega.Expect(k8sClient.Update(ctx, ns)).To(gomega.Succeed())
 
 			ginkgo.By("ensuring LocalQueue persists")
-			gomega.Consistently(func() error {
-				return k8sClient.Get(ctx, types.NamespacedName{Name: "default", Namespace: ns.Name}, &kueue.LocalQueue{})
+			gomega.Consistently(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default", Namespace: ns.Name}, createdLQ)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})

--- a/cmd/experimental/kueue-populator/test/integration/controller_test.go
+++ b/cmd/experimental/kueue-populator/test/integration/controller_test.go
@@ -163,8 +163,8 @@ var _ = ginkgo.Describe("KueuePopulator controller", ginkgo.Serial, func() {
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
 
+			createdLQ := &kueue.LocalQueue{}
 			gomega.Consistently(func(g gomega.Gomega) {
-				createdLQ := &kueue.LocalQueue{}
 				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default-lq", Namespace: ns.Name}, createdLQ)).To(gomega.Succeed())
 				g.Expect(createdLQ.Spec.ClusterQueue).To(gomega.Equal(kueue.ClusterQueueReference("some-other-cq")), "LocalQueue should not be modified")
 			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())

--- a/test/e2e/customconfigs/podintegrationautoenablement_test.go
+++ b/test/e2e/customconfigs/podintegrationautoenablement_test.go
@@ -127,16 +127,16 @@ var _ = ginkgo.Describe("Auto-Enablement of Pod Integration for Pod-Dependent Fr
 		util.MustCreate(ctx, k8sClient, testPod)
 
 		ginkgo.By("verifying pod is not managed by Kueue", func() {
+			createdPod := &corev1.Pod{}
 			gomega.Consistently(func(g gomega.Gomega) {
-				createdPod := &corev1.Pod{}
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testPod), createdPod)).To(gomega.Succeed())
 				g.Expect(createdPod.Spec.SchedulingGates).To(gomega.BeEmpty())
 			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 		})
 
 		ginkgo.By("verifying no workload is created for the pod", func() {
+			workloads := &kueue.WorkloadList{}
 			gomega.Consistently(func(g gomega.Gomega) {
-				workloads := &kueue.WorkloadList{}
 				g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				for _, wl := range workloads.Items {
 					g.Expect(wl.Name).NotTo(gomega.ContainSubstring("plain-pod"))

--- a/test/e2e/singlecluster/pod_test.go
+++ b/test/e2e/singlecluster/pod_test.go
@@ -151,11 +151,11 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 				for _, p := range group[:2] {
 					util.MustCreate(ctx, k8sClient, p.DeepCopy())
 				}
+				createdPod := &corev1.Pod{}
 				gomega.Consistently(func(g gomega.Gomega) {
 					for _, origPod := range group[:2] {
-						var p corev1.Pod
-						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(origPod), &p)).To(gomega.Succeed())
-						g.Expect(p.Spec.SchedulingGates).To(gomega.ContainElement(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}))
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(origPod), createdPod)).To(gomega.Succeed())
+						g.Expect(createdPod.Spec.SchedulingGates).To(gomega.ContainElement(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}))
 					}
 				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 			})

--- a/test/e2e/singlecluster/statefulset_test.go
+++ b/test/e2e/singlecluster/statefulset_test.go
@@ -350,10 +350,10 @@ var _ = ginkgo.Describe("StatefulSet integration", ginkgo.Label("area:singleclus
 			})
 
 			wlLookupKey := types.NamespacedName{Name: statefulset.GetWorkloadName(statefulSet.UID, statefulSet.Name), Namespace: ns.Name}
+			createdStatefulSet := &appsv1.StatefulSet{}
 
 			ginkgo.By("Checking that replicas is not ready", func() {
 				gomega.Consistently(func(g gomega.Gomega) {
-					createdStatefulSet := &appsv1.StatefulSet{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(statefulSet), createdStatefulSet)).To(gomega.Succeed())
 					g.Expect(createdStatefulSet.Status.ReadyReplicas).To(gomega.Equal(int32(0)))
 				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
@@ -361,7 +361,6 @@ var _ = ginkgo.Describe("StatefulSet integration", ginkgo.Label("area:singleclus
 
 			ginkgo.By("Update queue name", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
-					createdStatefulSet := &appsv1.StatefulSet{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(statefulSet), createdStatefulSet)).To(gomega.Succeed())
 					createdStatefulSet.Labels[controllerconstants.QueueLabel] = localQueueName
 					g.Expect(k8sClient.Update(ctx, createdStatefulSet)).To(gomega.Succeed())
@@ -370,7 +369,6 @@ var _ = ginkgo.Describe("StatefulSet integration", ginkgo.Label("area:singleclus
 
 			ginkgo.By("Waiting for replicas to be ready", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
-					createdStatefulSet := &appsv1.StatefulSet{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(statefulSet), createdStatefulSet)).To(gomega.Succeed())
 					g.Expect(createdStatefulSet.Status.ReadyReplicas).To(gomega.Equal(int32(3)))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())

--- a/test/integration/multikueue/provisioning_test.go
+++ b/test/integration/multikueue/provisioning_test.go
@@ -322,6 +322,9 @@ var _ = ginkgo.Describe("MultiKueue with ProvisioningRequest", ginkgo.Label("are
 			Namespace: worker2Ns.Name,
 		}
 
+		worker1Wl := &kueue.Workload{}
+		worker2Wl := &kueue.Workload{}
+
 		ginkgo.By("setting quota reservation on manager cluster", func() {
 			admission := utiltestingapi.MakeAdmission(managerCq.Name).
 				PodSets(
@@ -335,7 +338,6 @@ var _ = ginkgo.Describe("MultiKueue with ProvisioningRequest", ginkgo.Label("are
 
 		ginkgo.By("verifying workloads are created on both worker clusters", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
-				worker1Wl := &kueue.Workload{}
 				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, worker1WlKey, worker1Wl)).To(gomega.Succeed())
 				worker2Wl := &kueue.Workload{}
 				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, worker2WlKey, worker2Wl)).To(gomega.Succeed())
@@ -355,7 +357,6 @@ var _ = ginkgo.Describe("MultiKueue with ProvisioningRequest", ginkgo.Label("are
 
 		ginkgo.By("verifying worker2 workload still exists while worker1 is not admitted", func() {
 			gomega.Consistently(func(g gomega.Gomega) {
-				worker2Wl := &kueue.Workload{}
 				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, worker2WlKey, worker2Wl)).To(gomega.Succeed())
 			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 		})
@@ -380,7 +381,6 @@ var _ = ginkgo.Describe("MultiKueue with ProvisioningRequest", ginkgo.Label("are
 
 		ginkgo.By("verifying worker1 workload is admitted", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
-				worker1Wl := &kueue.Workload{}
 				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, worker1WlKey, worker1Wl)).To(gomega.Succeed())
 				g.Expect(apimeta.IsStatusConditionTrue(worker1Wl.Status.Conditions, kueue.WorkloadAdmitted)).To(gomega.BeTrue())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -388,7 +388,6 @@ var _ = ginkgo.Describe("MultiKueue with ProvisioningRequest", ginkgo.Label("are
 
 		ginkgo.By("verifying worker2 workload is deleted after worker1 is admitted", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
-				worker2Wl := &kueue.Workload{}
 				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, worker2WlKey, worker2Wl)).To(utiltesting.BeNotFoundError())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})

--- a/test/integration/multikueue/setup_test.go
+++ b/test/integration/multikueue/setup_test.go
@@ -992,10 +992,9 @@ var _ = ginkgo.Describe("MultiKueue with ClusterProfile", ginkgo.Label("area:mul
 			})
 
 			ginkgo.By("Status should remain as 'not found'", func() {
+				mkc := &kueue.MultiKueueCluster{}
 				gomega.Consistently(func(g gomega.Gomega) {
-					mkc := &kueue.MultiKueueCluster{}
 					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, clusterKey, mkc)).To(gomega.Succeed())
-
 					active := apimeta.FindStatusCondition(mkc.Status.Conditions, kueue.MultiKueueClusterActive)
 					g.Expect(active).NotTo(gomega.BeNil())
 					g.Expect(active.Reason).To(gomega.Equal("BadClusterProfile"))
@@ -1142,10 +1141,9 @@ var _ = ginkgo.Describe("MultiKueue with ClusterProfile", ginkgo.Label("area:mul
 				cp = utiltestingapi.MakeClusterProfile(cpName, managersConfigNamespace.Name).Obj()
 				gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, cp)).To(gomega.Succeed())
 
+				mkc := &kueue.MultiKueueCluster{}
 				gomega.Consistently(func(g gomega.Gomega) {
-					mkc := &kueue.MultiKueueCluster{}
 					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, clusterKey, mkc)).To(gomega.Succeed())
-
 					active := apimeta.FindStatusCondition(mkc.Status.Conditions, kueue.MultiKueueClusterActive)
 					g.Expect(active).NotTo(gomega.BeNil())
 					g.Expect(active.Reason).To(gomega.Equal("MultiKueueClusterProfileFeatureDisabled"))

--- a/test/integration/singlecluster/controller/dra/dra_test.go
+++ b/test/integration/singlecluster/controller/dra/dra_test.go
@@ -155,10 +155,10 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 
 			ginkgo.By("Verifying workload remains pending")
+			updatedWl := &kueue.Workload{}
 			gomega.Consistently(func(g gomega.Gomega) {
-				var updatedWl kueue.Workload
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
-				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeFalse())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), updatedWl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(updatedWl)).To(gomega.BeFalse())
 			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 		})
 
@@ -365,10 +365,10 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 
 			ginkgo.By("Verifying workload with ResourceClaimTemplate remains pending due to quota")
+			updatedWl := &kueue.Workload{}
 			gomega.Consistently(func(g gomega.Gomega) {
-				var updatedWl kueue.Workload
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
-				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeFalse())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), updatedWl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(updatedWl)).To(gomega.BeFalse())
 			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 		})
 

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -2581,17 +2581,16 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 
 			ginkgo.By("checking the first job and workload stay suspended and unadmitted")
 			gomega.Consistently(func(g gomega.Gomega) {
-				// Job should stay pending
+				// Job should stay suspended.
 				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: sampleJob.Name, Namespace: sampleJob.Namespace}, createdJob)).
 					Should(gomega.Succeed())
 				g.Expect(createdJob.Spec.Suspend).To(gomega.Equal(ptr.To(true)))
-				// Workload should get unadmitted
+
+				// Workload should stay unadmitted.
 				g.Expect(k8sClient.Get(ctx, wlKey, wll)).Should(gomega.Succeed())
-				util.ExpectWorkloadsToBePending(ctx, k8sClient, wll)
-				// Workload should stay pending
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wll), wll)).Should(gomega.Succeed())
-				// Should have Evicted condition
-				g.Expect(wll.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadEvicted))
+				g.Expect(wll.Status.Conditions).Should(utiltesting.HaveConditionStatusTrueAndReason(kueue.WorkloadEvicted, "Deactivated"))
+				g.Expect(wll.Status.Conditions).Should(utiltesting.HaveConditionStatusFalseAndReason(kueue.WorkloadQuotaReserved, "Pending"))
+				g.Expect(wll.Status.Conditions).Should(utiltesting.HaveConditionStatusFalseAndReason(kueue.WorkloadAdmitted, "NoReservation"))
 			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 
 			ginkgo.By("checking the first job becomes unsuspended after we update the Active field back to true")

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -24,6 +24,7 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -702,9 +703,7 @@ var _ = ginkgo.Describe("Job controller with preemption enabled", ginkgo.Ordered
 		createdJob := &rayv1.RayJob{}
 
 		gomega.Consistently(func(g gomega.Gomega) {
-			err := k8sClient.Get(ctx, lookupKey, createdWorkload)
-			g.Expect(err).Should(gomega.HaveOccurred())
-			g.Expect(client.IgnoreNotFound(err)).Should(gomega.Succeed())
+			g.Expect(errors.IsNotFound(k8sClient.Get(ctx, lookupKey, createdWorkload))).Should(gomega.BeTrue())
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), createdJob)).Should(gomega.Succeed())
 			g.Expect(createdJob.Spec.Suspend).Should(gomega.BeFalse())
 		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -1894,8 +1894,8 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, strictFIFOClusterQ.Name, wl1)
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
 			// wl3 doesn't even get a scheduling attempt, so can't check for conditions.
+			lookupKey := types.NamespacedName{Name: wl3.Name, Namespace: wl3.Namespace}
 			gomega.Consistently(func(g gomega.Gomega) {
-				lookupKey := types.NamespacedName{Name: wl3.Name, Namespace: wl3.Namespace}
 				g.Expect(k8sClient.Get(ctx, lookupKey, wl3)).Should(gomega.Succeed())
 				g.Expect(workload.HasQuotaReservation(wl3)).Should(gomega.BeFalse())
 			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
@@ -2033,10 +2033,10 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			ginkgo.By("Delete clusterQueue")
 			gomega.Expect(util.DeleteObject(ctx, k8sClient, cq)).To(gomega.Succeed())
+			createdCQ := &kueue.ClusterQueue{}
 			gomega.Consistently(func(g gomega.Gomega) {
-				var newCQ kueue.ClusterQueue
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &newCQ)).To(gomega.Succeed())
-				g.Expect(newCQ.GetFinalizers()).Should(gomega.Equal([]string{kueue.ResourceInUseFinalizerName}))
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), createdCQ)).To(gomega.Succeed())
+				g.Expect(createdCQ.GetFinalizers()).Should(gomega.Equal([]string{kueue.ResourceInUseFinalizerName}))
 			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 
 			ginkgo.By("New created workloads should be frozen")
@@ -3015,11 +3015,11 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("Verify second workload remains pending (10+2=12 exceeds quota limit of 10)")
+			createdWl := &kueue.Workload{}
 			gomega.Consistently(func(g gomega.Gomega) {
-				w := &kueue.Workload{}
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl3), w)).Should(gomega.Succeed())
-				g.Expect(workload.IsAdmitted(w)).Should(gomega.BeFalse())
-			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl3), createdWl)).Should(gomega.Succeed())
+				g.Expect(workload.IsAdmitted(createdWl)).Should(gomega.BeFalse())
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 		})
 	})
 })

--- a/test/integration/singlecluster/scheduler/workload_controller_test.go
+++ b/test/integration/singlecluster/scheduler/workload_controller_test.go
@@ -615,10 +615,10 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 					Obj()
 				util.MustCreate(ctx, k8sClient, wl2)
 
+				createdWl := kueue.Workload{}
 				gomega.Consistently(func(g gomega.Gomega) {
-					read := kueue.Workload{}
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), &read)).Should(gomega.Succeed())
-					g.Expect(workload.HasQuotaReservation(&read)).Should(gomega.BeFalse())
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), &createdWl)).Should(gomega.Succeed())
+					g.Expect(workload.HasQuotaReservation(&createdWl)).Should(gomega.BeFalse())
 				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 			})
 
@@ -700,10 +700,10 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 					Obj()
 				util.MustCreate(ctx, k8sClient, wl2)
 
+				createdWl2 := kueue.Workload{}
 				gomega.Consistently(func(g gomega.Gomega) {
-					read := kueue.Workload{}
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), &read)).Should(gomega.Succeed())
-					g.Expect(workload.HasQuotaReservation(&read)).Should(gomega.BeFalse())
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), &createdWl2)).Should(gomega.Succeed())
+					g.Expect(workload.HasQuotaReservation(&createdWl2)).Should(gomega.BeFalse())
 				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 			})
 

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -1099,7 +1099,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					gomega.Consistently(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), wl2)).To(gomega.Succeed())
 						g.Expect(workload.IsAdmitted(wl2)).To(gomega.BeFalse())
-					}, util.ShortConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+					}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 				})
 			})
 
@@ -1165,7 +1165,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					gomega.Consistently(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), wl2)).To(gomega.Succeed())
 						g.Expect(workload.IsAdmitted(wl2)).To(gomega.BeFalse())
-					}, util.ShortConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+					}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 				})
 			})
 
@@ -4360,10 +4360,10 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
 
 					ginkgo.By("Verifying workload stays pending (no quota reservation)")
+					updatedWl := &kueue.Workload{}
 					gomega.Consistently(func(g gomega.Gomega) {
-						var updatedWl kueue.Workload
-						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
-						g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeFalse())
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), updatedWl)).To(gomega.Succeed())
+						g.Expect(workload.HasQuotaReservation(updatedWl)).To(gomega.BeFalse())
 					}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 
 					ginkgo.By("Verifying no low-priority workloads were evicted")


### PR DESCRIPTION
Cherry pick of #9756 on release-0.16.

#9756: Cleanup Consistently.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note
NONE
```