### PR TITLE
Extend metricsdoc to support type-only var declarations

### DIFF
--- a/hack/tools/metricsdoc/main.go
+++ b/hack/tools/metricsdoc/main.go
@@ -79,6 +79,11 @@ func main() {
 	}
 }
 
+type varMarker struct {
+	group     string
+	labelDocs map[string]string
+}
+
 func extractMetricsFromPackage(dir string) ([]Metric, error) {
 	fset := token.NewFileSet()
 	entries, err := os.ReadDir(dir)
@@ -96,8 +101,28 @@ func extractMetricsFromPackage(dir string) ([]Metric, error) {
 		}
 		files = append(files, f)
 	}
+
+	// Collect markers from type-only var declarations (no initializer).
+	deferred := map[string]varMarker{}
+	for _, f := range files {
+		ast.Inspect(f, func(n ast.Node) bool {
+			vs, ok := n.(*ast.ValueSpec)
+			if !ok || len(vs.Values) != 0 || len(vs.Names) == 0 {
+				return true
+			}
+			group, labelDocs := parseMarkers(vs)
+			if group == "" {
+				return true
+			}
+			deferred[vs.Names[0].Name] = varMarker{group: group, labelDocs: labelDocs}
+			return true
+		})
+	}
+
 	var all []Metric
 	var missingGroups []string
+
+	// Extract from inline-initialized vars.
 	for _, f := range files {
 		ast.Inspect(f, func(n ast.Node) bool {
 			vs, ok := n.(*ast.ValueSpec)
@@ -105,59 +130,11 @@ func extractMetricsFromPackage(dir string) ([]Metric, error) {
 				return true
 			}
 			groupFromComment, labelDocs := parseMarkers(vs)
-			call, ok := vs.Values[0].(*ast.CallExpr)
+			m, ok := metricFromCall(vs.Values[0])
 			if !ok {
 				return true
 			}
-			sel, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok {
-				return true
-			}
-			pkgIdent, ok := sel.X.(*ast.Ident)
-			if !ok || pkgIdent.Name != "prometheus" {
-				return true
-			}
-			fun := sel.Sel.Name
-			if fun != "NewCounterVec" && fun != "NewGaugeVec" && fun != "NewHistogramVec" {
-				return true
-			}
-			if len(call.Args) < 2 {
-				return true
-			}
-			opts, ok := call.Args[0].(*ast.CompositeLit)
-			if !ok {
-				return true
-			}
-			var name, help string
-			for _, elt := range opts.Elts {
-				kv, ok := elt.(*ast.KeyValueExpr)
-				if !ok {
-					continue
-				}
-				var keyName string
-				switch k := kv.Key.(type) {
-				case *ast.Ident:
-					keyName = k.Name
-				case *ast.SelectorExpr:
-					keyName = k.Sel.Name
-				default:
-					keyName = exprToString(kv.Key)
-				}
-				switch keyName {
-				case "Name":
-					name = stringLiteral(kv.Value)
-				case "Help":
-					help = stringLiteral(kv.Value)
-				}
-			}
-			labels := parseLabels(call.Args[1])
-			m := Metric{
-				FullName:  "kueue_" + name,
-				Type:      map[string]string{"NewCounterVec": "Counter", "NewGaugeVec": "Gauge", "NewHistogramVec": "Histogram"}[fun],
-				Help:      normalizeHelp(help),
-				Labels:    labels,
-				LabelDocs: labelDocs,
-			}
+			m.LabelDocs = labelDocs
 			if groupFromComment == "" {
 				varName := ""
 				if len(vs.Names) > 0 && vs.Names[0] != nil {
@@ -171,11 +148,98 @@ func extractMetricsFromPackage(dir string) ([]Metric, error) {
 			return true
 		})
 	}
+
+	// Scan function bodies for assignments to deferred vars.
+	for _, f := range files {
+		ast.Inspect(f, func(n ast.Node) bool {
+			assign, ok := n.(*ast.AssignStmt)
+			if !ok || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+				return true
+			}
+			ident, ok := assign.Lhs[0].(*ast.Ident)
+			if !ok {
+				return true
+			}
+			marker, found := deferred[ident.Name]
+			if !found {
+				return true
+			}
+			m, ok := metricFromCall(assign.Rhs[0])
+			if !ok {
+				return true
+			}
+			m.Group = marker.group
+			m.LabelDocs = marker.labelDocs
+			all = append(all, m)
+			delete(deferred, ident.Name)
+			return true
+		})
+	}
+
 	if len(missingGroups) > 0 {
 		return nil, fmt.Errorf("missing metricsdoc:group marker on metrics: %s", strings.Join(missingGroups, ", "))
 	}
+	if len(deferred) > 0 {
+		names := slices.Sorted(maps.Keys(deferred))
+		return nil, fmt.Errorf("missing assignment for metrics with metricsdoc markers: %s", strings.Join(names, ", "))
+	}
 	// stable sort within package groups is applied later in render
 	return all, nil
+}
+
+func metricFromCall(expr ast.Expr) (Metric, bool) {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return Metric{}, false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return Metric{}, false
+	}
+	pkgIdent, ok := sel.X.(*ast.Ident)
+	if !ok || pkgIdent.Name != "prometheus" {
+		return Metric{}, false
+	}
+	fun := sel.Sel.Name
+	if fun != "NewCounterVec" && fun != "NewGaugeVec" && fun != "NewHistogramVec" {
+		return Metric{}, false
+	}
+	if len(call.Args) < 2 {
+		return Metric{}, false
+	}
+	opts, ok := call.Args[0].(*ast.CompositeLit)
+	if !ok {
+		return Metric{}, false
+	}
+	var name, help string
+	for _, elt := range opts.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		var keyName string
+		switch k := kv.Key.(type) {
+		case *ast.Ident:
+			keyName = k.Name
+		case *ast.SelectorExpr:
+			keyName = k.Sel.Name
+		default:
+			keyName = exprToString(kv.Key)
+		}
+		switch keyName {
+		case "Name":
+			name = stringLiteral(kv.Value)
+		case "Help":
+			help = stringLiteral(kv.Value)
+		}
+	}
+	labels := parseLabels(call.Args[1])
+	return Metric{
+		FullName: "kueue_" + name,
+		Type:     map[string]string{"NewCounterVec": "Counter", "NewGaugeVec": "Gauge", "NewHistogramVec": "Histogram"}[fun],
+		Help:     normalizeHelp(help),
+		Labels:   labels,
+	}, true
 }
 
 func parseLabels(arg ast.Expr) []string {

--- a/hack/tools/metricsdoc/main_test.go
+++ b/hack/tools/metricsdoc/main_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestExtractMetricsFromPackage(t *testing.T) {
+	dir := t.TempDir()
+
+	inline := `package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+const KueueName = "kueue"
+
+var (
+	// +metricsdoc:group=health
+	// +metricsdoc:labels=result="possible values are success or inadmissible",replica_role="one of leader, follower, or standalone"
+	AdmissionAttemptsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: KueueName,
+			Name:      "admission_attempts_total",
+			Help: "The total number of attempts to admit workloads. " +
+				"Each admission attempt might try to admit more than one workload.",
+		}, []string{"result", "replica_role"},
+	)
+)
+`
+
+	deferred := `package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	// +metricsdoc:group=clusterqueue
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",status="status label (varies by metric)"
+	PendingWorkloads *prometheus.GaugeVec
+
+	// +metricsdoc:group=health
+	Duration *prometheus.HistogramVec
+)
+
+func initMetrics() {
+	PendingWorkloads = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: KueueName,
+			Name:      "pending_workloads",
+			Help:      "The number of pending workloads, per cluster_queue and status",
+		},
+		[]string{"cluster_queue", "status"},
+	)
+	Duration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: KueueName,
+			Name:      "admission_cycle_duration_seconds",
+			Help:      "The latency of an admission cycle",
+		},
+		[]string{"operation"},
+	)
+}
+`
+
+	if err := os.WriteFile(filepath.Join(dir, "inline.go"), []byte(inline), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "deferred.go"), []byte(deferred), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := extractMetricsFromPackage(dir)
+	if err != nil {
+		t.Fatalf("extractMetricsFromPackage: %v", err)
+	}
+
+	want := []Metric{
+		{
+			FullName:  "kueue_admission_attempts_total",
+			Type:      "Counter",
+			Group:     "health",
+			Help:      "The total number of attempts to admit workloads. Each admission attempt might try to admit more than one workload.",
+			Labels:    []string{"result", "replica_role"},
+			LabelDocs: map[string]string{"result": "possible values are success or inadmissible", "replica_role": "one of leader, follower, or standalone"},
+		},
+		{
+			FullName: "kueue_admission_cycle_duration_seconds",
+			Type:     "Histogram",
+			Group:    "health",
+			Help:     "The latency of an admission cycle",
+			Labels:   []string{"operation"},
+		},
+		{
+			FullName:  "kueue_pending_workloads",
+			Type:      "Gauge",
+			Group:     "clusterqueue",
+			Help:      "The number of pending workloads, per cluster_queue and status",
+			Labels:    []string{"cluster_queue", "status"},
+			LabelDocs: map[string]string{"cluster_queue": "the name of the ClusterQueue", "status": "status label (varies by metric)"},
+		},
+	}
+
+	slices.SortFunc(got, func(a, b Metric) int { return strings.Compare(a.FullName, b.FullName) })
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected metrics (-want/+got):\n%s", diff)
+	}
+}
+
+func TestExtractMetricsMissingGroup(t *testing.T) {
+	dir := t.TempDir()
+	src := `package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	NoGroup = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "no_group_metric",
+			Help: "Missing group marker",
+		},
+		[]string{"label"},
+	)
+)
+`
+	if err := os.WriteFile(filepath.Join(dir, "metrics.go"), []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := extractMetricsFromPackage(dir)
+	if err == nil {
+		t.Fatal("expected error for missing group marker")
+	}
+	wantErr := "missing metricsdoc:group marker on metrics: NoGroup"
+	if err.Error() != wantErr {
+		t.Errorf("error = %q, want %q", err.Error(), wantErr)
+	}
+}
+
+func TestExtractMetricsUnresolvedDeferred(t *testing.T) {
+	dir := t.TempDir()
+	src := `package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	// +metricsdoc:group=health
+	Orphan *prometheus.GaugeVec
+)
+`
+	if err := os.WriteFile(filepath.Join(dir, "metrics.go"), []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := extractMetricsFromPackage(dir)
+	if err == nil {
+		t.Fatal("expected error for unresolved deferred var")
+	}
+	wantErr := "missing assignment for metrics with metricsdoc markers: Orphan"
+	if err.Error() != wantErr {
+		t.Errorf("error = %q, want %q", err.Error(), wantErr)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->
/kind cleanup

#### What this PR does / why we need it:

Extends the metricsdoc generator to support type-only var declarations with +metricsdoc: markers whose assignments happen inside function bodies.

This is a preparatory PR for the custom labels PR (#9774), where metric constructions currently have to be duplicated just to append custom labels at runtime. With this change, we can move metrics to a single initMetrics(extraLabels) function, eliminating the duplication entirely. 

See https://github.com/kubernetes-sigs/kueue/pull/9774#discussion_r2914161541

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #9774 

#### Special notes for your reviewer:

- This change extends (not replaces) the current inline-initialized pattern, both approaches work side by side.
- To keep the diff focused, the logic remains in `main.go` with `main_test.go`. As a follow-up, it can be extracted into a subpackage.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```