### PR TITLE
Automated cherry pick of #9863: Fix stuck pods bug for node replacement

### DIFF
--- a/pkg/controller/tas/indexer/indexer.go
+++ b/pkg/controller/tas/indexer/indexer.go
@@ -31,6 +31,8 @@ import (
 const (
 	TASKey                        = "metadata.tas"
 	WorkloadNameKey               = "metadata.workload"
+	PodNodeSelectorHostnameKey    = "spec.nodeSelector.hostname"
+	PodNodeNameKey                = "spec.nodeName"
 	ResourceFlavorTopologyNameKey = "spec.topologyName"
 )
 
@@ -54,6 +56,27 @@ func indexPodWorkload(o client.Object) []string {
 	return []string{value}
 }
 
+func indexPodNodeSelectorHostname(o client.Object) []string {
+	pod, ok := o.(*corev1.Pod)
+	if !ok || !utiltas.IsTAS(pod) {
+		return nil
+	}
+	if pod.Spec.NodeSelector != nil {
+		if nodeName, ok := pod.Spec.NodeSelector[corev1.LabelHostname]; ok {
+			return []string{nodeName}
+		}
+	}
+	return nil
+}
+
+func indexPodNodeName(o client.Object) []string {
+	pod, ok := o.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+	return []string{pod.Spec.NodeName}
+}
+
 func indexResourceFlavorTopologyName(o client.Object) []string {
 	flavor, ok := o.(*kueue.ResourceFlavor)
 	if !ok || flavor.Spec.TopologyName == nil {
@@ -69,6 +92,13 @@ func SetupIndexes(ctx context.Context, indexer client.FieldIndexer) error {
 
 	if err := indexer.IndexField(ctx, &corev1.Pod{}, WorkloadNameKey, indexPodWorkload); err != nil {
 		return fmt.Errorf("setting index pod workload: %w", err)
+	}
+
+	if err := indexer.IndexField(ctx, &corev1.Pod{}, PodNodeSelectorHostnameKey, indexPodNodeSelectorHostname); err != nil {
+		return fmt.Errorf("setting index pod node selector hostname: %w", err)
+	}
+	if err := indexer.IndexField(ctx, &corev1.Pod{}, PodNodeNameKey, indexPodNodeName); err != nil {
+		return fmt.Errorf("setting index on %s for Pod: %w", PodNodeNameKey, err)
 	}
 
 	if err := indexer.IndexField(ctx, &kueue.ResourceFlavor{}, ResourceFlavorTopologyNameKey, indexResourceFlavorTopologyName); err != nil {

--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -28,9 +28,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
@@ -51,30 +53,37 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
+	utilclient "sigs.k8s.io/kueue/pkg/util/client"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 	"sigs.k8s.io/kueue/pkg/workload"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
+)
+
+const (
+	nodeMultipleFailuresEvictionMessageFormat = "Workload eviction triggered due to multiple TAS assigned node failures, including: %s"
+	reconcileBatchPeriod                      = 100 * time.Millisecond
+
+	podTerminatedByKueueConditionType    = "TerminatedByKueue"
+	podTerminatedByKueueConditionReason  = "UnschedulableOnAssignedNode"
+	podTerminatedByKueueConditionMessage = "Pod terminated by Kueue NodeFailureController due to node taint"
+	podTerminatedByKueueEventReason      = "PodTerminatedByKueue"
 )
 
 type workloadStatus int
 
 const (
-	nodeMultipleFailuresEvictionMessageFormat = "Workload eviction triggered due to multiple TAS assigned node failures, including: %s"
-	podTerminationCheckPeriod                 = 1 * time.Second
-)
-
-const (
-	// workloadHealthy indicates that the workload does not need to be evicted from the node.
+	// workloadHealthy indicates that the workload does not need to be replaced on the node.
 	// This happens if the node is healthy, or if the workload has permanent tolerations for the node's taints.
 	workloadHealthy workloadStatus = iota
 
-	// workloadUnhealthy indicates that the workload needs to be evicted from the node,
-	// and is ready for eviction (e.g. all of its pods on the node have fully terminated).
+	// workloadUnhealthy indicates that the workload needs to be replaced or evicted from the node,
+	// and is ready for it (e.g. all of its pods on the node have fully terminated).
 	workloadUnhealthy
 
-	// workloadTemporarilyHealthy indicates that the workload will need to be evicted from the node,
-	// but is not ready yet (e.g. pods are still terminating, or taints are only temporarily tolerated).
-	workloadTemporarilyHealthy
+	// workloadHealthUnknown indicates that it's impossible to determine the workload health
+	// from the node (e.g. error fetching resources).
+	workloadHealthUnknown
 )
 
 type taintToleration int
@@ -102,6 +111,12 @@ func WithWatchers(watchers ...NodeUpdateWatcher) NodeReconcilerOption {
 	}
 }
 
+// workloadHealthCheck holds the health status of a workload on a specific node and any pods that need termination.
+type workloadHealthCheck struct {
+	status          workloadStatus
+	podsToTerminate []*corev1.Pod
+}
+
 // nodeReconciler reconciles Nodes to detect failures and update affected Workloads
 type nodeReconciler struct {
 	client   client.Client
@@ -123,33 +138,53 @@ func (r *nodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 	nodeExists := err == nil
 
-	affectedWorkloads, err := r.getWorkloadsOnNode(ctx, req.Name)
+	var readyCondition *corev1.NodeCondition
+	if nodeExists {
+		readyCondition = utiltas.GetNodeCondition(&node, corev1.NodeReady)
+	}
+
+	var timerExpired bool
+	if readyCondition != nil && readyCondition.Status != corev1.ConditionTrue {
+		timeSinceNotReady := r.clock.Now().Sub(readyCondition.LastTransitionTime.Time)
+		remainingTime := NodeFailureDelay - timeSinceNotReady
+		timerExpired = remainingTime <= 0
+		if !timerExpired && !features.Enabled(features.TASReplaceNodeOnPodTermination) {
+			return ctrl.Result{RequeueAfter: remainingTime}, nil
+		}
+	}
+
+	nodeSelectorPodsByWorkload, err := r.listPodsAssignedByNodeSelector(ctx, req.Name)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	affectedWorkloads, err := r.getWorkloadsOnNode(ctx, req.Name, nodeSelectorPodsByWorkload)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
 	if !nodeExists {
 		log.V(3).Info("Node not found. Marking as failed immediately")
-		return ctrl.Result{}, r.handleUnhealthyNode(ctx, req.Name, affectedWorkloads)
+		_, err := r.handleUnhealthyNode(ctx, req.Name, affectedWorkloads)
+		return ctrl.Result{}, err
 	}
 
-	readyCondition := utiltas.GetNodeCondition(&node, corev1.NodeReady)
 	if readyCondition == nil {
 		log.V(3).Info("NodeReady condition is missing. Marking as failed immediately")
-		return ctrl.Result{}, r.handleUnhealthyNode(ctx, req.Name, affectedWorkloads)
+		_, err := r.handleUnhealthyNode(ctx, req.Name, affectedWorkloads)
+		return ctrl.Result{}, err
 	}
 
-	isReady := readyCondition.Status == corev1.ConditionTrue
-	if isReady || features.Enabled(features.TASReplaceNodeOnPodTermination) {
-		return r.reconcileWorkloadsOnNode(ctx, req.Name, &node, affectedWorkloads)
+	if timerExpired {
+		log.V(3).Info("Node is not ready and NodeFailureDelay timer expired, marking as failed")
+		evictedWorkloads, err := r.handleUnhealthyNode(ctx, req.Name, affectedWorkloads)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		// Only reconcile workloads that were not evicted.
+		affectedWorkloads = affectedWorkloads.Difference(evictedWorkloads)
 	}
 
-	timeSinceNotReady := r.clock.Now().Sub(readyCondition.LastTransitionTime.Time)
-	if NodeFailureDelay > timeSinceNotReady {
-		return ctrl.Result{RequeueAfter: NodeFailureDelay - timeSinceNotReady}, nil
-	}
-	log.V(3).Info("Node is not ready and NodeFailureDelay timer expired, marking as failed")
-	return ctrl.Result{}, r.handleUnhealthyNode(ctx, req.Name, affectedWorkloads)
+	return r.reconcileWorkloadsOnNode(ctx, req.Name, &node, affectedWorkloads, nodeSelectorPodsByWorkload)
 }
 
 var _ reconcile.Reconciler = (*nodeReconciler)(nil)
@@ -192,6 +227,7 @@ func (r *nodeReconciler) Delete(e event.TypedDeleteEvent[*corev1.Node]) bool {
 
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=pods/status,verbs=patch
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads,verbs=get;list;watch;patch
 
 func newNodeReconciler(
@@ -221,6 +257,7 @@ func (r *nodeReconciler) notifyWatchers(oldNode, newNode *corev1.Node) {
 }
 
 func (r *nodeReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.Configuration) (string, error) {
+	podHandler := &nodeFailurePodHandler{client: r.client}
 	return TASNodeController, builder.ControllerManagedBy(mgr).
 		Named("tas_node_controller").
 		WatchesRawSource(source.TypedKind(
@@ -229,6 +266,7 @@ func (r *nodeReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.Configur
 			&handler.TypedEnqueueRequestForObject[*corev1.Node]{},
 			r,
 		)).
+		Watches(&corev1.Pod{}, podHandler).
 		WithOptions(controller.Options{
 			NeedLeaderElection:      ptr.To(false),
 			MaxConcurrentReconciles: mgr.GetControllerOptions().GroupKindConcurrency[corev1.SchemeGroupVersion.WithKind("Node").GroupKind().String()],
@@ -236,90 +274,115 @@ func (r *nodeReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.Configur
 		Complete(core.WithLeadingManager(mgr, r, &corev1.Node{}, cfg))
 }
 
+// / listPodsAssignedByNodeSelector returns a map of pods that are assigned to this node via nodeSelector, grouped by workload.
+func (r *nodeReconciler) listPodsAssignedByNodeSelector(ctx context.Context, nodeName string) (map[types.NamespacedName][]*corev1.Pod, error) {
+	var podList corev1.PodList
+	if err := r.client.List(ctx, &podList, client.MatchingFields{indexer.PodNodeSelectorHostnameKey: nodeName}); err != nil {
+		return nil, fmt.Errorf("failed to list pods for node selector %s: %w", nodeName, err)
+	}
+
+	return groupPodsByWorkload(podList.Items), nil
+}
+
+func groupPodsByWorkload(pods []corev1.Pod) map[types.NamespacedName][]*corev1.Pod {
+	result := make(map[types.NamespacedName][]*corev1.Pod)
+	for i := range pods {
+		pod := &pods[i]
+		if wlName, found := pod.Annotations[kueue.WorkloadAnnotation]; found {
+			key := types.NamespacedName{Name: wlName, Namespace: pod.Namespace}
+			result[key] = append(result[key], pod)
+		}
+	}
+	return result
+}
+
 // getWorkloadsOnNode gets all workloads that have the given node assigned in TAS topology assignment
-func (r *nodeReconciler) getWorkloadsOnNode(ctx context.Context, nodeName string) (sets.Set[types.NamespacedName], error) {
+// or have "late" pods assigned to this node via nodeSelector.
+func (r *nodeReconciler) getWorkloadsOnNode(ctx context.Context, nodeName string, nodeSelectorPodsByWorkload map[types.NamespacedName][]*corev1.Pod) (sets.Set[types.NamespacedName], error) {
 	var allWorkloads kueue.WorkloadList
 	if err := r.client.List(ctx, &allWorkloads); err != nil {
 		return nil, fmt.Errorf("failed to list workloads: %w", err)
 	}
 	tasWorkloadsOnNode := sets.New[types.NamespacedName]()
-	for _, wl := range allWorkloads.Items {
-		if hasTASAssignmentOnNode(&wl, nodeName) {
-			tasWorkloadsOnNode.Insert(types.NamespacedName{Name: wl.Name, Namespace: wl.Namespace})
+	for i := range allWorkloads.Items {
+		wl := &allWorkloads.Items[i]
+		if workload.IsFinished(wl) || workload.IsEvicted(wl) {
+			continue
+		}
+		wlKey := types.NamespacedName{Name: wl.Name, Namespace: wl.Namespace}
+		if utiltas.HasTASAssignmentOnNode(wl.Status.Admission.PodSetAssignments, nodeName) {
+			tasWorkloadsOnNode.Insert(wlKey)
+			continue
+		}
+
+		// Also find workloads from any pods that are assigned to this node by TopologyAssignment
+		// but not yet bound. These might be stale "late" pods for a workload that has already
+		// been reassigned to another node.
+		if len(nodeSelectorPodsByWorkload[wlKey]) > 0 {
+			tasWorkloadsOnNode.Insert(wlKey)
 		}
 	}
+
 	return tasWorkloadsOnNode, nil
 }
 
-func hasTASAssignmentOnNode(wl *kueue.Workload, nodeName string) bool {
-	if !workload.IsAdmittedByTAS(wl) {
-		return false
-	}
-	for _, podSetAssignment := range wl.Status.Admission.PodSetAssignments {
-		topologyAssignment := podSetAssignment.TopologyAssignment
-		if topologyAssignment == nil {
-			continue
-		}
-		if !utiltas.IsLowestLevelHostname(topologyAssignment.Levels) {
-			continue
-		}
-		for value := range utiltas.LowestLevelValues(topologyAssignment) {
-			if value == nodeName {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func (r *nodeReconciler) getWorkloadStatus(ctx context.Context, nodeName string, node *corev1.Node, wlKey types.NamespacedName, wl *kueue.Workload) (workloadStatus, error) {
+func (r *nodeReconciler) getWorkloadStatus(ctx context.Context, nodeName string, node *corev1.Node, wlKey types.NamespacedName, wl *kueue.Workload, nodeSelectorAssignedPods []*corev1.Pod) (workloadHealthCheck, error) {
 	if err := r.client.Get(ctx, wlKey, wl); err != nil {
 		if apierrors.IsNotFound(err) {
-			return workloadHealthy, nil
+			return workloadHealthCheck{status: workloadHealthy}, nil
 		}
-		return workloadHealthy, err
+		return workloadHealthCheck{status: workloadHealthUnknown}, err
 	}
 
-	shouldWait := false
 	ready := utiltas.IsNodeStatusConditionTrue(node.Status.Conditions, corev1.NodeReady)
+	hasTASAssignment := utiltas.HasTASAssignmentOnNode(wl.Status.Admission.PodSetAssignments, nodeName)
 
-	if ready && features.Enabled(features.TASReplaceNodeOnNodeTaints) {
-		// Ready node, check for taints
+	switch {
+	case !hasTASAssignment:
+		// If a pod arrives late (via nodeSelector) and its node is no longer part
+		// of the topology assignment, we must always check pods
+		// to catch and fail the stray pod.
+		return r.checkPodsOnNode(ctx, nodeName, wl, false, hasTASAssignment, nodeSelectorAssignedPods)
+	case !ready:
+		if !features.Enabled(features.TASReplaceNodeOnPodTermination) {
+			return workloadHealthCheck{status: workloadUnhealthy}, nil
+		}
+		return r.checkPodsOnNode(ctx, nodeName, wl, false, hasTASAssignment, nodeSelectorAssignedPods)
+	case !features.Enabled(features.TASReplaceNodeOnNodeTaints):
+		return workloadHealthCheck{status: workloadHealthy}, nil
+	default:
 		untolerated, temporarilyTolerated := classifyNoExecuteTaints(ctx, node.Spec.Taints, workload.PodSetsOnNode(wl, nodeName))
-		switch {
-		case len(untolerated) > 0:
+
+		if len(untolerated) > 0 {
 			if !features.Enabled(features.TASReplaceNodeOnPodTermination) {
-				return workloadUnhealthy, nil
+				return workloadHealthCheck{status: workloadUnhealthy}, nil
 			}
-			shouldWait = true
-		case len(temporarilyTolerated) > 0:
-			shouldWait = true
-		default:
-			return workloadHealthy, nil
+			return r.checkPodsOnNode(ctx, nodeName, wl, true, hasTASAssignment, nodeSelectorAssignedPods)
 		}
-	} else if !ready && features.Enabled(features.TASReplaceNodeOnPodTermination) {
-		// NotReady node
-		shouldWait = true
+		if len(temporarilyTolerated) > 0 {
+			return r.checkPodsOnNode(ctx, nodeName, wl, false, hasTASAssignment, nodeSelectorAssignedPods)
+		}
+		return workloadHealthCheck{status: workloadHealthy}, nil
+	}
+}
+
+func (r *nodeReconciler) checkPodsOnNode(ctx context.Context, nodeName string, wl *kueue.Workload, hasUntoleratedTaints bool, hasTASAssignment bool, nodeSelectorAssignedPods []*corev1.Pod) (workloadHealthCheck, error) {
+	podsToTerminate, hasProgressingPods, err := r.getPodsToTerminate(ctx, wl, nodeName, nodeSelectorAssignedPods)
+	if err != nil {
+		return workloadHealthCheck{status: workloadHealthUnknown}, fmt.Errorf("failed to get pods to terminate for node %s: %w", nodeName, err)
 	}
 
-	if shouldWait {
-		var podsForWl corev1.PodList
-		if err := r.client.List(ctx, &podsForWl, client.InNamespace(wlKey.Namespace), client.MatchingFields{indexer.WorkloadNameKey: wlKey.Name}); err != nil {
-			return workloadHealthy, fmt.Errorf("failed to list pods for workload %s: %w", wlKey, err)
-		}
-		allPodsTerminated := true
-		for _, pod := range podsForWl.Items {
-			if pod.Spec.NodeName == nodeName && pod.DeletionTimestamp.IsZero() && !utilpod.IsTerminated(&pod) {
-				allPodsTerminated = false
-				break
-			}
-		}
-		if allPodsTerminated {
-			return workloadUnhealthy, nil
-		}
-		return workloadTemporarilyHealthy, nil
+	if !hasTASAssignment {
+		// This node is not part of the workload's topology assignment. If pods are assigned
+		// here (e.g., late pods with old node selectors), they are stray and must be terminated.
+		return workloadHealthCheck{status: workloadHealthy, podsToTerminate: podsToTerminate}, nil
 	}
-	return workloadHealthy, nil
+
+	if hasProgressingPods && (!hasUntoleratedTaints || features.Enabled(features.TASReplaceNodeOnPodTermination)) {
+		return workloadHealthCheck{status: workloadHealthy, podsToTerminate: podsToTerminate}, nil
+	}
+
+	return workloadHealthCheck{status: workloadUnhealthy, podsToTerminate: podsToTerminate}, nil
 }
 
 // evictWorkloadIfNeeded idempotently evicts the workload when the node has failed.
@@ -343,9 +406,12 @@ func (r *nodeReconciler) evictWorkloadIfNeeded(ctx context.Context, wl *kueue.Wo
 
 // handleUnhealthyNode finds workloads with pods on the specified node
 // and patches their status to indicate the node is to replace.
-func (r *nodeReconciler) handleUnhealthyNode(ctx context.Context, nodeName string, affectedWorkloads sets.Set[types.NamespacedName]) error {
+// It also terminates any late pods assigned to the node via nodeSelector.
+// It returns a set of workloads that were evicted during this process.
+func (r *nodeReconciler) handleUnhealthyNode(ctx context.Context, nodeName string, affectedWorkloads sets.Set[types.NamespacedName]) (sets.Set[types.NamespacedName], error) {
 	log := ctrl.LoggerFrom(ctx)
 	var workloadProcessingErrors []error
+	evictedWorkloads := sets.New[types.NamespacedName]()
 	for wlKey := range affectedWorkloads {
 		wlLog := log.WithValues("workload", klog.KRef(wlKey.Namespace, wlKey.Name))
 		var wl kueue.Workload
@@ -364,51 +430,57 @@ func (r *nodeReconciler) handleUnhealthyNode(ctx context.Context, nodeName strin
 			workloadProcessingErrors = append(workloadProcessingErrors, err)
 			continue
 		}
-		if !evictedNow && !workload.IsEvicted(&wl) {
-			if err := r.addUnhealthyNode(ctx, &wl, nodeName); err != nil {
-				wlLog.Error(err, "Failed to add node to unhealthyNodes")
-				workloadProcessingErrors = append(workloadProcessingErrors, err)
-				continue
-			}
+		if evictedNow || workload.IsEvicted(&wl) {
+			evictedWorkloads.Insert(wlKey)
+			continue
+		}
+		if err := r.addUnhealthyNode(ctx, &wl, nodeName); err != nil {
+			wlLog.Error(err, "Failed to add node to unhealthyNodes")
+			workloadProcessingErrors = append(workloadProcessingErrors, err)
+			continue
 		}
 	}
 	if len(workloadProcessingErrors) > 0 {
-		return errors.Join(workloadProcessingErrors...)
+		return evictedWorkloads, errors.Join(workloadProcessingErrors...)
 	}
-	return nil
+	return evictedWorkloads, nil
 }
 
-func (r *nodeReconciler) reconcileWorkloadsOnNode(ctx context.Context, nodeName string, node *corev1.Node, allTASWorkloads sets.Set[types.NamespacedName]) (ctrl.Result, error) {
+func (r *nodeReconciler) reconcileWorkloadsOnNode(ctx context.Context, nodeName string, node *corev1.Node, allTASWorkloads sets.Set[types.NamespacedName], nodeSelectorPodsByWorkload map[types.NamespacedName][]*corev1.Pod) (ctrl.Result, error) {
 	if allTASWorkloads.Len() == 0 {
 		return ctrl.Result{}, nil
 	}
 
 	unhealthyWorkloads := sets.New[types.NamespacedName]()
 	notUnhealthyWorkloads := sets.New[types.NamespacedName]()
-	hasWaitingWorkloads := false
+	podsToTerminateMap := make(map[types.NamespacedName][]*corev1.Pod)
 
 	for wlKey := range allTASWorkloads {
 		var wl kueue.Workload
-		status, err := r.getWorkloadStatus(ctx, nodeName, node, wlKey, &wl)
+		result, err := r.getWorkloadStatus(ctx, nodeName, node, wlKey, &wl, nodeSelectorPodsByWorkload[wlKey])
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 
-		switch status {
+		if len(result.podsToTerminate) > 0 {
+			podsToTerminateMap[wlKey] = result.podsToTerminate
+		}
+
+		switch result.status {
 		case workloadUnhealthy:
 			unhealthyWorkloads.Insert(wlKey)
-		case workloadTemporarilyHealthy:
-			hasWaitingWorkloads = true
-			notUnhealthyWorkloads.Insert(wlKey)
 		case workloadHealthy:
 			notUnhealthyWorkloads.Insert(wlKey)
 		}
 	}
 
+	evictedWorkloads := sets.New[types.NamespacedName]()
 	if len(unhealthyWorkloads) > 0 {
-		if err := r.handleUnhealthyNode(ctx, nodeName, unhealthyWorkloads); err != nil {
+		evicted, err := r.handleUnhealthyNode(ctx, nodeName, unhealthyWorkloads)
+		if err != nil {
 			return ctrl.Result{}, err
 		}
+		evictedWorkloads = evicted
 	}
 
 	if len(notUnhealthyWorkloads) > 0 {
@@ -417,12 +489,40 @@ func (r *nodeReconciler) reconcileWorkloadsOnNode(ctx context.Context, nodeName 
 		}
 	}
 
-	result := ctrl.Result{}
-	if hasWaitingWorkloads {
-		result.RequeueAfter = podTerminationCheckPeriod
+	for wlKey, pods := range podsToTerminateMap {
+		if evictedWorkloads.Has(wlKey) {
+			continue
+		}
+		if err := r.markPodsFailed(ctx, pods); err != nil {
+			return ctrl.Result{}, fmt.Errorf("marking pods as failed: %w", err)
+		}
 	}
 
-	return result, nil
+	return ctrl.Result{}, nil
+}
+
+func (r *nodeReconciler) markPodsFailed(ctx context.Context, pods []*corev1.Pod) error {
+	for _, p := range pods {
+		err := utilclient.PatchStatus(ctx, r.client, p, func() (bool, error) {
+			p.Status.Phase = corev1.PodFailed
+			p.Status.Conditions = append(p.Status.Conditions, corev1.PodCondition{
+				Type:               podTerminatedByKueueConditionType,
+				Status:             corev1.ConditionTrue,
+				Reason:             podTerminatedByKueueConditionReason,
+				Message:            podTerminatedByKueueConditionMessage,
+				LastTransitionTime: metav1.NewTime(r.clock.Now()),
+			})
+			return true, nil
+		})
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return err
+			}
+		} else {
+			r.recorder.Eventf(p, corev1.EventTypeNormal, podTerminatedByKueueEventReason, podTerminatedByKueueConditionMessage)
+		}
+	}
+	return nil
 }
 
 // handleHealthyNode clears the unhealthyNodes field for each of the specified workloads.
@@ -482,7 +582,39 @@ func (r *nodeReconciler) addUnhealthyNode(ctx context.Context, wl *kueue.Workloa
 	return nil
 }
 
-func checkTaintTolerations(taint *corev1.Taint, podSets []kueue.PodSet) taintToleration {
+// getPodsToTerminate returns a list of pending pods that are assigned to the node by topology (but not yet scheduled),
+// and a boolean indicating if there is at least one pod to retain (e.g. any scheduled pod).
+func (r *nodeReconciler) getPodsToTerminate(ctx context.Context, wl *kueue.Workload, nodeName string, nodeSelectorAssignedPods []*corev1.Pod) ([]*corev1.Pod, bool, error) {
+	hasProgressingPods, err := r.hasProgressingPods(ctx, wl, nodeName)
+	if err != nil {
+		return nil, false, fmt.Errorf("list scheduled pods: %w", err)
+	}
+
+	var podsToTerminate []*corev1.Pod
+	for _, pod := range nodeSelectorAssignedPods {
+		if len(pod.Spec.NodeName) == 0 && pod.Status.Phase == corev1.PodPending && !utilpod.HasGate(pod, kueue.TopologySchedulingGate) {
+			podsToTerminate = append(podsToTerminate, pod)
+		}
+	}
+
+	return podsToTerminate, hasProgressingPods, nil
+}
+
+func (r *nodeReconciler) hasProgressingPods(ctx context.Context, wl *kueue.Workload, nodeName string) (bool, error) {
+	sliceName := workloadslicing.SliceName(wl)
+	pods, err := ListPodsForWorkloadSlice(ctx, r.client, wl.Namespace, sliceName, client.MatchingFields{
+		indexer.PodNodeNameKey: nodeName,
+	})
+	if err != nil {
+		return false, err
+	}
+	hasProgressingPods := slices.ContainsFunc(pods, func(pod *corev1.Pod) bool {
+		return pod.DeletionTimestamp.IsZero() && !utilpod.IsTerminated(pod)
+	})
+	return hasProgressingPods, nil
+}
+
+func checkTaintTolerations(logger logr.Logger, taint *corev1.Taint, podSets []kueue.PodSet) taintToleration {
 	isUntolerated := true
 	isPermanentlyTolerated := true
 
@@ -521,7 +653,7 @@ func classifyNoExecuteTaints(ctx context.Context, taints []corev1.Taint, podSets
 			continue
 		}
 
-		switch checkTaintTolerations(&taint, podSets) {
+		switch checkTaintTolerations(logger, &taint, podSets) {
 		case untoleratedTaint:
 			untolerated = append(untolerated, taint)
 		case toleratedTemporarily:
@@ -534,4 +666,52 @@ func classifyNoExecuteTaints(ctx context.Context, taints []corev1.Taint, podSets
 		logger.V(3).Info("Classified NoExecute taints", "untolerated", untolerated, "temporarilyTolerated", temporarilyTolerated)
 	}
 	return untolerated, temporarilyTolerated
+}
+
+var _ handler.EventHandler = (*nodeFailurePodHandler)(nil)
+
+type nodeFailurePodHandler struct {
+	client client.Client
+}
+
+func (h *nodeFailurePodHandler) Create(_ context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	h.queueReconcileForPod(e.Object, q)
+}
+
+func (h *nodeFailurePodHandler) Update(_ context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	h.queueReconcileForPod(e.ObjectNew, q)
+}
+
+func (h *nodeFailurePodHandler) Delete(_ context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	h.queueReconcileForPod(e.Object, q)
+}
+
+func (h *nodeFailurePodHandler) Generic(_ context.Context, _ event.GenericEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *nodeFailurePodHandler) queueReconcileForPod(object client.Object, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	pod, isPod := object.(*corev1.Pod)
+	if !isPod || !utiltas.IsTAS(pod) {
+		return
+	}
+
+	// queue for potential stuck pending pods
+	if len(pod.Spec.NodeName) == 0 && pod.Spec.NodeSelector != nil && len(pod.Spec.NodeSelector[corev1.LabelHostname]) > 0 {
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name: pod.Spec.NodeSelector[corev1.LabelHostname],
+			},
+		}
+		q.AddAfter(req, reconcileBatchPeriod)
+	}
+
+	// queue pods that are failed or being deleted
+	if len(pod.Spec.NodeName) > 0 && (!pod.DeletionTimestamp.IsZero() || utilpod.IsTerminated(pod)) {
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name: pod.Spec.NodeName,
+			},
+		}
+		q.AddAfter(req, reconcileBatchPeriod)
+	}
 }

--- a/pkg/controller/tas/node_controller_test.go
+++ b/pkg/controller/tas/node_controller_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	coreindexer "sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	"sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -42,6 +43,7 @@ import (
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
 func TestNodeFailureReconciler(t *testing.T) {
@@ -91,13 +93,44 @@ func TestNodeFailureReconciler(t *testing.T) {
 		Admitted(true).
 		Obj()
 
+	workloadWithTwoExpectedPods := utiltestingapi.MakeWorkload(wlName, nsName).
+		Finalizers(kueue.ResourceInUseFinalizerName).
+		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
+		ReserveQuotaAt(
+			utiltestingapi.MakeAdmission("cq").
+				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
+					TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+						Domains(utiltestingapi.MakeTopologyDomainAssignment([]string{nodeName}, 2).Obj()).
+						Obj()).
+					Obj()).
+				Obj(), testStartTime,
+		).
+		AdmittedAt(true, testStartTime).
+		Obj()
+
 	now := metav1.NewTime(fakeClock.Now())
 	earlierTime := metav1.NewTime(now.Add(-NodeFailureDelay))
 
 	basePod := testingpod.MakePod("test-pod", nsName).
 		Annotation(kueue.WorkloadAnnotation, wlName).
-		Label(kueue.TASLabel, "true").
+		Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
+		StatusPhase(corev1.PodRunning).
 		NodeName(nodeName).
+		Obj()
+
+	pendingPodWithSelector := testingpod.MakePod("pending-pod-selector", nsName).
+		Annotation(kueue.WorkloadAnnotation, wlName).
+		Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
+		NodeSelector(corev1.LabelHostname, nodeName).
+		StatusPhase(corev1.PodPending).
+		Obj()
+
+	gatedPod := testingpod.MakePod("gated-pod", nsName).
+		Annotation(kueue.WorkloadAnnotation, wlName).
+		Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
+		TopologySchedulingGate().
+		StatusPhase(corev1.PodPending).
 		Obj()
 
 	terminatingPod := basePod.DeepCopy()
@@ -232,9 +265,36 @@ func TestNodeFailureReconciler(t *testing.T) {
 				basePod.DeepCopy(),
 			},
 			reconcileRequests: []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
-			wantRequeue:       1 * time.Second,
 		},
-
+		"Node NotReady, 2 succeeded pods, 1 running pod -> waits": {
+			initObjs: []client.Object{
+				baseNode.Clone().StatusConditions(corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionFalse,
+					LastTransitionTime: now}).Obj(),
+				workloadWithTwoExpectedPods.DeepCopy(),
+				testingpod.MakePod("succeeded-pod-1", nsName).Annotation(kueue.WorkloadAnnotation, wlName).NodeName(nodeName).StatusPhase(corev1.PodSucceeded).Obj(),
+				testingpod.MakePod("succeeded-pod-2", nsName).Annotation(kueue.WorkloadAnnotation, wlName).NodeName(nodeName).StatusPhase(corev1.PodSucceeded).Obj(),
+				testingpod.MakePod("running-pod-2", nsName).Annotation(kueue.WorkloadAnnotation, wlName).NodeName(nodeName).StatusPhase(corev1.PodRunning).Obj(),
+			},
+			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
+			wantUnhealthyNodes: nil,
+		},
+		"Node NotReady, 2 succeeded pods, 1 pending pod, 1 failed pod -> waits": {
+			initObjs: []client.Object{
+				baseNode.Clone().StatusConditions(corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionFalse,
+					LastTransitionTime: now}).Obj(),
+				workloadWithTwoExpectedPods.DeepCopy(),
+				testingpod.MakePod("succeeded-pod-1", nsName).Annotation(kueue.WorkloadAnnotation, wlName).NodeName(nodeName).StatusPhase(corev1.PodSucceeded).Obj(),
+				testingpod.MakePod("succeeded-pod-2", nsName).Annotation(kueue.WorkloadAnnotation, wlName).NodeName(nodeName).StatusPhase(corev1.PodSucceeded).Obj(),
+				testingpod.MakePod("pending-pod-2", nsName).Annotation(kueue.WorkloadAnnotation, wlName).NodeName(nodeName).StatusPhase(corev1.PodPending).Obj(),
+				testingpod.MakePod("failed-pod-2", nsName).Annotation(kueue.WorkloadAnnotation, wlName).NodeName(nodeName).StatusPhase(corev1.PodFailed).Obj(),
+			},
+			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
+			wantUnhealthyNodes: nil,
+		},
 		"Node Deleted - marked as unavailable": {
 			initObjs: []client.Object{
 				baseWorkload.DeepCopy(),
@@ -321,7 +381,6 @@ func TestNodeFailureReconciler(t *testing.T) {
 			},
 			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
 			wantUnhealthyNodes: nil,
-			wantRequeue:        1 * time.Second,
 			featureGates:       map[featuregate.Feature]bool{features.TASReplaceNodeOnNodeTaints: true},
 		},
 		"Node has NoExecute taint with TolerationSeconds, pod terminating -> Unhealthy": {
@@ -372,7 +431,6 @@ func TestNodeFailureReconciler(t *testing.T) {
 			},
 			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
 			wantUnhealthyNodes: nil,
-			wantRequeue:        1 * time.Second,
 			featureGates: map[featuregate.Feature]bool{
 				features.TASReplaceNodeOnNodeTaints:     true,
 				features.TASReplaceNodeOnPodTermination: true,
@@ -395,7 +453,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 				features.TASReplaceNodeOnPodTermination: true,
 			},
 		},
-		"Node has untolerated NoExecute taint, ReplaceNodeOnPodTermination on, no pods -> Unhealthy": {
+		"Node has untolerated NoExecute taint, ReplaceNodeOnPodTermination on, no pods -> Unhealthy (immediate)": {
 			initObjs: []client.Object{
 				baseNode.Clone().StatusConditions(corev1.NodeCondition{
 					Type:               corev1.NodeReady,
@@ -462,7 +520,6 @@ func TestNodeFailureReconciler(t *testing.T) {
 			},
 			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
 			wantUnhealthyNodes: nil,
-			wantRequeue:        1 * time.Second,
 			featureGates: map[featuregate.Feature]bool{
 				features.TASReplaceNodeOnNodeTaints:     true,
 				features.TASReplaceNodeOnPodTermination: false,
@@ -507,7 +564,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 				features.TASReplaceNodeOnPodTermination: false,
 			},
 		},
-		"Node has NoExecute taint and pods missing -> Unhealthy": {
+		"Node has NoExecute taint and pods missing -> Unhealthy (immediate)": {
 			initObjs: []client.Object{
 				testingnode.MakeNode(nodeName).
 					Taints(corev1.Taint{
@@ -528,6 +585,92 @@ func TestNodeFailureReconciler(t *testing.T) {
 			featureGates: map[featuregate.Feature]bool{
 				features.TASReplaceNodeOnNodeTaints: true,
 			},
+		},
+		"Node NotReady, pod pending (assigned via nodeSelector) -> Unhealthy": {
+			initObjs: []client.Object{
+				baseNode.Clone().StatusConditions(corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionFalse,
+					LastTransitionTime: now}).Obj(),
+				baseWorkload.DeepCopy(),
+				pendingPodWithSelector,
+			},
+			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
+			wantUnhealthyNodes: []kueue.UnhealthyNode{{Name: nodeName}},
+		},
+		"Node NotReady, pod pending (gated by TopologySchedulingGate) -> Unhealthy (immediate)": {
+			initObjs: []client.Object{
+				baseNode.Clone().StatusConditions(corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionFalse,
+					LastTransitionTime: now}).Obj(),
+				baseWorkload.DeepCopy(),
+				gatedPod,
+			},
+			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
+			wantUnhealthyNodes: []kueue.UnhealthyNode{{Name: nodeName}},
+		},
+		"Node has untolerated NoExecute taint, pod pending (assigned via nodeSelector) -> Unhealthy": {
+			initObjs: []client.Object{
+				baseNode.Clone().StatusConditions(corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: now}).
+					Taints(corev1.Taint{Key: "foo", Effect: corev1.TaintEffectNoExecute}).Obj(),
+				baseWorkload.DeepCopy(),
+				pendingPodWithSelector,
+			},
+			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
+			wantUnhealthyNodes: []kueue.UnhealthyNode{{Name: nodeName}},
+			featureGates: map[featuregate.Feature]bool{
+				features.TASReplaceNodeOnNodeTaints: true,
+			},
+		},
+		"Node has untolerated NoExecute taint, pod pending (gated by TopologySchedulingGate) -> Unhealthy (immediate)": {
+			initObjs: []client.Object{
+				baseNode.Clone().StatusConditions(corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: now}).
+					Taints(corev1.Taint{Key: "foo", Effect: corev1.TaintEffectNoExecute}).Obj(),
+				baseWorkload.DeepCopy(),
+				gatedPod,
+			},
+			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
+			wantUnhealthyNodes: []kueue.UnhealthyNode{{Name: nodeName}},
+			featureGates: map[featuregate.Feature]bool{
+				features.TASReplaceNodeOnNodeTaints: true,
+			},
+		},
+		"Node NotReady, pod pending, no hostname topology level -> Healthy (ignore)": {
+			initObjs: []client.Object{
+				baseNode.Clone().StatusConditions(corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionFalse,
+					LastTransitionTime: now}).Obj(),
+				utiltestingapi.MakeWorkload(wlName, nsName).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{"rack"}).
+									Domains(utiltestingapi.MakeTopologyDomainAssignment([]string{"rack-1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(), testStartTime,
+					).
+					AdmittedAt(true, testStartTime).
+					Obj(),
+				testingpod.MakePod("pending-pod-rack", nsName).
+					Annotation(kueue.WorkloadAnnotation, wlName).
+					NodeSelector("rack", "rack-1").
+					StatusPhase(corev1.PodPending).
+					Obj(),
+			},
+			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
+			wantUnhealthyNodes: nil,
 		},
 	}
 	for name, tc := range tests {
@@ -576,6 +719,160 @@ func TestNodeFailureReconciler(t *testing.T) {
 			evictedCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadEvicted)
 			if diff := cmp.Diff(tc.wantEvictedCond, evictedCond, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")); diff != "" {
 				t.Errorf("Unexpected WorkloadEvicted condition (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetWorkloadStatus(t *testing.T) {
+	testStartTime := time.Now().Truncate(time.Second)
+	nodeName := "test-node-name"
+	nodeNameUnassigned := "test-node-unassigned"
+	wlName := "test-workload"
+	nsName := "default"
+	wlKey := types.NamespacedName{Name: wlName, Namespace: nsName}
+
+	baseWorkload := utiltestingapi.MakeWorkload(wlName, nsName).
+		Finalizers(kueue.ResourceInUseFinalizerName).
+		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
+		ReserveQuotaAt(
+			utiltestingapi.MakeAdmission("cq").
+				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
+					TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+						Domains(utiltestingapi.MakeTopologyDomainAssignment([]string{nodeName}, 1).Obj()).
+						Obj()).
+					Obj()).
+				Obj(), testStartTime,
+		).
+		AdmittedAt(true, testStartTime).
+		Obj()
+
+	baseNode := testingnode.MakeNode(nodeName).
+		StatusConditions(corev1.NodeCondition{
+			Type:               corev1.NodeReady,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: metav1.NewTime(testStartTime)}).
+		Obj()
+
+	unassignedNode := testingnode.MakeNode(nodeNameUnassigned).
+		StatusConditions(corev1.NodeCondition{
+			Type:               corev1.NodeReady,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: metav1.NewTime(testStartTime)}).
+		Obj()
+
+	basePod := testingpod.MakePod("test-pod", nsName).
+		Annotation(kueue.WorkloadAnnotation, wlName).
+		Annotation(kueue.PodSetPreferredTopologyAnnotation, "unconstrained").
+		NodeName(nodeName).
+		Obj()
+
+	strayPod := testingpod.MakePod("stray-pod", nsName).
+		Annotation(kueue.WorkloadAnnotation, wlName).
+		Annotation(kueue.PodSetPreferredTopologyAnnotation, "unconstrained").
+		NodeSelector(corev1.LabelHostname, nodeNameUnassigned).
+		StatusPhase(corev1.PodPending).
+		Obj()
+
+	tests := map[string]struct {
+		node         *corev1.Node
+		nodeName     string
+		initObjs     []client.Object
+		wantStatus   workloadStatus
+		wantDeleted  []string
+		featureGates map[featuregate.Feature]bool
+	}{
+		"Healthy pod on assigned node": {
+			node:       baseNode,
+			nodeName:   nodeName,
+			initObjs:   []client.Object{baseWorkload, basePod},
+			wantStatus: workloadHealthy,
+		},
+		"Workload not found returns workloadHealthy": {
+			node:       baseNode,
+			nodeName:   nodeName,
+			initObjs:   []client.Object{basePod}, // Only pod is created
+			wantStatus: workloadHealthy,
+		},
+		"Node Ready, TASReplaceNodeOnNodeTaints disabled -> Healthy": {
+			node:         baseNode,
+			nodeName:     nodeName,
+			initObjs:     []client.Object{baseWorkload, basePod},
+			wantStatus:   workloadHealthy,
+			featureGates: map[featuregate.Feature]bool{features.TASReplaceNodeOnNodeTaints: false},
+		},
+		"Node NotReady, ReplaceNodeOnPodTermination disabled -> Unhealthy immediately": {
+			node:         testingnode.MakeNode(nodeName).StatusConditions(corev1.NodeCondition{Type: corev1.NodeReady, Status: corev1.ConditionFalse, LastTransitionTime: metav1.NewTime(testStartTime)}).Obj(),
+			nodeName:     nodeName,
+			initObjs:     []client.Object{baseWorkload, basePod},
+			wantStatus:   workloadUnhealthy,
+			featureGates: map[featuregate.Feature]bool{features.TASReplaceNodeOnPodTermination: false},
+		},
+		"Node NotReady, ReplaceNodeOnPodTermination enabled -> Healthy (Waiting for pod termination)": {
+			node:     testingnode.MakeNode(nodeName).StatusConditions(corev1.NodeCondition{Type: corev1.NodeReady, Status: corev1.ConditionFalse, LastTransitionTime: metav1.NewTime(testStartTime)}).Obj(),
+			nodeName: nodeName,
+			initObjs: []client.Object{
+				baseWorkload.DeepCopy(),
+				testingpod.MakePod("valid-pod", nsName).
+					Annotation(kueue.WorkloadAnnotation, wlName).
+					NodeName(nodeName).
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+			wantStatus:   workloadHealthy,
+			featureGates: map[featuregate.Feature]bool{features.TASReplaceNodeOnPodTermination: true},
+		},
+		"Stray pending pod on unassigned node gets terminated (expectedOnNode == 0)": {
+			node:     unassignedNode,
+			nodeName: nodeNameUnassigned,
+			initObjs: []client.Object{
+				unassignedNode.DeepCopy(),
+				baseWorkload.DeepCopy(),
+				strayPod.DeepCopy(),
+			},
+			wantStatus:  workloadHealthy, // Node gets healthy status (doesn't trigger workload eviction)
+			wantDeleted: []string{"stray-pod"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			for fg, enable := range tc.featureGates {
+				features.SetFeatureGateDuringTest(t, fg, enable)
+			}
+			clientBuilder := utiltesting.NewClientBuilder().WithObjects(tc.initObjs...)
+			ctx, _ := utiltesting.ContextWithLog(t)
+			if err := indexer.SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder)); err != nil {
+				t.Fatalf("Failed to setup indexes: %v", err)
+			}
+			if err := utiltesting.AsIndexer(clientBuilder).IndexField(ctx, &corev1.Pod{}, coreindexer.WorkloadSliceNameKey, coreindexer.IndexPodWorkloadSliceName); err != nil {
+				t.Fatalf("Could not setup WorkloadSliceNameKey index: %v", err)
+			}
+			cl := clientBuilder.Build()
+
+			reconciler := newNodeReconciler(cl, &utiltesting.EventRecorder{}, nil)
+			wl := &kueue.Workload{}
+			_ = cl.Get(ctx, wlKey, wl)
+
+			sliceName := workloadslicing.SliceName(wl)
+			pods, err := ListPodsForWorkloadSlice(ctx, cl, wl.Namespace, sliceName, client.MatchingFields{indexer.PodNodeSelectorHostnameKey: tc.nodeName})
+			if err != nil {
+				t.Fatalf("Failed to list pods: %v", err)
+			}
+			health, err := reconciler.getWorkloadStatus(ctx, tc.nodeName, tc.node, wlKey, wl, pods)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if health.status != tc.wantStatus {
+				t.Errorf("Unexpected health status: %v", health.status)
+			}
+			var deletedNames []string
+			for _, p := range health.podsToTerminate {
+				deletedNames = append(deletedNames, p.Name)
+			}
+			if diff := cmp.Diff(tc.wantDeleted, deletedNames, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Unexpected pods to terminate (-want/+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/tas/pods.go
+++ b/pkg/controller/tas/pods.go
@@ -1,0 +1,45 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tas
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+)
+
+// ListPodsForWorkloadSlice lists pods belonging to a workload slice by querying
+// the WorkloadSliceNameKey index. Additional list options (e.g., label selectors)
+// can be passed for filtering. Returns pointers to avoid copying large Pod structs.
+func ListPodsForWorkloadSlice(ctx context.Context, c client.Client, namespace, workloadSliceName string, opts ...client.ListOption) ([]*corev1.Pod, error) {
+	var podList corev1.PodList
+	listOpts := append([]client.ListOption{
+		client.InNamespace(namespace),
+		client.MatchingFields{indexer.WorkloadSliceNameKey: workloadSliceName},
+	}, opts...)
+	if err := c.List(ctx, &podList, listOpts...); err != nil {
+		return nil, err
+	}
+	result := make([]*corev1.Pod, len(podList.Items))
+	for i := range podList.Items {
+		result[i] = &podList.Items[i]
+	}
+	return result, nil
+}

--- a/pkg/util/tas/tas_assignment.go
+++ b/pkg/util/tas/tas_assignment.go
@@ -255,3 +255,17 @@ func V1Beta2From(ta *TopologyAssignment) *kueue.TopologyAssignment {
 	}
 	return singleCompactSliceEncoding(ta)
 }
+
+func HasTASAssignmentOnNode(psa []kueue.PodSetAssignment, nodeName string) bool {
+	for _, psa := range psa {
+		if psa.TopologyAssignment == nil || !IsLowestLevelHostname(psa.TopologyAssignment.Levels) {
+			continue
+		}
+		for domain := range InternalSeqFrom(psa.TopologyAssignment) {
+			if len(domain.Values) > 0 && domain.Values[len(domain.Values)-1] == nodeName && domain.Count > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/util/tas/tas_assignment_test.go
+++ b/pkg/util/tas/tas_assignment_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -787,5 +788,191 @@ func TestLowestLevelValues_iteratorStops(t *testing.T) {
 		// Break the loop prematurely.
 		// If the iterator isn't smart enough to stop, this will panic.
 		break
+	}
+}
+
+func TestHasTASAssignmentOnNode(t *testing.T) {
+	testCases := []struct {
+		name     string
+		psa      []kueue.PodSetAssignment
+		nodeName string
+		want     bool
+	}{
+		{
+			name:     "empty assignments",
+			psa:      nil,
+			nodeName: "node1",
+			want:     false,
+		},
+		{
+			name: "no topology assignment",
+			psa: []kueue.PodSetAssignment{
+				{
+					Name: "ps1",
+				},
+			},
+			nodeName: "node1",
+			want:     false,
+		},
+		{
+			name: "topology level is not hostname",
+			psa: []kueue.PodSetAssignment{
+				{
+					Name: "ps1",
+					TopologyAssignment: &kueue.TopologyAssignment{
+						Levels: []string{"example.com/rack"},
+						Slices: []kueue.TopologyAssignmentSlice{
+							{
+								DomainCount: 1,
+								PodCounts: kueue.TopologyAssignmentSlicePodCounts{
+									Universal: ptr.To(int32(1)),
+								},
+								ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
+									{
+										Universal: ptr.To("rack1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			nodeName: "node1",
+			want:     false,
+		},
+		{
+			name: "pod on target node",
+			psa: []kueue.PodSetAssignment{
+				{
+					Name: "ps1",
+					TopologyAssignment: &kueue.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Slices: []kueue.TopologyAssignmentSlice{
+							{
+								DomainCount: 1,
+								PodCounts: kueue.TopologyAssignmentSlicePodCounts{
+									Universal: ptr.To(int32(1)),
+								},
+								ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
+									{
+										Universal: ptr.To("node1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			nodeName: "node1",
+			want:     true,
+		},
+		{
+			name: "pod on different node",
+			psa: []kueue.PodSetAssignment{
+				{
+					Name: "ps1",
+					TopologyAssignment: &kueue.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Slices: []kueue.TopologyAssignmentSlice{
+							{
+								DomainCount: 1,
+								PodCounts: kueue.TopologyAssignmentSlicePodCounts{
+									Universal: ptr.To(int32(1)),
+								},
+								ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
+									{
+										Universal: ptr.To("node2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			nodeName: "node1",
+			want:     false,
+		},
+		{
+			name: "multiple domains, target node present in one",
+			psa: []kueue.PodSetAssignment{
+				{
+					Name: "ps1",
+					TopologyAssignment: &kueue.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Slices: []kueue.TopologyAssignmentSlice{
+							{
+								DomainCount: 2,
+								PodCounts: kueue.TopologyAssignmentSlicePodCounts{
+									Individual: []int32{2, 3},
+								},
+								ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
+									{
+										Individual: &kueue.TopologyAssignmentSliceLevelIndividualValues{
+											Roots: []string{"node1", "node2"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			nodeName: "node1",
+			want:     true,
+		},
+		{
+			name: "multiple pod sets, target node present in multiple",
+			psa: []kueue.PodSetAssignment{
+				{
+					Name: "ps1",
+					TopologyAssignment: &kueue.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Slices: []kueue.TopologyAssignmentSlice{
+							{
+								DomainCount: 1,
+								PodCounts: kueue.TopologyAssignmentSlicePodCounts{
+									Universal: ptr.To(int32(1)),
+								},
+								ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
+									{
+										Universal: ptr.To("node1"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "ps2",
+					TopologyAssignment: &kueue.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Slices: []kueue.TopologyAssignmentSlice{
+							{
+								DomainCount: 1,
+								PodCounts: kueue.TopologyAssignmentSlicePodCounts{
+									Universal: ptr.To(int32(5)),
+								},
+								ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
+									{
+										Universal: ptr.To("node1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			nodeName: "node1",
+			want:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := HasTASAssignmentOnNode(tc.psa, tc.nodeName)
+			if got != tc.want {
+				t.Errorf("HasTASAssignmentOnNode() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -64,6 +64,11 @@ func MakeJob(name, ns string) *JobWrapper {
 }
 
 // Obj returns the inner Job.
+func (j *JobWrapper) SchedulingGate(name string) *JobWrapper {
+	j.Spec.Template.Spec.SchedulingGates = append(j.Spec.Template.Spec.SchedulingGates, corev1.PodSchedulingGate{Name: name})
+	return j
+}
+
 func (j *JobWrapper) Obj() *batchv1.Job {
 	return &j.Job
 }

--- a/test/e2e/tas/hotswap_test.go
+++ b/test/e2e/tas/hotswap_test.go
@@ -19,6 +19,7 @@ package tase2e
 import (
 	"context"
 	"fmt"
+	"os/exec"
 	"slices"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -26,7 +27,6 @@ import (
 	"github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -36,6 +36,7 @@ import (
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
+	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	"sigs.k8s.io/kueue/pkg/util/tas"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -91,6 +92,9 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 		ginkgo.AfterEach(func() {
 			if nodeToRestore != nil {
 				ginkgo.By(fmt.Sprintf("Restoring node %s", nodeToRestore.Name))
+				// Restart kubelet just in case it was stopped during the test
+				_ = exec.Command("docker", "exec", nodeToRestore.Name, "systemctl", "start", "kubelet").Run()
+
 				// We can't blindly create the node because it might still exist (if we just tainted it).
 				// We try to delete it first to ensure a clean slate for creation.
 				_ = k8sClient.Delete(ctx, &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeToRestore.Name}})
@@ -104,6 +108,13 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 					Type:   corev1.NodeReady,
 					Status: corev1.ConditionTrue,
 				})
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					var node corev1.Node
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: nodeToRestore.Name}, &node)).To(gomega.Succeed())
+					g.Expect(tas.IsNodeStatusConditionTrue(node.Status.Conditions, corev1.NodeReady)).To(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
 				waitForDummyWorkloadToRunOnNode(nodeToRestore, localQueue)
 				nodeToRestore = nil
 			}
@@ -301,33 +312,15 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 					Completions(int32(parallelism)).
 					Suspend(true).
 					PodLabel("job-name", jobName).
+					Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletionFailOnExit).
+					RequestAndLimit(corev1.ResourceCPU, "200m").
+					RequestAndLimit(extraResource, "1").
+					PodAnnotation(kueue.PodSetPreferredTopologyAnnotation, utiltesting.DefaultBlockTopologyLevel).
+					PodAnnotation(kueue.PodSetSliceRequiredTopologyAnnotation, utiltesting.DefaultRackTopologyLevel).
+					PodAnnotation(kueue.PodSetSliceSizeAnnotation, "2").
+					CompletionMode(batchv1.IndexedCompletion).
+					BackoffLimit(1).
 					Obj()
-
-				sampleJob.Spec.Template.Spec.Containers = []corev1.Container{
-					{
-						Name:  "c",
-						Image: util.GetAgnHostImage(),
-						Args:  util.BehaviorWaitForDeletionFailOnExit,
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("200m"),
-								extraResource:      resource.MustParse("1"),
-							},
-							Limits: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("200m"),
-								extraResource:      resource.MustParse("1"),
-							},
-						},
-					},
-				}
-
-				sampleJob.Spec.Template.Annotations = map[string]string{
-					kueue.PodSetPreferredTopologyAnnotation:     utiltesting.DefaultBlockTopologyLevel,
-					kueue.PodSetSliceRequiredTopologyAnnotation: utiltesting.DefaultRackTopologyLevel,
-					kueue.PodSetSliceSizeAnnotation:             "2",
-				}
-				sampleJob.Spec.CompletionMode = ptr.To(batchv1.IndexedCompletion)
-				sampleJob.Spec.BackoffLimit = ptr.To[int32](1)
 
 				util.MustCreate(ctx, k8sClient, sampleJob)
 
@@ -403,42 +396,22 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 					Completions(int32(parallelism)).
 					Suspend(true).
 					PodLabel("job-name", jobName).
-					Obj()
-
-				sampleJob.Spec.Template.Spec.Containers = []corev1.Container{
-					{
-						Name:  "c",
-						Image: util.GetAgnHostImage(),
-						Args:  util.BehaviorWaitForDeletionFailOnExit,
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("200m"),
-								extraResource:      resource.MustParse("1"),
-							},
-							Limits: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("200m"),
-								extraResource:      resource.MustParse("1"),
-							},
-						},
-					},
-				}
-				sampleJob.Spec.Template.Annotations = map[string]string{
-					kueue.PodSetPreferredTopologyAnnotation:     utiltesting.DefaultBlockTopologyLevel,
-					kueue.PodSetSliceRequiredTopologyAnnotation: utiltesting.DefaultBlockTopologyLevel,
-					kueue.PodSetSliceSizeAnnotation:             "3",
-				}
-				sampleJob.Spec.CompletionMode = ptr.To(batchv1.IndexedCompletion)
-				sampleJob.Spec.BackoffLimit = ptr.To[int32](1)
-
-				sampleJob.Spec.Template.Spec.Tolerations = []corev1.Toleration{
-					{
+					Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletionFailOnExit).
+					RequestAndLimit(corev1.ResourceCPU, "200m").
+					RequestAndLimit(extraResource, "1").
+					PodAnnotation(kueue.PodSetPreferredTopologyAnnotation, utiltesting.DefaultBlockTopologyLevel).
+					PodAnnotation(kueue.PodSetSliceRequiredTopologyAnnotation, utiltesting.DefaultBlockTopologyLevel).
+					PodAnnotation(kueue.PodSetSliceSizeAnnotation, "3").
+					CompletionMode(batchv1.IndexedCompletion).
+					BackoffLimit(1).
+					Toleration(corev1.Toleration{
 						Key:               "key1",
 						Operator:          corev1.TolerationOpEqual,
 						Value:             "value1",
 						Effect:            corev1.TaintEffectNoExecute,
 						TolerationSeconds: &tolerationSeconds,
-					},
-				}
+					}).
+					Obj()
 
 				util.MustCreate(ctx, k8sClient, sampleJob)
 
@@ -491,10 +464,153 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 						g.Expect(k8sClient.Update(ctx, node)).To(gomega.Succeed())
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
-				ginkgo.By("Check that the topology assignment is updated with the new node in the same block", func() {
+				ginkgo.By("Check that the topology assignment is updated after a node failure", func() {
 					expectedNodes := slices.DeleteFunc([]string{"kind-worker", "kind-worker2", "kind-worker3", "kind-worker4"}, func(n string) bool {
 						return n == node.Name
 					})
+					expectWorkloadTopologyAssignment(ctx, k8sClient, wlKey, numPods, expectedNodes)
+					expectPodsOnNodes(ctx, k8sClient, ns.Name, jobName, numPods, expectedNodes)
+				})
+			})
+
+			// In this test we use a job with SliceSize = 3 and SliceRequiredTopology = Block.
+			// Each pod requires 1 "extraResource" so the job will use three nodes from a Block.
+			// We simulate a node failure by making it NotReady while the pods are Pending (gated).
+			// The NodeFailureController should identify the pending pods assigned to the failed node and terminate them.
+			// The replacement mechanism should then find the available node in the same Block and replace the failed one.
+			// Note: This test verifies that NodeFailureController can act on pending pods that are assigned to the node (by the nodeSelector) but not scheduled yet.
+			ginkgo.It("Should replace a node when it becomes NotReady and pods are Pending", func() {
+				parallelism := 3
+				numPods := parallelism
+				jobName := "pending-notready-job"
+
+				// Use an artificial scheduling gate to keep pods pending
+				artificialGate := "kueue.x-k8s.io/dummy-gate"
+
+				sampleJob := testingjob.MakeJob(jobName, ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					Parallelism(int32(parallelism)).
+					Completions(int32(parallelism)).
+					Suspend(true).
+					PodLabel("job-name", jobName).
+					Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletionFailOnExit).
+					RequestAndLimit(corev1.ResourceCPU, "200m").
+					RequestAndLimit(extraResource, "1").
+					PodAnnotation(kueue.PodSetPreferredTopologyAnnotation, utiltesting.DefaultBlockTopologyLevel).
+					PodAnnotation(kueue.PodSetSliceRequiredTopologyAnnotation, utiltesting.DefaultBlockTopologyLevel).
+					PodAnnotation(kueue.PodSetSliceSizeAnnotation, "3").
+					CompletionMode(batchv1.IndexedCompletion).
+					BackoffLimit(1).
+					SchedulingGate(artificialGate).
+					Obj()
+
+				util.MustCreate(ctx, k8sClient, sampleJob)
+
+				ginkgo.By("Job is unsuspended", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sampleJob), sampleJob)).To(gomega.Succeed())
+						g.Expect(sampleJob.Spec.Suspend).Should(gomega.Equal(ptr.To(false)))
+					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				wlName := ""
+				var topologyAssignment *kueue.TopologyAssignment
+				ginkgo.By("Wait for topology assignment", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						wls := &kueue.WorkloadList{}
+						g.Expect(k8sClient.List(ctx, wls, client.InNamespace(ns.Name))).To(gomega.Succeed())
+						g.Expect(wls.Items).To(gomega.HaveLen(1))
+						g.Expect(wls.Items[0].Status.Admission).NotTo(gomega.BeNil())
+						g.Expect(wls.Items[0].Status.Admission.PodSetAssignments).To(gomega.HaveLen(1))
+						g.Expect(wls.Items[0].Status.Admission.PodSetAssignments[0].TopologyAssignment).NotTo(gomega.BeNil())
+						wlName = wls.Items[0].Name
+						topologyAssignment = wls.Items[0].Status.Admission.PodSetAssignments[0].TopologyAssignment
+					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				wlKey := client.ObjectKey{Name: wlName, Namespace: ns.Name}
+				initialNodes := slices.Collect(tas.LowestLevelValues(topologyAssignment))
+				ginkgo.By("Verify initial topology assignment of the workload", func() {
+					expectWorkloadTopologyAssignment(ctx, k8sClient, wlKey, numPods, initialNodes)
+				})
+
+				pods := &corev1.PodList{}
+				ginkgo.By("Wait for pods to be created and admitted (but still gated)", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name), client.MatchingLabels{
+							"job-name": jobName,
+						})).To(gomega.Succeed())
+						g.Expect(pods.Items).To(gomega.HaveLen(numPods))
+						for _, p := range pods.Items {
+							g.Expect(p.Spec.SchedulingGates).To(gomega.ContainElement(corev1.PodSchedulingGate{Name: artificialGate}))
+						}
+					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				node := &corev1.Node{}
+				nodeName := initialNodes[0]
+				ginkgo.By(fmt.Sprintf("Simulate failure of node %s", nodeName), func() {
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: nodeName}, node)).To(gomega.Succeed())
+					nodeToRestore = node.DeepCopy()
+
+					// Stop kubelet so it doesn't immediately overwrite the condition
+					err := exec.Command("docker", "exec", nodeName, "systemctl", "stop", "kubelet").Run()
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					util.SetNodeCondition(ctx, k8sClient, node, &corev1.NodeCondition{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionUnknown,
+					})
+				})
+
+				ginkgo.By("Removing the artificial scheduling gate from pods", func() {
+					for _, p := range pods.Items {
+						gomega.Eventually(func(g gomega.Gomega) {
+							updatedPod := &corev1.Pod{}
+							g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&p), updatedPod)).To(gomega.Succeed())
+							if utilpod.Ungate(updatedPod, artificialGate) {
+								g.Expect(k8sClient.Update(ctx, updatedPod)).To(gomega.Succeed())
+							}
+						}, util.Timeout, util.Interval).Should(gomega.Succeed())
+					}
+				})
+
+				var victimPodName string
+				ginkgo.By("Wait for the victim pod to be Failed", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						victimPod := findPod(ctx, k8sClient, g, ns.Name, jobName, "0", nodeName, false)
+						g.Expect(victimPod).NotTo(gomega.BeNil(), "Victim pod should still exist")
+						victimPodName = victimPod.Name
+					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+					util.ExpectPodTerminatedByKueueCondition(ctx, k8sClient, client.ObjectKey{Name: victimPodName, Namespace: ns.Name}, "UnschedulableOnAssignedNode")
+				})
+
+				var replacementPodName string
+				ginkgo.By("Wait for the replacement pod to be created", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						replacementPod := findPod(ctx, k8sClient, g, ns.Name, jobName, "0", nodeName, true)
+						g.Expect(replacementPod).NotTo(gomega.BeNil(), "Replacement pod should appear")
+						replacementPodName = replacementPod.Name
+					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Removing the artificial scheduling gate from the replacement pod", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						updatedPod := &corev1.Pod{}
+						g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: replacementPodName, Namespace: ns.Name}, updatedPod)).To(gomega.Succeed())
+						if utilpod.Ungate(updatedPod, artificialGate) {
+							g.Expect(k8sClient.Update(ctx, updatedPod)).To(gomega.Succeed())
+							g.Expect(utilpod.HasGate(updatedPod, artificialGate)).To(gomega.BeFalse(), "Still found artificial gate, retrying...")
+						}
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Check that the topology assignment is updated with the new node in the same block", func() {
+					expectedNodes := slices.DeleteFunc(slices.Clone(initialNodes), func(n string) bool {
+						return n == node.Name
+					})
+					expectedNodes = append(expectedNodes, "kind-worker4")
+					gomega.Expect(expectedNodes).To(gomega.HaveLen(3))
 					expectWorkloadTopologyAssignment(ctx, k8sClient, wlKey, numPods, expectedNodes)
 					expectPodsOnNodes(ctx, k8sClient, ns.Name, jobName, numPods, expectedNodes)
 				})
@@ -565,4 +681,25 @@ func expectPodsOnNodes(ctx context.Context, k8sClient client.Client, nsName stri
 		g.Expect(gotNodes).To(gomega.HaveLen(numPods))
 		g.Expect(gotNodes).To(gomega.ConsistOf(expectedNodes))
 	}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+}
+
+func findPod(ctx context.Context, k8sClient client.Client, g gomega.Gomega, nsName, jobName, index string, failedNodeName string, isReplacement bool) *corev1.Pod {
+	pods := &corev1.PodList{}
+	g.Expect(k8sClient.List(ctx, pods, client.InNamespace(nsName), client.MatchingLabels{
+		"job-name": jobName,
+	})).To(gomega.Succeed())
+
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		if p.Labels["batch.kubernetes.io/job-completion-index"] == index {
+			nodeName := p.Spec.NodeName
+			if nodeName == "" && p.Spec.NodeSelector != nil {
+				nodeName = p.Spec.NodeSelector[corev1.LabelHostname]
+			}
+			if (nodeName == failedNodeName) != isReplacement {
+				return p
+			}
+		}
+	}
+	return nil
 }

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -2575,6 +2575,7 @@ var _ = ginkgo.Describe("Pod controller with TASReplaceNodeOnPodTermination", gi
 					g.Expect(pod.Spec.NodeName).Should(gomega.Equal(nodeName))
 				}
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.SetPodsPhase(ctx, k8sClient, corev1.PodRunning, podgroup...)
 		})
 
 		ginkgo.By("making the node NotReady", func() {
@@ -2590,10 +2591,12 @@ var _ = ginkgo.Describe("Pod controller with TASReplaceNodeOnPodTermination", gi
 		ginkgo.By("terminating a pod", func() {
 			for _, p := range podgroup {
 				podKey := client.ObjectKeyFromObject(p)
-				podToTerminate := &corev1.Pod{}
-				gomega.Expect(k8sClient.Get(ctx, podKey, podToTerminate)).To(gomega.Succeed())
-				podToTerminate.Status.Phase = corev1.PodFailed
-				gomega.Expect(k8sClient.Status().Update(ctx, podToTerminate)).Should(gomega.Succeed())
+				gomega.Eventually(func(g gomega.Gomega) {
+					pod := &corev1.Pod{}
+					g.Expect(k8sClient.Get(ctx, podKey, pod)).To(gomega.Succeed())
+					pod.Status.Phase = corev1.PodFailed
+					g.Expect(k8sClient.Status().Update(ctx, pod)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			}
 		})
 

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -54,6 +54,43 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
+func createPodsForWorkload(wl *kueue.Workload, nsName string, withTopologyRequestAnnotation bool, running bool) {
+	gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+	ginkgo.By(fmt.Sprintf("creating pods (running=%v)", running), func() {
+		ta := utiltas.InternalFrom(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment)
+		idx := 0
+		for _, domain := range ta.Domains {
+			for range domain.Count {
+				podWrapper := testingpod.MakePod(fmt.Sprintf("%s-%d", wl.Name, idx), nsName).
+					Annotation(kueue.WorkloadAnnotation, wl.Name).
+					Annotation(kueue.WorkloadSliceNameAnnotation, wl.Name)
+				if withTopologyRequestAnnotation {
+					if wl.Spec.PodSets[0].TopologyRequest != nil && ptr.Deref(wl.Spec.PodSets[0].TopologyRequest.Unconstrained, false) {
+						podWrapper = podWrapper.Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true")
+					} else {
+						podWrapper = podWrapper.Annotation(kueue.PodSetRequiredTopologyAnnotation, utiltesting.DefaultBlockTopologyLevel)
+					}
+				}
+				if running {
+					podWrapper = podWrapper.NodeName(domain.Values[0])
+				} else {
+					// We use nodeSelector to "assign" the pod to the node by topology
+					// but leave it unscheduled (pending).
+					podWrapper = podWrapper.NodeSelector(corev1.LabelHostname, domain.Values[0])
+				}
+				pod := podWrapper.Obj()
+				util.MustCreate(ctx, k8sClient, pod)
+				phase := corev1.PodPending
+				if running {
+					phase = corev1.PodRunning
+				}
+				util.SetPodsPhase(ctx, k8sClient, phase, pod)
+				idx++
+			}
+		}
+	})
+}
+
 var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 	var (
 		ns *corev1.Namespace
@@ -2004,7 +2041,10 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				ginkgo.By("creating a pod for the workload assigned to nodeName", func() {
 					pod = testingpod.MakePod("pod1", ns.Name).
 						Annotation(kueue.WorkloadAnnotation, "wl1").
+						Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
 						NodeName(nodeName).
+						// envtest doesn't set deletion timestamp when there is no finalizer and we need it for node controller to be triggered
+						KueueFinalizer().
 						Obj()
 					util.MustCreate(ctx, k8sClient, pod)
 				})
@@ -2036,6 +2076,12 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), wl1)).To(gomega.Succeed())
 						g.Expect(wl1.Status.UnhealthyNodes).To(gomega.ContainElement(kueue.UnhealthyNode{Name: nodeName}))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("remove pod finalizer to allow cleanup", func() {
+					gomega.Expect(client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), pod))).Should(gomega.Succeed())
+					pod.Finalizers = nil
+					gomega.Expect(client.IgnoreNotFound(k8sClient.Update(ctx, pod))).Should(gomega.Succeed())
 				})
 			})
 			ginkgo.It("should selectively recover workload health based on tolerations of remaining taints", framework.SlowSpec, func() {
@@ -2195,6 +2241,95 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						g.Expect([]string{assignedNode1, assignedNode2}).NotTo(gomega.ContainElement(nodeName))
 						g.Expect(wl1.Status.UnhealthyNodes).NotTo(gomega.ContainElement(kueue.UnhealthyNode{Name: nodeName}))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+			})
+
+			ginkgo.It("should catch and terminate a late pod assigned to a replaced node", framework.SlowSpec, func() {
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.TASReplaceNodeOnNodeTaints, true)
+
+				var wl1 *kueue.Workload
+				nodeName := "x3"
+				taint := corev1.Taint{Key: "example.com/failure", Value: "true", Effect: corev1.TaintEffectNoExecute}
+
+				ginkgo.By("creating a workload", func() {
+					wl1 = utiltestingapi.MakeWorkload("wl1", ns.Name).
+						PodSets(*utiltestingapi.MakePodSet("worker", 2).
+							PreferredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+							Obj()).
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
+					util.MustCreate(ctx, k8sClient, wl1)
+				})
+
+				ginkgo.By("verify the workload is admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), wl1)).To(gomega.Succeed())
+					ta := utiltas.InternalFrom(wl1.Status.Admission.PodSetAssignments[0].TopologyAssignment)
+					gomega.Expect(ta.Domains).To(gomega.HaveLen(2))
+					nodeName = ta.Domains[0].Values[0]
+				})
+
+				// We must clear the NodeName to ensure the pods are treated as truly Pending (unscheduled)
+				// rather than running/scheduled pods in Pending phase.
+				createPodsForWorkload(wl1, ns.Name, false, false)
+
+				ginkgo.By("applying NoExecute taint to the first node", func() {
+					nodeToUpdate := &corev1.Node{}
+					gomega.Expect(k8sClient.Get(ctx, apitypes.NamespacedName{Name: nodeName}, nodeToUpdate)).Should(gomega.Succeed())
+					nodeToUpdate.Spec.Taints = append(nodeToUpdate.Spec.Taints, taint)
+					gomega.Expect(k8sClient.Update(ctx, nodeToUpdate)).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("verify that originally scheduled pods are automatically marked as Failed by Kueue", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						var pods corev1.PodList
+						g.Expect(k8sClient.List(ctx, &pods, client.InNamespace(ns.Name), client.MatchingLabels{kueue.WorkloadAnnotation: wl1.Name})).Should(gomega.Succeed())
+						for _, pod := range pods.Items {
+							g.Expect(pod.Status.Phase).To(gomega.Equal(corev1.PodFailed))
+							g.Expect(pod.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(corev1.PodCondition{
+								Type:   "TerminatedByKueue",
+								Status: corev1.ConditionTrue,
+							}, cmpopts.IgnoreFields(corev1.PodCondition{}, "LastTransitionTime", "Message", "LastProbeTime", "Reason"))))
+						}
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("verify that workload is rescheduled using a free node in the same block", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), wl1)).To(gomega.Succeed())
+						ta := utiltas.InternalFrom(wl1.Status.Admission.PodSetAssignments[0].TopologyAssignment)
+						g.Expect(ta.Domains).To(gomega.HaveLen(2))
+						assignedNode1 := ta.Domains[0].Values[0]
+						assignedNode2 := ta.Domains[1].Values[0]
+						g.Expect([]string{assignedNode1, assignedNode2}).NotTo(gomega.ContainElement(nodeName))
+						g.Expect(wl1.Status.UnhealthyNodes).NotTo(gomega.ContainElement(kueue.UnhealthyNode{Name: nodeName}))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				var latePod *corev1.Pod
+				ginkgo.By("simulating a late pod mapped to the old failed node by its nodeSelector", func() {
+					latePod = testingpod.MakePod(fmt.Sprintf("%s-late-arriving", wl1.Name), ns.Name).
+						Annotation(kueue.WorkloadAnnotation, wl1.Name).
+						Annotation(kueue.PodSetRequiredTopologyAnnotation, utiltesting.DefaultBlockTopologyLevel).
+						Annotation(kueue.WorkloadSliceNameAnnotation, wl1.Name).
+						NodeSelector(corev1.LabelHostname, nodeName).
+						Obj()
+					util.MustCreate(ctx, k8sClient, latePod)
+
+					// The controller only listens to Pending pods
+					latePod.Status.Phase = corev1.PodPending
+					gomega.Expect(k8sClient.Status().Update(ctx, latePod)).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("verify that the controller catches and fails the late pod", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						updatedPod := &corev1.Pod{}
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(latePod), updatedPod)).To(gomega.Succeed())
+						g.Expect(updatedPod.Status.Phase).To(gomega.Equal(corev1.PodFailed))
+						g.Expect(updatedPod.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(corev1.PodCondition{
+							Type:   "TerminatedByKueue",
+							Status: corev1.ConditionTrue,
+						}, cmpopts.IgnoreFields(corev1.PodCondition{}, "LastTransitionTime", "Message", "LastProbeTime", "Reason"))))
+					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 				})
 			})
 

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1067,6 +1067,27 @@ func BindPodWithNode(ctx context.Context, k8sClient client.Client, nodeName stri
 	}
 }
 
+func ExpectPodTerminatedByKueueCondition(ctx context.Context, k8sClient client.Client, podKey client.ObjectKey, reason string) {
+	ginkgo.GinkgoHelper()
+	gomega.Eventually(func(g gomega.Gomega) {
+		pod := &corev1.Pod{}
+		g.Expect(k8sClient.Get(ctx, podKey, pod)).To(gomega.Succeed())
+		g.Expect(pod.Status.Phase).To(gomega.Equal(corev1.PodFailed), "Pod should be Failed")
+
+		expectedCondition := corev1.PodCondition{
+			Type:   "TerminatedByKueue",
+			Status: corev1.ConditionTrue,
+		}
+		if reason != "" {
+			expectedCondition.Reason = reason
+		}
+
+		g.Expect(pod.Status.Conditions).To(gomega.ContainElement(
+			gomega.BeComparableTo(expectedCondition, cmpopts.IgnoreFields(corev1.PodCondition{}, "LastTransitionTime", "Message", "LastProbeTime")),
+		), "Pod should have TerminatedByKueue condition")
+	}, LongTimeout, Interval).Should(gomega.Succeed())
+}
+
 func ExpectPodUnsuspendedWithNodeSelectors(ctx context.Context, k8sClient client.Client, key types.NamespacedName, ns map[string]string) {
 	createdPod := &corev1.Pod{}
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {


### PR DESCRIPTION
Cherry pick of https://github.com/kubernetes-sigs/kueue/pull/9615 on release-0.15.

https://github.com/kubernetes-sigs/kueue/pull/9615: Fix stuck pods bug for node replacement

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug

```release-note
TAS: Fixed a bug where pods could become stuck in a `Pending` state during node replacement.
This may occur when a node gets tainted or `NotReady` after the topology assignment phase, but before
the pods are ungated.
```