### PR TITLE
Dump multiple objects when unit test asserts fail

### DIFF
--- a/test/util/util.go
+++ b/test/util/util.go
@@ -93,9 +93,14 @@ var SetupLoggerGetObservedLogs = sync.OnceValue(func() *observer.ObservedLogs {
 	return observedLogs
 })
 
-func assertMsg(message string, obj client.Object) func() string {
+func assertMsg[T client.Object](message string, objs ...T) func() string {
 	return func() string {
-		return message + "\n" + format.Object(obj, 1)
+		var output strings.Builder
+		fmt.Fprintln(&output, message)
+		for _, obj := range objs {
+			fmt.Fprintln(&output, format.Object(obj, 1))
+		}
+		return output.String()
 	}
 }
 
@@ -334,17 +339,19 @@ func ExpectWorkloadsToHaveQuotaReservation(ctx context.Context, k8sClient client
 func ExpectWorkloadsToHaveQuotaReservationByKey(ctx context.Context, k8sClient client.Client, cqName string, wlKeys ...client.ObjectKey) {
 	ginkgo.GinkgoHelper()
 	wlKeys = uniqueKeys(wlKeys)
-	wl := &kueue.Workload{}
+	wlObjects := make([]*kueue.Workload, len(wlKeys))
 	gomega.Eventually(func(g gomega.Gomega) {
 		admitted := make([]client.ObjectKey, 0, len(wlKeys))
-		for _, wlKey := range wlKeys {
+		for i, wlKey := range wlKeys {
+			wl := &kueue.Workload{}
 			g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
 			if workload.HasQuotaReservation(wl) && string(wl.Status.Admission.ClusterQueue) == cqName {
 				admitted = append(admitted, wlKey)
 			}
+			wlObjects[i] = wl
 		}
-		g.Expect(admitted).Should(gomega.Equal(wlKeys), "Unexpected workloads were admitted")
-	}, Timeout, Interval).Should(gomega.Succeed())
+		g.Expect(admitted).Should(gomega.Equal(wlKeys))
+	}, Timeout, Interval).Should(gomega.Succeed(), assertMsg("Unexpected workloads with QuotaReservation", wlObjects...))
 }
 
 func FilterEvictedWorkloads(ctx context.Context, k8sClient client.Client, wls ...*kueue.Workload) []*kueue.Workload {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

To serialize multiple workloads when for some of the asserts which require inspecting multiple workloads.

#### Special notes for your reviewer:

Example output after the change for the "Should unblock admission of new workloads in other ClusterQueues once the admitted workload exceeds timeout" test, after I adjusted L154 to expect two admitted workloads: `util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, prodClusterQ.Name, devWl, prodWl)`.

```
  The function passed to Eventually failed at /usr/local/google/home/michalwozniak/go/src/sigs.k8s.io/kueue/test/util/util.go:353 with:
  unexpected workloads were admitted; inspected objects:
      <*v1beta2.Workload | 0xc001b06248>: {
          TypeMeta: {Kind: "", APIVersion: ""},
          ObjectMeta: {
              Name: "dev-wl",
              GenerateName: "",
              Namespace: "podsready-d85xk",
              SelfLink: "",
              UID: "50150ecd-7413-486e-88dc-b9614680129c",
              ResourceVersion: "254",
              Generation: 1,
              CreationTimestamp: {
                  Time: 2026-03-16T11:01:51Z,
              },
              DeletionTimestamp: nil,
              DeletionGracePeriodSeconds: nil,
              Labels: nil,
              Annotations: nil,
              OwnerReferences: nil,
              Finalizers: nil,
              ManagedFields: [
                  {
                      Manager: "kueue-admission",
                      Operation: "Apply",
                      APIVersion: "kueue.x-k8s.io/v1beta2",
                      Time: {
                          Time: 2026-03-16T11:01:51Z,
                      },
                      FieldsType: "FieldsV1",
                      FieldsV1: {
                          Raw: "{\"f:status\":{\"f:conditions\":{\"k:{\\\"type\\\":\\\"QuotaReserved\\\"}\":{\".\":{},\"f:lastTransitionTime\":{},\"f:message\":{},\"f:observedGeneration\":{},\"f:reason\":{},\"f:status\":{},\"f:type\":{}}}}}",
                      },
                      Subresource: "status",
                  },
                  {
                      Manager: "podsready.test",
                      Operation: "Update",
                      APIVersion: "kueue.x-k8s.io/v1beta2",
                      Time: {
                          Time: 2026-03-16T11:01:51Z,
                      },
                      FieldsType: "FieldsV1",
                      FieldsV1: {
                          Raw: "{\"f:spec\":{\".\":{},\"f:active\":{},\"f:podSets\":{\".\":{},\"k:{\\\"name\\\":\\\"main\\\"}\":{\".\":{},\"f:count\":{},\"f:name\":{},\"f:template\":{\".\":{},\"f:metadata\":{},\"f:spec\":{\".\":{},\"f:containers\":{\".\":{},\"k:{\\\"name\\\":\\\"c\\\"}\":{\".\":{},\"f:name\":{},\"f:resources\":{\".\":{},\"f:requests\":{\".\":{},\"f:cpu\":{}}}}},\"f:restartPolicy\":{}}}}},\"f:queueName\":{}}}",
                      },
                      Subresource: "",
                  },
              ],
          },
          Spec: {
              PodSets: [
                  {
                      Name: "main",
                      Template: {
                          ObjectMeta: {
                              Name: "",
                              GenerateName: "",
                              Namespace: "",
                              SelfLink: "",
                              UID: "",
                              ResourceVersion: "",
                              Generation: 0,
                              CreationTimestamp: {
                                  Time: 0001-01-01T00:00:00Z,
                              },
                              DeletionTimestamp: nil,
                              DeletionGracePeriodSeconds: nil,
                              Labels: nil,
                              Annotations: nil,
                              OwnerReferences: nil,
                              Finalizers: nil,
                              ManagedFields: nil,
                          },
                          Spec: {
                              Volumes: nil,
                              InitContainers: nil,
                              Containers: [
                                  {
                                      Name: "c",
                                      Image: "",
                                      Command: nil,
                                      Args: nil,
                                      WorkingDir: "",
                                      Ports: nil,
                                      EnvFrom: nil,
                                      Env: nil,
                                      Resources: {Limits: nil, Requests: {...: ...}, Claims: nil},
                                      ResizePolicy: nil,
                                      RestartPolicy: nil,
                                      RestartPolicyRules: nil,
                                      VolumeMounts: nil,
                                      VolumeDevices: nil,
                                      LivenessProbe: nil,
                                      ReadinessProbe: nil,
                                      StartupProbe: nil,
                                      Lifecycle: nil,
                                      TerminationMessagePath: "",
                                      TerminationMessagePolicy: "",
                                      ImagePullPolicy: "",
                                      SecurityContext: nil,
                                      Stdin: false,
                                      StdinOnce: false,
                                      TTY: false,
                                  },
                              ],
                              EphemeralContainers: nil,
                              RestartPolicy: "Never",
                              TerminationGracePeriodSeconds: nil,
                              ActiveDeadlineSeconds: nil,
                              DNSPolicy: "",
                              NodeSelector: nil,
                              ServiceAccountName: "",
                              DeprecatedServiceAccount: "",
                              AutomountServiceAccountToken: nil,
                              NodeName: "",
                              HostNetwork: false,
                              HostPID: false,
                              HostIPC: false,
                              ShareProcessNamespace: nil,
                              SecurityContext: nil,
                              ImagePullSecrets: nil,
                              Hostname: "",
                              Subdomain: "",
                              Affinity: nil,
                              SchedulerName: "",
                              Tolerations: nil,
                              HostAliases: nil,
                              PriorityClassName: "",
                              Priority: nil,
                              DNSConfig: nil,
                              ReadinessGates: nil,
                              RuntimeClassName: nil,
                              EnableServiceLinks: nil,
                              PreemptionPolicy: nil,
                              Overhead: nil,
                              TopologySpreadConstraints: nil,
                              SetHostnameAsFQDN: nil,
                              OS: nil,
                              HostUsers: nil,
                              SchedulingGates: nil,
                              ResourceClaims: nil,
                              Resources: nil,
                              HostnameOverride: nil,
                              WorkloadRef: nil,
                          },
                      },
                      Count: 1,
                      MinCount: nil,
                      TopologyRequest: nil,
                  },
              ],
              QueueName: "dev-queue",
              PriorityClassRef: nil,
              Priority: nil,
              Active: true,
              MaximumExecutionTimeSeconds: nil,
          },
          Status: {
              Conditions: [
                  {
                      Type: "QuotaReserved",
                      Status: "False",
                      ObservedGeneration: 1,
                      LastTransitionTime: {
                          Time: 2026-03-16T11:01:51Z,
                      },
                      Reason: "Waiting",
                      Message: "waiting for all admitted workloads to be in PodsReady condition",
                  },
              ],
              Admission: nil,
              RequeueState: nil,
              ReclaimablePods: nil,
              AdmissionChecks: nil,
              ResourceRequests: nil,
              AccumulatedPastExecutionTimeSeconds: nil,
              SchedulingStats: nil,
              NominatedClusterNames: nil,
              ClusterName: nil,
              UnhealthyNodes: nil,
          },
      }
      <*v1beta2.Workload | 0xc001b06488>: {
          TypeMeta: {Kind: "", APIVersion: ""},
          ObjectMeta: {
              Name: "prod-wl",
              GenerateName: "",
              Namespace: "podsready-d85xk",
              SelfLink: "",
              UID: "c38838b1-902a-4ba2-b418-221cc8d7be0a",
              ResourceVersion: "252",
              Generation: 1,
              CreationTimestamp: {
                  Time: 2026-03-16T11:01:51Z,
              },
              DeletionTimestamp: nil,
              DeletionGracePeriodSeconds: nil,
              Labels: nil,
              Annotations: nil,
              OwnerReferences: nil,
              Finalizers: nil,
              ManagedFields: [
                  {
                      Manager: "kueue-admission",
                      Operation: "Apply",
                      APIVersion: "kueue.x-k8s.io/v1beta2",
                      Time: {
                          Time: 2026-03-16T11:01:51Z,
                      },
                      FieldsType: "FieldsV1",
                      FieldsV1: {
                          Raw: "{\"f:status\":{\"f:admission\":{\"f:clusterQueue\":{},\"f:podSetAssignments\":{\"k:{\\\"name\\\":\\\"main\\\"}\":{\".\":{},\"f:count\":{},\"f:flavors\":{\"f:cpu\":{}},\"f:name\":{},\"f:resourceUsage\":{\"f:cpu\":{}}}}},\"f:conditions\":{\"k:{\\\"type\\\":\\\"Admitted\\\"}\":{\".\":{},\"f:lastTransitionTime\":{},\"f:message\":{},\"f:observedGeneration\":{},\"f:reason\":{},\"f:status\":{},\"f:type\":{}},\"k:{\\\"type\\\":\\\"QuotaReserved\\\"}\":{\".\":{},\"f:lastTransitionTime\":{},\"f:message\":{},\"f:observedGeneration\":{},\"f:reason\":{},\"f:status\":{},\"f:type\":{}}}}}",
                      },
                      Subresource: "status",
                  },
                  {
                      Manager: "podsready.test",
                      Operation: "Update",
                      APIVersion: "kueue.x-k8s.io/v1beta2",
                      Time: {
                          Time: 2026-03-16T11:01:51Z,
                      },
                      FieldsType: "FieldsV1",
                      FieldsV1: {
                          Raw: "{\"f:spec\":{\".\":{},\"f:active\":{},\"f:podSets\":{\".\":{},\"k:{\\\"name\\\":\\\"main\\\"}\":{\".\":{},\"f:count\":{},\"f:name\":{},\"f:template\":{\".\":{},\"f:metadata\":{},\"f:spec\":{\".\":{},\"f:containers\":{\".\":{},\"k:{\\\"name\\\":\\\"c\\\"}\":{\".\":{},\"f:name\":{},\"f:resources\":{\".\":{},\"f:requests\":{\".\":{},\"f:cpu\":{}}}}},\"f:restartPolicy\":{}}}}},\"f:queueName\":{}}}",
                      },
                      Subresource: "",
                  },
              ],
          },
          Spec: {
              PodSets: [
                  {
                      Name: "main",
                      Template: {
                          ObjectMeta: {
                              Name: "",
                              GenerateName: "",
                              Namespace: "",
                              SelfLink: "",
                              UID: "",
                              ResourceVersion: "",
                              Generation: 0,
                              CreationTimestamp: {
                                  Time: 0001-01-01T00:00:00Z,
                              },
                              DeletionTimestamp: nil,
                              DeletionGracePeriodSeconds: nil,
                              Labels: nil,
                              Annotations: nil,
                              OwnerReferences: nil,
                              Finalizers: nil,
                              ManagedFields: nil,
                          },
                          Spec: {
                              Volumes: nil,
                              InitContainers: nil,
                              Containers: [
                                  {
                                      Name: "c",
                                      Image: "",
                                      Command: nil,
                                      Args: nil,
                                      WorkingDir: "",
                                      Ports: nil,
                                      EnvFrom: nil,
                                      Env: nil,
                                      Resources: {Limits: nil, Requests: {...: ...}, Claims: nil},
                                      ResizePolicy: nil,
                                      RestartPolicy: nil,
                                      RestartPolicyRules: nil,
                                      VolumeMounts: nil,
                                      VolumeDevices: nil,
                                      LivenessProbe: nil,
                                      ReadinessProbe: nil,
                                      StartupProbe: nil,
                                      Lifecycle: nil,
                                      TerminationMessagePath: "",
                                      TerminationMessagePolicy: "",
                                      ImagePullPolicy: "",
                                      SecurityContext: nil,
                                      Stdin: false,
                                      StdinOnce: false,
                                      TTY: false,
                                  },
                              ],
                              EphemeralContainers: nil,
                              RestartPolicy: "Never",
                              TerminationGracePeriodSeconds: nil,
                              ActiveDeadlineSeconds: nil,
                              DNSPolicy: "",
                              NodeSelector: nil,
                              ServiceAccountName: "",
                              DeprecatedServiceAccount: "",
                              AutomountServiceAccountToken: nil,
                              NodeName: "",
                              HostNetwork: false,
                              HostPID: false,
                              HostIPC: false,
                              ShareProcessNamespace: nil,
                              SecurityContext: nil,
                              ImagePullSecrets: nil,
                              Hostname: "",
                              Subdomain: "",
                              Affinity: nil,
                              SchedulerName: "",
                              Tolerations: nil,
                              HostAliases: nil,
                              PriorityClassName: "",
                              Priority: nil,
                              DNSConfig: nil,
                              ReadinessGates: nil,
                              RuntimeClassName: nil,
                              EnableServiceLinks: nil,
                              PreemptionPolicy: nil,
                              Overhead: nil,
                              TopologySpreadConstraints: nil,
                              SetHostnameAsFQDN: nil,
                              OS: nil,
                              HostUsers: nil,
                              SchedulingGates: nil,
                              ResourceClaims: nil,
                              Resources: nil,
                              HostnameOverride: nil,
                              WorkloadRef: nil,
                          },
                      },
                      Count: 1,
                      MinCount: nil,
                      TopologyRequest: nil,
                  },
              ],
              QueueName: "prod-queue",
              PriorityClassRef: nil,
              Priority: nil,
              Active: true,
              MaximumExecutionTimeSeconds: nil,
          },
          Status: {
              Conditions: [
                  {
                      Type: "QuotaReserved",
                      Status: "True",
                      ObservedGeneration: 1,
                      LastTransitionTime: {
                          Time: 2026-03-16T11:01:51Z,
                      },
                      Reason: "QuotaReserved",
                      Message: "Quota reserved in ClusterQueue prod-cq",
                  },
                  {
                      Type: "Admitted",
                      Status: "True",
                      ObservedGeneration: 1,
                      LastTransitionTime: {
                          Time: 2026-03-16T11:01:51Z,
                      },
                      Reason: "Admitted",
                      Message: "The workload is admitted",
                  },
              ],
              Admission: {
                  ClusterQueue: "prod-cq",
                  PodSetAssignments: [
                      {
                          Name: "main",
                          Flavors: {"cpu": "default"},
                          ResourceUsage: {
                              "cpu": {
                                  i: {value: 2, scale: 0},
                                  d: {Dec: nil},
                                  s: "2",
                                  Format: "DecimalSI",
                              },
                          },
                          Count: 1,
                          TopologyAssignment: nil,
                          DelayedTopologyRequest: nil,
                      },
                  ],
              },
              RequeueState: nil,
              ReclaimablePods: nil,
              AdmissionChecks: nil,
              ResourceRequests: nil,
              AccumulatedPastExecutionTimeSeconds: nil,
              SchedulingStats: nil,
              NominatedClusterNames: nil,
              ClusterName: nil,
              UnhealthyNodes: nil,
          },
      }

  Expected
      <[]types.NamespacedName | len:1, cap:2>: [
          {
              Namespace: "podsready-d85xk",
              Name: "prod-wl",
          },
      ]
  to equal
      <[]types.NamespacedName | len:2, cap:2>: [
          {
              Namespace: "podsready-d85xk",
              Name: "dev-wl",
          },
          {
              Namespace: "podsready-d85xk",
              Name: "prod-wl",
          },
      ][0m
  [38;5;9mIn [1m[It][0m[38;5;9m at: [1m/usr/local/google/home/michalwozniak/go/src/sigs.k8s.io/kueue/test/integration/singlecluster/scheduler/podsready/scheduler_test.go:154[0m [38;5;243m@ 03/16/26 11:02:01.538[0m
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```