### PR TITLE
WIP: Fix reporting of time to admit in perf-tests

### DIFF
--- a/test/performance/scheduler/runner/recorder/recorder.go
+++ b/test/performance/scheduler/runner/recorder/recorder.go
@@ -91,12 +91,15 @@ type WLEvent struct {
 	Admitted  bool
 	Evicted   bool
 	Finished  bool
+
+	WLCreationTime time.Time
 }
 
 type WLState struct {
 	ID int
 	types.NamespacedName
 	ClassName        string
+	CreationTime     time.Time
 	FirstEventTime   time.Time
 	TimeToAdmitMs    int64
 	TimeToFinishedMs int64
@@ -188,13 +191,14 @@ func (r *Recorder) recordWLEvent(ev *WLEvent) {
 			NamespacedName: ev.NamespacedName,
 			ClassName:      ev.ClassName,
 			FirstEventTime: ev.Time,
+			CreationTime:   ev.WLCreationTime,
 			LastEvent:      &WLEvent{},
 		}
 		r.Store.WL[ev.UID] = state
 	}
 
 	if ev.Admitted && !state.LastEvent.Admitted {
-		state.TimeToAdmitMs = ev.Time.Sub(state.FirstEventTime).Milliseconds()
+		state.TimeToAdmitMs = ev.Time.Sub(state.CreationTime).Milliseconds()
 	}
 
 	if ev.Evicted && !state.LastEvent.Evicted {
@@ -202,7 +206,7 @@ func (r *Recorder) recordWLEvent(ev *WLEvent) {
 	}
 
 	if ev.Finished && !state.LastEvent.Finished {
-		state.TimeToFinishedMs = ev.Time.Sub(state.FirstEventTime).Milliseconds()
+		state.TimeToFinishedMs = ev.Time.Sub(state.CreationTime).Milliseconds()
 	}
 
 	state.LastEvent = ev
@@ -460,6 +464,8 @@ func (r *Recorder) RecordWorkloadState(wl *kueue.Workload) {
 		Admitted:  workload.IsAdmitted(wl),
 		Evicted:   workload.IsEvicted(wl),
 		Finished:  workload.IsFinished(wl),
+
+		WLCreationTime: wl.CreationTimestamp.Time,
 	}
 	select {
 	case r.wlEvChan <- ev:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
To correctly calculate the time to admission from creation. 

Currently it does not work well, because the monitoring is started asynchronously. As a consequence we miss many creation events. 

Now, typically we record the first consideration of workload as Pending by scheduler as FirstEventTime, but this is unreliable, because
1. scheduler may schedule on the first pass 
2. After the change https://github.com/kubernetes-sigs/kueue/pull/9983 scheduler may skip annotating the workloads

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```