### PR TITLE
Apply ShouldSkipLocalExecution to all job types, not just ComposableJob

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1252,18 +1252,14 @@ func (r *JobReconciler) startJob(ctx context.Context, job GenericJob, object cli
 
 	log := ctrl.LoggerFrom(ctx)
 	if features.Enabled(features.MultiKueue) {
-		_, isComposable := job.(ComposableJob)
-
-		if isComposable {
-			skip, err := admissioncheck.ShouldSkipLocalExecution(ctx, r.client, wl)
-			if err != nil {
-				log.V(3).Info("Failed to check for MultiKueue admission check", "workload", klog.KObj(wl), "error", err)
-				return err
-			}
-			if skip {
-				log.V(3).Info("Workload has MultiKueue admission check, skipping local execution", "workload", klog.KObj(wl))
-				return nil
-			}
+		skip, err := admissioncheck.ShouldSkipLocalExecution(ctx, r.client, wl)
+		if err != nil {
+			log.V(3).Info("Failed to check for MultiKueue admission check", "workload", klog.KObj(wl), "error", err)
+			return err
+		}
+		if skip {
+			log.V(3).Info("Workload has MultiKueue admission check, skipping local execution", "workload", klog.KObj(wl))
+			return nil
 		}
 	}
 

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -1236,3 +1236,80 @@ func TestReconcileGenericJobWithWaitForPodsReady(t *testing.T) {
 		})
 	}
 }
+
+// Regression test for https://github.com/kubernetes-sigs/kueue/issues/10040.
+// Verifies that ShouldSkipLocalExecution applies to all job types, not just ComposableJob.
+// Without the fix, startJob runs on the manager for non-ComposableJob types (e.g., RayJob),
+// creating a 2-way race between startJob and SyncJob on the local job object.
+func TestStartJobSkippedForMultiKueueNonComposableJob(t *testing.T) {
+	var (
+		testJobName        = "test-job"
+		testLocalQueueName = kueue.LocalQueueName("test-lq")
+		testGVK            = batchv1.SchemeGroupVersion.WithKind("Job")
+		testACName         = "multikueue-check"
+	)
+
+	features.SetFeatureGateDuringTest(t, features.MultiKueue, true)
+
+	testJob := testingjob.MakeJob(testJobName, metav1.NamespaceDefault).
+		UID(testJobName).Queue(testLocalQueueName).Suspend(true).Obj()
+
+	ac := utiltestingapi.MakeAdmissionCheck(testACName).
+		ControllerName(kueue.MultiKueueControllerName).
+		Obj()
+
+	now := time.Now()
+	admission := utiltestingapi.MakeAdmission("test-cq").Obj()
+	wl := utiltestingapi.MakeWorkload("job-test-job", metav1.NamespaceDefault).
+		ResourceVersion("1").
+		Finalizers(kueue.ResourceInUseFinalizerName).
+		Label(constants.JobUIDLabel, testJobName).
+		ControllerReference(testGVK, testJobName, testJobName).
+		Queue(testLocalQueueName).
+		PodSets(*utiltestingapi.MakePodSet("main", 1).Obj()).
+		Priority(0).
+		ReserveQuotaAt(admission, now).
+		AdmittedAt(true, now).
+		AdmissionCheck(kueue.AdmissionCheckState{
+			Name:  kueue.AdmissionCheckReference(testACName),
+			State: kueue.CheckStateReady,
+		}).
+		Obj()
+
+	ctx, _ := utiltesting.ContextWithLog(t)
+	mockctrl := gomock.NewController(t)
+
+	mgj := mocks.NewMockGenericJob(mockctrl)
+	mgj.EXPECT().Object().Return(testJob).AnyTimes()
+	mgj.EXPECT().GVK().Return(testGVK).AnyTimes()
+	mgj.EXPECT().IsSuspended().Return(true).AnyTimes()
+	mgj.EXPECT().IsActive().Return(false).AnyTimes()
+	mgj.EXPECT().Finished(gomock.Any()).Return("", false, false).AnyTimes()
+	mgj.EXPECT().PodSets(gomock.Any()).Return([]kueue.PodSet{
+		*utiltestingapi.MakePodSet("main", 1).Obj(),
+	}, nil).AnyTimes()
+	// RunWithPodSetsInfo should NOT be called — startJob should be skipped.
+	mgj.EXPECT().RunWithPodSetsInfo(gomock.Any(), gomock.Any()).Times(0)
+
+	cl := utiltesting.NewClientBuilder(batchv1.AddToScheme, kueue.AddToScheme).
+		WithObjects(utiltesting.MakeNamespace(metav1.NamespaceDefault)).
+		WithObjects(testJob, wl, ac).
+		WithIndex(&kueue.Workload{}, indexer.OwnerReferenceIndexKey(testGVK), indexer.WorkloadOwnerIndexFunc(testGVK)).
+		Build()
+
+	recorder := &utiltesting.EventRecorder{}
+	_, err := NewReconciler(cl, recorder).ReconcileGenericJob(
+		ctx, controllerruntime.Request{NamespacedName: types.NamespacedName{Name: testJobName, Namespace: metav1.NamespaceDefault}}, mgj)
+	if err != nil {
+		t.Fatalf("ReconcileGenericJob failed: %v", err)
+	}
+
+	// Verify the job is still suspended.
+	var updatedJob batchv1.Job
+	if err := cl.Get(ctx, types.NamespacedName{Name: testJobName, Namespace: metav1.NamespaceDefault}, &updatedJob); err != nil {
+		t.Fatalf("Failed to get job: %v", err)
+	}
+	if !ptr.Deref(updatedJob.Spec.Suspend, false) {
+		t.Error("Job should remain suspended when workload has MultiKueue admission check, but it was unsuspended")
+	}
+}


### PR DESCRIPTION
## What type of PR is this?

/kind bug
/area multikueue

## What this PR does / why we need it

`ShouldSkipLocalExecution` in `startJob` was gated behind `isComposable`, so non-ComposableJob types like RayJob always ran `startJob` on the manager cluster — even when the workload had a MultiKueue admission check.

Since RayJobs on the manager have `managedBy=kueue.x-k8s.io/multikueue` set (KubeRay skips them), the only concurrent writers on the local RayJob were `startJob` and `SyncJob` — a 2-way race. Each write bumps `resourceVersion`, causing the other's strict MergePatch to fail with 409 Conflict.

The conflict self-resolves (startJob stops once it succeeds), but the error storm (133 startJob conflicts + 264 multikueue errors in 2.5h) makes the system look broken and can trigger operational responses (controller restarts) that cause real damage — restarting the controller drops remote cluster connections, and workloads whose AC was already `CheckStateReady` get evicted after `workerLostTimeout` (15 min) with "Reserving remote lost".

Beyond the conflicts, startJob running on the manager is architecturally wrong — the job should only be unsuspended on the worker.

### The fix

Remove the `isComposable` gate so `ShouldSkipLocalExecution` applies to all job types with a MultiKueue admission check. This eliminates startJob on the manager entirely — zero conflicts, zero error noise.

### Why removing the gate entirely

The gate was introduced in #8189 as `isComposable || isBatchJobWithoutManagedBy`. The idea was that `managedBy` on the job already prevents external controllers from touching it, making `ShouldSkipLocalExecution` redundant.

When `MultiKueueBatchJobWithManagedBy` went GA, `isBatchJobWithoutManagedBy` was always false and got removed, leaving only `isComposable` — which covers only Pod (the sole ComposableJob implementer). All other 17 job types with MultiKueue adapters (batch Job, RayJob, MPIJob, PyTorchJob, JobSet, etc.) were unprotected.

I considered three approaches:

1. **Remove the gate entirely** (this PR) — `ShouldSkipLocalExecution` applies to all job types
2. **Add RayJob explicitly** — fragile, every new job type risks the same bug
3. **Check if `managedBy` is set, fall back otherwise** — more complex, `GenericJob` doesn't expose `managedBy`

Option 1 is the right choice because:

- `ShouldSkipLocalExecution` is cheap (one `client.Get` on the AdmissionCheck, served from informer cache)
- `managedBy` and `ShouldSkipLocalExecution` protect against different things: `managedBy` stops external controllers, `ShouldSkipLocalExecution` stops the jobframework reconciler. Defense in depth
- No future job type integration can regress this path

### Production evidence

MultiKueue setup (1 manager, 4 workers) with KubeRay v1.5.0, v0.16.4 upgrade (2.5h window before rollback):

| Metric | v0.13.3 (4 hours) | v0.16.4 (2.5 hours) |
|--------|-------------------|---------------------|
| startJob conflicts | 17 (workers only, self-healed) | 133 (on manager — shouldn't happen) |
| MultiKueue reconciler errors | ~20 | 264 |
| Evictions | 0 | 23 (from controller restarts during debugging) |

The evictions were caused by controller restarts dropping remote connections, not directly by the conflicts. But the error storm from the bug is what prompted the restarts.

## Which issue(s) this PR fixes

Fixes #10040

## Does this PR introduce a user-facing change?

```release-note
Fixed ShouldSkipLocalExecution to apply to all job types in MultiKueue, not just ComposableJob. Previously, non-ComposableJob types (e.g., RayJob) always ran startJob on the manager, causing Patch conflicts with SyncJob and error noise that could lead to operational issues.
```