### PR TITLE
Automated cherry pick of #9814: Temporarily restore the FlavorFungibilityImplicitPreferenceDefault feature gate to allow upgrades 

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -164,6 +164,15 @@ const (
 	ManagedJobsNamespaceSelectorAlwaysRespected featuregate.Feature = "ManagedJobsNamespaceSelectorAlwaysRespected"
 
 	// owner: @pajakd
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/582-preempt-based-on-flavor-order
+	//
+	// In flavor fungibility, infer the preference between borrowing and preemption
+	// from the legacy policies when .spec.flavorFungibility.preference is unset.
+	//
+	// Deprecated: planned to be removed in 0.18.
+	FlavorFungibilityImplicitPreferenceDefault featuregate.Feature = "FlavorFungibilityImplicitPreferenceDefault"
+
+	// owner: @pajakd
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-scheduling
 	//
 	// Use balanced placement algorithm in TAS. This feature gate is going to be replaced by an API
@@ -374,6 +383,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	ManagedJobsNamespaceSelectorAlwaysRespected: {
 		{Version: version.MustParse("0.13"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("0.15"), Default: true, PreRelease: featuregate.Beta},
+	},
+	FlavorFungibilityImplicitPreferenceDefault: {
+		{Version: version.MustParse("0.13"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.16"), Default: false, PreRelease: featuregate.Deprecated},
 	},
 	TASBalancedPlacement: {
 		{Version: version.MustParse("0.15"), Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -433,6 +433,10 @@ func isPreferred(a, b granularMode, fungibilityConfig kueue.FlavorFungibility) b
 		}
 	}
 
+	if features.Enabled(features.FlavorFungibilityImplicitPreferenceDefault) && fungibilityConfig.WhenCanBorrow == kueue.TryNextFlavor {
+		return preemptionOverBorrowing()
+	}
+
 	return borrowingOverPreemption()
 }
 

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -3892,6 +3892,7 @@ func TestIsPreferred(t *testing.T) {
 	}
 
 	cases := map[string]struct {
+		enableGate    bool
 		a             granularMode
 		b             granularMode
 		config        kueue.FlavorFungibility
@@ -3905,6 +3906,26 @@ func TestIsPreferred(t *testing.T) {
 				WhenCanPreempt: kueue.TryNextFlavor,
 			},
 			wantPreferred: true,
+		},
+		"legacy gate enabled infers preference from borrow policy": {
+			enableGate: true,
+			a:          granularMode{preemptionMode: preempt, borrowingLevel: 0},
+			b:          granularMode{preemptionMode: fit, borrowingLevel: 1},
+			config: kueue.FlavorFungibility{
+				WhenCanBorrow:  kueue.TryNextFlavor,
+				WhenCanPreempt: kueue.TryNextFlavor,
+			},
+			wantPreferred: true,
+		},
+		"legacy gate enabled keeps borrowing default when borrow policy does not try next": {
+			enableGate: true,
+			a:          granularMode{preemptionMode: preempt, borrowingLevel: 0},
+			b:          granularMode{preemptionMode: fit, borrowingLevel: 1},
+			config: kueue.FlavorFungibility{
+				WhenCanBorrow:  kueue.MayStopSearch,
+				WhenCanPreempt: kueue.TryNextFlavor,
+			},
+			wantPreferred: false,
 		},
 		"explicit BorrowingOverPreemption prioritises borrowing distance": {
 			a: granularMode{preemptionMode: preempt, borrowingLevel: 1},
@@ -3940,6 +3961,7 @@ func TestIsPreferred(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.FlavorFungibilityImplicitPreferenceDefault, tc.enableGate)
 			if got := isPreferred(tc.a, tc.b, tc.config); got != tc.wantPreferred {
 				t.Fatalf("isPreferred(%+v, %+v, %+v)=%t, want %t", tc.a, tc.b, tc.config, got, tc.wantPreferred)
 			}

--- a/site/data/featuregates/removed_feature_list.yaml
+++ b/site/data/featuregates/removed_feature_list.yaml
@@ -98,14 +98,14 @@
   stage: GA
   from: "0.14"
   to: "0.16"
-- feature: FlavorFungibilityImplicitPreferenceDefault
+- feature: TASProfileLeastFreeCapacity
   default: false
   stage: Alpha
-  from: "0.13"
-  to: "0.15"
-- feature: FlavorFungibilityImplicitPreferenceDefault
+  from: "0.10"
+  to: "0.10"
+- feature: TASProfileLeastFreeCapacity
   default: false
   stage: Deprecated
-  from: "0.15"
+  from: "0.11"
   to: "0.16"
 

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -47,6 +47,16 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.5"
+- name: FlavorFungibilityImplicitPreferenceDefault
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.13"
+  - default: false
+    lockToDefault: false
+    preRelease: Deprecated
+    version: "0.16"
 - name: HierarchicalCohorts
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -47,6 +47,16 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.5"
+- name: FlavorFungibilityImplicitPreferenceDefault
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.13"
+  - default: false
+    lockToDefault: false
+    preRelease: Deprecated
+    version: "0.16"
 - name: HierarchicalCohorts
   versionedSpecs:
   - default: true


### PR DESCRIPTION
Cherry pick of #9814 on release-0.16.

#9814: Temporarily restore the FlavorFungibilityImplicitPreferenceDefault feature gate to allow upgrades 

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
Restore the FlavorFungibilityImplicitPreferenceDefault feature gate.
```