### PR TITLE
Optimize gomega.Eventually() for populator.

### DIFF
--- a/cmd/experimental/kueue-populator/test/e2e/populator_test.go
+++ b/cmd/experimental/kueue-populator/test/e2e/populator_test.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/test/util"
@@ -69,9 +70,10 @@ var _ = ginkgo.Describe("KueuePopulator", func() {
 			gomega.Expect(k8sClient.Update(ctx, ns)).To(gomega.Succeed())
 
 			ginkgo.By("checking that the localqueue is created")
+			createdLQKey := types.NamespacedName{Name: "default", Namespace: ns.Name}
 			createdLQ := &kueue.LocalQueue{}
-			gomega.Eventually(func() error {
-				return k8sClient.Get(ctx, types.NamespacedName{Name: "default", Namespace: ns.Name}, createdLQ)
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, createdLQKey, createdLQ)).To(gomega.Succeed())
 			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 
 			gomega.Expect(createdLQ.Spec.ClusterQueue).To(gomega.Equal(kueue.ClusterQueueReference(cq.Name)))
@@ -93,25 +95,27 @@ var _ = ginkgo.Describe("KueuePopulator", func() {
 			}
 			gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
 
-			ginkgo.By("verifying no localqueue is created initially")
+			createdLQKey := types.NamespacedName{Name: "default", Namespace: ns.Name}
 			createdLQ := &kueue.LocalQueue{}
+
+			ginkgo.By("verifying no localqueue is created initially")
 			gomega.Consistently(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default", Namespace: ns.Name}, createdLQ)).ToNot(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, createdLQKey, createdLQ)).ToNot(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("updating the ClusterQueue to match the namespace")
-			gomega.Eventually(func() error {
-				var currentCQ kueue.ClusterQueue
-				gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cq.Name}, &currentCQ)).To(gomega.Succeed())
-				currentCQ.Spec.NamespaceSelector = &metav1.LabelSelector{
-					MatchLabels: map[string]string{"foo": "baz"},
-				}
-				return k8sClient.Update(ctx, &currentCQ)
+			createdCQKey := client.ObjectKeyFromObject(cq)
+			createdCQ := &kueue.ClusterQueue{}
+			namespaceSelector := &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "baz"}}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, createdCQKey, createdCQ)).To(gomega.Succeed())
+				createdCQ.Spec.NamespaceSelector = namespaceSelector
+				g.Expect(k8sClient.Update(ctx, createdCQ)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("checking that the localqueue is created")
-			gomega.Eventually(func() error {
-				return k8sClient.Get(ctx, types.NamespacedName{Name: "default", Namespace: ns.Name}, createdLQ)
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, createdLQKey, createdLQ)).To(gomega.Succeed())
 			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 
 			gomega.Expect(createdLQ.Spec.ClusterQueue).To(gomega.Equal(kueue.ClusterQueueReference(cq.Name)))
@@ -146,9 +150,10 @@ var _ = ginkgo.Describe("KueuePopulator", func() {
 			gomega.Expect(k8sClient.Update(ctx, ns)).To(gomega.Succeed())
 
 			ginkgo.By("waiting to ensure controller doesn't modify it")
+			createdLQKey := types.NamespacedName{Name: "default", Namespace: ns.Name}
 			createdLQ := &kueue.LocalQueue{}
 			gomega.Consistently(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default", Namespace: ns.Name}, createdLQ)).Should(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, createdLQKey, createdLQ)).Should(gomega.Succeed())
 				g.Expect(string(createdLQ.Spec.ClusterQueue)).Should(gomega.Equal("some-other-queue"))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
@@ -169,10 +174,12 @@ var _ = ginkgo.Describe("KueuePopulator", func() {
 			}
 			gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
 
-			ginkgo.By("waiting for localqueue to be created")
+			createdLQKey := types.NamespacedName{Name: "default", Namespace: ns.Name}
 			createdLQ := &kueue.LocalQueue{}
-			gomega.Eventually(func() error {
-				return k8sClient.Get(ctx, types.NamespacedName{Name: "default", Namespace: ns.Name}, createdLQ)
+
+			ginkgo.By("waiting for localqueue to be created")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, createdLQKey, createdLQ)).To(gomega.Succeed())
 			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("updating namespace to no longer match")
@@ -181,7 +188,7 @@ var _ = ginkgo.Describe("KueuePopulator", func() {
 
 			ginkgo.By("ensuring LocalQueue persists")
 			gomega.Consistently(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default", Namespace: ns.Name}, createdLQ)).Should(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, createdLQKey, createdLQ)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})

--- a/cmd/experimental/kueue-populator/test/integration/controller_test.go
+++ b/cmd/experimental/kueue-populator/test/integration/controller_test.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -71,9 +72,10 @@ var _ = ginkgo.Describe("KueuePopulator controller", ginkgo.Serial, func() {
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
 
+			createdLQKey := types.NamespacedName{Name: "default-lq", Namespace: ns.Name}
 			createdLQ := &kueue.LocalQueue{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default-lq", Namespace: ns.Name}, createdLQ)).To(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, createdLQKey, createdLQ)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			gomega.Expect(createdLQ.Spec.ClusterQueue).To(gomega.Equal(kueue.ClusterQueueReference(cq.Name)))
@@ -104,9 +106,10 @@ var _ = ginkgo.Describe("KueuePopulator controller", ginkgo.Serial, func() {
 				gomega.Expect(util.DeleteNamespace(ctx, k8sClient, newNs)).To(gomega.Succeed())
 			}()
 
+			createdLQKey := types.NamespacedName{Name: "default-lq", Namespace: newNs.Name}
 			createdLQ := &kueue.LocalQueue{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default-lq", Namespace: newNs.Name}, createdLQ)).To(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, createdLQKey, createdLQ)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			gomega.Expect(createdLQ.Spec.ClusterQueue).To(gomega.Equal(kueue.ClusterQueueReference(cq.Name)))
@@ -134,15 +137,18 @@ var _ = ginkgo.Describe("KueuePopulator controller", ginkgo.Serial, func() {
 				gomega.Expect(util.DeleteNamespace(ctx, k8sClient, nonMatchingNs)).To(gomega.Succeed())
 			}()
 
+			createdLQKey := types.NamespacedName{Name: "default-lq", Namespace: nonMatchingNs.Name}
+			createdLQ := &kueue.LocalQueue{}
+
 			gomega.Consistently(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default-lq", Namespace: nonMatchingNs.Name}, &kueue.LocalQueue{})).To(gomega.Not(gomega.Succeed()))
+				g.Expect(k8sClient.Get(ctx, createdLQKey, createdLQ)).To(gomega.Not(gomega.Succeed()))
 			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 
 			nonMatchingNs.Labels = labels
 			gomega.Expect(k8sClient.Update(ctx, nonMatchingNs)).To(gomega.Succeed())
 
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default-lq", Namespace: nonMatchingNs.Name}, &kueue.LocalQueue{})).To(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, createdLQKey, createdLQ)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
@@ -163,9 +169,10 @@ var _ = ginkgo.Describe("KueuePopulator controller", ginkgo.Serial, func() {
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
 
+			createdLQKey := types.NamespacedName{Name: "default-lq", Namespace: ns.Name}
 			createdLQ := &kueue.LocalQueue{}
 			gomega.Consistently(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default-lq", Namespace: ns.Name}, createdLQ)).To(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, createdLQKey, createdLQ)).To(gomega.Succeed())
 				g.Expect(createdLQ.Spec.ClusterQueue).To(gomega.Equal(kueue.ClusterQueueReference("some-other-cq")), "LocalQueue should not be modified")
 			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 		})
@@ -180,24 +187,26 @@ var _ = ginkgo.Describe("KueuePopulator controller", ginkgo.Serial, func() {
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
 
+			updatedLqKey := types.NamespacedName{Name: "default-lq", Namespace: ns.Name}
+			updatedLq := &kueue.LocalQueue{}
+
 			gomega.Consistently(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default-lq", Namespace: ns.Name}, &kueue.LocalQueue{})).To(gomega.Not(gomega.Succeed()))
+				g.Expect(k8sClient.Get(ctx, updatedLqKey, updatedLq)).To(gomega.Not(gomega.Succeed()))
 			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("Updating ClusterQueue with default local queue")
+			updatedCqKey := client.ObjectKeyFromObject(cq)
+			updatedCq := &kueue.ClusterQueue{}
+			namespaceSelector := &metav1.LabelSelector{MatchLabels: ns.Labels}
 			gomega.Eventually(func(g gomega.Gomega) {
-				var updatedCq kueue.ClusterQueue
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cq.Name}, &updatedCq)).To(gomega.Succeed())
-				updatedCq.Spec.NamespaceSelector = &metav1.LabelSelector{
-					MatchLabels: ns.Labels,
-				}
-				g.Expect(k8sClient.Update(ctx, &updatedCq)).To(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, updatedCqKey, updatedCq)).To(gomega.Succeed())
+				updatedCq.Spec.NamespaceSelector = namespaceSelector
+				g.Expect(k8sClient.Update(ctx, updatedCq)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			gomega.Eventually(func(g gomega.Gomega) {
-				lq := &kueue.LocalQueue{}
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default-lq", Namespace: ns.Name}, lq)).To(gomega.Succeed())
-				g.Expect(lq.Spec.ClusterQueue).To(gomega.Equal(kueue.ClusterQueueReference(cq.Name)), "incorrect cluster queue reference")
+				g.Expect(k8sClient.Get(ctx, updatedLqKey, updatedLq)).To(gomega.Succeed())
+				g.Expect(updatedLq.Spec.ClusterQueue).To(gomega.Equal(kueue.ClusterQueueReference(cq.Name)), "incorrect cluster queue reference")
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
@@ -210,16 +219,17 @@ var _ = ginkgo.Describe("KueuePopulator controller", ginkgo.Serial, func() {
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
 
+			createdLQKey := types.NamespacedName{Name: "default-lq", Namespace: ns.Name}
 			createdLQ := &kueue.LocalQueue{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default-lq", Namespace: ns.Name}, createdLQ)).To(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, createdLQKey, createdLQ)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ns.Labels = map[string]string{"dep": "other"}
 			gomega.Expect(k8sClient.Update(ctx, ns)).To(gomega.Succeed())
 
 			gomega.Consistently(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default-lq", Namespace: ns.Name}, &kueue.LocalQueue{})).To(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, createdLQKey, &kueue.LocalQueue{})).To(gomega.Succeed())
 			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 		})
 
@@ -229,9 +239,10 @@ var _ = ginkgo.Describe("KueuePopulator controller", ginkgo.Serial, func() {
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
 
+			createdLQKey := types.NamespacedName{Name: "default-lq", Namespace: ns.Name}
 			createdLQ := &kueue.LocalQueue{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default-lq", Namespace: ns.Name}, createdLQ)).To(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, createdLQKey, createdLQ)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			gomega.Expect(createdLQ.Spec.ClusterQueue).To(gomega.Equal(kueue.ClusterQueueReference(cq.Name)))
@@ -256,8 +267,10 @@ var _ = ginkgo.Describe("KueuePopulator controller", ginkgo.Serial, func() {
 				gomega.Expect(util.DeleteNamespace(ctx, k8sClient, nonMatchingNs)).To(gomega.Succeed())
 			}()
 
+			createdLQKey := types.NamespacedName{Name: "default-lq", Namespace: nonMatchingNs.Name}
+			createdLQ := &kueue.LocalQueue{}
 			gomega.Consistently(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default-lq", Namespace: nonMatchingNs.Name}, &kueue.LocalQueue{})).To(gomega.Not(gomega.Succeed()))
+				g.Expect(k8sClient.Get(ctx, createdLQKey, createdLQ)).To(gomega.Not(gomega.Succeed()))
 			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 		})
 
@@ -270,16 +283,17 @@ var _ = ginkgo.Describe("KueuePopulator controller", ginkgo.Serial, func() {
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
 
+			createdLQKey := types.NamespacedName{Name: "default-lq", Namespace: ns.Name}
 			createdLQ := &kueue.LocalQueue{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default-lq", Namespace: ns.Name}, createdLQ)).To(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, createdLQKey, createdLQ)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			gomega.Expect(util.DeleteObject(ctx, k8sClient, cq)).To(gomega.Succeed())
 			cq = nil
 
 			gomega.Consistently(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default-lq", Namespace: ns.Name}, &kueue.LocalQueue{})).To(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, createdLQKey, &kueue.LocalQueue{})).To(gomega.Succeed())
 			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 		})
 
@@ -302,8 +316,10 @@ var _ = ginkgo.Describe("KueuePopulator controller", ginkgo.Serial, func() {
 			gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
 
 			// The namespace matches the CQ selector, but not the global selector
+			createdLQKey := types.NamespacedName{Name: "default-lq", Namespace: ns.Name}
+			createdLQ := &kueue.LocalQueue{}
 			gomega.Consistently(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "default-lq", Namespace: ns.Name}, &kueue.LocalQueue{})).To(gomega.Not(gomega.Succeed()))
+				g.Expect(k8sClient.Get(ctx, createdLQKey, createdLQ)).To(gomega.Not(gomega.Succeed()))
 			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area testing

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Optimize gomega.Eventually() for populator.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```