### PR TITLE
Automated cherry pick of #9812: Introduce SchedulerLongRequeueInterval feature gate.
#9822: Add a note about the starting version of SchedulerLongRequeueInterval.
#9835: Introduce SchedulerTimestampPreemptionBuffer feature.

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -243,6 +243,13 @@ const (
 	// issue: https://github.com/kubernetes-sigs/kueue/issues/9799
 	// Use 10s interval for scheduler requeuing.
 	SchedulerLongRequeueInterval featuregate.Feature = "SchedulerLongRequeueInterval"
+
+	// owner: @mbobrovskyi
+	//
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/9799
+	// Use a 5min buffer so that workloads with scheduling timestamps within this
+	// buffer do not preempt each other based on LowerOrNewerEqualPriority.
+	SchedulerTimestampPreemptionBuffer featuregate.Feature = "SchedulerTimestampPreemptionBuffer"
 )
 
 func init() {
@@ -376,7 +383,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.16"), Default: true, PreRelease: featuregate.Beta}, // GA in 0.18
 	},
 	SchedulerLongRequeueInterval: {
-		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha}, // remove in 0.20
+		{Version: version.MustParse("0.15"), Default: false, PreRelease: featuregate.Alpha}, // remove in 0.20
+	},
+	SchedulerTimestampPreemptionBuffer: {
+		{Version: version.MustParse("0.15"), Default: false, PreRelease: featuregate.Alpha}, // remove in 0.20
 	},
 }
 

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -288,7 +288,7 @@ spec:
 {{% alert title="Note" color="primary" %}}
 The SanitizePodSets and MultiKueueAllowInsecureKubeconfigs features are available starting from versions 0.13.8 and 0.14.3.
 The PropagateBatchJobLabelsToWorkload feature is available starting from versions 0.13.10 and 0.14.5.
-The SchedulerLongRequeueInterval features are available starting from versions 0.15.6 and 0.16.3.
+The SchedulerLongRequeueInterval and SchedulerTimestampPreemptionBuffer features are available starting from versions 0.15.6 and 0.16.3.
 {{% /alert %}}
 
 ### Feature gates for graduated or deprecated features

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -180,7 +180,13 @@
   - default: false
     lockToDefault: false
     preRelease: Alpha
-    version: "0.17"
+    version: "0.15"
+- name: SchedulerTimestampPreemptionBuffer
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.15"
 - name: SkipFinalizersForPodsSuspendedByParent
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -180,7 +180,13 @@
   - default: false
     lockToDefault: false
     preRelease: Alpha
-    version: "0.17"
+    version: "0.15"
+- name: SchedulerTimestampPreemptionBuffer
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.15"
 - name: SkipFinalizersForPodsSuspendedByParent
   versionedSpecs:
   - default: true


### PR DESCRIPTION
Cherry pick of #9812 #9822 #9835 on website.

#9812: Introduce SchedulerLongRequeueInterval feature gate.
#9822: Add a note about the starting version of SchedulerLongRequeueInterval.
#9835: Introduce SchedulerTimestampPreemptionBuffer feature.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```