### PR TITLE
Automated cherry pick of #9835: Introduce SchedulerTimestampPreemptionBuffer feature.

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -274,6 +274,13 @@ const (
 	// issue: https://github.com/kubernetes-sigs/kueue/issues/9799
 	// Use 10s interval for scheduler requeuing.
 	SchedulerLongRequeueInterval featuregate.Feature = "SchedulerLongRequeueInterval"
+
+	// owner: @mbobrovskyi
+	//
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/9799
+	// Use a 5min buffer so that workloads with scheduling timestamps within this
+	// buffer do not preempt each other based on LowerOrNewerEqualPriority.
+	SchedulerTimestampPreemptionBuffer featuregate.Feature = "SchedulerTimestampPreemptionBuffer"
 )
 
 func init() {
@@ -422,6 +429,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.16"), Default: true, PreRelease: featuregate.Beta},
 	},
 	SchedulerLongRequeueInterval: {
+		{Version: version.MustParse("0.16"), Default: false, PreRelease: featuregate.Alpha}, // remove in 0.20
+	},
+	SchedulerTimestampPreemptionBuffer: {
 		{Version: version.MustParse("0.16"), Default: false, PreRelease: featuregate.Alpha}, // remove in 0.20
 	},
 }

--- a/pkg/scheduler/preemption/common/preemption_policy.go
+++ b/pkg/scheduler/preemption/common/preemption_policy.go
@@ -17,10 +17,15 @@ limitations under the License.
 package preemptioncommon
 
 import (
+	"time"
+
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/priority"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
+
+const timestampPreemptionBuffer = 5 * time.Minute
 
 func SatisfiesPreemptionPolicy(preemptor, candidate *kueue.Workload, workloadOrdering workload.Ordering, policy kueue.PreemptionPolicy) bool {
 	preemptorPriority := priority.Priority(preemptor)
@@ -34,6 +39,9 @@ func SatisfiesPreemptionPolicy(preemptor, candidate *kueue.Workload, workloadOrd
 		preemptorTS := workloadOrdering.GetQueueOrderTimestamp(preemptor)
 		candidateTS := workloadOrdering.GetQueueOrderTimestamp(candidate)
 		newerEqualPriority := (preemptorPriority == candidatePriority) && preemptorTS.Before(candidateTS)
+		if newerEqualPriority && features.Enabled(features.SchedulerTimestampPreemptionBuffer) {
+			newerEqualPriority = candidateTS.Sub(preemptorTS.Time) > timestampPreemptionBuffer
+		}
 		return lowerPriority || newerEqualPriority
 	}
 	return policy == kueue.PreemptionPolicyAny

--- a/pkg/scheduler/preemption/common/preemption_policy_test.go
+++ b/pkg/scheduler/preemption/common/preemption_policy_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preemptioncommon
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/featuregate"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+func TestSatisfiesPreemptionPolicy(t *testing.T) {
+	now := time.Now()
+	nowPlus1Min := now.Add(time.Minute)
+	nowPlus6Min := now.Add(6 * time.Minute)
+
+	preemptor := utiltestingapi.MakeWorkload("preemptor", metav1.NamespaceDefault)
+	candidate := utiltestingapi.MakeWorkload("candidate", metav1.NamespaceDefault)
+
+	testCases := map[string]struct {
+		features  map[featuregate.Feature]bool
+		preemptor *kueue.Workload
+		candidate *kueue.Workload
+		policy    kueue.PreemptionPolicy
+		want      bool
+	}{
+		"LowerPriority: preemptor has higher priority": {
+			preemptor: preemptor.Clone().Priority(10).Obj(),
+			candidate: candidate.Clone().Priority(5).Obj(),
+			policy:    kueue.PreemptionPolicyLowerPriority,
+			want:      true,
+		},
+		"LowerPriority: preemptor has same priority": {
+			preemptor: preemptor.Clone().Priority(10).Obj(),
+			candidate: candidate.Clone().Priority(10).Obj(),
+			policy:    kueue.PreemptionPolicyLowerPriority,
+			want:      false,
+		},
+		"LowerOrNewerEqualPriority: preemptor has same priority, same timestamp": {
+			preemptor: preemptor.Clone().Priority(10).Creation(now).Obj(),
+			candidate: candidate.Clone().Priority(10).Creation(now).Obj(),
+			policy:    kueue.PreemptionPolicyLowerOrNewerEqualPriority,
+			want:      false,
+		},
+		"LowerOrNewerEqualPriority: preemptor has same priority, newer timestamp (within 5min buffer)": {
+			preemptor: preemptor.Clone().Priority(10).Creation(nowPlus1Min).Obj(),
+			candidate: candidate.Clone().Priority(10).Creation(now).Obj(),
+			policy:    kueue.PreemptionPolicyLowerOrNewerEqualPriority,
+			want:      false, // candidate is older, so candidate is NOT newer
+		},
+		"LowerOrNewerEqualPriority: preemptor has same priority, older timestamp (within 5min buffer)": {
+			preemptor: preemptor.Clone().Priority(10).Creation(now).Obj(),
+			candidate: candidate.Clone().Priority(10).Creation(nowPlus1Min).Obj(),
+			policy:    kueue.PreemptionPolicyLowerOrNewerEqualPriority,
+			want:      true, // candidate is newer
+		},
+		"LowerOrNewerEqualPriority with SchedulerTimestampPreemptionBuffer: preemptor has same priority, older timestamp (within 5min buffer)": {
+			features: map[featuregate.Feature]bool{
+				features.SchedulerTimestampPreemptionBuffer: true,
+			},
+			preemptor: preemptor.Clone().Priority(10).Creation(now).Obj(),
+			candidate: candidate.Clone().Priority(10).Creation(nowPlus1Min).Obj(),
+			policy:    kueue.PreemptionPolicyLowerOrNewerEqualPriority,
+			want:      false, // candidate is newer but within buffer
+		},
+		"LowerOrNewerEqualPriority with SchedulerTimestampPreemptionBuffer: preemptor has same priority, older timestamp (outside 5min buffer)": {
+			features: map[featuregate.Feature]bool{
+				features.SchedulerTimestampPreemptionBuffer: true,
+			},
+			preemptor: preemptor.Clone().Priority(10).Creation(now).Obj(),
+			candidate: candidate.Clone().Priority(10).Creation(nowPlus6Min).Obj(),
+			policy:    kueue.PreemptionPolicyLowerOrNewerEqualPriority,
+			want:      true, // candidate is newer and outside buffer
+		},
+		"PreemptionPolicyAny": {
+			preemptor: preemptor.Clone().Priority(10).Creation(now).Obj(),
+			candidate: candidate.Clone().Priority(10).Creation(nowPlus6Min).Obj(),
+			policy:    kueue.PreemptionPolicyAny,
+			want:      true,
+		},
+		"PreemptionPolicyNever": {
+			preemptor: preemptor.Clone().Priority(10).Creation(now).Obj(),
+			candidate: candidate.Clone().Priority(10).Creation(nowPlus6Min).Obj(),
+			policy:    kueue.PreemptionPolicyNever,
+			want:      false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			for feature, enabled := range tc.features {
+				features.SetFeatureGateDuringTest(t, feature, enabled)
+			}
+			ordering := workload.Ordering{}
+			got := SatisfiesPreemptionPolicy(tc.preemptor, tc.candidate, ordering, tc.policy)
+			if got != tc.want {
+				t.Errorf("SatisfiesPreemptionPolicy() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -285,7 +285,7 @@ spec:
 {{% alert title="Note" color="primary" %}}
 The SanitizePodSets and MultiKueueAllowInsecureKubeconfigs features are available starting from versions 0.13.8 and 0.14.3.
 The PropagateBatchJobLabelsToWorkload feature is available starting from versions 0.13.10 and 0.14.5.
-The SchedulerLongRequeueInterval features are available starting from versions 0.15.6 and 0.16.3.
+The SchedulerLongRequeueInterval and SchedulerTimestampPreemptionBuffer features are available starting from versions 0.15.6 and 0.16.3.
 {{% /alert %}}
 
 ### Feature gates for graduated or deprecated features

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -199,6 +199,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.16"
+- name: SchedulerTimestampPreemptionBuffer
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.16"
 - name: SchedulingEquivalenceHashing
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -199,6 +199,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.16"
+- name: SchedulerTimestampPreemptionBuffer
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.16"
 - name: SchedulingEquivalenceHashing
   versionedSpecs:
   - default: true


### PR DESCRIPTION
Cherry pick of #9835 on release-0.16.

#9835: Introduce SchedulerTimestampPreemptionBuffer feature.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind feature


```release-note
Scheduling: Add the alpha SchedulerTimestampPreemptionBuffer feature gate (disabled by default) to use
5-minute buffer so that workloads with scheduling timestamps within this buffer don’t preempt each other
based on LowerOrNewerEqualPriority.
```