### PR TITLE
Fix nil pointer panic in TAS node reconciler for unadmitted workloads

### DIFF
--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -319,7 +319,7 @@ func (r *nodeReconciler) getWorkloadsOnNode(ctx context.Context, nodeName string
 			continue
 		}
 		wlKey := types.NamespacedName{Name: wl.Name, Namespace: wl.Namespace}
-		if utiltas.HasTASAssignmentOnNode(wl.Status.Admission.PodSetAssignments, nodeName) {
+		if wl.Status.Admission != nil && utiltas.HasTASAssignmentOnNode(wl.Status.Admission.PodSetAssignments, nodeName) {
 			tasWorkloadsOnNode.Insert(wlKey)
 			continue
 		}

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -1427,6 +1427,62 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 			})
+			ginkgo.It("should not panic when unadmitted workload exists during node deletion", func() {
+				var wl1, wl2 *kueue.Workload
+				nodeName := nodes[0].Name
+
+				ginkgo.By("creating a workload that gets admitted", func() {
+					wl1 = utiltestingapi.MakeWorkload("wl1", ns.Name).
+						PodSets(*utiltestingapi.MakePodSet("worker", 2).
+							PreferredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+							Obj()).
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
+					util.MustCreate(ctx, k8sClient, wl1)
+				})
+
+				ginkgo.By("verify the first workload is admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+				})
+
+				ginkgo.By("creating a second workload that stays pending (not enough resources)", func() {
+					wl2 = utiltestingapi.MakeWorkload("wl2", ns.Name).
+						PodSets(*utiltestingapi.MakePodSet("worker", 10).
+							PreferredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+							Obj()).
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
+					util.MustCreate(ctx, k8sClient, wl2)
+				})
+
+				ginkgo.By("verify the second workload is pending (unadmitted, nil Admission)", func() {
+					util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
+				})
+
+				ginkgo.By("deleting the node to trigger node reconciliation", func() {
+					nodeToDelete := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+					gomega.Expect(k8sClient.Delete(ctx, nodeToDelete)).Should(gomega.Succeed())
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, nodeToDelete, false)
+				})
+
+				ginkgo.By("verify the admitted workload is updated without panic", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), wl1)).To(gomega.Succeed())
+						g.Expect(wl1.Status.Admission).NotTo(gomega.BeNil())
+						g.Expect(wl1.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+							utiltas.V1Beta2From(&utiltas.TopologyAssignment{
+								Levels: []string{corev1.LabelHostname},
+								Domains: []utiltas.TopologyDomainAssignment{
+									{Count: 1, Values: []string{"x1"}},
+									{Count: 1, Values: []string{"x4"}},
+								},
+							}),
+						))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("verify the pending workload is still pending", func() {
+					util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
+				})
+			})
 			ginkgo.It("should remove node from unhealthyNodes when the node recovers", func() {
 				var wl1 *kueue.Workload
 				nodeName := nodes[0].Name


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

The `getWorkloadsOnNode` function in the TAS node reconciler iterates over all workloads in the cluster but accesses `wl.Status.Admission.PodSetAssignments` without checking if `Admission` is nil. Workloads that haven't been admitted yet (e.g., pending in the queue) have a nil `Admission` field, causing a nil pointer panic whenever any node is reconciled.

This PR adds a nil check for `wl.Status.Admission` before accessing `PodSetAssignments`, and adds an integration test that reproduces the issue by creating an unadmitted workload alongside an admitted one, then deleting a node.

#### Which issue(s) this PR fixes:

Fixes #10033

#### Special notes for your reviewer:

The fix is a single nil guard on line 322 of `pkg/controller/tas/node_controller.go`. The integration test was verified to fail without the fix (panic) and pass with it.

#### Does this PR introduce a user-facing change?

```release-note
TAS: Fix nil pointer panic in TAS node reconciler when unadmitted workloads exist in the cluster.
```

---
> **AI Assistance Disclosure**: This pull request was created with the assistance of AI (Claude Code by Anthropic).