### PR TITLE
Fix webhook denial when ancestor owner is not found during GC teardown

### DIFF
--- a/pkg/controller/jobframework/defaults.go
+++ b/pkg/controller/jobframework/defaults.go
@@ -35,6 +35,10 @@ import (
 
 func ApplyDefaultForSuspend(ctx context.Context, job GenericJob, k8sClient client.Client,
 	manageJobsWithoutQueueName bool, managedJobsNamespaceSelector labels.Selector) error {
+	// Do not default suspend an object that is already being deleted (e.g. during GC teardown).
+	if job.Object().GetDeletionTimestamp() != nil {
+		return nil
+	}
 	suspend, err := WorkloadShouldBeSuspended(ctx, job.Object(), k8sClient, manageJobsWithoutQueueName, managedJobsNamespaceSelector)
 	if err != nil {
 		return err

--- a/pkg/controller/jobframework/defaults_test.go
+++ b/pkg/controller/jobframework/defaults_test.go
@@ -18,6 +18,7 @@ package jobframework
 
 import (
 	"testing"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -48,6 +49,7 @@ func TestWorkloadShouldBeSuspended(t *testing.T) {
 		obj                        client.Object
 		manageJobsWithoutQueueName bool
 		wantSuspend                bool
+		wantErr                    bool
 	}{
 		"job with queue name ": {
 			obj:                        utiltestingjob.MakeJob("test-job", managedNamespace.Name).Queue("default").Obj(),
@@ -76,6 +78,25 @@ func TestWorkloadShouldBeSuspended(t *testing.T) {
 			manageJobsWithoutQueueName: true,
 			wantSuspend:                false,
 		},
+		"job with ownerReference to a deleted known parent while terminating (GC teardown)": {
+			obj: utiltestingjob.MakeJob("test-job", managedNamespace.Name).
+				OwnerReference("nonexistent-parent", batchv1.SchemeGroupVersion.WithKind("Job")).
+				DeletionTimestamp(time.Now()).
+				Finalizer("batch.kubernetes.io/job-tracking").
+				Obj(),
+			manageJobsWithoutQueueName: true,
+			// FindAncestorJobManagedByKueue gracefully returns nil for the missing parent
+			// since the job is terminating. WorkloadShouldBeSuspended itself no longer has
+			// the DeletionTimestamp early exit; callers in webhook paths guard that separately.
+			wantSuspend: true,
+		},
+		"job with ownerReference to a missing parent while not terminating (cache lag)": {
+			obj: utiltestingjob.MakeJob("test-job", managedNamespace.Name).
+				OwnerReference("nonexistent-parent", batchv1.SchemeGroupVersion.WithKind("Job")).
+				Obj(),
+			manageJobsWithoutQueueName: true,
+			wantErr:                    true,
+		},
 		"job without queue name with manageJobs with feature disabled": {
 			obj:                        utiltestingjob.MakeJob("test-job", managedNamespace.Name).Obj(),
 			manageJobsWithoutQueueName: true,
@@ -96,10 +117,10 @@ func TestWorkloadShouldBeSuspended(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
 
 			suspend, err := WorkloadShouldBeSuspended(ctx, tc.obj, client, tc.manageJobsWithoutQueueName, namespaceSelector)
-			if err != nil {
-				t.Errorf("Got error: %v", err)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Unexpected error state: got err=%v, wantErr=%v", err, tc.wantErr)
 			}
-			if suspend != tc.wantSuspend {
+			if !tc.wantErr && suspend != tc.wantSuspend {
 				t.Errorf("Unexpected result: got %v wanted %v", suspend, tc.wantSuspend)
 			}
 		})

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -824,6 +824,12 @@ func FindAncestorJobManagedByKueue(ctx context.Context, c client.Client, jobObj 
 			}
 		}
 		if err := c.Get(ctx, client.ObjectKey{Name: owner.Name, Namespace: jobObj.GetNamespace()}, parentObj); err != nil {
+			if apierrors.IsNotFound(err) && jobObj.GetDeletionTimestamp() != nil {
+				// The object being processed is already being deleted; a missing owner is
+				// expected during GC teardown (e.g. foreground+background deletion mix).
+				// Return whatever ancestor we have found so far rather than blocking.
+				return topLevelJob, nil
+			}
 			return nil, errors.Join(ErrWorkloadOwnerNotFound, err)
 		}
 		if managed && (manageJobsWithoutQueueName || QueueNameForObject(parentObj) != "") {

--- a/pkg/controller/jobs/deployment/deployment_webhook.go
+++ b/pkg/controller/jobs/deployment/deployment_webhook.go
@@ -73,6 +73,9 @@ func (wh *Webhook) Default(ctx context.Context, obj *appsv1.Deployment) error {
 	log.V(5).Info("Propagating queue-name")
 
 	jobframework.ApplyDefaultLocalQueue(deployment.Object(), wh.queues.DefaultLocalQueueExist)
+	if obj.GetDeletionTimestamp() != nil {
+		return nil
+	}
 	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, deployment.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
 	if err != nil {
 		return err

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
@@ -77,6 +77,9 @@ func (wh *Webhook) Default(ctx context.Context, obj *leaderworkersetv1.LeaderWor
 	log.V(5).Info("Applying defaults")
 
 	jobframework.ApplyDefaultLocalQueue(obj, wh.queues.DefaultLocalQueueExist)
+	if obj.GetDeletionTimestamp() != nil {
+		return nil
+	}
 	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, lws.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
 	if err != nil {
 		return err
@@ -180,21 +183,24 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldObj, newObj *leaderwor
 		allErrs = append(allErrs, webhook.ValidateAdmissionGatedByAnnotationOnUpdate(oldLeaderWorkerSet.Object(), newLeaderWorkerSet.Object())...)
 	}
 
-	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, newLeaderWorkerSet.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
-	if err != nil {
-		return nil, err
-	}
-	if suspend {
-		allErrs = append(allErrs, validateImmutablePodTemplateSpec(
-			newLeaderWorkerSet.Spec.LeaderWorkerTemplate.LeaderTemplate,
-			oldLeaderWorkerSet.Spec.LeaderWorkerTemplate.LeaderTemplate,
-			leaderTemplatePath,
-		)...)
-		allErrs = append(allErrs, validateImmutablePodTemplateSpec(
-			&newLeaderWorkerSet.Spec.LeaderWorkerTemplate.WorkerTemplate,
-			&oldLeaderWorkerSet.Spec.LeaderWorkerTemplate.WorkerTemplate,
-			workerTemplatePath,
-		)...)
+	if newLeaderWorkerSet.Object().GetDeletionTimestamp() == nil {
+		var suspend bool
+		suspend, err = jobframework.WorkloadShouldBeSuspended(ctx, newLeaderWorkerSet.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
+		if err != nil {
+			return nil, err
+		}
+		if suspend {
+			allErrs = append(allErrs, validateImmutablePodTemplateSpec(
+				newLeaderWorkerSet.Spec.LeaderWorkerTemplate.LeaderTemplate,
+				oldLeaderWorkerSet.Spec.LeaderWorkerTemplate.LeaderTemplate,
+				leaderTemplatePath,
+			)...)
+			allErrs = append(allErrs, validateImmutablePodTemplateSpec(
+				&newLeaderWorkerSet.Spec.LeaderWorkerTemplate.WorkerTemplate,
+				&oldLeaderWorkerSet.Spec.LeaderWorkerTemplate.WorkerTemplate,
+				workerTemplatePath,
+			)...)
+		}
 	}
 
 	return warnings, allErrs.ToAggregate()

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -148,6 +148,12 @@ func (w *PodWebhook) Default(ctx context.Context, obj *corev1.Pod) error {
 			return err
 		}
 
+		// During GC teardown the pod may be terminating with its parent already gone;
+		// skip further mutation to avoid adding finalizers to a deleting pod.
+		if pod.pod.DeletionTimestamp != nil {
+			return nil
+		}
+
 		// Local queue defaulting
 		if jobframework.QueueNameForObject(pod.Object()) == "" &&
 			w.queues.DefaultLocalQueueExist(pod.pod.GetNamespace()) {

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package pod
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -209,6 +211,33 @@ func TestDefault(t *testing.T) {
 				Queue("test-queue").
 				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Obj(),
+		},
+		"pod with ownerReference to a deleted known parent while terminating (GC teardown)": {
+			initObjects:       []client.Object{defaultNamespace},
+			podSelector:       &metav1.LabelSelector{},
+			namespaceSelector: defaultNamespaceSelector,
+			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("test-queue").
+				OwnerReference("deleted-parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
+				DeletionTimestamp(time.Now()).
+				Obj(),
+			enableIntegrations: []string{"batch/job"},
+			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("test-queue").
+				OwnerReference("deleted-parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
+				DeletionTimestamp(time.Now()).
+				Obj(),
+		},
+		"pod with ownerReference to a missing parent while not terminating (cache lag, should error)": {
+			initObjects:       []client.Object{defaultNamespace},
+			podSelector:       &metav1.LabelSelector{},
+			namespaceSelector: defaultNamespaceSelector,
+			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("test-queue").
+				OwnerReference("deleted-parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
+				Obj(),
+			enableIntegrations: []string{"batch/job"},
+			wantErr:            errors.New("owner not found"),
 		},
 		"pod with owner managed by kueue (RayCluster)": {
 			initObjects: []client.Object{
@@ -583,8 +612,12 @@ func TestDefault(t *testing.T) {
 				podSelector:                  tc.podSelector,
 			}
 
-			if err := w.Default(ctx, tc.pod); err != nil {
-				t.Errorf("failed to set defaults for v1/pod: %s", err)
+			gotErr := w.Default(ctx, tc.pod)
+			if (gotErr != nil) != (tc.wantErr != nil) {
+				t.Errorf("Default() error = %v, wantErr %v", gotErr, tc.wantErr)
+			}
+			if gotErr != nil {
+				return
 			}
 
 			if diff := cmp.Diff(tc.want, tc.pod); len(diff) != 0 {

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -82,6 +82,9 @@ func (wh *Webhook) Default(ctx context.Context, stsObj *appsv1.StatefulSet) erro
 	log.V(5).Info("Propagating queue-name")
 
 	jobframework.ApplyDefaultLocalQueue(ss.Object(), wh.queues.DefaultLocalQueueExist)
+	if stsObj.GetDeletionTimestamp() != nil {
+		return nil
+	}
 	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, ss.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
 	if err != nil {
 		return err
@@ -163,6 +166,10 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldSTSObj, newSTSObj *app
 
 	if features.Enabled(features.AdmissionGatedBy) {
 		allErrs = append(allErrs, webhook.ValidateAdmissionGatedByAnnotationOnUpdate(oldStatefulSet.Object(), newStatefulSet.Object())...)
+	}
+
+	if newSTSObj.GetDeletionTimestamp() != nil {
+		return warnings, allErrs.ToAggregate()
 	}
 
 	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, newStatefulSet.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)

--- a/pkg/controller/jobs/trainjob/trainjob_webhook.go
+++ b/pkg/controller/jobs/trainjob/trainjob_webhook.go
@@ -75,6 +75,9 @@ func (w *TrainJobWebhook) Default(ctx context.Context, obj *kftrainerapi.TrainJo
 
 	jobframework.ApplyDefaultLocalQueue(trainJob.Object(), w.queues.DefaultLocalQueueExist)
 	jobframework.ApplyDefaultForManagedBy(trainJob, w.queues, w.cache, log)
+	if obj.GetDeletionTimestamp() != nil {
+		return nil
+	}
 	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, trainJob.Object(), w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector)
 	if err != nil {
 		return err

--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -250,6 +250,18 @@ func (j *JobWrapper) StartTime(t time.Time) *JobWrapper {
 	return j
 }
 
+// DeletionTimestamp sets the deletion timestamp, marking the job as terminating.
+func (j *JobWrapper) DeletionTimestamp(t time.Time) *JobWrapper {
+	j.Job.DeletionTimestamp = &metav1.Time{Time: t}
+	return j
+}
+
+// Finalizer adds a finalizer to the job.
+func (j *JobWrapper) Finalizer(f string) *JobWrapper {
+	j.Finalizers = append(j.Finalizers, f)
+	return j
+}
+
 // Active sets the .status.active
 func (j *JobWrapper) Active(c int32) *JobWrapper {
 	j.Status.Active = c

--- a/test/integration/singlecluster/webhook/jobs/statefulset_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/statefulset_webhook_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -91,6 +92,70 @@ var _ = ginkgo.Describe("StatefulSet Webhook", func() {
 							"Queue name should not be injected to pod template labels",
 						)
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		// Regression test for GC teardown deadlock:
+		// When foreground and background deletion are mixed in the same ownership chain,
+		// a child STS can get stuck in Terminating because the webhook denied the GC's
+		// PATCH to remove the foregroundDeletion finalizer (parent was already gone).
+		ginkgo.When("a child StatefulSet is terminating with its parent already deleted", func() {
+			ginkgo.It("Should allow removing foregroundDeletion finalizer", func() {
+				stsGVK := appsv1.SchemeGroupVersion.WithKind("StatefulSet")
+
+				// Create the parent STS (no finalizers, so it is deleted immediately).
+				parentSTS := testingstatefulset.MakeStatefulSet("parent-sts", ns.Name).Queue("user-queue").Obj()
+				util.MustCreate(ctx, k8sClient, parentSTS)
+
+				// Re-read to get the real UID assigned by the API server.
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(parentSTS), parentSTS)).To(gomega.Succeed())
+
+				// Create the child STS with an ownerReference to the parent and the
+				// foregroundDeletion finalizer (as the GC would add during teardown).
+				childSTS := testingstatefulset.MakeStatefulSet("child-sts", ns.Name).Obj()
+				childSTS.Finalizers = []string{metav1.FinalizerDeleteDependents}
+				isController := true
+				childSTS.OwnerReferences = []metav1.OwnerReference{
+					{
+						APIVersion: stsGVK.GroupVersion().String(),
+						Kind:       stsGVK.Kind,
+						Name:       parentSTS.Name,
+						UID:        parentSTS.UID,
+						Controller: &isController,
+					},
+				}
+				util.MustCreate(ctx, k8sClient, childSTS)
+
+				// Delete the parent STS with background propagation: it has no
+				// finalizers so it disappears from the API server immediately,
+				// simulating the "background delete while foreground chain is active"
+				// scenario described in the bug report.
+				background := metav1.DeletePropagationBackground
+				gomega.Expect(k8sClient.Delete(ctx, parentSTS, &client.DeleteOptions{
+					PropagationPolicy: &background,
+				})).To(gomega.Succeed())
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(parentSTS), &appsv1.StatefulSet{})).
+						Should(gomega.MatchError(gomega.ContainSubstring("not found")))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				// Delete the child STS so it enters Terminating state.
+				// The foregroundDeletion finalizer prevents it from being fully removed.
+				gomega.Expect(k8sClient.Delete(ctx, childSTS)).To(gomega.Succeed())
+
+				var terminatingChild appsv1.StatefulSet
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(childSTS), &terminatingChild)).To(gomega.Succeed())
+					g.Expect(terminatingChild.DeletionTimestamp).NotTo(gomega.BeNil())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				// Simulate what the GC does: PATCH the child STS to remove the
+				// foregroundDeletion finalizer.  Without the fix this PATCH is denied
+				// by the mutating webhook with "workload owner not found".
+				patch := client.MergeFrom(terminatingChild.DeepCopy())
+				terminatingChild.Finalizers = nil
+				gomega.Expect(k8sClient.Patch(ctx, &terminatingChild, patch)).To(gomega.Succeed())
 			})
 		})
 	})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area integrations

#### What this PR does / why we need it:

When the Garbage Collector PATCHes a child object to remove the foregroundDeletion finalizer, Kueue's mutating webhooks invoke WorkloadShouldBeSuspended → FindAncestorJobManagedByKueue to walk the ownerReference chain. If any owner in that chain has already been deleted (e.g. via background/helm uninstall while a foreground deletion is in progress on a child), c.Get returns NotFound and the function returns ErrWorkloadOwnerNotFound. This error propagates up and causes the webhook to deny the PATCH, permanently blocking the GC from removing the finalizer and leaving objects stuck in Terminating state.

This is a generalisation of the problem partially addressed in #8862. That fix added a managedByAnotherFramework() guard based on the kueue.x-k8s.io/pod-suspending-parent annotation, but objects created directly by controllers (e.g. StatefulSets created by the LWS controller without going through Kueue's webhook path) never receive this annotation, so the guard does not help them.

Fix: treat ErrWorkloadOwnerNotFound as "no Kueue-managed ancestor" (return false, nil) inside WorkloadShouldBeSuspended. A missing owner during a webhook admission call means the ownership chain is being garbage collected — there is nothing to suspend, and the operation should be allowed.

The fix is applied at two call sites:

- WorkloadShouldBeSuspended in pkg/controller/jobframework/defaults.go — covers all webhook Default() / ValidateUpdate() paths, plus the StatefulSet and LeaderWorkerSet reconcilers' use of this function.
- The pod webhook's direct call to FindAncestorJobManagedByKueue in pkg/controller/jobs/pod/pod_webhook.go.

The main reconciler's direct call to FindAncestorJobManagedByKueue in reconciler.go is intentionally left unchanged: requeuing on ErrWorkloadOwnerNotFound there is correct, since during normal operation a parent may transiently be absent due to creation ordering.

#### Which issue(s) this PR fixes:

Fixes # n/a

#### Special notes for your reviewer:
The scenario that triggers this bug requires a mix of foreground and background deletion in the same ownership chain (e.g. LWS → Parent STS → Leader Pod → Child STS → Worker Pods where a pod restart causes foreground deletion of the leader pod cascading foregroundDeletion finalizers down to the child STS, while helm uninstall concurrently removes the parent STS via background deletion). With a purely foreground or purely background chain the deadlock does not occur.

Reproducible evidence from a live cluster:

```
$ kubectl patch sts <name> -n <ns> --type=merge -p '{"metadata":{"finalizers":null}}' --dry-run=server
Error: admission webhook "mstatefulset.kb.io" denied the request: workload owner not found
```

#### Does this PR introduce a user-facing change?
no

```release-note
None
```