### PR TITLE
cleanup: move workload metrics from evict function

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -424,7 +424,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 		if updated {
 			if evicted {
-				if err := workload.Evict(ctx, r.client, r.recorder, &wl, reason, message, underlyingCause, r.clock, r.roleTracker, r.customLabels, workload.WithCustomPrepare(prepare)); err != nil {
+				if err := workload.Evict(ctx, r.client, &wl, reason, message, underlyingCause, r.clock, workload.WithCustomPrepare(prepare)); err != nil {
 					if !apierrors.IsNotFound(err) {
 						return ctrl.Result{}, fmt.Errorf("setting eviction: %w", err)
 					}
@@ -688,7 +688,7 @@ func (r *WorkloadReconciler) reconcileCheckBasedEviction(ctx context.Context, wl
 	}
 	// at this point we know a Workload has at least one Retry AdmissionCheck
 	message := "At least one admission check is false"
-	if err := workload.Evict(ctx, r.client, r.recorder, wl, kueue.WorkloadEvictedByAdmissionCheck, message, "", r.clock, r.roleTracker, r.customLabels); err != nil {
+	if err := workload.Evict(ctx, r.client, wl, kueue.WorkloadEvictedByAdmissionCheck, message, "", r.clock); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -755,7 +755,7 @@ func (r *WorkloadReconciler) reconcileOnLocalQueueActiveState(ctx context.Contex
 			return false, nil
 		}
 		log.V(3).Info("Workload is evicted because the LocalQueue is stopped", "localQueue", klog.KRef(wl.Namespace, string(wl.Spec.QueueName)))
-		err := workload.Evict(ctx, r.client, r.recorder, wl, kueue.WorkloadEvictedByLocalQueueStopped, "The LocalQueue is stopped", "", r.clock, r.roleTracker, r.customLabels)
+		err := workload.Evict(ctx, r.client, wl, kueue.WorkloadEvictedByLocalQueueStopped, "The LocalQueue is stopped", "", r.clock)
 		return true, err
 	}
 
@@ -797,7 +797,7 @@ func (r *WorkloadReconciler) reconcileOnClusterQueueActiveState(ctx context.Cont
 		}
 		log.V(3).Info("Workload is evicted because the ClusterQueue is stopped", "clusterQueue", klog.KRef("", string(cqName)))
 		message := "The ClusterQueue is stopped"
-		err := workload.Evict(ctx, r.client, r.recorder, wl, kueue.WorkloadEvictedByClusterQueueStopped, message, "", r.clock, r.roleTracker, r.customLabels)
+		err := workload.Evict(ctx, r.client, wl, kueue.WorkloadEvictedByClusterQueueStopped, message, "", r.clock)
 		return true, err
 	}
 
@@ -927,7 +927,7 @@ func (r *WorkloadReconciler) reconcileNotReadyTimeout(ctx context.Context, req c
 	// Increments a re-queueing count and update a time to be re-queued.
 	log.V(2).Info("Start the eviction of the workload due to exceeding the PodsReady timeout")
 	message := fmt.Sprintf("Exceeded the PodsReady timeout %s", req.String())
-	err = workload.Evict(ctx, r.client, r.recorder, wl, kueue.WorkloadEvictedByPodsReadyTimeout, message, underlyingCause, r.clock, r.roleTracker, r.customLabels, workload.WithCustomPrepare(func(wl *kueue.Workload) {
+	err = workload.Evict(ctx, r.client, wl, kueue.WorkloadEvictedByPodsReadyTimeout, message, underlyingCause, r.clock, workload.WithCustomPrepare(func(wl *kueue.Workload) {
 		workload.UpdateRequeueState(wl, r.waitForPodsReady.requeuingBackoffBaseSeconds, int32(r.waitForPodsReady.requeuingBackoffMaxDuration.Seconds()), r.clock)
 	}))
 
@@ -1022,6 +1022,7 @@ func (r *WorkloadReconciler) Update(e event.TypedUpdateEvent[*kueue.Workload]) b
 	log.V(2).Info("Workload update event")
 
 	if workload.IsEvicted(e.ObjectNew) && !workload.IsEvicted(e.ObjectOld) {
+		r.reportEvictedWorkload(e.ObjectNew)
 		r.preemptionExpectations.ObservedUID(log,
 			client.ObjectKeyFromObject(e.ObjectNew), e.ObjectNew.UID)
 	}
@@ -1163,6 +1164,35 @@ func (r *WorkloadReconciler) notifyWatchers(oldWl, newWl *kueue.Workload) {
 	for _, w := range r.watchers {
 		w.NotifyWorkloadUpdate(oldWl, newWl)
 	}
+}
+
+func (r *WorkloadReconciler) reportEvictedWorkload(wl *kueue.Workload) {
+	priorityClassName := workload.PriorityClassName(wl)
+	cqName := ptr.Deref(wl.Status.Admission, kueue.Admission{}).ClusterQueue
+	cqCustomLabels := r.customLabels.CQGet(cqName)
+	evictCondition := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadEvicted)
+	reason, underlyingCause := workload.SplitReasonWithCause(evictCondition.Reason)
+	metrics.ReportEvictedWorkloads(cqName, reason, underlyingCause, priorityClassName, cqCustomLabels, r.roleTracker)
+	if podsReadyToEvictionTime := workload.WorkloadsWithPodsReadyToEvictedTime(wl); podsReadyToEvictionTime != nil {
+		metrics.ReportPodsReadyToEvictedTimeSeconds(cqName, reason, underlyingCause, *podsReadyToEvictionTime, cqCustomLabels, r.roleTracker)
+	}
+	if features.Enabled(features.LocalQueueMetrics) {
+		lqRef := metrics.LQRefFromWorkload(wl)
+		metrics.ReportLocalQueueEvictedWorkloads(
+			lqRef,
+			reason,
+			underlyingCause,
+			priorityClassName,
+			r.customLabels.LQGet(qutil.KeyFromWorkload(wl)),
+			r.roleTracker,
+		)
+	}
+	if evictionState := workload.FindSchedulingStatsEvictionByReason(wl, reason, kueue.EvictionUnderlyingCause(underlyingCause)); evictionState != nil {
+		if evictionState.Count == 1 {
+			metrics.ReportEvictedWorkloadsOnce(cqName, reason, underlyingCause, priorityClassName, r.customLabels.CQGet(cqName), r.roleTracker)
+		}
+	}
+	r.recorder.Event(wl, corev1.EventTypeNormal, evictCondition.Reason, evictCondition.Message)
 }
 
 func (r *WorkloadReconciler) reportFinishedWorkload(wl *kueue.Workload) {

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -943,14 +943,6 @@ func TestReconcile(t *testing.T) {
 					},
 				).
 				Obj(),
-			wantEvents: []utiltesting.EventRecord{
-				{
-					Key:       types.NamespacedName{Namespace: "ns", Name: "wl"},
-					EventType: "Normal",
-					Reason:    "EvictedDueToDeactivatedDueToAdmissionCheck",
-					Message:   "The workload is deactivated due to Admission check(s): check-1, were rejected",
-				},
-			},
 		},
 		"workload with retry checks should be evicted and checks should be pending": {
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
@@ -990,14 +982,6 @@ func TestReconcile(t *testing.T) {
 					},
 				).
 				Obj(),
-			wantEvents: []utiltesting.EventRecord{
-				{
-					Key:       types.NamespacedName{Namespace: "ns", Name: "wl"},
-					EventType: "Normal",
-					Reason:    "EvictedDueToAdmissionCheck",
-					Message:   "At least one admission check is false",
-				},
-			},
 		},
 		"increment re-queue count": {
 			reconcilerOpts: []Option{
@@ -1074,14 +1058,6 @@ func TestReconcile(t *testing.T) {
 					},
 				).
 				Obj(),
-			wantEvents: []utiltesting.EventRecord{
-				{
-					Key:       types.NamespacedName{Name: "wl", Namespace: "ns"},
-					EventType: corev1.EventTypeNormal,
-					Reason:    "EvictedDueToPodsReadyTimeout",
-					Message:   "Exceeded the PodsReady timeout ns/wl",
-				},
-			},
 		},
 		"trigger deactivation of workload when reaching backoffLimitCount": {
 			reconcilerOpts: []Option{
@@ -1176,14 +1152,6 @@ func TestReconcile(t *testing.T) {
 					},
 				).
 				Obj(),
-			wantEvents: []utiltesting.EventRecord{
-				{
-					Key:       types.NamespacedName{Name: "wl", Namespace: "ns"},
-					EventType: corev1.EventTypeNormal,
-					Reason:    "EvictedDueToPodsReadyTimeout",
-					Message:   "Exceeded the PodsReady timeout ns/wl",
-				},
-			},
 		},
 		"recovery time should be limited to recoveryTimeout": {
 			reconcilerOpts: []Option{
@@ -1252,14 +1220,6 @@ func TestReconcile(t *testing.T) {
 					},
 				).
 				Obj(),
-			wantEvents: []utiltesting.EventRecord{
-				{
-					Key:       types.NamespacedName{Name: "wl", Namespace: "ns"},
-					EventType: corev1.EventTypeNormal,
-					Reason:    "EvictedDueToPodsReadyTimeout",
-					Message:   "Exceeded the PodsReady timeout ns/wl",
-				},
-			},
 		},
 		"should set the WorkloadRequeued condition to true on re-activated": {
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
@@ -1490,14 +1450,6 @@ func TestReconcile(t *testing.T) {
 					},
 				).
 				Obj(),
-			wantEvents: []utiltesting.EventRecord{
-				{
-					Key:       types.NamespacedName{Name: "wl", Namespace: "ns"},
-					EventType: corev1.EventTypeNormal,
-					Reason:    "EvictedDueToDeactivated",
-					Message:   "The workload is deactivated",
-				},
-			},
 		},
 		"should set the Evicted condition with Deactivated reason when the .spec.active is False, Admitted, and the Workload has Evicted=False condition": {
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
@@ -1542,14 +1494,6 @@ func TestReconcile(t *testing.T) {
 					},
 				).
 				Obj(),
-			wantEvents: []utiltesting.EventRecord{
-				{
-					Key:       types.NamespacedName{Name: "wl", Namespace: "ns"},
-					EventType: corev1.EventTypeNormal,
-					Reason:    "EvictedDueToDeactivated",
-					Message:   "The workload is deactivated",
-				},
-			},
 		},
 		"with reason PodsReady; should set the Evicted condition with Deactivated reason, exceeded the maximum number of requeue retries" +
 			"when the .spec.active is False, Admitted, the Workload has Evicted=False and DeactivationTarget=True condition": {
@@ -1633,14 +1577,6 @@ func TestReconcile(t *testing.T) {
 					},
 				).
 				Obj(),
-			wantEvents: []utiltesting.EventRecord{
-				{
-					Key:       types.NamespacedName{Name: "wl", Namespace: "ns"},
-					EventType: corev1.EventTypeNormal,
-					Reason:    "EvictedDueToDeactivatedDueToRequeuingLimitExceeded",
-					Message:   "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
-				},
-			},
 		},
 		"with reason WaitForPodsStart; should set the Evicted condition with Deactivated reason, exceeded the maximum number of requeue retries" +
 			"when the .spec.active is False, Admitted, the Workload has Evicted=False and DeactivationTarget=True condition": {
@@ -1724,14 +1660,6 @@ func TestReconcile(t *testing.T) {
 					},
 				).
 				Obj(),
-			wantEvents: []utiltesting.EventRecord{
-				{
-					Key:       types.NamespacedName{Name: "wl", Namespace: "ns"},
-					EventType: corev1.EventTypeNormal,
-					Reason:    "EvictedDueToDeactivatedDueToRequeuingLimitExceeded",
-					Message:   "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
-				},
-			},
 		},
 		"with reason PodsReady; [backoffLimitCount: 100] should set the Evicted condition with Deactivated reason, exceeded the maximum number of requeue retries" +
 			"when the .spec.active is False, Admitted, the Workload has Evicted=False and DeactivationTarget=True condition, and the requeueState.count equals to backoffLimitCount": {
@@ -1818,14 +1746,6 @@ func TestReconcile(t *testing.T) {
 					},
 				).
 				Obj(),
-			wantEvents: []utiltesting.EventRecord{
-				{
-					Key:       types.NamespacedName{Name: "wl", Namespace: "ns"},
-					EventType: corev1.EventTypeNormal,
-					Reason:    "EvictedDueToDeactivatedDueToRequeuingLimitExceeded",
-					Message:   "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
-				},
-			},
 		},
 		"with reason WaitForPodsStart; [backoffLimitCount: 100] should set the Evicted condition with Deactivated reason, exceeded the maximum number of requeue retries" +
 			"when the .spec.active is False, Admitted, the Workload has Evicted=False and DeactivationTarget=True condition, and the requeueState.count equals to backoffLimitCount": {
@@ -1912,14 +1832,6 @@ func TestReconcile(t *testing.T) {
 					},
 				).
 				Obj(),
-			wantEvents: []utiltesting.EventRecord{
-				{
-					Key:       types.NamespacedName{Name: "wl", Namespace: "ns"},
-					EventType: corev1.EventTypeNormal,
-					Reason:    "EvictedDueToDeactivatedDueToRequeuingLimitExceeded",
-					Message:   "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
-				},
-			},
 		},
 		"should keep the previous eviction reason when the Workload is already evicted by other reason even though the Workload is deactivated.": {
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
@@ -1972,14 +1884,6 @@ func TestReconcile(t *testing.T) {
 					},
 				).
 				Obj(),
-			wantEvents: []utiltesting.EventRecord{
-				{
-					Key:       types.NamespacedName{Name: "wl", Namespace: "ns"},
-					EventType: corev1.EventTypeNormal,
-					Reason:    "EvictedDueToClusterQueueStopped",
-					Message:   "The ClusterQueue is stopped",
-				},
-			},
 		},
 		"should set the Evicted condition with LocalQueueStopped reason when the StopPolicy is HoldAndDrain": {
 			cq: utiltestingapi.MakeClusterQueue("cq").Obj(),
@@ -2008,14 +1912,6 @@ func TestReconcile(t *testing.T) {
 					},
 				).
 				Obj(),
-			wantEvents: []utiltesting.EventRecord{
-				{
-					Key:       types.NamespacedName{Name: "wl", Namespace: "ns"},
-					EventType: corev1.EventTypeNormal,
-					Reason:    "EvictedDueToLocalQueueStopped",
-					Message:   "The LocalQueue is stopped",
-				},
-			},
 		},
 		"should set the Inadmissible reason on QuotaReservation condition when the LocalQueue was deleted": {
 			cq: utiltestingapi.MakeClusterQueue("cq").AdmissionChecks("check").Obj(),

--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -403,7 +403,7 @@ func (r *nodeReconciler) evictWorkloadIfNeeded(ctx context.Context, wl *kueue.Wo
 		log.V(3).Info("Evicting workload due to multiple node failures")
 		allUnhealthyNodeNames := append(unhealthyNodeNames, nodeName)
 		evictionMsg := fmt.Sprintf(nodeMultipleFailuresEvictionMessageFormat, strings.Join(allUnhealthyNodeNames, ", "))
-		if evictionErr := workload.Evict(ctx, r.client, r.recorder, wl, kueue.WorkloadEvictedDueToNodeFailures, evictionMsg, "", r.clock, r.roleTracker, nil); evictionErr != nil {
+		if evictionErr := workload.Evict(ctx, r.client, wl, kueue.WorkloadEvictedDueToNodeFailures, evictionMsg, "", r.clock); evictionErr != nil {
 			log.Error(evictionErr, "Failed to complete eviction process")
 			return false, evictionErr
 		} else {

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -209,7 +209,7 @@ func (p *Preemptor) IssuePreemptions(ctx context.Context, preemptor *workload.In
 		message := preemptionMessage(preemptor.Obj, target.Reason, preemptorPath, preempteePath)
 		wlCopy := target.WorkloadInfo.Obj.DeepCopy()
 		err := workload.Evict(
-			ctx, p.client, p.recorder, wlCopy, kueue.WorkloadEvictedByPreemption, message, "", p.clock, p.roleTracker, p.customLabels,
+			ctx, p.client, wlCopy, kueue.WorkloadEvictedByPreemption, message, "", p.clock,
 			workload.WithCustomPrepare(func(wl *kueue.Workload) {
 				workload.SetPreemptedCondition(wl, p.clock.Now(), target.Reason, message)
 			}),

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -650,7 +650,7 @@ func (s *Scheduler) evictWorkloadAfterFailedTASReplacement(ctx context.Context, 
 	log.V(3).Info("Evicting workload after failed try to find a node replacement; TASFailedNodeReplacementFailFast enabled", "unhealthyNodes", unhealthyNodes)
 	msg := fmt.Sprintf("Workload was evicted as there was no replacement for unhealthy node(s): %s", unhealthyNodesCsv)
 	if err := workload.Evict(
-		ctx, s.client, s.recorder, wl, kueue.WorkloadEvictedDueToNodeFailures, msg, "", s.clock, s.roleTracker, s.customLabels,
+		ctx, s.client, wl, kueue.WorkloadEvictedDueToNodeFailures, msg, "", s.clock,
 		workload.EvictWithLooseOnApply(), workload.EvictWithRetryOnConflictForPatch(),
 	); err != nil {
 		return fmt.Errorf("failed to evict workload after failed try to find a replacement for unhealthy nodes: %s, %w", unhealthyNodesCsv, err)

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -694,11 +694,6 @@ func TestScheduleForTAS(t *testing.T) {
 						Obj()).
 					Obj(),
 			},
-			wantEvents: []utiltesting.EventRecord{
-				utiltesting.MakeEventRecord("default", "foo", "EvictedDueToNodeFailures", corev1.EventTypeNormal).
-					Message("Workload was evicted as there was no replacement for unhealthy node(s): x0").
-					Obj(),
-			},
 		},
 		"workload with unhealthyNode annotation; second pass; preferred; no fit; FailFast (not found error on patch)": {
 			nodes:           defaultNodes,
@@ -2547,10 +2542,6 @@ func TestScheduleForTAS(t *testing.T) {
 						Obj()).
 					Obj(),
 			},
-			wantEvents: []utiltesting.EventRecord{
-				utiltesting.MakeEventRecord("default", "foo", "EvictedDueToNodeFailures", corev1.EventTypeNormal).
-					Message("Workload was evicted as there was no replacement for unhealthy node(s): x0").Obj(),
-			},
 		},
 		"does not admit workload when node does not match required affinity": {
 			nodes:           defaultSingleNode,
@@ -3350,9 +3341,6 @@ func TestScheduleForTASPreemption(t *testing.T) {
 				"tas-main": {"default/foo"},
 			},
 			wantEvents: []utiltesting.EventRecord{
-				utiltesting.MakeEventRecord("default", "low-priority-admitted", "EvictedDueToPreempted", "Normal").
-					Message("Preempted to accommodate a workload (UID: wl-foo, JobUID: job-foo) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main").
-					Obj(),
 				utiltesting.MakeEventRecord("default", "low-priority-admitted", "Preempted", "Normal").
 					Message("Preempted to accommodate a workload (UID: wl-foo, JobUID: job-foo) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main; preemptor effective priority: 3 (base: 3, boost: 0); preemptee effective priority: 1 (base: 1, boost: 0)").
 					Obj(),
@@ -3476,9 +3464,6 @@ func TestScheduleForTASPreemption(t *testing.T) {
 				"tas-main": {"default/foo"},
 			},
 			wantEvents: []utiltesting.EventRecord{
-				utiltesting.MakeEventRecord("default", "low-priority-admitted", "EvictedDueToPreempted", "Normal").
-					Message("Preempted to accommodate a workload (UID: wl-foo, JobUID: job-foo) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main").
-					Obj(),
 				utiltesting.MakeEventRecord("default", "low-priority-admitted", "Preempted", "Normal").
 					Message("Preempted to accommodate a workload (UID: wl-foo, JobUID: job-foo) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main; preemptor effective priority: 3 (base: 3, boost: 0); preemptee effective priority: 1 (base: 1, boost: 0)").
 					Obj(),
@@ -3595,9 +3580,6 @@ func TestScheduleForTASPreemption(t *testing.T) {
 				"tas-main": {"default/foo"},
 			},
 			wantEvents: []utiltesting.EventRecord{
-				utiltesting.MakeEventRecord("default", "low-priority-admitted", "EvictedDueToPreempted", "Normal").
-					Message("Preempted to accommodate a workload (UID: wl-foo, JobUID: job-foo) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main").
-					Obj(),
 				utiltesting.MakeEventRecord("default", "low-priority-admitted", "Preempted", "Normal").
 					Message("Preempted to accommodate a workload (UID: wl-foo, JobUID: job-foo) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main; preemptor effective priority: 3 (base: 3, boost: 0); preemptee effective priority: 1 (base: 1, boost: 0)").
 					Obj(),
@@ -3718,9 +3700,6 @@ func TestScheduleForTASPreemption(t *testing.T) {
 				"tas-main": {"default/high-priority-waiting"},
 			},
 			wantEvents: []utiltesting.EventRecord{
-				utiltesting.MakeEventRecord("default", "low-priority-admitted", "EvictedDueToPreempted", "Normal").
-					Message("Preempted to accommodate a workload (UID: wl-high-priority-waiting, JobUID: job-high-priority-waiting) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main").
-					Obj(),
 				utiltesting.MakeEventRecord("default", "low-priority-admitted", "Preempted", "Normal").
 					Message("Preempted to accommodate a workload (UID: wl-high-priority-waiting, JobUID: job-high-priority-waiting) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main; preemptor effective priority: 3 (base: 3, boost: 0); preemptee effective priority: 1 (base: 1, boost: 0)").
 					Obj(),
@@ -3877,9 +3856,6 @@ func TestScheduleForTASPreemption(t *testing.T) {
 				"tas-main": {"default/foo"},
 			},
 			wantEvents: []utiltesting.EventRecord{
-				utiltesting.MakeEventRecord("default", "low-priority-admitted", "EvictedDueToPreempted", "Normal").
-					Message("Preempted to accommodate a workload (UID: wl-foo, JobUID: job-foo) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main").
-					Obj(),
 				utiltesting.MakeEventRecord("default", "low-priority-admitted", "Preempted", "Normal").
 					Message("Preempted to accommodate a workload (UID: wl-foo, JobUID: job-foo) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main; preemptor effective priority: 3 (base: 3, boost: 0); preemptee effective priority: 1 (base: 1, boost: 0)").
 					Obj(),
@@ -4038,9 +4014,6 @@ func TestScheduleForTASPreemption(t *testing.T) {
 				"tas-main": {"default/foo"},
 			},
 			wantEvents: []utiltesting.EventRecord{
-				utiltesting.MakeEventRecord("default", "low-priority-admitted", "EvictedDueToPreempted", "Normal").
-					Message("Preempted to accommodate a workload (UID: wl-foo, JobUID: job-foo) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main").
-					Obj(),
 				utiltesting.MakeEventRecord("default", "low-priority-admitted", "Preempted", "Normal").
 					Message("Preempted to accommodate a workload (UID: wl-foo, JobUID: job-foo) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main; preemptor effective priority: 3 (base: 3, boost: 0); preemptee effective priority: 1 (base: 1, boost: 0)").
 					Obj(),
@@ -4282,7 +4255,6 @@ func TestScheduleForTASPreemption(t *testing.T) {
 			wantInadmissibleLeft: nil,
 			eventCmpOpts:         cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
-				utiltesting.MakeEventRecord("default", "low-priority", "EvictedDueToPreempted", "Normal").Obj(),
 				utiltesting.MakeEventRecord("default", "low-priority", "Preempted", "Normal").Obj(),
 				utiltesting.MakeEventRecord("default", "high-priority", "PreemptedWorkload", "Normal").Obj(),
 				utiltesting.MakeEventRecord("default", "high-priority", "Pending", "Warning").Obj(),
@@ -4682,7 +4654,6 @@ func TestScheduleForTASCohorts(t *testing.T) {
 				utiltesting.MakeEventRecord("default", "b1", "Pending", corev1.EventTypeWarning).Obj(),
 				utiltesting.MakeEventRecord("default", "a1-admitted", "Preempted", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("default", "b1", "PreemptedWorkload", corev1.EventTypeNormal).Obj(),
-				utiltesting.MakeEventRecord("default", "a1-admitted", "EvictedDueToPreempted", corev1.EventTypeNormal).Obj(),
 			},
 		},
 		"reclaim within cohort; single workload is preempted out three candidates": {
@@ -4874,7 +4845,6 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
-				utiltesting.MakeEventRecord("default", "a1-admitted", "EvictedDueToPreempted", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("default", "a1-admitted", "Preempted", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("default", "b1", "PreemptedWorkload", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("default", "b1", "Pending", corev1.EventTypeWarning).Obj(),
@@ -5035,7 +5005,6 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
-				utiltesting.MakeEventRecord("default", "a2-admitted", "EvictedDueToPreempted", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("default", "a2-admitted", "Preempted", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("default", "b1", "PreemptedWorkload", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("default", "b1", "Pending", corev1.EventTypeWarning).Obj(),
@@ -5275,8 +5244,6 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
-				utiltesting.MakeEventRecord("default", "a2-admitted", "EvictedDueToPreempted", corev1.EventTypeNormal).Obj(),
-				utiltesting.MakeEventRecord("default", "a3-admitted", "EvictedDueToPreempted", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("default", "b1", "Pending", corev1.EventTypeWarning).Obj(),
 				utiltesting.MakeEventRecord("default", "c1", "Pending", corev1.EventTypeWarning).Obj(),
 				utiltesting.MakeEventRecord("default", "a2-admitted", "Preempted", corev1.EventTypeNormal).Obj(),
@@ -5968,7 +5935,6 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
-				utiltesting.MakeEventRecord("default", "a1-admitted", "EvictedDueToPreempted", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("default", "a2", "PreemptedWorkload", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("default", "a2", "Pending", corev1.EventTypeWarning).Obj(),
 				utiltesting.MakeEventRecord("default", "a1-admitted", "Preempted", corev1.EventTypeNormal).Obj(),
@@ -6474,11 +6440,6 @@ func TestScheduleForTASWhenWorkloadModifiedConcurrently(t *testing.T) {
 						Reason: "NodeFailures",
 						Count:  1,
 					}).
-					Obj(),
-			},
-			wantEvents: []utiltesting.EventRecord{
-				utiltesting.MakeEventRecord("default", "wl", "EvictedDueToNodeFailures", corev1.EventTypeNormal).
-					Message("Workload was evicted as there was no replacement for unhealthy node(s): x0").
 					Obj(),
 			},
 		},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -7780,7 +7780,6 @@ func TestSchedule(t *testing.T) {
 			},
 			eventCmpOpts: ignoreEventMessageCmpOpts,
 			wantEvents: []utiltesting.EventRecord{
-				utiltesting.MakeEventRecord("sales", "low-priority", "EvictedDueToPreempted", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("sales", "low-priority", "Preempted", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("sales", "preemptor", "PreemptedWorkload", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("sales", "preemptor", "Pending", corev1.EventTypeWarning).Obj(),
@@ -7896,7 +7895,6 @@ func TestSchedule(t *testing.T) {
 			},
 			eventCmpOpts: ignoreEventMessageCmpOpts,
 			wantEvents: []utiltesting.EventRecord{
-				utiltesting.MakeEventRecord("default", "low-pob", "EvictedDueToPreempted", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("default", "low-pob", "Preempted", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("default", "high-pob", "PreemptedWorkload", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("default", "high-pob", "Pending", corev1.EventTypeWarning).Obj(),
@@ -8119,7 +8117,6 @@ func TestSchedule(t *testing.T) {
 			},
 			eventCmpOpts: ignoreEventMessageCmpOpts,
 			wantEvents: []utiltesting.EventRecord{
-				utiltesting.MakeEventRecord("default", "fs-low-pob", "EvictedDueToPreempted", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("default", "fs-low-pob", "Preempted", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("default", "fs-high-pob", "PreemptedWorkload", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("default", "fs-high-pob", "Pending", corev1.EventTypeWarning).Obj(),

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -32,7 +32,6 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/tools/record"
 	resourcehelpers "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
@@ -777,9 +776,9 @@ func QueuedWaitTime(wl *kueue.Workload, clock clock.Clock) time.Duration {
 	return clock.Since(queuedTime)
 }
 
-// workloadsWithPodsReadyToEvictedTime is the amount of time it takes a workload's pods running to getting evicted.
+// WorkloadsWithPodsReadyToEvictedTime is the amount of time it takes a workload's pods running to getting evicted.
 // This measures runtime of workloads that do not run to completion (ie are evicted).
-func workloadsWithPodsReadyToEvictedTime(wl *kueue.Workload) *time.Duration {
+func WorkloadsWithPodsReadyToEvictedTime(wl *kueue.Workload) *time.Duration {
 	var podsReady *time.Time
 	if c := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadPodsReady); c != nil && c.Status == metav1.ConditionTrue {
 		podsReady = &c.LastTransitionTime.Time
@@ -1575,15 +1574,14 @@ func EvictWithRetryOnConflictForPatch() EvictOption {
 	}
 }
 
-func Evict(ctx context.Context, c client.Client, recorder record.EventRecorder, wl *kueue.Workload, reason, msg string, underlyingCause kueue.EvictionUnderlyingCause, clock clock.Clock, tracker *roletracker.RoleTracker, cl *metrics.CustomLabels, options ...EvictOption) error {
+func Evict(ctx context.Context, c client.Client, wl *kueue.Workload, reason, msg string, underlyingCause kueue.EvictionUnderlyingCause, clock clock.Clock, options ...EvictOption) error {
 	opts := DefaultEvictOptions()
 	for _, opt := range options {
 		opt(opts)
 	}
 
 	var (
-		hadAdmission              = wl.Status.Admission != nil
-		reportWorkloadEvictedOnce bool
+		hadAdmission = wl.Status.Admission != nil
 	)
 
 	var patchOpts []PatchStatusOption
@@ -1606,7 +1604,7 @@ func Evict(ctx context.Context, c client.Client, recorder record.EventRecorder, 
 			evictionReason = ReasonWithCause(evictionReason, string(underlyingCause))
 		}
 		prepareForEviction(wl, clock.Now(), evictionReason, msg)
-		reportWorkloadEvictedOnce = workloadEvictionStateInc(wl, reason, underlyingCause)
+		workloadEvictionStateInc(wl, reason, underlyingCause)
 		return true, nil
 	}, patchOpts...); err != nil {
 		return err
@@ -1618,10 +1616,6 @@ func Evict(ctx context.Context, c client.Client, recorder record.EventRecorder, 
 		log := log.FromContext(ctx)
 		log.V(3).Info("WARNING: unexpected eviction of workload without status.Admission", "workload", klog.KObj(wl))
 		return nil
-	}
-	reportEvictedWorkload(recorder, wl, wl.Status.Admission.ClusterQueue, reason, msg, underlyingCause, tracker, cl)
-	if reportWorkloadEvictedOnce {
-		metrics.ReportEvictedWorkloadsOnce(wl.Status.Admission.ClusterQueue, reason, string(underlyingCause), PriorityClassName(wl), cl.CQGet(wl.Status.Admission.ClusterQueue), tracker)
 	}
 	return nil
 }
@@ -1704,31 +1698,6 @@ func closeAllPreemptionGates(w *kueue.Workload, now time.Time) {
 	}
 }
 
-func reportEvictedWorkload(recorder record.EventRecorder, wl *kueue.Workload, cqName kueue.ClusterQueueReference, reason, message string, underlyingCause kueue.EvictionUnderlyingCause, tracker *roletracker.RoleTracker, cl *metrics.CustomLabels) {
-	priorityClassName := PriorityClassName(wl)
-	cqCustomLabels := cl.CQGet(cqName)
-	metrics.ReportEvictedWorkloads(cqName, reason, string(underlyingCause), priorityClassName, cqCustomLabels, tracker)
-	if podsReadyToEvictionTime := workloadsWithPodsReadyToEvictedTime(wl); podsReadyToEvictionTime != nil {
-		metrics.ReportPodsReadyToEvictedTimeSeconds(cqName, reason, string(underlyingCause), *podsReadyToEvictionTime, cqCustomLabels, tracker)
-	}
-	if features.Enabled(features.LocalQueueMetrics) {
-		lqRef := metrics.LQRefFromWorkload(wl)
-		metrics.ReportLocalQueueEvictedWorkloads(
-			lqRef,
-			reason,
-			string(underlyingCause),
-			priorityClassName,
-			cl.LQGet(utilqueue.KeyFromWorkload(wl)),
-			tracker,
-		)
-	}
-	eventReason := ReasonWithCause(kueue.WorkloadEvicted, reason)
-	if reason == kueue.WorkloadDeactivated && underlyingCause != "" {
-		eventReason = ReasonWithCause(eventReason, string(underlyingCause))
-	}
-	recorder.Event(wl, corev1.EventTypeNormal, eventReason, message)
-}
-
 func ReportPreemption(preemptingCqName kueue.ClusterQueueReference, preemptingReason string, targetCqName kueue.ClusterQueueReference, tracker *roletracker.RoleTracker, cl *metrics.CustomLabels) {
 	metrics.ReportPreemption(preemptingCqName, preemptingReason, targetCqName, cl.CQGet(preemptingCqName), tracker)
 }
@@ -1744,21 +1713,19 @@ func References(wls []*Info) []klog.ObjectRef {
 	return keys
 }
 
-func workloadEvictionStateInc(wl *kueue.Workload, reason string, underlyingCause kueue.EvictionUnderlyingCause) bool {
-	evictionState := findSchedulingStatsEvictionByReason(wl, reason, underlyingCause)
+func workloadEvictionStateInc(wl *kueue.Workload, reason string, underlyingCause kueue.EvictionUnderlyingCause) {
+	evictionState := FindSchedulingStatsEvictionByReason(wl, reason, underlyingCause)
 	if evictionState == nil {
 		evictionState = &kueue.WorkloadSchedulingStatsEviction{
 			Reason:          reason,
 			UnderlyingCause: underlyingCause,
 		}
 	}
-	report := evictionState.Count == 0
 	evictionState.Count++
 	setSchedulingStatsEviction(wl, *evictionState)
-	return report
 }
 
-func findSchedulingStatsEvictionByReason(wl *kueue.Workload, reason string, underlyingCause kueue.EvictionUnderlyingCause) *kueue.WorkloadSchedulingStatsEviction {
+func FindSchedulingStatsEvictionByReason(wl *kueue.Workload, reason string, underlyingCause kueue.EvictionUnderlyingCause) *kueue.WorkloadSchedulingStatsEviction {
 	if wl.Status.SchedulingStats != nil {
 		for i := range wl.Status.SchedulingStats.Evictions {
 			if wl.Status.SchedulingStats.Evictions[i].Reason == reason && wl.Status.SchedulingStats.Evictions[i].UnderlyingCause == underlyingCause {
@@ -1773,7 +1740,7 @@ func setSchedulingStatsEviction(wl *kueue.Workload, newEvictionState kueue.Workl
 	if wl.Status.SchedulingStats == nil {
 		wl.Status.SchedulingStats = &kueue.SchedulingStats{}
 	}
-	evictionState := findSchedulingStatsEvictionByReason(wl, newEvictionState.Reason, newEvictionState.UnderlyingCause)
+	evictionState := FindSchedulingStatsEvictionByReason(wl, newEvictionState.Reason, newEvictionState.UnderlyingCause)
 	if evictionState == nil {
 		wl.Status.SchedulingStats.Evictions = append(wl.Status.SchedulingStats.Evictions, newEvictionState)
 		return true
@@ -1787,6 +1754,11 @@ func setSchedulingStatsEviction(wl *kueue.Workload, newEvictionState kueue.Workl
 
 func ReasonWithCause(reason, underlyingCause string) string {
 	return fmt.Sprintf("%sDueTo%s", reason, underlyingCause)
+}
+
+func SplitReasonWithCause(reasonWithCause string) (string, string) {
+	reason, cause, _ := strings.Cut(reasonWithCause, "DueTo")
+	return reason, cause
 }
 
 // ClusterName returns the name of the remote cluster where the original workload

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -2654,3 +2654,53 @@ func TestSchedulingHash(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitReasonWithCause(t *testing.T) {
+	cases := map[string]struct {
+		reasonWithCause string
+		wantReason      string
+		wantCause       string
+	}{
+		"no ReasonWithCause": {
+			reasonWithCause: "",
+			wantReason:      "",
+			wantCause:       "",
+		},
+		"no DueTo": {
+			reasonWithCause: "Evicted",
+			wantReason:      "Evicted",
+			wantCause:       "",
+		},
+		"no cause": {
+			reasonWithCause: "EvictedDueTo",
+			wantReason:      "Evicted",
+			wantCause:       "",
+		},
+		"no reason": {
+			reasonWithCause: "DueToDeactivated",
+			wantReason:      "",
+			wantCause:       "Deactivated",
+		},
+		"reason with cause": {
+			reasonWithCause: "EvictedDueToDeactivated",
+			wantReason:      "Evicted",
+			wantCause:       "Deactivated",
+		},
+		"reason with cause containing DueTo": {
+			reasonWithCause: "EvictedDueToDeactivatedDueToRequeuingLimitExceeded",
+			wantReason:      "Evicted",
+			wantCause:       "DeactivatedDueToRequeuingLimitExceeded",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			gotReason, gotCause := SplitReasonWithCause(tc.reasonWithCause)
+			if tc.wantReason != gotReason {
+				t.Errorf("expected reason %s, got %s", tc.wantReason, gotReason)
+			}
+			if tc.wantCause != gotCause {
+				t.Errorf("expected cause %s, got %s", tc.wantCause, gotCause)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Move workload metrics out of Evict function

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #8830

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```