### PR TITLE
Automated cherry pick of #9897: [StatefulSets] Add JobUID label to Workloads.

### DIFF
--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -303,6 +303,11 @@ func (r *Reconciler) constructWorkload(sts *appsv1.StatefulSet) (*kueue.Workload
 
 	wl := podcontroller.NewGroupWorkload(GetWorkloadName(GetOwnerUID(sts), sts.Name), sts, []kueue.PodSet{podSet}, nil)
 
+	if wl.Labels == nil {
+		wl.Labels = make(map[string]string, 1)
+	}
+	wl.Labels[controllerconstants.JobUIDLabel] = string(sts.UID)
+
 	if err := controllerutil.SetOwnerReference(sts, wl, r.client.Scheme()); err != nil {
 		return nil, err
 	}

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -250,6 +250,7 @@ func TestReconciler(t *testing.T) {
 				DeepCopy(),
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					JobUID("sts-uid").
 					Queue("lq").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					Priority(0).
@@ -280,6 +281,7 @@ func TestReconciler(t *testing.T) {
 				DeepCopy(),
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					JobUID("sts-uid").
 					Queue("lq").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					Priority(0).

--- a/test/e2e/singlecluster/statefulset_test.go
+++ b/test/e2e/singlecluster/statefulset_test.go
@@ -98,8 +98,12 @@ var _ = ginkgo.Describe("StatefulSet integration", func() {
 					To(gomega.Succeed())
 				g.Expect(createdStatefulSet.Status.ReadyReplicas).To(gomega.Equal(int32(3)))
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+
 			createdWorkload := &kueue.Workload{}
-			gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+			ginkgo.By("Checking that the workload is created and has JobUID label", func() {
+				gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				gomega.Expect(createdWorkload.Labels[controllerconstants.JobUIDLabel]).To(gomega.Equal(string(statefulSet.UID)))
+			})
 
 			ginkgo.By("Creating potentially conflicting stateful-set", func() {
 				conflictingStatefulSet := statefulsettesting.MakeStatefulSet("sts-conflict", ns.Name).


### PR DESCRIPTION
Cherry pick of #9897 on release-0.15.

#9897: [StatefulSets] Add JobUID label to Workloads.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
StatefulSet integration: Fixed a bug that the `kueue.x-k8s.io/job-uid` label was not set on the workloads.
```