### PR TITLE
featureGates unit tests cleanup

### DIFF
--- a/pkg/cache/queue/inadmissible_workloads_test.go
+++ b/pkg/cache/queue/inadmissible_workloads_test.go
@@ -31,8 +31,8 @@ import (
 
 func TestNewRequeuer(t *testing.T) {
 	type args struct {
-		features map[featuregate.Feature]bool
-		opts     []RequeuerOption
+		featureGates map[featuregate.Feature]bool
+		opts         []RequeuerOption
 	}
 
 	type want struct {
@@ -45,7 +45,7 @@ func TestNewRequeuer(t *testing.T) {
 	}{
 		"SchedulerLongRequeueInterval feature disabled": {
 			args: args{
-				features: map[featuregate.Feature]bool{
+				featureGates: map[featuregate.Feature]bool{
 					features.SchedulerLongRequeueInterval: false,
 				},
 			},
@@ -55,7 +55,7 @@ func TestNewRequeuer(t *testing.T) {
 		},
 		"SchedulerLongRequeueInterval feature enabled": {
 			args: args{
-				features: map[featuregate.Feature]bool{
+				featureGates: map[featuregate.Feature]bool{
 					features.SchedulerLongRequeueInterval: true,
 				},
 			},
@@ -76,9 +76,7 @@ func TestNewRequeuer(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			for feature, enabled := range tc.args.features {
-				features.SetFeatureGateDuringTest(t, feature, enabled)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.args.featureGates)
 			requeuer := NewRequeuer(tc.args.opts...)
 			if diff := cmp.Diff(tc.want.batchPeriod, requeuer.batchPeriod); len(diff) != 0 {
 				t.Errorf("Unexpected requeue batch period (-want,+got):\n%s", diff)

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -381,12 +381,12 @@ func TestFindTopologyAssignments(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		enableFeatureGates []featuregate.Feature
-		nodes              []corev1.Node
-		pods               []corev1.Pod
-		levels             []string
-		nodeLabels         map[string]string
-		podSets            []PodSetTestCase
+		featureGates map[featuregate.Feature]bool
+		nodes        []corev1.Node
+		pods         []corev1.Pod
+		levels       []string
+		nodeLabels   map[string]string
+		podSets      []PodSetTestCase
 	}{
 		"minimize the number of used racks before optimizing the number of nodes; BestFit": {
 			// Solution by optimizing the number of racks then nodes: [r3]: [x1,x6,x2,x4]
@@ -499,7 +499,6 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{},
 		},
 		"choose the node that can accommodate all Pods": {
 			//        b1
@@ -651,7 +650,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMixed},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileMixed: true},
 		},
 		"block required; 4 pods fit into one host each; BestFit": {
 			nodes:  binaryTreesNodes,
@@ -742,7 +741,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMixed},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileMixed: true},
 		},
 		"host preferred; single Pod fits in the host; BestFit; TASProfileMixed": {
 			nodes:  defaultNodes,
@@ -767,7 +766,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMixed},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileMixed: true},
 		},
 		"rack required; single Pod fits in a rack; BestFit": {
 			nodes:  defaultNodes,
@@ -2435,7 +2434,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// request: 25
 		// expected outcome: x1:13, x2:12
 		"balanced placement; basic": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -2490,7 +2489,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// request: 23
 		// expected outcome: x1:12, x2:11
 		"balanced placement; select optmial set of domains": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -2556,7 +2555,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// sliceSize: 5
 		// expected outcome: x2:15, x3:10
 		"balanced placement; select optmial set of domains; with slices": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -2623,7 +2622,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// request: 22
 		// expected outcome: x3:11, x4:11
 		"balanced placement; select correct block": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -2699,7 +2698,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// request: 25
 		// expected outcome: x1:14, x2:11
 		"balanced placement; cannot chose domains from different blocks": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -2776,7 +2775,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// sizeSize: 5
 		// expected outcome: x3:15, x4:10
 		"balanced placement; select correct block; prefer blocks with single rack; with slices": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -2856,7 +2855,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// sliceSize: 2
 		// expected outcome: x3:10, x4:8, x5:2
 		"balanced placement; four level topology; slice two levels below balanced level": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-sb1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -2954,7 +2953,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// request: 20
 		// expected outcome: x3:10, x4:3, x5:7
 		"balanced placement; four level topology; slice one level below balanced level": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-sb1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -3053,7 +3052,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// sliceSize: 2
 		// expected outcome: x3:10, x4:10
 		"balanced placement; four level topology; balance on rack level; slice not on the lowest level": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-sb1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -3135,7 +3134,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// sliceSize: 2
 		// expected outcome: x2:12, x3:10
 		"balanced placement; three level topology; balance on the same level as slice": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -3222,7 +3221,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// request: 22
 		// expected outcome: x3:11, x4:11
 		"balanced placement; three level topology; balance on the lowest level": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -3309,7 +3308,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// leaders: 1
 		// expected outcome: x2:15, x3:10 + leader
 		"balanced placement; leader worker set": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -3401,7 +3400,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// request: 15
 		// expected outcome: x3:5, x4:5, x5:5
 		"balanced placement; prioritize (using entropy) balanced domains; second rack wins": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -3490,7 +3489,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// request: 24
 		// expected outcome: x1:8, x2:8, x3:8
 		"balanced placement; prioritize (using entropy) balanced domains; first rack wins": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -3577,7 +3576,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// request: 23
 		// expected outcome: x1:12, x3:11
 		"balanced placement; two level topology; balance on the highest level": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("r1-x1").
 					Label(tasRackLabel, "r1").
@@ -3657,7 +3656,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// request: 20
 		// expected outcome: x1:5, x2:5, x3:5, x4:5
 		"balanced placement; select correct block taking into account pruning": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -3801,7 +3800,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// leaders: 1
 		// expected outcome: x1:5 + leader, x2:5
 		"balanced placement; should not prune domain": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -5117,9 +5116,9 @@ func TestFindTopologyAssignments(t *testing.T) {
 			},
 		},
 		"multiple podsets: block required for one, unconstrained for another; TASProfileMixed": {
-			nodes:              multipodNodeset,
-			levels:             defaultThreeLevels,
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMixed},
+			nodes:        multipodNodeset,
+			levels:       defaultThreeLevels,
+			featureGates: map[featuregate.Feature]bool{features.TASProfileMixed: true},
 			podSets: []PodSetTestCase{
 				{
 					podSetName: "podset1",
@@ -5257,7 +5256,10 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.ElasticJobsViaWorkloadSlices, features.ElasticJobsViaWorkloadSlicesWithTAS},
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:        true,
+				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
+			},
 		},
 		"elastic workload scale up: spread across multiple nodes preserved": {
 			nodes: []corev1.Node{
@@ -5311,7 +5313,10 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.ElasticJobsViaWorkloadSlices, features.ElasticJobsViaWorkloadSlicesWithTAS},
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:        true,
+				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
+			},
 		},
 		"elastic workload scale down: truncates assignment": {
 			nodes: []corev1.Node{
@@ -5355,7 +5360,10 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.ElasticJobsViaWorkloadSlices, features.ElasticJobsViaWorkloadSlicesWithTAS},
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:        true,
+				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
+			},
 		},
 		"elastic workload same count: reuses previous assignment exactly": {
 			nodes: []corev1.Node{
@@ -5400,7 +5408,10 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.ElasticJobsViaWorkloadSlices, features.ElasticJobsViaWorkloadSlicesWithTAS},
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:        true,
+				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
+			},
 		},
 		"multi-layer topology: block required; rack slices of 4; host slices of 2; TASMultiLayerTopology": {
 			// 4-level topology: block → rack → hostname
@@ -5411,7 +5422,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			//  x1(1)  x2(4)  x3(3)  x4(4)
 			//
 			// 8 pods total: 4 per rack, 2 per host
-			enableFeatureGates: []featuregate.Feature{features.TASMultiLayerTopology},
+			featureGates: map[featuregate.Feature]bool{features.TASMultiLayerTopology: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -5560,7 +5571,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			// 18 nodes per rack (18 × 2 GPU = 36 GPUs → 18 pods at 2 GPUs each).
 			// 96 pods with constraints: 48 per aizone, 16 per rack.
 			// Expected: 6 racks used, 16 pods each (3 per aizone).
-			enableFeatureGates: []featuregate.Feature{features.TASMultiLayerTopology},
+			featureGates: map[featuregate.Feature]bool{features.TASMultiLayerTopology: true},
 			nodes: func() []corev1.Node {
 				type rackDef struct {
 					dc, az, block, rack string
@@ -5637,7 +5648,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			//         r1
 			//      /   |   \
 			//   x1(3) x2(3) x3(0)
-			enableFeatureGates: []featuregate.Feature{features.TASMultiLayerTopology},
+			featureGates: map[featuregate.Feature]bool{features.TASMultiLayerTopology: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -5693,7 +5704,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			//      r1             r2
 			//   /      \        /    \
 			//  x1(7)  x2(4)  x3(7)  x4(3)
-			enableFeatureGates: []featuregate.Feature{features.TASMultiLayerTopology},
+			featureGates: map[featuregate.Feature]bool{features.TASMultiLayerTopology: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -5759,7 +5770,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			//      r1    r2    r3
 			//      |     |      |
 			//    x1(4) x2(4)  x3(4)
-			enableFeatureGates: []featuregate.Feature{features.TASMultiLayerTopology},
+			featureGates: map[featuregate.Feature]bool{features.TASMultiLayerTopology: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -5821,7 +5832,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			// Each rack has 2 nodes; x7,x8 are weaker (1 CPU each).
 			// The incoming workload requests 24 pods: hostname slice=3, rack slice=6, block slice=12.
 			// x7,x8 too small for hostname slices → r4 loses slices → b2 can't fit.
-			enableFeatureGates: []featuregate.Feature{features.TASMultiLayerTopology},
+			featureGates: map[featuregate.Feature]bool{features.TASMultiLayerTopology: true},
 			nodes: []corev1.Node{
 				// b1 / r1
 				*testingnode.MakeNode("dc1-b1-r1-x1").
@@ -5937,10 +5948,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ctx, log := utiltesting.ContextWithLog(t)
-			// TODO: remove after dropping the TAS profiles feature gates
-			for _, gate := range tc.enableFeatureGates {
-				features.SetFeatureGateDuringTest(t, gate, true)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			initialObjects := make([]client.Object, 0)
 			for i := range tc.nodes {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -40,6 +40,7 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
@@ -909,14 +910,14 @@ webhook:
 	testcases := []struct {
 		name              string
 		configFile        string
-		featureGateValue  bool
+		featureGates      map[featuregate.Feature]bool
 		wantConfiguration configapi.Configuration
 		verifyTLSApplied  bool
 	}{
 		{
-			name:             "TLS config applied when feature gate enabled",
-			configFile:       tlsConfigWithCipherSuites,
-			featureGateValue: true,
+			name:         "TLS config applied when feature gate enabled",
+			configFile:   tlsConfigWithCipherSuites,
+			featureGates: map[featuregate.Feature]bool{features.TLSOptions: true},
 			wantConfiguration: configapi.Configuration{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: configapi.GroupVersion.String(),
@@ -964,9 +965,9 @@ webhook:
 			verifyTLSApplied: true,
 		},
 		{
-			name:             "TLS config NOT applied when feature gate disabled",
-			configFile:       tlsConfigWithCipherSuites,
-			featureGateValue: false,
+			name:         "TLS config NOT applied when feature gate disabled",
+			configFile:   tlsConfigWithCipherSuites,
+			featureGates: map[featuregate.Feature]bool{features.TLSOptions: false},
 			wantConfiguration: configapi.Configuration{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: configapi.GroupVersion.String(),
@@ -1014,9 +1015,9 @@ webhook:
 			verifyTLSApplied: false,
 		},
 		{
-			name:             "TLS 1.3 config applied when feature gate enabled",
-			configFile:       tlsConfigTLS13,
-			featureGateValue: true,
+			name:         "TLS 1.3 config applied when feature gate enabled",
+			configFile:   tlsConfigTLS13,
+			featureGates: map[featuregate.Feature]bool{features.TLSOptions: true},
 			wantConfiguration: configapi.Configuration{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: configapi.GroupVersion.String(),
@@ -1060,9 +1061,9 @@ webhook:
 			verifyTLSApplied: true,
 		},
 		{
-			name:             "TLS 1.3 config NOT applied when feature gate disabled",
-			configFile:       tlsConfigTLS13,
-			featureGateValue: false,
+			name:         "TLS 1.3 config NOT applied when feature gate disabled",
+			configFile:   tlsConfigTLS13,
+			featureGates: map[featuregate.Feature]bool{features.TLSOptions: false},
 			wantConfiguration: configapi.Configuration{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: configapi.GroupVersion.String(),
@@ -1110,7 +1111,7 @@ webhook:
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Set the feature gate for this test
-			features.SetFeatureGateDuringTest(t, features.TLSOptions, tc.featureGateValue)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			options, cfg, err := Load(testScheme, tc.configFile)
 			if err != nil {

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1018,10 +1018,10 @@ func TestValidate(t *testing.T) {
 
 func TestValidateFeatureGates(t *testing.T) {
 	cases := map[string]struct {
-		featureGatesCLI   string
-		featureGateMap    map[string]bool
-		setupFeatureGates map[featuregate.Feature]bool
-		wantErr           field.ErrorList
+		featureGatesCLI string
+		featureGateMap  map[string]bool
+		featureGates    map[featuregate.Feature]bool
+		wantErr         field.ErrorList
 	}{
 		"no feature gates is null": {
 			featureGatesCLI: "",
@@ -1041,7 +1041,7 @@ func TestValidateFeatureGates(t *testing.T) {
 			},
 		},
 		"cannot set TAS profile with TAS disabled": {
-			setupFeatureGates: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TASProfileMixed:         true,
 				features.TopologyAwareScheduling: false,
 			},
@@ -1054,7 +1054,7 @@ func TestValidateFeatureGates(t *testing.T) {
 			},
 		},
 		"ElasticJobsViaWorkloadSlicesWithTAS requires ElasticJobsViaWorkloadSlices": {
-			setupFeatureGates: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
 				features.TopologyAwareScheduling:             true,
 				features.ElasticJobsViaWorkloadSlices:        false,
@@ -1069,7 +1069,7 @@ func TestValidateFeatureGates(t *testing.T) {
 			},
 		},
 		"ElasticJobsViaWorkloadSlicesWithTAS requires TopologyAwareScheduling": {
-			setupFeatureGates: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
 				features.ElasticJobsViaWorkloadSlices:        true,
 				features.TopologyAwareScheduling:             false,
@@ -1084,7 +1084,7 @@ func TestValidateFeatureGates(t *testing.T) {
 			},
 		},
 		"ElasticJobsViaWorkloadSlicesWithTAS valid when all dependencies enabled": {
-			setupFeatureGates: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
 				features.ElasticJobsViaWorkloadSlices:        true,
 				features.TopologyAwareScheduling:             true,
@@ -1092,7 +1092,7 @@ func TestValidateFeatureGates(t *testing.T) {
 			},
 		},
 		"multiple FG validation errors at once": {
-			setupFeatureGates: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TASProfileMixed:                     true,
 				features.TopologyAwareScheduling:             false,
 				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
@@ -1117,7 +1117,7 @@ func TestValidateFeatureGates(t *testing.T) {
 			},
 		},
 		"DRAExtendedResources requires DynamicResourceAllocation": {
-			setupFeatureGates: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.DRAExtendedResources:      true,
 				features.DynamicResourceAllocation: false,
 			},
@@ -1133,9 +1133,7 @@ func TestValidateFeatureGates(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			// Set up feature gates for this test
-			for fg, enabled := range tc.setupFeatureGates {
-				features.SetFeatureGateDuringTest(t, fg, enabled)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			got := ValidateFeatureGates(tc.featureGatesCLI, tc.featureGateMap)
 			if diff := cmp.Diff(tc.wantErr, got, cmpopts.IgnoreFields(field.Error{}, "BadValue")); diff != "" {
 				t.Errorf("Unexpected result from ValidateFeatureGates (-want,+got):\n%s", diff)

--- a/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter_test.go
+++ b/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -34,12 +35,12 @@ import (
 
 func TestAdapter_IsJobManagedByKueue(t *testing.T) {
 	tests := []struct {
-		name           string
-		object         *unstructured.Unstructured
-		featureEnabled bool
-		want           bool
-		wantReason     string
-		wantErr        error
+		name         string
+		object       *unstructured.Unstructured
+		featureGates map[featuregate.Feature]bool
+		want         bool
+		wantReason   string
+		wantErr      error
 	}{
 		{
 			name: "feature gate disabled",
@@ -50,10 +51,10 @@ func TestAdapter_IsJobManagedByKueue(t *testing.T) {
 					},
 				},
 			},
-			featureEnabled: false,
-			want:           false,
-			wantReason:     "MultiKueueAdaptersForCustomJobs feature gate is disabled",
-			wantErr:        nil,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueAdaptersForCustomJobs: false},
+			want:         false,
+			wantReason:   "MultiKueueAdaptersForCustomJobs feature gate is disabled",
+			wantErr:      nil,
 		},
 		{
 			name: "managed by kueue with default path",
@@ -64,10 +65,10 @@ func TestAdapter_IsJobManagedByKueue(t *testing.T) {
 					},
 				},
 			},
-			featureEnabled: true,
-			want:           true,
-			wantReason:     "",
-			wantErr:        nil,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueAdaptersForCustomJobs: true},
+			want:         true,
+			wantReason:   "",
+			wantErr:      nil,
 		},
 		{
 			name: "not managed by kueue",
@@ -78,10 +79,10 @@ func TestAdapter_IsJobManagedByKueue(t *testing.T) {
 					},
 				},
 			},
-			featureEnabled: true,
-			want:           false,
-			wantReason:     "Expecting .spec.managedBy to be \"kueue.x-k8s.io/multikueue\" not \"other-controller\"",
-			wantErr:        nil,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueAdaptersForCustomJobs: true},
+			want:         false,
+			wantReason:   "Expecting .spec.managedBy to be \"kueue.x-k8s.io/multikueue\" not \"other-controller\"",
+			wantErr:      nil,
 		},
 		{
 			name: "managedBy field not found",
@@ -92,10 +93,10 @@ func TestAdapter_IsJobManagedByKueue(t *testing.T) {
 					},
 				},
 			},
-			featureEnabled: true,
-			want:           false,
-			wantReason:     "Expecting .spec.managedBy to be \"kueue.x-k8s.io/multikueue\" not \"\"",
-			wantErr:        nil,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueAdaptersForCustomJobs: true},
+			want:         false,
+			wantReason:   "Expecting .spec.managedBy to be \"kueue.x-k8s.io/multikueue\" not \"\"",
+			wantErr:      nil,
 		},
 		{
 			name: "managedBy value is not a string",
@@ -106,16 +107,16 @@ func TestAdapter_IsJobManagedByKueue(t *testing.T) {
 					},
 				},
 			},
-			featureEnabled: true,
-			want:           false,
-			wantReason:     "Expecting .spec.managedBy to be \"kueue.x-k8s.io/multikueue\" not \"not-a-string\"",
-			wantErr:        nil,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueAdaptersForCustomJobs: true},
+			want:         false,
+			wantReason:   "Expecting .spec.managedBy to be \"kueue.x-k8s.io/multikueue\" not \"not-a-string\"",
+			wantErr:      nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.MultiKueueAdaptersForCustomJobs, tt.featureEnabled)
+			features.SetFeatureGatesDuringTest(t, tt.featureGates)
 
 			adapter := &Adapter{
 				gvk: schema.GroupVersionKind{

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -77,7 +77,7 @@ func TestWlReconcile(t *testing.T) {
 	baseJobManagedByKueueBuilder := baseJobBuilder.Clone().ManagedBy(kueue.MultiKueueControllerName)
 
 	cases := map[string]struct {
-		features map[featuregate.Feature]bool
+		featureGates map[featuregate.Feature]bool
 
 		reconcileFor             string
 		managersWorkloads        []kueue.Workload
@@ -368,7 +368,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"remote wl with reservation, unable to delete the second worker's workload": {
-			features:     map[featuregate.Feature]bool{features.MultiKueueWaitForWorkloadAdmitted: false},
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueWaitForWorkloadAdmitted: false},
 			reconcileFor: "wl1",
 			managersWorkloads: []kueue.Workload{
 				*baseWorkloadBuilder.Clone().
@@ -417,7 +417,7 @@ func TestWlReconcile(t *testing.T) {
 			wantError: errFake,
 		},
 		"remote wl with reservation": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueWaitForWorkloadAdmitted: false,
 			},
 			reconcileFor: "wl1",
@@ -484,7 +484,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"remote wl with reservation but not admitted, feature gate enabled - other workers not deleted": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueWaitForWorkloadAdmitted: true,
 			},
 			reconcileFor: "wl1",
@@ -534,7 +534,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"remote wl admitted, feature gate enabled - other workers deleted": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueWaitForWorkloadAdmitted: true,
 			},
 			reconcileFor: "wl1",
@@ -607,7 +607,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"remote wl evicted due to eviction on manager cluster": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueWaitForWorkloadAdmitted: false,
 			},
 			reconcileFor: "wl1",
@@ -845,7 +845,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"remote job is changing status the local Job is updated ": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueWaitForWorkloadAdmitted: false,
 			},
 			reconcileFor: "wl1",
@@ -1130,7 +1130,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"worker reconnects after the local workload is requeued and got reservation on a second worker": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueWaitForWorkloadAdmitted: false,
 			},
 			// the worker with the oldest reservation is kept
@@ -1211,7 +1211,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"elastic job finished local workload via replacement is ignored": {
-			features:     map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			reconcileFor: "wl1",
 
 			managersWorkloads: []kueue.Workload{
@@ -1283,7 +1283,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"elastic job local workload without quota reservation": {
-			features:     map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			reconcileFor: "wl1",
 
 			managersWorkloads: []kueue.Workload{
@@ -1332,7 +1332,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"elastic job local scaled-up workload slice without quota reservation": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.ElasticJobsViaWorkloadSlices: true,
 			},
 			reconcileFor: "wl1",
@@ -1396,7 +1396,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"elastic job local workload out-of-sync other than scaled-down": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.ElasticJobsViaWorkloadSlices: true,
 			},
 			reconcileFor: "wl1",
@@ -1451,7 +1451,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"elastic job local workload out-of-sync scaled-down": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.ElasticJobsViaWorkloadSlices:      true,
 				features.MultiKueueWaitForWorkloadAdmitted: false,
 			},
@@ -1525,7 +1525,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"creating remote workloads with preemption gates": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueOrchestratedPreemption: true,
 			},
 			reconcileFor: "wl1",
@@ -1568,7 +1568,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"opening preemption gate for first workload requiring preemption": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueOrchestratedPreemption: true,
 			},
 			reconcileFor: "wl1",
@@ -1673,7 +1673,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"opening preemption gate for the second workload requiring preemption if timeout elapsed": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueOrchestratedPreemption: true,
 			},
 			reconcileFor: "wl1",
@@ -1762,7 +1762,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"not opening preemption gate for the second workload if timeout did not elapse": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueOrchestratedPreemption: true,
 			},
 			reconcileFor: "wl1",
@@ -1851,7 +1851,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"not opening preemption gate for the second workload if timeout elapsed but it does not require preemption": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueOrchestratedPreemption: true,
 			},
 			reconcileFor: "wl1",
@@ -1931,10 +1931,7 @@ func TestWlReconcile(t *testing.T) {
 		for _, useMergePatch := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s when the WorkloadRequestUseMergePatch feature is %t", name, useMergePatch), func(t *testing.T) {
 				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, useMergePatch)
-
-				for feature, enabled := range tc.features {
-					features.SetFeatureGateDuringTest(t, feature, enabled)
-				}
+				features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 				ctx, _ := utiltesting.ContextWithLog(t)
 				managerBuilder := getClientBuilder(ctx)

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -403,8 +404,7 @@ func TestReconcile(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(now)
 
 	cases := map[string]struct {
-		enableDRAFeature                      bool
-		enableMKOrchestratedPreemptionFeature bool
+		featureGates map[featuregate.Feature]bool
 
 		workload                  *kueue.Workload
 		cq                        *kueue.ClusterQueue
@@ -422,7 +422,10 @@ func TestReconcile(t *testing.T) {
 		reconcilerOpts            []Option
 	}{
 		"reconcile DRA ResourceClaim should be rejected as inadmissible": {
-			enableDRAFeature: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.DynamicResourceAllocation:        true,
+				features.MultiKueueOrchestratedPreemption: false,
+			},
 			workload: utiltestingapi.MakeWorkload("wlWithDRAResourceClaim", "ns").
 				Queue("lq").
 				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
@@ -461,7 +464,10 @@ func TestReconcile(t *testing.T) {
 			wantEvents: nil,
 		},
 		"reconcile DRA ResourceClaimTemplate should be pre-processed and queued": {
-			enableDRAFeature:     true,
+			featureGates: map[featuregate.Feature]bool{
+				features.DynamicResourceAllocation:        true,
+				features.MultiKueueOrchestratedPreemption: false,
+			},
 			wantDRAResourceTotal: ptr.To(int64(1)),
 			wantWorkloadsInQueue: ptr.To(1),
 			workload: utiltestingapi.MakeWorkload("wlWithDRAResourceClaimTemplate", "ns").
@@ -496,7 +502,10 @@ func TestReconcile(t *testing.T) {
 			wantEvents: nil,
 		},
 		"reconcile DRA ResourceClaimTemplate multi-pod should be pre-processed and queued": {
-			enableDRAFeature:     true,
+			featureGates: map[featuregate.Feature]bool{
+				features.DynamicResourceAllocation:        true,
+				features.MultiKueueOrchestratedPreemption: false,
+			},
 			wantDRAResourceTotal: ptr.To(int64(6)),
 			wantWorkloadsInQueue: ptr.To(1),
 			workload: utiltestingapi.MakeWorkload("wlMultiPodDRA", "ns").
@@ -531,7 +540,10 @@ func TestReconcile(t *testing.T) {
 			wantEvents: nil,
 		},
 		"reconcile DRA ResourceClaimTemplate with unmapped device class": {
-			enableDRAFeature: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.DynamicResourceAllocation:        true,
+				features.MultiKueueOrchestratedPreemption: false,
+			},
 			workload: utiltestingapi.MakeWorkload("wlUnmappedDRA", "ns").
 				Queue("lq").
 				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
@@ -580,7 +592,10 @@ func TestReconcile(t *testing.T) {
 			wantEvents:   nil,
 		},
 		"reconcile DRA ResourceClaimTemplate not found should return error": {
-			enableDRAFeature: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.DynamicResourceAllocation:        true,
+				features.MultiKueueOrchestratedPreemption: false,
+			},
 			workload: utiltestingapi.MakeWorkload("wlMissingTemplate", "ns").
 				Queue("lq").
 				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
@@ -2564,8 +2579,10 @@ func TestReconcile(t *testing.T) {
 			wantResult: reconcile.Result{},
 		},
 		"should synchronize the status of preemption gates": {
-			enableMKOrchestratedPreemptionFeature: true,
-
+			featureGates: map[featuregate.Feature]bool{
+				features.DynamicResourceAllocation:        false,
+				features.MultiKueueOrchestratedPreemption: true,
+			},
 			cq: utiltestingapi.MakeClusterQueue("cq").Obj(),
 			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
@@ -2793,8 +2810,7 @@ func TestReconcile(t *testing.T) {
 	for name, tc := range cases {
 		for _, enabled := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", name, enabled), func(t *testing.T) {
-				features.SetFeatureGateDuringTest(t, features.DynamicResourceAllocation, tc.enableDRAFeature)
-				features.SetFeatureGateDuringTest(t, features.MultiKueueOrchestratedPreemption, tc.enableMKOrchestratedPreemptionFeature)
+				features.SetFeatureGatesDuringTest(t, tc.featureGates)
 				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, enabled)
 				features.SetFeatureGateDuringTest(t, features.AdmissionGatedBy, true)
 
@@ -2907,7 +2923,7 @@ func TestReconcile(t *testing.T) {
 				}
 
 				// For DRA tests, verify that workloads are properly queued/cached
-				if tc.enableDRAFeature && testWl != nil &&
+				if tc.featureGates[features.DynamicResourceAllocation] && testWl != nil &&
 					len(testWl.Spec.PodSets) > 0 &&
 					len(testWl.Spec.PodSets[0].Template.Spec.ResourceClaims) > 0 {
 					workloadKey := client.ObjectKeyFromObject(testWl)

--- a/pkg/controller/jobframework/base_webhook_test.go
+++ b/pkg/controller/jobframework/base_webhook_test.go
@@ -25,6 +25,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -44,7 +45,7 @@ func TestBaseWebhookDefault(t *testing.T) {
 	testcases := map[string]struct {
 		manageJobsWithoutQueueName bool
 		defaultLqExist             bool
-		enableMultiKueue           bool
+		featureGates               map[featuregate.Feature]bool
 		job                        *batchv1.Job
 		want                       *batchv1.Job
 	}{
@@ -80,7 +81,7 @@ func TestBaseWebhookDefault(t *testing.T) {
 				Queue("multikueue").
 				ManagedBy(kueue.MultiKueueControllerName).
 				Obj(),
-			enableMultiKueue: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueue: true},
 		},
 		"ManagedByDefaulting, targeting multikueue local queue but already managaed by someone else": {
 			job: utiljob.MakeJob("job", metav1.NamespaceDefault).
@@ -91,7 +92,7 @@ func TestBaseWebhookDefault(t *testing.T) {
 				Queue("multikueue").
 				ManagedBy("someone-else").
 				Obj(),
-			enableMultiKueue: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueue: true},
 		},
 		"ManagedByDefaulting, targeting non-multikueue local queue": {
 			job: utiljob.MakeJob("job", metav1.NamespaceDefault).
@@ -100,13 +101,13 @@ func TestBaseWebhookDefault(t *testing.T) {
 			want: utiljob.MakeJob("job", metav1.NamespaceDefault).
 				Queue("queue").
 				Obj(),
-			enableMultiKueue: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueue: true},
 		},
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			ctx, log := utiltesting.ContextWithLog(t)
-			features.SetFeatureGateDuringTest(t, features.MultiKueue, tc.enableMultiKueue)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			clientBuilder := utiltesting.NewClientBuilder().
 				WithObjects(
 					utiltesting.MakeNamespace(metav1.NamespaceDefault),
@@ -120,7 +121,7 @@ func TestBaseWebhookDefault(t *testing.T) {
 					t.Fatalf("failed to create default local queue: %s", err)
 				}
 			}
-			if tc.enableMultiKueue {
+			if tc.featureGates[features.MultiKueue] {
 				if err := queueManager.AddLocalQueue(ctx, utiltestingapi.MakeLocalQueue("multikueue", metav1.NamespaceDefault).
 					ClusterQueue("cluster-queue").Obj()); err != nil {
 					t.Fatalf("failed to create default local queue: %s", err)

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -34,6 +34,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
@@ -89,27 +90,26 @@ func TestReconcileGenericJob(t *testing.T) {
 		Priority(0)
 
 	testCases := map[string]struct {
-		elasticJobsViaWorkloadSlicesEnabled bool
-		admissionGatedByEnabled             bool
-		req                                 types.NamespacedName
-		job                                 *batchv1.Job
-		podSets                             []kueue.PodSet
-		objs                                []client.Object
-		wantWorkloads                       []kueue.Workload
-		wantEvents                          []utiltesting.EventRecord
+		featureGates  map[featuregate.Feature]bool
+		req           types.NamespacedName
+		job           *batchv1.Job
+		podSets       []kueue.PodSet
+		objs          []client.Object
+		wantWorkloads []kueue.Workload
+		wantEvents    []utiltesting.EventRecord
 	}{
 		"handle job with no workload (elasticJobsViaWorkloadSlicesEnabled = false)": {
-			elasticJobsViaWorkloadSlicesEnabled: false,
-			req:                                 baseReq,
-			job:                                 baseJob.DeepCopy(),
-			podSets:                             basePodSets,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: false},
+			req:          baseReq,
+			job:          baseJob.DeepCopy(),
+			podSets:      basePodSets,
 			wantWorkloads: []kueue.Workload{
 				*baseWl.Clone().Name("job-test-job-ce737").Obj(),
 			},
 		},
 		"handle job with no workload (elasticJobsViaWorkloadSlicesEnabled = false and elastic job annotation)": {
-			elasticJobsViaWorkloadSlicesEnabled: false,
-			req:                                 baseReq,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: false},
+			req:          baseReq,
 			job: baseJob.Clone().
 				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 				Obj(),
@@ -119,17 +119,17 @@ func TestReconcileGenericJob(t *testing.T) {
 			},
 		},
 		"handle job with no workload (elasticJobsViaWorkloadSlicesEnabled = true)": {
-			elasticJobsViaWorkloadSlicesEnabled: true,
-			req:                                 baseReq,
-			job:                                 baseJob.DeepCopy(),
-			podSets:                             basePodSets,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			req:          baseReq,
+			job:          baseJob.DeepCopy(),
+			podSets:      basePodSets,
 			wantWorkloads: []kueue.Workload{
 				*baseWl.Clone().Name("job-test-job-ce737").Obj(),
 			},
 		},
 		"handle job with no workload (elasticJobsViaWorkloadSlicesEnabled = true and elastic job annotation)": {
-			elasticJobsViaWorkloadSlicesEnabled: true,
-			req:                                 baseReq,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			req:          baseReq,
 			job: baseJob.Clone().
 				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 				Obj(),
@@ -144,8 +144,8 @@ func TestReconcileGenericJob(t *testing.T) {
 			},
 		},
 		"update workload to match job (one existing workload)": {
-			elasticJobsViaWorkloadSlicesEnabled: true,
-			req:                                 baseReq,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			req:          baseReq,
 			job: baseJob.Clone().
 				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 				Obj(),
@@ -212,8 +212,8 @@ func TestReconcileGenericJob(t *testing.T) {
 			},
 		},
 		"job with AdmissionGatedBy annotation should create workload with annotation": {
-			admissionGatedByEnabled: true,
-			req:                     baseReq,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
+			req:          baseReq,
 			job: baseJob.Clone().
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller1").
 				Obj(),
@@ -226,8 +226,8 @@ func TestReconcileGenericJob(t *testing.T) {
 			},
 		},
 		"job with AdmissionGatedBy annotation removed should update workload": {
-			admissionGatedByEnabled: true,
-			req:                     baseReq,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
+			req:          baseReq,
 			job: baseJob.Clone().
 				Obj(),
 			podSets: basePodSets,
@@ -241,8 +241,8 @@ func TestReconcileGenericJob(t *testing.T) {
 			},
 		},
 		"job with multiple AdmissionGatedBy gates should create workload with annotation": {
-			admissionGatedByEnabled: true,
-			req:                     baseReq,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
+			req:          baseReq,
 			job: baseJob.Clone().
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller1,example.com/controller2").
 				Obj(),
@@ -255,8 +255,8 @@ func TestReconcileGenericJob(t *testing.T) {
 			},
 		},
 		"job with AdmissionGatedBy annotation when feature gate disabled should not propagate annotation": {
-			admissionGatedByEnabled: false,
-			req:                     baseReq,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: false},
+			req:          baseReq,
 			job: baseJob.Clone().
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller1").
 				Obj(),
@@ -268,8 +268,8 @@ func TestReconcileGenericJob(t *testing.T) {
 			},
 		},
 		"job with AdmissionGatedBy annotation unchanged should not emit event": {
-			admissionGatedByEnabled: true,
-			req:                     baseReq,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
+			req:          baseReq,
 			job: baseJob.Clone().
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller1").
 				Obj(),
@@ -287,8 +287,8 @@ func TestReconcileGenericJob(t *testing.T) {
 			wantEvents: nil,
 		},
 		"job with AdmissionGatedBy annotation changed should emit event": {
-			admissionGatedByEnabled: true,
-			req:                     baseReq,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
+			req:          baseReq,
 			job: baseJob.Clone().
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller1,example.com/controller2").
 				Obj(),
@@ -313,8 +313,8 @@ func TestReconcileGenericJob(t *testing.T) {
 			},
 		},
 		"job with AdmissionGatedBy annotation changed when feature disabled should not emit event": {
-			admissionGatedByEnabled: false,
-			req:                     baseReq,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: false},
+			req:          baseReq,
 			job: baseJob.Clone().
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller1,example.com/controller2").
 				Obj(),
@@ -334,8 +334,7 @@ func TestReconcileGenericJob(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, tc.elasticJobsViaWorkloadSlicesEnabled)
-			features.SetFeatureGateDuringTest(t, features.AdmissionGatedBy, tc.admissionGatedByEnabled)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			ctx, _ := utiltesting.ContextWithLog(t)
 			mockctrl := gomock.NewController(t)

--- a/pkg/controller/jobframework/tas_validation_test.go
+++ b/pkg/controller/jobframework/tas_validation_test.go
@@ -21,6 +21,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -30,12 +31,12 @@ func TestValidateSliceRequiredTopologyConstraintsAnnotation(t *testing.T) {
 	replicaPath := field.NewPath("spec", "template", "metadata")
 
 	testCases := map[string]struct {
-		enableTASMultiLayer bool
-		annotations         map[string]string
-		wantErrNum          int
+		featureGates map[featuregate.Feature]bool
+		annotations  map[string]string
+		wantErrNum   int
 	}{
 		"valid: single constraint layer": {
-			enableTASMultiLayer: true,
+			featureGates: map[featuregate.Feature]bool{features.TASMultiLayerTopology: true},
 			annotations: map[string]string{
 				kueue.PodSetRequiredTopologyAnnotation:                 "cloud.com/block",
 				kueue.PodSetSliceRequiredTopologyConstraintsAnnotation: `[{"topology":"cloud.com/rack","size":16}]`,
@@ -43,7 +44,7 @@ func TestValidateSliceRequiredTopologyConstraintsAnnotation(t *testing.T) {
 			wantErrNum: 0,
 		},
 		"valid: two constraint layers": {
-			enableTASMultiLayer: true,
+			featureGates: map[featuregate.Feature]bool{features.TASMultiLayerTopology: true},
 			annotations: map[string]string{
 				kueue.PodSetRequiredTopologyAnnotation:                 "cloud.com/block",
 				kueue.PodSetSliceRequiredTopologyConstraintsAnnotation: `[{"topology":"cloud.com/rack","size":16},{"topology":"kubernetes.io/hostname","size":4}]`,
@@ -51,7 +52,7 @@ func TestValidateSliceRequiredTopologyConstraintsAnnotation(t *testing.T) {
 			wantErrNum: 0,
 		},
 		"valid: three constraint layers": {
-			enableTASMultiLayer: true,
+			featureGates: map[featuregate.Feature]bool{features.TASMultiLayerTopology: true},
 			annotations: map[string]string{
 				kueue.PodSetRequiredTopologyAnnotation:                 "cloud.com/block",
 				kueue.PodSetSliceRequiredTopologyConstraintsAnnotation: `[{"topology":"cloud.com/rack","size":16},{"topology":"cloud.com/sub-rack","size":4},{"topology":"kubernetes.io/hostname","size":2}]`,
@@ -59,7 +60,7 @@ func TestValidateSliceRequiredTopologyConstraintsAnnotation(t *testing.T) {
 			wantErrNum: 0,
 		},
 		"invalid: not valid JSON": {
-			enableTASMultiLayer: true,
+			featureGates: map[featuregate.Feature]bool{features.TASMultiLayerTopology: true},
 			annotations: map[string]string{
 				kueue.PodSetRequiredTopologyAnnotation:                 "cloud.com/block",
 				kueue.PodSetSliceRequiredTopologyConstraintsAnnotation: `invalid-json`,
@@ -67,7 +68,7 @@ func TestValidateSliceRequiredTopologyConstraintsAnnotation(t *testing.T) {
 			wantErrNum: 1, // invalid JSON
 		},
 		"invalid: empty array": {
-			enableTASMultiLayer: true,
+			featureGates: map[featuregate.Feature]bool{features.TASMultiLayerTopology: true},
 			annotations: map[string]string{
 				kueue.PodSetRequiredTopologyAnnotation:                 "cloud.com/block",
 				kueue.PodSetSliceRequiredTopologyConstraintsAnnotation: `[]`,
@@ -75,7 +76,7 @@ func TestValidateSliceRequiredTopologyConstraintsAnnotation(t *testing.T) {
 			wantErrNum: 1, // must contain at least 1 entry
 		},
 		"invalid: more than 3 entries": {
-			enableTASMultiLayer: true,
+			featureGates: map[featuregate.Feature]bool{features.TASMultiLayerTopology: true},
 			annotations: map[string]string{
 				kueue.PodSetRequiredTopologyAnnotation:                 "cloud.com/block",
 				kueue.PodSetSliceRequiredTopologyConstraintsAnnotation: `[{"topology":"a","size":64},{"topology":"b","size":16},{"topology":"c","size":4},{"topology":"d","size":1}]`,
@@ -83,7 +84,7 @@ func TestValidateSliceRequiredTopologyConstraintsAnnotation(t *testing.T) {
 			wantErrNum: 1, // more than 3 entries
 		},
 		"invalid: size less than 1": {
-			enableTASMultiLayer: true,
+			featureGates: map[featuregate.Feature]bool{features.TASMultiLayerTopology: true},
 			annotations: map[string]string{
 				kueue.PodSetRequiredTopologyAnnotation:                 "cloud.com/block",
 				kueue.PodSetSliceRequiredTopologyConstraintsAnnotation: `[{"topology":"cloud.com/rack","size":0}]`,
@@ -91,7 +92,7 @@ func TestValidateSliceRequiredTopologyConstraintsAnnotation(t *testing.T) {
 			wantErrNum: 1, // size < 1
 		},
 		"invalid: size does not divide parent": {
-			enableTASMultiLayer: true,
+			featureGates: map[featuregate.Feature]bool{features.TASMultiLayerTopology: true},
 			annotations: map[string]string{
 				kueue.PodSetRequiredTopologyAnnotation:                 "cloud.com/block",
 				kueue.PodSetSliceRequiredTopologyConstraintsAnnotation: `[{"topology":"cloud.com/rack","size":16},{"topology":"kubernetes.io/hostname","size":5}]`,
@@ -99,7 +100,7 @@ func TestValidateSliceRequiredTopologyConstraintsAnnotation(t *testing.T) {
 			wantErrNum: 1, // 16 % 5 != 0
 		},
 		"invalid: mutual exclusivity with podset-slice-required-topology": {
-			enableTASMultiLayer: true,
+			featureGates: map[featuregate.Feature]bool{features.TASMultiLayerTopology: true},
 			annotations: map[string]string{
 				kueue.PodSetRequiredTopologyAnnotation:                 "cloud.com/block",
 				kueue.PodSetSliceRequiredTopologyAnnotation:            "cloud.com/rack",
@@ -109,7 +110,7 @@ func TestValidateSliceRequiredTopologyConstraintsAnnotation(t *testing.T) {
 			wantErrNum: 2, // forbidden with slice-required-topology AND slice-size
 		},
 		"invalid: with podset-group-name": {
-			enableTASMultiLayer: true,
+			featureGates: map[featuregate.Feature]bool{features.TASMultiLayerTopology: true},
 			annotations: map[string]string{
 				kueue.PodSetRequiredTopologyAnnotation:                 "cloud.com/block",
 				kueue.PodSetSliceRequiredTopologyConstraintsAnnotation: `[{"topology":"cloud.com/rack","size":16}]`,
@@ -125,7 +126,7 @@ func TestValidateSliceRequiredTopologyConstraintsAnnotation(t *testing.T) {
 			wantErrNum: 1, // feature gate not enabled
 		},
 		"invalid: duplicate topology labels": {
-			enableTASMultiLayer: true,
+			featureGates: map[featuregate.Feature]bool{features.TASMultiLayerTopology: true},
 			annotations: map[string]string{
 				kueue.PodSetRequiredTopologyAnnotation:                 "cloud.com/block",
 				kueue.PodSetSliceRequiredTopologyConstraintsAnnotation: `[{"topology":"cloud.com/rack","size":16},{"topology":"cloud.com/rack","size":4}]`,
@@ -133,7 +134,7 @@ func TestValidateSliceRequiredTopologyConstraintsAnnotation(t *testing.T) {
 			wantErrNum: 1,
 		},
 		"invalid: duplicate topology label among three entries": {
-			enableTASMultiLayer: true,
+			featureGates: map[featuregate.Feature]bool{features.TASMultiLayerTopology: true},
 			annotations: map[string]string{
 				kueue.PodSetRequiredTopologyAnnotation:                 "cloud.com/block",
 				kueue.PodSetSliceRequiredTopologyConstraintsAnnotation: `[{"topology":"cloud.com/rack","size":16},{"topology":"kubernetes.io/hostname","size":4},{"topology":"cloud.com/rack","size":2}]`,
@@ -144,7 +145,7 @@ func TestValidateSliceRequiredTopologyConstraintsAnnotation(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TASMultiLayerTopology, tc.enableTASMultiLayer)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			meta := &metav1.ObjectMeta{
 				Annotations: tc.annotations,

--- a/pkg/controller/jobframework/validation_test.go
+++ b/pkg/controller/jobframework/validation_test.go
@@ -321,9 +321,7 @@ func TestValidateJobOnUpdate(t *testing.T) {
 
 	for tcName, tc := range testCases {
 		t.Run(tcName, func(t *testing.T) {
-			for feature, enabled := range tc.featureGates {
-				features.SetFeatureGateDuringTest(t, feature, enabled)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			mockctrl := gomock.NewController(t)
 

--- a/pkg/controller/jobs/appwrapper/appwrapper_controller_test.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_controller_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -89,9 +90,9 @@ func TestPodSets(t *testing.T) {
 		Obj()
 
 	testCases := map[string]struct {
-		job                           *awv1beta2.AppWrapper
-		wantPodSets                   []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		job          *awv1beta2.AppWrapper
+		wantPodSets  []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingappwrapper.MakeAppWrapper("aw", "ns").
@@ -109,7 +110,7 @@ func TestPodSets(t *testing.T) {
 					PodSpec(batchJob.Spec.Template.Spec).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required and preferred topology annotation": {
 			job: testingappwrapper.MakeAppWrapper("aw", "ns").
@@ -131,7 +132,7 @@ func TestPodSets(t *testing.T) {
 					Obj(),
 			},
 
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"without required and preferred topology annotation if TAS is disabled": {
 			job: testingappwrapper.MakeAppWrapper("aw", "ns").
@@ -149,13 +150,13 @@ func TestPodSets(t *testing.T) {
 					Obj(),
 			},
 
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := fromObject(tc.job).PodSets(ctx)
 			if err != nil {

--- a/pkg/controller/jobs/deployment/deployment_webhook_test.go
+++ b/pkg/controller/jobs/deployment/deployment_webhook_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
@@ -181,10 +182,10 @@ func TestDefault(t *testing.T) {
 
 func TestValidateCreate(t *testing.T) {
 	testCases := map[string]struct {
-		deployment       *appsv1.Deployment
-		wantErr          error
-		wantWarns        admission.Warnings
-		admissionGatedBy bool
+		deployment   *appsv1.Deployment
+		wantErr      error
+		wantWarns    admission.Warnings
+		featureGates map[featuregate.Feature]bool
 	}{
 		"without queue": {
 			deployment: testingdeployment.MakeDeployment("test-pod", "").Obj(),
@@ -210,48 +211,48 @@ func TestValidateCreate(t *testing.T) {
 				Queue("queue").
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"AdmissionGatedBy annotation - trailing space": {
 			deployment: testingdeployment.MakeDeployment("test-deployment", "default").
 				Queue("queue").
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/gate ").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"AdmissionGatedBy annotation - space before comma": {
 			deployment: testingdeployment.MakeDeployment("test-deployment", "default").
 				Queue("queue").
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/gate ,example.com/gate2").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"AdmissionGatedBy annotation - space after comma": {
 			deployment: testingdeployment.MakeDeployment("test-deployment", "default").
 				Queue("queue").
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/gate, example.com/gate2").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"AdmissionGatedBy annotation - leading space": {
 			deployment: testingdeployment.MakeDeployment("test-deployment", "default").
 				Queue("queue").
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, " example.com/gate").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"AdmissionGatedBy annotation - multiple gates": {
 			deployment: testingdeployment.MakeDeployment("test-deployment", "default").
 				Queue("queue").
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/a,not.example.com/b").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"invalid AdmissionGatedBy annotation - not in subdomain/path format": {
 			deployment: testingdeployment.MakeDeployment("test-deployment", "default").
@@ -261,7 +262,7 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Invalid(admissionGatedByAnnotationsPath, "this is an invalid value", "must be a domain-prefixed path (such as \"acme.io/foo\")"),
 			}.ToAggregate(),
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"invalid AdmissionGatedBy annotation - duplicate gates": {
 			deployment: testingdeployment.MakeDeployment("test-deployment", "default").
@@ -271,7 +272,7 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Invalid(admissionGatedByAnnotationsPath, "duplicates.are/invalid,duplicates.are/invalid", "duplicate gate name: duplicates.are/invalid"),
 			}.ToAggregate(),
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"invalid AdmissionGatedBy annotation - gate name too long": {
 			deployment: testingdeployment.MakeDeployment("test-deployment", "default").
@@ -281,7 +282,7 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.TooLong(admissionGatedByAnnotationsPath, "", webhook.MaxGateNameLengthForAdmissionGatedBy),
 			}.ToAggregate(),
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"invalid AdmissionGatedBy annotation - space in path component": {
 			deployment: testingdeployment.MakeDeployment("test-deployment", "default").
@@ -291,7 +292,7 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Invalid(admissionGatedByAnnotationsPath, "gate name", testutil.InvalidPathMessage),
 			}.ToAggregate(),
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"invalid AdmissionGatedBy annotation - space in domain component": {
 			deployment: testingdeployment.MakeDeployment("test-deployment", "default").
@@ -301,7 +302,7 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Invalid(admissionGatedByAnnotationsPath, "example .com", testutil.InvalidRFC1123Message),
 			}.ToAggregate(),
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"invalid AdmissionGatedBy annotation - multiple gates with one containing space": {
 			deployment: testingdeployment.MakeDeployment("test-deployment", "default").
@@ -311,37 +312,37 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Invalid(admissionGatedByAnnotationsPath, "invalid gate.com", testutil.InvalidRFC1123Message),
 			}.ToAggregate(),
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"AdmissionGatedBy annotation with feature gate disabled - valid value": {
 			deployment: testingdeployment.MakeDeployment("test-deployment", "default").
 				Queue("queue").
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/gate").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: false,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: false},
 		},
 		"AdmissionGatedBy annotation with feature gate disabled - invalid value": {
 			deployment: testingdeployment.MakeDeployment("test-deployment", "default").
 				Queue("queue").
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "this is an invalid value").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: false,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: false},
 		},
 		"AdmissionGatedBy annotation with feature gate enabled - empty string": {
 			deployment: testingdeployment.MakeDeployment("test-deployment", "default").
 				Queue("queue").
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.AdmissionGatedBy, tc.admissionGatedBy)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			t.Cleanup(jobframework.EnableIntegrationsForTest(t, "pod"))
 
 			builder := utiltesting.NewClientBuilder()
@@ -364,11 +365,11 @@ func TestValidateCreate(t *testing.T) {
 
 func TestValidateUpdate(t *testing.T) {
 	testCases := map[string]struct {
-		oldDeployment    *appsv1.Deployment
-		newDeployment    *appsv1.Deployment
-		wantErr          error
-		wantWarns        admission.Warnings
-		admissionGatedBy bool
+		oldDeployment *appsv1.Deployment
+		newDeployment *appsv1.Deployment
+		wantErr       error
+		wantWarns     admission.Warnings
+		featureGates  map[featuregate.Feature]bool
 	}{
 		"without queue (no changes)": {
 			oldDeployment: testingdeployment.MakeDeployment("test-pod", "").Obj(),
@@ -534,7 +535,7 @@ func TestValidateUpdate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Forbidden(admissionGatedByAnnotationsPath, "cannot add admission gate after creation"),
 			}.ToAggregate(),
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"allow removing AdmissionGatedBy annotation with single gate": {
 			oldDeployment: testingdeployment.MakeDeployment("test-deployment", "default").
@@ -544,8 +545,8 @@ func TestValidateUpdate(t *testing.T) {
 			newDeployment: testingdeployment.MakeDeployment("test-deployment", "default").
 				Queue("queue").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"allow removing AdmissionGatedBy annotation with multiple gates": {
 			oldDeployment: testingdeployment.MakeDeployment("test-deployment", "default").
@@ -555,8 +556,8 @@ func TestValidateUpdate(t *testing.T) {
 			newDeployment: testingdeployment.MakeDeployment("test-deployment", "default").
 				Queue("queue").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"allow removing one gate from AdmissionGatedBy annotation": {
 			oldDeployment: testingdeployment.MakeDeployment("test-deployment", "default").
@@ -567,8 +568,8 @@ func TestValidateUpdate(t *testing.T) {
 				Queue("queue").
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller2").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"reject injecting new gate in AdmissionGatedBy annotation": {
 			oldDeployment: testingdeployment.MakeDeployment("test-deployment", "default").
@@ -582,7 +583,7 @@ func TestValidateUpdate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Forbidden(admissionGatedByAnnotationsPath, "can only remove gates, not add new ones"),
 			}.ToAggregate(),
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"allow reordering gates in AdmissionGatedBy annotation": {
 			oldDeployment: testingdeployment.MakeDeployment("test-deployment", "default").
@@ -593,14 +594,14 @@ func TestValidateUpdate(t *testing.T) {
 				Queue("queue").
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller2,example.com/controller1").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.AdmissionGatedBy, tc.admissionGatedBy)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			t.Cleanup(jobframework.EnableIntegrationsForTest(t, "pod"))
 
 			builder := utiltesting.NewClientBuilder()

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -335,20 +336,21 @@ func TestPodSets(t *testing.T) {
 	jobTemplate := utiltestingjob.MakeJob("job", "ns")
 
 	cases := map[string]struct {
-		job                           *Job
-		wantPodSets                   []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		featureGates map[featuregate.Feature]bool
+		job          *Job
+		wantPodSets  []kueue.PodSet
 	}{
 		"no partial admission": {
-			job: (*Job)(jobTemplate.Clone().Parallelism(3).Obj()),
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			job:          (*Job)(jobTemplate.Clone().Parallelism(3).Obj()),
 			wantPodSets: []kueue.PodSet{
 				*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).
 					PodSpec(*jobTemplate.Clone().Spec.Template.Spec.DeepCopy()).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: false,
 		},
 		"partial admission": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			job: (*Job)(
 				jobTemplate.Clone().
 					Parallelism(3).
@@ -361,9 +363,9 @@ func TestPodSets(t *testing.T) {
 					SetMinimumCount(2).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: false,
 		},
 		"with required topology annotation": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			job: (*Job)(
 				jobTemplate.Clone().
 					Parallelism(3).
@@ -378,9 +380,9 @@ func TestPodSets(t *testing.T) {
 					PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: true,
 		},
 		"with preferred topology annotation": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			job: (*Job)(
 				jobTemplate.Clone().
 					Parallelism(3).
@@ -395,9 +397,9 @@ func TestPodSets(t *testing.T) {
 					PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: true,
 		},
 		"with slice-only topology": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			job: (*Job)(
 				jobTemplate.Clone().
 					Parallelism(3).
@@ -417,9 +419,9 @@ func TestPodSets(t *testing.T) {
 					SliceSizeTopologyRequest(1).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: true,
 		},
 		"with slice-only topology if TAS is disabled": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			job: (*Job)(
 				jobTemplate.Clone().
 					Parallelism(3).
@@ -436,9 +438,9 @@ func TestPodSets(t *testing.T) {
 					}).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: false,
 		},
 		"with slice-only topology – only podset slice required topology annotation": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			job: (*Job)(
 				jobTemplate.Clone().
 					Parallelism(3).
@@ -454,9 +456,9 @@ func TestPodSets(t *testing.T) {
 					PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: true,
 		},
 		"with slice-only topology – only podset slice size annotation": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			job: (*Job)(
 				jobTemplate.Clone().
 					Parallelism(3).
@@ -472,9 +474,9 @@ func TestPodSets(t *testing.T) {
 					PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: true,
 		},
 		"without preferred topology annotation if TAS is disabled": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			job: (*Job)(
 				jobTemplate.Clone().
 					Parallelism(3).
@@ -487,9 +489,9 @@ func TestPodSets(t *testing.T) {
 					Annotations(map[string]string{kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: false,
 		},
 		"without required topology annotation if TAS is disabled": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			job: (*Job)(
 				jobTemplate.Clone().
 					Parallelism(3).
@@ -502,12 +504,11 @@ func TestPodSets(t *testing.T) {
 					Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: false,
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := tc.job.PodSets(ctx)
 			if err != nil {
@@ -595,9 +596,7 @@ func TestReconciler(t *testing.T) {
 	baseWaitForPodsReadyConf := &configapi.WaitForPodsReady{}
 
 	cases := map[string]struct {
-		enableTopologyAwareScheduling                     bool
-		enableManagedJobsNamespaceSelectorAlwaysRespected bool
-		disableAssignQueueLabelsForPods                   bool
+		featureGates map[featuregate.Feature]bool
 
 		reconcilerOptions []jobframework.Option
 		job               batchv1.Job
@@ -610,6 +609,11 @@ func TestReconciler(t *testing.T) {
 		wantErr           error
 	}{
 		"PodsReady is set to False before Workload is Admitted": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -631,6 +635,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodsReady is set to False after Workload is Admitted but not all Pods reached readiness": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -652,6 +661,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodsReady is set to False after Workload is Admitted, some Pods became ready but not all Pods reached readiness": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -687,6 +701,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodsReady is set to True after Workload is Admitted and all Pods reached readiness": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -718,6 +737,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodsReady is set to True after Workload is Admitted and all Pods reached readiness without previous PodsReady condition": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -743,6 +767,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodsReady is set to False after Workload is running and one pod failed": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -776,6 +805,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodsReady continues to be False after a pod failed and workload is still recovering": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -811,6 +845,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodsReady is set to True after failing pod recovered": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -842,6 +881,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodsReady=False has the new Reason if there was the old one before (pre v0.11.0)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -869,6 +913,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodsReady=True has the new Reason if there was the old one before (pre v0.11.0)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -900,6 +949,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodsReady is set to False if there's an invalid Reason (pre v0.11.0)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -927,7 +981,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodSet label and Workload annotation are set when Job is starting; TopologyAwareScheduling enabled": {
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     true,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
@@ -960,8 +1018,12 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"Pod queue labels are not set when AssignQueueLabelsForPods is disabled": {
-			disableAssignQueueLabelsForPods: true,
-			job:                             *baseJobWrapper.DeepCopy(),
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    false,
+			},
+			job: *baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(false).
 				PodLabel(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
@@ -986,6 +1048,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"Pod cluster queue label is not set when cluster queue name is too long": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(false).
@@ -1020,6 +1087,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is created, it has its owner ProvReq annotations": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				SetAnnotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
 				SetAnnotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
@@ -1052,6 +1124,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is created, it has correct labels set": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Label("toCopyKey", "toCopyValue").
 				Label("dontCopyKey", "dontCopyValue").
@@ -1087,6 +1164,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is admitted the PodSetUpdates are propagated to job": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -1140,6 +1222,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is evicted due to spec.active field being false, job gets suspended and quota is unset": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
@@ -1222,6 +1309,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is active after deactivation; objectRetentionPolicies.workloads.afterDeactivatedByKueue=0; should not delete the job": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithObjectRetentionPolicies(&configapi.ObjectRetentionPolicies{
 					Workloads: &configapi.WorkloadRetentionPolicy{
@@ -1312,6 +1404,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is manually deactivated; objectRetentionPolicies.workloads.afterDeactivatedByKueue=0; should not delete the job": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithObjectRetentionPolicies(&configapi.ObjectRetentionPolicies{
 					Workloads: &configapi.WorkloadRetentionPolicy{
@@ -1402,6 +1499,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is deactivated by kueue; objectRetentionPolicies.workloads.afterDeactivatedByKueue=0; should delete the job": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithObjectRetentionPolicies(&configapi.ObjectRetentionPolicies{
 					Workloads: &configapi.WorkloadRetentionPolicy{
@@ -1495,6 +1597,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is deactivated by kueue; objectRetentionPolicies.workloads.afterDeactivatedByKueue=60; retention period has not expired": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithObjectRetentionPolicies(&configapi.ObjectRetentionPolicies{
 					Workloads: &configapi.WorkloadRetentionPolicy{
@@ -1585,6 +1692,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is deactivated by kueue; objectRetentionPolicies.workloads.afterDeactivatedByKueue=60; retention period has expired": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithObjectRetentionPolicies(&configapi.ObjectRetentionPolicies{
 					Workloads: &configapi.WorkloadRetentionPolicy{
@@ -1678,6 +1790,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is evicted due to pods ready timeout, job gets suspended and quota is unset": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
@@ -1734,6 +1851,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is evicted due to admission check, job gets suspended": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
@@ -1814,6 +1936,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is evicted due to cluster queue stopped, job gets suspended": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
@@ -1894,6 +2021,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is evicted due to local queue stopped, job gets suspended": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
@@ -1974,6 +2106,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is evicted due to preemption, job gets suspended": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
@@ -2055,6 +2192,11 @@ func TestReconciler(t *testing.T) {
 		},
 		"when job is initially suspended, the Workload has active=false and it's not admitted, " +
 			"it should not get an evicted condition, but the job should remain suspended": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(true).
 				Obj(),
@@ -2125,6 +2267,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is admitted and PodSetUpdates conflict between admission checks on labels, the workload is finished with failure": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2196,6 +2343,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is admitted and PodSetUpdates conflict between admission checks on annotations, the workload is finished with failure": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2267,6 +2419,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is admitted and PodSetUpdates conflict between admission checks on nodeSelector, the workload is finished with failure": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2338,6 +2495,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is admitted and PodSetUpdates conflict between admission check nodeSelector and current node selector, the workload is finished with failure": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				NodeSelector("provisioning", "spot").
 				Obj(),
@@ -2387,6 +2549,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is admitted the PodSetUpdates values matching for key": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2496,6 +2663,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"suspended job with matching admitted workload is unsuspended": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
@@ -2527,6 +2699,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"non-matching admitted workload is deleted": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
@@ -2550,6 +2727,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"non-matching non-admitted workload is updated": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
@@ -2581,6 +2763,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"suspended job with partial admission and admitted workload is unsuspended": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
@@ -2629,6 +2816,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"unsuspended job with partial admission and non-matching admitted workload is suspended and workload is deleted": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
@@ -2670,6 +2862,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload is created when queue name is set": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -2708,6 +2905,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload is updated when queue name has changed for suspended job": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(true).
@@ -2743,6 +2945,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload is updated when priority class has changed for suspended job": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(true).
@@ -2791,6 +2998,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"shouldn't update workload when priority class no changes": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(true).
@@ -2831,6 +3043,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload without uid label is created when job's uid is longer than 63 characters": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -2867,6 +3084,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload is not created when queue name is not set": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *utiltestingjob.MakeJob("job", "ns").
 				Suspend(false).
 				Obj(),
@@ -2875,6 +3097,11 @@ func TestReconciler(t *testing.T) {
 				Obj(),
 		},
 		"non-standalone job is suspended if its parent workload is not found": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				OwnerReference("parent", batchv1.SchemeGroupVersion.WithKind("Job")).
@@ -2903,6 +3130,11 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
 			},
 			job: *baseJobWrapper.
 				Clone().
@@ -2938,6 +3170,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"non-standalone job is suspended if its parent workload is found and not admitted": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
@@ -2981,6 +3218,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"non-standalone job is not suspended if its parent workload is admitted and queue name is set": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -3019,6 +3261,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"checking a second non-matching workload is deleted": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
@@ -3101,6 +3348,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is evicted but suspended, reset startTime and restore node affinity": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(true).
 				StartTime(now).
@@ -3131,6 +3383,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is evicted, suspended and startTime is reset, restore node affinity": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(true).
 				NodeSelector("provisioning", "spot").
@@ -3160,6 +3417,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when job completes, workload is marked as finished": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Condition(batchv1.JobCondition{
 					Type:    batchv1.JobComplete,
@@ -3203,6 +3465,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when the workload is finished, its finalizer is removed": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().Obj(),
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("a", "ns").
@@ -3242,6 +3509,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload is created when queue name is set, with workloadPriorityClass": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -3286,6 +3558,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload is created when queue name is set, with PriorityClass": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -3330,6 +3607,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload is created when queue name is set, with workloadPriorityClass and PriorityClass": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -3376,6 +3658,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload shouldn't be recreated for the completed job": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
 				Obj(),
@@ -3386,6 +3673,11 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{},
 		},
 		"when the prebuilt workload is missing, no new one is created, the job is suspended and prebuilt workload not found error is returned": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -3408,6 +3700,11 @@ func TestReconciler(t *testing.T) {
 			wantErr: jobframework.ErrPrebuiltWorkloadNotFound,
 		},
 		"when the prebuilt workload exists its owner info is updated": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -3451,6 +3748,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when the prebuilt workload is owned by another object": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -3493,6 +3795,11 @@ func TestReconciler(t *testing.T) {
 			wantErr: jobframework.ErrPrebuiltWorkloadNotFound,
 		},
 		"when the prebuilt workload is not equivalent to the job": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -3543,6 +3850,11 @@ func TestReconciler(t *testing.T) {
 			wantErr: jobframework.ErrPrebuiltWorkloadNotFound,
 		},
 		"the workload is not admitted, tolerations and node selector change": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
 				Operator: corev1.TolerationOpExists,
@@ -3607,6 +3919,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload is admitted, tolerations and node selector change": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
 				Operator: corev1.TolerationOpExists,
@@ -3681,6 +3998,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload is admitted, job still suspended and tolerations change": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
 				Operator: corev1.TolerationOpExists,
@@ -3731,6 +4053,11 @@ func TestReconciler(t *testing.T) {
 			wantErr: jobframework.ErrNoMatchingWorkloads,
 		},
 		"admission check message is emitted as event for job": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(true).
 				Obj(),
@@ -3781,6 +4108,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"multiple admission check messages are emitted as a single event for job": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(true).
 				Obj(),
@@ -3841,6 +4173,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the maximum execution time is passed to the created workload": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 				Obj(),
@@ -3867,6 +4204,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the maximum execution time is updated in the workload": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			job: *baseJobWrapper.Clone().
 				Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 				Obj(),
@@ -3903,7 +4245,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"job with queue name is not reconciled in unlabelled namespace when AlwaysRespected is enabled": {
-			enableManagedJobsNamespaceSelectorAlwaysRespected: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: true,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManagedJobsNamespaceSelector(labels.SelectorFromSet(map[string]string{
 					"managed-by-kueue": "true",
@@ -3922,7 +4268,11 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: nil,
 		},
 		"job with queue name is reconciled in labelled namespace when AlwaysRespected is enabled": {
-			enableManagedJobsNamespaceSelectorAlwaysRespected: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: true,
+				features.AssignQueueLabelsForPods:                    true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManagedJobsNamespaceSelector(labels.SelectorFromSet(map[string]string{
 					"managed-by-kueue": "true",
@@ -3971,10 +4321,8 @@ func TestReconciler(t *testing.T) {
 	for name, tc := range cases {
 		for _, enabled := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", name, enabled), func(t *testing.T) {
-				features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
-				features.SetFeatureGateDuringTest(t, features.ManagedJobsNamespaceSelectorAlwaysRespected, tc.enableManagedJobsNamespaceSelectorAlwaysRespected)
+				features.SetFeatureGatesDuringTest(t, tc.featureGates)
 				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, enabled)
-				features.SetFeatureGateDuringTest(t, features.AssignQueueLabelsForPods, !tc.disableAssignQueueLabelsForPods)
 
 				ctx, _ := utiltesting.ContextWithLog(t)
 				clientBuilder := utiltesting.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})

--- a/pkg/controller/jobs/job/job_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter_test.go
@@ -263,7 +263,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 
 func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 	type fields struct {
-		features map[featuregate.Feature]bool
+		featureGates map[featuregate.Feature]bool
 	}
 	type args struct {
 		localClient  client.Client
@@ -429,7 +429,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"ElasticJob_RemoteInSync": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+				featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
@@ -458,7 +458,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"ElasticJob_LocalIsStale": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+				featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
@@ -489,7 +489,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"ElasticJob_WorkloadNameOnlyChange_EdgeCase": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+				featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
@@ -517,7 +517,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"ElasticJob_RemoteOutOfSync": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+				featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
@@ -550,7 +550,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"ElasticJob_RemoteOutOfSync_PatchFailure": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+				featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
@@ -588,9 +588,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			// Setup feature gates if any provided.
-			for featureName, enabled := range tt.fields.features {
-				features.SetFeatureGateDuringTest(t, featureName, enabled)
-			}
+			features.SetFeatureGatesDuringTest(t, tt.fields.featureGates)
 
 			adapter := &multiKueueAdapter{}
 			ctx, _ := utiltesting.ContextWithLog(t)

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	jobsetapi "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
@@ -64,13 +65,11 @@ var (
 
 func TestValidateCreate(t *testing.T) {
 	testcases := []struct {
-		name                         string
-		job                          *batchv1.Job
-		wantValidationErrs           field.ErrorList
-		wantErr                      error
-		topologyAwareScheduling      bool
-		elasticJobsViaWorkloadSlices bool
-		admissionGatedBy             bool
+		name               string
+		job                *batchv1.Job
+		wantValidationErrs field.ErrorList
+		wantErr            error
+		featureGates       map[featuregate.Feature]bool
 	}{
 		{
 			name:               "simple",
@@ -242,8 +241,8 @@ func TestValidateCreate(t *testing.T) {
 			job: testingutil.MakeJob("job", "default").
 				PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				Obj(),
-			wantValidationErrs:      nil,
-			topologyAwareScheduling: true,
+			wantValidationErrs: nil,
+			featureGates:       map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid topology request - both annotations",
@@ -256,7 +255,7 @@ func TestValidateCreate(t *testing.T) {
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid topology request - invalid required",
@@ -267,7 +266,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(replicaMetaPath.Child("annotations").Key("kueue.x-k8s.io/podset-required-topology"), "some required value",
 					testutil.InvalidLabelKeyMessage).WithOrigin("format=k8s-label-key"),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid topology request - invalid preferred",
@@ -278,7 +277,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(replicaMetaPath.Child("annotations").Key("kueue.x-k8s.io/podset-preferred-topology"), "some preferred value",
 					testutil.InvalidLabelKeyMessage).WithOrigin("format=k8s-label-key"),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "valid slice topology request",
@@ -287,8 +286,8 @@ func TestValidateCreate(t *testing.T) {
 				PodAnnotation(kueue.PodSetSliceRequiredTopologyAnnotation, "cloud.com/block").
 				PodAnnotation(kueue.PodSetSliceSizeAnnotation, "1").
 				Obj(),
-			wantValidationErrs:      nil,
-			topologyAwareScheduling: true,
+			wantValidationErrs: nil,
+			featureGates:       map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "valid topology request - slice-only topology - unconstrained with slices defined",
@@ -297,8 +296,8 @@ func TestValidateCreate(t *testing.T) {
 				PodAnnotation(kueue.PodSetSliceRequiredTopologyAnnotation, "cloud.com/block").
 				PodAnnotation(kueue.PodSetSliceSizeAnnotation, "1").
 				Obj(),
-			wantValidationErrs:      nil,
-			topologyAwareScheduling: true,
+			wantValidationErrs: nil,
+			featureGates:       map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid topology request - slice requested without slice size",
@@ -309,7 +308,7 @@ func TestValidateCreate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.Required(replicaMetaPath.Child("annotations").Key("kueue.x-k8s.io/podset-slice-size"), "must be set when 'kueue.x-k8s.io/podset-slice-required-topology' is specified"),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid topology request - slice size is not a number",
@@ -321,7 +320,7 @@ func TestValidateCreate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.Invalid(replicaMetaPath.Child("annotations").Key("kueue.x-k8s.io/podset-slice-size"), "not a number", "must be a numeric value"),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid topology request - slice size is negative",
@@ -333,7 +332,7 @@ func TestValidateCreate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.Invalid(replicaMetaPath.Child("annotations").Key("kueue.x-k8s.io/podset-slice-size"), "-1", "must be greater than or equal to 1"),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid topology request - slice size is zero",
@@ -345,7 +344,7 @@ func TestValidateCreate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.Invalid(replicaMetaPath.Child("annotations").Key("kueue.x-k8s.io/podset-slice-size"), "0", "must be greater than or equal to 1"),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid topology request - slice size provided without slice topology",
@@ -356,7 +355,7 @@ func TestValidateCreate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.Forbidden(replicaMetaPath.Child("annotations").Key("kueue.x-k8s.io/podset-slice-size"), "may not be set when 'kueue.x-k8s.io/podset-slice-required-topology' is not specified"),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "valid topology request - slice-only topology",
@@ -364,8 +363,8 @@ func TestValidateCreate(t *testing.T) {
 				PodAnnotation(kueue.PodSetSliceRequiredTopologyAnnotation, "cloud.com/block").
 				PodAnnotation(kueue.PodSetSliceSizeAnnotation, "1").
 				Obj(),
-			wantValidationErrs:      nil,
-			topologyAwareScheduling: true,
+			wantValidationErrs: nil,
+			featureGates:       map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid slice topology request - slice size larger than number of podsets",
@@ -379,7 +378,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(replicaMetaPath.Child("annotations").
 					Key("kueue.x-k8s.io/podset-slice-size"), "20", "must not be greater than pod set count 4"),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "elastic job with required topology is rejected",
@@ -391,8 +390,10 @@ func TestValidateCreate(t *testing.T) {
 				field.Forbidden(replicaMetaPath.Child("annotations", kueue.PodSetRequiredTopologyAnnotation),
 					"required topology is not supported with elastic jobs"),
 			},
-			topologyAwareScheduling:      true,
-			elasticJobsViaWorkloadSlices: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:      true,
+				features.ElasticJobsViaWorkloadSlices: true,
+			},
 		},
 		{
 			name: "elastic job with preferred topology is rejected",
@@ -404,8 +405,10 @@ func TestValidateCreate(t *testing.T) {
 				field.Forbidden(replicaMetaPath.Child("annotations", kueue.PodSetPreferredTopologyAnnotation),
 					"preferred topology is not supported with elastic jobs"),
 			},
-			topologyAwareScheduling:      true,
-			elasticJobsViaWorkloadSlices: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:      true,
+				features.ElasticJobsViaWorkloadSlices: true,
+			},
 		},
 		{
 			name: "elastic job with unconstrained topology is accepted",
@@ -413,9 +416,11 @@ func TestValidateCreate(t *testing.T) {
 				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 				PodAnnotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
 				Obj(),
-			wantValidationErrs:           nil,
-			topologyAwareScheduling:      true,
-			elasticJobsViaWorkloadSlices: true,
+			wantValidationErrs: nil,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:      true,
+				features.ElasticJobsViaWorkloadSlices: true,
+			},
 		},
 		{
 			name: "valid AdmissionGatedBy annotation with single gate",
@@ -424,7 +429,7 @@ func TestValidateCreate(t *testing.T) {
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller").
 				Obj(),
 			wantValidationErrs: nil,
-			admissionGatedBy:   true,
+			featureGates:       map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		{
 			name: "AdmissionGatedBy annotation - trailing space",
@@ -433,7 +438,7 @@ func TestValidateCreate(t *testing.T) {
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/gate ").
 				Obj(),
 			wantValidationErrs: nil,
-			admissionGatedBy:   true,
+			featureGates:       map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		{
 			name: "AdmissionGatedBy annotation - space before comma",
@@ -442,7 +447,7 @@ func TestValidateCreate(t *testing.T) {
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/gate ,example.com/gate2").
 				Obj(),
 			wantValidationErrs: nil,
-			admissionGatedBy:   true,
+			featureGates:       map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		{
 			name: "AdmissionGatedBy annotation - space after comma",
@@ -451,7 +456,7 @@ func TestValidateCreate(t *testing.T) {
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/gate, example.com/gate2").
 				Obj(),
 			wantValidationErrs: nil,
-			admissionGatedBy:   true,
+			featureGates:       map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		{
 			name: "AdmissionGatedBy annotation - leading space",
@@ -460,7 +465,7 @@ func TestValidateCreate(t *testing.T) {
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, " example.com/gate").
 				Obj(),
 			wantValidationErrs: nil,
-			admissionGatedBy:   true,
+			featureGates:       map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		{
 			name: "valid AdmissionGatedBy annotation with multiple gates",
@@ -469,7 +474,7 @@ func TestValidateCreate(t *testing.T) {
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/a,not.example.com/b").
 				Obj(),
 			wantValidationErrs: nil,
-			admissionGatedBy:   true,
+			featureGates:       map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		{
 			name: "invalid AdmissionGatedBy annotation - not in subdomain/path format",
@@ -480,7 +485,7 @@ func TestValidateCreate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.Invalid(admissionGatedByAnnotationsPath, "this is an invalid value", "must be a domain-prefixed path (such as \"acme.io/foo\")"),
 			},
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		{
 			name: "invalid AdmissionGatedBy annotation - duplicate gates",
@@ -491,7 +496,7 @@ func TestValidateCreate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.Invalid(admissionGatedByAnnotationsPath, "duplicates.are/invalid,duplicates.are/invalid", "duplicate gate name: duplicates.are/invalid"),
 			},
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		{
 			name: "invalid AdmissionGatedBy annotation - gate name too long",
@@ -502,7 +507,7 @@ func TestValidateCreate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.TooLong(admissionGatedByAnnotationsPath, "", webhook.MaxGateNameLengthForAdmissionGatedBy),
 			},
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		{
 			name: "invalid AdmissionGatedBy annotation - space in path component",
@@ -513,7 +518,7 @@ func TestValidateCreate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.Invalid(admissionGatedByAnnotationsPath, "gate name", testutil.InvalidPathMessage),
 			},
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		{
 			name: "invalid AdmissionGatedBy annotation - space in domain component",
@@ -524,7 +529,7 @@ func TestValidateCreate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.Invalid(admissionGatedByAnnotationsPath, "example .com", testutil.InvalidRFC1123Message),
 			},
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		{
 			name: "invalid AdmissionGatedBy annotation - multiple gates with one containing space",
@@ -535,7 +540,7 @@ func TestValidateCreate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.Invalid(admissionGatedByAnnotationsPath, "invalid gate.com", testutil.InvalidRFC1123Message),
 			},
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		{
 			name: "AdmissionGatedBy annotation with feature gate disabled - valid value",
@@ -543,7 +548,7 @@ func TestValidateCreate(t *testing.T) {
 				Queue("queue").
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/gate").
 				Obj(),
-			admissionGatedBy: false,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: false},
 		},
 		{
 			name: "AdmissionGatedBy annotation with feature gate disabled - invalid value",
@@ -551,7 +556,7 @@ func TestValidateCreate(t *testing.T) {
 				Queue("queue").
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "this is an invalid value").
 				Obj(),
-			admissionGatedBy: false,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: false},
 		},
 		{
 			name: "AdmissionGatedBy annotation with feature gate enabled - empty string",
@@ -559,15 +564,13 @@ func TestValidateCreate(t *testing.T) {
 				Queue("queue").
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "").
 				Obj(),
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
-			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, tc.elasticJobsViaWorkloadSlices)
-			features.SetFeatureGateDuringTest(t, features.AdmissionGatedBy, tc.admissionGatedBy)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			jw := &JobWebhook{}
 
@@ -587,13 +590,12 @@ func TestValidateCreate(t *testing.T) {
 
 func TestValidateUpdate(t *testing.T) {
 	testcases := []struct {
-		name                    string
-		oldJob                  *batchv1.Job
-		newJob                  *batchv1.Job
-		wantValidationErrs      field.ErrorList
-		wantErr                 error
-		topologyAwareScheduling bool
-		admissionGatedBy        bool
+		name               string
+		oldJob             *batchv1.Job
+		newJob             *batchv1.Job
+		wantValidationErrs field.ErrorList
+		wantErr            error
+		featureGates       map[featuregate.Feature]bool
 	}{
 		{
 			name:               "normal update",
@@ -843,7 +845,7 @@ func TestValidateUpdate(t *testing.T) {
 			newJob: testingutil.MakeJob("job", "default").
 				PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "attempt to set invalid TAS request",
@@ -857,7 +859,7 @@ func TestValidateUpdate(t *testing.T) {
 				field.Invalid(replicaMetaPath.Child("annotations"), field.OmitValueType{},
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`)},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "valid slice topology request",
@@ -868,7 +870,7 @@ func TestValidateUpdate(t *testing.T) {
 				PodAnnotation(kueue.PodSetSliceRequiredTopologyAnnotation, "cloud.com/block").
 				PodAnnotation(kueue.PodSetSliceSizeAnnotation, "1").
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "attempt to set invalid slice topology request",
@@ -881,7 +883,7 @@ func TestValidateUpdate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.Required(replicaMetaPath.Child("annotations").Key("kueue.x-k8s.io/podset-slice-size"), "must be set when 'kueue.x-k8s.io/podset-slice-required-topology' is specified"),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "reject adding AdmissionGatedBy annotation after Job creation",
@@ -895,7 +897,7 @@ func TestValidateUpdate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.Forbidden(admissionGatedByAnnotationsPath, "cannot add admission gate after creation"),
 			},
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		{
 			name: "allow removing AdmissionGatedBy annotation with single gate",
@@ -907,7 +909,7 @@ func TestValidateUpdate(t *testing.T) {
 				Queue("queue").
 				Obj(),
 			wantValidationErrs: nil,
-			admissionGatedBy:   true,
+			featureGates:       map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		{
 			name: "allow removing AdmissionGatedBy annotation with multiple gates",
@@ -919,7 +921,7 @@ func TestValidateUpdate(t *testing.T) {
 				Queue("queue").
 				Obj(),
 			wantValidationErrs: nil,
-			admissionGatedBy:   true,
+			featureGates:       map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		{
 			name: "allow removing one gate from AdmissionGatedBy annotation",
@@ -932,7 +934,7 @@ func TestValidateUpdate(t *testing.T) {
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller2").
 				Obj(),
 			wantValidationErrs: nil,
-			admissionGatedBy:   true,
+			featureGates:       map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		{
 			name: "reject injecting new gate in AdmissionGatedBy annotation",
@@ -947,7 +949,7 @@ func TestValidateUpdate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.Forbidden(admissionGatedByAnnotationsPath, "can only remove gates, not add new ones"),
 			},
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		{
 			name: "allow reordering gates in AdmissionGatedBy annotation",
@@ -960,14 +962,13 @@ func TestValidateUpdate(t *testing.T) {
 				SetAnnotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller2,example.com/controller1").
 				Obj(),
 			wantValidationErrs: nil,
-			admissionGatedBy:   true,
+			featureGates:       map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
-			features.SetFeatureGateDuringTest(t, features.AdmissionGatedBy, tc.admissionGatedBy)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotValidationErrs, gotErr := new(JobWebhook).validateUpdate(ctx, (*Job)(tc.oldJob), (*Job)(tc.newJob))
 			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.IgnoreFields(field.Error{})); diff != "" {
@@ -988,7 +989,7 @@ func TestDefault(t *testing.T) {
 		clusterQueues              []kueue.ClusterQueue
 		admissionCheck             *kueue.AdmissionCheck
 		manageJobsWithoutQueueName bool
-		multiKueueEnabled          bool
+		featureGates               map[featuregate.Feature]bool
 		defaultLqExist             bool
 		enableIntegrations         []string
 		want                       *batchv1.Job
@@ -1004,9 +1005,9 @@ func TestDefault(t *testing.T) {
 			want:                       testingutil.MakeJob("job", "default").Obj(),
 		},
 		"no change in managed by: features.MultiKueue disabled": {
-			job:               testingutil.MakeJob("job", "default").Queue("queue").Suspend(false).Obj(),
-			multiKueueEnabled: false,
-			want:              testingutil.MakeJob("job", "default").Queue("queue").Obj(),
+			job:          testingutil.MakeJob("job", "default").Queue("queue").Suspend(false).Obj(),
+			featureGates: map[featuregate.Feature]bool{features.MultiKueue: false},
+			want:         testingutil.MakeJob("job", "default").Queue("queue").Obj(),
 		},
 		"managed by is defaulted: queue label was set": {
 			job: testingutil.MakeJob("job", "default").
@@ -1031,7 +1032,7 @@ func TestDefault(t *testing.T) {
 				Queue("local-queue").
 				ManagedBy(kueue.MultiKueueControllerName).
 				Obj(),
-			multiKueueEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueue: true},
 		},
 		"no change in managed by: user specified managed by": {
 			job: testingutil.MakeJob("job", "default").
@@ -1057,7 +1058,7 @@ func TestDefault(t *testing.T) {
 				Queue("local-queue").
 				ManagedBy("example.com/foo").
 				Obj(),
-			multiKueueEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueue: true},
 		},
 		"invalid queue name": {
 			job: testingutil.MakeJob("job", "default").
@@ -1067,7 +1068,7 @@ func TestDefault(t *testing.T) {
 			want: testingutil.MakeJob("job", "default").
 				Queue("invalid-local-queue").
 				Obj(),
-			multiKueueEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueue: true},
 		},
 		"default lq is created, job doesn't have queue label": {
 			defaultLqExist: true,
@@ -1116,7 +1117,7 @@ func TestDefault(t *testing.T) {
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.MultiKueue, tc.multiKueueEnabled)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			ctx, log := utiltesting.ContextWithLog(t)
 
@@ -1176,9 +1177,9 @@ func Test_applyWorkloadSliceSchedulingGate(t *testing.T) {
 	//   - WorkloadSlice feature enabled: true or false
 	//   - Job opt-in via annotation: present or absent
 	tests := map[string]struct {
-		featureEnabled bool
-		args           args
-		want           []corev1.PodSchedulingGate
+		featureGates map[featuregate.Feature]bool
+		args         args
+		want         []corev1.PodSchedulingGate
 	}{
 		"FeatureDisabledAndNotOptIn": {
 			args: args{job: &Job{}},
@@ -1195,11 +1196,11 @@ func Test_applyWorkloadSliceSchedulingGate(t *testing.T) {
 			},
 		},
 		"FeatureEnabledButNotOptIn": {
-			featureEnabled: true,
-			args:           args{job: &Job{}},
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			args:         args{job: &Job{}},
 		},
 		"FeatureEnabledAndOptIn": {
-			featureEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			args: args{
 				job: &Job{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1225,7 +1226,7 @@ func Test_applyWorkloadSliceSchedulingGate(t *testing.T) {
 			},
 		},
 		"FeatureEnabledAndOptIn_SpecAlreadyContainsWorkloadSliceGate": {
-			featureEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			args: args{
 				job: &Job{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1251,7 +1252,7 @@ func Test_applyWorkloadSliceSchedulingGate(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, tt.featureEnabled)
+			features.SetFeatureGatesDuringTest(t, tt.featureGates)
 			applyWorkloadSliceSchedulingGate(tt.args.job)
 			if diff := cmp.Diff(tt.args.job.Spec.Template.Spec.SchedulingGates, tt.want); diff != "" {
 				t.Errorf("applyWorkloadSliceSchedulingGate() got(-),want(+): %s", diff)

--- a/pkg/controller/jobs/jobset/jobset_controller_test.go
+++ b/pkg/controller/jobs/jobset/jobset_controller_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -206,9 +207,9 @@ func TestPodSets(t *testing.T) {
 	jobSetTemplate := testingjobset.MakeJobSet("jobset", "ns")
 
 	testCases := map[string]struct {
-		jobSet                        *JobSet
-		wantPodSets                   func(jobSet *JobSet) []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		jobSet       *JobSet
+		wantPodSets  func(jobSet *JobSet) []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			jobSet: (*JobSet)(jobSetTemplate.Clone().
@@ -227,7 +228,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required topology annotation": {
 			jobSet: (*JobSet)(jobSetTemplate.Clone().
@@ -262,7 +263,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"with preferred topology annotation": {
 			jobSet: (*JobSet)(jobSetTemplate.Clone().
@@ -297,7 +298,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"without required and preferred topology annotation if TAS is disabled": {
 			jobSet: (*JobSet)(jobSetTemplate.Clone().
@@ -338,12 +339,12 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := tc.jobSet.PodSets(ctx)
 			if err != nil {

--- a/pkg/controller/jobs/jobset/jobset_webhook_test.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
@@ -45,10 +46,10 @@ var (
 
 func TestValidateCreate(t *testing.T) {
 	testcases := []struct {
-		name                    string
-		job                     *jobset.JobSet
-		wantErr                 error
-		topologyAwareScheduling bool
+		name         string
+		job          *jobset.JobSet
+		wantErr      error
+		featureGates map[featuregate.Feature]bool
 	}{
 		{
 			name:    "simple",
@@ -78,7 +79,7 @@ func TestValidateCreate(t *testing.T) {
 					kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 				},
 			}).Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid topology request",
@@ -97,7 +98,7 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{field.Invalid(field.NewPath("spec.replicatedJobs[1].template.spec.template.metadata.annotations"),
 				field.OmitValueType{}, `must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 					`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`)}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid slice topology request - slice size larger than number of podsets",
@@ -114,7 +115,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.replicatedJobs[0].template.spec.template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-slice-size"), "20", "must not be greater than pod set count 2"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "valid PodSet grouping request",
@@ -131,7 +132,7 @@ func TestValidateCreate(t *testing.T) {
 					kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 				},
 			}).Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid PodSet grouping request - groups of size other than 2",
@@ -173,7 +174,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.replicatedJobs[3].template.spec.template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-group-name"), "3podsets", "can only define groups of exactly 2 pod sets, got: 3 pod set(s)"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid PodSet grouping request - no leader in group",
@@ -199,7 +200,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.replicatedJobs[1].template.spec.template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-group-name"), "groupname", "can only define groups where at least one pod set has only 1 replica, got: 2 replica(s) and 3 replica(s) in the group"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid PodSet grouping request - required topology does not match",
@@ -223,7 +224,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.replicatedJobs[0].template.spec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.replicatedJobs[1].template.spec.template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.replicatedJobs[1].template.spec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.replicatedJobs[0].template.spec.template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid PodSet grouping request - preferred topology does not match",
@@ -247,7 +248,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.replicatedJobs[0].template.spec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.replicatedJobs[1].template.spec.template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.replicatedJobs[1].template.spec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.replicatedJobs[0].template.spec.template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid PodSet grouping request - different topology annotations within group",
@@ -271,13 +272,13 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.replicatedJobs[0].template.spec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.replicatedJobs[1].template.spec.template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.replicatedJobs[1].template.spec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.replicatedJobs[0].template.spec.template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			jsw := &JobSetWebhook{}
 			ctx, _ := utiltesting.ContextWithLog(t)
@@ -292,12 +293,12 @@ func TestValidateCreate(t *testing.T) {
 
 func TestValidateUpdate(t *testing.T) {
 	testcases := []struct {
-		name                    string
-		oldJob                  *jobset.JobSet
-		newJob                  *jobset.JobSet
-		wantValidationErrs      field.ErrorList
-		wantErr                 error
-		topologyAwareScheduling bool
+		name               string
+		oldJob             *jobset.JobSet
+		newJob             *jobset.JobSet
+		wantValidationErrs field.ErrorList
+		wantErr            error
+		featureGates       map[featuregate.Feature]bool
 	}{
 		{
 			name: "set valid topology request",
@@ -311,7 +312,7 @@ func TestValidateUpdate(t *testing.T) {
 					kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block",
 				},
 			}).Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "attempt to set invalid topology request",
@@ -329,13 +330,13 @@ func TestValidateUpdate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{field.Invalid(field.NewPath("spec.replicatedJobs[0].template.spec.template.metadata.annotations"),
 				field.OmitValueType{}, `must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 					`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`)},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotValidationErrs, gotErr := new(JobSetWebhook).validateUpdate(ctx, (*JobSet)(tc.oldJob), (*JobSet)(tc.newJob))
 			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.IgnoreFields(field.Error{})); diff != "" {
@@ -350,16 +351,16 @@ func TestValidateUpdate(t *testing.T) {
 
 func TestDefault(t *testing.T) {
 	testCases := []struct {
-		name              string
-		jobSet            *jobset.JobSet
-		queues            []kueue.LocalQueue
-		clusterQueues     []kueue.ClusterQueue
-		admissionCheck    *kueue.AdmissionCheck
-		multiKueueEnabled bool
-		defaultLqExist    bool
-		want              *jobset.JobSet
-		wantManagedBy     *string
-		wantErr           error
+		name           string
+		jobSet         *jobset.JobSet
+		queues         []kueue.LocalQueue
+		clusterQueues  []kueue.ClusterQueue
+		admissionCheck *kueue.AdmissionCheck
+		featureGates   map[featuregate.Feature]bool
+		defaultLqExist bool
+		want           *jobset.JobSet
+		wantManagedBy  *string
+		wantErr        error
 	}{
 		{
 			name: "TestDefault_JobSetManagedBy_jobsetapi.JobSetControllerName",
@@ -388,8 +389,8 @@ func TestDefault(t *testing.T) {
 				ControllerName(kueue.MultiKueueControllerName).
 				Active(metav1.ConditionTrue).
 				Obj(),
-			multiKueueEnabled: true,
-			wantManagedBy:     ptr.To(kueue.MultiKueueControllerName),
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: ptr.To(kueue.MultiKueueControllerName),
 		},
 		{
 			name: "TestDefault_WithQueueLabel",
@@ -415,16 +416,16 @@ func TestDefault(t *testing.T) {
 				ControllerName(kueue.MultiKueueControllerName).
 				Active(metav1.ConditionTrue).
 				Obj(),
-			multiKueueEnabled: true,
-			wantManagedBy:     ptr.To(kueue.MultiKueueControllerName),
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: ptr.To(kueue.MultiKueueControllerName),
 		},
 		{
 			name: "TestDefault_WithoutQueueLabel",
 			jobSet: &jobset.JobSet{
 				ObjectMeta: ctrl.ObjectMeta{Namespace: "default"},
 			},
-			multiKueueEnabled: true,
-			wantManagedBy:     nil,
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: nil,
 		},
 		{
 			name: "TestDefault_InvalidQueueName",
@@ -434,7 +435,7 @@ func TestDefault(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			multiKueueEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueue: true},
 		},
 		{
 			name: "TestDefault_QueueNotFound",
@@ -446,7 +447,7 @@ func TestDefault(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			multiKueueEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueue: true},
 		},
 		{
 			name: "TestDefault_AdmissionCheckNotFound",
@@ -468,8 +469,8 @@ func TestDefault(t *testing.T) {
 					AdmissionChecks("non-existent-admission-check").
 					Obj(),
 			},
-			multiKueueEnabled: true,
-			wantManagedBy:     nil,
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: nil,
 		},
 		{
 			name: "TestDefault_MultiKueueFeatureDisabled",
@@ -495,8 +496,8 @@ func TestDefault(t *testing.T) {
 				ControllerName(kueue.MultiKueueControllerName).
 				Active(metav1.ConditionTrue).
 				Obj(),
-			multiKueueEnabled: false,
-			wantManagedBy:     nil,
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: false},
+			wantManagedBy: nil,
 		},
 		{
 			name: "TestDefault_UserSpecifiedManagedBy",
@@ -525,8 +526,8 @@ func TestDefault(t *testing.T) {
 				ControllerName(kueue.MultiKueueControllerName).
 				Active(metav1.ConditionTrue).
 				Obj(),
-			multiKueueEnabled: true,
-			wantManagedBy:     ptr.To("example.com/foo"),
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: ptr.To("example.com/foo"),
 		},
 		{
 			name: "TestDefault_ClusterQueueWithoutAdmissionCheck",
@@ -547,8 +548,8 @@ func TestDefault(t *testing.T) {
 				*utiltestingapi.MakeClusterQueue("cluster-queue").
 					Obj(),
 			},
-			multiKueueEnabled: true,
-			wantManagedBy:     nil,
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: nil,
 		},
 		{
 			name:           "default lq is created, job doesn't have queue label",
@@ -572,8 +573,7 @@ func TestDefault(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.MultiKueue, tc.multiKueueEnabled)
-
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, log := utiltesting.ContextWithLog(t)
 
 			clientBuilder := utiltesting.NewClientBuilder().WithObjects(utiltesting.MakeNamespace("default"))

--- a/pkg/controller/jobs/kubeflow/jobs/jaxjob/jaxjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/jaxjob/jaxjob_controller_test.go
@@ -111,9 +111,9 @@ func TestOrderedReplicaTypes(t *testing.T) {
 
 func TestPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		job                *kftraining.JAXJob
-		wantPodSets        func(job *kftraining.JAXJob) []kueue.PodSet
-		enableFeatureGates []featuregate.Feature
+		job          *kftraining.JAXJob
+		wantPodSets  func(job *kftraining.JAXJob) []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingJAXjob.MakeJAXJob("JAXjob", "ns").
@@ -155,16 +155,12 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableFeatureGates: []featuregate.Feature{
-				features.TopologyAwareScheduling,
-			},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			for _, gate := range tc.enableFeatureGates {
-				features.SetFeatureGateDuringTest(t, gate, true)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := fromObject(tc.job).PodSets(ctx)
 			if err != nil {
@@ -179,10 +175,10 @@ func TestPodSets(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	testCases := map[string]struct {
-		job                     *kftraining.JAXJob
-		wantValidationErrs      field.ErrorList
-		wantErr                 error
-		topologyAwareScheduling bool
+		job                *kftraining.JAXJob
+		wantValidationErrs field.ErrorList
+		wantErr            error
+		featureGates       map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingJAXjob.MakeJAXJob("JAXjob", "ns").
@@ -206,7 +202,7 @@ func TestValidate(t *testing.T) {
 					},
 				).
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid TAS request": {
 			job: testingJAXjob.MakeJAXJob("JAXjob", "ns").
@@ -230,7 +226,7 @@ func TestValidate(t *testing.T) {
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid slice topology request - slice size larger than number of podsets": {
 			job: testingJAXjob.MakeJAXJob("JAXjob", "ns").
@@ -255,13 +251,12 @@ func TestValidate(t *testing.T) {
 					"20", "must not be greater than pod set count 3",
 				),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
-
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotValidationErrs, gotErr := fromObject(tc.job).ValidateOnCreate(ctx)
 			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {

--- a/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -236,9 +237,9 @@ func TestOrderedReplicaTypes(t *testing.T) {
 
 func TestPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		job                           *kftraining.PaddleJob
-		wantPodSets                   func(job *kftraining.PaddleJob) []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		job          *kftraining.PaddleJob
+		wantPodSets  func(job *kftraining.PaddleJob) []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingpaddlejob.MakePaddleJob("paddlejob", "ns").
@@ -263,7 +264,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required and preferred topology annotation": {
 			job: testingpaddlejob.MakePaddleJob("paddlejob", "ns").
@@ -300,7 +301,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"without required and preferred topology annotation if TAS is disabled": {
 			job: testingpaddlejob.MakePaddleJob("paddlejob", "ns").
@@ -333,12 +334,12 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := fromObject(tc.job).PodSets(ctx)
 			if err != nil {
@@ -353,10 +354,10 @@ func TestPodSets(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	testCases := map[string]struct {
-		job                     *kftraining.PaddleJob
-		wantValidationErrs      field.ErrorList
-		wantErr                 error
-		topologyAwareScheduling bool
+		job                *kftraining.PaddleJob
+		wantValidationErrs field.ErrorList
+		wantErr            error
+		featureGates       map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingpaddlejob.MakePaddleJob("paddlejob", "ns").PaddleReplicaSpecsDefault().Obj(),
@@ -380,7 +381,7 @@ func TestValidate(t *testing.T) {
 					},
 				).
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid TAS request": {
 			job: testingpaddlejob.MakePaddleJob("paddlejob", "ns").
@@ -419,7 +420,7 @@ func TestValidate(t *testing.T) {
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid slice topology request - slice size larger than number of podsets": {
 			job: testingpaddlejob.MakePaddleJob("paddlejob", "ns").
@@ -460,13 +461,12 @@ func TestValidate(t *testing.T) {
 					"20", "must not be greater than pod set count 10",
 				),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
-
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotValidationErrs, gotErr := fromObject(tc.job).ValidateOnCreate(ctx)
 			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {

--- a/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller_test.go
@@ -23,6 +23,7 @@ import (
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -226,9 +227,9 @@ func TestOrderedReplicaTypes(t *testing.T) {
 
 func TestPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		job                           *kftraining.PyTorchJob
-		wantPodSets                   func(job *kftraining.PyTorchJob) []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		job          *kftraining.PyTorchJob
+		wantPodSets  func(job *kftraining.PyTorchJob) []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingpytorchjob.MakePyTorchJob("pytorchjob", "ns").
@@ -253,7 +254,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required and preferred topology annotation": {
 			job: testingpytorchjob.MakePyTorchJob("pytorchjob", "ns").
@@ -290,7 +291,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"without required and preferred topology annotation if TAS is disabled": {
 			job: testingpytorchjob.MakePyTorchJob("pytorchjob", "ns").
@@ -323,12 +324,12 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := fromObject(tc.job).PodSets(ctx)
 			if err != nil {
@@ -343,10 +344,10 @@ func TestPodSets(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	testCases := map[string]struct {
-		job                     *kftraining.PyTorchJob
-		wantValidationErrs      field.ErrorList
-		wantErr                 error
-		topologyAwareScheduling bool
+		job                *kftraining.PyTorchJob
+		wantValidationErrs field.ErrorList
+		wantErr            error
+		featureGates       map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingpytorchjob.MakePyTorchJob("pytorchjob", "ns").
@@ -381,7 +382,7 @@ func TestValidate(t *testing.T) {
 					},
 				).
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid TAS request": {
 			job: testingpytorchjob.MakePyTorchJob("pytorchjob", "ns").
@@ -420,7 +421,7 @@ func TestValidate(t *testing.T) {
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid slice topology request - slice size larger than number of podsets": {
 			job: testingpytorchjob.MakePyTorchJob("pytorchjob", "ns").
@@ -461,13 +462,12 @@ func TestValidate(t *testing.T) {
 					"20", "must not be greater than pod set count 10",
 				),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
-
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotValidationErrs, gotErr := fromObject(tc.job).ValidateOnCreate(ctx)
 			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {

--- a/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_controller_test.go
@@ -23,6 +23,7 @@ import (
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -244,9 +245,9 @@ func TestOrderedReplicaTypes(t *testing.T) {
 
 func TestPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		job                           *kftraining.TFJob
-		wantPodSets                   func(job *kftraining.TFJob) []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		job          *kftraining.TFJob
+		wantPodSets  func(job *kftraining.TFJob) []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingtfjob.MakeTFJob("tfjob", "ns").TFReplicaSpecsDefault().Obj(),
@@ -263,7 +264,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required and preferred topology annotation": {
 			job: testingtfjob.MakeTFJob("tfjob", "ns").
@@ -308,7 +309,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"without required and preferred topology annotation if TAS is disabled": {
 			job: testingtfjob.MakeTFJob("tfjob", "ns").
@@ -348,12 +349,12 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := fromObject(tc.job).PodSets(ctx)
 			if err != nil {
@@ -368,10 +369,10 @@ func TestPodSets(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	testCases := map[string]struct {
-		job                     *kftraining.TFJob
-		wantValidationErrs      field.ErrorList
-		wantErr                 error
-		topologyAwareScheduling bool
+		job                *kftraining.TFJob
+		wantValidationErrs field.ErrorList
+		wantErr            error
+		featureGates       map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingtfjob.MakeTFJob("tfjob", "ns").TFReplicaSpecsDefault().Obj(),
@@ -399,7 +400,7 @@ func TestValidate(t *testing.T) {
 					},
 				).
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid TAS request": {
 			job: testingtfjob.MakeTFJob("tfjob", "ns").
@@ -445,7 +446,7 @@ func TestValidate(t *testing.T) {
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid slice topology request - slice size larger than number of podsets": {
 			job: testingtfjob.MakeTFJob("tfjob", "ns").
@@ -502,13 +503,12 @@ func TestValidate(t *testing.T) {
 					"20", "must not be greater than pod set count 10",
 				),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
-
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotValidationErrs, gotErr := fromObject(tc.job).ValidateOnCreate(ctx)
 			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {

--- a/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -234,9 +235,9 @@ func TestOrderedReplicaTypes(t *testing.T) {
 
 func TestPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		job                           *kftraining.XGBoostJob
-		wantPodSets                   func(job *kftraining.XGBoostJob) []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		job          *kftraining.XGBoostJob
+		wantPodSets  func(job *kftraining.XGBoostJob) []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingxgboostjob.MakeXGBoostJob("xgboostjob", "ns").
@@ -261,7 +262,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required and preferred topology annotation": {
 			job: testingxgboostjob.MakeXGBoostJob("xgboostjob", "ns").
@@ -298,7 +299,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"without required and preferred topology annotation if TAS is disabled": {
 			job: testingxgboostjob.MakeXGBoostJob("xgboostjob", "ns").
@@ -331,12 +332,12 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := fromObject(tc.job).PodSets(ctx)
 			if err != nil {
@@ -351,10 +352,10 @@ func TestPodSets(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	testCases := map[string]struct {
-		job                     *kftraining.XGBoostJob
-		wantValidationErrs      field.ErrorList
-		wantErr                 error
-		topologyAwareScheduling bool
+		job                *kftraining.XGBoostJob
+		wantValidationErrs field.ErrorList
+		wantErr            error
+		featureGates       map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingxgboostjob.MakeXGBoostJob("xgboostjob", "ns").
@@ -389,7 +390,7 @@ func TestValidate(t *testing.T) {
 					},
 				).
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid TAS request": {
 			job: testingxgboostjob.MakeXGBoostJob("xgboostjob", "ns").
@@ -428,7 +429,7 @@ func TestValidate(t *testing.T) {
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid slice topology request - slice size larger than number of podsets": {
 			job: testingxgboostjob.MakeXGBoostJob("xgboostjob", "ns").
@@ -469,13 +470,12 @@ func TestValidate(t *testing.T) {
 					"20", "must not be greater than pod set count 10",
 				),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
-
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotValidationErrs, gotErr := fromObject(tc.job).ValidateOnCreate(ctx)
 			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -58,7 +58,7 @@ var (
 
 func TestReconciler(t *testing.T) {
 	cases := map[string]struct {
-		features                map[featuregate.Feature]bool
+		featureGates            map[featuregate.Feature]bool
 		labelKeysToCopy         []string
 		leaderWorkerSet         *leaderworkersetv1.LeaderWorkerSet
 		workloads               []kueue.Workload
@@ -69,7 +69,7 @@ func TestReconciler(t *testing.T) {
 		wantErr                 error
 	}{
 		"should create prebuilt workload": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
 			},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testUID).Obj(),
@@ -107,7 +107,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should create prebuilt workload with leader template": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
 			},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
@@ -170,7 +170,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should create prebuilt workloads with leader template": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
 			},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
@@ -362,7 +362,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should create prebuilt workload without required topology annotation is TAS is disabled": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
 			},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
@@ -459,7 +459,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should create prebuilt workload with workload priority": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
 			},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
@@ -512,7 +512,7 @@ func TestReconciler(t *testing.T) {
 		// maxSurge > 0 alone would cause filterWorkloads to use stale status.Replicas, keeping the
 		// excess workload in toUpdate instead of toDelete.
 		"should delete excess workload on scale down with maxSurge configured but no active rolling update": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
 			},
 			leaderWorkerSet: func() *leaderworkersetv1.LeaderWorkerSet {
@@ -575,7 +575,7 @@ func TestReconciler(t *testing.T) {
 		// must be kept. This, paired with the test above, proves that maxSurge > 0 alone is
 		// not sufficient — the UpdatedReplicas check is needed to distinguish the two cases.
 		"should keep surge workloads during active rolling update with maxSurge": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
 			},
 			leaderWorkerSet: func() *leaderworkersetv1.LeaderWorkerSet {
@@ -668,7 +668,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should delete LeaderWorkerSet ownerReference from the redundant prebuilt workload": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
 			},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testUID).Obj(),
@@ -716,7 +716,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should create prebuilt workload with AdmissionGatedBy annotation": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
 				features.AdmissionGatedBy:        true,
 			},
@@ -762,7 +762,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should create prebuilt workload with multiple AdmissionGatedBy gates": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
 				features.AdmissionGatedBy:        true,
 			},
@@ -808,7 +808,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should not propagate AdmissionGatedBy annotation when feature gate is disabled": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
 				features.AdmissionGatedBy:        false,
 			},
@@ -855,9 +855,7 @@ func TestReconciler(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			for feature, enable := range tc.features {
-				features.SetFeatureGateDuringTest(t, feature, enable)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			clientBuilder := utiltesting.NewClientBuilder(leaderworkersetv1.AddToScheme)
 			indexer := utiltesting.AsIndexer(clientBuilder)

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
@@ -177,11 +178,11 @@ func TestDefault(t *testing.T) {
 
 func TestValidateCreate(t *testing.T) {
 	testCases := map[string]struct {
-		integrations     []string
-		lws              *leaderworkersetv1.LeaderWorkerSet
-		admissionGatedBy bool
-		wantErr          error
-		wantWarns        admission.Warnings
+		integrations []string
+		lws          *leaderworkersetv1.LeaderWorkerSet
+		featureGates map[featuregate.Feature]bool
+		wantErr      error
+		wantWarns    admission.Warnings
 	}{
 		"without queue": {
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
@@ -601,7 +602,7 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"AdmissionGatedBy Annotation - single gate": {
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -609,7 +610,7 @@ func TestValidateCreate(t *testing.T) {
 				Obj(),
 		},
 		"AdmissionGatedBy Annotation - trailing space": {
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -617,7 +618,7 @@ func TestValidateCreate(t *testing.T) {
 				Obj(),
 		},
 		"AdmissionGatedBy Annotation - space before comma": {
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -625,7 +626,7 @@ func TestValidateCreate(t *testing.T) {
 				Obj(),
 		},
 		"AdmissionGatedBy Annotation - space after comma": {
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -633,7 +634,7 @@ func TestValidateCreate(t *testing.T) {
 				Obj(),
 		},
 		"AdmissionGatedBy Annotation - leading space": {
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -641,7 +642,7 @@ func TestValidateCreate(t *testing.T) {
 				Obj(),
 		},
 		"AdmissionGatedBy Annotation - multiple gates": {
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -649,7 +650,7 @@ func TestValidateCreate(t *testing.T) {
 				Obj(),
 		},
 		"invalid AdmissionGatedBy Annotation - invalid format": {
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -660,7 +661,7 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"invalid AdmissionGatedBy Annotation - duplicate gates": {
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -671,7 +672,7 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"invalid AdmissionGatedBy Annotation - gate name too long": {
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -682,7 +683,7 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"invalid AdmissionGatedBy Annotation - space in path component": {
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -693,7 +694,7 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"invalid AdmissionGatedBy Annotation - space in domain component": {
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -704,7 +705,7 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"invalid AdmissionGatedBy Annotation - multiple gates where one is invalid": {
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -715,7 +716,7 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"AdmissionGatedBy Annotation with feature gate disabled - valid value": {
-			admissionGatedBy: false,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: false},
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -724,7 +725,7 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: nil,
 		},
 		"AdmissionGatedBy Annotation with feature gate disabled - invalid value": {
-			admissionGatedBy: false,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: false},
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -733,7 +734,7 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: nil,
 		},
 		"AdmissionGatedBy Annotation with feature gate enabled - empty string": {
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -749,9 +750,7 @@ func TestValidateCreate(t *testing.T) {
 			for _, integration := range tc.integrations {
 				jobframework.EnableIntegrationsForTest(t, integration)
 			}
-			if tc.admissionGatedBy {
-				features.SetFeatureGateDuringTest(t, features.AdmissionGatedBy, true)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			builder := utiltesting.NewClientBuilder()
 			client := builder.Build()
 			w := &Webhook{client: client}
@@ -769,11 +768,11 @@ func TestValidateCreate(t *testing.T) {
 
 func TestValidateUpdate(t *testing.T) {
 	testCases := map[string]struct {
-		integrations     []string
-		oldObj           *leaderworkersetv1.LeaderWorkerSet
-		newObj           *leaderworkersetv1.LeaderWorkerSet
-		admissionGatedBy bool
-		wantErr          error
+		integrations []string
+		oldObj       *leaderworkersetv1.LeaderWorkerSet
+		newObj       *leaderworkersetv1.LeaderWorkerSet
+		featureGates map[featuregate.Feature]bool
+		wantErr      error
 	}{
 		"no changes": {
 			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
@@ -1278,7 +1277,7 @@ func TestValidateUpdate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"AdmissionGatedBy Annotation - reject adding gates after creation": {
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -1293,7 +1292,7 @@ func TestValidateUpdate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"AdmissionGatedBy Annotation - allow removing single gate": {
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -1305,7 +1304,7 @@ func TestValidateUpdate(t *testing.T) {
 				Obj(),
 		},
 		"AdmissionGatedBy Annotation - allow removing all gates": {
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -1317,7 +1316,7 @@ func TestValidateUpdate(t *testing.T) {
 				Obj(),
 		},
 		"AdmissionGatedBy Annotation - allow removing one gate from multiple": {
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -1330,7 +1329,7 @@ func TestValidateUpdate(t *testing.T) {
 				Obj(),
 		},
 		"AdmissionGatedBy Annotation - reject injecting new gates": {
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -1346,7 +1345,7 @@ func TestValidateUpdate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"AdmissionGatedBy Annotation - allow reordering gates": {
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -1365,9 +1364,7 @@ func TestValidateUpdate(t *testing.T) {
 			for _, integration := range tc.integrations {
 				jobframework.EnableIntegrationsForTest(t, integration)
 			}
-			if tc.admissionGatedBy {
-				features.SetFeatureGateDuringTest(t, features.AdmissionGatedBy, true)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			wh := &Webhook{}
 
 			ctx, _ := utiltesting.ContextWithLog(t)

--- a/pkg/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -196,9 +197,9 @@ func TestPodSets(t *testing.T) {
 	)
 
 	testCases := map[string]struct {
-		job                           *MPIJob
-		wantPodSets                   []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		job          *MPIJob
+		wantPodSets  []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: (*MPIJob)(jobTemplate.DeepCopy()),
@@ -210,7 +211,7 @@ func TestPodSets(t *testing.T) {
 					PodSpec(jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker].Template.Spec).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required topology annotation": {
 			job: (*MPIJob)(jobTemplate.Clone().
@@ -240,7 +241,7 @@ func TestPodSets(t *testing.T) {
 					PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"with preferred topology annotation": {
 			job: (*MPIJob)(jobTemplate.Clone().
@@ -270,7 +271,7 @@ func TestPodSets(t *testing.T) {
 					PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"without required and preferred topology annotation if TAS is disabled": {
 			job: (*MPIJob)(jobTemplate.Clone().
@@ -296,7 +297,7 @@ func TestPodSets(t *testing.T) {
 					Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"without preferred topology annotation if TAS is disabled": {
 			job: (*MPIJob)(jobTemplate.Clone().
@@ -322,12 +323,12 @@ func TestPodSets(t *testing.T) {
 					Annotations(map[string]string{kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := tc.job.PodSets(ctx)
 			if err != nil {

--- a/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -45,10 +46,10 @@ var (
 
 func TestValidateCreate(t *testing.T) {
 	testcases := []struct {
-		name                    string
-		job                     *v2beta1.MPIJob
-		wantErr                 error
-		topologyAwareScheduling bool
+		name         string
+		job          *v2beta1.MPIJob
+		wantErr      error
+		featureGates map[featuregate.Feature]bool
 	}{
 		{
 			name:    "simple",
@@ -82,7 +83,7 @@ func TestValidateCreate(t *testing.T) {
 				PodAnnotation(v2beta1.MPIReplicaTypeLauncher, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid topology request",
@@ -115,7 +116,7 @@ func TestValidateCreate(t *testing.T) {
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid slice topology request - slice size larger than number of podsets",
@@ -144,7 +145,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.mpiReplicaSpecs[Worker].template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-slice-size"), "20", "must not be greater than pod set count 3"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "valid PodSet grouping request",
@@ -165,7 +166,7 @@ func TestValidateCreate(t *testing.T) {
 				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetGroupName, "groupname").
 				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid PodSet grouping request - groups of size other than 2",
@@ -192,7 +193,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.mpiReplicaSpecs[Worker].template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-group-name"), "groupname2", "can only define groups of exactly 2 pod sets, got: 1 pod set(s)"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid PodSet grouping request - no leader in group",
@@ -219,7 +220,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.mpiReplicaSpecs[Worker].template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-group-name"), "groupname", "can only define groups where at least one pod set has only 1 replica, got: 2 replica(s) and 3 replica(s) in the group"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid PodSet grouping request - required topology does not match",
@@ -244,7 +245,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.mpiReplicaSpecs[Launcher].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.mpiReplicaSpecs[Worker].template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.mpiReplicaSpecs[Worker].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.mpiReplicaSpecs[Launcher].template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid PodSet grouping request - preferred topology does not match",
@@ -269,7 +270,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.mpiReplicaSpecs[Launcher].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.mpiReplicaSpecs[Worker].template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.mpiReplicaSpecs[Worker].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.mpiReplicaSpecs[Launcher].template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid PodSet grouping request - different topology annotations within group",
@@ -294,13 +295,13 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.mpiReplicaSpecs[Launcher].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.mpiReplicaSpecs[Worker].template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.mpiReplicaSpecs[Worker].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.mpiReplicaSpecs[Launcher].template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			jsw := &MpiJobWebhook{}
 			ctx, _ := utiltesting.ContextWithLog(t)
@@ -315,17 +316,16 @@ func TestValidateCreate(t *testing.T) {
 
 func TestDefault(t *testing.T) {
 	testCases := []struct {
-		name                    string
-		mpiJob                  *v2beta1.MPIJob
-		queues                  []kueue.LocalQueue
-		clusterQueues           []kueue.ClusterQueue
-		admissionCheck          *kueue.AdmissionCheck
-		multiKueueEnabled       bool
-		topologyAwareScheduling bool
-		defaultLqExist          bool
-		want                    *v2beta1.MPIJob
-		wantManagedBy           *string
-		wantErr                 error
+		name           string
+		mpiJob         *v2beta1.MPIJob
+		queues         []kueue.LocalQueue
+		clusterQueues  []kueue.ClusterQueue
+		admissionCheck *kueue.AdmissionCheck
+		featureGates   map[featuregate.Feature]bool
+		defaultLqExist bool
+		want           *v2beta1.MPIJob
+		wantManagedBy  *string
+		wantErr        error
 	}{
 		{
 			name: "TestDefault_MPIJobManagedBy_mpijobapi.MPIJobControllerName",
@@ -356,8 +356,8 @@ func TestDefault(t *testing.T) {
 				ControllerName(kueue.MultiKueueControllerName).
 				Active(metav1.ConditionTrue).
 				Obj(),
-			multiKueueEnabled: true,
-			wantManagedBy:     ptr.To(kueue.MultiKueueControllerName),
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: ptr.To(kueue.MultiKueueControllerName),
 		},
 		{
 			name: "TestDefault_WithQueueLabel",
@@ -383,16 +383,16 @@ func TestDefault(t *testing.T) {
 				ControllerName(kueue.MultiKueueControllerName).
 				Active(metav1.ConditionTrue).
 				Obj(),
-			multiKueueEnabled: true,
-			wantManagedBy:     ptr.To(kueue.MultiKueueControllerName),
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: ptr.To(kueue.MultiKueueControllerName),
 		},
 		{
 			name: "TestDefault_WithoutQueueLabel",
 			mpiJob: &v2beta1.MPIJob{
 				ObjectMeta: ctrl.ObjectMeta{Namespace: "default"},
 			},
-			multiKueueEnabled: true,
-			wantManagedBy:     nil,
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: nil,
 		},
 		{
 			name: "TestDefault_InvalidQueueName",
@@ -402,7 +402,7 @@ func TestDefault(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			multiKueueEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueue: true},
 		},
 		{
 			name: "TestDefault_QueueNotFound",
@@ -414,7 +414,7 @@ func TestDefault(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			multiKueueEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueue: true},
 		},
 		{
 			name: "TestDefault_AdmissionCheckNotFound",
@@ -436,8 +436,8 @@ func TestDefault(t *testing.T) {
 					AdmissionChecks("non-existent-admission-check").
 					Obj(),
 			},
-			multiKueueEnabled: true,
-			wantManagedBy:     nil,
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: nil,
 		},
 		{
 			name: "TestDefault_MultiKueueFeatureDisabled",
@@ -463,8 +463,8 @@ func TestDefault(t *testing.T) {
 				ControllerName(kueue.MultiKueueControllerName).
 				Active(metav1.ConditionTrue).
 				Obj(),
-			multiKueueEnabled: false,
-			wantManagedBy:     nil,
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: false},
+			wantManagedBy: nil,
 		},
 		{
 			name: "TestDefault_UserSpecifiedManagedBy",
@@ -495,8 +495,8 @@ func TestDefault(t *testing.T) {
 				ControllerName(kueue.MultiKueueControllerName).
 				Active(metav1.ConditionTrue).
 				Obj(),
-			multiKueueEnabled: true,
-			wantManagedBy:     ptr.To("example.com/foo"),
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: ptr.To("example.com/foo"),
 		},
 		{
 			name: "TestDefault_ClusterQueueWithoutAdmissionCheck",
@@ -517,8 +517,8 @@ func TestDefault(t *testing.T) {
 				*utiltestingapi.MakeClusterQueue("cluster-queue").
 					Obj(),
 			},
-			multiKueueEnabled: true,
-			wantManagedBy:     nil,
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: nil,
 		},
 		{
 			name:           "default lq is created, job doesn't have queue label",
@@ -539,8 +539,8 @@ func TestDefault(t *testing.T) {
 			want:           testingutil.MakeMPIJob("job", "default").Obj(),
 		},
 		{
-			name:                    "TAS enabled, RunLauncherAsWorker true with 2 replica specs",
-			topologyAwareScheduling: true,
+			name:         "TAS enabled, RunLauncherAsWorker true with 2 replica specs",
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			mpiJob: testingutil.MakeMPIJob("job", "default").
 				Queue("queue").
 				MPIJobReplicaSpecs(
@@ -572,8 +572,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		{
-			name:                    "TAS enabled, RunLauncherAsWorker false",
-			topologyAwareScheduling: true,
+			name:         "TAS enabled, RunLauncherAsWorker false",
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			mpiJob: testingutil.MakeMPIJob("job", "default").
 				Queue("queue").
 				MPIJobReplicaSpecs(
@@ -604,8 +604,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		{
-			name:                    "TAS enabled, RunLauncherAsWorker nil",
-			topologyAwareScheduling: true,
+			name:         "TAS enabled, RunLauncherAsWorker nil",
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			mpiJob: testingutil.MakeMPIJob("job", "default").
 				Queue("queue").
 				MPIJobReplicaSpecs(
@@ -634,8 +634,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		{
-			name:                    "TAS disabled, RunLauncherAsWorker true",
-			topologyAwareScheduling: false,
+			name:         "TAS disabled, RunLauncherAsWorker true",
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			mpiJob: testingutil.MakeMPIJob("job", "default").
 				Queue("queue").
 				MPIJobReplicaSpecs(
@@ -666,8 +666,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		{
-			name:                    "TAS enabled, RunLauncherAsWorker true, only Launcher replica",
-			topologyAwareScheduling: true,
+			name:         "TAS enabled, RunLauncherAsWorker true, only Launcher replica",
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			mpiJob: testingutil.MakeMPIJob("job", "default").
 				Queue("queue").
 				GenericLauncher().
@@ -680,8 +680,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		{
-			name:                    "TAS enabled, RunLauncherAsWorker true, Worker has existing annotations",
-			topologyAwareScheduling: true,
+			name:         "TAS enabled, RunLauncherAsWorker true, Worker has existing annotations",
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			mpiJob: testingutil.MakeMPIJob("job", "default").
 				Queue("queue").
 				MPIJobReplicaSpecs(
@@ -715,8 +715,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		{
-			name:                    "TAS enabled, RunLauncherAsWorker true, Launcher has PodSetGroupName annotation",
-			topologyAwareScheduling: true,
+			name:         "TAS enabled, RunLauncherAsWorker true, Launcher has PodSetGroupName annotation",
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			mpiJob: testingutil.MakeMPIJob("job", "default").
 				Queue("queue").
 				MPIJobReplicaSpecs(
@@ -752,8 +752,7 @@ func TestDefault(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.MultiKueue, tc.multiKueueEnabled)
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			ctx, log := utiltesting.ContextWithLog(t)
 

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -135,9 +136,9 @@ func TestRun(t *testing.T) {
 
 func TestPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		pod                           *Pod
-		wantPodSets                   func(pod *Pod) []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		pod          *Pod
+		wantPodSets  func(pod *Pod) []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			pod: FromObject(testingpod.MakePod("pod", "ns").Obj()),
@@ -148,7 +149,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required topology annotation": {
 			pod: FromObject(testingpod.MakePod("pod", "ns").
@@ -164,7 +165,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"with required topology preferred": {
 			pod: FromObject(testingpod.MakePod("pod", "ns").
@@ -180,7 +181,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"without required topology annotation if TAS is disabled": {
 			pod: FromObject(testingpod.MakePod("pod", "ns").
@@ -194,7 +195,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"without preferred topology annotation if TAS is disabled": {
 			pod: FromObject(testingpod.MakePod("pod", "ns").
@@ -208,12 +209,13 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := tc.pod.PodSets(ctx)
 			if err != nil {

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -84,9 +84,7 @@ func TestDefault(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		enableTopologyAwareScheduling bool
-
-		features                     map[featuregate.Feature]bool
+		featureGates                 map[featuregate.Feature]bool
 		initObjects                  []client.Object
 		pod                          *corev1.Pod
 		defaultLqExist               bool
@@ -99,7 +97,8 @@ func TestDefault(t *testing.T) {
 		wantErr                      error
 	}{
 		"pod with suspend by parent annotation shouldn't skip finalizer when SkipFinalizersForPodsSuspendedByParent disabled": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                false,
 				features.SkipFinalizersForPodsSuspendedByParent: false,
 			},
 			initObjects: []client.Object{defaultNamespace},
@@ -116,7 +115,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with suspend by parent annotation should skip finalizer when SkipFinalizersForPodsSuspendedByParent enabled": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                false,
 				features.SkipFinalizersForPodsSuspendedByParent: true,
 			},
 			initObjects: []client.Object{defaultNamespace},
@@ -132,7 +132,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with queue nil ns selector": {
-			initObjects: []client.Object{defaultNamespace},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			initObjects:  []client.Object{defaultNamespace},
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
 				Obj(),
@@ -145,7 +146,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with queue matching ns selector": {
-			initObjects: []client.Object{defaultNamespace},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			initObjects:  []client.Object{defaultNamespace},
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
 				Obj(),
@@ -160,7 +162,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod without queue matching ns selector manage jobs without queue name": {
-			initObjects: []client.Object{defaultNamespace},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			initObjects:  []client.Object{defaultNamespace},
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Obj(),
 			manageJobsWithoutQueueName: true,
@@ -174,6 +177,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with owner managed by kueue (Job) while not enabled": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects: []client.Object{
 				defaultNamespace,
 				testingjob.MakeJob("parent-job", defaultNamespace.Name).UID("parent-job").Queue("test-queue").Obj(),
@@ -194,6 +198,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with owner managed by kueue (Job)": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects: []client.Object{
 				defaultNamespace,
 				testingjob.MakeJob("parent-job", defaultNamespace.Name).UID("parent-job").Queue("test-queue").Obj(),
@@ -211,6 +216,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with owner managed by kueue (RayCluster)": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects: []client.Object{
 				defaultNamespace,
 				&rayv1.RayCluster{
@@ -237,6 +243,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with owner managed by kueue (MPIJob)": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects: []client.Object{
 				defaultNamespace,
 				testingmpijob.MakeMPIJob("parent-mpi-job", defaultNamespace.Name).UID("parent-mpi-job").Queue("test-queue").Obj(),
@@ -260,6 +267,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with owner managed by kueue (PyTorchJob)": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects: []client.Object{
 				defaultNamespace,
 				testingpytorchjob.MakePyTorchJob("parent-pytorch-job", defaultNamespace.Name).UID("parent-pytorch-job").Queue("test-queue").Obj(),
@@ -283,6 +291,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with owner managed by kueue (TFJob)": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects: []client.Object{
 				defaultNamespace,
 				testingtfjob.MakeTFJob("parent-tf-job", defaultNamespace.Name).UID("parent-tf-job").Queue("test-queue").Obj(),
@@ -306,6 +315,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with owner managed by kueue (XGBoostJob)": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects: []client.Object{
 				defaultNamespace,
 				testingxgboostjob.MakeXGBoostJob("parent-xgboost-job", defaultNamespace.Name).UID("parent-xgboost-job").Queue("test-queue").Obj(),
@@ -329,6 +339,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with owner managed by kueue (PaddleJob)": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects: []client.Object{
 				defaultNamespace,
 				paddlejob.MakePaddleJob("parent-paddle-job", defaultNamespace.Name).UID("parent-paddle-job").Queue("test-queue").Obj(),
@@ -352,6 +363,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with a group name label, but without group total count label": {
+			featureGates:      map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects:       []client.Object{defaultNamespace},
 			podSelector:       &metav1.LabelSelector{},
 			namespaceSelector: defaultNamespaceSelector,
@@ -369,6 +381,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with a group name label": {
+			featureGates:      map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects:       []client.Object{defaultNamespace},
 			podSelector:       &metav1.LabelSelector{},
 			namespaceSelector: defaultNamespaceSelector,
@@ -386,10 +399,10 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with TAS": {
-			enableTopologyAwareScheduling: true,
-			initObjects:                   []client.Object{defaultNamespace},
-			podSelector:                   &metav1.LabelSelector{},
-			namespaceSelector:             defaultNamespaceSelector,
+			featureGates:      map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+			initObjects:       []client.Object{defaultNamespace},
+			podSelector:       &metav1.LabelSelector{},
+			namespaceSelector: defaultNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
 				Annotation(kueue.PodSetRequiredTopologyAnnotation, "block").
@@ -405,10 +418,10 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with TAS and PodGroupPodIndexLabelAnnotation": {
-			enableTopologyAwareScheduling: true,
-			initObjects:                   []client.Object{defaultNamespace},
-			podSelector:                   &metav1.LabelSelector{},
-			namespaceSelector:             defaultNamespaceSelector,
+			featureGates:      map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+			initObjects:       []client.Object{defaultNamespace},
+			podSelector:       &metav1.LabelSelector{},
+			namespaceSelector: defaultNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
 				Label("test-label", "test-value").
@@ -429,6 +442,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"default queue is created, pod has no queue label": {
+			featureGates:      map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects:       []client.Object{defaultNamespace},
 			defaultLqExist:    true,
 			podSelector:       &metav1.LabelSelector{},
@@ -444,6 +458,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"default queue isn't created, pod has no queue label": {
+			featureGates:      map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects:       []client.Object{defaultNamespace},
 			defaultLqExist:    false,
 			podSelector:       &metav1.LabelSelector{},
@@ -454,6 +469,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"default queue is created, pod has queue label": {
+			featureGates:      map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects:       []client.Object{defaultNamespace},
 			defaultLqExist:    true,
 			podSelector:       &metav1.LabelSelector{},
@@ -470,6 +486,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"the namespace matches the selector": {
+			featureGates:                 map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects:                  []client.Object{defaultNamespace},
 			managedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
@@ -484,6 +501,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"doesn’t match the managedJobsNamespaceSelector": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects: []client.Object{
 				utiltesting.MakeNamespaceWrapper("kube-system").Label(corev1.LabelMetadataName, "kube-system").Obj(),
 			},
@@ -496,6 +514,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"the namespace matches the namespace selector": {
+			featureGates:      map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects:       []client.Object{defaultNamespace},
 			namespaceSelector: defaultNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
@@ -510,6 +529,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"the namespace doesn't match the namespace selector": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects: []client.Object{
 				utiltesting.MakeNamespaceWrapper("kube-system").Label(corev1.LabelMetadataName, "kube-system").Obj(),
 			},
@@ -522,8 +542,9 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"the pod matches the pod selector": {
-			initObjects: []client.Object{defaultNamespace},
-			podSelector: defaultPodSelector,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			initObjects:  []client.Object{defaultNamespace},
+			podSelector:  defaultPodSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Label(corev1.LabelMetadataName, "test-pod").
 				Queue("queue").
@@ -538,8 +559,9 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"the pod doesn't match the pod selector": {
-			initObjects: []client.Object{defaultNamespace},
-			podSelector: defaultPodSelector,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			initObjects:  []client.Object{defaultNamespace},
+			podSelector:  defaultPodSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Label(corev1.LabelMetadataName, "kube-system").
 				Queue("queue").
@@ -553,10 +575,7 @@ func TestDefault(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			for feature, enabled := range tc.features {
-				features.SetFeatureGateDuringTest(t, feature, enabled)
-			}
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			t.Cleanup(jobframework.EnableIntegrationsForTest(t, tc.enableIntegrations...))
 			builder := utiltesting.NewClientBuilder(rayv1.AddToScheme, kfmpi.AddToScheme, kftraining.AddToScheme, appsv1.AddToScheme)
 			builder = builder.WithObjects(tc.initObjects...)

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -44,10 +44,9 @@ import (
 
 func TestBuildPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		rayClusterSpec                *rayv1.RayClusterSpec
-		wantPodSets                   []kueue.PodSet
-		enableTopologyAwareScheduling bool
-		wantErr                       bool
+		rayClusterSpec *rayv1.RayClusterSpec
+		wantPodSets    []kueue.PodSet
+		wantErr        bool
 	}{
 		"basic spec with head and single worker group": {
 			rayClusterSpec: &rayv1.RayClusterSpec{
@@ -203,8 +202,6 @@ func TestBuildPodSets(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
-
 			gotPodSets, err := BuildPodSets(tc.rayClusterSpec)
 
 			if tc.wantErr {

--- a/pkg/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -60,9 +61,9 @@ var (
 
 func TestPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		rayCluster                    *RayCluster
-		wantPodSets                   func(rayJob *RayCluster) []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		rayCluster   *RayCluster
+		wantPodSets  func(rayJob *RayCluster) []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			rayCluster: (*RayCluster)(testingrayutil.MakeCluster("raycluster", "ns").
@@ -102,7 +103,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required topology annotation": {
 			rayCluster: (*RayCluster)(testingrayutil.MakeCluster("raycluster", "ns").
@@ -156,7 +157,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"with preferred topology annotation": {
 			rayCluster: (*RayCluster)(testingrayutil.MakeCluster("raycluster", "ns").
@@ -210,7 +211,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"without required and preferred topology annotation if TAS is disabled": {
 			rayCluster: (*RayCluster)(testingrayutil.MakeCluster("raycluster", "ns").
@@ -278,12 +279,12 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := tc.rayCluster.PodSets(ctx)
 			if err != nil {

--- a/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
@@ -26,6 +26,7 @@ import (
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -129,10 +130,10 @@ func TestValidateCreate(t *testing.T) {
 	bigWorkerGroup := []rayv1.WorkerGroupSpec{worker, worker, worker, worker, worker, worker, worker, worker}
 
 	testcases := map[string]struct {
-		job                     *rayv1.RayCluster
-		manageAll               bool
-		wantErr                 error
-		topologyAwareScheduling bool
+		job          *rayv1.RayCluster
+		manageAll    bool
+		wantErr      error
+		featureGates map[featuregate.Feature]bool
 	}{
 		"invalid unmanaged": {
 			job: testingrayutil.MakeCluster("job", "ns").
@@ -200,7 +201,7 @@ func TestValidateCreate(t *testing.T) {
 					rayv1.WorkerGroupSpec{GroupName: "wg3"},
 				).
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid topology request": {
 			job: testingrayutil.MakeCluster("raycluster", "ns").Queue("queue").
@@ -240,7 +241,7 @@ func TestValidateCreate(t *testing.T) {
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid slice topology request - slice size larger than number of podsets": {
 			job: testingrayutil.MakeCluster("raycluster", "ns").Queue("queue").
@@ -292,7 +293,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.workerGroupSpecs[1].template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-slice-size"), "20", "must not be greater than pod set count 10"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"valid PodSet grouping request": {
 			job: testingrayutil.MakeCluster("raycluster", "ns").Queue("queue").
@@ -320,7 +321,7 @@ func TestValidateCreate(t *testing.T) {
 					},
 				).
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid PodSet grouping request - groups of size other than 2": {
 			job: testingrayutil.MakeCluster("rayjob", "ns").Queue("queue").
@@ -383,7 +384,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.workerGroupSpecs[2].template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-group-name"), "3podsets", "can only define groups of exactly 2 pod sets, got: 3 pod set(s)"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid PodSet grouping request - no leader in group": {
 			job: testingrayutil.MakeCluster("rayjob", "ns").Queue("queue").
@@ -420,7 +421,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.workerGroupSpecs[1].template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-group-name"), "groupname", "can only define groups where at least one pod set has only 1 replica, got: 5 replica(s) and 10 replica(s) in the group"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid PodSet grouping request - required topology does not match": {
 			job: testingrayutil.MakeCluster("rayjob", "ns").Queue("queue").
@@ -453,7 +454,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.headGroupSpec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.workerGroupSpecs[0].template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.workerGroupSpecs[0].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.headGroupSpec.template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid PodSet grouping request - preferred topology does not match": {
 			job: testingrayutil.MakeCluster("rayjob", "ns").Queue("queue").
@@ -486,7 +487,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.headGroupSpec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.workerGroupSpecs[0].template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.workerGroupSpecs[0].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.headGroupSpec.template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid PodSet grouping request - different topology annotations within group": {
 			job: testingrayutil.MakeCluster("rayjob", "ns").Queue("queue").
@@ -519,13 +520,13 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.headGroupSpec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.workerGroupSpecs[0].template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.workerGroupSpecs[0].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.headGroupSpec.template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			wh := &RayClusterWebhook{
 				manageJobsWithoutQueueName: tc.manageAll,
 			}

--- a/pkg/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -40,9 +41,9 @@ import (
 
 func TestPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		rayJob                        *RayJob
-		wantPodSets                   func(rayJob *RayJob) []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		rayJob       *RayJob
+		wantPodSets  func(rayJob *RayJob) []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			rayJob: (*RayJob)(testingrayutil.MakeJob("rayjob", "ns").
@@ -82,7 +83,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required topology annotation": {
 			rayJob: (*RayJob)(testingrayutil.MakeJob("rayjob", "ns").
@@ -136,7 +137,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"with preferred topology annotation": {
 			rayJob: (*RayJob)(testingrayutil.MakeJob("rayjob", "ns").
@@ -190,7 +191,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"without required and preferred topology annotation if TAS is disabled": {
 			rayJob: (*RayJob)(testingrayutil.MakeJob("rayjob", "ns").
@@ -248,7 +249,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with submitter topology annotation not specified": {
 			rayJob: (*RayJob)(testingrayutil.MakeJob("rayjob", "ns").
@@ -297,7 +298,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"with submitter topology annotation specified": {
 			rayJob: (*RayJob)(testingrayutil.MakeJob("rayjob", "ns").
@@ -363,7 +364,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"with NumOfHosts > 1": {
 			rayJob: (*RayJob)(testingrayutil.MakeJob("rayjob", "ns").
@@ -405,7 +406,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with default job submitter": {
 			rayJob: (*RayJob)(testingrayutil.MakeJob("rayjob", "ns").
@@ -449,7 +450,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with submitter job pod template override": {
 			rayJob: (*RayJob)(testingrayutil.MakeJob("rayjob", "ns").
@@ -518,12 +519,12 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := tc.rayJob.PodSets(ctx)
 			if err != nil {

--- a/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
@@ -26,6 +26,7 @@ import (
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -129,11 +130,10 @@ func TestValidateCreate(t *testing.T) {
 	bigWorkerGroup := []rayv1.WorkerGroupSpec{worker, worker, worker, worker, worker, worker, worker, worker}
 
 	testcases := map[string]struct {
-		job                          *rayv1.RayJob
-		manageAll                    bool
-		wantErr                      error
-		topologyAwareScheduling      bool
-		elasticJobsViaWorkloadSlices bool
+		job          *rayv1.RayJob
+		manageAll    bool
+		wantErr      error
+		featureGates map[featuregate.Feature]bool
 	}{
 		"invalid unmanaged": {
 			job: testingrayutil.MakeJob("job", "ns").
@@ -188,8 +188,8 @@ func TestValidateCreate(t *testing.T) {
 				WithEnableAutoscaling(ptr.To(true)).
 				Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 				Obj(),
-			elasticJobsViaWorkloadSlices: true,
-			wantErr:                      nil,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			wantErr:      nil,
 		},
 		"invalid managed - too many worker groups": {
 			job: testingrayutil.MakeJob("job", "ns").Queue("queue").
@@ -244,7 +244,7 @@ func TestValidateCreate(t *testing.T) {
 					rayv1.WorkerGroupSpec{GroupName: "wg3"},
 				).
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid topology request": {
 			job: testingrayutil.MakeJob("rayjob", "ns").Queue("queue").
@@ -284,7 +284,7 @@ func TestValidateCreate(t *testing.T) {
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid slice topology request - slice size larger than number of podsets": {
 			job: testingrayutil.MakeJob("rayjob", "ns").Queue("queue").
@@ -335,7 +335,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.rayClusterSpec.workerGroupSpecs[1].template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-slice-size"), "20", "must not be greater than pod set count 10"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"valid PodSet grouping request": {
 			job: testingrayutil.MakeJob("rayjob", "ns").Queue("queue").
@@ -363,7 +363,7 @@ func TestValidateCreate(t *testing.T) {
 					},
 				).
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid PodSet grouping request - groups of size other than 2": {
 			job: testingrayutil.MakeJob("rayjob", "ns").Queue("queue").
@@ -426,7 +426,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.rayClusterSpec.workerGroupSpecs[2].template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-group-name"), "3podsets", "can only define groups of exactly 2 pod sets, got: 3 pod set(s)"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid PodSet grouping request - no leader in group": {
 			job: testingrayutil.MakeJob("rayjob", "ns").Queue("queue").
@@ -463,7 +463,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.rayClusterSpec.workerGroupSpecs[1].template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-group-name"), "groupname", "can only define groups where at least one pod set has only 1 replica, got: 5 replica(s) and 10 replica(s) in the group"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid PodSet grouping request - required topology does not match": {
 			job: testingrayutil.MakeJob("rayjob", "ns").Queue("queue").
@@ -496,7 +496,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.rayClusterSpec.headGroupSpec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.rayClusterSpec.workerGroupSpecs[0].template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.rayClusterSpec.workerGroupSpecs[0].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.rayClusterSpec.headGroupSpec.template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid PodSet grouping request - preferred topology does not match": {
 			job: testingrayutil.MakeJob("rayjob", "ns").Queue("queue").
@@ -529,7 +529,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.rayClusterSpec.headGroupSpec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.rayClusterSpec.workerGroupSpecs[0].template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.rayClusterSpec.workerGroupSpecs[0].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.rayClusterSpec.headGroupSpec.template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid PodSet grouping request - different topology annotations within group": {
 			job: testingrayutil.MakeJob("rayjob", "ns").Queue("queue").
@@ -562,7 +562,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.rayClusterSpec.headGroupSpec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.rayClusterSpec.workerGroupSpecs[0].template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.rayClusterSpec.workerGroupSpecs[0].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.rayClusterSpec.headGroupSpec.template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 
@@ -571,8 +571,7 @@ func TestValidateCreate(t *testing.T) {
 			wh := &RayJobWebhook{
 				manageJobsWithoutQueueName: tc.manageAll,
 			}
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
-			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, tc.elasticJobsViaWorkloadSlices)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			_, result := wh.ValidateCreate(ctx, tc.job)
 			if diff := cmp.Diff(tc.wantErr, result); diff != "" {

--- a/pkg/controller/jobs/rayservice/rayservice_controller_test.go
+++ b/pkg/controller/jobs/rayservice/rayservice_controller_test.go
@@ -24,6 +24,7 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -36,11 +37,10 @@ import (
 
 func TestPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		rayService                    *RayService
-		rayCluster                    *rayv1.RayCluster
-		wantPodSets                   func(rayService *RayService) []kueue.PodSet
-		enableTopologyAwareScheduling bool
-		enableElasticJobsFeature      bool
+		rayService   *RayService
+		rayCluster   *rayv1.RayCluster
+		wantPodSets  func(rayService *RayService) []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			rayService: (*RayService)(&rayv1.RayService{
@@ -86,7 +86,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required topology annotation": {
 			rayService: (*RayService)(&rayv1.RayService{
@@ -136,7 +136,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"with NumOfHosts > 1": {
 			rayService: (*RayService)(&rayv1.RayService{
@@ -174,7 +174,7 @@ func TestPodSets(t *testing.T) {
 											Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with workload slicing and autoscaling enabled, update from RayCluster": {
 			rayService: (*RayService)(&rayv1.RayService{
@@ -242,8 +242,10 @@ func TestPodSets(t *testing.T) {
 											Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
-			enableElasticJobsFeature:      true,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:      false,
+				features.ElasticJobsViaWorkloadSlices: true,
+			},
 		},
 		"with workload slicing enabled but autoscaling disabled, use spec count": {
 			rayService: (*RayService)(&rayv1.RayService{
@@ -303,8 +305,10 @@ func TestPodSets(t *testing.T) {
 											Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
-			enableElasticJobsFeature:      true,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:      false,
+				features.ElasticJobsViaWorkloadSlices: true,
+			},
 		},
 		"with workload slicing and autoscaling enabled, RayCluster not found fallback to spec": {
 			rayService: (*RayService)(&rayv1.RayService{
@@ -351,8 +355,10 @@ func TestPodSets(t *testing.T) {
 											Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
-			enableElasticJobsFeature:      true,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:      false,
+				features.ElasticJobsViaWorkloadSlices: true,
+			},
 		},
 		"with workload slicing and autoscaling enabled, no RayClusterName in status": {
 			rayService: (*RayService)(&rayv1.RayService{
@@ -399,15 +405,16 @@ func TestPodSets(t *testing.T) {
 											Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
-			enableElasticJobsFeature:      true,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:      false,
+				features.ElasticJobsViaWorkloadSlices: true,
+			},
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
-			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, tc.enableElasticJobsFeature)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			// Set up fake client with optional RayCluster
 			objs := []client.Object{}

--- a/pkg/controller/jobs/sparkapplication/sparkapplication_controller_test.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_controller_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -67,9 +68,9 @@ func TestPodSets(t *testing.T) {
 	testSparkApp := sparkapplicationtesting.MakeSparkApplication("sparkapp", "ns")
 
 	testCases := map[string]struct {
-		sparkApp                           *sparkappv1beta2.SparkApplication
-		topologyAwareSchedulingFeatureGate bool
-		want                               []kueue.PodSet
+		sparkApp     *sparkappv1beta2.SparkApplication
+		featureGates map[featuregate.Feature]bool
+		want         []kueue.PodSet
 	}{
 		"base": {
 			sparkApp: testSparkApp.Clone().
@@ -114,7 +115,7 @@ func TestPodSets(t *testing.T) {
 			},
 		},
 		"with TopologyAwareScheduling": {
-			topologyAwareSchedulingFeatureGate: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			sparkApp: testSparkApp.Clone().Queue("local-queue").
 				DriverAnnotation(
 					kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block",
@@ -169,7 +170,7 @@ func TestPodSets(t *testing.T) {
 			},
 		},
 		"with TopologyAwareScheduling annotation but TopologyAwareScheduling feature gate disabled": {
-			topologyAwareSchedulingFeatureGate: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			sparkApp: testSparkApp.Clone().Queue("local-queue").
 				DriverAnnotation(
 					kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block",
@@ -225,7 +226,7 @@ func TestPodSets(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareSchedulingFeatureGate)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			ctx, _ := utiltesting.ContextWithLog(t)
 

--- a/pkg/controller/jobs/sparkapplication/sparkapplication_webhook_test.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_webhook_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -40,10 +41,9 @@ import (
 func TestValidateCreate(t *testing.T) {
 	testSparkApp := sparkapplicationtesting.MakeSparkApplication("test-sparkapp", "test").Suspend(false)
 	testcases := map[string]struct {
-		sparkApp                                *sparkappv1beta2.SparkApplication
-		elasticJobsViaWorkloadSlicesFeatureGate bool
-		topologyAwareSchedulingFeatureGate      bool
-		wantErr                                 error
+		sparkApp     *sparkappv1beta2.SparkApplication
+		featureGates map[featuregate.Feature]bool
+		wantErr      error
 	}{
 		"base": {
 			sparkApp: testSparkApp.Clone().Queue("local-queue").Obj(),
@@ -63,7 +63,7 @@ func TestValidateCreate(t *testing.T) {
 			)}.ToAggregate(),
 		},
 		"dynamicAllocation with elastic job feature": {
-			elasticJobsViaWorkloadSlicesFeatureGate: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			sparkApp: testSparkApp.Clone().Queue("local-queue").Annotation(
 				workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue,
 			).DynamicAllocation(&sparkappv1beta2.DynamicAllocation{
@@ -79,14 +79,14 @@ func TestValidateCreate(t *testing.T) {
 			)}.ToAggregate(),
 		},
 		"base with TAS": {
-			topologyAwareSchedulingFeatureGate: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			sparkApp: testSparkApp.Clone().Queue("local-queue").ExecutorAnnotation(
 				kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block",
 			).Obj(),
 			wantErr: nil,
 		},
 		"invalid TAS configuration": {
-			topologyAwareSchedulingFeatureGate: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			sparkApp: testSparkApp.Clone().Queue("local-queue").ExecutorAnnotation(
 				kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block",
 			).ExecutorAnnotation(
@@ -102,8 +102,7 @@ func TestValidateCreate(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, tc.elasticJobsViaWorkloadSlicesFeatureGate)
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareSchedulingFeatureGate)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			webhook := &SparkApplicationWebhook{}
 			ctx, _ := utiltesting.ContextWithLog(t)

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -52,22 +53,23 @@ var (
 func TestReconciler(t *testing.T) {
 	now := time.Now()
 	cases := map[string]struct {
-		enableTAS               bool
-		admissionGatedByEnabled bool
-		stsKey                  client.ObjectKey
-		statefulSet             *appsv1.StatefulSet
-		pods                    []corev1.Pod
-		workloads               []kueue.Workload
-		wantStatefulSet         *appsv1.StatefulSet
-		wantPods                []corev1.Pod
-		wantWorkloads           []kueue.Workload
-		wantErr                 error
+		featureGates    map[featuregate.Feature]bool
+		stsKey          client.ObjectKey
+		statefulSet     *appsv1.StatefulSet
+		pods            []corev1.Pod
+		workloads       []kueue.Workload
+		wantStatefulSet *appsv1.StatefulSet
+		wantPods        []corev1.Pod
+		wantWorkloads   []kueue.Workload
+		wantErr         error
 	}{
 		"statefulset not found": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 		},
 		"statefulset with finished pods": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Replicas(0).
@@ -110,7 +112,8 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"statefulset with update revision": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				CurrentRevision("1").
@@ -158,7 +161,8 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should add StatefulSet to Workload owner references if replicas > 0": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("lq").
@@ -181,7 +185,8 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"shouldn't add StatefulSet to Workload owner references if replicas = 0": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Replicas(0).
@@ -202,7 +207,8 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should remove StatefulSet from Workload owner references if replicas = 0": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("lq").
@@ -224,7 +230,8 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should create workload when replicas > 0 and workload doesn't exist": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("lq").
@@ -254,8 +261,8 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should create workload with TAS topology request when TAS enabled": {
-			enableTAS: true,
-			stsKey:    client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("lq").
@@ -291,7 +298,8 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should not create workload when replicas == 0": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Replicas(0).
@@ -304,7 +312,8 @@ func TestReconciler(t *testing.T) {
 				DeepCopy(),
 		},
 		"should not create workload when queue name is empty": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Obj(),
@@ -313,7 +322,8 @@ func TestReconciler(t *testing.T) {
 				DeepCopy(),
 		},
 		"should adopt legacy workload instead of creating duplicate": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("lq").
@@ -347,7 +357,8 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should list pods by legacy workload name": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Replicas(0).
@@ -381,7 +392,8 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should finalize deleted pod": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Replicas(0).
@@ -402,8 +414,11 @@ func TestReconciler(t *testing.T) {
 			wantPods: nil,
 		},
 		"statefulset with single AdmissionGatedBy gate should propagate to workload": {
-			admissionGatedByEnabled: true,
-			stsKey:                  client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling: false,
+				features.AdmissionGatedBy:        true,
+			},
+			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("lq").
@@ -436,8 +451,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"statefulset with multiple AdmissionGatedBy gates should propagate to workload": {
-			admissionGatedByEnabled: true,
-			stsKey:                  client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling: false,
+				features.AdmissionGatedBy:        true,
+			},
+			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("lq").
@@ -470,7 +488,8 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"statefulset with AdmissionGatedBy annotation but feature gate disabled should not propagate": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("lq").
@@ -504,8 +523,7 @@ func TestReconciler(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTAS)
-			features.SetFeatureGateDuringTest(t, features.AdmissionGatedBy, tc.admissionGatedByEnabled)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			clientBuilder := utiltesting.NewClientBuilder()
 			indexer := utiltesting.AsIndexer(clientBuilder)

--- a/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -183,10 +184,10 @@ func TestDefault(t *testing.T) {
 
 func TestValidateCreate(t *testing.T) {
 	testCases := map[string]struct {
-		sts              *appsv1.StatefulSet
-		wantErr          error
-		wantWarns        admission.Warnings
-		admissionGatedBy bool
+		sts          *appsv1.StatefulSet
+		wantErr      error
+		wantWarns    admission.Warnings
+		featureGates map[featuregate.Feature]bool
 	}{
 		"without queue": {
 			sts: testingstatefulset.MakeStatefulSet("test-pod", "").Obj(),
@@ -218,48 +219,48 @@ func TestValidateCreate(t *testing.T) {
 				Queue("queue").
 				Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"AdmissionGatedBy annotation - trailing space": {
 			sts: testingstatefulset.MakeStatefulSet("test-sts", "default").
 				Queue("queue").
 				Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/gate ").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"AdmissionGatedBy annotation - space before comma": {
 			sts: testingstatefulset.MakeStatefulSet("test-sts", "default").
 				Queue("queue").
 				Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/gate ,example.com/gate2").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"AdmissionGatedBy annotation - space after comma": {
 			sts: testingstatefulset.MakeStatefulSet("test-sts", "default").
 				Queue("queue").
 				Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/gate, example.com/gate2").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"AdmissionGatedBy annotation - leading space": {
 			sts: testingstatefulset.MakeStatefulSet("test-sts", "default").
 				Queue("queue").
 				Annotation(kueueconstants.AdmissionGatedByAnnotation, " example.com/gate").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"AdmissionGatedBy annotation - multiple gates": {
 			sts: testingstatefulset.MakeStatefulSet("test-sts", "default").
 				Queue("queue").
 				Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/a,not.example.com/b").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"invalid AdmissionGatedBy annotation - not in subdomain/path format": {
 			sts: testingstatefulset.MakeStatefulSet("test-sts", "default").
@@ -269,7 +270,7 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Invalid(admissionGatedByAnnotationsPath, "this is an invalid value", "must be a domain-prefixed path (such as \"acme.io/foo\")"),
 			}.ToAggregate(),
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"invalid AdmissionGatedBy annotation - duplicate gates": {
 			sts: testingstatefulset.MakeStatefulSet("test-sts", "default").
@@ -279,7 +280,7 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Invalid(admissionGatedByAnnotationsPath, "duplicates.are/invalid,duplicates.are/invalid", "duplicate gate name: duplicates.are/invalid"),
 			}.ToAggregate(),
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"invalid AdmissionGatedBy annotation - gate name too long": {
 			sts: testingstatefulset.MakeStatefulSet("test-sts", "default").
@@ -289,7 +290,7 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.TooLong(admissionGatedByAnnotationsPath, "", webhook.MaxGateNameLengthForAdmissionGatedBy),
 			}.ToAggregate(),
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"invalid AdmissionGatedBy annotation - space in path component": {
 			sts: testingstatefulset.MakeStatefulSet("test-sts", "default").
@@ -299,7 +300,7 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Invalid(admissionGatedByAnnotationsPath, "gate name", testutil.InvalidPathMessage),
 			}.ToAggregate(),
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"invalid AdmissionGatedBy annotation - space in domain component": {
 			sts: testingstatefulset.MakeStatefulSet("test-sts", "default").
@@ -309,7 +310,7 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Invalid(admissionGatedByAnnotationsPath, "example .com", testutil.InvalidRFC1123Message),
 			}.ToAggregate(),
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"invalid AdmissionGatedBy annotation - multiple gates with one containing space": {
 			sts: testingstatefulset.MakeStatefulSet("test-sts", "default").
@@ -319,37 +320,37 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Invalid(admissionGatedByAnnotationsPath, "invalid gate.com", testutil.InvalidRFC1123Message),
 			}.ToAggregate(),
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"AdmissionGatedBy annotation with feature gate disabled - valid value": {
 			sts: testingstatefulset.MakeStatefulSet("test-sts", "default").
 				Queue("queue").
 				Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/gate").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: false,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: false},
 		},
 		"AdmissionGatedBy annotation with feature gate disabled - invalid value": {
 			sts: testingstatefulset.MakeStatefulSet("test-sts", "default").
 				Queue("queue").
 				Annotation(kueueconstants.AdmissionGatedByAnnotation, "this is an invalid value").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: false,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: false},
 		},
 		"AdmissionGatedBy annotation with feature gate enabled - empty string": {
 			sts: testingstatefulset.MakeStatefulSet("test-sts", "default").
 				Queue("queue").
 				Annotation(kueueconstants.AdmissionGatedByAnnotation, "").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.AdmissionGatedBy, tc.admissionGatedBy)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			t.Cleanup(jobframework.EnableIntegrationsForTest(t, "pod"))
 			builder := utiltesting.NewClientBuilder()
 			client := builder.Build()
@@ -368,12 +369,12 @@ func TestValidateCreate(t *testing.T) {
 
 func TestValidateUpdate(t *testing.T) {
 	testCases := map[string]struct {
-		integrations     []string
-		objs             []runtime.Object
-		oldObj           *appsv1.StatefulSet
-		newObj           *appsv1.StatefulSet
-		wantErr          error
-		admissionGatedBy bool
+		integrations []string
+		objs         []runtime.Object
+		oldObj       *appsv1.StatefulSet
+		newObj       *appsv1.StatefulSet
+		wantErr      error
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no changes": {
 			oldObj: &appsv1.StatefulSet{
@@ -948,7 +949,7 @@ func TestValidateUpdate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Forbidden(admissionGatedByAnnotationsPath, "cannot add admission gate after creation"),
 			}.ToAggregate(),
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"allow removing AdmissionGatedBy annotation with single gate": {
 			oldObj: testingstatefulset.MakeStatefulSet("test-sts", "default").
@@ -958,8 +959,8 @@ func TestValidateUpdate(t *testing.T) {
 			newObj: testingstatefulset.MakeStatefulSet("test-sts", "default").
 				Queue("queue").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"allow removing AdmissionGatedBy annotation with multiple gates": {
 			oldObj: testingstatefulset.MakeStatefulSet("test-sts", "default").
@@ -969,8 +970,8 @@ func TestValidateUpdate(t *testing.T) {
 			newObj: testingstatefulset.MakeStatefulSet("test-sts", "default").
 				Queue("queue").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"allow removing one gate from AdmissionGatedBy annotation": {
 			oldObj: testingstatefulset.MakeStatefulSet("test-sts", "default").
@@ -981,8 +982,8 @@ func TestValidateUpdate(t *testing.T) {
 				Queue("queue").
 				Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller2").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"reject injecting new gate in AdmissionGatedBy annotation": {
 			oldObj: testingstatefulset.MakeStatefulSet("test-sts", "default").
@@ -996,7 +997,7 @@ func TestValidateUpdate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Forbidden(admissionGatedByAnnotationsPath, "can only remove gates, not add new ones"),
 			}.ToAggregate(),
-			admissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		"allow reordering gates in AdmissionGatedBy annotation": {
 			oldObj: testingstatefulset.MakeStatefulSet("test-sts", "default").
@@ -1007,14 +1008,14 @@ func TestValidateUpdate(t *testing.T) {
 				Queue("queue").
 				Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller2,example.com/controller1").
 				Obj(),
-			wantErr:          nil,
-			admissionGatedBy: true,
+			wantErr:      nil,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.AdmissionGatedBy, tc.admissionGatedBy)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			t.Cleanup(jobframework.EnableIntegrationsForTest(t, tc.integrations...))
 
 			client := utiltesting.NewClientBuilder(awv1beta2.AddToScheme, leaderworkersetv1.AddToScheme).

--- a/pkg/controller/jobs/trainjob/trainjob_webhook_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_webhook_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	jobsetapi "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
@@ -205,7 +206,7 @@ func TestDefault(t *testing.T) {
 		manageJobsWithoutQueueName   bool
 		withMultiKueueAdmissionCheck bool
 		withDefaultLocalQueue        bool
-		multiKueueEnabled            bool
+		featureGates                 map[featuregate.Feature]bool
 		wantTrainJob                 *kftrainerapi.TrainJob
 		wantErr                      error
 	}{
@@ -248,7 +249,7 @@ func TestDefault(t *testing.T) {
 				JobSetLabel(controllerconstants.QueueLabel, testLocalQueue.Name).
 				ManagedBy(kueue.MultiKueueControllerName).
 				Obj(),
-			multiKueueEnabled:            true,
+			featureGates:                 map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			withMultiKueueAdmissionCheck: true,
 		},
 		"should not set managedBy to multiKueue if already specified by the user": {
@@ -258,7 +259,7 @@ func TestDefault(t *testing.T) {
 				JobSetLabel(controllerconstants.QueueLabel, testLocalQueue.Name).
 				ManagedBy("user").
 				Obj(),
-			multiKueueEnabled:            true,
+			featureGates:                 map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			withMultiKueueAdmissionCheck: true,
 		},
 		"should not set managedBy to multiKueue if the selected clusterQueue doesn't have the corresponding admissionCheck": {
@@ -267,14 +268,14 @@ func TestDefault(t *testing.T) {
 				Suspend(true).
 				JobSetLabel(controllerconstants.QueueLabel, testLocalQueue.Name).
 				Obj(),
-			multiKueueEnabled:            true,
+			featureGates:                 map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			withMultiKueueAdmissionCheck: false,
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.MultiKueue, tc.multiKueueEnabled)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			ctx, log := utiltesting.ContextWithLog(t)
 

--- a/pkg/controller/tas/node_controller_test.go
+++ b/pkg/controller/tas/node_controller_test.go
@@ -893,9 +893,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 	for name, tc := range tests {
 		fakeClock.SetTime(testStartTime)
 		t.Run(name, func(t *testing.T) {
-			for fg, enable := range tc.featureGates {
-				features.SetFeatureGateDuringTest(t, fg, enable)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			fakeClock.SetTime(testStartTime)
 
 			clientBuilder := utiltesting.NewClientBuilder().
@@ -1080,9 +1078,7 @@ func TestGetWorkloadStatus(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			for fg, enable := range tc.featureGates {
-				features.SetFeatureGateDuringTest(t, fg, enable)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			clientBuilder := utiltesting.NewClientBuilder().WithObjects(tc.initObjs...)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			if err := indexer.SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder)); err != nil {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -525,6 +525,12 @@ func SetFeatureGateDuringTest(tb testing.TB, f featuregate.Feature, value bool) 
 	featuregatetesting.SetFeatureGateDuringTest(tb, utilfeature.DefaultFeatureGate, f, value)
 }
 
+func SetFeatureGatesDuringTest(tb testing.TB, featureGates map[featuregate.Feature]bool) {
+	for fg, enable := range featureGates {
+		featuregatetesting.SetFeatureGateDuringTest(tb, utilfeature.DefaultFeatureGate, fg, enable)
+	}
+}
+
 // Enabled is helper for `utilfeature.DefaultFeatureGate.Enabled()`
 func Enabled(f featuregate.Feature) bool {
 	return utilfeature.DefaultFeatureGate.Enabled(f)

--- a/pkg/podset/podset_test.go
+++ b/pkg/podset/podset_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -66,7 +67,7 @@ func TestFromAssignment(t *testing.T) {
 		Obj()
 
 	cases := map[string]struct {
-		enableTopologyAwareScheduling bool
+		featureGates map[featuregate.Feature]bool
 
 		assignment   *kueue.PodSetAssignment
 		defaultCount int32
@@ -169,7 +170,7 @@ func TestFromAssignment(t *testing.T) {
 			},
 		},
 		"with topology assignment; TopologyAwareScheduling enabled - scheduling gate added": {
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			assignment: &kueue.PodSetAssignment{
 				Name: "name",
 				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
@@ -206,6 +207,7 @@ func TestFromAssignment(t *testing.T) {
 			},
 		},
 		"with topology assignment; TopologyAwareScheduling disabled - no scheduling gate added": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			assignment: &kueue.PodSetAssignment{
 				Name: "name",
 				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
@@ -237,7 +239,7 @@ func TestFromAssignment(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			client := utiltesting.NewClientBuilder().WithLists(&kueue.ResourceFlavorList{Items: tc.flavors}).Build()
 
 			podSet := kueue.PodSet{

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -191,19 +191,18 @@ func TestAssignFlavors(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		wlPods                              []kueue.PodSet
-		wlReclaimablePods                   []kueue.ReclaimablePod
-		clusterQueue                        kueue.ClusterQueue
-		clusterQueueUsage                   resources.FlavorResourceQuantities
-		secondaryClusterQueue               *kueue.ClusterQueue
-		secondaryClusterQueueUsage          resources.FlavorResourceQuantities
-		wantRepMode                         FlavorAssignmentMode
-		wantAssignment                      Assignment
-		enableFairSharing                   bool
-		simulationResult                    map[resources.FlavorResource]simulationResultForFlavor
-		elasticJobsViaWorkloadSlicesEnabled bool
-		preemptWorkloadSlice                *workload.Info
-		featureGates                        map[featuregate.Feature]bool
+		wlPods                     []kueue.PodSet
+		wlReclaimablePods          []kueue.ReclaimablePod
+		clusterQueue               kueue.ClusterQueue
+		clusterQueueUsage          resources.FlavorResourceQuantities
+		secondaryClusterQueue      *kueue.ClusterQueue
+		secondaryClusterQueueUsage resources.FlavorResourceQuantities
+		wantRepMode                FlavorAssignmentMode
+		wantAssignment             Assignment
+		enableFairSharing          bool
+		simulationResult           map[resources.FlavorResource]simulationResultForFlavor
+		preemptWorkloadSlice       *workload.Info
+		featureGates               map[featuregate.Feature]bool
 	}{
 		"single flavor, fits": {
 			wlPods: []kueue.PodSet{
@@ -3171,7 +3170,7 @@ func TestAssignFlavors(t *testing.T) {
 			},
 		},
 		"workload slice preemption fits in the original workload resource flavor": {
-			elasticJobsViaWorkloadSlicesEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			wlPods: []kueue.PodSet{
 				*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 					Request(corev1.ResourceCPU, "3").
@@ -3236,7 +3235,7 @@ func TestAssignFlavors(t *testing.T) {
 			},
 		},
 		"workload slice preemption does not fit in the original workload resource flavor": {
-			elasticJobsViaWorkloadSlicesEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			wlPods: []kueue.PodSet{
 				*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 					Request(corev1.ResourceCPU, "3").
@@ -3351,10 +3350,6 @@ func TestAssignFlavors(t *testing.T) {
 					t.Fatalf("Failed to create secondary CQ snapshot")
 				}
 				secondaryClusterQueue.AddUsage(workload.Usage{Quota: tc.secondaryClusterQueueUsage})
-			}
-
-			if tc.elasticJobsViaWorkloadSlicesEnabled {
-				features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
 			}
 
 			flvAssigner := New(wlInfo, clusterQueue, resourceFlavors, tc.enableFairSharing, &testOracle{simulationResult: tc.simulationResult}, tc.preemptWorkloadSlice)

--- a/pkg/scheduler/preemption/common/preemption_policy_test.go
+++ b/pkg/scheduler/preemption/common/preemption_policy_test.go
@@ -165,9 +165,7 @@ func TestSatisfiesPreemptionPolicy(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
-			for feature, enabled := range tc.featureGates {
-				features.SetFeatureGateDuringTest(t, feature, enabled)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ordering := workload.Ordering{}
 			got := SatisfiesPreemptionPolicy(log, tc.preemptor, tc.candidate, ordering, tc.policy)
 			if got != tc.want {

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -4677,9 +4677,7 @@ func TestCandidatesOrdering(t *testing.T) {
 
 	_, log := utiltesting.ContextWithLog(t)
 	for _, tc := range cases {
-		for fg, enable := range tc.featureGates {
-			features.SetFeatureGateDuringTest(t, fg, enable)
-		}
+		features.SetFeatureGatesDuringTest(t, tc.featureGates)
 		slices.SortFunc(tc.candidates, func(a, b workload.Info) int {
 			return preemptioncommon.CandidatesOrdering(log, tc.featureGates != nil && tc.featureGates[features.AdmissionFairSharing], &a, &b, kueue.ClusterQueueReference(preemptorCq), now)
 		})
@@ -4831,9 +4829,7 @@ func TestPriorityInfo(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			for fg, enable := range tc.featureGates {
-				features.SetFeatureGateDuringTest(t, fg, enable)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			_, log := utiltesting.ContextWithLog(t)
 			gotEff, gotBase, gotBoost := priorityInfo(log, tc.wl)
 			if gotEff != tc.wantEffective || gotBase != tc.wantBase || gotBoost != tc.wantBoost {

--- a/pkg/scheduler/scheduler_afs_test.go
+++ b/pkg/scheduler/scheduler_afs_test.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -78,13 +79,13 @@ func TestScheduleForAFS(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		enableFairSharing bool
-		initialUsage      map[string]corev1.ResourceList
-		workloads         []kueue.Workload
-		wantWorkloads     []kueue.Workload
+		featureGates  map[featuregate.Feature]bool
+		initialUsage  map[string]corev1.ResourceList
+		workloads     []kueue.Workload
+		wantWorkloads []kueue.Workload
 	}{
 		"admits workload from less active localqueue": {
-			enableFairSharing: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionFairSharing: true},
 			initialUsage: map[string]corev1.ResourceList{
 				"lq-a": {corev1.ResourceCPU: resource.MustParse("8")},
 				"lq-b": {corev1.ResourceCPU: resource.MustParse("2")},
@@ -160,7 +161,7 @@ func TestScheduleForAFS(t *testing.T) {
 			},
 		},
 		"without AFS: classic admission decision ignores queue usage": {
-			enableFairSharing: false,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionFairSharing: false},
 			initialUsage: map[string]corev1.ResourceList{
 				"lq-a": {corev1.ResourceCPU: resource.MustParse("8")},
 				"lq-b": {corev1.ResourceCPU: resource.MustParse("2")},
@@ -236,7 +237,7 @@ func TestScheduleForAFS(t *testing.T) {
 			},
 		},
 		"admits one workload from each localqueue when quota is limited": {
-			enableFairSharing: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionFairSharing: true},
 			initialUsage: map[string]corev1.ResourceList{
 				"lq-a": {corev1.ResourceCPU: resource.MustParse("4")},
 				"lq-b": {corev1.ResourceCPU: resource.MustParse("4")},
@@ -377,7 +378,7 @@ func TestScheduleForAFS(t *testing.T) {
 			},
 		},
 		"schedules normally when queues have equal usage": {
-			enableFairSharing: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionFairSharing: true},
 			initialUsage: map[string]corev1.ResourceList{
 				"lq-a": {corev1.ResourceCPU: resource.MustParse("2")},
 				"lq-b": {corev1.ResourceCPU: resource.MustParse("2")},
@@ -497,7 +498,7 @@ func TestScheduleForAFS(t *testing.T) {
 			},
 		},
 		"admits workload from lq-b with uninitialized cache": {
-			enableFairSharing: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionFairSharing: true},
 			initialUsage: map[string]corev1.ResourceList{
 				"lq-a": {corev1.ResourceCPU: resource.MustParse("8")},
 			},
@@ -577,7 +578,7 @@ func TestScheduleForAFS(t *testing.T) {
 		for _, enabled := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", name, enabled), func(t *testing.T) {
 				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, enabled)
-				features.SetFeatureGateDuringTest(t, features.AdmissionFairSharing, tc.enableFairSharing)
+				features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 				clientBuilder := utiltesting.NewClientBuilder().
 					WithLists(
@@ -591,7 +592,7 @@ func TestScheduleForAFS(t *testing.T) {
 					WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 				cl := clientBuilder.Build()
 
-				cqCache := schdcache.New(cl, schdcache.WithFairSharing(tc.enableFairSharing), schdcache.WithAdmissionFairSharing(afsConfig))
+				cqCache := schdcache.New(cl, schdcache.WithFairSharing(tc.featureGates[features.AdmissionFairSharing]), schdcache.WithAdmissionFairSharing(afsConfig))
 				qManager := qcache.NewManagerForUnitTests(cl, cqCache, qcache.WithAdmissionFairSharing(afsConfig))
 
 				ctx, log := utiltesting.ContextWithLog(t)
@@ -617,7 +618,7 @@ func TestScheduleForAFS(t *testing.T) {
 				}
 				recorder := &utiltesting.EventRecorder{}
 				var preemptionFairSharing *config.FairSharing
-				if tc.enableFairSharing {
+				if tc.featureGates[features.AdmissionFairSharing] {
 					preemptionFairSharing = &config.FairSharing{}
 				}
 				scheduler := New(qManager, cqCache, cl, recorder,

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -3029,9 +3029,7 @@ func TestScheduleForTAS(t *testing.T) {
 		for _, enabled := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", name, enabled), func(t *testing.T) {
 				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, enabled)
-				for fg, enable := range tc.featureGates {
-					features.SetFeatureGateDuringTest(t, fg, enable)
-				}
+				features.SetFeatureGatesDuringTest(t, tc.featureGates)
 				ctx, log := utiltesting.ContextWithLog(t)
 				testWls := make([]kueue.Workload, 0, len(tc.workloads))
 				for _, wl := range tc.workloads {
@@ -4296,9 +4294,8 @@ func TestScheduleForTASPreemption(t *testing.T) {
 		for _, enabled := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", name, enabled), func(t *testing.T) {
 				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, enabled)
-				for feature, value := range tc.featureGates {
-					features.SetFeatureGateDuringTest(t, feature, value)
-				}
+				features.SetFeatureGatesDuringTest(t, tc.featureGates)
+
 				ctx, log := utiltesting.ContextWithLog(t)
 				testWls := make([]kueue.Workload, 0, len(tc.workloads))
 				for _, wl := range tc.workloads {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/component-base/metrics/testutil"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
@@ -174,10 +175,8 @@ func TestSchedule(t *testing.T) {
 	}
 	cases := map[string]struct {
 		// Features
-		disablePartialAdmission                bool
-		enableFairSharing                      bool
-		enableElasticJobsViaWorkloadSlice      bool
-		enableMultiKueueOrchestratedPreemption bool
+		featureGates      map[featuregate.Feature]bool
+		enableFairSharing bool
 
 		workloads      []kueue.Workload
 		objects        []client.Object
@@ -207,6 +206,7 @@ func TestSchedule(t *testing.T) {
 		wantSkippedPreemptions map[string]int
 	}{
 		"use second flavor when the first has no preemption candidates; WhenCanPreempt: MayStopSearch": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			additionalClusterQueues: []kueue.ClusterQueue{
 				*utiltestingapi.MakeClusterQueue("other-alpha").
 					Preemption(kueue.ClusterQueuePreemption{
@@ -295,6 +295,7 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"workload fits in single clusterQueue, with check state ready": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("foo", "sales").
 					Queue("main").
@@ -363,6 +364,7 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"skip workload with missing or deleted ClusterQueue (NoFit)": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("missing-cq-workload", "sales").
 					Queue("non-existent-queue").
@@ -387,6 +389,7 @@ func TestSchedule(t *testing.T) {
 			eventCmpOpts: ignoreEventMessageCmpOpts,
 		},
 		"workload fits in single clusterQueue, with check state pending": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("foo", "sales").
 					Queue("main").
@@ -443,6 +446,7 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"error during admission": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("foo", "sales").
 					Queue("main").
@@ -465,6 +469,7 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"single clusterQueue full": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("new", "sales").
 					Queue("main").
@@ -536,6 +541,7 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"failed to match clusterQueue selector": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("new", "sales").
 					Queue("blocked").
@@ -570,6 +576,7 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"admit in different cohorts": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("new", "sales").
 					Queue("main").
@@ -663,6 +670,7 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"admit in same cohort with no borrowing": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("new", "eng-alpha").
 					Queue("main").
@@ -757,6 +765,7 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"assign multiple resources and flavors": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("new", "eng-beta").
 					Queue("main").
@@ -2398,7 +2407,7 @@ func TestSchedule(t *testing.T) {
 			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"sales": {"sales/new"},
 			},
-			disablePartialAdmission: true,
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: false},
 		},
 		"two workloads can borrow different resources from the same flavor in the same cycle": {
 			additionalClusterQueues: func() []kueue.ClusterQueue {
@@ -7124,7 +7133,7 @@ func TestSchedule(t *testing.T) {
 		},
 		// Workload-slice scheduling test case.
 		"workload-slice fits in single clusterQueue": {
-			enableElasticJobsViaWorkloadSlice: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			// workloads that will be returned by the fake.client.
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("foo-1", "sales").
@@ -8126,7 +8135,7 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"block preemptions and signal `BlockedOnPreemptionGates` when a preemption gate is present": {
-			enableMultiKueueOrchestratedPreemption: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueOrchestratedPreemption: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("preemptor", "eng-beta").
 					UID("wl-preemptor").
@@ -8200,7 +8209,7 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"do not signal `BlockedOnPreemptionGates` when a preemption gate is present, but the workload fits without preemption": {
-			enableMultiKueueOrchestratedPreemption: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueOrchestratedPreemption: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("preemptor", "eng-beta").
 					UID("wl-preemptor").
@@ -8250,7 +8259,7 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"do not signal `BlockedOnPreemptionGates` when a preemption gate is present, but the workload had nothing to preempt": {
-			enableMultiKueueOrchestratedPreemption: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueOrchestratedPreemption: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("preemptor", "eng-beta").
 					UID("wl-preemptor").
@@ -8322,11 +8331,7 @@ func TestSchedule(t *testing.T) {
 			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", name, enabled), func(t *testing.T) {
 				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, enabled)
 				metrics.AdmissionCyclePreemptionSkips.Reset()
-				if tc.disablePartialAdmission {
-					features.SetFeatureGateDuringTest(t, features.PartialAdmission, false)
-				}
-				features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, tc.enableElasticJobsViaWorkloadSlice)
-				features.SetFeatureGateDuringTest(t, features.MultiKueueOrchestratedPreemption, tc.enableMultiKueueOrchestratedPreemption)
+				features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 				ctx, log := utiltesting.ContextWithLog(t)
 
@@ -8688,42 +8693,42 @@ func TestEntryOrdering(t *testing.T) {
 	for _, tc := range []struct {
 		name             string
 		input            []entry
-		prioritySorting  bool
+		featureGates     map[featuregate.Feature]bool
 		workloadOrdering workload.Ordering
 		wantOrder        []string
 	}{
 		{
 			name:             "Priority sorting is enabled (default) using pods-ready Eviction timestamp (default)",
 			input:            input,
-			prioritySorting:  true,
+			featureGates:     map[featuregate.Feature]bool{features.PrioritySortingWithinCohort: true},
 			workloadOrdering: workload.Ordering{PodsReadyRequeuingTimestamp: config.EvictionTimestamp},
 			wantOrder:        []string{"new_high_pri", "old", "recently_evicted", "new", "high_pri_borrowing", "old_borrowing", "evicted_borrowing", "new_borrowing", "high_pri_borrowing_more"},
 		},
 		{
 			name:             "Priority sorting is enabled (default) using pods-ready Creation timestamp",
 			input:            input,
-			prioritySorting:  true,
+			featureGates:     map[featuregate.Feature]bool{features.PrioritySortingWithinCohort: true},
 			workloadOrdering: workload.Ordering{PodsReadyRequeuingTimestamp: config.CreationTimestamp},
 			wantOrder:        []string{"new_high_pri", "recently_evicted", "old", "new", "high_pri_borrowing", "old_borrowing", "evicted_borrowing", "new_borrowing", "high_pri_borrowing_more"},
 		},
 		{
 			name:             "Priority sorting is disabled using pods-ready Eviction timestamp",
 			input:            input,
-			prioritySorting:  false,
+			featureGates:     map[featuregate.Feature]bool{features.PrioritySortingWithinCohort: false},
 			workloadOrdering: workload.Ordering{PodsReadyRequeuingTimestamp: config.EvictionTimestamp},
 			wantOrder:        []string{"old", "recently_evicted", "new", "new_high_pri", "old_borrowing", "evicted_borrowing", "high_pri_borrowing", "new_borrowing", "high_pri_borrowing_more"},
 		},
 		{
 			name:             "Priority sorting is disabled using pods-ready Creation timestamp",
 			input:            input,
-			prioritySorting:  false,
+			featureGates:     map[featuregate.Feature]bool{features.PrioritySortingWithinCohort: false},
 			workloadOrdering: workload.Ordering{PodsReadyRequeuingTimestamp: config.CreationTimestamp},
 			wantOrder:        []string{"recently_evicted", "old", "new", "new_high_pri", "old_borrowing", "evicted_borrowing", "high_pri_borrowing", "new_borrowing", "high_pri_borrowing_more"},
 		},
 		{
-			name:            "Some workloads are preempted; Priority sorting is disabled",
-			input:           inputForOrderingPreemptedWorkloads,
-			prioritySorting: false,
+			name:         "Some workloads are preempted; Priority sorting is disabled",
+			input:        inputForOrderingPreemptedWorkloads,
+			featureGates: map[featuregate.Feature]bool{features.PrioritySortingWithinCohort: false},
 			wantOrder: []string{
 				"old-mid-recently-preempted-in-queue",
 				"old-mid-not-preempted-yet",
@@ -8733,9 +8738,9 @@ func TestEntryOrdering(t *testing.T) {
 			},
 		},
 		{
-			name:            "Some workloads are preempted; Priority sorting is enabled",
-			input:           inputForOrderingPreemptedWorkloads,
-			prioritySorting: true,
+			name:         "Some workloads are preempted; Priority sorting is enabled",
+			input:        inputForOrderingPreemptedWorkloads,
+			featureGates: map[featuregate.Feature]bool{features.PrioritySortingWithinCohort: true},
 			wantOrder: []string{
 				"preemptor",
 				"old-mid-recently-preempted-in-queue",
@@ -8746,7 +8751,7 @@ func TestEntryOrdering(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.PrioritySortingWithinCohort, tc.prioritySorting)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			iter := makeIterator(ctx, tc.input, tc.workloadOrdering, false)
 			order := make([]string, len(tc.input))

--- a/pkg/util/priority/priority_test.go
+++ b/pkg/util/priority/priority_test.go
@@ -265,9 +265,7 @@ func TestPriorityBoost(t *testing.T) {
 
 	for desc, tt := range tests {
 		t.Run(desc, func(t *testing.T) {
-			for fg, enable := range tt.featureGates {
-				features.SetFeatureGateDuringTest(t, fg, enable)
-			}
+			features.SetFeatureGatesDuringTest(t, tt.featureGates)
 			got, err := PriorityBoost(tt.workload)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("PriorityBoost() error = %v, wantErr %v", err, tt.wantErr)
@@ -326,9 +324,7 @@ func TestParseEffectivePriority(t *testing.T) {
 
 	for desc, tt := range tests {
 		t.Run(desc, func(t *testing.T) {
-			for fg, enable := range tt.featureGates {
-				features.SetFeatureGateDuringTest(t, fg, enable)
-			}
+			features.SetFeatureGatesDuringTest(t, tt.featureGates)
 			got, err := ParseEffectivePriority(tt.workload)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseEffectivePriority() error = %v, wantErr %v", err, tt.wantErr)
@@ -370,9 +366,7 @@ func TestEffectivePriority(t *testing.T) {
 
 	for desc, tt := range tests {
 		t.Run(desc, func(t *testing.T) {
-			for fg, enable := range tt.featureGates {
-				features.SetFeatureGateDuringTest(t, fg, enable)
-			}
+			features.SetFeatureGatesDuringTest(t, tt.featureGates)
 			_, log := utiltesting.ContextWithLog(t)
 			got := EffectivePriority(log, tt.workload)
 			if got != tt.wantPriority {

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -411,9 +411,7 @@ func TestValidateWorkload(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			for f, v := range tc.featureGates {
-				features.SetFeatureGateDuringTest(t, f, v)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			gotErr := ValidateWorkload(tc.workload)
 			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.IgnoreFields(field.Error{}, "Detail", "BadValue")); diff != "" {
 				t.Errorf("ValidateWorkload() mismatch (-want +got):\n%s", diff)
@@ -425,9 +423,7 @@ func TestValidateWorkload(t *testing.T) {
 func TestValidateWorkloadUpdate(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	testCases := map[string]struct {
-		enableTopologyAwareScheduling bool
-		enableElasticJobsFeature      bool
-		enableAdmissionGatedBy        bool
+		featureGates map[featuregate.Feature]bool
 
 		before, after *kueue.Workload
 		wantErr       field.ErrorList
@@ -572,7 +568,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 			}).Obj(),
 		},
 		"TopologyAssignment can be mutated": {
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				PodSets(
 					*utiltestingapi.MakePodSet("ps1", 3).Obj(),
@@ -618,7 +614,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 			wantErr: nil,
 		},
 		"PodSets cannot be removed from admission": {
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				PodSets(
 					*utiltestingapi.MakePodSet("ps1", 3).Obj(),
@@ -653,7 +649,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 			},
 		},
 		"PodSets cannot be added to admission": {
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				PodSets(
 					*utiltestingapi.MakePodSet("ps1", 3).Obj(),
@@ -708,7 +704,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 			},
 		},
 		"workload.podSets[].count is mutable with ElasticJobs feature gate": {
-			enableElasticJobsFeature: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				PodSets(
 					*utiltestingapi.MakePodSet("ps1", 3).Obj(),
@@ -725,7 +721,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 					kueue.PodSetAssignment{Name: "ps2"}).Obj(), now).Obj(),
 		},
 		"ClusterName doesn't have to be one of the nominatedClusterNames with ElasticJobs feature gate": {
-			enableElasticJobsFeature: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				PodSets(
 					*utiltestingapi.MakePodSet("ps1", 3).Obj(),
@@ -743,7 +739,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 				Obj(),
 		},
 		"reject adding AdmissionGatedBy annotation after workload creation": {
-			enableAdmissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				PodSets(*utiltestingapi.MakePodSet("main", 1).Obj()).
 				Obj(),
@@ -758,7 +754,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 			},
 		},
 		"allow removing AdmissionGatedBy annotation with single gate": {
-			enableAdmissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				Annotations(map[string]string{
 					constants.AdmissionGatedByAnnotation: "example.com/controller1",
@@ -771,7 +767,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 			wantErr: nil,
 		},
 		"allow removing AdmissionGatedBy annotation with multiple gates": {
-			enableAdmissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				Annotations(map[string]string{
 					constants.AdmissionGatedByAnnotation: "example.com/controller1,example.com/controller2",
@@ -784,7 +780,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 			wantErr: nil,
 		},
 		"allow removing one gate from AdmissionGatedBy annotation": {
-			enableAdmissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				Annotations(map[string]string{
 					constants.AdmissionGatedByAnnotation: "example.com/controller1,example.com/controller2",
@@ -800,7 +796,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 			wantErr: nil,
 		},
 		"reject injecting new gate in AdmissionGatedBy annotation": {
-			enableAdmissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				Annotations(map[string]string{
 					constants.AdmissionGatedByAnnotation: "example.com/controller1,example.com/controller2",
@@ -818,7 +814,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 			},
 		},
 		"allow reordering gates in AdmissionGatedBy annotation": {
-			enableAdmissionGatedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				Annotations(map[string]string{
 					constants.AdmissionGatedByAnnotation: "example.com/controller1,example.com/controller2",
@@ -836,9 +832,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.AdmissionGatedBy, tc.enableAdmissionGatedBy)
-			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, tc.enableElasticJobsFeature)
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			errList := ValidateWorkloadUpdate(tc.after, tc.before)
 			if diff := cmp.Diff(tc.wantErr, errList, cmpopts.IgnoreFields(field.Error{}, "Detail", "BadValue")); diff != "" {
 				t.Errorf("ValidateWorkloadUpdate() mismatch (-want +got):\n%s", diff)

--- a/pkg/workload/admissionchecks_test.go
+++ b/pkg/workload/admissionchecks_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 
@@ -36,7 +37,7 @@ import (
 func TestSyncAdmittedCondition(t *testing.T) {
 	testTime := time.Now().Truncate(time.Second)
 	cases := map[string]struct {
-		enableTopologyAwareScheduling bool
+		featureGates map[featuregate.Feature]bool
 
 		admission        *kueue.Admission
 		checkStates      []kueue.AdmissionCheckState
@@ -258,7 +259,7 @@ func TestSyncAdmittedCondition(t *testing.T) {
 			wantAdmittedTime: 2,
 		},
 		"pending delayed topology request; flip from Admitted=true": {
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			admission: &kueue.Admission{
 				PodSetAssignments: []kueue.PodSetAssignment{
 					{
@@ -299,7 +300,7 @@ func TestSyncAdmittedCondition(t *testing.T) {
 			wantChange: true,
 		},
 		"pending delayed topology request; already Admitted=false": {
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			admission: &kueue.Admission{
 				PodSetAssignments: []kueue.PodSetAssignment{
 					{
@@ -343,7 +344,7 @@ func TestSyncAdmittedCondition(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			builder := utiltestingapi.MakeWorkload("foo", "bar").
 				Admission(tc.admission).
 				AdmissionChecks(tc.checkStates...).

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -2716,9 +2716,7 @@ func TestSchedulingHash(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			for fg, enable := range tc.featureGates {
-				features.SetFeatureGateDuringTest(t, fg, enable)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			info1 := NewInfo(tc.wl1)
 			info1.UpdateSchedulingHash(logr.Discard())
 			info2 := NewInfo(tc.wl2)

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -1150,29 +1151,31 @@ func TestReplacedWorkloadSlice(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		featureEnabled bool
-		args           args
-		want           want
+		featureGates map[featuregate.Feature]bool
+		args         args
+		want         want
 	}{
-		"FeatureNotEnabled": {},
+		"FeatureNotEnabled": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: false},
+		},
 		"EdgeCase_WorkloadIsNil": {
-			featureEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 		},
 		"EdgeCase_SnapshotIsNil": {
-			featureEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			args: args{
 				wl: workload.NewInfo(utiltestingapi.MakeWorkload("test", "default").Obj()),
 			},
 		},
 		"WorkloadWithoutReplacementAnnotation": {
-			featureEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			args: args{
 				wl:   workload.NewInfo(utiltestingapi.MakeWorkload("test", "default").Obj()),
 				snap: &schdcache.Snapshot{},
 			},
 		},
 		"ReplacedWorkloadIsNotFound_MissingClusterQueue": {
-			featureEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			args: args{
 				wl: workload.NewInfo(utiltestingapi.MakeWorkload("test-new", "default").
 					Annotation(WorkloadSliceReplacementFor, "test-old").
@@ -1185,7 +1188,7 @@ func TestReplacedWorkloadSlice(t *testing.T) {
 			},
 		},
 		"EdgeCase_ReplacedWorkloadIsNotFound_NotInClusterQueue": {
-			featureEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			args: args{
 				wl: workload.NewInfo(utiltestingapi.MakeWorkload("test-new", "default").
 					Annotation(WorkloadSliceReplacementFor, "test-old").
@@ -1201,7 +1204,7 @@ func TestReplacedWorkloadSlice(t *testing.T) {
 			},
 		},
 		"ReplacedWorkloadIsFound": {
-			featureEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			args: args{
 				wl: workload.NewInfo(utiltestingapi.MakeWorkload("test-new", "default").
 					Annotation(WorkloadSliceReplacementFor, "test-old").
@@ -1229,7 +1232,7 @@ func TestReplacedWorkloadSlice(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, tt.featureEnabled)
+			features.SetFeatureGatesDuringTest(t, tt.featureGates)
 			targets, wl := ReplacedWorkloadSlice(tt.args.wl, tt.args.snap)
 			if diff := cmp.Diff(tt.want.targets, targets); diff != "" {
 				t.Errorf("ReplacedWorkloadSlice() targets (+want,-got):\n%s", diff)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->
/kind cleanup
/area testing

#### What this PR does / why we need it:
This PR refactors unit tests to use a standardized featureGates map[featuregate.Feature]bool instead of individual boolean fields per feature gate.
This approach simplifies test setup, improves readability, and ensures consistency across the codebase when enabling or disabling feature gates.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9957

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```