### PR TITLE
Strip managedFields from informer cache to reduce memory footprint

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -104,6 +104,12 @@ func addCacheByObjectTo(o *ctrl.Options, cfg *configapi.Configuration) {
 		return
 	}
 
+	// Strip managedFields from all cached objects to reduce memory usage.
+	// ManagedFields are server-side apply tracking metadata that no kueue
+	// controller reads at runtime, and they can account for 30-50% of
+	// cached object size.
+	o.Cache.DefaultTransform = ctrlcache.TransformStripManagedFields()
+
 	if o.Cache.ByObject == nil {
 		o.Cache.ByObject = make(map[ctrlclient.Object]ctrlcache.ByObject)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -380,6 +380,9 @@ objectRetentionPolicies:
 		cmpopts.IgnoreUnexported(net.ListenConfig{}),
 		cmpopts.IgnoreFields(ctrl.Options{}, "Scheme", "Logger"),
 		cmpopts.IgnoreFields(webhook.Options{}, "TLSOpts"),
+		// DefaultTransform is a function and cannot be compared with cmp.Diff;
+		// it is tested separately in TestDefaultTransformStripsManagedFields.
+		cmpopts.IgnoreFields(ctrlcache.Options{}, "DefaultTransform"),
 	}
 
 	// Ignore the controller manager section since it's side effect is checked against
@@ -860,6 +863,9 @@ objectRetentionPolicies:
 				}
 				if diff := cmp.Diff(tc.wantOptions, options, ctrlOptsCmpOpts...); diff != "" {
 					t.Errorf("Unexpected options (-want +got):\n%s", diff)
+				}
+				if options.Cache.DefaultTransform == nil {
+					t.Error("Expected DefaultTransform to be set, got nil")
 				}
 			} else {
 				if diff := cmp.Diff(tc.wantError.Error(), err.Error()); diff != "" {
@@ -1393,6 +1399,101 @@ func TestConfigureClusterProfileCache(t *testing.T) {
 
 			if err == nil {
 				t.Error("Expected error but got none")
+			}
+		})
+	}
+}
+
+func TestDefaultTransformStripsManagedFields(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	if err := configapi.AddToScheme(testScheme); err != nil {
+		t.Fatal(err)
+	}
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configFile, []byte(`
+apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+namespace: kueue-system
+`), os.FileMode(0600)); err != nil {
+		t.Fatal(err)
+	}
+
+	options, _, err := Load(testScheme, configFile)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+	if options.Cache.DefaultTransform == nil {
+		t.Fatal("DefaultTransform is nil, cannot test transform behavior")
+	}
+
+	testCases := map[string]struct {
+		pod     *corev1.Pod
+		wantPod *corev1.Pod
+	}{
+		"strips managedFields and preserves object data": {
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Labels:    map[string]string{"app": "test"},
+					Annotations: map[string]string{
+						"note": "keep-me",
+					},
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{
+							Manager:   "kubectl",
+							Operation: metav1.ManagedFieldsOperationApply,
+						},
+						{
+							Manager:   "kube-controller-manager",
+							Operation: metav1.ManagedFieldsOperationUpdate,
+						},
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "node-1",
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-pod",
+					Namespace:   "default",
+					Labels:      map[string]string{"app": "test"},
+					Annotations: map[string]string{"note": "keep-me"},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "node-1",
+				},
+			},
+		},
+		"no-op when managedFields already nil": {
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			result, err := options.Cache.DefaultTransform(tc.pod)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			got, ok := result.(*corev1.Pod)
+			if !ok {
+				t.Fatal("DefaultTransform returned unexpected type")
+			}
+			if diff := cmp.Diff(tc.wantPod, got); diff != "" {
+				t.Errorf("Unexpected pod after transform (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Sets `DefaultTransform` to `TransformStripManagedFields()` on the
controller-runtime cache, stripping `metadata.managedFields` from all
objects before they enter the informer store.

Audit that outside of unit tests managedFields is [not used](https://github.com/search?q=repo%3Akubernetes-sigs%2Fkueue+managedFields+language%3AGo&type=code&l=Go). There was one other attempt to [strip these fields](https://github.com/kubernetes-sigs/kueue/pull/8342/changes) when comparing whether Node objects have changed 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Strip managedFields from informer cache via DefaultTransform to reduce memory footprint on large clusters.
```