### PR TITLE
KEP-8303: Add explicit opt-in API to graduation criteria

### DIFF
--- a/keps/8303-multikueue-orchestrated-preemption/README.md
+++ b/keps/8303-multikueue-orchestrated-preemption/README.md
@@ -365,6 +365,7 @@ The `SingleClusterPreemptionTimeout` will be configurable in the Kueue configura
   - Unit and integration tests are implemented.
 - **Beta**:
   - Feature gate is enabled by default.
+  - An API to configure and explicitly opt-in to this feature is added (for example to `Configuration`).
   - The feature has been tested in a production-like environment.
   - User feedback was gathered and emerging use-cases are taken into consideration.
   - The Kueue APIs are finalized and potentially extended, based upon the alpha experience.


### PR DESCRIPTION
#### What type of PR is this?
/kind kep
/area multikueue

#### What this PR does / why we need it:
See https://github.com/kubernetes-sigs/kueue/issues/9852.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
https://github.com/kubernetes-sigs/kueue/issues/9852 is the follow-up issue for the implementation.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```