### PR TITLE
Introduce kueue_cohort_admitted_workloads_total metric.

### DIFF
--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -784,11 +784,44 @@ func (c *Cache) ClusterQueueAncestors(cqObj *kueue.ClusterQueue) ([]kueue.Cohort
 	c.RLock()
 	defer c.RUnlock()
 
-	if cqObj.Spec.CohortName == "" {
+	ancestors, err := c.ancestors(cqObj.Spec.CohortName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Exclude the root cohort
+	if len(ancestors) > 0 {
+		ancestors = ancestors[:len(ancestors)-1]
+	}
+
+	return ancestors, nil
+}
+
+// workloadAncestors retrieves all ancestor Cohorts for a given Workload.
+// The caller MUST hold either c.RLock() or c.Lock() before calling this function.
+// This function does not acquire any locks internally and assumes the cache is already locked.
+func (c *Cache) workloadAncestors(wl *kueue.Workload) ([]kueue.CohortReference, error) {
+	if wl == nil || wl.Status.Admission == nil {
 		return nil, nil
 	}
 
-	cohort := c.hm.Cohort(cqObj.Spec.CohortName)
+	cq := c.hm.ClusterQueue(wl.Status.Admission.ClusterQueue)
+	if cq == nil || !cq.HasParent() {
+		return nil, nil
+	}
+
+	return c.ancestors(cq.Parent().Name)
+}
+
+// ancestors retrieves all ancestor Cohorts for a given Cohort, starting with the Cohort itself and ending at the root.
+// The caller MUST hold either c.RLock() or c.Lock() before calling this function.
+// This function does not acquire any locks internally and assumes the cache is already locked.
+func (c *Cache) ancestors(cohortName kueue.CohortReference) ([]kueue.CohortReference, error) {
+	if cohortName == "" {
+		return nil, nil
+	}
+
+	cohort := c.hm.Cohort(cohortName)
 	if cohort == nil {
 		return nil, nil
 	}
@@ -802,7 +835,7 @@ func (c *Cache) ClusterQueueAncestors(cqObj *kueue.ClusterQueue) ([]kueue.Cohort
 		ancestors = append(ancestors, ancestor.Name)
 	}
 
-	return ancestors[:len(ancestors)-1], nil
+	return ancestors, nil
 }
 
 func getUsage(frq resources.FlavorResourceQuantities, cq *clusterQueue) []kueue.FlavorUsage {

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -3633,7 +3633,225 @@ func TestClusterQueueAncestors(t *testing.T) {
 			gotAncestors, gotErr := cache.ClusterQueueAncestors(tc.cq)
 
 			if diff := cmp.Diff(tc.wantAncestors, gotAncestors); diff != "" {
+				t.Fatalf("Unexpected ancestors (-want/+got)\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.EquateErrors()); diff != "" {
 				t.Fatalf("Unexpected error (-want/+got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestWorkloadAncestors(t *testing.T) {
+	testCases := map[string]struct {
+		cohorts       []*kueue.Cohort
+		cqs           []*kueue.ClusterQueue
+		wl            *kueue.Workload
+		wantAncestors []kueue.CohortReference
+		wantErr       error
+	}{
+		"workload is nil": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root").Obj(),
+			},
+			cqs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq").Cohort("root").Obj(),
+			},
+			wl:            nil,
+			wantAncestors: nil,
+			wantErr:       nil,
+		},
+		"not admitted workload": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root").Obj(),
+			},
+			cqs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq").Cohort("root").Obj(),
+			},
+			wl:            utiltestingapi.MakeWorkload("wl", metav1.NamespaceDefault).Obj(),
+			wantAncestors: nil,
+			wantErr:       nil,
+		},
+		"clusterqueue not found": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root").Obj(),
+			},
+			cqs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq").Cohort("root").Obj(),
+			},
+			wl: utiltestingapi.MakeWorkload("wl", metav1.NamespaceDefault).
+				Admission(utiltestingapi.MakeAdmission("invalid").Obj()).
+				Obj(),
+			wantAncestors: nil,
+			wantErr:       nil,
+		},
+		"clusterqueue doesn't have parent": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root").Obj(),
+			},
+			cqs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq").Obj(),
+			},
+			wl: utiltestingapi.MakeWorkload("wl", metav1.NamespaceDefault).
+				Admission(utiltestingapi.MakeAdmission("cq").Obj()).
+				Obj(),
+			wantAncestors: nil,
+			wantErr:       nil,
+		},
+		"one level": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root").Obj(),
+			},
+			cqs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq").Cohort("root").Obj(),
+			},
+			wl: utiltestingapi.MakeWorkload("wl", metav1.NamespaceDefault).
+				Admission(utiltestingapi.MakeAdmission("cq").Obj()).
+				Obj(),
+			wantAncestors: []kueue.CohortReference{"root"},
+			wantErr:       nil,
+		},
+		"two level": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root").Obj(),
+				utiltestingapi.MakeCohort("left").Parent("root").Obj(),
+				utiltestingapi.MakeCohort("right").Parent("root").Obj(),
+			},
+			cqs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq").Cohort("left").Obj(),
+			},
+			wl: utiltestingapi.MakeWorkload("wl", metav1.NamespaceDefault).
+				Admission(utiltestingapi.MakeAdmission("cq").Obj()).
+				Obj(),
+			wantAncestors: []kueue.CohortReference{"left", "root"},
+			wantErr:       nil,
+		},
+		"three levels": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root").Obj(),
+				utiltestingapi.MakeCohort("first-left").Parent("root").Obj(),
+				utiltestingapi.MakeCohort("first-right").Parent("root").Obj(),
+				utiltestingapi.MakeCohort("second-left").Parent("first-left").Obj(),
+				utiltestingapi.MakeCohort("second-right").Parent("first-left").Obj(),
+			},
+			cqs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq").Cohort("second-left").Obj(),
+			},
+			wl: utiltestingapi.MakeWorkload("wl", metav1.NamespaceDefault).
+				Admission(utiltestingapi.MakeAdmission("cq").Obj()).
+				Obj(),
+			wantAncestors: []kueue.CohortReference{"second-left", "first-left", "root"},
+			wantErr:       nil,
+		},
+		"with cycle": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root").Parent("second-right").Obj(),
+				utiltestingapi.MakeCohort("first-left").Parent("root").Obj(),
+				utiltestingapi.MakeCohort("first-right").Parent("root").Obj(),
+				utiltestingapi.MakeCohort("second-left").Parent("first-left").Obj(),
+				utiltestingapi.MakeCohort("second-right").Parent("first-left").Obj(),
+			},
+			cqs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq").Cohort("second-left").Obj(),
+			},
+			wl: utiltestingapi.MakeWorkload("wl", metav1.NamespaceDefault).
+				Admission(utiltestingapi.MakeAdmission("cq").Obj()).
+				Obj(),
+			wantAncestors: nil,
+			wantErr:       ErrCohortHasCycle,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+
+			client := utiltesting.NewClientBuilder().Build()
+			cache := New(client)
+			for _, cohort := range tc.cohorts {
+				_ = cache.AddOrUpdateCohort(cohort)
+			}
+			for _, cq := range tc.cqs {
+				_ = cache.AddClusterQueue(ctx, cq)
+			}
+
+			gotAncestors, gotErr := cache.workloadAncestors(tc.wl)
+
+			if diff := cmp.Diff(tc.wantAncestors, gotAncestors); diff != "" {
+				t.Fatalf("Unexpected ancestors (-want/+got)\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.EquateErrors()); diff != "" {
+				t.Fatalf("Unexpected error (-want/+got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAncestors(t *testing.T) {
+	testCases := map[string]struct {
+		cohorts       []*kueue.Cohort
+		cohortName    kueue.CohortReference
+		wantAncestors []kueue.CohortReference
+		wantErr       error
+	}{
+		"without cohort": {
+			cohortName: "",
+		},
+		"cohort not found": {
+			cohortName: "root",
+		},
+		"one level": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root").Obj(),
+			},
+			cohortName:    "root",
+			wantAncestors: []kueue.CohortReference{"root"},
+		},
+		"two level": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root").Obj(),
+				utiltestingapi.MakeCohort("left").Parent("root").Obj(),
+				utiltestingapi.MakeCohort("right").Parent("root").Obj(),
+			},
+			cohortName:    "left",
+			wantAncestors: []kueue.CohortReference{"left", "root"},
+		},
+		"three levels": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root").Obj(),
+				utiltestingapi.MakeCohort("first-left").Parent("root").Obj(),
+				utiltestingapi.MakeCohort("first-right").Parent("root").Obj(),
+				utiltestingapi.MakeCohort("second-left").Parent("first-left").Obj(),
+				utiltestingapi.MakeCohort("second-right").Parent("first-left").Obj(),
+			},
+			cohortName:    "second-left",
+			wantAncestors: []kueue.CohortReference{"second-left", "first-left", "root"},
+		},
+		"with cycle": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root").Parent("second-right").Obj(),
+				utiltestingapi.MakeCohort("first-left").Parent("root").Obj(),
+				utiltestingapi.MakeCohort("first-right").Parent("root").Obj(),
+				utiltestingapi.MakeCohort("second-left").Parent("first-left").Obj(),
+				utiltestingapi.MakeCohort("second-right").Parent("first-left").Obj(),
+			},
+			cohortName: "second-left",
+			wantErr:    ErrCohortHasCycle,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			client := utiltesting.NewClientBuilder().Build()
+			cache := New(client)
+			for _, cohort := range tc.cohorts {
+				_ = cache.AddOrUpdateCohort(cohort)
+			}
+
+			gotAncestors, gotErr := cache.ancestors(tc.cohortName)
+
+			if diff := cmp.Diff(tc.wantAncestors, gotAncestors); diff != "" {
+				t.Fatalf("Unexpected ancestors (-want/+got)\n%s", diff)
 			}
 
 			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.EquateErrors()); diff != "" {

--- a/pkg/cache/scheduler/cohort_metrics.go
+++ b/pkg/cache/scheduler/cohort_metrics.go
@@ -18,11 +18,13 @@ package scheduler
 
 import (
 	"github.com/go-logr/logr"
+	"k8s.io/klog/v2"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/cache/hierarchy"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/resources"
+	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 type cohortMetricPoint struct {
@@ -114,4 +116,24 @@ func (c *Cache) applyCohortMetricPoint(p cohortMetricPoint) {
 		float64(p.qty),
 		c.roleTracker,
 	)
+}
+
+func (c *Cache) ReportCohortSubtreeAdmittedWorkload(log logr.Logger, wl *kueue.Workload) {
+	c.RLock()
+	defer c.RUnlock()
+
+	ancestors, err := c.workloadAncestors(wl)
+	if err != nil {
+		log.Error(err, "Failed getting ancestors for workload", "workload", klog.KObj(wl))
+		return
+	}
+
+	for _, ancestor := range ancestors {
+		metrics.ReportCohortSubtreeAdmittedWorkload(
+			ancestor,
+			workload.PriorityClassName(wl),
+			c.customLabels.CohortGet(ancestor),
+			c.roleTracker,
+		)
+	}
 }

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -497,6 +497,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			quotaReservedWaitTime := r.clock.Since(quotaReservedCondition.LastTransitionTime.Time)
 			r.recorder.Eventf(&wl, corev1.EventTypeNormal, "Admitted", "Admitted by ClusterQueue %v, wait time since reservation was %.0fs", wl.Status.Admission.ClusterQueue, quotaReservedWaitTime.Seconds())
 			priorityClassName := workload.PriorityClassName(&wl)
+			r.cache.ReportCohortSubtreeAdmittedWorkload(log, &wl)
 			metrics.AdmittedWorkload(cqName, priorityClassName, queuedWaitTime, r.customLabels.CQGet(cqName), r.roleTracker)
 			metrics.ReportAdmissionChecksWaitTime(cqName, priorityClassName, quotaReservedWaitTime, r.customLabels.CQGet(cqName), r.roleTracker)
 			if features.Enabled(features.LocalQueueMetrics) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -254,6 +254,10 @@ var (
 	// +metricsdoc:group=cohort
 	// +metricsdoc:labels=cohort="the name of the Cohort",flavor="the resource flavor name",resource="the resource name",replica_role="one of `leader`, `follower`, or `standalone`"
 	CohortSubtreeQuota *prometheus.GaugeVec
+
+	// +metricsdoc:group=cohort
+	// +metricsdoc:labels=cohort="the name of the Cohort",priority_class="the priority class name",replica_role="one of `leader`, `follower`, or `standalone`"
+	CohortSubtreeAdmittedWorkloadsTotal *prometheus.CounterVec
 )
 
 func trackGaugeVec(g *prometheus.GaugeVec) *prometheus.GaugeVec {
@@ -728,6 +732,14 @@ If the Cohort has a weight of zero and is borrowing, this will return NaN.`,
 			Help:      `Reports the cohort's nominal quota aggregated within the cohort's subtree. The values are reported per resource and flavor`,
 		}, []string{"cohort", "flavor", "resource", "replica_role"},
 	))
+
+	CohortSubtreeAdmittedWorkloadsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: constants.KueueName,
+			Name:      "cohort_subtree_admitted_workloads_total",
+			Help:      "The total number of admitted workloads per cohort's subtree",
+		}, append([]string{"cohort", "priority_class", "replica_role"}, extraLabels...),
+	)
 }
 
 func init() {
@@ -916,6 +928,7 @@ func ClearLocalQueueMetrics(lq LocalQueueReference) {
 func ClearCohortMetrics(cohortName string) {
 	CohortSubtreeQuota.DeletePartialMatch(prometheus.Labels{"cohort": cohortName})
 	CohortWeightedShare.DeletePartialMatch(prometheus.Labels{"cohort": cohortName})
+	CohortSubtreeAdmittedWorkloadsTotal.DeletePartialMatch(prometheus.Labels{"cohort": cohortName})
 }
 
 func ReportClusterQueueStatus(cqName kueue.ClusterQueueReference, cqStatus ClusterQueueStatus, customLabelValues []string, tracker *roletracker.RoleTracker) {
@@ -967,6 +980,11 @@ func ReportClusterQueueQuotas(cohort kueue.CohortReference, queue, flavor, resou
 
 func ReportCohortSubtreeQuota(cohort kueue.CohortReference, flavor, resource string, quota float64, tracker *roletracker.RoleTracker) {
 	CohortSubtreeQuota.WithLabelValues(string(cohort), flavor, resource, roletracker.GetRole(tracker)).Set(quota)
+}
+
+func ReportCohortSubtreeAdmittedWorkload(cohort kueue.CohortReference, priorityClass string, customLabelValues []string, tracker *roletracker.RoleTracker) {
+	labels := append([]string{string(cohort), priorityClass, roletracker.GetRole(tracker)}, customLabelValues...)
+	CohortSubtreeAdmittedWorkloadsTotal.WithLabelValues(labels...).Inc()
 }
 
 func ClearCohortSubtreeQuota(cohort kueue.CohortReference, flavor, resource string) {
@@ -1146,6 +1164,7 @@ func Register() {
 		ClusterQueueWeightedShare,
 		CohortWeightedShare,
 		CohortSubtreeQuota,
+		CohortSubtreeAdmittedWorkloadsTotal,
 	)
 	if features.Enabled(features.LocalQueueMetrics) {
 		RegisterLQMetrics()

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -707,7 +707,7 @@ func (s *Scheduler) admit(ctx context.Context, e *entry, cq *schdcache.ClusterQu
 		}, workload.WithLooseOnApply(), workload.WithRetryOnConflictForPatch())
 		if err == nil {
 			// Record metrics and events for quota reservation and admission
-			s.recordWorkloadAdmissionMetrics(newWorkload, e.Obj, admission, consideredStr)
+			s.recordWorkloadAdmissionMetrics(log, newWorkload, e.Obj, admission, consideredStr)
 
 			log.V(2).Info("Workload successfully admitted and assigned flavors", "assignments", admission.PodSetAssignments)
 			return
@@ -868,11 +868,11 @@ func (s *Scheduler) requeueAndUpdate(ctx context.Context, e entry) {
 }
 
 // recordWorkloadAdmissionMetrics records metrics and events for workload admission process
-func (s *Scheduler) recordWorkloadAdmissionMetrics(newWorkload, originalWorkload *kueue.Workload, admission *kueue.Admission, consideredFlavors string) {
+func (s *Scheduler) recordWorkloadAdmissionMetrics(log logr.Logger, newWorkload, originalWorkload *kueue.Workload, admission *kueue.Admission, consideredFlavors string) {
 	waitTime := workload.QueuedWaitTime(newWorkload, s.clock)
 
 	s.recordQuotaReservationMetrics(newWorkload, originalWorkload, admission, waitTime, consideredFlavors)
-	s.recordWorkloadAdmissionEvents(newWorkload, originalWorkload, admission, waitTime)
+	s.recordWorkloadAdmissionEvents(log, newWorkload, originalWorkload, admission, waitTime)
 }
 
 // recordQuotaReservationMetrics records metrics and events for quota reservation
@@ -897,7 +897,7 @@ func (s *Scheduler) recordQuotaReservationMetrics(newWorkload, originalWorkload 
 }
 
 // recordWorkloadAdmissionEvents records metrics and events for workload admission
-func (s *Scheduler) recordWorkloadAdmissionEvents(newWorkload, originalWorkload *kueue.Workload, admission *kueue.Admission, waitTime time.Duration) {
+func (s *Scheduler) recordWorkloadAdmissionEvents(log logr.Logger, newWorkload, originalWorkload *kueue.Workload, admission *kueue.Admission, waitTime time.Duration) {
 	if !workload.IsAdmitted(newWorkload) || workload.HasUnhealthyNodes(originalWorkload) {
 		return
 	}
@@ -906,6 +906,7 @@ func (s *Scheduler) recordWorkloadAdmissionEvents(newWorkload, originalWorkload 
 
 	priorityClassName := workload.PriorityClassName(newWorkload)
 	cqCustomLabels := s.customLabels.CQGet(admission.ClusterQueue)
+	s.cache.ReportCohortSubtreeAdmittedWorkload(log, newWorkload)
 	metrics.AdmittedWorkload(admission.ClusterQueue, priorityClassName, waitTime, cqCustomLabels, s.roleTracker)
 	if features.Enabled(features.LocalQueueMetrics) {
 		lqRef := metrics.LQRefFromWorkload(newWorkload)

--- a/site/content/en/docs/reference/metrics.md
+++ b/site/content/en/docs/reference/metrics.md
@@ -82,6 +82,7 @@ The following metrics are available only if `LocalQueueMetrics` feature gate is 
 <!-- BEGIN GENERATED TABLE: cohort -->
 | Metric name | Type | Description | Labels |
 | --- | --- | --- | --- |
+| `kueue_cohort_subtree_admitted_workloads_total` | Counter | The total number of admitted workloads per cohort's subtree | `cohort`: the name of the Cohort<br> `priority_class`: the priority class name<br> `replica_role`: one of `leader`, `follower`, or `standalone` |
 | `kueue_cohort_subtree_quota` | Gauge | Reports the cohort's nominal quota aggregated within the cohort's subtree. The values are reported per resource and flavor | `cohort`: the name of the Cohort<br> `flavor`: the resource flavor name<br> `resource`: the resource name<br> `replica_role`: one of `leader`, `follower`, or `standalone` |
 | `kueue_cohort_weighted_share` | Gauge | Reports a value that representing the maximum of the ratios of usage above nominal<br>quota to the lendable resources in the Cohort, among all the resources provided by<br>the Cohort, and divided by the weight.<br>If zero, it means that the usage of the Cohort is below the nominal quota.<br>If the Cohort has a weight of zero and is borrowing, this will return NaN. | `cohort`: the name of the Cohort<br> `replica_role`: one of `leader`, `follower`, or `standalone` |
 <!-- END GENERATED TABLE: cohort -->

--- a/test/integration/singlecluster/scheduler/fairsharing/metrics_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/metrics_test.go
@@ -30,11 +30,14 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/test/util"
 )
 
 var _ = ginkgo.Describe("Cohorts", func() {
 	var (
+		admissionChecks map[string]*kueue.AdmissionCheck
+
 		defaultFlavor *kueue.ResourceFlavor
 		flavor1       *kueue.ResourceFlavor
 		flavor2       *kueue.ResourceFlavor
@@ -43,7 +46,15 @@ var _ = ginkgo.Describe("Cohorts", func() {
 		cohorts map[string]*kueue.Cohort
 		cqs     map[string]*kueue.ClusterQueue
 		lqs     map[string]*kueue.LocalQueue
+
+		wls map[string]*kueue.Workload
 	)
+
+	var createAdmissionCheck = func(ac *kueue.AdmissionCheck) {
+		util.MustCreate(ctx, k8sClient, ac)
+		util.SetAdmissionCheckActive(ctx, k8sClient, ac, metav1.ConditionTrue)
+		admissionChecks[ac.Name] = ac
+	}
 
 	var createCohort = func(cohort *kueue.Cohort) *kueue.Cohort {
 		util.MustCreate(ctx, k8sClient, cohort)
@@ -61,11 +72,19 @@ var _ = ginkgo.Describe("Cohorts", func() {
 		return cq
 	}
 
+	var createWorkload = func(wl *kueue.Workload) *kueue.Workload {
+		wls[wl.Name] = wl
+		util.MustCreate(ctx, k8sClient, wl)
+		return wl
+	}
+
 	ginkgo.When("creating, modifying and removing", func() {
 		ginkgo.BeforeEach(func() {
+			admissionChecks = make(map[string]*kueue.AdmissionCheck)
 			cohorts = make(map[string]*kueue.Cohort)
 			cqs = make(map[string]*kueue.ClusterQueue)
 			lqs = make(map[string]*kueue.LocalQueue)
+			wls = make(map[string]*kueue.Workload)
 
 			fwk.StartManager(ctx, cfg, managerAndSchedulerSetup(
 				&config.AdmissionFairSharing{
@@ -88,6 +107,9 @@ var _ = ginkgo.Describe("Cohorts", func() {
 		})
 
 		ginkgo.AfterEach(func() {
+			for _, wl := range wls {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, wl, true)
+			}
 			for _, lq := range lqs {
 				util.ExpectObjectToBeDeleted(ctx, k8sClient, lq, true)
 			}
@@ -102,6 +124,9 @@ var _ = ginkgo.Describe("Cohorts", func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, defaultFlavor, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, flavor1, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, flavor2, true)
+			for _, ac := range admissionChecks {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, ac, true)
+			}
 			fwk.StopManager(ctx)
 		})
 
@@ -423,6 +448,176 @@ var _ = ginkgo.Describe("Cohorts", func() {
 				// updated values for ch1 with cq1 removed
 				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", flavor1.Name, corev1.ResourceCPU.String(), 5_000)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", flavor1.Name, "nvidia.com/gpu", 1)
+			})
+		})
+
+		ginkgo.It("correctly handles cohort metrics when workload admitted with admission check", func() {
+			const (
+				numWorkloadsForCQ1 = 5
+				numWorkloadsForCQ2 = 2
+			)
+
+			ginkgo.By("Creating AdmissionCheck", func() {
+				createAdmissionCheck(utiltestingapi.MakeAdmissionCheck("check1").ControllerName("ctrl1").Obj())
+			})
+
+			ginkgo.By("Creating Cohorts", func() {
+				createCohort(utiltestingapi.MakeCohort("ch1").
+					Parent("root").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(flavor1.Name).
+							Resource(corev1.ResourceCPU, "5").
+							Obj(),
+					).Obj())
+
+				createCohort(utiltestingapi.MakeCohort("ch2").
+					Parent("root").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(flavor1.Name).
+							Resource(corev1.ResourceCPU, "2").
+							Obj(),
+					).Obj())
+			})
+
+			ginkgo.By("Create ClusterQueues", func() {
+				createQueue(utiltestingapi.MakeClusterQueue("cq1").
+					Cohort("ch1").
+					AdmissionChecks("check1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(flavor1.Name).
+							Resource(corev1.ResourceCPU, "5").
+							Obj(),
+					).Obj())
+
+				createQueue(utiltestingapi.MakeClusterQueue("cq2").
+					Cohort("ch2").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(flavor1.Name).
+							Resource(corev1.ResourceCPU, "2").
+							Obj(),
+					).Obj())
+			})
+
+			shouldAdmit := make([]*kueue.Workload, 0, numWorkloadsForCQ1)
+
+			ginkgo.By("Creating Workloads", func() {
+				for range numWorkloadsForCQ1 {
+					shouldAdmit = append(shouldAdmit,
+						createWorkload(
+							utiltestingapi.MakeWorkloadWithGeneratedName("workload-", ns.Name).
+								Queue("cq1").
+								Request(corev1.ResourceCPU, "1").Obj(),
+						),
+					)
+				}
+
+				for range numWorkloadsForCQ2 {
+					createWorkload(
+						utiltestingapi.MakeWorkloadWithGeneratedName("workload-", ns.Name).
+							Queue("cq2").
+							Request(corev1.ResourceCPU, "1").Obj(),
+					)
+				}
+			})
+
+			ginkgo.By("Checking that only cq2 Workloads admitted", func() {
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root", "", numWorkloadsForCQ2)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("ch1", "", 0)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("ch2", "", numWorkloadsForCQ2)
+			})
+
+			ginkgo.By("Marking the checks as passed", func() {
+				for _, wl := range shouldAdmit {
+					createdWorkload := &kueue.Workload{}
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), createdWorkload)).To(gomega.Succeed())
+						workload.SetAdmissionCheckState(&createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckState{
+							Name:    "check1",
+							State:   kueue.CheckStateReady,
+							Message: "Check successfully passed",
+						}, util.RealClock)
+						g.Expect(k8sClient.Status().Update(ctx, createdWorkload)).Should(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				}
+			})
+
+			ginkgo.By("Checking that all Workloads admitted", func() {
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root", "", numWorkloadsForCQ1+numWorkloadsForCQ2)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("ch1", "", numWorkloadsForCQ1)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("ch2", "", numWorkloadsForCQ2)
+			})
+		})
+
+		ginkgo.It("correctly handles cohort metrics when workload admitted with workload priority class", func() {
+			const (
+				numWorkloadsForCQ1 = 5
+				numWorkloadsForCQ2 = 2
+			)
+
+			ginkgo.By("Creating Cohorts", func() {
+				createCohort(utiltestingapi.MakeCohort("ch1").
+					Parent("root").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(flavor1.Name).
+							Resource(corev1.ResourceCPU, "5").
+							Obj(),
+					).Obj())
+
+				createCohort(utiltestingapi.MakeCohort("ch2").
+					Parent("root").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(flavor1.Name).
+							Resource(corev1.ResourceCPU, "2").
+							Obj(),
+					).Obj())
+			})
+
+			ginkgo.By("Create ClusterQueues", func() {
+				createQueue(utiltestingapi.MakeClusterQueue("cq1").
+					Cohort("ch1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(flavor1.Name).
+							Resource(corev1.ResourceCPU, "5").
+							Obj(),
+					).Obj())
+
+				createQueue(utiltestingapi.MakeClusterQueue("cq2").
+					Cohort("ch2").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(flavor1.Name).
+							Resource(corev1.ResourceCPU, "2").
+							Obj(),
+					).Obj())
+			})
+
+			ginkgo.By("Creating Workloads", func() {
+				for range numWorkloadsForCQ1 {
+					createWorkload(
+						utiltestingapi.MakeWorkloadWithGeneratedName("workload-", ns.Name).
+							Queue("cq1").
+							WorkloadPriorityClassRef("high").
+							Priority(100).
+							Request(corev1.ResourceCPU, "1").
+							Obj(),
+					)
+				}
+
+				for range numWorkloadsForCQ2 {
+					createWorkload(utiltestingapi.MakeWorkloadWithGeneratedName("workload-", ns.Name).
+						Queue("cq2").
+						WorkloadPriorityClassRef("low").
+						Priority(10).
+						Request(corev1.ResourceCPU, "1").
+						Obj(),
+					)
+				}
+			})
+
+			ginkgo.By("Checking that only cq2 Workloads admitted", func() {
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root", "high", numWorkloadsForCQ1)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root", "low", numWorkloadsForCQ2)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("ch1", "high", numWorkloadsForCQ1)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("ch2", "low", numWorkloadsForCQ2)
 			})
 		})
 	})

--- a/test/util/metrics.go
+++ b/test/util/metrics.go
@@ -312,3 +312,10 @@ func ExpectCohortSubtreeQuotaGaugeMetricCleaned(cohortName, flavor, resource str
 	ginkgo.GinkgoHelper()
 	ExpectCohortSubtreeQuotaGaugeMetric(cohortName, flavor, resource, 0)
 }
+
+func ExpectCohortSubtreeAdmittedWorkloadsTotalMetric(cohortName kueue.CohortReference, priorityClass string, v int, customLabels ...string) {
+	ginkgo.GinkgoHelper()
+	lvs := append([]string{string(cohortName), priorityClass, roletracker.RoleStandalone}, customLabels...)
+	metric := metrics.CohortSubtreeAdmittedWorkloadsTotal.WithLabelValues(lvs...)
+	expectCounterMetric(metric, v)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Introduce kueue_cohort_admitted_workloads_total metric.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #7539

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Observability: Introduce kueue_cohort_admitted_workloads_total metric
```