### PR TITLE
WIP: Fix flaky pod group e2e test by bumping ExpectWorkloadToFinish timeout

### DIFF
--- a/test/e2e/singlecluster/pod_test.go
+++ b/test/e2e/singlecluster/pod_test.go
@@ -139,45 +139,47 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 			})
 		})
 
-		ginkgo.It("Should only admit a complete group", func() {
-			group := podtesting.MakePod("group", ns.Name).
-				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
-				Queue(lq.Name).
-				RequestAndLimit(corev1.ResourceCPU, "1").
-				MakeGroup(3)
+		for i := range 200 {
+			ginkgo.FIt(fmt.Sprintf("Should only admit a complete group %d", i), func() {
+				group := podtesting.MakePod("group", ns.Name).
+					Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+					Queue(lq.Name).
+					RequestAndLimit(corev1.ResourceCPU, "1").
+					MakeGroup(3)
 
-			ginkgo.By("Incomplete group should not start", func() {
-				// Create incomplete group.
-				for _, p := range group[:2] {
-					util.MustCreate(ctx, k8sClient, p.DeepCopy())
-				}
-				createdPod := &corev1.Pod{}
-				gomega.Consistently(func(g gomega.Gomega) {
-					for _, origPod := range group[:2] {
-						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(origPod), createdPod)).To(gomega.Succeed())
-						g.Expect(createdPod.Spec.SchedulingGates).To(gomega.ContainElement(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}))
+				ginkgo.By("Incomplete group should not start", func() {
+					// Create incomplete group.
+					for _, p := range group[:2] {
+						util.MustCreate(ctx, k8sClient, p.DeepCopy())
 					}
-				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
-			})
-			ginkgo.By("Incomplete group can be deleted", func() {
-				for _, p := range group[:2] {
-					gomega.Expect(k8sClient.Delete(ctx, p)).To(gomega.Succeed())
-				}
-				gomega.Eventually(func(g gomega.Gomega) {
-					for _, origPod := range group[:2] {
-						var p corev1.Pod
-						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(origPod), &p)).To(utiltesting.BeNotFoundError())
+					createdPod := &corev1.Pod{}
+					gomega.Consistently(func(g gomega.Gomega) {
+						for _, origPod := range group[:2] {
+							g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(origPod), createdPod)).To(gomega.Succeed())
+							g.Expect(createdPod.Spec.SchedulingGates).To(gomega.ContainElement(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}))
+						}
+					}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+				})
+				ginkgo.By("Incomplete group can be deleted", func() {
+					for _, p := range group[:2] {
+						gomega.Expect(k8sClient.Delete(ctx, p)).To(gomega.Succeed())
 					}
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-			ginkgo.By("Complete group runs successfully", func() {
-				for _, p := range group {
-					util.MustCreate(ctx, k8sClient, p.DeepCopy())
-				}
+					gomega.Eventually(func(g gomega.Gomega) {
+						for _, origPod := range group[:2] {
+							var p corev1.Pod
+							g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(origPod), &p)).To(utiltesting.BeNotFoundError())
+						}
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+				ginkgo.By("Complete group runs successfully", func() {
+					for _, p := range group {
+						util.MustCreate(ctx, k8sClient, p.DeepCopy())
+					}
 
-				util.ExpectWorkloadToFinish(ctx, k8sClient, client.ObjectKey{Namespace: ns.Name, Name: "group"})
+					util.ExpectWorkloadToFinish(ctx, k8sClient, client.ObjectKey{Namespace: ns.Name, Name: "group"})
+				})
 			})
-		})
+		}
 
 		ginkgo.It("Failed Pod can be replaced in group", func() {
 			eventList := corev1.EventList{}

--- a/test/e2e/singlecluster/pod_test.go
+++ b/test/e2e/singlecluster/pod_test.go
@@ -176,7 +176,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 						util.MustCreate(ctx, k8sClient, p.DeepCopy())
 					}
 
-					util.ExpectWorkloadToFinish(ctx, k8sClient, client.ObjectKey{Namespace: ns.Name, Name: "group"})
+					util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, client.ObjectKey{Namespace: ns.Name, Name: "group"}, util.LongTimeout)
 				})
 			})
 		}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -531,7 +531,7 @@ func ExpectWorkloadToFinish(ctx context.Context, k8sClient client.Client, wlKey 
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
 		g.Expect(k8sClient.Get(ctx, wlKey, &wl)).To(gomega.Succeed())
 		g.Expect(wl.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished), "it's finished")
-	}, MediumTimeout, Interval).Should(gomega.Succeed(), assertMsg("Workload did not finish", &wl))
+	}, LongTimeout, Interval).Should(gomega.Succeed())
 }
 
 func ExpectPodsReadyCondition(ctx context.Context, k8sClient client.Client, wlKey client.ObjectKey) {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -527,11 +527,17 @@ func expectWorkloadsWithPriority(ctx context.Context, c client.Client, priorityC
 }
 
 func ExpectWorkloadToFinish(ctx context.Context, k8sClient client.Client, wlKey client.ObjectKey) {
+	ginkgo.GinkgoHelper()
+	ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlKey, MediumTimeout)
+}
+
+func ExpectWorkloadToFinishWithTimeout(ctx context.Context, k8sClient client.Client, wlKey client.ObjectKey, timeout time.Duration) {
+	ginkgo.GinkgoHelper()
 	var wl kueue.Workload
-	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
+	gomega.Eventually(func(g gomega.Gomega) {
 		g.Expect(k8sClient.Get(ctx, wlKey, &wl)).To(gomega.Succeed())
 		g.Expect(wl.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished), "it's finished")
-	}, LongTimeout, Interval).Should(gomega.Succeed())
+	}, timeout, Interval).Should(gomega.Succeed(), assertMsg("Workload did not finish", &wl))
 }
 
 func ExpectPodsReadyCondition(ctx context.Context, k8sClient client.Client, wlKey client.ObjectKey) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```