### PR TITLE
chore: Use slices instead of sort

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -60,11 +60,12 @@ linters:
             - - skip-package-name-collision-with-go-std: true
         - name: redundant-import-alias
         - name: use-any
+        - name: use-slices-sort
         - name: use-waitgroup-go
     forbidigo:
       forbid:
-        - pattern: ^sort\.Slice$
-          msg: Please use slices.SortFunc instead of sort.Slice for better performance and consistency
+        - pattern: ^sort\.(Slice|Sort|Stable|String).*$
+          msg: Please use slices package instead of sort for better performance and consistency
     modernize:
       disable:
         - omitzero

--- a/cmd/kueuectl-docs/generators/doc.go
+++ b/cmd/kueuectl-docs/generators/doc.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -58,12 +58,6 @@ type Link struct {
 	Description string
 	Path        string
 }
-
-type byName []*cobra.Command
-
-func (s byName) Len() int           { return len(s) }
-func (s byName) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-func (s byName) Less(i, j int) bool { return s[i].Name() < s[j].Name() }
 
 func GenMarkdownTree(cmd *cobra.Command, templatesDir, outputDir string) error {
 	identity := func(s string) string { return s }
@@ -311,8 +305,9 @@ func getLinks(cmd *cobra.Command, linkHandler func(string) string, indexFile boo
 	}
 
 	name := cmd.CommandPath()
-	children := cmd.Commands()
-	sort.Sort(byName(children))
+	children := slices.SortedFunc(slices.Values(cmd.Commands()), func(a, b *cobra.Command) int {
+		return strings.Compare(a.Name(), b.Name())
+	})
 
 	for _, child := range children {
 		if !child.IsAvailableCommand() || child.IsAdditionalHelpTopicCommand() {

--- a/cmd/kueueviz/backend/handlers/namespaces.go
+++ b/cmd/kueueviz/backend/handlers/namespaces.go
@@ -18,9 +18,9 @@ package handlers
 
 import (
 	"context"
-	"sort"
 
 	"github.com/gin-gonic/gin"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	kueueapi "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 )
@@ -44,31 +44,17 @@ func (h *Handlers) fetchNamespaces(ctx context.Context) (any, error) {
 	}
 
 	// Extract unique namespaces from LocalQueues
-	namespaceSet := make(map[string]struct{})
+	namespaceSet := sets.NewString()
 	for _, lq := range lql.Items {
-		namespaceSet[lq.GetNamespace()] = struct{}{}
+		namespaceSet.Insert(lq.GetNamespace())
 	}
 
-	// If no LocalQueues found, return empty result with proper structure
-	if len(namespaceSet) == 0 {
-		return map[string]any{
-			"namespaces": []string{},
-		}, nil
+	namespaces := namespaceSet.List()
+	if namespaceSet.Len() == 0 {
+		namespaces = []string{}
 	}
 
-	// Convert namespace set to a slice of strings (just the names)
-	var namespaceNames []string
-	for namespaceName := range namespaceSet {
-		namespaceNames = append(namespaceNames, namespaceName)
-	}
-
-	// Sort namespaces alphabetically for consistent ordering
-	sort.Strings(namespaceNames)
-
-	// Return in the same format as other endpoints
-	result := map[string]any{
-		"namespaces": namespaceNames,
-	}
-
-	return result, nil
+	return map[string]any{
+		"namespaces": namespaces,
+	}, nil
 }

--- a/pkg/cache/scheduler/tas_balanced_placement_test.go
+++ b/pkg/cache/scheduler/tas_balanced_placement_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package scheduler
 
 import (
-	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -79,9 +78,7 @@ func TestSelectOptimalDomainSetToFit(t *testing.T) {
 			for i, d := range got {
 				gotIDs[i] = string(d.id)
 			}
-			sort.Strings(gotIDs)
-			sort.Strings(tc.want)
-			if diff := cmp.Diff(tc.want, gotIDs); diff != "" {
+			if diff := cmp.Diff(tc.want, gotIDs, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
 				t.Errorf("unexpected optimal domain set (-want,+got): %s", diff)
 			}
 		})

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -46,7 +46,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
-	"sigs.k8s.io/kueue/pkg/util/slices"
+	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
@@ -1541,8 +1541,8 @@ func TestWlReconcile(t *testing.T) {
 					workerClusters = append(workerClusters, "worker2")
 				}
 				managerBuilder = managerBuilder.WithLists(&kueue.WorkloadList{Items: tc.managersWorkloads}, &batchv1.JobList{Items: tc.managersJobs})
-				managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersWorkloads, func(w *kueue.Workload) client.Object { return w })...)
-				managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersJobs, func(w *batchv1.Job) client.Object { return w })...)
+				managerBuilder = managerBuilder.WithStatusSubresource(utilslices.Map(tc.managersWorkloads, func(w *kueue.Workload) client.Object { return w })...)
+				managerBuilder = managerBuilder.WithStatusSubresource(utilslices.Map(tc.managersJobs, func(w *batchv1.Job) client.Object { return w })...)
 				managerBuilder = managerBuilder.WithObjects(
 					utiltestingapi.MakeMultiKueueConfig("config1").Clusters(workerClusters...).Obj(),
 					utiltestingapi.MakeAdmissionCheck("ac1").ControllerName(kueue.MultiKueueControllerName).
@@ -1632,10 +1632,10 @@ func TestWlReconcile(t *testing.T) {
 				} else {
 					// ensure deterministic comparison
 					for i := range gotManagersWorkloads.Items {
-						sort.Strings(gotManagersWorkloads.Items[i].Status.NominatedClusterNames)
+						slices.Sort(gotManagersWorkloads.Items[i].Status.NominatedClusterNames)
 					}
 					for i := range tc.wantManagersWorkloads {
-						sort.Strings(tc.wantManagersWorkloads[i].Status.NominatedClusterNames)
+						slices.Sort(tc.wantManagersWorkloads[i].Status.NominatedClusterNames)
 					}
 					if diff := cmp.Diff(tc.wantManagersWorkloads, gotManagersWorkloads.Items, objCheckOpts...); diff != "" {
 						t.Errorf("unexpected manager's workloads (-want/+got):\n%s", diff)
@@ -1829,11 +1829,7 @@ func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
 			for _, c := range created {
 				gotCreated = append(gotCreated, c.cluster)
 			}
-			s1 := sort.StringSlice(tt.wantCreated)
-			s1.Sort()
-			s2 := sort.StringSlice(gotCreated)
-			s2.Sort()
-			if diff := cmp.Diff(s1, s2); diff != "" {
+			if diff := cmp.Diff(tt.wantCreated, gotCreated, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
 				t.Errorf("unexpected created remotes (-want/+got):\n%s", diff)
 			}
 		})
@@ -1957,10 +1953,8 @@ func TestConfigHandlerUpdate(t *testing.T) {
 			for _, req := range mockQ.addedItems {
 				actualQueuedWLs = append(actualQueuedWLs, req.Name)
 			}
-			sort.Strings(actualQueuedWLs)
-			sort.Strings(tc.expectedQueuedWLs)
 
-			if diff := cmp.Diff(tc.expectedQueuedWLs, actualQueuedWLs); diff != "" {
+			if diff := cmp.Diff(tc.expectedQueuedWLs, actualQueuedWLs, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
 				t.Errorf("unexpected queued workloads (-want/+got):\n%s", diff)
 			}
 		})

--- a/pkg/controller/jobframework/integrationmanager.go
+++ b/pkg/controller/jobframework/integrationmanager.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"sort"
 	"sync"
 	"testing"
 
@@ -207,7 +206,7 @@ func (m *integrationManager) enableIntegration(name string) {
 func (m *integrationManager) getList() []string {
 	ret := make([]string, len(m.names))
 	copy(ret, m.names)
-	sort.Strings(ret)
+	slices.Sort(ret)
 	return ret
 }
 

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -21,7 +21,6 @@ import (
 	"maps"
 	"math"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -249,7 +248,7 @@ func (s *Status) Message() string {
 	if s.err != nil {
 		return s.err.Error()
 	}
-	sort.Strings(s.reasons)
+	slices.Sort(s.reasons)
 	return strings.Join(s.reasons, ", ")
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -17,11 +17,11 @@ limitations under the License.
 package scheduler
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"maps"
 	"slices"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -720,54 +720,6 @@ func (s *Scheduler) assumeWorkload(log logr.Logger, e *entry, cq *schdcache.Clus
 	return cacheWl, nil
 }
 
-type entryOrdering struct {
-	entries          []entry
-	workloadOrdering workload.Ordering
-}
-
-func (e entryOrdering) Len() int {
-	return len(e.entries)
-}
-
-func (e entryOrdering) Swap(i, j int) {
-	e.entries[i], e.entries[j] = e.entries[j], e.entries[i]
-}
-
-// Less is the ordering criteria
-func (e entryOrdering) Less(i, j int) bool {
-	a := e.entries[i]
-	b := e.entries[j]
-
-	// First process workloads which already have quota reserved. Such workload
-	// may be considered if this is their second pass.
-	aHasQuota := workload.HasQuotaReservation(a.Obj)
-	bHasQuota := workload.HasQuotaReservation(b.Obj)
-	if aHasQuota != bHasQuota {
-		return aHasQuota
-	}
-
-	// 1. Request under nominal quota.
-	aBorrows := a.assignment.Borrows()
-	bBorrows := b.assignment.Borrows()
-	if aBorrows != bBorrows {
-		return aBorrows < bBorrows
-	}
-
-	// 2. Higher priority first if not disabled.
-	if features.Enabled(features.PrioritySortingWithinCohort) {
-		p1 := priority.Priority(a.Obj)
-		p2 := priority.Priority(b.Obj)
-		if p1 != p2 {
-			return p1 > p2
-		}
-	}
-
-	// 3. FIFO.
-	aComparisonTimestamp := e.workloadOrdering.GetQueueOrderTimestamp(a.Obj)
-	bComparisonTimestamp := e.workloadOrdering.GetQueueOrderTimestamp(b.Obj)
-	return aComparisonTimestamp.Before(bComparisonTimestamp)
-}
-
 // entryInterator defines order that entries are returned.
 // pop->nil IFF hasNext->False
 type entryIterator interface {
@@ -802,9 +754,44 @@ func (co *classicalIterator) pop() *entry {
 }
 
 func makeClassicalIterator(entries []entry, workloadOrdering workload.Ordering) *classicalIterator {
-	sort.Sort(entryOrdering{
-		entries:          entries,
-		workloadOrdering: workloadOrdering,
+	slices.SortFunc(entries, func(a, b entry) int {
+		// First process workloads which already have quota reserved. Such workload
+		// may be considered if this is their second pass.
+		aHasQuota := workload.HasQuotaReservation(a.Obj)
+		bHasQuota := workload.HasQuotaReservation(b.Obj)
+		if aHasQuota != bHasQuota {
+			if aHasQuota {
+				return -1
+			}
+			return 1
+		}
+
+		// 1. Request under nominal quota.
+		aBorrows := a.assignment.Borrows()
+		bBorrows := b.assignment.Borrows()
+		if aBorrows != bBorrows {
+			return cmp.Compare(aBorrows, bBorrows)
+		}
+
+		// 2. Higher priority first if not disabled.
+		if features.Enabled(features.PrioritySortingWithinCohort) {
+			p1 := priority.Priority(a.Obj)
+			p2 := priority.Priority(b.Obj)
+			if p1 != p2 {
+				return cmp.Compare(p2, p1)
+			}
+		}
+
+		// 3. FIFO.
+		aComparisonTimestamp := workloadOrdering.GetQueueOrderTimestamp(a.Obj)
+		bComparisonTimestamp := workloadOrdering.GetQueueOrderTimestamp(b.Obj)
+		if aComparisonTimestamp.Before(bComparisonTimestamp) {
+			return -1
+		}
+		if bComparisonTimestamp.Before(aComparisonTimestamp) {
+			return 1
+		}
+		return 0
 	})
 	return &classicalIterator{
 		entries: entries,

--- a/pkg/util/tas/tas_assignment_performance_test.go
+++ b/pkg/util/tas/tas_assignment_performance_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand/v2"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -265,7 +266,7 @@ func BenchmarkV1Beta2From(b *testing.B) {
 		// (This is because longer common prefix & suffix will "hold" for longer).
 		// If we ever wish to test other approaches, we may want to also have
 		// a variant of this benchmark when node names get shuffled quasi-randomly.
-		sort.Strings(nodeNames)
+		slices.Sort(nodeNames)
 		ta := internalSinglePodsOn(nodeNames)
 
 		desc := fmt.Sprintf("Naming scheme %q, %d nodes", tc.name, targetNodeCount)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Replace `sort.Sort` and `sort.Strings` with `slices.Sort`.

Enable `revive.use-slices-sort` and extend `forbidigo.pattern` to prevent regressions.

#### Which issue(s) this PR fixes:

Updates #6675

#### Special notes for your reviewer:

In tests, I use `cmpopts.SortSlices`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```