### PR TITLE
Clear metrics after deleting an implicit Cohort.

### DIFF
--- a/pkg/cache/hierarchy/cohort.go
+++ b/pkg/cache/hierarchy/cohort.go
@@ -87,7 +87,7 @@ func (c *Cohort[CQ, C]) hasChildren() bool {
 	return c.childCqs.Len()+c.childCohorts.Len() > 0
 }
 
-func (c *Cohort[CQ, C]) isExplicit() bool {
+func (c *Cohort[CQ, C]) IsExplicit() bool {
 	return c.explicit
 }
 

--- a/pkg/cache/hierarchy/manager.go
+++ b/pkg/cache/hierarchy/manager.go
@@ -80,7 +80,7 @@ func (m *Manager[CQ, C]) DeleteClusterQueue(name kueue.ClusterQueueReference) {
 
 func (m *Manager[CQ, C]) AddCohort(cohortName kueue.CohortReference) {
 	oldCohort, ok := m.cohorts[cohortName]
-	if ok && oldCohort.isExplicit() {
+	if ok && oldCohort.IsExplicit() {
 		return
 	}
 	if !ok {
@@ -163,7 +163,7 @@ func (m *Manager[CQ, C]) getOrCreateCohort(cohortName kueue.CohortReference) C {
 }
 
 func (m *Manager[CQ, C]) cleanupCohort(cohort C) {
-	if !cohort.isExplicit() && !cohort.hasChildren() {
+	if !cohort.IsExplicit() && !cohort.hasChildren() {
 		delete(m.cohorts, cohort.GetName())
 	}
 }
@@ -200,7 +200,7 @@ type cohortNode[CQ nodeBase[kueue.ClusterQueueReference], C nodeBase[kueue.Cohor
 	deleteClusterQueue(CQ)
 	hasChildren() bool
 	ChildCQs() []CQ
-	isExplicit() bool
+	IsExplicit() bool
 	markExplicit()
 	nodeBase[kueue.CohortReference]
 }

--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -484,6 +484,7 @@ func (c *Cache) UpdateClusterQueue(log logr.Logger, cq *kueue.ClusterQueue) erro
 	if err := cqImpl.updateClusterQueue(log, cq, c.resourceFlavors, c.admissionChecks, oldParent); err != nil {
 		return err
 	}
+	c.handleParentUpdate(oldParent)
 	for _, qImpl := range cqImpl.localQueues {
 		if qImpl == nil {
 			return errQNotFound
@@ -516,9 +517,10 @@ func (c *Cache) DeleteClusterQueue(cq *kueue.ClusterQueue) {
 	c.hm.DeleteClusterQueue(cqName)
 	metrics.ClearCacheMetrics(cq.Name)
 
-	// Update cohort resources after deletion
 	if parent != nil {
+		// Update cohort resources after deletion
 		updateCohortTreeResourcesIfNoCycle(parent)
+		c.handleParentUpdate(parent)
 	}
 }
 
@@ -530,18 +532,27 @@ func (c *Cache) AddOrUpdateCohort(apiCohort *kueue.Cohort) error {
 	cohort := c.hm.Cohort(cohortName)
 	oldParent := cohort.Parent()
 	c.hm.UpdateCohortEdge(cohortName, apiCohort.Spec.ParentName)
-	return cohort.updateCohort(apiCohort, oldParent)
+	err := cohort.updateCohort(apiCohort, oldParent)
+	if err != nil {
+		return err
+	}
+	c.handleParentUpdate(oldParent)
+	return nil
 }
 
 func (c *Cache) DeleteCohort(cohortName kueue.CohortReference) {
 	c.Lock()
 	defer c.Unlock()
 
+	var parent *cohort
 	if cohort := c.hm.Cohort(cohortName); cohort != nil {
 		cohort.updateAdmittedWorkloadsCount(-cohort.admittedWorkloadsCount)
+		metrics.ClearCohortAdmittedWorkloadsMetrics(cohort.Name)
+		parent = cohort.Parent()
 	}
 
 	c.hm.DeleteCohort(cohortName)
+	c.handleParentUpdate(parent)
 
 	// If the cohort still exists after deletion, it means
 	// that it has one or more children referencing it.
@@ -549,6 +560,21 @@ func (c *Cache) DeleteCohort(cohortName kueue.CohortReference) {
 	if cohort := c.hm.Cohort(cohortName); cohort != nil {
 		updateCohortResourceNode(cohort)
 	}
+}
+
+func (c *Cache) handleParentUpdate(cachedParent *cohort) {
+	if cachedParent == nil {
+		return
+	}
+	if updatedParent := c.hm.Cohort(cachedParent.Name); updatedParent != nil {
+		if updatedParent.IsExplicit() {
+			return
+		}
+		if len(updatedParent.ChildCohorts()) > 0 || len(updatedParent.ChildCQs()) > 0 {
+			return
+		}
+	}
+	metrics.ClearCohortAdmittedWorkloadsMetrics(cachedParent.Name)
 }
 
 func (c *Cache) AddLocalQueue(q *kueue.LocalQueue) error {

--- a/pkg/controller/core/cohort_controller.go
+++ b/pkg/controller/core/cohort_controller.go
@@ -185,7 +185,6 @@ func (r *CohortReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			r.cache.DeleteCohort(kueue.CohortReference(req.Name))
 			r.qManager.DeleteCohort(kueue.CohortReference(req.Name))
 			metrics.ClearCohortMetrics(kueue.CohortReference(req.Name))
-			metrics.ClearCohortAdmittedWorkloadsMetrics(kueue.CohortReference(req.Name))
 			if features.Enabled(features.CustomMetricLabels) {
 				r.customLabels.CohortDelete(kueue.CohortReference(req.Name))
 			}

--- a/test/integration/singlecluster/scheduler/fairsharing/metrics_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/metrics_test.go
@@ -28,7 +28,6 @@ import (
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/metrics"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/test/util"
@@ -73,8 +72,8 @@ var _ = ginkgo.Describe("Cohorts", func() {
 	}
 
 	var createWorkload = func(wl *kueue.Workload) *kueue.Workload {
-		wls[wl.Name] = wl
 		util.MustCreate(ctx, k8sClient, wl)
+		wls[wl.Name] = wl
 		return wl
 	}
 
@@ -125,7 +124,6 @@ var _ = ginkgo.Describe("Cohorts", func() {
 				util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
 			}
 			for _, cohort := range cohorts {
-				metrics.ClearCohortMetrics(kueue.CohortReference(cohort.Name))
 				util.ExpectObjectToBeDeleted(ctx, k8sClient, cohort, true)
 			}
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, defaultFlavor, true)
@@ -458,7 +456,7 @@ var _ = ginkgo.Describe("Cohorts", func() {
 			})
 		})
 
-		ginkgo.XIt("correctly handles cohort metrics when workload admitted with admission check", func() {
+		ginkgo.It("correctly handles cohort metrics when workload admitted with admission check", func() {
 			const (
 				numWorkloadsForCQ1 = 5
 				numWorkloadsForCQ2 = 2
@@ -646,6 +644,351 @@ var _ = ginkgo.Describe("Cohorts", func() {
 				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("root", numWorkloadsForCQ1+numWorkloadsForCQ2)
 				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("ch1", numWorkloadsForCQ1)
 				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("ch2", numWorkloadsForCQ2)
+			})
+		})
+
+		ginkgo.It("should clear metrics for the implicit root Cohort after deleting Cohort then ClusterQueues", func() {
+			ginkgo.By("Creating Cohorts", func() {
+				createCohort(utiltestingapi.MakeCohort("ch1").
+					Parent("root").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(flavor1.Name).
+							Resource(corev1.ResourceCPU, "5").
+							Obj(),
+					).Obj())
+			})
+
+			var cq1 *kueue.ClusterQueue
+
+			ginkgo.By("Create ClusterQueues", func() {
+				cq1 = createQueue(utiltestingapi.MakeClusterQueue("cq1").
+					Cohort("ch1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(flavor1.Name).
+							Resource(corev1.ResourceCPU, "5").
+							Obj(),
+					).Obj())
+			})
+
+			ginkgo.By("Creating Workloads", func() {
+				for range 5 {
+					createWorkload(
+						utiltestingapi.MakeWorkloadWithGeneratedName("workload-", ns.Name).
+							Queue("cq1").
+							Request(corev1.ResourceCPU, "1").
+							Obj(),
+					)
+				}
+			})
+
+			ginkgo.By("Checking that Workloads are admitted", func() {
+				util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 5)
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric("cq1", 5)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root", "", 5)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("ch1", "", 5)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("root", 5)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("ch1", 5)
+			})
+
+			ginkgo.By("Deleting Cohorts", func() {
+				for _, cohort := range cohorts {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, cohort, true)
+				}
+			})
+
+			ginkgo.By("Checking that metrics cleared", func() {
+				util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 5)
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric("cq1", 5)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("ch1", "", 0)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root", "", 0)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("root", 0)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("ch1", 0)
+			})
+
+			ginkgo.By("Deleting Workloads", func() {
+				for _, wl := range wls {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, wl, true)
+				}
+			})
+
+			ginkgo.By("Deleting LocalQueues", func() {
+				for _, lq := range lqs {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, lq, true)
+				}
+			})
+
+			ginkgo.By("Deleting ClusterQueues", func() {
+				for _, cq := range cqs {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+				}
+			})
+
+			ginkgo.By("Checking that metrics cleared", func() {
+				util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 0)
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric("cq1", 0)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("ch1", "", 0)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root", "", 0)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("root", 0)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("ch1", 0)
+			})
+		})
+
+		ginkgo.It("should clear metrics for the implicit root Cohort after deleting ClusterQueues then Cohort", func() {
+			ginkgo.By("Creating Cohorts", func() {
+				createCohort(utiltestingapi.MakeCohort("ch1").
+					Parent("root").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(flavor1.Name).
+							Resource(corev1.ResourceCPU, "5").
+							Obj(),
+					).Obj())
+			})
+
+			var cq1 *kueue.ClusterQueue
+
+			ginkgo.By("Create ClusterQueues", func() {
+				cq1 = createQueue(utiltestingapi.MakeClusterQueue("cq1").
+					Cohort("ch1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(flavor1.Name).
+							Resource(corev1.ResourceCPU, "5").
+							Obj(),
+					).Obj())
+			})
+
+			ginkgo.By("Creating Workloads", func() {
+				for range 5 {
+					createWorkload(
+						utiltestingapi.MakeWorkloadWithGeneratedName("workload-", ns.Name).
+							Queue("cq1").
+							Request(corev1.ResourceCPU, "1").
+							Obj(),
+					)
+				}
+			})
+
+			ginkgo.By("Checking that Workloads are admitted", func() {
+				util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 5)
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric("cq1", 5)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root", "", 5)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("ch1", "", 5)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("root", 5)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("ch1", 5)
+			})
+
+			ginkgo.By("Deleting Workloads", func() {
+				for _, wl := range wls {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, wl, true)
+				}
+			})
+
+			ginkgo.By("Deleting LocalQueues", func() {
+				for _, lq := range lqs {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, lq, true)
+				}
+			})
+
+			ginkgo.By("Checking that metrics cleared", func() {
+				util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 5)
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric("cq1", 0)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("ch1", "", 5)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root", "", 5)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("root", 0)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("ch1", 0)
+			})
+
+			ginkgo.By("Deleting ClusterQueues", func() {
+				for _, cq := range cqs {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+				}
+			})
+
+			ginkgo.By("Checking that metrics cleared", func() {
+				util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 0)
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric("cq1", 0)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("ch1", "", 5)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root", "", 5)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("root", 0)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("ch1", 0)
+			})
+
+			ginkgo.By("Deleting Cohorts", func() {
+				for _, cohort := range cohorts {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, cohort, true)
+				}
+			})
+
+			ginkgo.By("Checking that metrics cleared", func() {
+				util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 0)
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric("cq1", 0)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("ch1", "", 0)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root", "", 0)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("root", 0)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("ch1", 0)
+			})
+		})
+
+		ginkgo.It("should clear metrics for the implicit root Cohort after deleting ClusterQueues", func() {
+			var cq1 *kueue.ClusterQueue
+
+			ginkgo.By("Create ClusterQueues", func() {
+				cq1 = createQueue(utiltestingapi.MakeClusterQueue("cq1").
+					Cohort("root").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(flavor1.Name).
+							Resource(corev1.ResourceCPU, "5").
+							Obj(),
+					).Obj())
+			})
+
+			ginkgo.By("Creating Workloads", func() {
+				for range 5 {
+					createWorkload(
+						utiltestingapi.MakeWorkloadWithGeneratedName("workload-", ns.Name).
+							Queue("cq1").
+							Request(corev1.ResourceCPU, "1").
+							Obj(),
+					)
+				}
+			})
+
+			ginkgo.By("Checking that Workloads are admitted", func() {
+				util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 5)
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric("cq1", 5)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root", "", 5)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("root", 5)
+			})
+
+			ginkgo.By("Deleting Workloads", func() {
+				for _, wl := range wls {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, wl, true)
+				}
+			})
+
+			ginkgo.By("Deleting LocalQueues", func() {
+				for _, lq := range lqs {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, lq, true)
+				}
+			})
+
+			ginkgo.By("Checking that metrics cleared", func() {
+				util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 5)
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric("cq1", 0)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root", "", 5)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("root", 0)
+			})
+
+			ginkgo.By("Deleting ClusterQueues", func() {
+				for _, cq := range cqs {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+				}
+			})
+
+			ginkgo.By("Checking that metrics cleared", func() {
+				util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 0)
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric("cq1", 0)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root", "", 0)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("root", 0)
+			})
+		})
+
+		// cq1 -> ch1 -> root1 (implicit)	=> cq1 -> ch1 -> root2 (explicit)
+		// cq2 -> root2 (explicit)			=> cq2 -> root2 (explicit)
+		ginkgo.It("should clear metrics for the implicit root Cohort after switching to another root Cohort", func() {
+			var (
+				cq1 *kueue.ClusterQueue
+				cq2 *kueue.ClusterQueue
+				ch1 *kueue.Cohort
+			)
+
+			ginkgo.By("Creating Cohorts", func() {
+				ch1 = createCohort(utiltestingapi.MakeCohort("ch1").
+					Parent("root1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(flavor1.Name).
+							Resource(corev1.ResourceCPU, "5").
+							Obj(),
+					).Obj())
+
+				createCohort(utiltestingapi.MakeCohort("root2").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(flavor1.Name).
+							Resource(corev1.ResourceCPU, "5").
+							Obj(),
+					).Obj())
+			})
+
+			ginkgo.By("Create ClusterQueues", func() {
+				cq1 = createQueue(utiltestingapi.MakeClusterQueue("cq1").
+					Cohort("ch1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(flavor1.Name).
+							Resource(corev1.ResourceCPU, "5").
+							Obj(),
+					).Obj())
+
+				cq2 = createQueue(utiltestingapi.MakeClusterQueue("cq2").
+					Cohort("root2").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(flavor1.Name).
+							Resource(corev1.ResourceCPU, "5").
+							Obj(),
+					).Obj())
+			})
+
+			ginkgo.By("Creating Workloads", func() {
+				for range 3 {
+					createWorkload(
+						utiltestingapi.MakeWorkloadWithGeneratedName("workload-", ns.Name).
+							Queue("cq1").
+							Request(corev1.ResourceCPU, "1").
+							Obj(),
+					)
+				}
+
+				for range 2 {
+					createWorkload(
+						utiltestingapi.MakeWorkloadWithGeneratedName("workload-", ns.Name).
+							Queue("cq2").
+							Request(corev1.ResourceCPU, "1").
+							Obj(),
+					)
+				}
+			})
+
+			ginkgo.By("Checking that Workloads are admitted", func() {
+				util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 3)
+				util.ExpectAdmittedWorkloadsTotalMetric(cq2, "", 2)
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric("cq1", 3)
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric("cq2", 2)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("ch1", "", 3)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("ch1", 3)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root1", "", 3)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("root1", 3)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root2", "", 2)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("root2", 2)
+			})
+
+			ginkgo.By("Switch ch1->root1 to ch1->root2", func() {
+				createdCh1 := &kueue.Cohort{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ch1), createdCh1)).Should(gomega.Succeed())
+					createdCh1.Spec.ParentName = "root2"
+					g.Expect(k8sClient.Update(ctx, createdCh1)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking that root1 metrics are cleaned cleared", func() {
+				util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 3)
+				util.ExpectAdmittedWorkloadsTotalMetric(cq2, "", 2)
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric("cq1", 3)
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric("cq2", 2)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("ch1", "", 3)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("ch1", 3)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root1", "", 0)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("root1", 0)
+				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root2", "", 2)
+				util.ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric("root2", 2)
 			})
 		})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind failing-test
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Clear metrics after deleting a Cohort.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10057

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Observability: Fix a bug where kueue_cohort_subtree_admitted_workloads_total and kueue_cohort_subtree_admitted_active_workloads metrics could include results for an implicit root Cohort after deletion of a child Cohort or ClusterQueue.
```