### PR TITLE
Automated cherry pick of #9835: Introduce SchedulerTimestampPreemptionBuffer feature.

### DIFF
--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -288,6 +288,7 @@ spec:
 {{% alert title="Note" color="primary" %}}
 The SanitizePodSets and MultiKueueAllowInsecureKubeconfigs features are available starting from versions 0.13.8 and 0.14.3.
 The PropagateBatchJobLabelsToWorkload feature is available starting from versions 0.13.10 and 0.14.5.
+The SchedulerLongRequeueInterval and SchedulerTimestampPreemptionBuffer features are available starting from versions 0.15.6 and 0.16.3.
 {{% /alert %}}
 
 ### Feature gates for graduated or deprecated features


### PR DESCRIPTION
Cherry pick of #9835 on website.

#9835: Introduce SchedulerTimestampPreemptionBuffer feature.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind feature


```release-note
Scheduling: Add the alpha SchedulerTimestampPreemptionBuffer feature gate (disabled by default) to use
5-minute buffer so that workloads with scheduling timestamps within this buffer don’t preempt each other
based on LowerOrNewerEqualPriority.
```