### PR TITLE
Prioritize workload priority over sticky workload status

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -732,6 +732,13 @@ func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.
 // baseCompareFunc orders workloads by sticky status, priority, timestamp, and UID.
 func baseCompareFunc(log logr.Logger, wo workload.Ordering, sw *stickyWorkload) func(a, b *workload.Info) int {
 	return func(a, b *workload.Info) int {
+		p1 := utilpriority.EffectivePriority(log, a.Obj)
+		p2 := utilpriority.EffectivePriority(log, b.Obj)
+		// Higher priority comes first (reverse order).
+		if cmpResult := cmp.Compare(p2, p1); cmpResult != 0 {
+			return cmpResult
+		}
+
 		aSticky := sw.matches(workload.Key(a.Obj))
 		bSticky := sw.matches(workload.Key(b.Obj))
 		if aSticky != bSticky {
@@ -741,13 +748,6 @@ func baseCompareFunc(log logr.Logger, wo workload.Ordering, sw *stickyWorkload) 
 			}
 			logStickyWorkloadSelectionIfVerbose(log, b.Obj)
 			return 1
-		}
-
-		p1 := utilpriority.EffectivePriority(log, a.Obj)
-		p2 := utilpriority.EffectivePriority(log, b.Obj)
-		// Higher priority comes first (reverse order).
-		if cmpResult := cmp.Compare(p2, p1); cmpResult != 0 {
-			return cmpResult
 		}
 
 		tA := wo.GetQueueOrderTimestamp(a.Obj)

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -863,6 +863,36 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 			util.ExpectClusterQueueWeightedShareMetric(cq2, 0.0)
 		})
 
+		ginkgo.It("higher priority workload should jump ahead of sticky low priority workload (#7301)", func() {
+			ginkgo.By("Creating borrowing workloads in queue2")
+			createWorkload("cq2", "3")
+			util.ExpectAdmittedWorkloadsTotalMetric(cq2, "", 1)
+
+			ginkgo.By("Create low priority workload in queue1 that requires preemption")
+			// cq1 has nominal 0, but cohort has 3. Since cq2 borrowed 3, cq1 must preempt.
+			lowPriorityWl := createWorkloadWithPriority("cq1", "3", 10)
+
+			ginkgo.By("Wait until scheduler attempts to schedule low priority wl (it becomes sticky)")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lowPriorityWl), lowPriorityWl)).To(gomega.Succeed())
+				cond := meta.FindStatusCondition(lowPriorityWl.Status.Conditions, kueue.WorkloadQuotaReserved)
+				g.Expect(cond).NotTo(gomega.BeNil())
+				g.Expect(cond.Message).To(gomega.ContainSubstring("insufficient unused quota"))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Create higher priority workload in queue1")
+			highPriorityWl := createWorkloadWithPriority("cq1", "3", 100)
+
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, lowPriorityWl)
+
+			ginkgo.By("Complete preemption")
+			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cq2, 1)
+
+			ginkgo.By("Verify that higher priority workload is admitted")
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, highPriorityWl)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, lowPriorityWl)
+		})
+
 		ginkgo.It("sticky workload becomes inadmissible. next workload admits", func() {
 			ginkgo.By("Creating borrowing workloads in queue2")
 			createWorkload("cq2", "1")
@@ -1482,6 +1512,155 @@ var _ = ginkgo.Describe("Scheduler with AdmissionFairSharing = nil", ginkgo.Labe
 			ginkgo.By("Checking that FairSharing status is nil")
 			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lqA), lqA)).To(gomega.Succeed())
 			gomega.Expect(lqA.Status.FairSharing).Should(gomega.BeNil())
+		})
+	})
+	ginkgo.When("Priority Comparison with Sticky Workloads", func() {
+		var (
+			cq1 *kueue.ClusterQueue
+			cq2 *kueue.ClusterQueue
+			lq1 *kueue.LocalQueue
+			lq2 *kueue.LocalQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			cq1 = utiltestingapi.MakeClusterQueue("cq1").
+				Cohort("all").
+				QueueingStrategy(kueue.BestEffortFIFO).
+				Preemption(kueue.ClusterQueuePreemption{
+					ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+				}).
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "3").Obj()).
+				Obj()
+			util.MustCreate(ctx, k8sClient, cq1)
+
+			cq2 = utiltestingapi.MakeClusterQueue("cq2").
+				Cohort("all").
+				QueueingStrategy(kueue.BestEffortFIFO).
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "0", "3").Obj()).
+				Obj()
+			util.MustCreate(ctx, k8sClient, cq2)
+
+			lq1 = utiltestingapi.MakeLocalQueue("lq1", ns.Name).ClusterQueue("cq1").Obj()
+			util.MustCreate(ctx, k8sClient, lq1)
+			lq2 = utiltestingapi.MakeLocalQueue("lq2", ns.Name).ClusterQueue("cq2").Obj()
+			util.MustCreate(ctx, k8sClient, lq2)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq1, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq2, true)
+		})
+
+		ginkgo.It("Should prioritize higher priority Workload over sticky Workload", func() {
+			ginkgo.By("Submitting j01 (P100, 2 CPU) to cq2 which borrows from cohort")
+			j01 := utiltestingapi.MakeWorkload("j01", ns.Name).
+				Queue("lq2").
+				Request(corev1.ResourceCPU, "2").
+				Priority(100).
+				Obj()
+			util.MustCreate(ctx, k8sClient, j01)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, j01)
+
+			ginkgo.By("Submitting j02 (P50, 2 CPU) to cq1 to trigger preemption of j01")
+			j02 := utiltestingapi.MakeWorkload("j02", ns.Name).
+				Queue("lq1").
+				Request(corev1.ResourceCPU, "2").
+				Priority(50).
+				Obj()
+			util.MustCreate(ctx, k8sClient, j02)
+			util.ExpectWorkloadsToBePreempted(ctx, k8sClient, j01)
+			// We don't release quota yet, so j02 stays inadmissible as a sticky workload.
+
+			ginkgo.By("Submitting j03 (P200, 2 CPU) to cq1, which has higher priority than j02")
+			j03 := utiltestingapi.MakeWorkload("j03", ns.Name).
+				Queue("lq1").
+				Request(corev1.ResourceCPU, "2").
+				Priority(200).
+				Obj()
+			util.MustCreate(ctx, k8sClient, j03)
+
+			ginkgo.By("Ensuring j03 is admitted instead of the sticky j02")
+			util.FinishEvictionForWorkloads(ctx, k8sClient, j01)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, j03)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, j02)
+		})
+
+		ginkgo.It("Should respect priority update for sticky Workload", func() {
+			ginkgo.By("Submitting j01 (P100, 2 CPU) to cq2 which borrows from cohort")
+			j01 := utiltestingapi.MakeWorkload("j01", ns.Name).
+				Queue("lq2").
+				Request(corev1.ResourceCPU, "2").
+				Priority(100).
+				Obj()
+			util.MustCreate(ctx, k8sClient, j01)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, j01)
+
+			ginkgo.By("Submitting j02 (P50, 2 CPU) to cq1 to trigger preemption of j01")
+			j02 := utiltestingapi.MakeWorkload("j02", ns.Name).
+				Queue("lq1").
+				Request(corev1.ResourceCPU, "2").
+				Priority(50).
+				Obj()
+			util.MustCreate(ctx, k8sClient, j02)
+			util.ExpectWorkloadsToBePreempted(ctx, k8sClient, j01)
+			// We don't release quota yet, so j02 stays inadmissible as a sticky workload.
+
+			ginkgo.By("Submitting j03 (P40, 2 CPU) which is lower priority than j02")
+			j03 := utiltestingapi.MakeWorkload("j03", ns.Name).
+				Queue("lq1").
+				Request(corev1.ResourceCPU, "2").
+				Priority(40).
+				Obj()
+			util.MustCreate(ctx, k8sClient, j03)
+
+			ginkgo.By("Demoting j02 priority to P10")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(j02), j02)).To(gomega.Succeed())
+				j02.Spec.Priority = ptr.To[int32](10)
+				g.Expect(k8sClient.Update(ctx, j02)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Ensuring j03 (P40) is admitted instead of j02 (P10)")
+			util.FinishEvictionForWorkloads(ctx, k8sClient, j01)
+
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, j03)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, j02)
+		})
+
+		ginkgo.It("Should overwrite sticky Workload when higher priority Workload triggers new preemption", func() {
+			ginkgo.By("Submitting j01/j02 (P100, 2 CPU sets) to cq2 which borrows from cohort")
+			j01 := utiltestingapi.MakeWorkload("j01", ns.Name).Queue("lq2").Request(corev1.ResourceCPU, "1").Priority(100).Obj()
+			j02 := utiltestingapi.MakeWorkload("j02", ns.Name).Queue("lq2").Request(corev1.ResourceCPU, "1").Priority(90).Obj()
+			j03 := utiltestingapi.MakeWorkload("j03", ns.Name).Queue("lq2").Request(corev1.ResourceCPU, "1").Priority(100).Obj()
+
+			util.MustCreate(ctx, k8sClient, j01)
+			util.MustCreate(ctx, k8sClient, j02)
+			util.MustCreate(ctx, k8sClient, j03)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, j01, j02, j03)
+
+			ginkgo.By("Submitting j04 (P50, 1 CPU) to cq1. Preempts j02 (Lowest Priority).")
+			j04 := utiltestingapi.MakeWorkload("j04", ns.Name).Queue("lq1").Request(corev1.ResourceCPU, "1").Priority(50).Obj()
+			util.MustCreate(ctx, k8sClient, j04)
+			util.ExpectWorkloadsToBePreempted(ctx, k8sClient, j02)
+			// We don't release quota yet, so j04 stays inadmissible as a sticky workload.
+
+			ginkgo.By("Submitting j05 (P200, 3 CPU) to cq1. Needs 3 CPUs, so must preempt j01 AND j02 (and use j03's spot).")
+			j05 := utiltestingapi.MakeWorkload("j05", ns.Name).Queue("lq1").Request(corev1.ResourceCPU, "3").Priority(200).Obj()
+			util.MustCreate(ctx, k8sClient, j05)
+
+			util.FinishEvictionForWorkloads(ctx, k8sClient, j02)
+
+			util.ExpectWorkloadsToBePreempted(ctx, k8sClient, j01, j02, j03)
+
+			ginkgo.By("Ensuring j05 is admitted")
+			util.FinishEvictionForWorkloads(ctx, k8sClient, j01, j02, j03)
+
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, j05)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, j04)
 		})
 	})
 })

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -863,36 +863,6 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 			util.ExpectClusterQueueWeightedShareMetric(cq2, 0.0)
 		})
 
-		ginkgo.It("higher priority workload should jump ahead of sticky low priority workload (#7301)", func() {
-			ginkgo.By("Creating borrowing workloads in queue2")
-			createWorkload("cq2", "3")
-			util.ExpectAdmittedWorkloadsTotalMetric(cq2, "", 1)
-
-			ginkgo.By("Create low priority workload in queue1 that requires preemption")
-			// cq1 has nominal 0, but cohort has 3. Since cq2 borrowed 3, cq1 must preempt.
-			lowPriorityWl := createWorkloadWithPriority("cq1", "3", 10)
-
-			ginkgo.By("Wait until scheduler attempts to schedule low priority wl (it becomes sticky)")
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lowPriorityWl), lowPriorityWl)).To(gomega.Succeed())
-				cond := meta.FindStatusCondition(lowPriorityWl.Status.Conditions, kueue.WorkloadQuotaReserved)
-				g.Expect(cond).NotTo(gomega.BeNil())
-				g.Expect(cond.Message).To(gomega.ContainSubstring("insufficient unused quota"))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			ginkgo.By("Create higher priority workload in queue1")
-			highPriorityWl := createWorkloadWithPriority("cq1", "3", 100)
-
-			util.ExpectWorkloadsToBePending(ctx, k8sClient, lowPriorityWl)
-
-			ginkgo.By("Complete preemption")
-			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cq2, 1)
-
-			ginkgo.By("Verify that higher priority workload is admitted")
-			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, highPriorityWl)
-			util.ExpectWorkloadsToBePending(ctx, k8sClient, lowPriorityWl)
-		})
-
 		ginkgo.It("sticky workload becomes inadmissible. next workload admits", func() {
 			ginkgo.By("Creating borrowing workloads in queue2")
 			createWorkload("cq2", "1")


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR modifies the workload ordering logic in the ClusterQueue to ensure that workload priority takes precedence over sticky status.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7301

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed an issue in ClusterQueue workload ordering where workloads performing preemption could incorrectly block higher-priority workloads from being admitted. Priority now takes precedence over preemption status in the scheduling queue.
```