### PR TITLE
Ginkgo: introduce dedicated formatter for k8s objects

### DIFF
--- a/test/util/util.go
+++ b/test/util/util.go
@@ -65,6 +65,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	"sigs.k8s.io/yaml"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/leaderworkerset"
@@ -81,6 +82,19 @@ import (
 func init() {
 	// Use large MaxLength to make sure the diff contains relevant output
 	format.MaxLength = 500000
+	format.RegisterCustomFormatter(formatK8sObject)
+}
+
+func formatK8sObject(value any) (string, bool) {
+	obj, ok := value.(client.Object)
+	if !ok {
+		return "", false
+	}
+	objYAML, err := yaml.Marshal(obj)
+	if err != nil {
+		return "", false
+	}
+	return string(objYAML), true
 }
 
 var SetupLogger = sync.OnceFunc(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Improve assertMsg: add support for multiple object dump, ignore nil fields

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9895

#### Special notes for your reviewer:
Old assertMsg output
```
[FAILED] Timed out after 10.001s.
  Unexpected workloads with QuotaReservation
      <*v1beta2.Workload | 0x2d43e90e3d48>: {
          TypeMeta: {Kind: "", APIVersion: ""},
          ObjectMeta: {
              Name: "job-low-35d3c",
              GenerateName: "",
              Namespace: "core-hk5bk",
              SelfLink: "",
              UID: "b1f1a80e-3ee4-47e9-848c-c5339b9809c9",
              ResourceVersion: "282",
              Generation: 1,
              CreationTimestamp: {
                  Time: 2026-03-16T17:31:20+01:00,
              },
              DeletionTimestamp: nil,
              DeletionGracePeriodSeconds: nil,
              Labels: {
                  "kueue.x-k8s.io/job-uid": "be194934-9a0d-41db-ac87-f2891387fbb1",
              },
              Annotations: nil,
              OwnerReferences: [
                  {
                      APIVersion: "batch/v1",
                      Kind: "Job",
                      Name: "low",
                      UID: "be194934-9a0d-41db-ac87-f2891387fbb1",
                      Controller: true,
                      BlockOwnerDeletion: true,
                  },
              ],
              Finalizers: [
                  "kueue.x-k8s.io/resource-in-use",
              ],
              ManagedFields: [
                  {
                      Manager: "kueue-admission",
                      Operation: "Apply",
                      APIVersion: "kueue.x-k8s.io/v1beta2",
                      Time: {
                          Time: 2026-03-16T17:31:20+01:00,
                      },
                      FieldsType: "FieldsV1",
                      FieldsV1: {
                          Raw: "{\"f:metadata\":{\"f:labels\":{\"f:kueue.x-k8s.io/job-uid\":{}}},\"f:status\":{\"f:admission\":{\"f:clusterQueue\":{},\"f:podSetAssignments\":{\"k:{\\\"name\\\":\\\"main\\\"}\":{\".\":{},\"f:count\":{},\"f:flavors\":{\"f:cpu\":{}},\"f:name\":{},\"f:resourceUsage\":{\"f:cpu\":{}}}}},\"f:conditions\":{\"k:{\\\"type\\\":\\\"QuotaReserved\\\"}\":{\".\":{},\"f:lastTransitionTime\":{},\"f:message\":{},\"f:observedGeneration\":{},\"f:reason\":{},\"f:status\":{},\"f:type\":{}}}}}",
                      },
                      Subresource: "status",
                  },
                  {
                      Manager: "__debug_bin620955364",
                      Operation: "Update",
                      APIVersion: "kueue.x-k8s.io/v1beta2",
                      Time: {
                          Time: 2026-03-16T17:31:20+01:00,
                      },
                      FieldsType: "FieldsV1",
                      FieldsV1: {
                          Raw: "{\"f:metadata\":{\"f:finalizers\":{\".\":{},\"v:\\\"kueue.x-k8s.io/resource-in-use\\\"\":{}},\"f:labels\":{\".\":{},\"f:kueue.x-k8s.io/job-uid\":{}},\"f:ownerReferences\":{\".\":{},\"k:{\\\"uid\\\":\\\"be194934-9a0d-41db-ac87-f2891387fbb1\\\"}\":{}}},\"f:spec\":{\".\":{},\"f:active\":{},\"f:podSets\":{\".\":{},\"k:{\\\"name\\\":\\\"main\\\"}\":{\".\":{},\"f:count\":{},\"f:name\":{},\"f:template\":{\".\":{},\"f:metadata\":{\".\":{},\"f:labels\":{\".\":{},\"f:batch.kubernetes.io/job-name\":{}}},\"f:spec\":{\".\":{},\"f:containers\":{\".\":{},\"k:{\\\"name\\\":\\\"c\\\"}\":{\".\":{},\"f:image\":{},\"f:imagePullPolicy\":{},\"f:name\":{},\"f:resources\":{\".\":{},\"f:requests\":{\".\":{},\"f:cpu\":{}}},\"f:terminationMessagePath\":{},\"f:terminationMessagePolicy\":{}}},\"f:dnsPolicy\":{},\"f:restartPolicy\":{},\"f:schedulerName\":{},\"f:securityContext\":{},\"f:terminationGracePeriodSeconds\":{}}},\"f:topologyRequest\":{\".\":{},\"f:podIndexLabel\":{}}}},\"f:priority\":{},\"f:priorityClassRef\":{\".\":{},\"f:group\":{},\"f:kind\":{},\"f:name\":{}},\"f:queueName\":{}}}",
                      },
                      Subresource: "",
                  },
                  {
                      Manager: "__debug_bin620955364",
                      Operation: "Update",
                      APIVersion: "kueue.x-k8s.io/v1beta2",
                      Time: {
                          Time: 2026-03-16T17:31:20+01:00,
                      },
                      FieldsType: "FieldsV1",
                      FieldsV1: {
                          Raw: "{\"f:status\":{\".\":{},\"f:admissionChecks\":{\".\":{},\"k:{\\\"name\\\":\\\"ac\\\"}\":{\".\":{},\"f:lastTransitionTime\":{},\"f:message\":{},\"f:name\":{},\"f:state\":{}}}}}",
                      },
                      Subresource: "status",
                  },
              ],
          },
          Spec: {
              PodSets: [
                  {
                      Name: "main",
                      Template: {
                          ObjectMeta: {
                              Name: "",
                              GenerateName: "",
                              Namespace: "",
                              SelfLink: "",
                              UID: "",
                              ResourceVersion: "",
                              Generation: 0,
                              CreationTimestamp: {
                                  Time: 0001-01-01T00:00:00Z,
                              },
                              DeletionTimestamp: nil,
                              DeletionGracePeriodSeconds: nil,
                              Labels: {
                                  "batch.kubernetes.io/job-name": "low",
                              },
                              Annotations: nil,
                              OwnerReferences: nil,
                              Finalizers: nil,
                              ManagedFields: nil,
                          },
                          Spec: {
                              Volumes: nil,
                              InitContainers: nil,
                              Containers: [
                                  {
                                      Name: "c",
                                      Image: "pause",
                                      Command: nil,
                                      Args: nil,
                                      WorkingDir: "",
                                      Ports: nil,
                                      EnvFrom: nil,
                                      Env: nil,
                                      Resources: {Limits: nil, Requests: {...: ...}, Claims: nil},
                                      ResizePolicy: nil,
                                      RestartPolicy: nil,
                                      RestartPolicyRules: nil,
                                      VolumeMounts: nil,
                                      VolumeDevices: nil,
                                      LivenessProbe: nil,
                                      ReadinessProbe: nil,
                                      StartupProbe: nil,
                                      Lifecycle: nil,
                                      TerminationMessagePath: "/dev/termination-log",
                                      TerminationMessagePolicy: "File",
                                      ImagePullPolicy: "Always",
                                      SecurityContext: nil,
                                      Stdin: false,
                                      StdinOnce: false,
                                      TTY: false,
                                  },
                              ],
                              EphemeralContainers: nil,
                              RestartPolicy: "Never",
                              TerminationGracePeriodSeconds: 30,
                              ActiveDeadlineSeconds: nil,
                              DNSPolicy: "ClusterFirst",
                              NodeSelector: nil,
                              ServiceAccountName: "",
                              DeprecatedServiceAccount: "",
                              AutomountServiceAccountToken: nil,
                              NodeName: "",
                              HostNetwork: false,
                              HostPID: false,
                              HostIPC: false,
                              ShareProcessNamespace: nil,
                              SecurityContext: {
                                  SELinuxOptions: nil,
                                  WindowsOptions: nil,
                                  RunAsUser: nil,
                                  RunAsGroup: nil,
                                  RunAsNonRoot: nil,
                                  SupplementalGroups: nil,
                                  SupplementalGroupsPolicy: nil,
                                  FSGroup: nil,
                                  Sysctls: nil,
                                  FSGroupChangePolicy: nil,
                                  SeccompProfile: nil,
                                  AppArmorProfile: nil,
                                  SELinuxChangePolicy: nil,
                              },
                              ImagePullSecrets: nil,
                              Hostname: "",
                              Subdomain: "",
                              Affinity: nil,
                              SchedulerName: "default-scheduler",
                              Tolerations: nil,
                              HostAliases: nil,
                              PriorityClassName: "",
                              Priority: nil,
                              DNSConfig: nil,
                              ReadinessGates: nil,
                              RuntimeClassName: nil,
                              EnableServiceLinks: nil,
                              PreemptionPolicy: nil,
                              Overhead: nil,
                              TopologySpreadConstraints: nil,
                              SetHostnameAsFQDN: nil,
                              OS: nil,
                              HostUsers: nil,
                              SchedulingGates: nil,
                              ResourceClaims: nil,
                              Resources: nil,
                              HostnameOverride: nil,
                              WorkloadRef: nil,
                          },
                      },
                      Count: 5,
                      MinCount: nil,
                      TopologyRequest: {
                          Required: nil,
                          Preferred: nil,
                          Unconstrained: nil,
                          PodIndexLabel: "batch.kubernetes.io/job-completion-index",
                          SubGroupIndexLabel: nil,
                          SubGroupCount: nil,
                          PodSetGroupName: nil,
                          PodSetSliceRequiredTopology: nil,
                          PodSetSliceSize: nil,
                          PodsetSliceRequiredTopologyConstraints: nil,
                      },
                  },
              ],
              QueueName: "lq",
              PriorityClassRef: {
                  Group: "kueue.x-k8s.io",
                  Kind: "WorkloadPriorityClass",
                  Name: "low",
              },
              Priority: 10,
              Active: true,
              MaximumExecutionTimeSeconds: nil,
          },
          Status: {
              Conditions: [
                  {
                      Type: "QuotaReserved",
                      Status: "True",
                      ObservedGeneration: 1,
                      LastTransitionTime: {
                          Time: 2026-03-16T17:31:20+01:00,
                      },
                      Reason: "QuotaReserved",
                      Message: "Quota reserved in ClusterQueue cq",
                  },
              ],
              Admission: {
                  ClusterQueue: "cq",
                  PodSetAssignments: [
                      {
                          Name: "main",
                          Flavors: {"cpu": "rf"},
                          ResourceUsage: {
                              "cpu": {
                                  i: {value: 5, scale: 0},
                                  d: {Dec: nil},
                                  s: "5",
                                  Format: "DecimalSI",
                              },
                          },
                          Count: 5,
                          TopologyAssignment: nil,
                          DelayedTopologyRequest: nil,
                      },
                  ],
              },
              RequeueState: nil,
              ReclaimablePods: nil,
              AdmissionChecks: [
                  {
                      Name: "ac",
                      State: "Pending",
                      LastTransitionTime: {
                          Time: 2026-03-16T17:31:20+01:00,
                      },
                      Message: "",
                      RequeueAfterSeconds: nil,
                      RetryCount: nil,
                      PodSetUpdates: nil,
                  },
              ],
              ResourceRequests: nil,
              AccumulatedPastExecutionTimeSeconds: nil,
              SchedulingStats: nil,
              NominatedClusterNames: nil,
              ClusterName: nil,
              UnhealthyNodes: nil,
          },
      }

  The function passed to Eventually failed at /Users/mykhailo_kan/Projects/kueue/test/util/util.go:368 with:
  Expected
      <bool>: false
  to be true
```

Improved assertMsg output
```
  [FAILED] Timed out after 10.000s.
  Unexpected workloads with QuotaReservation
      <*v1beta2.Workload | 0x3733357c1b08>: metadata:
            creationTimestamp: "2026-03-16T16:28:44Z"
            finalizers:
            - kueue.x-k8s.io/resource-in-use
            generation: 1
            labels:
              kueue.x-k8s.io/job-uid: 7ea89b24-0ab2-48b3-a60c-2e73579eb7eb
            managedFields:
            - apiVersion: kueue.x-k8s.io/v1beta2
              fieldsType: FieldsV1
              fieldsV1:
                f:metadata:
                  f:labels:
                    f:kueue.x-k8s.io/job-uid: {}
                f:status:
                  f:admission:
                    f:clusterQueue: {}
                    f:podSetAssignments:
                      k:{"name":"main"}:
                        .: {}
                        f:count: {}
                        f:flavors:
                          f:cpu: {}
                        f:name: {}
                        f:resourceUsage:
                          f:cpu: {}
                  f:conditions:
                    k:{"type":"QuotaReserved"}:
                      .: {}
                      f:lastTransitionTime: {}
                      f:message: {}
                      f:observedGeneration: {}
                      f:reason: {}
                      f:status: {}
                      f:type: {}
              manager: kueue-admission
              operation: Apply
              subresource: status
              time: "2026-03-16T16:28:44Z"
            - apiVersion: kueue.x-k8s.io/v1beta2
              fieldsType: FieldsV1
              fieldsV1:
                f:metadata:
                  f:finalizers:
                    .: {}
                    v:"kueue.x-k8s.io/resource-in-use": {}
                  f:labels:
                    .: {}
                    f:kueue.x-k8s.io/job-uid: {}
                  f:ownerReferences:
                    .: {}
                    k:{"uid":"7ea89b24-0ab2-48b3-a60c-2e73579eb7eb"}: {}
                f:spec:
                  .: {}
                  f:active: {}
                  f:podSets:
                    .: {}
                    k:{"name":"main"}:
                      .: {}
                      f:count: {}
                      f:name: {}
                      f:template:
                        .: {}
                        f:metadata:
                          .: {}
                          f:labels:
                            .: {}
                            f:batch.kubernetes.io/job-name: {}
                        f:spec:
                          .: {}
                          f:containers:
                            .: {}
                            k:{"name":"c"}:
                              .: {}
                              f:image: {}
                              f:imagePullPolicy: {}
                              f:name: {}
                              f:resources:
                                .: {}
                                f:requests:
                                  .: {}
                                  f:cpu: {}
                              f:terminationMessagePath: {}
                              f:terminationMessagePolicy: {}
                          f:dnsPolicy: {}
                          f:restartPolicy: {}
                          f:schedulerName: {}
                          f:securityContext: {}
                          f:terminationGracePeriodSeconds: {}
                      f:topologyRequest:
                        .: {}
                        f:podIndexLabel: {}
                  f:priority: {}
                  f:priorityClassRef:
                    .: {}
                    f:group: {}
                    f:kind: {}
                    f:name: {}
                  f:queueName: {}
              manager: __debug_bin689309877
              operation: Update
              time: "2026-03-16T16:28:44Z"
            - apiVersion: kueue.x-k8s.io/v1beta2
              fieldsType: FieldsV1
              fieldsV1:
                f:status:
                  .: {}
                  f:admissionChecks:
                    .: {}
                    k:{"name":"ac"}:
                      .: {}
                      f:lastTransitionTime: {}
                      f:message: {}
                      f:name: {}
                      f:state: {}
              manager: __debug_bin689309877
              operation: Update
              subresource: status
              time: "2026-03-16T16:28:44Z"
            name: job-low-7a228
            namespace: core-465w2
            ownerReferences:
            - apiVersion: batch/v1
              blockOwnerDeletion: true
              controller: true
              kind: Job
              name: low
              uid: 7ea89b24-0ab2-48b3-a60c-2e73579eb7eb
            resourceVersion: "282"
            uid: bb8bf100-1299-4054-a69d-36eb2e61f285
          spec:
            active: true
            podSets:
            - count: 5
              name: main
              template:
                metadata:
                  labels:
                    batch.kubernetes.io/job-name: low
                spec:
                  containers:
                  - image: pause
                    imagePullPolicy: Always
                    name: c
                    resources:
                      requests:
                        cpu: "1"
                    terminationMessagePath: /dev/termination-log
                    terminationMessagePolicy: File
                  dnsPolicy: ClusterFirst
                  restartPolicy: Never
                  schedulerName: default-scheduler
                  securityContext: {}
                  terminationGracePeriodSeconds: 30
              topologyRequest:
                podIndexLabel: batch.kubernetes.io/job-completion-index
            priority: 10
            priorityClassRef:
              group: kueue.x-k8s.io
              kind: WorkloadPriorityClass
              name: low
            queueName: lq
          status:
            admission:
              clusterQueue: cq
              podSetAssignments:
              - count: 5
                flavors:
                  cpu: rf
                name: main
                resourceUsage:
                  cpu: "5"
            admissionChecks:
            - lastTransitionTime: "2026-03-16T16:28:44Z"
              message: ""
              name: ac
              state: Pending
            conditions:
            - lastTransitionTime: "2026-03-16T16:28:44Z"
              message: Quota reserved in ClusterQueue cq
              observedGeneration: 1
              reason: QuotaReserved
              status: "True"
              type: QuotaReserved
          

  The function passed to Eventually failed at /Users/mykhailo_kan/Projects/kueue/test/util/util.go:368 with:
  Expected
      <bool>: false
  to be true
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```