### PR TITLE
Automated cherry pick of #9899: Fix Snapshot() sort inconsistency with UsageBasedAdmissionFairSharing

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -83,6 +83,12 @@ func (s *stickyWorkload) set(workload workload.Reference) {
 	s.workloadName = workload
 }
 
+func logStickyWorkloadSelectionIfVerbose(log logr.Logger, wl *kueue.Workload) {
+	if logV := log.V(5); logV.Enabled() {
+		logV.Info("Prioritizing sticky workload", "workload", workload.Key(wl))
+	}
+}
+
 type ClusterQueue struct {
 	hierarchy.ClusterQueue[*cohort]
 	name              kueue.ClusterQueueReference
@@ -111,7 +117,8 @@ type ClusterQueue struct {
 	// QueueInadmissibleWorkloads is called.
 	queueInadmissibleCycle int64
 
-	compareFunc func(a, b *workload.Info) int
+	compareFunc  func(a, b *workload.Info) int
+	snapshotSort func(elements []*workload.Info)
 
 	queueingStrategy kueue.QueueingStrategy
 
@@ -193,9 +200,16 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.
 		opt(options)
 	}
 	sw := stickyWorkload{}
+	log := ctrl.LoggerFrom(ctx)
+	baseCmp := baseCompareFunc(log, wo, &sw)
 	compareFunc := queueOrderingFunc(ctx, client, wo, options.fsResWeights, options.enableAdmissionFs, options.afsEntryPenalties, options.afsConsumedResources, &sw)
 	// Derive lessFunc from compareFunc for the heap.
 	lessFunc := func(a, b *workload.Info) bool { return compareFunc(a, b) < 0 }
+	snapshotSort := buildSnapshotSort(
+		ctx, compareFunc, baseCmp, client,
+		options.enableAdmissionFs, options.fsResWeights,
+		options.afsEntryPenalties, options.afsConsumedResources,
+	)
 	return &ClusterQueue{
 		heap:                      *heap.New(workloadKey, lessFunc),
 		inadmissibleWorkloads:     make(inadmissibleWorkloads),
@@ -203,6 +217,7 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.
 		finishedWorkloads:         sets.New[workload.Reference](),
 		queueInadmissibleCycle:    -1,
 		compareFunc:               compareFunc,
+		snapshotSort:              snapshotSort,
 		rwm:                       sync.RWMutex{},
 		clock:                     clock,
 		afsEntryPenalties:         options.afsEntryPenalties,
@@ -553,11 +568,86 @@ func (c *ClusterQueue) DumpInadmissible() ([]workload.Reference, bool) {
 }
 
 // Snapshot returns a copy of pending workloads in queue order.
-// The ordering is deterministic and consistent with the scheduler's heap order.
+// When fair-sharing is enabled, FS usage is pre-computed per LocalQueue
+// from a point-in-time copy of AFS state before sorting.
 func (c *ClusterQueue) Snapshot() []*workload.Info {
 	elements := c.totalElements()
-	slices.SortFunc(elements, c.compareFunc)
+	c.snapshotSort(elements)
 	return elements
+}
+
+// buildSnapshotSort returns a function that sorts workload elements for Snapshot().
+// When fair-sharing is enabled, it pre-computes FS usage per LocalQueue from
+// deep-copied AFS state to avoid inconsistent comparisons from concurrent updates.
+func buildSnapshotSort(
+	ctx context.Context,
+	compareFunc func(a, b *workload.Info) int,
+	baseCmp func(a, b *workload.Info) int,
+	cl client.Client,
+	enableAdmissionFs bool,
+	fsResWeights map[corev1.ResourceName]float64,
+	afsEntryPenalties *queueafs.AfsEntryPenalties,
+	afsConsumedResources *queueafs.AfsConsumedResources,
+) func(elements []*workload.Info) {
+	if !enableAdmissionFs {
+		return func(elements []*workload.Info) {
+			slices.SortFunc(elements, compareFunc)
+		}
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+	getLQWeight := func(lqKey utilqueue.LocalQueueReference) (float64, bool) {
+		if cl == nil {
+			return 1, true
+		}
+		ns, name := utilqueue.MustParseLocalQueueReference(lqKey)
+		var lq kueue.LocalQueue
+		if err := cl.Get(ctx, client.ObjectKey{Namespace: ns, Name: string(name)}, &lq); err != nil {
+			log.V(2).Error(err, "Failed to get LocalQueue for FS weight", "localQueue", klog.KRef(ns, string(name)))
+			return 0, false
+		}
+		if lq.Spec.FairSharing != nil && lq.Spec.FairSharing.Weight != nil {
+			return lq.Spec.FairSharing.Weight.AsApproximateFloat64(), true
+		}
+		return 1, true
+	}
+
+	return func(elements []*workload.Info) {
+		usageCache := make(map[utilqueue.LocalQueueReference]float64)
+		for _, wInfo := range elements {
+			lqKey := utilqueue.KeyFromWorkload(wInfo.Obj)
+			if _, exists := usageCache[lqKey]; exists {
+				continue
+			}
+			var consumed, penalty corev1.ResourceList
+			if afsConsumedResources != nil {
+				if entry, found := afsConsumedResources.Get(lqKey); found {
+					consumed = entry.Resources.DeepCopy()
+				}
+			}
+			if afsEntryPenalties != nil {
+				penalty = afsEntryPenalties.Peek(lqKey).DeepCopy()
+			}
+			lqWeight, ok := getLQWeight(lqKey)
+			if !ok {
+				continue
+			}
+			usageCache[lqKey] = workload.CalcFSUsageFromResources(consumed, penalty, lqWeight, fsResWeights)
+		}
+
+		slices.SortFunc(elements, func(a, b *workload.Info) int {
+			lqA := utilqueue.KeyFromWorkload(a.Obj)
+			lqB := utilqueue.KeyFromWorkload(b.Obj)
+			usageA, okA := usageCache[lqA]
+			usageB, okB := usageCache[lqB]
+			if okA && okB {
+				if cmpResult := cmp.Compare(usageA, usageB); cmpResult != 0 {
+					return cmpResult
+				}
+			}
+			return baseCmp(a, b)
+		})
+	}
 }
 
 // Info returns workload.Info for the workload key.
@@ -622,46 +712,22 @@ func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.
 			reason == RequeueReasonPreemptionFailed)
 }
 
-// queueOrderingFunc returns a comparison function used to sort workloads.
-// It returns -1 if a should come before b, 1 if b should come before a, and 0 if equal.
-// The function sorts workloads based on their priority. When priorities are equal,
-// it uses the workload's creation or eviction time, with UID as a final tie-breaker.
-func queueOrderingFunc(ctx context.Context, cl client.Client, wo workload.Ordering, fsResWeights map[corev1.ResourceName]float64, enableAdmissionFs bool, afsEntryPenalties *queueafs.AfsEntryPenalties, afsConsumedResources *queueafs.AfsConsumedResources, sw *stickyWorkload) func(a, b *workload.Info) int {
-	log := ctrl.LoggerFrom(ctx)
+// baseCompareFunc orders workloads by sticky status, priority, timestamp, and UID.
+func baseCompareFunc(log logr.Logger, wo workload.Ordering, sw *stickyWorkload) func(a, b *workload.Info) int {
 	return func(a, b *workload.Info) int {
-		if enableAdmissionFs {
-			lqAUsage, errA := a.CalcLocalQueueFSUsage(ctx, cl, fsResWeights, afsEntryPenalties, afsConsumedResources)
-			lqBUsage, errB := b.CalcLocalQueueFSUsage(ctx, cl, fsResWeights, afsEntryPenalties, afsConsumedResources)
-			switch {
-			case errA != nil:
-				log.V(2).Error(errA, "Error determining LocalQueue usage")
-			case errB != nil:
-				log.V(2).Error(errB, "Error determining LocalQueue usage")
-			default:
-				log.V(3).Info("Resource usage from LocalQueue", "localQueue", klog.KRef(a.Obj.Namespace, string(a.Obj.Spec.QueueName)), "usage", lqAUsage)
-				log.V(3).Info("Resource usage from LocalQueue", "localQueue", klog.KRef(b.Obj.Namespace, string(b.Obj.Spec.QueueName)), "usage", lqBUsage)
-				if cmpResult := cmp.Compare(lqAUsage, lqBUsage); cmpResult != 0 {
-					return cmpResult
-				}
+		aSticky := sw.matches(workload.Key(a.Obj))
+		bSticky := sw.matches(workload.Key(b.Obj))
+		if aSticky != bSticky {
+			if aSticky {
+				logStickyWorkloadSelectionIfVerbose(log, a.Obj)
+				return -1
 			}
-		}
-
-		if sw.matches(workload.Key(a.Obj)) {
-			if logV := log.V(5); logV.Enabled() {
-				logV.Info("Prioritizing sticky workload", "workload", workload.Key(a.Obj))
-			}
-			return -1
-		}
-		if sw.matches(workload.Key(b.Obj)) {
-			if logV := log.V(5); logV.Enabled() {
-				logV.Info("Prioritizing sticky workload", "workload", workload.Key(b.Obj))
-			}
+			logStickyWorkloadSelectionIfVerbose(log, b.Obj)
 			return 1
 		}
 
 		p1 := utilpriority.Priority(a.Obj)
 		p2 := utilpriority.Priority(b.Obj)
-		// Higher priority comes first (reverse order).
 		if cmpResult := cmp.Compare(p2, p1); cmpResult != 0 {
 			return cmpResult
 		}
@@ -674,8 +740,33 @@ func queueOrderingFunc(ctx context.Context, cl client.Client, wo workload.Orderi
 			}
 			return 1
 		}
-		// UID tie-breaker ensures deterministic ordering when timestamps are equal.
 		return cmp.Compare(a.Obj.UID, b.Obj.UID)
+	}
+}
+
+// queueOrderingFunc composes fair-sharing usage (when enabled) with baseCompareFunc.
+func queueOrderingFunc(ctx context.Context, cl client.Client, wo workload.Ordering, fsResWeights map[corev1.ResourceName]float64, enableAdmissionFs bool, afsEntryPenalties *queueafs.AfsEntryPenalties, afsConsumedResources *queueafs.AfsConsumedResources, sw *stickyWorkload) func(a, b *workload.Info) int {
+	log := ctrl.LoggerFrom(ctx)
+	baseCmp := baseCompareFunc(log, wo, sw)
+	if !enableAdmissionFs {
+		return baseCmp
+	}
+	return func(a, b *workload.Info) int {
+		lqAUsage, errA := a.CalcLocalQueueFSUsage(ctx, cl, fsResWeights, afsEntryPenalties, afsConsumedResources)
+		lqBUsage, errB := b.CalcLocalQueueFSUsage(ctx, cl, fsResWeights, afsEntryPenalties, afsConsumedResources)
+		switch {
+		case errA != nil:
+			log.V(2).Error(errA, "Error determining LocalQueue usage")
+		case errB != nil:
+			log.V(2).Error(errB, "Error determining LocalQueue usage")
+		default:
+			log.V(3).Info("Resource usage from LocalQueue", "localQueue", klog.KRef(a.Obj.Namespace, string(a.Obj.Spec.QueueName)), "usage", lqAUsage)
+			log.V(3).Info("Resource usage from LocalQueue", "localQueue", klog.KRef(b.Obj.Namespace, string(b.Obj.Spec.QueueName)), "usage", lqBUsage)
+			if cmpResult := cmp.Compare(lqAUsage, lqBUsage); cmpResult != 0 {
+				return cmpResult
+			}
+		}
+		return baseCmp(a, b)
 	}
 }
 

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -18,6 +18,7 @@ package queue
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -409,6 +410,71 @@ func TestSnapshotDeterministicOrder(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestSnapshotStableWithConcurrentFSUpdates(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+
+	builder := utiltesting.NewClientBuilder().WithObjects(
+		utiltestingapi.MakeLocalQueue("lq1", defaultNamespace).
+			FairSharing(&kueue.FairSharing{Weight: ptr.To(resource.MustParse("1"))}).Obj(),
+		utiltestingapi.MakeLocalQueue("lq2", defaultNamespace).
+			FairSharing(&kueue.FairSharing{Weight: ptr.To(resource.MustParse("1"))}).Obj(),
+	)
+
+	afsConsumedResources := queueafs.NewAfsConsumedResources()
+	afsConsumedResources.Set("default/lq1", corev1.ResourceList{resourceGPU: resource.MustParse("5")}, now)
+	afsConsumedResources.Set("default/lq2", corev1.ResourceList{resourceGPU: resource.MustParse("5")}, now)
+
+	penaltyMap := queueafs.NewPenaltyMap()
+	ctx, _ := utiltesting.ContextWithLog(t)
+	cq, err := newClusterQueue(ctx, builder.Build(),
+		utiltestingapi.MakeClusterQueue("cq").AdmissionMode(kueue.UsageBasedAdmissionFairSharing).Obj(),
+		defaultOrdering,
+		&config.AdmissionFairSharing{ResourceWeights: map[corev1.ResourceName]float64{resourceGPU: 1.0}},
+		penaltyMap, afsConsumedResources)
+	if err != nil {
+		t.Fatalf("failed to create ClusterQueue: %v", err)
+	}
+
+	for _, w := range []*kueue.Workload{
+		utiltestingapi.MakeWorkload("wl1", defaultNamespace).Queue("lq1").Creation(now).UID("uid-1").Obj(),
+		utiltestingapi.MakeWorkload("wl2", defaultNamespace).Queue("lq2").Creation(now).UID("uid-2").Obj(),
+		utiltestingapi.MakeWorkload("wl3", defaultNamespace).Queue("lq1").Creation(now).UID("uid-3").Obj(),
+		utiltestingapi.MakeWorkload("wl4", defaultNamespace).Queue("lq2").Creation(now).UID("uid-4").Obj(),
+	} {
+		cq.PushOrUpdate(workload.NewInfo(w))
+	}
+
+	// Toggle lq1 penalty between 0 and 100 to create mid-sort inconsistency.
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				penaltyMap.Push("default/lq1", corev1.ResourceList{resourceGPU: resource.MustParse("100")})
+				penaltyMap.Sub("default/lq1", corev1.ResourceList{resourceGPU: resource.MustParse("100")})
+			}
+		}
+	}()
+	defer close(stop)
+
+	// Each snapshot must match one of two valid orderings:
+	// equal usage (by UID) or lq1 penalized (lq2 first).
+	validA := []string{"lq1", "lq2", "lq1", "lq2"}
+	validB := []string{"lq2", "lq2", "lq1", "lq1"}
+	for i := range 1000 {
+		snap := cq.Snapshot()
+		got := make([]string, len(snap))
+		for j, wInfo := range snap {
+			got[j] = string(wInfo.Obj.Spec.QueueName)
+		}
+		if !slices.Equal(got, validA) && !slices.Equal(got, validB) {
+			t.Fatalf("call %d: invalid ordering %v (expected %v or %v)", i+1, got, validA, validB)
+		}
 	}
 }
 

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -389,7 +389,6 @@ func dropExcludedResources(input corev1.ResourceList, excludedPrefixes []string)
 }
 
 func (i *Info) CalcLocalQueueFSUsage(ctx context.Context, c client.Client, resWeights map[corev1.ResourceName]float64, afsEntryPenalties *queueafs.AfsEntryPenalties, afsConsumedResources *queueafs.AfsConsumedResources) (float64, error) {
-	var usage float64
 	lqKey := utilqueue.KeyFromWorkload(i.Obj)
 
 	consumed := corev1.ResourceList{}
@@ -405,25 +404,32 @@ func (i *Info) CalcLocalQueueFSUsage(ctx context.Context, c client.Client, resWe
 		penalty = afsEntryPenalties.Peek(lqKey)
 	}
 
+	var lq kueue.LocalQueue
+	lqObjKey := client.ObjectKey{Namespace: i.Obj.Namespace, Name: string(i.Obj.Spec.QueueName)}
+	if err := c.Get(ctx, lqObjKey, &lq); err != nil {
+		return 0, err
+	}
+	var lqWeight float64 = 1
+	if lq.Spec.FairSharing != nil && lq.Spec.FairSharing.Weight != nil {
+		lqWeight = lq.Spec.FairSharing.Weight.AsApproximateFloat64()
+	}
+	return CalcFSUsageFromResources(consumed, penalty, lqWeight, resWeights), nil
+}
+
+// CalcFSUsageFromResources computes fair-sharing usage from consumed resources
+// and penalties. Keys are iterated in sorted order for deterministic results.
+func CalcFSUsageFromResources(consumed, penalty corev1.ResourceList, lqWeight float64, resWeights map[corev1.ResourceName]float64) float64 {
 	allResources := resource.MergeResourceListKeepSum(consumed, penalty)
-	for resName, resVal := range allResources {
+	var usage float64
+	for _, resName := range slices.Sorted(maps.Keys(allResources)) {
+		resVal := allResources[resName]
 		weight, found := resWeights[resName]
 		if !found {
 			weight = 1
 		}
 		usage += weight * resVal.AsApproximateFloat64()
 	}
-
-	var lq kueue.LocalQueue
-	lqObjKey := client.ObjectKey{Namespace: i.Obj.Namespace, Name: string(i.Obj.Spec.QueueName)}
-	if err := c.Get(ctx, lqObjKey, &lq); err != nil {
-		return 0, err
-	}
-	if lq.Spec.FairSharing != nil && lq.Spec.FairSharing.Weight != nil {
-		// if no weight for lq was defined, use default weight of 1
-		usage /= lq.Spec.FairSharing.Weight.AsApproximateFloat64()
-	}
-	return usage, nil
+	return usage / lqWeight
 }
 
 // IsUsingTAS returns information if the workload is using TAS


### PR DESCRIPTION
Cherry pick of #9899 on release-0.16.

#9899: Fix Snapshot() sort inconsistency with UsageBasedAdmissionFairSharing

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
VisibilityOnDemand: Fix non-deterministic workload ordering with UsageBasedAdmissionFairSharing enabled.
```