### PR TITLE
Optimize ContextWithLog() to support testing.TB.

### DIFF
--- a/pkg/util/testing/context.go
+++ b/pkg/util/testing/context.go
@@ -37,7 +37,7 @@ func LogLevelWithDefault(defaultLogLevel int) int {
 	return level
 }
 
-func NewLogger(t *testing.T) logr.Logger {
+func NewLogger(t testing.TB) logr.Logger {
 	// Map TEST_LOG_LEVEL to testr verbosity so that lower (more negative)
 	// values increase verbosity consistently with integration/e2e logging.
 	level := LogLevelWithDefault(DefaultLogLevel)
@@ -45,12 +45,12 @@ func NewLogger(t *testing.T) logr.Logger {
 	// more negative TEST_LOG_LEVEL means more verbose. Translate by negating
 	// the level, so -3 => 3. Positive levels result in negative verbosity
 	// which effectively disables extra V logs.
-	return testr.NewWithOptions(t, testr.Options{
+	return testr.NewWithInterface(t, testr.Options{
 		Verbosity: -level,
 	})
 }
 
-func ContextWithLog(t *testing.T) (context.Context, logr.Logger) {
-	logger := NewLogger(t)
-	return ctrl.LoggerInto(t.Context(), logger), logger
+func ContextWithLog(tb testing.TB) (context.Context, logr.Logger) {
+	logger := NewLogger(tb)
+	return ctrl.LoggerInto(tb.Context(), logger), logger
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area testing

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Optimize ContextWithLog() to support testing.TB. This allows it to be used with both *testing.T and *testing.B.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```