### PR TITLE
Defer metric vector init with automatic gauge vec tracking

### DIFF
--- a/hack/tools/metricsdoc/main.go
+++ b/hack/tools/metricsdoc/main.go
@@ -194,10 +194,17 @@ func metricFromCall(expr ast.Expr) (Metric, bool) {
 	}
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok {
+		// Unwrap single-argument wrapper (e.g. trackGaugeVec(prometheus.NewGaugeVec(...))).
+		if len(call.Args) == 1 {
+			return metricFromCall(call.Args[0])
+		}
 		return Metric{}, false
 	}
 	pkgIdent, ok := sel.X.(*ast.Ident)
 	if !ok || pkgIdent.Name != "prometheus" {
+		if len(call.Args) == 1 {
+			return metricFromCall(call.Args[0])
+		}
 		return Metric{}, false
 	}
 	fun := sel.Sel.Name
@@ -243,15 +250,20 @@ func metricFromCall(expr ast.Expr) (Metric, bool) {
 }
 
 func parseLabels(arg ast.Expr) []string {
-	var labels []string
-	cl, ok := arg.(*ast.CompositeLit)
-	if !ok {
+	switch v := arg.(type) {
+	case *ast.CompositeLit:
+		var labels []string
+		for _, elt := range v.Elts {
+			labels = append(labels, stringLiteral(elt))
+		}
 		return labels
+	case *ast.CallExpr:
+		// Extract only the static labels from append(base, dynamic...) calls.
+		if ident, ok := v.Fun.(*ast.Ident); ok && ident.Name == "append" && len(v.Args) >= 1 {
+			return parseLabels(v.Args[0])
+		}
 	}
-	for _, elt := range cl.Elts {
-		labels = append(labels, stringLiteral(elt))
-	}
-	return labels
+	return nil
 }
 
 func stringLiteral(e ast.Expr) string {

--- a/hack/tools/metricsdoc/main_test.go
+++ b/hack/tools/metricsdoc/main_test.go
@@ -155,6 +155,56 @@ var (
 	}
 }
 
+func TestExtractMetricsWrapperAndAppendLabels(t *testing.T) {
+	dir := t.TempDir()
+	src := `package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+const KueueName = "kueue"
+
+var extraLabels []string
+
+func trackGaugeVec(g *prometheus.GaugeVec) *prometheus.GaugeVec { return g }
+
+var (
+	// +metricsdoc:group=clusterqueue
+	PendingWorkloads *prometheus.GaugeVec
+)
+
+func initMetrics() {
+	PendingWorkloads = trackGaugeVec(prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: KueueName,
+			Name:      "pending_workloads",
+			Help:      "The number of pending workloads",
+		},
+		append([]string{"cluster_queue", "status"}, extraLabels...),
+	))
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "metrics.go"), []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := extractMetricsFromPackage(dir)
+	if err != nil {
+		t.Fatalf("extractMetricsFromPackage: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(got))
+	}
+	want := Metric{
+		FullName: "kueue_pending_workloads",
+		Type:     "Gauge",
+		Group:    "clusterqueue",
+		Help:     "The number of pending workloads",
+		Labels:   []string{"cluster_queue", "status"},
+	}
+	if diff := cmp.Diff(want, got[0]); diff != "" {
+		t.Errorf("unexpected metric (-want/+got):\n%s", diff)
+	}
+}
+
 func TestExtractMetricsUnresolvedDeferred(t *testing.T) {
 	dir := t.TempDir()
 	src := `package metrics

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -67,6 +67,203 @@ var (
 
 	// +metricsdoc:group=health
 	// +metricsdoc:labels=result="possible values are `success` or `inadmissible`",replica_role="one of `leader`, `follower`, or `standalone`"
+	AdmissionAttemptsTotal *prometheus.CounterVec
+
+	// +metricsdoc:group=health
+	// +metricsdoc:labels=result="possible values are `success` or `inadmissible`",replica_role="one of `leader`, `follower`, or `standalone`"
+	admissionAttemptDuration *prometheus.HistogramVec
+
+	// +metricsdoc:group=clusterqueue
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",replica_role="one of `leader`, `follower`, or `standalone`"
+	AdmissionCyclePreemptionSkips *prometheus.GaugeVec
+
+	// Metrics tied to the queue system.
+
+	// +metricsdoc:group=clusterqueue
+	// +metricsdoc:labels=git_version="git version",git_commit="git commit",build_date="build date",go_version="go version",compiler="compiler",platform="platform"
+	buildInfo *prometheus.GaugeVec
+
+	// +metricsdoc:group=clusterqueue
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",status="status label (varies by metric)",replica_role="one of `leader`, `follower`, or `standalone`"
+	PendingWorkloads *prometheus.GaugeVec
+
+	// +metricsdoc:group=localqueue
+	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",status="status label (varies by metric)",replica_role="one of `leader`, `follower`, or `standalone`"
+	LocalQueuePendingWorkloads *prometheus.GaugeVec
+
+	// +metricsdoc:group=clusterqueue
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",replica_role="one of `leader`, `follower`, or `standalone`"
+	FinishedWorkloads *prometheus.GaugeVec
+
+	// +metricsdoc:group=localqueue
+	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",replica_role="one of `leader`, `follower`, or `standalone`"
+	LocalQueueFinishedWorkloads *prometheus.GaugeVec
+
+	// +metricsdoc:group=clusterqueue
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
+	QuotaReservedWorkloadsTotal *prometheus.CounterVec
+
+	// +metricsdoc:group=localqueue
+	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
+	LocalQueueQuotaReservedWorkloadsTotal *prometheus.CounterVec
+
+	// +metricsdoc:group=clusterqueue
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
+	FinishedWorkloadsTotal *prometheus.CounterVec
+
+	// +metricsdoc:group=localqueue
+	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
+	LocalQueueFinishedWorkloadsTotal *prometheus.CounterVec
+
+	// +metricsdoc:group=clusterqueue
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
+	QuotaReservedWaitTime *prometheus.HistogramVec
+
+	// +metricsdoc:group=clusterqueue
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",reason="eviction or preemption reason",underlying_cause="root cause for eviction",replica_role="one of `leader`, `follower`, or `standalone`"
+	PodsReadyToEvictedTimeSeconds *prometheus.HistogramVec
+
+	// +metricsdoc:group=localqueue
+	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
+	LocalQueueQuotaReservedWaitTime *prometheus.HistogramVec
+
+	// +metricsdoc:group=clusterqueue
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
+	AdmittedWorkloadsTotal *prometheus.CounterVec
+
+	// +metricsdoc:group=localqueue
+	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
+	LocalQueueAdmittedWorkloadsTotal *prometheus.CounterVec
+
+	// +metricsdoc:group=clusterqueue
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
+	AdmissionWaitTime *prometheus.HistogramVec
+
+	// +metricsdoc:group=optional_wait_for_pods_ready
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
+	QueuedUntilReadyWaitTime *prometheus.HistogramVec
+
+	// +metricsdoc:group=optional_wait_for_pods_ready
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
+	AdmittedUntilReadyWaitTime *prometheus.HistogramVec
+
+	// +metricsdoc:group=localqueue
+	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
+	LocalQueueAdmissionWaitTime *prometheus.HistogramVec
+
+	// +metricsdoc:group=clusterqueue
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
+	AdmissionChecksWaitTime *prometheus.HistogramVec
+
+	// +metricsdoc:group=localqueue
+	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
+	LocalQueueAdmissionChecksWaitTime *prometheus.HistogramVec
+
+	// +metricsdoc:group=optional_wait_for_pods_ready
+	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
+	LocalQueueQueuedUntilReadyWaitTime *prometheus.HistogramVec
+
+	// +metricsdoc:group=optional_wait_for_pods_ready
+	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
+	LocalQueueAdmittedUntilReadyWaitTime *prometheus.HistogramVec
+
+	// +metricsdoc:group=clusterqueue
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",reason="eviction or preemption reason",underlying_cause="root cause for eviction",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
+	EvictedWorkloadsTotal *prometheus.CounterVec
+
+	// +metricsdoc:group=clusterqueue
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",replica_role="one of `leader`, `follower`, or `standalone`"
+	ReplacedWorkloadSlicesTotal *prometheus.CounterVec
+
+	// +metricsdoc:group=localqueue
+	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",reason="eviction or preemption reason",underlying_cause="root cause for eviction",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
+	LocalQueueEvictedWorkloadsTotal *prometheus.CounterVec
+
+	// +metricsdoc:group=clusterqueue
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",reason="eviction or preemption reason",detailed_reason="finer-grained eviction cause",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
+	EvictedWorkloadsOnceTotal *prometheus.CounterVec
+
+	// +metricsdoc:group=clusterqueue
+	// +metricsdoc:labels=preempting_cluster_queue="the ClusterQueue executing preemption",reason="eviction or preemption reason",replica_role="one of `leader`, `follower`, or `standalone`"
+	PreemptedWorkloadsTotal *prometheus.CounterVec
+
+	// Metrics tied to the cache.
+
+	// +metricsdoc:group=clusterqueue
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",replica_role="one of `leader`, `follower`, or `standalone`"
+	ReservingActiveWorkloads *prometheus.GaugeVec
+
+	// +metricsdoc:group=localqueue
+	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",replica_role="one of `leader`, `follower`, or `standalone`"
+	LocalQueueReservingActiveWorkloads *prometheus.GaugeVec
+
+	// +metricsdoc:group=clusterqueue
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",replica_role="one of `leader`, `follower`, or `standalone`"
+	AdmittedActiveWorkloads *prometheus.GaugeVec
+
+	// +metricsdoc:group=localqueue
+	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",replica_role="one of `leader`, `follower`, or `standalone`"
+	LocalQueueAdmittedActiveWorkloads *prometheus.GaugeVec
+
+	// +metricsdoc:group=clusterqueue
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",status="one of `pending`, `active`, or `terminated`",replica_role="one of `leader`, `follower`, or `standalone`"
+	ClusterQueueByStatus *prometheus.GaugeVec
+
+	// +metricsdoc:group=localqueue
+	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",active="one of `True`, `False`, or `Unknown`",replica_role="one of `leader`, `follower`, or `standalone`"
+	LocalQueueByStatus *prometheus.GaugeVec
+
+	// Optional cluster queue metrics
+
+	// +metricsdoc:group=optional_clusterqueue_resources
+	// +metricsdoc:labels=cohort="the name of the Cohort",cluster_queue="the name of the ClusterQueue",flavor="the resource flavor name",resource="the resource name",replica_role="one of `leader`, `follower`, or `standalone`"
+	ClusterQueueResourceReservations *prometheus.GaugeVec
+
+	// +metricsdoc:group=optional_clusterqueue_resources
+	// +metricsdoc:labels=cohort="the name of the Cohort",cluster_queue="the name of the ClusterQueue",flavor="the resource flavor name",resource="the resource name",replica_role="one of `leader`, `follower`, or `standalone`"
+	ClusterQueueResourceUsage *prometheus.GaugeVec
+
+	// +metricsdoc:group=localqueue
+	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",flavor="the resource flavor name",resource="the resource name",replica_role="one of `leader`, `follower`, or `standalone`"
+	LocalQueueResourceReservations *prometheus.GaugeVec
+
+	// +metricsdoc:group=localqueue
+	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",flavor="the resource flavor name",resource="the resource name",replica_role="one of `leader`, `follower`, or `standalone`"
+	LocalQueueResourceUsage *prometheus.GaugeVec
+
+	// +metricsdoc:group=optional_clusterqueue_resources
+	// +metricsdoc:labels=cohort="the name of the Cohort",cluster_queue="the name of the ClusterQueue",flavor="the resource flavor name",resource="the resource name",replica_role="one of `leader`, `follower`, or `standalone`"
+	ClusterQueueResourceNominalQuota *prometheus.GaugeVec
+
+	// +metricsdoc:group=optional_clusterqueue_resources
+	// +metricsdoc:labels=cohort="the name of the Cohort",cluster_queue="the name of the ClusterQueue",flavor="the resource flavor name",resource="the resource name",replica_role="one of `leader`, `follower`, or `standalone`"
+	ClusterQueueResourceBorrowingLimit *prometheus.GaugeVec
+
+	// +metricsdoc:group=optional_clusterqueue_resources
+	// +metricsdoc:labels=cohort="the name of the Cohort",cluster_queue="the name of the ClusterQueue",flavor="the resource flavor name",resource="the resource name",replica_role="one of `leader`, `follower`, or `standalone`"
+	ClusterQueueResourceLendingLimit *prometheus.GaugeVec
+
+	// +metricsdoc:group=optional_clusterqueue_resources
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",cohort="the name of the Cohort",replica_role="one of `leader`, `follower`, or `standalone`"
+	ClusterQueueWeightedShare *prometheus.GaugeVec
+
+	// +metricsdoc:group=cohort
+	// +metricsdoc:labels=cohort="the name of the Cohort",replica_role="one of `leader`, `follower`, or `standalone`"
+	CohortWeightedShare *prometheus.GaugeVec
+
+	// +metricsdoc:group=cohort
+	// +metricsdoc:labels=cohort="the name of the Cohort",flavor="the resource flavor name",resource="the resource name",replica_role="one of `leader`, `follower`, or `standalone`"
+	CohortSubtreeQuota *prometheus.GaugeVec
+)
+
+func trackGaugeVec(g *prometheus.GaugeVec) *prometheus.GaugeVec {
+	allGaugeVecs = append(allGaugeVecs, g)
+	return g
+}
+
+func initMetricVectors(extraLabels []string) {
+	allGaugeVecs = nil
+
 	AdmissionAttemptsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: constants.KueueName,
@@ -76,11 +273,9 @@ Each admission attempt might try to admit more than one workload.
 The label 'result' can have the following values:
 - 'success' means that at least one workload was admitted.,
 - 'inadmissible' means that no workload was admitted.`,
-		}, []string{"result", "replica_role"},
+		}, append([]string{"result", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=health
-	// +metricsdoc:labels=result="possible values are `success` or `inadmissible`",replica_role="one of `leader`, `follower`, or `standalone`"
 	admissionAttemptDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: constants.KueueName,
@@ -89,24 +284,18 @@ The label 'result' can have the following values:
 The label 'result' can have the following values:
 - 'success' means that at least one workload was admitted.,
 - 'inadmissible' means that no workload was admitted.`,
-		}, []string{"result", "replica_role"},
+		}, append([]string{"result", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=clusterqueue
-	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",replica_role="one of `leader`, `follower`, or `standalone`"
-	AdmissionCyclePreemptionSkips = prometheus.NewGaugeVec(
+	AdmissionCyclePreemptionSkips = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "admission_cycle_preemption_skips",
 			Help: "The number of Workloads in the ClusterQueue that got preemption candidates " +
 				"but had to be skipped because other ClusterQueues needed the same resources in the same cycle",
-		}, []string{"cluster_queue", "replica_role"},
-	)
+		}, append([]string{"cluster_queue", "replica_role"}, extraLabels...),
+	))
 
-	// Metrics tied to the queue system.
-
-	// +metricsdoc:group=clusterqueue
-	// +metricsdoc:labels=git_version="git version",git_commit="git commit",build_date="build date",go_version="go version",compiler="compiler",platform="platform"
 	buildInfo = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
@@ -116,9 +305,7 @@ The label 'result' can have the following values:
 		[]string{"git_version", "git_commit", "build_date", "go_version", "compiler", "platform"},
 	)
 
-	// +metricsdoc:group=clusterqueue
-	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",status="status label (varies by metric)",replica_role="one of `leader`, `follower`, or `standalone`"
-	PendingWorkloads = prometheus.NewGaugeVec(
+	PendingWorkloads = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "pending_workloads",
@@ -126,12 +313,10 @@ The label 'result' can have the following values:
 'status' can have the following values:
 - "active" means that the workloads are in the admission queue.
 - "inadmissible" means there was a failed admission attempt for these workloads and they won't be retried until cluster conditions, which could make this workload admissible, change`,
-		}, []string{"cluster_queue", "status", "replica_role"},
-	)
+		}, append([]string{"cluster_queue", "status", "replica_role"}, extraLabels...),
+	))
 
-	// +metricsdoc:group=localqueue
-	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",status="status label (varies by metric)",replica_role="one of `leader`, `follower`, or `standalone`"
-	LocalQueuePendingWorkloads = prometheus.NewGaugeVec(
+	LocalQueuePendingWorkloads = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_pending_workloads",
@@ -139,82 +324,66 @@ The label 'result' can have the following values:
 'status' can have the following values:
 - "active" means that the workloads are in the admission queue.
 - "inadmissible" means there was a failed admission attempt for these workloads and they won't be retried until cluster conditions, which could make this workload admissible, change`,
-		}, []string{"name", "namespace", "status", "replica_role"},
-	)
+		}, append([]string{"name", "namespace", "status", "replica_role"}, extraLabels...),
+	))
 
-	// +metricsdoc:group=clusterqueue
-	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",replica_role="one of `leader`, `follower`, or `standalone`"
-	FinishedWorkloads = prometheus.NewGaugeVec(
+	FinishedWorkloads = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "finished_workloads",
 			Help:      `The number of finished workloads per 'cluster_queue'.`,
-		}, []string{"cluster_queue", "replica_role"},
-	)
+		}, append([]string{"cluster_queue", "replica_role"}, extraLabels...),
+	))
 
-	// +metricsdoc:group=localqueue
-	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",replica_role="one of `leader`, `follower`, or `standalone`"
-	LocalQueueFinishedWorkloads = prometheus.NewGaugeVec(
+	LocalQueueFinishedWorkloads = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_finished_workloads",
 			Help:      `The number of finished workloads, per 'local_queue'.`,
-		}, []string{"name", "namespace", "replica_role"},
-	)
+		}, append([]string{"name", "namespace", "replica_role"}, extraLabels...),
+	))
 
-	// +metricsdoc:group=clusterqueue
-	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
 	QuotaReservedWorkloadsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: constants.KueueName,
 			Name:      "quota_reserved_workloads_total",
 			Help:      "The total number of quota reserved workloads per 'cluster_queue'",
-		}, []string{"cluster_queue", "priority_class", "replica_role"},
+		}, append([]string{"cluster_queue", "priority_class", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=localqueue
-	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
 	LocalQueueQuotaReservedWorkloadsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_quota_reserved_workloads_total",
 			Help:      "The total number of quota reserved workloads per 'local_queue'",
-		}, []string{"name", "namespace", "priority_class", "replica_role"},
+		}, append([]string{"name", "namespace", "priority_class", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=clusterqueue
-	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
 	FinishedWorkloadsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: constants.KueueName,
 			Name:      "finished_workloads_total",
 			Help:      "The total number of finished workloads per 'cluster_queue'",
-		}, []string{"cluster_queue", "priority_class", "replica_role"},
+		}, append([]string{"cluster_queue", "priority_class", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=localqueue
-	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
 	LocalQueueFinishedWorkloadsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_finished_workloads_total",
 			Help:      "The total number of finished workloads per 'local_queue'",
-		}, []string{"name", "namespace", "priority_class", "replica_role"},
+		}, append([]string{"name", "namespace", "priority_class", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=clusterqueue
-	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
 	QuotaReservedWaitTime = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: constants.KueueName,
 			Name:      "quota_reserved_wait_time_seconds",
 			Help:      "The time between a workload was created or requeued until it got quota reservation, per 'cluster_queue'",
 			Buckets:   generateExponentialBuckets(14),
-		}, []string{"cluster_queue", "priority_class", "replica_role"},
+		}, append([]string{"cluster_queue", "priority_class", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=clusterqueue
-	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",reason="eviction or preemption reason",underlying_cause="root cause for eviction",replica_role="one of `leader`, `follower`, or `standalone`"
 	PodsReadyToEvictedTimeSeconds = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: constants.KueueName,
@@ -234,130 +403,106 @@ The label 'underlying_cause' can have the following values:
 - "MaximumExecutionTimeExceeded" means that the workload was evicted by Kueue due to maximum execution time exceeded.
 - "RequeuingLimitExceeded" means that the workload was evicted by Kueue due to requeuing limit exceeded.`,
 			Buckets: generateExponentialBuckets(14),
-		}, []string{"cluster_queue", "reason", "underlying_cause", "replica_role"},
+		}, append([]string{"cluster_queue", "reason", "underlying_cause", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=localqueue
-	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
 	LocalQueueQuotaReservedWaitTime = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_quota_reserved_wait_time_seconds",
 			Help:      "The time between a workload was created or requeued until it got quota reservation, per 'local_queue'",
 			Buckets:   generateExponentialBuckets(14),
-		}, []string{"name", "namespace", "priority_class", "replica_role"},
+		}, append([]string{"name", "namespace", "priority_class", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=clusterqueue
-	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
 	AdmittedWorkloadsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: constants.KueueName,
 			Name:      "admitted_workloads_total",
 			Help:      "The total number of admitted workloads per 'cluster_queue'",
-		}, []string{"cluster_queue", "priority_class", "replica_role"},
+		}, append([]string{"cluster_queue", "priority_class", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=localqueue
-	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
 	LocalQueueAdmittedWorkloadsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_admitted_workloads_total",
 			Help:      "The total number of admitted workloads per 'local_queue'",
-		}, []string{"name", "namespace", "priority_class", "replica_role"},
+		}, append([]string{"name", "namespace", "priority_class", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=clusterqueue
-	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
 	AdmissionWaitTime = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: constants.KueueName,
 			Name:      "admission_wait_time_seconds",
 			Help:      "The time between a workload was created or requeued until admission, per 'cluster_queue'",
 			Buckets:   generateExponentialBuckets(16),
-		}, []string{"cluster_queue", "priority_class", "replica_role"},
+		}, append([]string{"cluster_queue", "priority_class", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=optional_wait_for_pods_ready
-	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
 	QueuedUntilReadyWaitTime = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: constants.KueueName,
 			Name:      "ready_wait_time_seconds",
 			Help:      "The time between a workload was created or requeued until ready, per 'cluster_queue'",
 			Buckets:   generateExponentialBuckets(14),
-		}, []string{"cluster_queue", "priority_class", "replica_role"},
+		}, append([]string{"cluster_queue", "priority_class", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=optional_wait_for_pods_ready
-	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
 	AdmittedUntilReadyWaitTime = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: constants.KueueName,
 			Name:      "admitted_until_ready_wait_time_seconds",
 			Help:      "The time between a workload was admitted until ready, per 'cluster_queue'",
 			Buckets:   generateExponentialBuckets(14),
-		}, []string{"cluster_queue", "priority_class", "replica_role"},
+		}, append([]string{"cluster_queue", "priority_class", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=localqueue
-	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
 	LocalQueueAdmissionWaitTime = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_admission_wait_time_seconds",
 			Help:      "The time between a workload was created or requeued until admission, per 'local_queue'",
 			Buckets:   generateExponentialBuckets(14),
-		}, []string{"name", "namespace", "priority_class", "replica_role"},
+		}, append([]string{"name", "namespace", "priority_class", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=clusterqueue
-	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
 	AdmissionChecksWaitTime = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: constants.KueueName,
 			Name:      "admission_checks_wait_time_seconds",
 			Help:      "The time from when a workload got the quota reservation until admission, per 'cluster_queue'",
 			Buckets:   generateExponentialBuckets(14),
-		}, []string{"cluster_queue", "priority_class", "replica_role"},
+		}, append([]string{"cluster_queue", "priority_class", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=localqueue
-	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
 	LocalQueueAdmissionChecksWaitTime = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_admission_checks_wait_time_seconds",
 			Help:      "The time from when a workload got the quota reservation until admission, per 'local_queue'",
 			Buckets:   generateExponentialBuckets(14),
-		}, []string{"name", "namespace", "priority_class", "replica_role"},
+		}, append([]string{"name", "namespace", "priority_class", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=optional_wait_for_pods_ready
-	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
 	LocalQueueQueuedUntilReadyWaitTime = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_ready_wait_time_seconds",
 			Help:      "The time between a workload was created or requeued until ready, per 'local_queue'",
 			Buckets:   generateExponentialBuckets(14),
-		}, []string{"name", "namespace", "priority_class", "replica_role"},
+		}, append([]string{"name", "namespace", "priority_class", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=optional_wait_for_pods_ready
-	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
 	LocalQueueAdmittedUntilReadyWaitTime = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_admitted_until_ready_wait_time_seconds",
 			Help:      "The time between a workload was admitted until ready, per 'local_queue'",
 			Buckets:   generateExponentialBuckets(14),
-		}, []string{"name", "namespace", "priority_class", "replica_role"},
+		}, append([]string{"name", "namespace", "priority_class", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=clusterqueue
-	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",reason="eviction or preemption reason",underlying_cause="root cause for eviction",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
 	EvictedWorkloadsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: constants.KueueName,
@@ -376,21 +521,17 @@ The label 'underlying_cause' can have the following values:
 - "AdmissionCheck" means that the workload was evicted by Kueue due to a rejected admission check.
 - "MaximumExecutionTimeExceeded" means that the workload was evicted by Kueue due to maximum execution time exceeded.
 - "RequeuingLimitExceeded" means that the workload was evicted by Kueue due to requeuing limit exceeded.`,
-		}, []string{"cluster_queue", "reason", "underlying_cause", "priority_class", "replica_role"},
+		}, append([]string{"cluster_queue", "reason", "underlying_cause", "priority_class", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=clusterqueue
-	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",replica_role="one of `leader`, `follower`, or `standalone`"
 	ReplacedWorkloadSlicesTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: constants.KueueName,
 			Name:      "replaced_workload_slices_total",
 			Help:      `The number of replaced workload slices per 'cluster_queue'`,
-		}, []string{"cluster_queue", "replica_role"},
+		}, append([]string{"cluster_queue", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=localqueue
-	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",reason="eviction or preemption reason",underlying_cause="root cause for eviction",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
 	LocalQueueEvictedWorkloadsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: constants.KueueName,
@@ -409,11 +550,9 @@ The label 'underlying_cause' can have the following values:
 - "AdmissionCheck" means that the workload was evicted by Kueue due to a rejected admission check.
 - "MaximumExecutionTimeExceeded" means that the workload was evicted by Kueue due to maximum execution time exceeded.
 - "RequeuingLimitExceeded" means that the workload was evicted by Kueue due to requeuing limit exceeded.`,
-		}, []string{"name", "namespace", "reason", "underlying_cause", "priority_class", "replica_role"},
+		}, append([]string{"name", "namespace", "reason", "underlying_cause", "priority_class", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=clusterqueue
-	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",reason="eviction or preemption reason",detailed_reason="finer-grained eviction cause",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
 	EvictedWorkloadsOnceTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: constants.KueueName,
@@ -434,11 +573,9 @@ The label 'detailed_reason' can have the following values:
 - "AdmissionCheck" means that the workload was evicted by Kueue due to a rejected admission check.
 - "MaximumExecutionTimeExceeded" means that the workload was evicted by Kueue due to maximum execution time exceeded.
 - "RequeuingLimitExceeded" means that the workload was evicted by Kueue due to requeuing limit exceeded.`,
-		}, []string{"cluster_queue", "reason", "detailed_reason", "priority_class", "replica_role"},
+		}, append([]string{"cluster_queue", "reason", "detailed_reason", "priority_class", "replica_role"}, extraLabels...),
 	)
 
-	// +metricsdoc:group=clusterqueue
-	// +metricsdoc:labels=preempting_cluster_queue="the ClusterQueue executing preemption",reason="eviction or preemption reason",replica_role="one of `leader`, `follower`, or `standalone`"
 	PreemptedWorkloadsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: constants.KueueName,
@@ -449,148 +586,116 @@ The label 'reason' can have the following values:
 - "InCohortReclamation" means that the workload was preempted by a workload in the same cohort due to reclamation of nominal quota.
 - "InCohortFairSharing" means that the workload was preempted by a workload in the same cohort Fair Sharing.
 - "InCohortReclaimWhileBorrowing" means that the workload was preempted by a workload in the same cohort due to reclamation of nominal quota while borrowing.`,
-		}, []string{"preempting_cluster_queue", "reason", "replica_role"},
+		}, append([]string{"preempting_cluster_queue", "reason", "replica_role"}, extraLabels...),
 	)
 
-	// Metrics tied to the cache.
-
-	// +metricsdoc:group=clusterqueue
-	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",replica_role="one of `leader`, `follower`, or `standalone`"
-	ReservingActiveWorkloads = prometheus.NewGaugeVec(
+	ReservingActiveWorkloads = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "reserving_active_workloads",
 			Help:      "The number of Workloads that are reserving quota, per 'cluster_queue'",
-		}, []string{"cluster_queue", "replica_role"},
-	)
+		}, append([]string{"cluster_queue", "replica_role"}, extraLabels...),
+	))
 
-	// +metricsdoc:group=localqueue
-	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",replica_role="one of `leader`, `follower`, or `standalone`"
-	LocalQueueReservingActiveWorkloads = prometheus.NewGaugeVec(
+	LocalQueueReservingActiveWorkloads = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_reserving_active_workloads",
 			Help:      "The number of Workloads that are reserving quota, per 'localQueue'",
-		}, []string{"name", "namespace", "replica_role"},
-	)
+		}, append([]string{"name", "namespace", "replica_role"}, extraLabels...),
+	))
 
-	// +metricsdoc:group=clusterqueue
-	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",replica_role="one of `leader`, `follower`, or `standalone`"
-	AdmittedActiveWorkloads = prometheus.NewGaugeVec(
+	AdmittedActiveWorkloads = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "admitted_active_workloads",
 			Help:      "The number of admitted Workloads that are active (unsuspended and not finished), per 'cluster_queue'",
-		}, []string{"cluster_queue", "replica_role"},
-	)
+		}, append([]string{"cluster_queue", "replica_role"}, extraLabels...),
+	))
 
-	// +metricsdoc:group=localqueue
-	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",replica_role="one of `leader`, `follower`, or `standalone`"
-	LocalQueueAdmittedActiveWorkloads = prometheus.NewGaugeVec(
+	LocalQueueAdmittedActiveWorkloads = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_admitted_active_workloads",
 			Help:      "The number of admitted Workloads that are active (unsuspended and not finished), per 'localQueue'",
-		}, []string{"name", "namespace", "replica_role"},
-	)
+		}, append([]string{"name", "namespace", "replica_role"}, extraLabels...),
+	))
 
-	// +metricsdoc:group=clusterqueue
-	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",status="one of `pending`, `active`, or `terminated`",replica_role="one of `leader`, `follower`, or `standalone`"
-	ClusterQueueByStatus = prometheus.NewGaugeVec(
+	ClusterQueueByStatus = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "cluster_queue_status",
 			Help: `Reports 'cluster_queue' with its 'status' (with possible values 'pending', 'active' or 'terminated').
 For a ClusterQueue, the metric only reports a value of 1 for one of the statuses.`,
-		}, []string{"cluster_queue", "status", "replica_role"},
-	)
+		}, append([]string{"cluster_queue", "status", "replica_role"}, extraLabels...),
+	))
 
-	// +metricsdoc:group=localqueue
-	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",active="one of `True`, `False`, or `Unknown`",replica_role="one of `leader`, `follower`, or `standalone`"
-	LocalQueueByStatus = prometheus.NewGaugeVec(
+	LocalQueueByStatus = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_status",
 			Help: `Reports 'localQueue' with its 'active' status (with possible values 'True', 'False', or 'Unknown').
 For a LocalQueue, the metric only reports a value of 1 for one of the statuses.`,
-		}, []string{"name", "namespace", "active", "replica_role"},
-	)
+		}, append([]string{"name", "namespace", "active", "replica_role"}, extraLabels...),
+	))
 
-	// Optional cluster queue metrics
-
-	// +metricsdoc:group=optional_clusterqueue_resources
-	// +metricsdoc:labels=cohort="the name of the Cohort",cluster_queue="the name of the ClusterQueue",flavor="the resource flavor name",resource="the resource name",replica_role="one of `leader`, `follower`, or `standalone`"
-	ClusterQueueResourceReservations = prometheus.NewGaugeVec(
+	ClusterQueueResourceReservations = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "cluster_queue_resource_reservation",
 			Help:      `Reports the cluster_queue's total resource reservation within all the flavors`,
-		}, []string{"cohort", "cluster_queue", "flavor", "resource", "replica_role"},
-	)
+		}, append([]string{"cohort", "cluster_queue", "flavor", "resource", "replica_role"}, extraLabels...),
+	))
 
-	// +metricsdoc:group=optional_clusterqueue_resources
-	// +metricsdoc:labels=cohort="the name of the Cohort",cluster_queue="the name of the ClusterQueue",flavor="the resource flavor name",resource="the resource name",replica_role="one of `leader`, `follower`, or `standalone`"
-	ClusterQueueResourceUsage = prometheus.NewGaugeVec(
+	ClusterQueueResourceUsage = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "cluster_queue_resource_usage",
 			Help:      `Reports the cluster_queue's total resource usage within all the flavors`,
-		}, []string{"cohort", "cluster_queue", "flavor", "resource", "replica_role"},
-	)
+		}, append([]string{"cohort", "cluster_queue", "flavor", "resource", "replica_role"}, extraLabels...),
+	))
 
-	// +metricsdoc:group=localqueue
-	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",flavor="the resource flavor name",resource="the resource name",replica_role="one of `leader`, `follower`, or `standalone`"
-	LocalQueueResourceReservations = prometheus.NewGaugeVec(
+	LocalQueueResourceReservations = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_resource_reservation",
 			Help:      `Reports the localQueue's total resource reservation within all the flavors`,
-		}, []string{"name", "namespace", "flavor", "resource", "replica_role"},
-	)
+		}, append([]string{"name", "namespace", "flavor", "resource", "replica_role"}, extraLabels...),
+	))
 
-	// +metricsdoc:group=localqueue
-	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",flavor="the resource flavor name",resource="the resource name",replica_role="one of `leader`, `follower`, or `standalone`"
-	LocalQueueResourceUsage = prometheus.NewGaugeVec(
+	LocalQueueResourceUsage = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_resource_usage",
 			Help:      `Reports the localQueue's total resource usage within all the flavors`,
-		}, []string{"name", "namespace", "flavor", "resource", "replica_role"},
-	)
+		}, append([]string{"name", "namespace", "flavor", "resource", "replica_role"}, extraLabels...),
+	))
 
-	// +metricsdoc:group=optional_clusterqueue_resources
-	// +metricsdoc:labels=cohort="the name of the Cohort",cluster_queue="the name of the ClusterQueue",flavor="the resource flavor name",resource="the resource name",replica_role="one of `leader`, `follower`, or `standalone`"
-	ClusterQueueResourceNominalQuota = prometheus.NewGaugeVec(
+	ClusterQueueResourceNominalQuota = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "cluster_queue_nominal_quota",
 			Help:      `Reports the cluster_queue's resource nominal quota within all the flavors`,
-		}, []string{"cohort", "cluster_queue", "flavor", "resource", "replica_role"},
-	)
+		}, append([]string{"cohort", "cluster_queue", "flavor", "resource", "replica_role"}, extraLabels...),
+	))
 
-	// +metricsdoc:group=optional_clusterqueue_resources
-	// +metricsdoc:labels=cohort="the name of the Cohort",cluster_queue="the name of the ClusterQueue",flavor="the resource flavor name",resource="the resource name",replica_role="one of `leader`, `follower`, or `standalone`"
-	ClusterQueueResourceBorrowingLimit = prometheus.NewGaugeVec(
+	ClusterQueueResourceBorrowingLimit = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "cluster_queue_borrowing_limit",
 			Help:      `Reports the cluster_queue's resource borrowing limit within all the flavors`,
-		}, []string{"cohort", "cluster_queue", "flavor", "resource", "replica_role"},
-	)
+		}, append([]string{"cohort", "cluster_queue", "flavor", "resource", "replica_role"}, extraLabels...),
+	))
 
-	// +metricsdoc:group=optional_clusterqueue_resources
-	// +metricsdoc:labels=cohort="the name of the Cohort",cluster_queue="the name of the ClusterQueue",flavor="the resource flavor name",resource="the resource name",replica_role="one of `leader`, `follower`, or `standalone`"
-	ClusterQueueResourceLendingLimit = prometheus.NewGaugeVec(
+	ClusterQueueResourceLendingLimit = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "cluster_queue_lending_limit",
 			Help:      `Reports the cluster_queue's resource lending limit within all the flavors`,
-		}, []string{"cohort", "cluster_queue", "flavor", "resource", "replica_role"},
-	)
+		}, append([]string{"cohort", "cluster_queue", "flavor", "resource", "replica_role"}, extraLabels...),
+	))
 
-	// +metricsdoc:group=optional_clusterqueue_resources
-	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",cohort="the name of the Cohort",replica_role="one of `leader`, `follower`, or `standalone`"
-	ClusterQueueWeightedShare = prometheus.NewGaugeVec(
+	ClusterQueueWeightedShare = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "cluster_queue_weighted_share",
@@ -599,12 +704,10 @@ quota to the lendable resources in the cohort, among all the resources provided 
 the ClusterQueue, and divided by the weight.
 If zero, it means that the usage of the ClusterQueue is below the nominal quota.
 If the ClusterQueue has a weight of zero and is borrowing, this will return NaN.`,
-		}, []string{"cluster_queue", "cohort", "replica_role"},
-	)
+		}, append([]string{"cluster_queue", "cohort", "replica_role"}, extraLabels...),
+	))
 
-	// +metricsdoc:group=cohort
-	// +metricsdoc:labels=cohort="the name of the Cohort",replica_role="one of `leader`, `follower`, or `standalone`"
-	CohortWeightedShare = prometheus.NewGaugeVec(
+	CohortWeightedShare = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "cohort_weighted_share",
@@ -613,21 +716,20 @@ quota to the lendable resources in the Cohort, among all the resources provided 
 the Cohort, and divided by the weight.
 If zero, it means that the usage of the Cohort is below the nominal quota.
 If the Cohort has a weight of zero and is borrowing, this will return NaN.`,
-		}, []string{"cohort", "replica_role"},
-	)
+		}, append([]string{"cohort", "replica_role"}, extraLabels...),
+	))
 
-	// +metricsdoc:group=cohort
-	// +metricsdoc:labels=cohort="the name of the Cohort",flavor="the resource flavor name",resource="the resource name",replica_role="one of `leader`, `follower`, or `standalone`"
-	CohortSubtreeQuota = prometheus.NewGaugeVec(
+	CohortSubtreeQuota = trackGaugeVec(prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "cohort_subtree_quota",
 			Help:      `Reports the cohort's nominal quota aggregated within the cohort's subtree. The values are reported per resource and flavor`,
 		}, []string{"cohort", "flavor", "resource", "replica_role"},
-	)
-)
+	))
+}
 
 func init() {
+	initMetricVectors(nil)
 	versionInfo := version.Get()
 	buildInfo.WithLabelValues(versionInfo.GitVersion, versionInfo.GitCommit, versionInfo.BuildDate, versionInfo.GoVersion, versionInfo.Compiler, versionInfo.Platform).Set(1)
 }
@@ -952,40 +1054,31 @@ func ClearClusterQueueResourceReservations(cqName, flavor, resource string) {
 	ClusterQueueResourceReservations.DeletePartialMatch(lbls)
 }
 
-func registerGaugeVecs(gauges ...*prometheus.GaugeVec) {
-	for _, g := range gauges {
-		metrics.Registry.MustRegister(g)
-		allGaugeVecs = append(allGaugeVecs, g)
-	}
-}
-
 func Register() {
 	metrics.Registry.MustRegister(
 		buildInfo,
 		AdmissionAttemptsTotal,
 		admissionAttemptDuration,
+		AdmissionCyclePreemptionSkips,
+		PendingWorkloads,
+		FinishedWorkloads,
 		QuotaReservedWorkloadsTotal,
-		QuotaReservedWaitTime,
 		FinishedWorkloadsTotal,
+		QuotaReservedWaitTime,
 		PodsReadyToEvictedTimeSeconds,
 		AdmittedWorkloadsTotal,
-		EvictedWorkloadsTotal,
-		EvictedWorkloadsOnceTotal,
-		PreemptedWorkloadsTotal,
 		AdmissionWaitTime,
 		AdmissionChecksWaitTime,
 		QueuedUntilReadyWaitTime,
 		AdmittedUntilReadyWaitTime,
-	)
-	registerGaugeVecs(
-		AdmissionCyclePreemptionSkips,
-		PendingWorkloads,
+		EvictedWorkloadsTotal,
+		EvictedWorkloadsOnceTotal,
+		PreemptedWorkloadsTotal,
 		ReservingActiveWorkloads,
 		AdmittedActiveWorkloads,
-		FinishedWorkloads,
-		ClusterQueueResourceUsage,
 		ClusterQueueByStatus,
 		ClusterQueueResourceReservations,
+		ClusterQueueResourceUsage,
 		ClusterQueueResourceNominalQuota,
 		ClusterQueueResourceBorrowingLimit,
 		ClusterQueueResourceLendingLimit,
@@ -1000,6 +1093,8 @@ func Register() {
 
 func RegisterLQMetrics() {
 	metrics.Registry.MustRegister(
+		LocalQueuePendingWorkloads,
+		LocalQueueFinishedWorkloads,
 		LocalQueueQuotaReservedWorkloadsTotal,
 		LocalQueueFinishedWorkloadsTotal,
 		LocalQueueQuotaReservedWaitTime,
@@ -1009,12 +1104,8 @@ func RegisterLQMetrics() {
 		LocalQueueQueuedUntilReadyWaitTime,
 		LocalQueueAdmittedUntilReadyWaitTime,
 		LocalQueueEvictedWorkloadsTotal,
-	)
-	registerGaugeVecs(
-		LocalQueuePendingWorkloads,
 		LocalQueueReservingActiveWorkloads,
 		LocalQueueAdmittedActiveWorkloads,
-		LocalQueueFinishedWorkloads,
 		LocalQueueByStatus,
 		LocalQueueResourceReservations,
 		LocalQueueResourceUsage,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->
/kind cleanup

#### What this PR does / why we need it:

Moves metric vector creation from static var declarations into `initMetricVectors()`, making them re-initializable. `GaugeVecs` are automatically tracked via `trackGaugeVec` for `ClearGaugeMetricsForRole`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Follow-up to #9802
Preparatory PR for #9774

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```