### PR TITLE
feat: clean local queue metrics based on label change if required

### DIFF
--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -588,7 +588,7 @@ func (c *Cache) GetLocalQueueLabels(cqName kueue.ClusterQueueReference, lqKey qu
 	if err != nil {
 		return nil, err
 	}
-	return lq.labels, nil
+	return lq.GetLabels(), nil
 }
 
 func (c *Cache) ClusterQueueUsesAdmissionFairSharing(cqName kueue.ClusterQueueReference) bool {
@@ -603,18 +603,7 @@ func (c *Cache) ClusterQueueUsesAdmissionFairSharing(cqName kueue.ClusterQueueRe
 
 func (c *Cache) UpdateLocalQueue(oldQ, newQ *kueue.LocalQueue) error {
 	if oldQ.Spec.ClusterQueue == newQ.Spec.ClusterQueue {
-		if features.Enabled(features.CustomMetricLabels) {
-			c.RLock()
-			defer c.RUnlock()
-			cq := c.hm.ClusterQueue(newQ.Spec.ClusterQueue)
-			if cq != nil {
-				if lq := cq.localQueues[queue.Key(newQ)]; lq != nil {
-					lq.Lock()
-					lq.customMetricLabelValues = c.customLabels.ExtractValues(newQ.Labels, newQ.Annotations)
-					lq.Unlock()
-				}
-			}
-		}
+		c.updateLqMetricLabels(newQ)
 		return nil
 	}
 	c.Lock()
@@ -632,6 +621,19 @@ func (c *Cache) UpdateLocalQueue(oldQ, newQ *kueue.LocalQueue) error {
 		return cq.addLocalQueue(newQ, customLabelValues)
 	}
 	return nil
+}
+
+func (c *Cache) updateLqMetricLabels(newLq *kueue.LocalQueue) {
+	cachedLq, err := c.GetCacheLocalQueue(newLq.Spec.ClusterQueue, queue.Key(newLq))
+	if err != nil {
+		return
+	}
+	cachedLq.Lock()
+	defer cachedLq.Unlock()
+	cachedLq.labels = newLq.GetLabels()
+	if features.Enabled(features.CustomMetricLabels) {
+		cachedLq.customMetricLabelValues = c.customLabels.ExtractValues(newLq.Labels, newLq.Annotations)
+	}
 }
 
 func (c *Cache) AddOrUpdateWorkload(log logr.Logger, w *kueue.Workload) bool {
@@ -1013,7 +1015,7 @@ func (c *Cache) ResyncGaugeMetrics() {
 			cq.reportResourceMetrics(c.fairSharingEnabled)
 		}
 		for _, lq := range cq.localQueues {
-			if c.lqMetrics.ShouldExposeLocalQueueMetrics(lq.labels) {
+			if lq.shouldExposeMetrics(c.lqMetrics) {
 				lq.reportActiveWorkloads(c.roleTracker)
 				lq.reportResourceMetrics(cq.resourceNode.Quotas, c.roleTracker)
 			}

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -558,7 +558,7 @@ func (c *clusterQueue) updateWorkloadUsage(log logr.Logger, wi *workload.Info, o
 			lq.updateAdmittedUsage(frUsage, op)
 			lq.admittedWorkloads += op.asSignedOne()
 		}
-		if c.lqMetrics.ShouldExposeLocalQueueMetrics(lq.labels) {
+		if lq.shouldExposeMetrics(c.lqMetrics) {
 			lq.reportActiveWorkloads(c.roleTracker)
 		}
 	}

--- a/pkg/cache/scheduler/localqueue.go
+++ b/pkg/cache/scheduler/localqueue.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scheduler
 
 import (
+	"maps"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
@@ -46,7 +47,9 @@ func (q *LocalQueue) GetAdmittedUsage() corev1.ResourceList {
 }
 
 func (q *LocalQueue) GetLabels() map[string]string {
-	return q.labels
+	q.RLock()
+	defer q.RUnlock()
+	return maps.Clone(q.labels)
 }
 
 func (q *LocalQueue) resetFlavorsAndResources(cqUsage resources.FlavorResourceQuantities, cqAdmittedUsage resources.FlavorResourceQuantities) {
@@ -81,4 +84,10 @@ func (q *LocalQueue) reportResourceMetrics(cqQuotas map[resources.FlavorResource
 		metrics.ReportLocalQueueResourceReservations(lqRef, fName, rName, resourceFloat(fr.Resource, q.totalReserved[fr]), q.customMetricLabelValues, tracker)
 		metrics.ReportLocalQueueResourceUsage(lqRef, fName, rName, resourceFloat(fr.Resource, q.admittedUsage[fr]), q.customMetricLabelValues, tracker)
 	}
+}
+
+func (q *LocalQueue) shouldExposeMetrics(lqMetrics *metrics.LocalQueueMetricsConfig) bool {
+	q.RLock()
+	defer q.RUnlock()
+	return lqMetrics.ShouldExposeLocalQueueMetrics(q.labels)
 }

--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -294,15 +294,14 @@ func (r *LocalQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.LocalQueue
 		r.customLabels.LQStoreAndClear(utilqueue.Key(e.ObjectNew),
 			e.ObjectNew.GetLabels(), e.ObjectNew.GetAnnotations(),
 			func() {
-				lqRef := localQueueReferenceFromLocalQueue(e.ObjectNew)
-				metrics.ClearLocalQueueMetrics(lqRef)
-				metrics.ClearLocalQueueCacheMetrics(lqRef)
-				metrics.ClearLocalQueueResourceMetrics(lqRef)
+				clearLocalQueueMetrics(e.ObjectNew)
 			})
 	}
 
 	if r.lqMetrics.ShouldExposeLocalQueueMetrics(e.ObjectNew.GetLabels()) {
 		updateLocalQueueResourceMetrics(e.ObjectNew, r.roleTracker, r.customLabels)
+	} else if r.lqMetrics.ShouldExposeLocalQueueMetrics(e.ObjectOld.GetLabels()) {
+		clearLocalQueueMetrics(e.ObjectOld)
 	}
 
 	oldStopPolicy := ptr.Deref(e.ObjectOld.Spec.StopPolicy, kueue.None)
@@ -436,6 +435,13 @@ func recordLocalQueueUsageMetrics(queue *kueue.LocalQueue, tracker *roletracker.
 func updateLocalQueueResourceMetrics(queue *kueue.LocalQueue, tracker *roletracker.RoleTracker, cl *metrics.CustomLabels) {
 	metrics.ClearLocalQueueResourceMetrics(localQueueReferenceFromLocalQueue(queue))
 	recordLocalQueueUsageMetrics(queue, tracker, cl)
+}
+
+func clearLocalQueueMetrics(lq *kueue.LocalQueue) {
+	lqRef := localQueueReferenceFromLocalQueue(lq)
+	metrics.ClearLocalQueueMetrics(lqRef)
+	metrics.ClearLocalQueueCacheMetrics(lqRef)
+	metrics.ClearLocalQueueResourceMetrics(lqRef)
 }
 
 func (r *LocalQueueReconciler) Generic(e event.TypedGenericEvent[*kueue.LocalQueue]) bool {

--- a/test/integration/singlecluster/controller/core/localqueue_controller_test.go
+++ b/test/integration/singlecluster/controller/core/localqueue_controller_test.go
@@ -690,4 +690,47 @@ var _ = ginkgo.Describe("Queue controller metrics filtering", ginkgo.Label("cont
 			util.ExpectLQPendingWorkloadsMetric(queueDynamic, 1, 0)
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
+
+	ginkgo.It("Should delete local queue metrics after changing labels to not matching", func() {
+		ginkgo.By("Creating a localQueue with matching labels")
+		queueDeleteMetrics := utiltestingapi.MakeLocalQueue("queue-delete-metrics", ns.Name).
+			ClusterQueue(clusterQueue.Name).
+			Label("metrics-test", "true").
+			Obj()
+		util.MustCreate(ctx, k8sClient, queueDeleteMetrics)
+
+		wlDeleteMetrics := utiltestingapi.MakeWorkload("wl-delete-metrics", ns.Name).
+			Queue(kueue.LocalQueueName(queueDeleteMetrics.Name)).
+			Request(resourceGPU, "1").
+			Obj()
+		util.MustCreate(ctx, k8sClient, wlDeleteMetrics)
+
+		ginkgo.By("Waiting for workload to be reflected in status (Pending)")
+		gomega.Eventually(func(g gomega.Gomega) {
+			var updated kueue.LocalQueue
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(queueDeleteMetrics), &updated)).To(gomega.Succeed())
+			g.Expect(updated.Status.PendingWorkloads).Should(gomega.Equal(int32(1)))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("Verifying metrics are initially available for matching labels")
+		gomega.Eventually(func(g gomega.Gomega) {
+			util.ExpectLQPendingWorkloadsMetric(queueDeleteMetrics, 1, 0)
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("Updating the localQueue to non-matching labels")
+		gomega.Eventually(func(g gomega.Gomega) {
+			var updated kueue.LocalQueue
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(queueDeleteMetrics), &updated)).To(gomega.Succeed())
+			if updated.Labels == nil {
+				updated.Labels = make(map[string]string)
+			}
+			updated.Labels["metrics-test"] = "false"
+			g.Expect(k8sClient.Update(ctx, &updated)).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("Verifying metrics are cleared after labels are updated to non-matching")
+		gomega.Eventually(func(g gomega.Gomega) {
+			util.ExpectLQPendingWorkloadsMetric(queueDeleteMetrics, 0, 0)
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Clean LocalQueue metrics on label change if the new labels are not included in the config.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #8830

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Observability: clean local queue metrics if the labels are not matching with the configuration after update.
```