### PR TITLE
[e2e] Drop ginkgo.Ordered from singlecluster tests to enable parallelism

### DIFF
--- a/test/e2e/singlecluster/fair_sharing_test.go
+++ b/test/e2e/singlecluster/fair_sharing_test.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("Fair Sharing", ginkgo.Label("area:singlecluster", "feature:fairsharing"), ginkgo.Serial, ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("Fair Sharing", ginkgo.Label("area:singlecluster", "feature:fairsharing"), func() {
 	var (
 		ns  *corev1.Namespace
 		rf  *kueue.ResourceFlavor
@@ -45,25 +45,27 @@ var _ = ginkgo.Describe("Fair Sharing", ginkgo.Label("area:singlecluster", "feat
 	ginkgo.BeforeEach(func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "ns-")
 
-		rf = utiltestingapi.MakeResourceFlavor("rf").Obj()
+		rf = utiltestingapi.MakeResourceFlavor("rf-" + ns.Name).Obj()
 		util.MustCreate(ctx, k8sClient, rf)
 
-		cq1 = utiltestingapi.MakeClusterQueue("cq1").
-			Cohort("cohort").
+		cohort := kueue.CohortReference("cohort-" + ns.Name)
+
+		cq1 = utiltestingapi.MakeClusterQueue("cq1-" + ns.Name).
+			Cohort(cohort).
 			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(rf.Name).
 				Resource(corev1.ResourceCPU, "9").
 				Resource(corev1.ResourceMemory, "36G").
 				Obj()).
 			Obj()
-		cq2 = utiltestingapi.MakeClusterQueue("cq2").
-			Cohort("cohort").
+		cq2 = utiltestingapi.MakeClusterQueue("cq2-" + ns.Name).
+			Cohort(cohort).
 			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(rf.Name).
 				Resource(corev1.ResourceCPU, "9").
 				Resource(corev1.ResourceMemory, "36G").
 				Obj()).
 			Obj()
-		cq3 = utiltestingapi.MakeClusterQueue("cq3").
-			Cohort("cohort").
+		cq3 = utiltestingapi.MakeClusterQueue("cq3-" + ns.Name).
+			Cohort(cohort).
 			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(rf.Name).
 				Resource(corev1.ResourceCPU, "9").
 				Resource(corev1.ResourceMemory, "36G").

--- a/test/e2e/singlecluster/kueuectl_test.go
+++ b/test/e2e/singlecluster/kueuectl_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Label("area:singlecluster", "feature:kueuectl"), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Label("area:singlecluster", "feature:kueuectl"), func() {
 	var (
 		ns *corev1.Namespace
 		cq *kueue.ClusterQueue


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it:
Removes `ginkgo.Ordered` from singlecluster e2e tests (`fair_sharing_test.go` and `kueuectl_test.go`). Both test suites already use `BeforeEach`/`AfterEach` for setup and teardown, so specs are independent and don't rely on execution order. Dropping `Ordered` allows ginkgo to randomize and parallelize these specs.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9881

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```