### PR TITLE
KEP-8303: Align the KEP with the new field names

### DIFF
--- a/keps/8303-multikueue-orchestrated-preemption/README.md
+++ b/keps/8303-multikueue-orchestrated-preemption/README.md
@@ -57,7 +57,8 @@ This can cause them to make decisions which make sense from a single cluster's p
 taking the whole system (other workers) into account.
 
 For example, a high-priority workload can trigger simultaneous preemptions in multiple worker clusters.
-For instance, a workload sent to three clusters using the `AllAtOnce` strategy might initiate preemptions on all three.
+For instance, a workload sent to three clusters using the `AllAtOnce` strategy might initiate preemptions on all three (although this is not
+specific to any one dispatch strategy and might occur as long as there is more than one nominated cluster).
 Since the workload can only be admitted to one cluster, the preemptions on the other two are unnecessary and lead to wasted resources by
 halting running workloads and then having to re-admit them.
 
@@ -259,8 +260,9 @@ This is done in anticipation of a new opt-in API in beta, in order to avoid lock
 
 ### MultiKueue Controller
 
-When a workload is submitted to MultiKueue, its remote replicas will automatically be assigned the `kueue.x-k8s.io/multikueue` preemption gate
-via its `spec`. This will prevent any of the replicas from triggering a preemption until allowed by the manager controller.
+When a workload is submitted to MultiKueue, its remote replicas in the nominated clusters (irrespective of the nomination algorithm)
+will automatically be assigned the `kueue.x-k8s.io/multikueue` preemption gate via its `spec`.
+This will prevent any of the replicas from triggering a preemption until allowed by the manager controller.
 The `status` of the remote workloads will be updated with the `PreemptionGateState` by a workload controller running on the worker clusters.
 
 A manager-level preemption orchestration controller will be responsible for ungating the replicated workloads.


### PR DESCRIPTION
#### What type of PR is this?
/kind kep
/area multikueue

#### What this PR does / why we need it:
Apply content update comments from https://github.com/kubernetes-sigs/kueue/pull/8985#pullrequestreview-3945497276.

https://github.com/kubernetes-sigs/kueue/pull/9721 was aligned with the changes.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```