### PR TITLE
Add integration test reproducing startJob Patch conflict race

### DIFF
--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -33,6 +33,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
@@ -1234,5 +1235,77 @@ func TestReconcileGenericJobWithWaitForPodsReady(t *testing.T) {
 				t.Errorf("unexpected reconcile error want %s got %s)", tc.wantError, err)
 			}
 		})
+	}
+}
+
+// Regression test for https://github.com/kubernetes-sigs/kueue/issues/10040.
+func TestStartJobRetriesOnConflict(t *testing.T) {
+	var (
+		testJobName        = "test-job"
+		testLocalQueueName = kueue.LocalQueueName("test-lq")
+		testGVK            = batchv1.SchemeGroupVersion.WithKind("Job")
+	)
+
+	testJob := testingjob.MakeJob(testJobName, metav1.NamespaceDefault).
+		UID(testJobName).Queue(testLocalQueueName).Suspend(true).Obj()
+
+	admission := utiltestingapi.MakeAdmission("test-cq").Obj()
+	now := time.Now()
+	wl := utiltestingapi.MakeWorkload("job-test-job", metav1.NamespaceDefault).
+		ResourceVersion("1").
+		Finalizers(kueue.ResourceInUseFinalizerName).
+		Label(constants.JobUIDLabel, testJobName).
+		ControllerReference(testGVK, testJobName, testJobName).
+		Queue(testLocalQueueName).
+		PodSets(*utiltestingapi.MakePodSet("main", 1).Obj()).
+		Priority(0).
+		ReserveQuotaAt(admission, now).
+		AdmittedAt(true, now).
+		Obj()
+
+	ctx, _ := utiltesting.ContextWithLog(t)
+	mockctrl := gomock.NewController(t)
+
+	mgj := mocks.NewMockGenericJob(mockctrl)
+	mgj.EXPECT().Object().Return(testJob).AnyTimes()
+	mgj.EXPECT().GVK().Return(testGVK).AnyTimes()
+	mgj.EXPECT().IsSuspended().Return(true).AnyTimes()
+	mgj.EXPECT().IsActive().Return(false).AnyTimes()
+	mgj.EXPECT().Finished(gomock.Any()).Return("", false, false).AnyTimes()
+	mgj.EXPECT().PodSets(gomock.Any()).Return([]kueue.PodSet{
+		*utiltestingapi.MakePodSet("main", 1).Obj(),
+	}, nil).AnyTimes()
+	mgj.EXPECT().RunWithPodSetsInfo(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	patchCalls := 0
+	cl := utiltesting.NewClientBuilder(batchv1.AddToScheme, kueue.AddToScheme).
+		WithObjects(utiltesting.MakeNamespace(metav1.NamespaceDefault)).
+		WithObjects(testJob, wl).
+		WithIndex(&kueue.Workload{}, indexer.OwnerReferenceIndexKey(testGVK), indexer.WorkloadOwnerIndexFunc(testGVK)).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if _, ok := obj.(*batchv1.Job); ok {
+					patchCalls++
+					if patchCalls == 1 {
+						return apierrors.NewConflict(
+							schema.GroupResource{Group: "batch", Resource: "jobs"},
+							testJobName,
+							errors.New("object was modified"),
+						)
+					}
+				}
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	recorder := &utiltesting.EventRecorder{}
+	_, err := NewReconciler(cl, recorder).ReconcileGenericJob(
+		ctx, controllerruntime.Request{NamespacedName: types.NamespacedName{Name: testJobName, Namespace: metav1.NamespaceDefault}}, mgj)
+	if err != nil {
+		t.Fatalf("ReconcileGenericJob should retry on conflict but failed: %v", err)
+	}
+	if patchCalls < 2 {
+		t.Errorf("expected at least 2 Patch attempts (1 conflict + 1 retry), got %d", patchCalls)
 	}
 }

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package rayjob
 
 import (
+	"context"
 	"fmt"
+	"sync/atomic"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -27,10 +29,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -709,3 +714,95 @@ var _ = ginkgo.Describe("Job controller with preemption enabled", ginkgo.Ordered
 		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 	})
 })
+
+// Regression test for https://github.com/kubernetes-sigs/kueue/issues/10040
+var _ = ginkgo.Describe("Job controller startJob conflict retry",
+	ginkgo.Label("job:ray", "area:jobs"), ginkgo.Ordered, func() {
+
+		var conflictsRemaining atomic.Int32
+
+		ginkgo.BeforeAll(func() {
+			fwk.StartManager(ctx, cfg, managerSetup(), framework.WithNewClient(func(cfg *rest.Config, opts client.Options) (client.Client, error) {
+				baseClient, err := client.NewWithWatch(cfg, opts)
+				if err != nil {
+					return nil, err
+				}
+				return interceptor.NewClient(baseClient, interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, patchOpts ...client.PatchOption) error {
+						if _, ok := obj.(*rayv1.RayJob); ok && conflictsRemaining.Add(-1) >= 0 {
+							return errors.NewConflict(
+								schema.GroupResource{Group: "ray.io", Resource: "rayjobs"},
+								obj.GetName(),
+								fmt.Errorf("simulated concurrent modification"),
+							)
+						}
+						return c.Patch(ctx, obj, patch, patchOpts...)
+					},
+				}), nil
+			}))
+		})
+
+		ginkgo.AfterAll(func() {
+			fwk.StopManager(ctx)
+		})
+
+		var ns *corev1.Namespace
+		ginkgo.BeforeEach(func() {
+			ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "conflict-")
+			conflictsRemaining.Store(0)
+		})
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		})
+
+		ginkgo.It("Should unsuspend RayJob despite Patch conflicts from concurrent controllers", func() {
+			job := testingrayjob.MakeJob(jobName, ns.Name).
+				Suspend(false).
+				Queue("test-queue").
+				Obj()
+			util.MustCreate(ctx, k8sClient, job)
+			setInitStatus(jobName, ns.Name)
+
+			createdJob := &rayv1.RayJob{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), createdJob)).Should(gomega.Succeed())
+				g.Expect(createdJob.Spec.Suspend).Should(gomega.BeTrue())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			createdWorkload := &kueue.Workload{}
+			wlLookupKey := types.NamespacedName{Name: workloadrayjob.GetWorkloadNameForRayJob(job.Name, job.UID), Namespace: ns.Name}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("injecting 12 Patch conflicts then admitting the workload")
+			conflictsRemaining.Store(12)
+
+			onDemandFlavor := utiltestingapi.MakeResourceFlavor("on-demand").NodeLabel(instanceKey, "on-demand").Obj()
+			util.MustCreate(ctx, k8sClient, onDemandFlavor)
+			defer func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
+			}()
+			admission := utiltestingapi.MakeAdmission("cluster-queue").PodSets(
+				kueue.PodSetAssignment{
+					Name: createdWorkload.Spec.PodSets[0].Name,
+					Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+						corev1.ResourceCPU: "on-demand",
+					},
+				}, kueue.PodSetAssignment{
+					Name: createdWorkload.Spec.PodSets[1].Name,
+					Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+						corev1.ResourceCPU: "on-demand",
+					},
+				},
+			).Obj()
+			util.SetQuotaReservation(ctx, k8sClient, wlLookupKey, admission)
+			util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+
+			ginkgo.By("checking the job gets unsuspended despite conflicts")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), createdJob)).Should(gomega.Succeed())
+				g.Expect(createdJob.Spec.Suspend).Should(gomega.BeFalse())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})


### PR DESCRIPTION
## What type of PR is this?

/kind bug
/area jobs

## What this PR does / why we need it

Adds tests that reproduce the startJob Patch conflict race condition described in #10040. Both tests **fail without the fix**, serving as regression tests.

**Unit test** (`TestStartJobRetriesOnConflict`): Injects a single Patch conflict via interceptor and asserts that `ReconcileGenericJob` retries and succeeds.

**Integration test** (`Job controller startJob conflict retry`): Injects 12 consecutive Patch conflicts for RayJob objects via a manager-level client interceptor. After admitting a workload, asserts the job gets unsuspended (`Eventually(Suspend=false)`) within the test timeout. Without retry-on-conflict, exponential backoff accumulates to ~20s, exceeding the 10s timeout.

## Which issue(s) this PR fixes

Ref #10040

## Does this PR introduce a user-facing change?

```release-note
NONE
```

## Additional context

Companion to #10041 (which contains the fix). The tests assert the correct behavior — both fail on current main, demonstrating the bug.

The conflict race occurs in MultiKueue + KubeRay deployments where three controllers write to the same job object during the admission-to-unsuspend window, causing `clientutil.Patch` to fail with 409 Conflict. Without retry, each failure triggers controller-runtime exponential backoff (5ms base, doubling), keeping the job suspended for extended periods.