### PR TITLE
Automated cherry pick of #9822: Add a note about the starting version of SchedulerLongRequeueInterval.

### DIFF
--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -285,6 +285,7 @@ spec:
 {{% alert title="Note" color="primary" %}}
 The SanitizePodSets and MultiKueueAllowInsecureKubeconfigs features are available starting from versions 0.13.8 and 0.14.3.
 The PropagateBatchJobLabelsToWorkload feature is available starting from versions 0.13.10 and 0.14.5.
+The SchedulerLongRequeueInterval features are available starting from versions 0.15.6 and 0.16.3.
 {{% /alert %}}
 
 ### Feature gates for graduated or deprecated features


### PR DESCRIPTION
Cherry pick of #9822 on release-0.16.

#9822: Add a note about the starting version of SchedulerLongRequeueInterval.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind documentation


```release-note
NONE
```