### PR TITLE
bug: IsExplicitlyRequestingTAS ignores PodsetSliceRequiredTopologyConstraints

### DIFF
--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -451,7 +451,7 @@ func IsExplicitlyRequestingTAS(podSets ...kueue.PodSet) bool {
 	return slices.ContainsFunc(podSets,
 		func(ps kueue.PodSet) bool {
 			tr := ps.TopologyRequest
-			return tr != nil && (tr.Unconstrained != nil || tr.Required != nil || tr.Preferred != nil || tr.PodSetSliceRequiredTopology != nil || tr.PodSetSliceSize != nil)
+			return tr != nil && (tr.Unconstrained != nil || tr.Required != nil || tr.Preferred != nil || tr.PodSetSliceRequiredTopology != nil || tr.PodSetSliceSize != nil || len(tr.PodsetSliceRequiredTopologyConstraints) > 0)
 		})
 }
 

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -2979,3 +2979,43 @@ func TestUsedNodes(t *testing.T) {
 		})
 	}
 }
+
+func TestIsExplicitlyRequestingTAS(t *testing.T) {
+	cases := map[string]struct {
+		podSets []kueue.PodSet
+		want    bool
+	}{
+		"podset slice required topology constraints only": {
+			podSets: []kueue.PodSet{
+				{
+					TopologyRequest: &kueue.PodSetTopologyRequest{
+						PodsetSliceRequiredTopologyConstraints: []kueue.PodsetSliceRequiredTopologyConstraint{
+							{
+								Topology: "cloud.provider.com/topology-rack",
+								Size:     4,
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		"empty topology request": {
+			podSets: []kueue.PodSet{
+				{
+					TopologyRequest: &kueue.PodSetTopologyRequest{},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := IsExplicitlyRequestingTAS(tc.podSets...)
+			if got != tc.want {
+				t.Errorf("IsExplicitlyRequestingTAS() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

When only `podset-slice-required-topology-constraints` annotation is set, `IsExplicitlyRequestingTAS()` returns false, and hence multi-layer topology request will be silently ignored in non-TAS-only ClusterQueues.

In reality this is a corner case b/c we usually set the top-level `podset-required-topology` to "datacenter" or other topology, which evaluates `IsExplicitlyRequestingTAS()` to true. But we'd better not make that assumption.

#### Which issue(s) this PR fixes:

Part of #9046 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```