### PR TITLE
Introduce SchedulerLongRequeueInterval feature gate.

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -302,7 +302,7 @@ func main() {
 	cCache := schdcache.New(mgr.GetClient(), cacheOptions...)
 
 	// setup inadmissible workload requeuer
-	requeuer := qcache.NewRequeuer(qcache.RequeueBatchPeriodProd)
+	requeuer := qcache.NewRequeuer()
 	if err := mgr.Add(requeuer); err != nil {
 		setupLog.Error(err, "Unable to add workloadRequeuer to manager")
 		os.Exit(1)

--- a/pkg/cache/queue/inadmissible_workloads.go
+++ b/pkg/cache/queue/inadmissible_workloads.go
@@ -30,12 +30,33 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/cache/hierarchy"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 const (
-	RequeueBatchPeriodProd = 1 * time.Second
+	requeueBatchPeriod     = 1 * time.Second
+	requeueLongBatchPeriod = 10 * time.Second
 )
+
+func getRequeueBatchPeriod() time.Duration {
+	if features.Enabled(features.SchedulerLongRequeueInterval) {
+		return requeueLongBatchPeriod
+	}
+	return requeueBatchPeriod
+}
+
+type requeuerOptions struct {
+	batchPeriod time.Duration
+}
+
+type RequeuerOption func(*requeuerOptions)
+
+func WithBatchPeriod(period time.Duration) RequeuerOption {
+	return func(o *requeuerOptions) {
+		o.batchPeriod = period
+	}
+}
 
 // inadmissibleWorkloads is a thin wrapper around a map to encapsulate
 // operations on inadmissible workloads and prevent direct map access.
@@ -225,10 +246,16 @@ type workqueueRequeuer struct {
 	batchPeriod time.Duration
 }
 
-func NewRequeuer(batchPeriod time.Duration) *workqueueRequeuer {
+func NewRequeuer(opts ...RequeuerOption) *workqueueRequeuer {
+	options := requeuerOptions{
+		batchPeriod: getRequeueBatchPeriod(),
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
 	return &workqueueRequeuer{
 		queue:       workqueue.NewTypedDelayingQueue[requeueRequest](),
-		batchPeriod: batchPeriod,
+		batchPeriod: options.batchPeriod,
 	}
 }
 

--- a/pkg/cache/queue/inadmissible_workloads_test.go
+++ b/pkg/cache/queue/inadmissible_workloads_test.go
@@ -19,10 +19,73 @@ package queue
 import (
 	"maps"
 	"testing"
+	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/component-base/featuregate"
+
+	"sigs.k8s.io/kueue/pkg/features"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
+
+func TestNewRequeuer(t *testing.T) {
+	type args struct {
+		features map[featuregate.Feature]bool
+		opts     []RequeuerOption
+	}
+
+	type want struct {
+		batchPeriod time.Duration
+	}
+
+	testCases := map[string]struct {
+		args args
+		want want
+	}{
+		"SchedulerLongRequeueInterval feature disabled": {
+			args: args{
+				features: map[featuregate.Feature]bool{
+					features.SchedulerLongRequeueInterval: false,
+				},
+			},
+			want: want{
+				batchPeriod: time.Second,
+			},
+		},
+		"SchedulerLongRequeueInterval feature enabled": {
+			args: args{
+				features: map[featuregate.Feature]bool{
+					features.SchedulerLongRequeueInterval: true,
+				},
+			},
+			want: want{
+				batchPeriod: 10 * time.Second,
+			},
+		},
+		"custom batch period": {
+			args: args{
+				opts: []RequeuerOption{
+					WithBatchPeriod(10 * time.Millisecond),
+				},
+			},
+			want: want{
+				batchPeriod: 10 * time.Millisecond,
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			for feature, enabled := range tc.args.features {
+				features.SetFeatureGateDuringTest(t, feature, enabled)
+			}
+			requeuer := NewRequeuer(tc.args.opts...)
+			if diff := cmp.Diff(tc.want.batchPeriod, requeuer.batchPeriod); len(diff) != 0 {
+				t.Errorf("Unexpected requeue batch period (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
 
 func TestInadmissibleWorkloads_Get(t *testing.T) {
 	wl1 := workload.NewInfo(utiltestingapi.MakeWorkload("wl1", "ns1").Obj())

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -282,6 +282,12 @@ const (
 	// issue: https://github.com/kubernetes-sigs/kueue/issues/9694
 	// Skip equivalent inadmissible workloads in BestEffortFIFO scheduling.
 	SchedulingEquivalenceHashing featuregate.Feature = "SchedulingEquivalenceHashing"
+
+	// owner: @mbobrovskyi
+	//
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/9799
+	// Use 10s interval for scheduler requeuing.
+	SchedulerLongRequeueInterval featuregate.Feature = "SchedulerLongRequeueInterval"
 )
 
 func init() {
@@ -439,9 +445,11 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	TASMultiLayerTopology: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha},
 	},
-
 	SchedulingEquivalenceHashing: {
 		{Version: version.MustParse("0.17"), Default: true, PreRelease: featuregate.Beta},
+	},
+	SchedulerLongRequeueInterval: {
+		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha}, // remove in 0.20
 	},
 }
 

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -237,6 +237,12 @@
     lockToDefault: true
     preRelease: GA
     version: "0.17"
+- name: SchedulerLongRequeueInterval
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.17"
 - name: SchedulingEquivalenceHashing
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -237,6 +237,12 @@
     lockToDefault: true
     preRelease: GA
     version: "0.17"
+- name: SchedulerLongRequeueInterval
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.17"
 - name: SchedulingEquivalenceHashing
   versionedSpecs:
   - default: true

--- a/test/performance/scheduler/minimalkueue/main.go
+++ b/test/performance/scheduler/minimalkueue/main.go
@@ -205,7 +205,7 @@ func run() int {
 	cCache := schdcache.New(mgr.GetClient())
 
 	// setup inadmissible workload requeuer
-	requeuer := qcache.NewRequeuer(qcache.RequeueBatchPeriodProd)
+	requeuer := qcache.NewRequeuer()
 	if err := mgr.Add(requeuer); err != nil {
 		log.Error(err, "Unable to add workloadRequeuer to manager")
 		return 1

--- a/test/util/factory.go
+++ b/test/util/factory.go
@@ -30,7 +30,7 @@ func NewManagerForIntegrationTests(ctx context.Context, client client.Client, ch
 }
 
 func NewManagerForIntegrationTestsWithBatchPeriod(ctx context.Context, client client.Client, checker qcache.StatusChecker, batchPeriod time.Duration, options ...qcache.Option) *qcache.Manager {
-	requeuer := qcache.NewRequeuer(batchPeriod)
+	requeuer := qcache.NewRequeuer(qcache.WithBatchPeriod(batchPeriod))
 	go func() {
 		// ignore error to make linter happy.
 		_ = requeuer.Start(ctx)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Introduce SchedulerLongRequeueInterval feature gate.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #9799

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Scheduling: Add the alpha SchedulerLongRequeueInterval feature gate (disabled by default) to increase the 
inadmissible workload requeue interval from 1s to 10s. This may help to mitigate, on large environments with 
many pending workloads, issues with frequent re-queues that prevent the scheduler from reaching schedulable 
workloads deeper in the queue and result in constant re-evaluation of the same top workloads.
```