### PR TITLE
Enable AllowWatchBookmarks for MultiKueue remote client watches

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -204,7 +204,10 @@ func (rc *remoteClient) setConfig(watchCtx context.Context, config *clientConfig
 
 func (rc *remoteClient) startWatcher(ctx context.Context, kind string, w jobframework.MultiKueueWatcher) error {
 	log := ctrl.LoggerFrom(ctx).WithValues("watchKind", kind)
-	newWatcher, err := rc.client.Watch(ctx, w.GetEmptyList(), client.MatchingLabels{kueue.MultiKueueOriginLabel: rc.origin})
+	newWatcher, err := rc.client.Watch(ctx, w.GetEmptyList(),
+		client.MatchingLabels{kueue.MultiKueueOriginLabel: rc.origin},
+		&client.ListOptions{Raw: &metav1.ListOptions{AllowWatchBookmarks: true}},
+	)
 	if err != nil {
 		return err
 	}
@@ -213,6 +216,11 @@ func (rc *remoteClient) startWatcher(ctx context.Context, kind string, w jobfram
 		log.V(2).Info("Starting watch")
 		for r := range newWatcher.ResultChan() {
 			switch r.Type {
+			case watch.Bookmark:
+				// Bookmark events are periodic signals from the API server to
+				// keep the connection alive. They carry no meaningful payload
+				// and can be safely ignored.
+				log.V(5).Info("Watch bookmark received")
 			case watch.Error:
 				switch s := r.Object.(type) {
 				case *metav1.Status:


### PR DESCRIPTION
## What this PR does

Enables `AllowWatchBookmarks` on MultiKueue remote client watch connections and adds explicit handling for bookmark events.

## Why this is needed

The MultiKueue remote client uses raw `client.Watch()` calls to watch resources (Jobs, RayJobs, Workloads, etc.) on worker clusters. Unlike informers and reflectors — which set `AllowWatchBookmarks: true` by default — these raw watch calls do not request bookmark events from the API server.

When the network path between the manager and worker cluster includes an HTTP reverse proxy with an idle connection timeout (e.g., Cloudflare Tunnel with a default ~120s `proxy_read_timeout`), watch connections for infrequently-changing resources are terminated because no data flows within the timeout window. This causes:

- Repeated `Unable to start the watcher` errors with HTTP 524 responses
- `MultiKueueCluster` condition flipping to `Active=False` / `ClientConnectionFailed`
- All watches being torn down and restarted in a ~2-minute failure loop

With `AllowWatchBookmarks: true`, the API server sends periodic `BOOKMARK` events (~60s interval) that keep the connection alive through proxies with idle timeouts.

## Why this hasn't been reported before

Most MultiKueue deployments connect clusters on the same private network (same VPC, VPN, or cloud-provider peering), where connections are L4 TCP with no HTTP-level idle timeouts. The missing bookmarks only become a problem when the manager-to-worker path traverses an L7 HTTP reverse proxy that enforces idle connection timeouts — an uncommon but valid topology for multi-cloud or cross-region setups.

## Changes

1. **`startWatcher()`**: Added `AllowWatchBookmarks: true` via `client.ListOptions{Raw: &metav1.ListOptions{AllowWatchBookmarks: true}}` to the `Watch()` call
2. **Watch event loop**: Added explicit `case watch.Bookmark:` to handle bookmark events gracefully (log at V(5) and continue) instead of falling into the `default` case which attempts workload key extraction

## How this was verified

Tested with a MultiKueue setup where the manager cluster connects to a worker cluster through a Cloudflare Tunnel:

- **Without bookmarks**: Watch connections die after exactly ~128s with Cloudflare 524 errors
- **With `allowWatchBookmarks=true`**: Watch connections survive indefinitely, with bookmark events arriving every ~60s

All existing unit tests pass (`go test ./pkg/controller/admissionchecks/multikueue/...` and `go test ./pkg/controller/...`).

## Context

The fix aligns the MultiKueue watch behavior with how client-go's `Reflector` and controller-runtime's cache layer already handle watches — both enable `AllowWatchBookmarks` by default.


```release-note
MultiKueue: Enable AllowWatchBookmarks for remote client watches to prevent idle watch connections from being terminated by HTTP proxies with idle timeouts (e.g., Cloudflare 524 errors).
```
