### PR TITLE
cleanup: move ShouldExposeLocalQueueMetricsForWorkload to cache

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -362,7 +362,7 @@ func main() {
 
 	preemptionExpectations := preemptexpectations.New()
 
-	if err := setupControllers(ctx, mgr, cCache, queues, &cfg, serverVersionFetcher, roleTracker, preemptionExpectations, customLabels, lqMetrics); err != nil {
+	if err := setupControllers(ctx, mgr, cCache, queues, &cfg, serverVersionFetcher, roleTracker, preemptionExpectations, customLabels); err != nil {
 		setupLog.Error(err, "Unable to setup controllers")
 		os.Exit(1)
 	}
@@ -384,7 +384,7 @@ func main() {
 		}()
 	}
 
-	if err := setupScheduler(mgr, cCache, queues, &cfg, roleTracker, preemptionExpectations, customLabels, lqMetrics); err != nil {
+	if err := setupScheduler(mgr, cCache, queues, &cfg, roleTracker, preemptionExpectations, customLabels); err != nil {
 		setupLog.Error(err, "Could not setup scheduler")
 		os.Exit(1)
 	}
@@ -429,7 +429,7 @@ func setupIndexes(ctx context.Context, mgr ctrl.Manager, cfg *configapi.Configur
 
 func setupControllers(ctx context.Context, mgr ctrl.Manager, cCache *schdcache.Cache, queues *qcache.Manager,
 	cfg *configapi.Configuration, serverVersionFetcher *kubeversion.ServerVersionFetcher, roleTracker *roletracker.RoleTracker,
-	preemptionExpectations *expectations.Store, customLabels *metrics.CustomLabels, lqMetrics *metrics.LocalQueueMetricsConfig) error {
+	preemptionExpectations *expectations.Store, customLabels *metrics.CustomLabels) error {
 	if failedCtrl, err := core.SetupControllers(mgr, queues, cCache, cfg, roleTracker, preemptionExpectations, customLabels); err != nil {
 		return fmt.Errorf("unable to create controller %s: %w", failedCtrl, err)
 	}
@@ -509,7 +509,6 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, cCache *schdcache.C
 		jobframework.WithObjectRetentionPolicies(cfg.ObjectRetentionPolicies),
 		jobframework.WithRoleTracker(roleTracker),
 		jobframework.WithCustomLabels(customLabels),
-		jobframework.WithLocalQueueMetrics(lqMetrics),
 	}
 	nsSelector, err := metav1.LabelSelectorAsSelector(cfg.ManagedJobsNamespaceSelector)
 	if err != nil {
@@ -555,7 +554,6 @@ func setupProbeEndpoints(mgr ctrl.Manager, certsReady <-chan struct{}) error {
 
 func setupScheduler(mgr ctrl.Manager, cCache *schdcache.Cache, queues *qcache.Manager, cfg *configapi.Configuration,
 	roleTracker *roletracker.RoleTracker, preemptionExpectations *expectations.Store, customLabels *metrics.CustomLabels,
-	lqMetrics *metrics.LocalQueueMetricsConfig,
 ) error {
 	sched := scheduler.New(
 		queues,
@@ -568,7 +566,6 @@ func setupScheduler(mgr ctrl.Manager, cCache *schdcache.Cache, queues *qcache.Ma
 		scheduler.WithRoleTracker(roleTracker),
 		scheduler.WithPreemptionExpectations(preemptionExpectations),
 		scheduler.WithCustomLabels(customLabels),
-		scheduler.WithLocalQueueMetrics(lqMetrics),
 	)
 	if err := mgr.Add(sched); err != nil {
 		return fmt.Errorf("unable to add scheduler to manager: %w", err)

--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -583,14 +583,6 @@ func (c *Cache) GetCacheLocalQueue(cqName kueue.ClusterQueueReference, lqKey que
 	return nil, errQNotFound
 }
 
-func (c *Cache) GetLocalQueueLabels(cqName kueue.ClusterQueueReference, lqKey queue.LocalQueueReference) (map[string]string, error) {
-	lq, err := c.GetCacheLocalQueue(cqName, lqKey)
-	if err != nil {
-		return nil, err
-	}
-	return lq.GetLabels(), nil
-}
-
 func (c *Cache) ClusterQueueUsesAdmissionFairSharing(cqName kueue.ClusterQueueReference) bool {
 	c.RLock()
 	defer c.RUnlock()
@@ -1041,4 +1033,21 @@ func resourceFloat(name corev1.ResourceName, v int64) float64 {
 // Key is the key used to index the queue.
 func queueKey(q *kueue.LocalQueue) queue.LocalQueueReference {
 	return queue.NewLocalQueueReference(q.Namespace, kueue.LocalQueueName(q.Name))
+}
+
+// ShouldExposeLocalQueueMetricsForWorkload determines if LocalQueue metric reporting should be made for the associated LocalQueue.
+func (c *Cache) ShouldExposeLocalQueueMetricsForWorkload(log logr.Logger, wl *kueue.Workload) bool {
+	if !c.lqMetrics.IsEnabled() {
+		return false
+	}
+	if wl.Status.Admission == nil {
+		log.V(5).Info("Skip the update for local queue metrics for a workload without admission", "workload", klog.KObj(wl))
+		return false
+	}
+	lq, err := c.GetCacheLocalQueue(wl.Status.Admission.ClusterQueue, queue.KeyFromWorkload(wl))
+	if err != nil {
+		log.Error(err, "Failed to get LocalQueue for metrics", "localQueue", klog.KRef(wl.Namespace, string(wl.Spec.QueueName)))
+		return false
+	}
+	return lq.shouldExposeMetrics(c.lqMetrics)
 }

--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -98,7 +98,6 @@ func SetupControllers(mgr ctrl.Manager, qManager *qcache.Manager, cc *schdcache.
 		WithWorkloadRoleTracker(roleTracker),
 		WithPreemptionExpectations(preemptionExpectations),
 		WithWorkloadCustomLabels(customLabels),
-		WithWorkloadLocalQueueMetrics(lqMetrics),
 	)
 	if features.Enabled(features.DynamicResourceAllocation) {
 		qManager.SetDRAReconcileChannel(workloadRec.GetDRAReconcileChannel())

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -133,13 +133,6 @@ func WithPreemptionExpectations(value *expectations.Store) Option {
 	}
 }
 
-// WithWorkloadLocalQueueMetrics sets the configuration for local queue metrics.
-func WithWorkloadLocalQueueMetrics(value *metrics.LocalQueueMetricsConfig) Option {
-	return func(r *WorkloadReconciler) {
-		r.lqMetrics = value
-	}
-}
-
 type WorkloadUpdateWatcher interface {
 	NotifyWorkloadUpdate(oldWl, newWl *kueue.Workload)
 }
@@ -160,7 +153,6 @@ type WorkloadReconciler struct {
 	roleTracker            *roletracker.RoleTracker
 	preemptionExpectations *expectations.Store
 	customLabels           *metrics.CustomLabels
-	lqMetrics              *metrics.LocalQueueMetricsConfig
 }
 
 var _ reconcile.Reconciler = (*WorkloadReconciler)(nil)
@@ -473,7 +465,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 		if updated {
 			if evicted {
-				exposeLqMetrics := r.lqMetrics.ShouldExposeLocalQueueMetricsForWorkload(log, r.cache, &wl)
+				exposeLqMetrics := r.cache.ShouldExposeLocalQueueMetricsForWorkload(log, &wl)
 				if err := workload.Evict(ctx, r.client, r.recorder, &wl, reason, message, underlyingCause, r.clock, exposeLqMetrics, r.roleTracker, r.customLabels, workload.WithCustomPrepare(prepare)); err != nil {
 					if !apierrors.IsNotFound(err) {
 						return ctrl.Result{}, fmt.Errorf("setting eviction: %w", err)
@@ -550,7 +542,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			r.cache.ReportCohortSubtreeAdmittedWorkload(log, &wl)
 			metrics.AdmittedWorkload(cqName, priorityClassName, queuedWaitTime, r.customLabels.CQGet(cqName), r.roleTracker)
 			metrics.ReportAdmissionChecksWaitTime(cqName, priorityClassName, quotaReservedWaitTime, r.customLabels.CQGet(cqName), r.roleTracker)
-			if r.lqMetrics.ShouldExposeLocalQueueMetricsForWorkload(log, r.cache, &wl) {
+			if r.cache.ShouldExposeLocalQueueMetricsForWorkload(log, &wl) {
 				lqRef := metrics.LQRefFromWorkload(&wl)
 				lqKey := qutil.KeyFromWorkload(&wl)
 				metrics.LocalQueueAdmittedWorkload(
@@ -739,7 +731,7 @@ func (r *WorkloadReconciler) reconcileCheckBasedEviction(ctx context.Context, wl
 	}
 	// at this point we know a Workload has at least one Retry AdmissionCheck
 	message := "At least one admission check is false"
-	exposeLqMetrics := r.lqMetrics.ShouldExposeLocalQueueMetricsForWorkload(log, r.cache, wl)
+	exposeLqMetrics := r.cache.ShouldExposeLocalQueueMetricsForWorkload(log, wl)
 	if err := workload.Evict(ctx, r.client, r.recorder, wl, kueue.WorkloadEvictedByAdmissionCheck, message, "", r.clock, exposeLqMetrics, r.roleTracker, r.customLabels); err != nil {
 		return false, err
 	}
@@ -807,7 +799,7 @@ func (r *WorkloadReconciler) reconcileOnLocalQueueActiveState(ctx context.Contex
 			return false, nil
 		}
 		log.V(3).Info("Workload is evicted because the LocalQueue is stopped", "localQueue", klog.KRef(wl.Namespace, string(wl.Spec.QueueName)))
-		exposeLqMetrics := r.lqMetrics.ShouldExposeLocalQueueMetricsForWorkload(log, r.cache, wl)
+		exposeLqMetrics := r.cache.ShouldExposeLocalQueueMetricsForWorkload(log, wl)
 		err := workload.Evict(ctx, r.client, r.recorder, wl, kueue.WorkloadEvictedByLocalQueueStopped, "The LocalQueue is stopped", "", r.clock, exposeLqMetrics, r.roleTracker, r.customLabels)
 		return true, err
 	}
@@ -850,7 +842,7 @@ func (r *WorkloadReconciler) reconcileOnClusterQueueActiveState(ctx context.Cont
 		}
 		log.V(3).Info("Workload is evicted because the ClusterQueue is stopped", "clusterQueue", klog.KRef("", string(cqName)))
 		message := "The ClusterQueue is stopped"
-		exposeLqMetrics := r.lqMetrics.ShouldExposeLocalQueueMetricsForWorkload(log, r.cache, wl)
+		exposeLqMetrics := r.cache.ShouldExposeLocalQueueMetricsForWorkload(log, wl)
 		err := workload.Evict(ctx, r.client, r.recorder, wl, kueue.WorkloadEvictedByClusterQueueStopped, message, "", r.clock, exposeLqMetrics, r.roleTracker, r.customLabels)
 		return true, err
 	}
@@ -981,7 +973,7 @@ func (r *WorkloadReconciler) reconcileNotReadyTimeout(ctx context.Context, req c
 	// Increments a re-queueing count and update a time to be re-queued.
 	log.V(2).Info("Start the eviction of the workload due to exceeding the PodsReady timeout")
 	message := fmt.Sprintf("Exceeded the PodsReady timeout %s", req.String())
-	exposeLqMetrics := r.lqMetrics.ShouldExposeLocalQueueMetricsForWorkload(log, r.cache, wl)
+	exposeLqMetrics := r.cache.ShouldExposeLocalQueueMetricsForWorkload(log, wl)
 	err = workload.Evict(ctx, r.client, r.recorder, wl, kueue.WorkloadEvictedByPodsReadyTimeout, message, underlyingCause, r.clock, exposeLqMetrics, r.roleTracker, r.customLabels, workload.WithCustomPrepare(func(wl *kueue.Workload) {
 		workload.UpdateRequeueState(wl, r.waitForPodsReady.requeuingBackoffBaseSeconds, int32(r.waitForPodsReady.requeuingBackoffMaxDuration.Seconds()), r.clock)
 	}))
@@ -1223,7 +1215,7 @@ func (r *WorkloadReconciler) reportFinishedWorkload(log logr.Logger, wl *kueue.W
 	cqName := ptr.Deref(wl.Status.Admission, kueue.Admission{}).ClusterQueue
 	metrics.IncrementFinishedWorkloadTotal(cqName, priorityClassName, r.customLabels.CQGet(cqName), r.roleTracker)
 	lqRef := metrics.LQRefFromWorkload(wl)
-	if r.lqMetrics.ShouldExposeLocalQueueMetricsForWorkload(log, r.cache, wl) {
+	if r.cache.ShouldExposeLocalQueueMetricsForWorkload(log, wl) {
 		metrics.IncrementLocalQueueFinishedWorkloadTotal(lqRef, priorityClassName, r.customLabels.LQGet(qutil.KeyFromWorkload(wl)), r.roleTracker)
 	}
 }

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -99,7 +99,6 @@ type JobReconciler struct {
 	workloadRetentionPolicy      WorkloadRetentionPolicy
 	roleTracker                  *roletracker.RoleTracker
 	customLabels                 *metrics.CustomLabels
-	lqMetrics                    *metrics.LocalQueueMetricsConfig
 }
 
 // RoleTracker returns the role tracker for HA logging.
@@ -124,7 +123,6 @@ type Options struct {
 	RoleTracker                  *roletracker.RoleTracker
 	CustomLabels                 *metrics.CustomLabels
 	NoopWebhook                  bool
-	LqMetrics                    *metrics.LocalQueueMetricsConfig
 }
 
 // Option configures the reconciler.
@@ -254,13 +252,6 @@ func WithNoopWebhook(noop bool) Option {
 	}
 }
 
-// WithLocalQueueMetrics sets the configuration for local queue metrics.
-func WithLocalQueueMetrics(value *metrics.LocalQueueMetricsConfig) Option {
-	return func(o *Options) {
-		o.LqMetrics = value
-	}
-}
-
 var defaultOptions = Options{
 	Clock: clock.RealClock{},
 }
@@ -283,7 +274,6 @@ func NewReconciler(
 		workloadRetentionPolicy:      options.WorkloadRetentionPolicy,
 		roleTracker:                  options.RoleTracker,
 		customLabels:                 options.CustomLabels,
-		lqMetrics:                    options.LqMetrics,
 	}
 }
 
@@ -572,7 +562,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 				admittedCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadAdmitted)
 				admittedUntilReadyWaitTime := condition.LastTransitionTime.Sub(admittedCond.LastTransitionTime.Time)
 				metrics.ReportAdmittedUntilReadyWaitTime(cqName, priorityClassName, admittedUntilReadyWaitTime, r.customLabels.CQGet(cqName), r.roleTracker)
-				if r.lqMetrics.ShouldExposeLocalQueueMetricsForWorkload(log, r.cache, wl) {
+				if r.cache.ShouldExposeLocalQueueMetricsForWorkload(log, wl) {
 					lqRef := metrics.LQRefFromWorkload(wl)
 					lqCustomLabels := r.customLabels.LQGet(utilqueue.KeyFromWorkload(wl))
 					metrics.LocalQueueReadyWaitTime(lqRef, priorityClassName, queuedUntilReadyWaitTime, lqCustomLabels, r.roleTracker)

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -52,7 +52,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/features"
-	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -1051,13 +1050,6 @@ func TestFindAncestorJobManagedByKueue(t *testing.T) {
 
 func TestProcessOptions(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now())
-	lqMetricsConfig := metrics.NewLocalQueueMetricsConfig(&configapi.LocalQueueMetrics{
-		Enable: true,
-		LocalQueueSelector: &metav1.LabelSelector{
-			MatchLabels: map[string]string{"key": "value"},
-		},
-	},
-	)
 	cases := map[string]struct {
 		inputOpts []Option
 		wantOpts  Options
@@ -1069,7 +1061,6 @@ func TestProcessOptions(t *testing.T) {
 				WithKubeServerVersion(&kubeversion.ServerVersionFetcher{}),
 				WithLabelKeysToCopy([]string{"toCopyKey"}),
 				WithClock(fakeClock),
-				WithLocalQueueMetrics(lqMetricsConfig),
 			},
 			wantOpts: Options{
 				ManageJobsWithoutQueueName: true,
@@ -1078,7 +1069,6 @@ func TestProcessOptions(t *testing.T) {
 				IntegrationOptions:         nil,
 				LabelKeysToCopy:            []string{"toCopyKey"},
 				Clock:                      fakeClock,
-				LqMetrics:                  lqMetricsConfig,
 			},
 		},
 		"a single option is passed": {

--- a/pkg/controller/tas/controllers.go
+++ b/pkg/controller/tas/controllers.go
@@ -22,7 +22,6 @@ import (
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
-	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 )
 
@@ -40,7 +39,7 @@ func SetupControllers(mgr ctrl.Manager, queues *qcache.Manager, cache *schdcache
 	if ctrlName, err := topologyUngater.setupWithManager(mgr, cfg); err != nil {
 		return ctrlName, err
 	}
-	nodeRec := newNodeReconciler(mgr.GetClient(), recorder, cache, metrics.NewLocalQueueMetricsConfig(cfg.Metrics.LocalQueueMetrics), roleTracker, WithWatchers(rfRec))
+	nodeRec := newNodeReconciler(mgr.GetClient(), recorder, cache, roleTracker, WithWatchers(rfRec))
 	if ctrlName, err := nodeRec.SetupWithManager(mgr, cfg); err != nil {
 		return ctrlName, err
 	}

--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -53,7 +53,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
-	"sigs.k8s.io/kueue/pkg/metrics"
 	utilclient "sigs.k8s.io/kueue/pkg/util/client"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
@@ -127,7 +126,6 @@ type nodeReconciler struct {
 	logName     string
 	recorder    record.EventRecorder
 	roleTracker *roletracker.RoleTracker
-	lqMetrics   *metrics.LocalQueueMetricsConfig
 	watchers    []NodeUpdateWatcher
 }
 
@@ -238,7 +236,6 @@ func newNodeReconciler(
 	client client.Client,
 	recorder record.EventRecorder,
 	cache *schdcache.Cache,
-	lqMetrics *metrics.LocalQueueMetricsConfig,
 	roleTracker *roletracker.RoleTracker,
 	opts ...NodeReconcilerOption,
 ) *nodeReconciler {
@@ -253,7 +250,6 @@ func newNodeReconciler(
 		clock:       clock.RealClock{},
 		recorder:    recorder,
 		roleTracker: roleTracker,
-		lqMetrics:   lqMetrics,
 		watchers:    options.watchers,
 	}
 }
@@ -411,7 +407,7 @@ func (r *nodeReconciler) evictWorkloadIfNeeded(ctx context.Context, wl *kueue.Wo
 		log.V(3).Info("Evicting workload due to multiple node failures")
 		allUnhealthyNodeNames := append(unhealthyNodeNames, nodeName)
 		evictionMsg := fmt.Sprintf(nodeMultipleFailuresEvictionMessageFormat, strings.Join(allUnhealthyNodeNames, ", "))
-		exposeLqMetrics := r.lqMetrics.ShouldExposeLocalQueueMetricsForWorkload(log, r.cache, wl)
+		exposeLqMetrics := r.cache.ShouldExposeLocalQueueMetricsForWorkload(log, wl)
 		if evictionErr := workload.Evict(ctx, r.client, r.recorder, wl, kueue.WorkloadEvictedDueToNodeFailures, evictionMsg, "", r.clock, exposeLqMetrics, r.roleTracker, nil); evictionErr != nil {
 			log.Error(evictionErr, "Failed to complete eviction process")
 			return false, evictionErr

--- a/pkg/controller/tas/node_controller_test.go
+++ b/pkg/controller/tas/node_controller_test.go
@@ -911,7 +911,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 			}
 			cl := clientBuilder.Build()
 			recorder := &utiltesting.EventRecorder{}
-			r := newNodeReconciler(cl, recorder, schdcache.New(cl), nil, nil)
+			r := newNodeReconciler(cl, recorder, schdcache.New(cl), nil)
 			r.clock = fakeClock
 
 			var result reconcile.Result
@@ -1089,7 +1089,7 @@ func TestGetWorkloadStatus(t *testing.T) {
 			}
 			cl := clientBuilder.Build()
 
-			reconciler := newNodeReconciler(cl, &utiltesting.EventRecorder{}, nil, nil, nil)
+			reconciler := newNodeReconciler(cl, &utiltesting.EventRecorder{}, nil, nil)
 			wl := &kueue.Workload{}
 			_ = cl.Get(ctx, wlKey, wl)
 

--- a/pkg/metrics/localqueue.go
+++ b/pkg/metrics/localqueue.go
@@ -17,20 +17,12 @@ limitations under the License.
 package metrics
 
 import (
-	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/klog/v2"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
-	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
-	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 )
-
-type LocalQueueLabelStorage interface {
-	GetLocalQueueLabels(cqName kueue.ClusterQueueReference, lqKey utilqueue.LocalQueueReference) (map[string]string, error)
-}
 
 type LocalQueueMetricsConfig struct {
 	Enabled       bool
@@ -73,21 +65,4 @@ func (cfg *LocalQueueMetricsConfig) IsEnabled() bool {
 // based on the global configuration.
 func (cfg *LocalQueueMetricsConfig) ShouldExposeLocalQueueMetrics(lqLabels map[string]string) bool {
 	return cfg.IsEnabled() && (cfg == nil || cfg.QueueSelector.Matches(labels.Set(lqLabels)))
-}
-
-// ShouldExposeLocalQueueMetricsForWorkload detemines if LocalQueue metric reporting should be made for the associated LocalQueue.
-func (cfg *LocalQueueMetricsConfig) ShouldExposeLocalQueueMetricsForWorkload(log logr.Logger, lqLabelStorage LocalQueueLabelStorage, wl *kueue.Workload) bool {
-	if !cfg.IsEnabled() {
-		return false
-	}
-	if wl.Status.Admission == nil {
-		log.V(5).Info("WARNING: cannot expose local queue metrics of workload without status.Admission", "workload", wl)
-		return false
-	}
-	lqLabels, err := lqLabelStorage.GetLocalQueueLabels(wl.Status.Admission.ClusterQueue, utilqueue.NewLocalQueueReference(wl.Namespace, wl.Spec.QueueName))
-	if err != nil {
-		log.V(5).Error(err, "Failed to get LocalQueue for metrics", "localQueue", klog.KRef(wl.Namespace, string(wl.Spec.QueueName)))
-		return false
-	}
-	return cfg.ShouldExposeLocalQueueMetrics(lqLabels)
 }

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -70,7 +70,6 @@ type Preemptor struct {
 	roleTracker            *roletracker.RoleTracker
 	customLabels           *metrics.CustomLabels
 	preemptionExpectations *expectations.Store
-	lqMetrics              *metrics.LocalQueueMetricsConfig
 }
 
 type preemptionCtx struct {
@@ -91,7 +90,6 @@ func New(
 	fs *config.FairSharing,
 	enabledAfs bool,
 	clock clock.Clock,
-	lqMetrics *metrics.LocalQueueMetricsConfig,
 	tracker *roletracker.RoleTracker,
 	preemptionExpectations *expectations.Store,
 	customLabels *metrics.CustomLabels,
@@ -107,7 +105,6 @@ func New(
 		roleTracker:            tracker,
 		customLabels:           customLabels,
 		preemptionExpectations: preemptionExpectations,
-		lqMetrics:              lqMetrics,
 	}
 	return p
 }
@@ -211,7 +208,7 @@ func (p *Preemptor) IssuePreemptions(ctx context.Context, cache *schdcache.Cache
 
 		message := preemptionMessage(preemptor.Obj, target.Reason, preemptorPath, preempteePath)
 		wlCopy := target.WorkloadInfo.Obj.DeepCopy()
-		exposeLqMetrics := p.lqMetrics.ShouldExposeLocalQueueMetricsForWorkload(log, cache, wlCopy)
+		exposeLqMetrics := cache.ShouldExposeLocalQueueMetricsForWorkload(log, wlCopy)
 		err := workload.Evict(
 			ctx, p.client, p.recorder, wlCopy, kueue.WorkloadEvictedByPreemption, message, "", p.clock, exposeLqMetrics, p.roleTracker, p.customLabels,
 			workload.WithCustomPrepare(func(wl *kueue.Workload) {

--- a/pkg/scheduler/preemption/preemption_fair_test.go
+++ b/pkg/scheduler/preemption/preemption_fair_test.go
@@ -979,7 +979,7 @@ func TestFairPreemptions(t *testing.T) {
 			recorder := broadcaster.NewRecorder(scheme, corev1.EventSource{Component: constants.AdmissionName})
 			preemptor := New(cl, workload.Ordering{}, recorder, &config.FairSharing{
 				PreemptionStrategies: tc.strategies,
-			}, false, clocktesting.NewFakeClock(now), nil, nil, preemptexpectations.New(), nil)
+			}, false, clocktesting.NewFakeClock(now), nil, preemptexpectations.New(), nil)
 
 			beforeSnapshot, err := cqCache.Snapshot(ctx)
 			if err != nil {

--- a/pkg/scheduler/preemption/preemption_hierarchical_test.go
+++ b/pkg/scheduler/preemption/preemption_hierarchical_test.go
@@ -1848,7 +1848,7 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					t.Fatalf("Failed adding kueue scheme: %v", err)
 				}
 				recorder := broadcaster.NewRecorder(scheme, corev1.EventSource{Component: constants.AdmissionName})
-				preemptor := New(cl, workload.Ordering{}, recorder, nil, false, clocktesting.NewFakeClock(now), nil, nil, preemptexpectations.New(), nil)
+				preemptor := New(cl, workload.Ordering{}, recorder, nil, false, clocktesting.NewFakeClock(now), nil, preemptexpectations.New(), nil)
 
 				beforeSnapshot, err := cqCache.Snapshot(ctx)
 				if err != nil {

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -4134,7 +4134,7 @@ func TestPreemption(t *testing.T) {
 					t.Fatalf("Failed adding kueue scheme: %v", err)
 				}
 				recorder := broadcaster.NewRecorder(scheme, corev1.EventSource{Component: constants.AdmissionName})
-				preemptor := New(cl, workload.Ordering{}, recorder, nil, false, clocktesting.NewFakeClock(now), nil, nil, preemptexpectations.New(), nil)
+				preemptor := New(cl, workload.Ordering{}, recorder, nil, false, clocktesting.NewFakeClock(now), nil, preemptexpectations.New(), nil)
 
 				beforeSnapshot, err := cqCache.Snapshot(ctx)
 				if err != nil {
@@ -4356,7 +4356,7 @@ func TestPreemptionWhenWorkloadModifiedConcurrently(t *testing.T) {
 					t.Fatalf("Failed adding kueue scheme: %v", err)
 				}
 				recorder := broadcaster.NewRecorder(scheme, corev1.EventSource{Component: constants.AdmissionName})
-				preemptor := New(cl, workload.Ordering{}, recorder, nil, false, clocktesting.NewFakeClock(now), nil, nil, preemptexpectations.New(), nil)
+				preemptor := New(cl, workload.Ordering{}, recorder, nil, false, clocktesting.NewFakeClock(now), nil, preemptexpectations.New(), nil)
 
 				beforeSnapshot, err := cqCache.Snapshot(ctx)
 				if err != nil {
@@ -4481,7 +4481,7 @@ func TestIssuePreemptionsSkipsDuplicate(t *testing.T) {
 					t.Fatalf("Failed adding kueue scheme: %v", err)
 				}
 				recorder := broadcaster.NewRecorder(scheme, corev1.EventSource{Component: constants.AdmissionName})
-				preemptor := New(cl, workload.Ordering{}, recorder, nil, false, clocktesting.NewFakeClock(now), nil, nil, store, nil)
+				preemptor := New(cl, workload.Ordering{}, recorder, nil, false, clocktesting.NewFakeClock(now), nil, store, nil)
 
 				snapshot, err := cqCache.Snapshot(ctx)
 				if err != nil {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -83,7 +83,6 @@ type Scheduler struct {
 	clock                   clock.Clock
 	roleTracker             *roletracker.RoleTracker
 	customLabels            *metrics.CustomLabels
-	lqMetrics               *metrics.LocalQueueMetricsConfig
 
 	// schedulingCycle identifies the number of scheduling
 	// attempts since the last restart.
@@ -98,7 +97,6 @@ type options struct {
 	roleTracker                 *roletracker.RoleTracker
 	preemptionExpectations      *expectations.Store
 	customLabels                *metrics.CustomLabels
-	lqMetrics                   *metrics.LocalQueueMetricsConfig
 }
 
 // Option configures the reconciler.
@@ -158,13 +156,6 @@ func WithCustomLabels(cl *metrics.CustomLabels) Option {
 	}
 }
 
-// WithLocalQueueMetrics sets the configuration for local queue metrics.
-func WithLocalQueueMetrics(value *metrics.LocalQueueMetricsConfig) Option {
-	return func(o *options) {
-		o.lqMetrics = value
-	}
-}
-
 func New(queues *qcache.Manager, cache *schdcache.Cache, cl client.Client, recorder record.EventRecorder, opts ...Option) *Scheduler {
 	options := defaultOptions
 	for _, opt := range opts {
@@ -179,14 +170,13 @@ func New(queues *qcache.Manager, cache *schdcache.Cache, cl client.Client, recor
 		cache:                   cache,
 		client:                  cl,
 		recorder:                recorder,
-		preemptor:               preemption.New(cl, wo, recorder, options.fairSharing, afs.Enabled(options.admissionFairSharing), options.clock, options.lqMetrics, options.roleTracker, options.preemptionExpectations, options.customLabels),
+		preemptor:               preemption.New(cl, wo, recorder, options.fairSharing, afs.Enabled(options.admissionFairSharing), options.clock, options.roleTracker, options.preemptionExpectations, options.customLabels),
 		admissionRoutineWrapper: routine.DefaultWrapper,
 		workloadOrdering:        wo,
 		clock:                   options.clock,
 		admissionFairSharing:    options.admissionFairSharing,
 		roleTracker:             options.roleTracker,
 		customLabels:            options.customLabels,
-		lqMetrics:               options.lqMetrics,
 	}
 	return s
 }
@@ -653,7 +643,7 @@ func (s *Scheduler) evictWorkloadAfterFailedTASReplacement(ctx context.Context, 
 	unhealthyNodesCsv := strings.Join(unhealthyNodes, ",")
 	log.V(3).Info("Evicting workload after failed try to find a node replacement; TASFailedNodeReplacementFailFast enabled", "unhealthyNodes", unhealthyNodes)
 	msg := fmt.Sprintf("Workload was evicted as there was no replacement for unhealthy node(s): %s", unhealthyNodesCsv)
-	exposeLqMetrics := s.lqMetrics.ShouldExposeLocalQueueMetricsForWorkload(log, s.cache, wl)
+	exposeLqMetrics := s.cache.ShouldExposeLocalQueueMetricsForWorkload(log, wl)
 	if err := workload.Evict(
 		ctx, s.client, s.recorder, wl, kueue.WorkloadEvictedDueToNodeFailures, msg, "", s.clock, exposeLqMetrics, s.roleTracker, s.customLabels,
 		workload.EvictWithLooseOnApply(), workload.EvictWithRetryOnConflictForPatch(),
@@ -902,7 +892,7 @@ func (s *Scheduler) recordQuotaReservationMetrics(log logr.Logger, newWorkload, 
 	priorityClassName := workload.PriorityClassName(newWorkload)
 	metrics.QuotaReservedWorkload(admission.ClusterQueue, priorityClassName, waitTime, s.customLabels.CQGet(admission.ClusterQueue), s.roleTracker)
 	lqRef := metrics.LQRefFromWorkload(newWorkload)
-	if s.lqMetrics.ShouldExposeLocalQueueMetricsForWorkload(log, s.cache, newWorkload) {
+	if s.cache.ShouldExposeLocalQueueMetricsForWorkload(log, newWorkload) {
 		metrics.LocalQueueQuotaReservedWorkload(lqRef, priorityClassName, waitTime, s.customLabels.LQGet(utilqueue.KeyFromWorkload(newWorkload)), s.roleTracker)
 	}
 }
@@ -919,7 +909,7 @@ func (s *Scheduler) recordWorkloadAdmissionEvents(log logr.Logger, newWorkload, 
 	cqCustomLabels := s.customLabels.CQGet(admission.ClusterQueue)
 	s.cache.ReportCohortSubtreeAdmittedWorkload(log, newWorkload)
 	metrics.AdmittedWorkload(admission.ClusterQueue, priorityClassName, waitTime, cqCustomLabels, s.roleTracker)
-	shouldExposeLqMetrics := s.lqMetrics.ShouldExposeLocalQueueMetricsForWorkload(log, s.cache, newWorkload)
+	shouldExposeLqMetrics := s.cache.ShouldExposeLocalQueueMetricsForWorkload(log, newWorkload)
 	if shouldExposeLqMetrics {
 		lqRef := metrics.LQRefFromWorkload(newWorkload)
 		lqCustomLabels := s.customLabels.LQGet(utilqueue.KeyFromWorkload(newWorkload))

--- a/test/integration/singlecluster/controller/core/suite_test.go
+++ b/test/integration/singlecluster/controller/core/suite_test.go
@@ -151,7 +151,7 @@ func managerAndControllerSetup(controllersCfg *config.Configuration, options ...
 		}
 
 		if opts.runScheduler {
-			sched := scheduler.New(queues, cCache, mgr.GetClient(), mgr.GetEventRecorderFor(constants.AdmissionName), scheduler.WithPreemptionExpectations(preemptionExpectations), scheduler.WithCustomLabels(customLabels), scheduler.WithLocalQueueMetrics(lqMetrics))
+			sched := scheduler.New(queues, cCache, mgr.GetClient(), mgr.GetEventRecorderFor(constants.AdmissionName), scheduler.WithPreemptionExpectations(preemptionExpectations), scheduler.WithCustomLabels(customLabels))
 			err = sched.Start(ctx)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}

--- a/test/integration/singlecluster/controller/jobs/job/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/suite_test.go
@@ -109,7 +109,7 @@ func managerAndControllersSetup(
 		cCache := schdcache.New(mgr.GetClient(), schdcache.WithLocalQueueMetrics(lqMetrics))
 		queues := util.NewManagerForIntegrationTests(ctx, mgr.GetClient(), cCache, qcache.WithLocalQueueMetrics(lqMetrics))
 
-		opts = append(opts, jobframework.WithCache(cCache), jobframework.WithLocalQueueMetrics(lqMetrics))
+		opts = append(opts, jobframework.WithCache(cCache))
 		managerSetup(opts...)(ctx, mgr)
 
 		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration, nil, preemptexpectations.New(), nil)
@@ -125,7 +125,7 @@ func managerAndControllersSetup(
 
 		if enableScheduler {
 			sched := scheduler.New(queues, cCache, mgr.GetClient(), mgr.GetEventRecorderFor(constants.AdmissionName),
-				scheduler.WithPreemptionExpectations(preemptexpectations.New()), scheduler.WithLocalQueueMetrics(lqMetrics))
+				scheduler.WithPreemptionExpectations(preemptexpectations.New()))
 			err = sched.Start(ctx)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Cleanup ShouldExposeLocalQueueMetricsForWorkload

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #8830

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```