### PR TITLE
chore: Fix exptostd and usetesting lint issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,6 +7,7 @@ linters:
     - copyloopvar
     - dupword
     - durationcheck
+    - exptostd
     - fatcontext
     - ginkgolinter
     - gocritic
@@ -22,6 +23,7 @@ linters:
     - perfsprint
     - revive
     - unconvert
+    - usetesting
     - forbidigo
   settings:
     gocritic:
@@ -69,6 +71,10 @@ linters:
     modernize:
       disable:
         - omitzero
+    usetesting:
+      os-temp-dir: true
+      context-background: true
+      context-todo: true
   exclusions:
     generated: lax
     presets:

--- a/cmd/experimental/kueue-populator/pkg/controller/controller_test.go
+++ b/cmd/experimental/kueue-populator/pkg/controller/controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controller
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -455,7 +454,7 @@ func TestKueuePopulatorReconciler(t *testing.T) {
 				opts...,
 			)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			_, gotErr := reconciler.Reconcile(ctx, tc.req)
 			if diff := cmp.Diff(tc.wantError, gotErr, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("Reconcile() error (-want +got):\n%s", diff)

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/spf13/pflag v1.0.10
 	go.uber.org/mock v0.6.0
 	go.uber.org/zap v1.27.1
-	golang.org/x/exp v0.0.0-20250718183923-645b1fa84792
 	golang.org/x/sync v0.20.0
 	k8s.io/api v0.35.2
 	k8s.io/apiextensions-apiserver v0.35.2
@@ -142,6 +141,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
+	golang.org/x/exp v0.0.0-20250718183923-645b1fa84792 // indirect
 	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package queue
 
 import (
-	"context"
 	"slices"
 	"testing"
 	"time"
@@ -1270,14 +1269,13 @@ func TestFsAdmission(t *testing.T) {
 				builder = builder.WithObjects(&lq)
 			}
 			client := builder.Build()
-			ctx := context.Background()
 
 			afsConsumedResources := queueafs.NewAfsConsumedResources()
 			for lqKey, consumedResources := range tc.initConsumedResources {
 				afsConsumedResources.Set(utilqueue.LocalQueueReference(lqKey), consumedResources, time.Now())
 			}
 
-			cq, _ := newClusterQueue(ctx, client, tc.cq, defaultOrdering, tc.afsConfig, nil, afsConsumedResources)
+			cq, _ := newClusterQueue(t.Context(), client, tc.cq, defaultOrdering, tc.afsConfig, nil, afsConsumedResources)
 			for _, wl := range tc.wls {
 				cq.PushOrUpdate(workload.NewInfo(&wl))
 			}

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -466,7 +466,7 @@ func TestQueueInadmissibleWorkloads(t *testing.T) {
 					moveWorkloadsLogCount++
 				}
 			}, funcr.Options{Verbosity: 2})
-			ctx := logr.NewContext(context.Background(), logger)
+			ctx := logr.NewContext(t.Context(), logger)
 
 			cl := utiltesting.NewFakeClient(utiltesting.MakeNamespace(defaultNamespace))
 			manager, watcher := NewManagerForUnitTestsWithRequeuer(cl, nil)

--- a/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter_test.go
+++ b/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package externalframeworks
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -134,7 +133,7 @@ func TestAdapter_IsJobManagedByKueue(t *testing.T) {
 			client := fake.NewClientBuilder().WithObjects(tt.object).Build()
 			key := types.NamespacedName{Name: "test-job", Namespace: "default"}
 
-			got, gotReason, err := adapter.IsJobManagedByKueue(context.Background(), client, key)
+			got, gotReason, err := adapter.IsJobManagedByKueue(t.Context(), client, key)
 
 			if diff := cmp.Diff(tt.wantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("Adapter.IsJobManagedByKueue() error (-want,+got):\n%s", diff)

--- a/pkg/controller/admissionchecks/multikueue/fswatch_test.go
+++ b/pkg/controller/admissionchecks/multikueue/fswatch_test.go
@@ -147,7 +147,7 @@ func TestFSWatch(t *testing.T) {
 				}
 			}
 			// Using an empty context here to avoid a race condition with the test context when setting the logger.
-			ctx := ctrl.LoggerInto(context.Background(), utiltesting.NewLogger(t))
+			ctx := ctrl.LoggerInto(t.Context(), utiltesting.NewLogger(t))
 			ctx, cancel := context.WithTimeout(ctx, time.Second)
 			wg := sync.WaitGroup{}
 			defer func() {
@@ -204,7 +204,7 @@ func TestFSWatch(t *testing.T) {
 
 func TestFSWatchAddRm(t *testing.T) {
 	// Using an empty context here to avoid a race condition with the test context when setting the logger.
-	ctx := ctrl.LoggerInto(context.Background(), utiltesting.NewLogger(t))
+	ctx := ctrl.LoggerInto(t.Context(), utiltesting.NewLogger(t))
 	ctx, cancel := context.WithCancel(ctx)
 	wg := sync.WaitGroup{}
 	defer func() {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
-	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"

--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -251,7 +251,7 @@ func TestWorkloadPriorityClassReconcile(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 
 			builder := utiltesting.NewClientBuilder().
 				WithObjects(tc.wpc).

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -360,7 +360,6 @@ func TestUpdatePodSets(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
-			ctx := context.Background()
 
 			scheme := runtime.NewScheme()
 			_ = rayv1.AddToScheme(scheme)
@@ -375,7 +374,7 @@ func TestUpdatePodSets(t *testing.T) {
 				WithObjects(objs...).
 				Build()
 
-			gotPodSets, err := UpdatePodSets(ctx, tc.podSets, c, tc.object, tc.enableInTreeAutoscaling, tc.rayClusterName)
+			gotPodSets, err := UpdatePodSets(t.Context(), tc.podSets, c, tc.object, tc.enableInTreeAutoscaling, tc.rayClusterName)
 
 			if tc.wantErr {
 				if err == nil {
@@ -889,7 +888,6 @@ func TestValidateCreateRayClusterSpec(t *testing.T) {
 
 func TestUpdatePodSetsFayCluster_GetError(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
-	ctx := context.Background()
 	scheme := runtime.NewScheme()
 	_ = rayv1.AddToScheme(scheme)
 
@@ -916,7 +914,7 @@ func TestUpdatePodSetsFayCluster_GetError(t *testing.T) {
 		WithEnableAutoscaling(ptr.To(true)).
 		Obj()
 
-	_, err := UpdatePodSets(ctx, podSets, c, object, ptr.To(true), "target-raycluster")
+	_, err := UpdatePodSets(t.Context(), podSets, c, object, ptr.To(true), "target-raycluster")
 
 	if err == nil {
 		t.Error("Expected error but got none")

--- a/pkg/controller/jobs/rayservice/rayservice_webhook_test.go
+++ b/pkg/controller/jobs/rayservice/rayservice_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package rayservice
 
 import (
-	"context"
 	"testing"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
@@ -29,7 +28,6 @@ import (
 )
 
 func TestValidateCreate(t *testing.T) {
-	ctx := context.Background()
 	testCases := map[string]struct {
 		service   *rayv1.RayService
 		manageAll bool
@@ -135,7 +133,7 @@ func TestValidateCreate(t *testing.T) {
 			webhook := &RayServiceWebhook{
 				manageJobsWithoutQueueName: tc.manageAll,
 			}
-			_, err := webhook.ValidateCreate(ctx, tc.service)
+			_, err := webhook.ValidateCreate(t.Context(), tc.service)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("ValidateCreate() error = %v, wantErr %v", err, tc.wantErr)
 			}
@@ -144,7 +142,6 @@ func TestValidateCreate(t *testing.T) {
 }
 
 func TestValidateUpdate(t *testing.T) {
-	ctx := context.Background()
 	testCases := map[string]struct {
 		oldService *rayv1.RayService
 		newService *rayv1.RayService
@@ -200,7 +197,7 @@ func TestValidateUpdate(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			webhook := &RayServiceWebhook{}
-			_, err := webhook.ValidateUpdate(ctx, tc.oldService, tc.newService)
+			_, err := webhook.ValidateUpdate(t.Context(), tc.oldService, tc.newService)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("ValidateUpdate() error = %v, wantErr %v", err, tc.wantErr)
 			}

--- a/pkg/util/roletracker/tracker_test.go
+++ b/pkg/util/roletracker/tracker_test.go
@@ -64,7 +64,7 @@ func TestRoleTracker_StartLeaderElection(t *testing.T) {
 				t.Errorf("Initial role = %q, want %q", got, RoleFollower)
 			}
 
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			done := make(chan struct{})
@@ -132,7 +132,7 @@ func TestOnElected(t *testing.T) {
 				})
 			}
 
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			if tc.closeChannel {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

/area testing

#### What this PR does / why we need it:

Enable `exptostd` and `usetesting` linters. Fix appeared lint issues.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

We need to explicitly enable a few checks from `usetesting` (`os-temp-dir`, `context-background`, `context-todo`) because they are `false` by default.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```