### PR TITLE
Self-nominate sohankunkerkar as reviewer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -13,6 +13,7 @@ aliases:
     - pajakd
     - olekzabl
     - kshalot
+    - sohankunkerkar
   dependency-approvers:
     - mbobrovskyi
     - pbundyra


### PR DESCRIPTION
  #### What type of PR is this?                                                                                                                                                                                    
  /kind documentation                                                                                                                                                                                              
                                                                                                                                                                                                                   
  #### What this PR does / why we need it:                                                                                                                                                                         
                                                                                                                                                                                                                   
  Following https://github.com/kubernetes/community/blob/master/community-membership.md#reviewer                                                                                                                   

  - [x] Member for at least 3 months (first PR merged June 2025)
  - [x] Primary reviewer for at least 5 PRs to the codebase.
      [Assigned to 15 PRs](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+reviewed-by%3Asohankunkerkar+-author%3Asohankunkerkar+assignee%3Asohankunkerkar+is%3Amerged):
      * https://github.com/kubernetes-sigs/kueue/pull/9232 - Asynchronous Inadmissible Workload Requeueing (size/XL, bug)
      * https://github.com/kubernetes-sigs/kueue/pull/9631 - Fix lws reconciler (size/M, bug)
      * https://github.com/kubernetes-sigs/kueue/pull/9137 - Fix: lock cleanup broadcast to avoid missed wakeup (size/M, bug)
      * https://github.com/kubernetes-sigs/kueue/pull/9071 - Fix metrics certificate reload (size/M, bug)
      * https://github.com/kubernetes-sigs/kueue/pull/9135 - Fix flake in scale-down logic for LeaderWorkerSet (size/L, bug)
  - [x] Reviewed or merged at least 20 substantial PRs to the codebase:
      * [85 authored PRs merged](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+author%3Asohankunkerkar+is%3Amerged)
      * [32 reviewed PRs merged](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+reviewed-by%3Asohankunkerkar+-author%3Asohankunkerkar+is%3Amerged), [20 of which were >=
  size/M](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+reviewed-by%3Asohankunkerkar+-author%3Asohankunkerkar+is%3Amerged+-label%3Asize%2FXS+-label%3Asize%2FS)
  - [x] Knowledgeable about the codebase
  - [x] Significant PRs reviewed — features, KEPs, and involved bug fixes (addressing feedback from [previous nomination](https://github.com/kubernetes-sigs/kueue/pull/8868)):
      * **KEPs:**
          * https://github.com/kubernetes-sigs/kueue/pull/8396 - KEP: limiting quota check to resources declared in CQ (size/L)
          * https://github.com/kubernetes-sigs/kueue/pull/8551 - KEP: preemption cost mechanism (size/L)
          * https://github.com/kubernetes-sigs/kueue/pull/9251 - KEP-8902: Flavor-Aware Dominant Resource Share (size/L, in-flight)
      * **Features / API changes:**
          * https://github.com/kubernetes-sigs/kueue/pull/8963 - TAS: support ResourceTransformations (size/L)
          * https://github.com/kubernetes-sigs/kueue/pull/9742 - Support CEL expressions in DRA ResourceClaimTemplates (size/XXL, in-flight)
          * https://github.com/kubernetes-sigs/kueue/pull/8935 - Add e2e test target for k8s main with WAS enabled (size/M)
          * https://github.com/kubernetes-sigs/kueue/pull/8268 - StatefulSet pod reconciliation improvement (feature)
      * **Involved bug fixes:**
          * https://github.com/kubernetes-sigs/kueue/pull/9232 - Asynchronous Inadmissible Workload Requeueing (size/XL)
          * https://github.com/kubernetes-sigs/kueue/pull/9322 - Fix quota double-counting for unchanged podSets in Workload Slices (size/L)
          * https://github.com/kubernetes-sigs/kueue/pull/8341 - Make RayJob top level for autoscaling (size/XL)
          * https://github.com/kubernetes-sigs/kueue/pull/8862 - LWS: Fix bug blocking Pod deletion after LWS delete (size/L)
          * https://github.com/kubernetes-sigs/kueue/pull/8801 - Handle surge replicas during LWS rolling updates (size/L)

  #### Special notes for your reviewer:
  This is a re-nomination after [#8868](https://github.com/kubernetes-sigs/kueue/pull/8868) was closed per @mimowo's suggestion to revisit after a month. Since then I have reviewed several significant PRs including features, KEPs, and involved bug fixes addressing @gabesaba's feedback.

  #### Does this PR introduce a user-facing change?
  ```release-note
  NONE
```