### PR TITLE
Automated cherry pick of #9812: Introduce SchedulerLongRequeueInterval feature gate.

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -298,7 +298,7 @@ func main() {
 	cCache := schdcache.New(mgr.GetClient(), cacheOptions...)
 
 	// setup inadmissible workload requeuer
-	requeuer := qcache.NewRequeuer(qcache.RequeueBatchPeriodProd)
+	requeuer := qcache.NewRequeuer()
 	if err := mgr.Add(requeuer); err != nil {
 		setupLog.Error(err, "Unable to add workloadRequeuer to manager")
 		os.Exit(1)

--- a/pkg/cache/queue/inadmissible_workloads.go
+++ b/pkg/cache/queue/inadmissible_workloads.go
@@ -30,12 +30,33 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/cache/hierarchy"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 const (
-	RequeueBatchPeriodProd = 1 * time.Second
+	requeueBatchPeriod     = 1 * time.Second
+	requeueLongBatchPeriod = 10 * time.Second
 )
+
+func getRequeueBatchPeriod() time.Duration {
+	if features.Enabled(features.SchedulerLongRequeueInterval) {
+		return requeueLongBatchPeriod
+	}
+	return requeueBatchPeriod
+}
+
+type requeuerOptions struct {
+	batchPeriod time.Duration
+}
+
+type RequeuerOption func(*requeuerOptions)
+
+func WithBatchPeriod(period time.Duration) RequeuerOption {
+	return func(o *requeuerOptions) {
+		o.batchPeriod = period
+	}
+}
 
 // inadmissibleWorkloads is a thin wrapper around a map to encapsulate
 // operations on inadmissible workloads and prevent direct map access.
@@ -225,10 +246,16 @@ type workqueueRequeuer struct {
 	batchPeriod time.Duration
 }
 
-func NewRequeuer(batchPeriod time.Duration) *workqueueRequeuer {
+func NewRequeuer(opts ...RequeuerOption) *workqueueRequeuer {
+	options := requeuerOptions{
+		batchPeriod: getRequeueBatchPeriod(),
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
 	return &workqueueRequeuer{
 		queue:       workqueue.NewTypedDelayingQueue[requeueRequest](),
-		batchPeriod: batchPeriod,
+		batchPeriod: options.batchPeriod,
 	}
 }
 

--- a/pkg/cache/queue/inadmissible_workloads_test.go
+++ b/pkg/cache/queue/inadmissible_workloads_test.go
@@ -19,10 +19,73 @@ package queue
 import (
 	"maps"
 	"testing"
+	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/component-base/featuregate"
+
+	"sigs.k8s.io/kueue/pkg/features"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
+
+func TestNewRequeuer(t *testing.T) {
+	type args struct {
+		features map[featuregate.Feature]bool
+		opts     []RequeuerOption
+	}
+
+	type want struct {
+		batchPeriod time.Duration
+	}
+
+	testCases := map[string]struct {
+		args args
+		want want
+	}{
+		"SchedulerLongRequeueInterval feature disabled": {
+			args: args{
+				features: map[featuregate.Feature]bool{
+					features.SchedulerLongRequeueInterval: false,
+				},
+			},
+			want: want{
+				batchPeriod: time.Second,
+			},
+		},
+		"SchedulerLongRequeueInterval feature enabled": {
+			args: args{
+				features: map[featuregate.Feature]bool{
+					features.SchedulerLongRequeueInterval: true,
+				},
+			},
+			want: want{
+				batchPeriod: 10 * time.Second,
+			},
+		},
+		"custom batch period": {
+			args: args{
+				opts: []RequeuerOption{
+					WithBatchPeriod(10 * time.Millisecond),
+				},
+			},
+			want: want{
+				batchPeriod: 10 * time.Millisecond,
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			for feature, enabled := range tc.args.features {
+				features.SetFeatureGateDuringTest(t, feature, enabled)
+			}
+			requeuer := NewRequeuer(tc.args.opts...)
+			if diff := cmp.Diff(tc.want.batchPeriod, requeuer.batchPeriod); len(diff) != 0 {
+				t.Errorf("Unexpected requeue batch period (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
 
 func TestInadmissibleWorkloads_Get(t *testing.T) {
 	wl1 := workload.NewInfo(utiltestingapi.MakeWorkload("wl1", "ns1").Obj())

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -268,6 +268,12 @@ const (
 	// issue: https://github.com/kubernetes-sigs/kueue/issues/9694
 	// Skip equivalent inadmissible workloads in BestEffortFIFO scheduling.
 	SchedulingEquivalenceHashing featuregate.Feature = "SchedulingEquivalenceHashing"
+
+	// owner: @mbobrovskyi
+	//
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/9799
+	// Use 10s interval for scheduler requeuing.
+	SchedulerLongRequeueInterval featuregate.Feature = "SchedulerLongRequeueInterval"
 )
 
 func init() {
@@ -412,9 +418,11 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	TASReplaceNodeOnNodeTaints: {
 		{Version: version.MustParse("0.16"), Default: false, PreRelease: featuregate.Alpha},
 	},
-
 	SchedulingEquivalenceHashing: {
 		{Version: version.MustParse("0.16"), Default: true, PreRelease: featuregate.Beta},
+	},
+	SchedulerLongRequeueInterval: {
+		{Version: version.MustParse("0.16"), Default: false, PreRelease: featuregate.Alpha}, // remove in 0.20
 	},
 }
 

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -193,6 +193,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.13"
+- name: SchedulerLongRequeueInterval
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.16"
 - name: SchedulingEquivalenceHashing
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -193,6 +193,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.13"
+- name: SchedulerLongRequeueInterval
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.16"
 - name: SchedulingEquivalenceHashing
   versionedSpecs:
   - default: true

--- a/test/performance/scheduler/minimalkueue/main.go
+++ b/test/performance/scheduler/minimalkueue/main.go
@@ -186,7 +186,7 @@ func run() int {
 	cCache := schdcache.New(mgr.GetClient())
 
 	// setup inadmissible workload requeuer
-	requeuer := qcache.NewRequeuer(qcache.RequeueBatchPeriodProd)
+	requeuer := qcache.NewRequeuer()
 	if err := mgr.Add(requeuer); err != nil {
 		log.Error(err, "Unable to add workloadRequeuer to manager")
 		return 1

--- a/test/util/factory.go
+++ b/test/util/factory.go
@@ -30,7 +30,7 @@ func NewManagerForIntegrationTests(ctx context.Context, client client.Client, ch
 }
 
 func NewManagerForIntegrationTestsWithBatchPeriod(ctx context.Context, client client.Client, checker qcache.StatusChecker, batchPeriod time.Duration, options ...qcache.Option) *qcache.Manager {
-	requeuer := qcache.NewRequeuer(batchPeriod)
+	requeuer := qcache.NewRequeuer(qcache.WithBatchPeriod(batchPeriod))
 	go func() {
 		// ignore error to make linter happy.
 		_ = requeuer.Start(ctx)


### PR DESCRIPTION
Cherry pick of #9812 on release-0.16.

#9812: Introduce SchedulerLongRequeueInterval feature gate.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

```release-note
Scheduling: Add the alpha SchedulerLongRequeueInterval feature gate (disabled by default) to increase the 
inadmissible workload requeue interval from 1s to 10s. This may help to mitigate, on large environments with 
many pending workloads, issues with frequent re-queues that prevent the scheduler from reaching schedulable 
workloads deeper in the queue and result in constant re-evaluation of the same top workloads.
```