### PR TITLE
Fix scheduling hashes and disable temporarily

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -413,6 +413,12 @@ func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info
 	}
 	log.V(2).Info(logMsg, "clusterQueue", c.name, "workload", key)
 
+	if features.Enabled(features.SchedulingEquivalenceHashing) && wInfo.SchedulingHash != workload.SchedulingHashUnknown && !immediate {
+		if moved := c.handleInadmissibleHash(wInfo.SchedulingHash); moved > 0 {
+			log.V(2).Info("Bulk-moved equivalent workloads to inadmissible", "hash", wInfo.SchedulingHash, "movedCount", moved)
+		}
+	}
+
 	return true
 }
 
@@ -427,8 +433,6 @@ func (c *ClusterQueue) forgetInflightByKey(key workload.Reference) {
 // Only applies to BestEffortFIFO queues; in StrictFIFO the head workload
 // stays in the heap and must not cause equivalent workloads to be skipped.
 func (c *ClusterQueue) handleInadmissibleHash(hash string) int {
-	c.rwm.Lock()
-	defer c.rwm.Unlock()
 	if c.queueingStrategy != kueue.BestEffortFIFO {
 		return 0
 	}

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -601,23 +601,6 @@ func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reas
 	return added
 }
 
-// HandleInadmissibleHash bulk-moves all workloads in the ClusterQueue's heap
-// that share the given scheduling hash to inadmissibleWorkloads.
-func (m *Manager) HandleInadmissibleHash(cqName kueue.ClusterQueueReference, hash string) int {
-	m.RLock()
-	defer m.RUnlock()
-	cq := m.hm.ClusterQueue(cqName)
-	if cq == nil {
-		return 0
-	}
-	moved := cq.handleInadmissibleHash(hash)
-	if moved > 0 {
-		// Update pending metrics for the CQ and all its LocalQueues.
-		reportPendingWorkloads(m, cqName)
-	}
-	return moved
-}
-
 // Delete the workload from queue or cluster queue.
 // Does not remove the queue assignment caching.
 func (m *Manager) DeleteWorkload(log logr.Logger, wlKey workload.Reference) {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -486,7 +486,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	SchedulingEquivalenceHashing: {
-		{Version: version.MustParse("0.17"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Beta},
 	},
 	SchedulerLongRequeueInterval: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha}, // remove in 0.20

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -300,12 +300,6 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 
 		if mode == flavorassigner.NoFit {
 			log.V(3).Info("Skipping workload as FlavorAssigner assigned NoFit mode")
-			if features.Enabled(features.SchedulingEquivalenceHashing) && e.SchedulingHash != workload.SchedulingHashUnknown {
-				if moved := s.queues.HandleInadmissibleHash(e.ClusterQueue, e.SchedulingHash); moved > 0 {
-					log.V(2).Info("Bulk-moved equivalent workloads to inadmissible",
-						"hash", e.SchedulingHash, "movedCount", moved)
-				}
-			}
 			continue
 		}
 

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -275,7 +275,7 @@
     version: "0.17"
 - name: SchedulingEquivalenceHashing
   versionedSpecs:
-  - default: true
+  - default: false
     lockToDefault: false
     preRelease: Beta
     version: "0.17"

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -275,7 +275,7 @@
     version: "0.17"
 - name: SchedulingEquivalenceHashing
   versionedSpecs:
-  - default: true
+  - default: false
     lockToDefault: false
     preRelease: Beta
     version: "0.17"


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
To fix the problem observed on large deployments with FairSharing enabled that the hash-based bulk scheduling was no-op, because in that case allmost all inadmissible workloads are categorized as "Preempt", but with noPreemptionCandidates.

This change uses the bulk-scheduling if and only if a pair of workloads have identical scheduling hash, and the "Popped" workload is considered "inadmissible", regardless of the categorization.

#### Special notes for your reviewer:

At the same time, since this change has a bigger impact, we need more time to:
1. properly investigate the performance regression reported by our testing framework, this is probably just an artifact of the testing approach, but we should be careful
2. Fix the compatibility with MultiKueue preemption gates, cc @kshalot 
3. Adjust many unit and integration tests carefully

So, I propose to disable the feature gate by default.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Scheduling: fixed SchedulingEquivalenceHashing so equivalent workloads that become inadmissible through
the preemption path with no candidates are also covered by the mechanism. 

As a safety measure while the broader fix is validated, the beta SchedulingEquivalenceHashing feature gate
is temporarily disabled by default. 
```