### PR TITLE
[release-0.16] Self-nominate sohankunkerkar as reviewer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,6 +11,7 @@ aliases:
     - tenzen-y
     - kannon92
     - pajakd
+    - sohankunkerkar
   dependency-approvers:
     - mbobrovskyi
     - pbundyra


### PR DESCRIPTION
This is a manual cherry pick of https://github.com/kubernetes-sigs/kueue/pull/9776
/assign sohankunkerkar
```release-note
NONE
```