### PR TITLE
Automated cherry pick of #9757: LeaderWorkerSet integration when LeaderWorkerSet created with RestartPolicy should recreate pods when policy is set to RecreateGroupOnPodRestart

### DIFF
--- a/test/util/util.go
+++ b/test/util/util.go
@@ -271,13 +271,7 @@ func ExpectAllPodsInNamespaceDeleted(ctx context.Context, c client.Client, ns *c
 	gomega.Eventually(func(g gomega.Gomega) {
 		g.Expect(c.List(ctx, &pods, client.InNamespace(ns.Name))).Should(gomega.Succeed())
 		g.Expect(pods.Items).Should(gomega.BeEmpty())
-	}, LongTimeout, Interval).Should(gomega.Succeed(), func() string {
-		ptrs := make([]*corev1.Pod, len(pods.Items))
-		for i := range pods.Items {
-			ptrs[i] = &pods.Items[i]
-		}
-		return assertMsg(fmt.Sprintf("Expected all pods to be deleted in namespace %q", ns.Name), ptrs...)()
-	})
+	}, LongTimeout, Interval).Should(gomega.Succeed())
 }
 
 func DeleteWorkloadsInNamespace(ctx context.Context, c client.Client, ns *corev1.Namespace) error {


### PR DESCRIPTION
Cherry pick of #9757 on release-0.16.

#9757: LeaderWorkerSet integration when LeaderWorkerSet created with RestartPolicy should recreate pods when policy is set to RecreateGroupOnPodRestart

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind flake


```release-note
NONE
```