### PR TITLE
refactor: use sync.WaitGroup.Go where possible

### DIFF
--- a/cmd/importer/util/util.go
+++ b/cmd/importer/util/util.go
@@ -257,15 +257,13 @@ func ConcurrentProcessPod(ch <-chan corev1.Pod, jobs uint, f func(p *corev1.Pod)
 	wg := sync.WaitGroup{}
 	resultCh := make(chan Result)
 
-	wg.Add(int(jobs))
 	for range int(jobs) {
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for pod := range ch {
 				skip, err := f(&pod)
 				resultCh <- Result{Pod: client.ObjectKeyFromObject(&pod).String(), Err: err, Skip: skip}
 			}
-		}()
+		})
 	}
 	go func() {
 		wg.Wait()

--- a/test/integration/multikueue/scheduler/suite_test.go
+++ b/test/integration/multikueue/scheduler/suite_test.go
@@ -186,26 +186,22 @@ var _ = ginkgo.BeforeSuite(func() {
 	ginkgo.By("creating the clusters", func() {
 		mu = sync.Mutex{}
 		wg := sync.WaitGroup{}
-		wg.Add(3)
-		go func() {
+		wg.Go(func() {
 			defer ginkgo.GinkgoRecover()
-			defer wg.Done()
 			// pass nil setup since the manager for the manage cluster is different in some specs.
 			c := createCluster(nil, managerFeatureGates...)
 			managerTestCluster = c
-		}()
-		go func() {
+		})
+		wg.Go(func() {
 			defer ginkgo.GinkgoRecover()
-			defer wg.Done()
 			c := createCluster(managerSetup)
 			worker1TestCluster = c
-		}()
-		go func() {
+		})
+		wg.Go(func() {
 			defer ginkgo.GinkgoRecover()
-			defer wg.Done()
 			c := createCluster(managerSetup)
 			worker2TestCluster = c
-		}()
+		})
 		wg.Wait()
 	})
 

--- a/test/integration/multikueue/suite_test.go
+++ b/test/integration/multikueue/suite_test.go
@@ -386,26 +386,22 @@ var _ = ginkgo.BeforeSuite(func() {
 	ginkgo.By("creating the clusters", func() {
 		mu = sync.Mutex{}
 		wg := sync.WaitGroup{}
-		wg.Add(3)
-		go func() {
+		wg.Go(func() {
 			defer ginkgo.GinkgoRecover()
-			defer wg.Done()
 			// pass nil setup since the manager for the manage cluster is different in some specs.
 			c := createCluster(nil, managerFeatureGates...)
 			managerTestCluster = c
-		}()
-		go func() {
+		})
+		wg.Go(func() {
 			defer ginkgo.GinkgoRecover()
-			defer wg.Done()
 			c := createCluster(managerSetup)
 			worker1TestCluster = c
-		}()
-		go func() {
+		})
+		wg.Go(func() {
 			defer ginkgo.GinkgoRecover()
-			defer wg.Done()
 			c := createCluster(managerSetup)
 			worker2TestCluster = c
-		}()
+		})
 		wg.Wait()
 	})
 

--- a/test/integration/multikueue/tas/suite_test.go
+++ b/test/integration/multikueue/tas/suite_test.go
@@ -192,26 +192,22 @@ var _ = ginkgo.BeforeSuite(func() {
 	ginkgo.By("creating the clusters", func() {
 		mu = sync.Mutex{}
 		wg := sync.WaitGroup{}
-		wg.Add(3)
-		go func() {
+		wg.Go(func() {
 			defer ginkgo.GinkgoRecover()
-			defer wg.Done()
 			// pass nil setup since the manager for the manage cluster is different in some specs.
 			c := createCluster(nil, managerFeatureGates...)
 			managerTestCluster = c
-		}()
-		go func() {
+		})
+		wg.Go(func() {
 			defer ginkgo.GinkgoRecover()
-			defer wg.Done()
 			c := createCluster(managerSetup)
 			worker1TestCluster = c
-		}()
-		go func() {
+		})
+		wg.Go(func() {
 			defer ginkgo.GinkgoRecover()
-			defer wg.Done()
 			c := createCluster(managerSetup)
 			worker2TestCluster = c
-		}()
+		})
 		wg.Wait()
 	})
 

--- a/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
@@ -1099,7 +1099,6 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Label("controller:clus
 
 			setClusterStatusPending := func() {
 				defer ginkgo.GinkgoRecover()
-				defer wg.Done()
 
 				for {
 					var updatedCq kueue.ClusterQueue
@@ -1129,9 +1128,8 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Label("controller:clus
 				}
 			}
 
-			wg.Add(nGoroutines)
 			for range nGoroutines {
-				go setClusterStatusPending()
+				wg.Go(setClusterStatusPending)
 			}
 
 			gomega.Eventually(func(g gomega.Gomega) {

--- a/test/performance/scheduler/runner/generator/generator.go
+++ b/test/performance/scheduler/runner/generator/generator.go
@@ -117,15 +117,13 @@ func concurrent[T any](set T, count func(T) int, call func(int) error) error {
 		close(done)
 	}()
 	total := count(set)
-	wg.Add(total)
 	for i := range total {
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			err := call(i)
 			if err != nil {
 				errCh <- err
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	close(errCh)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

/area testing

#### What this PR does / why we need it:

This PR refactors code to use the `WaitGroup.Go` method instead of `wg.Add` + `go` + `wg.Done`. 

#### Special notes for your reviewer:

Follows #7284

#### Does this PR introduce a user-facing change?

```release-note
NONE
```