### PR TITLE
Fix limits only issue code

### DIFF
--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -583,6 +583,7 @@ func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reas
 		return false
 	}
 	log := ctrl.LoggerFrom(ctx)
+	workload.AdjustResources(ctx, m.client, &w)
 	info.Update(log, &w)
 	m.addWorkload(info, q)
 

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -557,11 +557,10 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
 					ResourceGroup(*utiltestingapi.MakeFlavorQuotas(tasFlavor.Name).Resource(corev1.ResourceCPU, "5").Obj()).
 					Obj()
-				util.MustCreate(ctx, k8sClient, clusterQueue)
-				util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
+				util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
 
 				localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
-				util.MustCreate(ctx, k8sClient, localQueue)
+				util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
 			})
 
 			ginkgo.AfterEach(func() {
@@ -574,6 +573,37 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				for _, node := range nodes {
 					util.ExpectObjectToBeDeleted(ctx, k8sClient, &node, true)
 				}
+			})
+
+			ginkgo.It("Should admit a previously inadmissible limits-only workload after another workload finishes", func() {
+				ginkgo.By("Creating a blocker workload and waiting until it reserves most of the available GPU quota")
+				blocker := utiltestingapi.MakeWorkload("blocker", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).PodSets(*utiltestingapi.MakePodSet("worker", 4).
+					PreferredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+					Obj()).Request(corev1.ResourceCPU, "1").Obj()
+				util.MustCreate(ctx, k8sClient, blocker)
+
+				util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, clusterQueue.Name, blocker)
+				util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
+
+				ginkgo.By("Creating a second workload with only limits so it becomes inadmissible while the blocker holds quota")
+				limitsOnly := utiltestingapi.MakeWorkload("limits-only", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).PodSets(*utiltestingapi.MakePodSet("worker", 4).
+					PreferredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+					Obj()).Limit(corev1.ResourceCPU, "1").Obj()
+				util.MustCreate(ctx, k8sClient, limitsOnly)
+
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, limitsOnly)
+				util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
+
+				ginkgo.By("Marking the blocker workload as finished")
+				util.FinishWorkloads(ctx, k8sClient, blocker)
+
+				ginkgo.By("Verifying that once quota is released, the previously inadmissible limits-only workload now reserves quota")
+				util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, clusterQueue.Name, limitsOnly)
+
+				util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
+				util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
 			})
 
 			ginkgo.It("should not admit workload which does not fit to the required topology domain", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9889

#### Special notes for your reviewer:

See PR reproducing the problem: https://github.com/kubernetes-sigs/kueue/pull/9893

Example failure: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_kueue/9893/pull-kueue-test-integration-baseline-main/2033626544118697984

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Scheduling: fix the issue that scheduler could indefinitely try re-queueing a workload which was once 
inadmissible, but is admissible after an update. The issue affected workloads which don't specify 
resource requests explicitly, but rely on defaulting based on limits.
```