### PR TITLE
[release-0.16] Skip equivalent inadmissible workloads in BestEffortFIFO scheduling

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -93,6 +93,10 @@ type ClusterQueue struct {
 	// inadmissibleWorkloads are workloads that have been tried at least once and couldn't be admitted.
 	inadmissibleWorkloads inadmissibleWorkloads
 
+	// noFitSchedulingHashes tracks scheduling equivalence classes that received NoFit.
+	// Cleared when queueInadmissibleWorkloads runs.
+	noFitSchedulingHashes sets.Set[string]
+
 	finishedWorkloads sets.Set[workload.Reference]
 
 	// popCycle identifies the last call to Pop. It's incremented when calling Pop.
@@ -195,6 +199,7 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.
 	return &ClusterQueue{
 		heap:                      *heap.New(workloadKey, lessFunc),
 		inadmissibleWorkloads:     make(inadmissibleWorkloads),
+		noFitSchedulingHashes:     sets.New[string](),
 		finishedWorkloads:         sets.New[workload.Reference](),
 		queueInadmissibleCycle:    -1,
 		compareFunc:               compareFunc,
@@ -270,6 +275,12 @@ func (c *ClusterQueue) PushOrUpdate(wInfo *workload.Info) {
 		c.inadmissibleWorkloads.delete(key)
 	}
 	if c.heap.GetByKey(key) == nil && !c.backoffWaitingTimeExpired(wInfo) {
+		c.inadmissibleWorkloads.insert(key, wInfo)
+		return
+	}
+	// Skip to inadmissible if the workload's equivalence class is already known to be NoFit
+	// (only for BestEffortFIFO; StrictFIFO preserves strict ordering).
+	if c.queueingStrategy == kueue.BestEffortFIFO && c.heap.GetByKey(key) == nil && wInfo.SchedulingHash != workload.SchedulingHashUnknown && c.noFitSchedulingHashes.Has(wInfo.SchedulingHash) {
 		c.inadmissibleWorkloads.insert(key, wInfo)
 		return
 	}
@@ -381,6 +392,29 @@ func (c *ClusterQueue) forgetInflightByKey(key workload.Reference) {
 	if c.inflight != nil && workload.Key(c.inflight.Obj) == key {
 		c.inflight = nil
 	}
+}
+
+// handleInadmissibleHash bulk-moves all heap workloads matching the given
+// scheduling hash to inadmissibleWorkloads. Returns the number moved.
+// Only applies to BestEffortFIFO queues; in StrictFIFO the head workload
+// stays in the heap and must not cause equivalent workloads to be skipped.
+func (c *ClusterQueue) handleInadmissibleHash(hash string) int {
+	c.rwm.Lock()
+	defer c.rwm.Unlock()
+	if c.queueingStrategy != kueue.BestEffortFIFO {
+		return 0
+	}
+	c.noFitSchedulingHashes.Insert(hash)
+	moved := 0
+	for _, wInfo := range c.heap.List() {
+		if wInfo.SchedulingHash == hash {
+			key := workloadKey(wInfo)
+			c.heap.Delete(key)
+			c.inadmissibleWorkloads.insert(key, wInfo)
+			moved++
+		}
+	}
+	return moved
 }
 
 // PendingTotal returns the total number of pending workloads.

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -1223,3 +1223,156 @@ func TestFsAdmission(t *testing.T) {
 		})
 	}
 }
+
+func TestRecordInadmissibleHash(t *testing.T) {
+	cases := map[string]struct {
+		hashToRecord     string
+		heapWorkloads    map[string]string // name -> schedulingHash
+		wantMoved        int
+		wantActive       int
+		wantInadmissible int
+	}{
+		"bulk-moves matching workloads": {
+			hashToRecord: "gpu-class",
+			heapWorkloads: map[string]string{
+				"gpu-1": "gpu-class",
+				"gpu-2": "gpu-class",
+				"gpu-3": "gpu-class",
+				"cpu-1": "cpu-class",
+				"cpu-2": "cpu-class",
+			},
+			wantMoved:        3,
+			wantActive:       2,
+			wantInadmissible: 3,
+		},
+		"no-op for empty hash": {
+			hashToRecord: "",
+			heapWorkloads: map[string]string{
+				"wl-1": "some-hash",
+			},
+			wantMoved:        0,
+			wantActive:       1,
+			wantInadmissible: 0,
+		},
+		"no-op when no workloads match": {
+			hashToRecord: "nonexistent",
+			heapWorkloads: map[string]string{
+				"wl-1": "hash-a",
+				"wl-2": "hash-b",
+			},
+			wantMoved:        0,
+			wantActive:       2,
+			wantInadmissible: 0,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			now := time.Now()
+			cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(now))
+			cq.queueingStrategy = kueue.BestEffortFIFO
+
+			i := 0
+			for wlName, hash := range tc.heapWorkloads {
+				wl := utiltestingapi.MakeWorkload(wlName, defaultNamespace).
+					Creation(now.Add(time.Duration(i)*time.Second)).
+					Request(corev1.ResourceCPU, "1").Obj()
+				info := workload.NewInfo(wl)
+				info.SchedulingHash = hash
+				cq.PushOrUpdate(info)
+				i++
+			}
+
+			moved := cq.handleInadmissibleHash(tc.hashToRecord)
+			if moved != tc.wantMoved {
+				t.Errorf("handleInadmissibleHash moved %d, want %d", moved, tc.wantMoved)
+			}
+
+			active, inadmissible := cq.Pending()
+			if active != tc.wantActive {
+				t.Errorf("active workloads = %d, want %d", active, tc.wantActive)
+			}
+			if inadmissible != tc.wantInadmissible {
+				t.Errorf("inadmissible workloads = %d, want %d", inadmissible, tc.wantInadmissible)
+			}
+		})
+	}
+}
+
+func TestPushOrUpdateRespectsInadmissibleHashes(t *testing.T) {
+	cases := map[string]struct {
+		noFitSchedulingHashes []string
+		pushHash              string
+		wantActive            int
+		wantInadmissible      int
+	}{
+		"workload with blocked hash goes to inadmissible": {
+			noFitSchedulingHashes: []string{"blocked"},
+			pushHash:              "blocked",
+			wantActive:            0,
+			wantInadmissible:      1,
+		},
+		"workload with non-blocked hash goes to heap": {
+			noFitSchedulingHashes: []string{"blocked"},
+			pushHash:              "allowed",
+			wantActive:            1,
+			wantInadmissible:      0,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(time.Now()))
+			cq.queueingStrategy = kueue.BestEffortFIFO
+
+			for _, h := range tc.noFitSchedulingHashes {
+				cq.noFitSchedulingHashes.Insert(h)
+			}
+
+			wl := utiltestingapi.MakeWorkload("wl", defaultNamespace).
+				Request(corev1.ResourceCPU, "1").Obj()
+			info := workload.NewInfo(wl)
+			info.SchedulingHash = tc.pushHash
+			cq.PushOrUpdate(info)
+
+			active, inadmissible := cq.Pending()
+			if active != tc.wantActive {
+				t.Errorf("active = %d, want %d", active, tc.wantActive)
+			}
+			if inadmissible != tc.wantInadmissible {
+				t.Errorf("inadmissible = %d, want %d", inadmissible, tc.wantInadmissible)
+			}
+		})
+	}
+}
+
+func TestQueueInadmissibleWorkloadsClearsHashes(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(time.Now()))
+	cq.queueingStrategy = kueue.BestEffortFIFO
+	cq.namespaceSelector = labels.Everything()
+
+	wl := utiltestingapi.MakeWorkload("wl", defaultNamespace).
+		Request(corev1.ResourceCPU, "1").Obj()
+	info := workload.NewInfo(wl)
+	info.SchedulingHash = "test-hash"
+	cq.PushOrUpdate(info)
+	cq.handleInadmissibleHash("test-hash")
+
+	if !cq.noFitSchedulingHashes.Has("test-hash") {
+		t.Fatal("hash should be recorded before clearing")
+	}
+
+	queueInadmissibleWorkloads(ctx, cq, utiltesting.NewFakeClient(
+		wl, utiltesting.MakeNamespace(defaultNamespace),
+	))
+
+	if cq.noFitSchedulingHashes.Has("test-hash") {
+		t.Error("noFitSchedulingHashes should be cleared after queueInadmissibleWorkloads")
+	}
+
+	active, inadmissible := cq.Pending()
+	if active != 1 || inadmissible != 0 {
+		t.Errorf("after requeue: active=%d inadmissible=%d, want active=1 inadmissible=0", active, inadmissible)
+	}
+}

--- a/pkg/cache/queue/inadmissible_workloads.go
+++ b/pkg/cache/queue/inadmissible_workloads.go
@@ -149,6 +149,8 @@ func queueInadmissibleWorkloads(ctx context.Context, c *ClusterQueue, client cli
 	defer c.rwm.Unlock()
 	log := ctrl.LoggerFrom(ctx)
 	c.queueInadmissibleCycle = c.popCycle
+	// Clear NoFit scheduling hashes so re-queued workloads are re-evaluated fresh.
+	c.noFitSchedulingHashes = sets.New[string]()
 	if c.inadmissibleWorkloads.empty() {
 		return 0
 	}

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -585,6 +585,23 @@ func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reas
 	return added
 }
 
+// HandleInadmissibleHash bulk-moves all workloads in the ClusterQueue's heap
+// that share the given scheduling hash to inadmissibleWorkloads.
+func (m *Manager) HandleInadmissibleHash(cqName kueue.ClusterQueueReference, hash string) int {
+	m.RLock()
+	defer m.RUnlock()
+	cq := m.hm.ClusterQueue(cqName)
+	if cq == nil {
+		return 0
+	}
+	moved := cq.handleInadmissibleHash(hash)
+	if moved > 0 {
+		// Update pending metrics for the CQ and all its LocalQueues.
+		reportPendingWorkloads(m, cqName)
+	}
+	return moved
+}
+
 // Delete the workload from queue or cluster queue.
 // Does not remove the queue assignment caching.
 func (m *Manager) DeleteWorkload(log logr.Logger, wlKey workload.Reference) {

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -1301,7 +1301,12 @@ func TestHeads(t *testing.T) {
 	}
 }
 
-var ignoreTypeMeta = cmpopts.IgnoreTypes(metav1.TypeMeta{})
+var (
+	ignoreTypeMeta = cmpopts.IgnoreTypes(metav1.TypeMeta{})
+	// ignoreSchedulingHash is used in tests that compare workload.Info structs
+	// but don't care about the scheduling hash value (computed dynamically in NewInfo).
+	ignoreSchedulingHash = cmpopts.IgnoreFields(workload.Info{}, "SchedulingHash")
+)
 
 // TestHeadAsync ensures that Heads call is blocked until the queues are filled
 // asynchronously.
@@ -1515,7 +1520,7 @@ func TestHeadsAsync(t *testing.T) {
 			go manager.CleanUpOnContext(ctx)
 			tc.op(ctx, manager)
 			heads := manager.Heads(ctx)
-			if diff := cmp.Diff(tc.wantHeads, heads, ignoreTypeMeta); diff != "" {
+			if diff := cmp.Diff(tc.wantHeads, heads, ignoreTypeMeta, ignoreSchedulingHash); diff != "" {
 				t.Errorf("GetHeads returned wrong heads (-want,+got):\n%s", diff)
 			}
 		})
@@ -1635,6 +1640,7 @@ func TestGetPendingWorkloadsInfo(t *testing.T) {
 			pendingWorkloadsInfo := manager.PendingWorkloadsInfo(tc.cqName)
 			if diff := cmp.Diff(tc.wantPendingWorkloadsInfo, pendingWorkloadsInfo,
 				ignoreTypeMeta,
+				ignoreSchedulingHash,
 				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "CreationTimestamp"),
 				cmpopts.IgnoreFields(kueue.WorkloadSpec{}, "PodSets"),
 				cmpopts.IgnoreFields(workload.Info{}, "TotalRequests"),

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -1134,7 +1134,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.wantClusterQueues, cache.hm.ClusterQueues(),
 				cmpopts.IgnoreFields(clusterQueue{}, "ResourceGroups"),
-				cmpopts.IgnoreFields(workload.Info{}, "Obj", "LastAssignment"),
+				cmpopts.IgnoreFields(workload.Info{}, "Obj", "LastAssignment", "SchedulingHash"),
 				cmpopts.IgnoreUnexported(clusterQueue{}, hierarchy.ClusterQueue[*cohort]{}),
 				cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Unexpected clusterQueues (-want,+got):\n%s", diff)

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -262,6 +262,12 @@ const (
 	// issue: https://github.com/kubernetes-sigs/kueue/issues/8828
 	// Enable workload eviction when node is tainted and pods are not able to run.
 	TASReplaceNodeOnNodeTaints featuregate.Feature = "TASReplaceNodeOnNodeTaints"
+
+	// owner: @sohankunkerkar
+	//
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/9694
+	// Skip equivalent inadmissible workloads in BestEffortFIFO scheduling.
+	SchedulingEquivalenceHashing featuregate.Feature = "SchedulingEquivalenceHashing"
 )
 
 func init() {
@@ -405,6 +411,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	TASReplaceNodeOnNodeTaints: {
 		{Version: version.MustParse("0.16"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
+	SchedulingEquivalenceHashing: {
+		{Version: version.MustParse("0.16"), Default: true, PreRelease: featuregate.Beta},
 	},
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -270,6 +270,12 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 
 		if mode == flavorassigner.NoFit {
 			log.V(3).Info("Skipping workload as FlavorAssigner assigned NoFit mode")
+			if features.Enabled(features.SchedulingEquivalenceHashing) && e.SchedulingHash != workload.SchedulingHashUnknown {
+				if moved := s.queues.HandleInadmissibleHash(e.ClusterQueue, e.SchedulingHash); moved > 0 {
+					log.V(2).Info("Bulk-moved equivalent workloads to inadmissible",
+						"hash", e.SchedulingHash, "movedCount", moved)
+				}
+			}
 			continue
 		}
 

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -18,6 +18,8 @@ package workload
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"slices"
@@ -48,6 +50,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/api"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
+	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	"sigs.k8s.io/kueue/pkg/util/podset"
 	"sigs.k8s.io/kueue/pkg/util/priority"
 	utilptr "sigs.k8s.io/kueue/pkg/util/ptr"
@@ -64,6 +67,9 @@ const (
 	StatusQuotaReserved = "quotaReserved"
 	StatusAdmitted      = "admitted"
 	StatusFinished      = "finished"
+
+	// SchedulingHashUnknown indicates the scheduling hash could not be computed.
+	SchedulingHashUnknown = "unknown"
 )
 
 var (
@@ -204,6 +210,11 @@ type Info struct {
 	// popped this workload for evaluation. Used by PushOrUpdate to detect spec
 	// changes masked by RequeueWorkload's info.Update.
 	LastEvaluatedGeneration int64
+
+	// SchedulingHash identifies the workload's scheduling equivalence class.
+	// Workloads with the same hash have identical scheduling-relevant shape
+	// and will receive the same FlavorAssigner result given the same cluster state.
+	SchedulingHash string
 }
 
 type PodSetResources struct {
@@ -277,12 +288,53 @@ func NewInfo(w *kueue.Workload, opts ...InfoOption) *Info {
 	} else {
 		info.TotalRequests = totalRequestsFromPodSets(w, &options)
 	}
+	info.SchedulingHash = computeSchedulingHash(log.Log, w, info.TotalRequests)
 	return info
 }
 
+// Update refreshes the object reference and recomputes the scheduling hash
+// to reflect any changes (e.g., priority updates).
 func (i *Info) Update(log logr.Logger, wl *kueue.Workload) {
 	log.V(5).Info("Workload info updated", "workload", klog.KObj(wl))
 	i.Obj = wl
+	i.SchedulingHash = computeSchedulingHash(log, wl, i.TotalRequests)
+}
+
+// computeSchedulingHash returns a deterministic hash of the workload's
+// scheduling-relevant shape: workload priority, pod spec (via SpecShape),
+// effective count, minCount, and topologyRequest per PodSet.
+func computeSchedulingHash(log logr.Logger, wl *kueue.Workload, totalRequests []PodSetResources) string {
+	if !features.Enabled(features.SchedulingEquivalenceHashing) {
+		return SchedulingHashUnknown
+	}
+	podSetShapes := make([]map[string]any, 0, len(wl.Spec.PodSets))
+	for i, ps := range wl.Spec.PodSets {
+		effectiveCount := ps.Count
+		if i < len(totalRequests) {
+			effectiveCount = totalRequests[i].Count
+		}
+		podSetShapes = append(podSetShapes, map[string]any{
+			"name":            ps.Name,
+			"spec":            utilpod.SpecShape(&ps.Template.Spec),
+			"count":           effectiveCount,
+			"minCount":        ps.MinCount,
+			"topologyRequest": ps.TopologyRequest,
+		})
+	}
+	shape := map[string]any{
+		"podSets":  podSetShapes,
+		"priority": wl.Spec.Priority,
+	}
+	shapeJSON, err := json.Marshal(shape)
+	if err != nil {
+		log.Error(err, "Failed to compute scheduling hash", "workload", klog.KObj(wl))
+		return SchedulingHashUnknown
+	}
+	hash := fmt.Sprintf("%x", sha256.Sum256(shapeJSON))[:16]
+	if logV := log.V(5); logV.Enabled() {
+		logV.Info("Computed scheduling hash", "workload", klog.KObj(wl), "hash", hash, "shapeJSON", string(shapeJSON))
+	}
+	return hash
 }
 
 func (i *Info) CanBePartiallyAdmitted() bool {

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -506,7 +506,7 @@ func TestNewInfo(t *testing.T) {
 				features.SetFeatureGateDuringTest(t, fg, enabled)
 			}
 			info := NewInfo(&tc.workload, tc.infoOptions...)
-			if diff := cmp.Diff(info, &tc.wantInfo, cmpopts.IgnoreFields(Info{}, "Obj")); diff != "" {
+			if diff := cmp.Diff(info, &tc.wantInfo, cmpopts.IgnoreFields(Info{}, "Obj", "SchedulingHash")); diff != "" {
 				t.Errorf("NewInfo(_) = (-want,+got):\n%s", diff)
 			}
 		})

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -193,6 +193,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.13"
+- name: SchedulingEquivalenceHashing
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.16"
 - name: SkipFinalizersForPodsSuspendedByParent
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -193,6 +193,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.13"
+- name: SchedulingEquivalenceHashing
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.16"
 - name: SkipFinalizersForPodsSuspendedByParent
   versionedSpecs:
   - default: true

--- a/test/integration/singlecluster/scheduler/inadmissible/equivalence_test.go
+++ b/test/integration/singlecluster/scheduler/inadmissible/equivalence_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inadmissible
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("Scheduler", func() {
+	var (
+		ns             *corev1.Namespace
+		onDemandFlavor *kueue.ResourceFlavor
+	)
+
+	ginkgo.BeforeEach(func() {
+		fwk.StartManager(ctx, cfg, managerAndSchedulerSetup)
+
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "equivalence-")
+		onDemandFlavor = utiltestingapi.MakeResourceFlavor("on-demand").Obj()
+		util.MustCreate(ctx, k8sClient, onDemandFlavor)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.When("Using scheduling equivalence classes", func() {
+		var cq *kueue.ClusterQueue
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, cq)).To(gomega.Succeed())
+		})
+
+		ginkgo.It("Should admit a fitting workload behind identical no-fit workloads in BestEffortFIFO", func() {
+			cq = utiltestingapi.MakeClusterQueue("equiv-cq").
+				QueueingStrategy(kueue.BestEffortFIFO).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "2").Obj(),
+				).Obj()
+			util.MustCreate(ctx, k8sClient, cq)
+
+			queue := utiltestingapi.MakeLocalQueue("equiv-queue", ns.Name).ClusterQueue("equiv-cq").Obj()
+			util.MustCreate(ctx, k8sClient, queue)
+
+			ginkgo.By("creating all workloads at once: 10 identical no-fit + 1 fitting")
+			for i := range 10 {
+				util.MustCreate(ctx, k8sClient, utiltestingapi.MakeWorkload(fmt.Sprintf("nofit-%d", i), ns.Name).
+					Queue(kueue.LocalQueueName(queue.Name)).
+					Request(corev1.ResourceCPU, "10").Obj())
+			}
+			fitWl := utiltestingapi.MakeWorkload("fits", ns.Name).
+				Queue(kueue.LocalQueueName(queue.Name)).
+				Request(corev1.ResourceCPU, "1").Obj()
+			util.MustCreate(ctx, k8sClient, fitWl)
+
+			ginkgo.By("verifying all no-fit workloads become inadmissible via bulk-move")
+			util.ExpectPendingWorkloadsMetric(cq, 0, 10)
+
+			ginkgo.By("verifying the fitting workload gets admitted")
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, fitWl)
+		})
+	})
+})


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubernetes-sigs/kueue/pull/9698
/assign sohankunkerkar
```release-note
Scheduling: Fix a BestEffortFIFO performance issue where many equivalent workloads could
prevent the scheduler from reaching schedulable workloads deeper in the queue. Kueue now
skips redundant evaluation by bulk-moving same-hash workloads to inadmissible when one
representative is categorized as NoFit.
```