### PR TITLE
docs: clarify deprecation status and future removal of the `--visibil…

### DIFF
--- a/site/content/en/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand.md
+++ b/site/content/en/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand.md
@@ -76,7 +76,7 @@ If you disable the feature, you also need to remove the associated `APIService` 
 
 If you need the embedded visibility server to run on a different port, you can use the Configuration API `visibilityServer.bindPort`.
 
-Alternatively, you can use the `--visibility-server-port` flag when running the Kueue controller manager. For example: `--visibility-server-port=8443`. However, this option is deprecated as of 0.17 and will be removed in the future.
+(Deprecated as of 0.17, to be removed in the future) Alternatively, you can use the `--visibility-server-port` flag when running the Kueue controller manager. For example: `--visibility-server-port=8443`.
 
 {{% /alert %}}
 

--- a/site/content/zh-CN/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand.md
+++ b/site/content/zh-CN/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand.md
@@ -76,7 +76,7 @@ If you disable the feature, you also need to remove the associated `APIService` 
 
 If you need the embedded visibility server to run on a different port, you can use the Configuration API `visibilityServer.bindPort`.
 
-Alternatively, you can use the `--visibility-server-port` flag when running the Kueue controller manager. For example: `--visibility-server-port=8443`. However, this option is deprecated as of 0.17 and will be removed in the future.
+(Deprecated as of 0.17, to be removed in the future) Alternatively, you can use the `--visibility-server-port` flag when running the Kueue controller manager. For example: `--visibility-server-port=8443`.
 
 {{% /alert %}}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Update the doc to deprecate `visibility-server-port` in 0.17.

#### Which issue(s) this PR fixes:
Fixes #

#### Does this PR introduce a user-facing change?
NONE

```release-note
NONE
```