### PR TITLE
Add back Chinese translation for priority boost annotation description

### DIFF
--- a/site/data/labels_and_annotations.yaml
+++ b/site/data/labels_and_annotations.yaml
@@ -215,14 +215,7 @@
   example: '`kueue.x-k8s.io/priority-boost: "10"`'
   used_on: |
     [Workload](/docs/concepts/workload/).
-  description: |
-    An optional signed integer that adjusts a workload's effective priority:
-    `effectivePriority = workloadPriority + priorityBoost`.
-    Positive values increase priority; negative values decrease it.
-    The effective priority is used for both scheduling order and preemption candidate ordering.
-    This annotation is intended to be set directly on Workloads by external controllers (not propagated from Jobs).
-    If the value is missing or empty, it is treated as `0`.
-    If the value is invalid, Workload create or update is **rejected** by the admission webhook.
+  description: labels_and_annotations_priority_boost_description
 
 - key: kueue.x-k8s.io/priority-class
   type: Label

--- a/site/i18n/en.yaml
+++ b/site/i18n/en.yaml
@@ -34,3 +34,12 @@
   translation: "Yes"
 - id: feedback_negative
   translation: "No"
+- id: labels_and_annotations_priority_boost_description
+  translation: |
+    An optional signed integer that adjusts a workload's effective priority:
+    `effectivePriority = workloadPriority + priorityBoost`.
+    Positive values increase priority; negative values decrease it.
+    The effective priority is used for both scheduling order and preemption candidate ordering.
+    This annotation is intended to be set directly on Workloads by external controllers (not propagated from Jobs).
+    If the value is missing or empty, it is treated as `0`.
+    If the value is invalid, Workload create or update is **rejected** by the admission webhook.

--- a/site/i18n/zh-CN.yaml
+++ b/site/i18n/zh-CN.yaml
@@ -34,3 +34,11 @@
   translation: "满意"
 - id: feedback_negative
   translation: "不满意"
+- id: labels_and_annotations_priority_boost_description
+  translation: |
+    可选的有符号整数注解，用于调整工作负载的有效优先级：
+    `effectivePriority = workloadPriority + priorityBoost`。
+    正值提高优先级，负值降低优先级。
+    有效优先级同时用于调度排序和抢占候选排序。
+    此注解由外部控制器直接设置在 Workload 上（不从 Job 传播）。
+    如果值缺失或非法，会按 `0` 处理。

--- a/site/layouts/shortcodes/labels-and-annotations.html
+++ b/site/layouts/shortcodes/labels-and-annotations.html
@@ -9,7 +9,11 @@
 
 <p>Used on: {{ $.Page.RenderString .used_on }}</p>
 
-<p>{{ $.Page.RenderString .description }}</p>
+{{ $desc := i18n .description }}
+{{ if hasPrefix $desc "[i18n]" }}
+{{ $desc = .description }}
+{{ end }}
+<p>{{ $.Page.RenderString $desc }}</p>
 
 {{ if .note }}
 <div class="alert alert-primary" role="note">


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

/kind documentation

#### What this PR does / why we need it:
Adds back Chinese translation for priority boost annotation description.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10030

#### Special notes for your reviewer:
I used the `i18n` function to resolve the description translation, falling back to the original value when no translation is available.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```