### PR TITLE
Refactor Ray MultiKueue adapters to use shared generic adapter

### DIFF
--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -1,0 +1,165 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ray
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	clientutil "sigs.k8s.io/kueue/pkg/util/client"
+)
+
+type objAsPtr[T any] interface {
+	metav1.Object
+	client.Object
+	*T
+}
+
+type adapter[PtrT objAsPtr[T], T any] struct {
+	copySpec     func(dst, src PtrT)
+	copyStatus   func(dst, src PtrT)
+	emptyList    func() client.ObjectList
+	gvk          schema.GroupVersionKind
+	getManagedBy func(PtrT) *string
+	setManagedBy func(PtrT, *string)
+}
+
+type fullInterface interface {
+	jobframework.MultiKueueAdapter
+	jobframework.MultiKueueWatcher
+}
+
+// NewMKAdapter creates a generic MultiKueue adapter for Ray job types.
+// It follows the same pattern as kubeflowjob.NewMKAdapter but adapted for
+// Ray types (RayCluster, RayJob, RayService) which share an identical
+// MultiKueue adapter structure.
+func NewMKAdapter[PtrT objAsPtr[T], T any](
+	copySpec func(dst, src PtrT),
+	copyStatus func(dst, src PtrT),
+	emptyList func() client.ObjectList,
+	gvk schema.GroupVersionKind,
+	getManagedBy func(PtrT) *string,
+	setManagedBy func(PtrT, *string),
+) fullInterface {
+	return &adapter[PtrT, T]{
+		copySpec:     copySpec,
+		copyStatus:   copyStatus,
+		emptyList:    emptyList,
+		gvk:          gvk,
+		getManagedBy: getManagedBy,
+		setManagedBy: setManagedBy,
+	}
+}
+
+func (a *adapter[PtrT, T]) GVK() schema.GroupVersionKind {
+	return a.gvk
+}
+
+func (a *adapter[PtrT, T]) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName) (bool, string, error) {
+	job := PtrT(new(T))
+	err := c.Get(ctx, key, job)
+	if err != nil {
+		return false, "", err
+	}
+
+	jobControllerName := ptr.Deref(a.getManagedBy(job), "")
+	if jobControllerName != kueue.MultiKueueControllerName {
+		return false, fmt.Sprintf("Expecting spec.managedBy to be %q not %q", kueue.MultiKueueControllerName, jobControllerName), nil
+	}
+	return true, "", nil
+}
+
+func (a *adapter[PtrT, T]) SyncJob(
+	ctx context.Context,
+	localClient client.Client,
+	remoteClient client.Client,
+	key types.NamespacedName,
+	workloadName, origin string,
+) error {
+	localJob := PtrT(new(T))
+	err := localClient.Get(ctx, key, localJob)
+	if err != nil {
+		return err
+	}
+
+	remoteJob := PtrT(new(T))
+	err = remoteClient.Get(ctx, key, remoteJob)
+	if client.IgnoreNotFound(err) != nil {
+		return err
+	}
+
+	// if the remote exists, just copy the status
+	if err == nil {
+		return clientutil.PatchStatus(ctx, localClient, localJob, func() (bool, error) {
+			a.copyStatus(localJob, remoteJob)
+			return true, nil
+		})
+	}
+
+	remoteJob = PtrT(new(T))
+	a.copySpec(remoteJob, localJob)
+
+	// add the prebuilt workload
+	labels := remoteJob.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string, 2)
+	}
+	labels[constants.PrebuiltWorkloadLabel] = workloadName
+	labels[kueue.MultiKueueOriginLabel] = origin
+	remoteJob.SetLabels(labels)
+
+	// clearing the managedBy enables the controller to take over
+	a.setManagedBy(remoteJob, nil)
+
+	return remoteClient.Create(ctx, remoteJob)
+}
+
+func (a *adapter[PtrT, T]) DeleteRemoteObject(ctx context.Context, remoteClient client.Client, key types.NamespacedName) error {
+	job := PtrT(new(T))
+	job.SetName(key.Name)
+	job.SetNamespace(key.Namespace)
+	return client.IgnoreNotFound(remoteClient.Delete(ctx, job))
+}
+
+func (a *adapter[PtrT, T]) GetEmptyList() client.ObjectList {
+	return a.emptyList()
+}
+
+func (a *adapter[PtrT, T]) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedName, error) {
+	job, isTheJob := o.(PtrT)
+	if !isTheJob {
+		return nil, fmt.Errorf("not a %s", a.gvk.Kind)
+	}
+
+	prebuiltWl, hasPrebuiltWorkload := job.GetLabels()[constants.PrebuiltWorkloadLabel]
+	if !hasPrebuiltWorkload {
+		return nil, fmt.Errorf("no prebuilt workload found for %s: %s", a.gvk.Kind, klog.KObj(job))
+	}
+
+	return []types.NamespacedName{{Name: prebuiltWl, Namespace: job.GetNamespace()}}, nil
+}

--- a/pkg/controller/jobs/raycluster/raycluster_controller.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller.go
@@ -31,6 +31,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/ray"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/podset"
 )
@@ -52,7 +53,7 @@ func init() {
 		SetupWebhook:      SetupRayClusterWebhook,
 		JobType:           &rayv1.RayCluster{},
 		AddToScheme:       rayv1.AddToScheme,
-		MultiKueueAdapter: &multiKueueAdapter{},
+		MultiKueueAdapter: ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy),
 	}))
 }
 

--- a/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter.go
+++ b/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter.go
@@ -17,108 +17,35 @@ limitations under the License.
 package raycluster
 
 import (
-	"context"
-	"errors"
-	"fmt"
-
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/ray"
 	"sigs.k8s.io/kueue/pkg/util/api"
-	clientutil "sigs.k8s.io/kueue/pkg/util/client"
 )
 
-type multiKueueAdapter struct{}
+var _ jobframework.MultiKueueAdapter = ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy)
 
-var _ jobframework.MultiKueueAdapter = (*multiKueueAdapter)(nil)
-
-func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) error {
-	localJob := rayv1.RayCluster{}
-	err := localClient.Get(ctx, key, &localJob)
-	if err != nil {
-		return err
-	}
-
-	remoteJob := rayv1.RayCluster{}
-	err = remoteClient.Get(ctx, key, &remoteJob)
-	if client.IgnoreNotFound(err) != nil {
-		return err
-	}
-
-	// if the remote exists, just copy the status
-	if err == nil {
-		return clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
-			localJob.Status = remoteJob.Status
-			return true, nil
-		})
-	}
-
-	remoteJob = rayv1.RayCluster{
-		ObjectMeta: api.CloneObjectMetaForCreation(&localJob.ObjectMeta),
-		Spec:       *localJob.Spec.DeepCopy(),
-	}
-
-	// add the prebuilt workload
-	if remoteJob.Labels == nil {
-		remoteJob.Labels = make(map[string]string, 2)
-	}
-	remoteJob.Labels[constants.PrebuiltWorkloadLabel] = workloadName
-	remoteJob.Labels[kueue.MultiKueueOriginLabel] = origin
-
-	// clear the managedBy enables the controller to take over
-	remoteJob.Spec.ManagedBy = nil
-
-	return remoteClient.Create(ctx, &remoteJob)
+func copyJobStatus(dst, src *rayv1.RayCluster) {
+	dst.Status = src.Status
 }
 
-func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, remoteClient client.Client, key types.NamespacedName) error {
-	job := rayv1.RayCluster{}
-	job.SetName(key.Name)
-	job.SetNamespace(key.Namespace)
-	return client.IgnoreNotFound(remoteClient.Delete(ctx, &job))
-}
-
-func (b *multiKueueAdapter) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName) (bool, string, error) {
-	job := rayv1.RayCluster{}
-	err := c.Get(ctx, key, &job)
-	if err != nil {
-		return false, "", err
+func copyJobSpec(dst, src *rayv1.RayCluster) {
+	*dst = rayv1.RayCluster{
+		ObjectMeta: api.CloneObjectMetaForCreation(&src.ObjectMeta),
+		Spec:       *src.Spec.DeepCopy(),
 	}
-	jobControllerName := ptr.Deref(job.Spec.ManagedBy, "")
-	if jobControllerName != kueue.MultiKueueControllerName {
-		return false, fmt.Sprintf("Expecting spec.managedBy to be %q not %q", kueue.MultiKueueControllerName, jobControllerName), nil
-	}
-	return true, "", nil
 }
 
-func (b *multiKueueAdapter) GVK() schema.GroupVersionKind {
-	return gvk
-}
-
-var _ jobframework.MultiKueueWatcher = (*multiKueueAdapter)(nil)
-
-func (*multiKueueAdapter) GetEmptyList() client.ObjectList {
+func getEmptyList() client.ObjectList {
 	return &rayv1.RayClusterList{}
 }
 
-func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedName, error) {
-	job, isJob := o.(*rayv1.RayCluster)
-	if !isJob {
-		return nil, errors.New("not a raycluster")
-	}
+func getManagedBy(job *rayv1.RayCluster) *string {
+	return job.Spec.ManagedBy
+}
 
-	prebuiltWl, hasPrebuiltWorkload := job.Labels[constants.PrebuiltWorkloadLabel]
-	if !hasPrebuiltWorkload {
-		return nil, fmt.Errorf("no prebuilt workload found for raycluster: %s", klog.KObj(job))
-	}
-
-	return []types.NamespacedName{{Name: prebuiltWl, Namespace: job.Namespace}}, nil
+func setManagedBy(job *rayv1.RayCluster, val *string) {
+	job.Spec.ManagedBy = val
 }

--- a/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
@@ -32,6 +32,8 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/ray"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
@@ -53,7 +55,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		managersRayClusters []rayv1.RayCluster
 		workerRayClusters   []rayv1.RayCluster
 
-		operation func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error
+		operation func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error
 
 		wantError               error
 		wantManagersRayClusters []rayv1.RayCluster
@@ -63,7 +65,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			managersRayClusters: []rayv1.RayCluster{
 				*rayClusterBuilder.DeepCopy(),
 			},
-			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}, "wl1", "origin1")
 			},
 
@@ -88,7 +90,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					StatusConditions(metav1.Condition{Type: string(rayv1.HeadPodReady), Status: metav1.ConditionStatus(corev1.ConditionTrue)}).
 					Obj(),
 			},
-			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}, "wl1", "origin1")
 			},
 
@@ -119,7 +121,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					StatusConditions(metav1.Condition{Type: string(rayv1.HeadPodReady), Status: metav1.ConditionStatus(corev1.ConditionTrue)}).
 					Obj(),
 			},
-			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}, "wl1", "origin1")
 			},
 			wantManagersRayClusters: []rayv1.RayCluster{
@@ -144,7 +146,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},
-			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				return adapter.DeleteRemoteObject(ctx, workerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace})
 			},
 		},
@@ -154,7 +156,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					ManagedBy("some-other-controller").
 					Obj(),
 			},
-			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}); isManged {
 					return errors.New("expecting false")
 				}
@@ -173,7 +175,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					ManagedBy(kueue.MultiKueueControllerName).
 					Obj(),
 			},
-			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}); !isManged {
 					return errors.New("expecting true")
 				}
@@ -186,7 +188,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"missing raycluster is not considered managed": {
-			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}); isManged {
 					return errors.New("expecting false")
 				}
@@ -207,7 +209,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 
 			ctx, _ := utiltesting.ContextWithLog(t)
 
-			adapter := &multiKueueAdapter{}
+			adapter := ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy)
 
 			gotErr := tc.operation(ctx, adapter, managerClient, workerClient)
 

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -38,6 +38,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/ray"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/podset"
@@ -62,7 +63,7 @@ func init() {
 		SetupWebhook:      SetupRayJobWebhook,
 		JobType:           &rayv1.RayJob{},
 		AddToScheme:       rayv1.AddToScheme,
-		MultiKueueAdapter: &multiKueueAdapter{},
+		MultiKueueAdapter: ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy),
 	}))
 }
 

--- a/pkg/controller/jobs/rayjob/rayjob_multikueue_adapter.go
+++ b/pkg/controller/jobs/rayjob/rayjob_multikueue_adapter.go
@@ -17,108 +17,35 @@ limitations under the License.
 package rayjob
 
 import (
-	"context"
-	"errors"
-	"fmt"
-
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/ray"
 	"sigs.k8s.io/kueue/pkg/util/api"
-	clientutil "sigs.k8s.io/kueue/pkg/util/client"
 )
 
-type multiKueueAdapter struct{}
+var _ jobframework.MultiKueueAdapter = ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy)
 
-var _ jobframework.MultiKueueAdapter = (*multiKueueAdapter)(nil)
-
-func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) error {
-	localJob := rayv1.RayJob{}
-	err := localClient.Get(ctx, key, &localJob)
-	if err != nil {
-		return err
-	}
-
-	remoteJob := rayv1.RayJob{}
-	err = remoteClient.Get(ctx, key, &remoteJob)
-	if client.IgnoreNotFound(err) != nil {
-		return err
-	}
-
-	// if the remote exists, just copy the status
-	if err == nil {
-		return clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
-			localJob.Status = remoteJob.Status
-			return true, nil
-		})
-	}
-
-	remoteJob = rayv1.RayJob{
-		ObjectMeta: api.CloneObjectMetaForCreation(&localJob.ObjectMeta),
-		Spec:       *localJob.Spec.DeepCopy(),
-	}
-
-	// add the prebuilt workload
-	if remoteJob.Labels == nil {
-		remoteJob.Labels = make(map[string]string, 2)
-	}
-	remoteJob.Labels[constants.PrebuiltWorkloadLabel] = workloadName
-	remoteJob.Labels[kueue.MultiKueueOriginLabel] = origin
-
-	// clear the managedBy enables the controller to take over
-	remoteJob.Spec.ManagedBy = nil
-
-	return remoteClient.Create(ctx, &remoteJob)
+func copyJobStatus(dst, src *rayv1.RayJob) {
+	dst.Status = src.Status
 }
 
-func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, remoteClient client.Client, key types.NamespacedName) error {
-	job := rayv1.RayJob{}
-	job.SetName(key.Name)
-	job.SetNamespace(key.Namespace)
-	return client.IgnoreNotFound(remoteClient.Delete(ctx, &job))
-}
-
-func (b *multiKueueAdapter) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName) (bool, string, error) {
-	job := rayv1.RayJob{}
-	err := c.Get(ctx, key, &job)
-	if err != nil {
-		return false, "", err
+func copyJobSpec(dst, src *rayv1.RayJob) {
+	*dst = rayv1.RayJob{
+		ObjectMeta: api.CloneObjectMetaForCreation(&src.ObjectMeta),
+		Spec:       *src.Spec.DeepCopy(),
 	}
-	jobControllerName := ptr.Deref(job.Spec.ManagedBy, "")
-	if jobControllerName != kueue.MultiKueueControllerName {
-		return false, fmt.Sprintf("Expecting spec.managedBy to be %q not %q", kueue.MultiKueueControllerName, jobControllerName), nil
-	}
-	return true, "", nil
 }
 
-func (b *multiKueueAdapter) GVK() schema.GroupVersionKind {
-	return gvk
-}
-
-var _ jobframework.MultiKueueWatcher = (*multiKueueAdapter)(nil)
-
-func (*multiKueueAdapter) GetEmptyList() client.ObjectList {
+func getEmptyList() client.ObjectList {
 	return &rayv1.RayJobList{}
 }
 
-func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedName, error) {
-	job, isJob := o.(*rayv1.RayJob)
-	if !isJob {
-		return nil, errors.New("not a rayjob")
-	}
+func getManagedBy(job *rayv1.RayJob) *string {
+	return job.Spec.ManagedBy
+}
 
-	prebuiltWl, hasPrebuiltWorkload := job.Labels[constants.PrebuiltWorkloadLabel]
-	if !hasPrebuiltWorkload {
-		return nil, fmt.Errorf("no prebuilt workload found for rayjob: %s", klog.KObj(job))
-	}
-
-	return []types.NamespacedName{{Name: prebuiltWl, Namespace: job.Namespace}}, nil
+func setManagedBy(job *rayv1.RayJob, val *string) {
+	job.Spec.ManagedBy = val
 }

--- a/pkg/controller/jobs/rayjob/rayjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_multikueue_adapter_test.go
@@ -31,6 +31,8 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/ray"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingrayjob "sigs.k8s.io/kueue/pkg/util/testingjobs/rayjob"
@@ -52,7 +54,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		managersRayJobs []rayv1.RayJob
 		workerRayJobs   []rayv1.RayJob
 
-		operation func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error
+		operation func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error
 
 		wantError           error
 		wantManagersRayJobs []rayv1.RayJob
@@ -62,7 +64,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			managersRayJobs: []rayv1.RayJob{
 				*rayJobBuilder.DeepCopy(),
 			},
-			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayjob1", Namespace: TestNamespace}, "wl1", "origin1")
 			},
 
@@ -87,7 +89,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					JobDeploymentStatus(rayv1.JobDeploymentStatusComplete).
 					Obj(),
 			},
-			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayjob1", Namespace: TestNamespace}, "wl1", "origin1")
 			},
 
@@ -118,7 +120,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					JobDeploymentStatus(rayv1.JobDeploymentStatusComplete).
 					Obj(),
 			},
-			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayjob1", Namespace: TestNamespace}, "wl1", "origin1")
 			},
 			wantManagersRayJobs: []rayv1.RayJob{
@@ -143,7 +145,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},
-			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				return adapter.DeleteRemoteObject(ctx, workerClient, types.NamespacedName{Name: "rayjob1", Namespace: TestNamespace})
 			},
 		},
@@ -153,7 +155,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					ManagedBy("some-other-controller").
 					Obj(),
 			},
-			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "rayjob1", Namespace: TestNamespace}); isManged {
 					return errors.New("expecting false")
 				}
@@ -172,7 +174,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					ManagedBy(kueue.MultiKueueControllerName).
 					Obj(),
 			},
-			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "rayjob1", Namespace: TestNamespace}); !isManged {
 					return errors.New("expecting true")
 				}
@@ -185,7 +187,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"missing job is not considered managed": {
-			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "rayjob1", Namespace: TestNamespace}); isManged {
 					return errors.New("expecting false")
 				}
@@ -206,7 +208,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 
 			ctx, _ := utiltesting.ContextWithLog(t)
 
-			adapter := &multiKueueAdapter{}
+			adapter := ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy)
 
 			gotErr := tc.operation(ctx, adapter, managerClient, workerClient)
 


### PR DESCRIPTION
## What type of PR is this?

/kind cleanup

## What this PR does / why we need it

Refactors the RayCluster and RayJob MultiKueue adapters to use a shared generic adapter (`ray.NewMKAdapter()`), eliminating code duplication between the two adapters. Each adapter is reduced from ~124 lines to ~51 lines.

The shared generic adapter in `pkg/controller/jobs/ray/ray_multikueue_adapter.go` follows the same pattern as the Kubeflow generic adapter (`kubeflowjob.NewMKAdapter()`). It uses Go generics with callback functions for type-specific operations (`copySpec`, `copyStatus`, `emptyList`, `gvk`, `getManagedBy`, `setManagedBy`).

This is a pure refactoring — no behavioral changes, no dependency changes.

Split from #9882 per @mimowo's feedback. The kuberay bump is in a separate PR.

## Which issue(s) this PR fixes

Prep work for #9439
Prep work for #9449

## Does this PR introduce a user-facing change?

```release-note
None
```