### PR TITLE
test/e2e: expect internal error for visibility delegated authz failure

### DIFF
--- a/test/e2e/customconfigs/visibility_server_test.go
+++ b/test/e2e/customconfigs/visibility_server_test.go
@@ -52,6 +52,8 @@ const (
 	customSAMountPath         = "/etc/custom-sa"
 	cqName                    = "test-kubeconfig-cq"
 	customVisibilityPort      = 9444
+	tokenReviewerRoleName     = "visibility-test-token-reviewer"
+	tokenReviewerBindingName  = "visibility-test-token-reviewer"
 )
 
 var _ = ginkgo.Describe("Visibility Server", func() {
@@ -138,6 +140,7 @@ var _ = ginkgo.Describe("Visibility Server", func() {
 		cloneControllerRBAC(ctx)
 		ginkgo.DeferCleanup(func() {
 			ginkgo.By("Cleaning up our dynamically cloned roles")
+			gomega.Expect(k8sClient.DeleteAllOf(ctx, &rbacv1.ClusterRole{}, client.MatchingLabels{testLabelKey: testLabelValue})).To(gomega.Succeed())
 			gomega.Expect(k8sClient.DeleteAllOf(ctx, &rbacv1.ClusterRoleBinding{}, client.MatchingLabels{testLabelKey: testLabelValue})).To(gomega.Succeed())
 			gomega.Expect(k8sClient.DeleteAllOf(ctx, &rbacv1.RoleBinding{}, client.InNamespace(kueueNS), client.MatchingLabels{testLabelKey: testLabelValue})).To(gomega.Succeed())
 			gomega.Expect(k8sClient.DeleteAllOf(ctx, &rbacv1.RoleBinding{}, client.InNamespace(kubeSystemNamespace), client.MatchingLabels{testLabelKey: testLabelValue})).To(gomega.Succeed())
@@ -154,6 +157,30 @@ var _ = ginkgo.Describe("Visibility Server", func() {
 			Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Name: customSAName, Namespace: kueueNS}},
 		}
 		util.MustCreate(ctx, k8sClient, authReaderBinding)
+
+		ginkgo.By("Granting token review permissions so delegated authentication still works during the negative authorization check.")
+		tokenReviewerRole := &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   tokenReviewerRoleName,
+				Labels: map[string]string{testLabelKey: testLabelValue},
+			},
+			Rules: []rbacv1.PolicyRule{{
+				APIGroups: []string{"authentication.k8s.io"},
+				Resources: []string{"tokenreviews"},
+				Verbs:     []string{"create"},
+			}},
+		}
+		util.MustCreate(ctx, k8sClient, tokenReviewerRole)
+
+		tokenReviewerBinding := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   tokenReviewerBindingName,
+				Labels: map[string]string{testLabelKey: testLabelValue},
+			},
+			RoleRef:  rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: tokenReviewerRoleName},
+			Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Name: customSAName, Namespace: kueueNS}},
+		}
+		util.MustCreate(ctx, k8sClient, tokenReviewerBinding)
 
 		patchedDeployment := originalDeployment.DeepCopy()
 
@@ -183,22 +210,15 @@ var _ = ginkgo.Describe("Visibility Server", func() {
 		gomega.Expect(k8sClient.Update(ctx, patchedDeployment)).To(gomega.Succeed())
 		util.WaitForKueueAvailabilityNoRestartCountCheck(ctx, k8sClient)
 
-		// NEGATIVE TEST: The custom SA lacks 'system:auth-delegator'. The visibility server
-		// is forced to use it, so it cannot perform SubjectAccessReviews.
-		ginkgo.By("Expecting API requests to fail due to lack of auth delegation permissions")
+		// NEGATIVE TEST: The request is authenticated via TokenReview, but the visibility server
+		// itself cannot complete delegated authorization because its identity lacks SubjectAccessReview permission.
+		ginkgo.By("Expecting API requests to fail with internal error due to delegated authorization misconfiguration")
 		gomega.Eventually(func(g gomega.Gomega) {
 			visClient := util.CreateVisibilityClient("")
 			_, err := visClient.ClusterQueues().GetPendingWorkloadsSummary(ctx, cqName, metav1.GetOptions{})
 			g.Expect(err).To(gomega.HaveOccurred())
 
-			// TODO: Fix the internal server error when lacking SubjectAccessReview permissions
-			// See: https://github.com/kubernetes-sigs/kueue/issues/9779
-			isExpectedError := k8serrors.IsUnauthorized(err) ||
-				k8serrors.IsForbidden(err) ||
-				k8serrors.IsInternalError(err) ||
-				k8serrors.IsServiceUnavailable(err)
-
-			g.Expect(isExpectedError).To(gomega.BeTrue(), "Expected an auth or internal error, but got: %v", err)
+			g.Expect(k8serrors.IsInternalError(err)).To(gomega.BeTrue(), "Expected an internal error, but got: %v", err)
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		// POSITIVE TEST: Grant the required permissions to our custom ServiceAccount


### PR DESCRIPTION
Tighten the e2e to isolate delegated authorization failure from delegated authentication.

#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it:
This PR keeps the default apiserver behavior for delegated authorization failures and tightens the existing custom kubeconfig e2e.

The negative case now isolates delegated authorization from delegated authentication and expects `InternalError`, which matches the server-side failure we see in practice when the visibility server cannot create `SubjectAccessReview` objects.

#### Which issue(s) this PR fixes:
Related to #9779

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```