### PR TITLE
Fix running ginkgo when focus and label filter is used

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -1263,3 +1263,33 @@ EOF
     echo "Upgrade complete (rolling update finished)"
     echo "========================================="
 }
+
+# Run ginkgo e2e tests with extra CLI flags from GINKGO_ARGS.
+#
+# GINKGO_ARGS may contain multiple flags and quoted values with spaces, e.g.
+#   GINKGO_ARGS='--repeat=2 --focus="should run one case"'
+# so it must be reparsed into an array before invocation.
+# Package paths must not be passed via GINKGO_ARGS; they come from "$@".
+run_e2e_ginkgo() {
+  local ginkgo_extra=()
+  local had_noglob=0
+  local rc=0
+
+  if [[ -n ${GINKGO_ARGS:-} ]]; then
+    # Preserve the caller's globbing state. While reparsing GINKGO_ARGS we want
+    # shell quoting to work, but we do not want '*' or '?' expanded to filenames.
+    [[ $- == *f* ]] && had_noglob=1
+    set -f
+    eval "ginkgo_extra=($GINKGO_ARGS)"
+    rc=$?
+    (( had_noglob == 0 )) && set +f
+    (( rc == 0 )) || return "$rc"
+  fi
+
+  # Print the exact argv for troubleshooting quoting / flag-order issues.
+  printf 'running:' >&2
+  printf ' %q' "$GINKGO" run "${ginkgo_extra[@]}" "$@" >&2
+  printf '\n' >&2
+
+  "$GINKGO" run "${ginkgo_extra[@]}" "$@"
+}

--- a/hack/testing/e2e-multikueue-test.sh
+++ b/hack/testing/e2e-multikueue-test.sh
@@ -118,6 +118,5 @@ if [ "$E2E_RUN_ONLY_ENV" = "true" ]; then
   exit 0
 fi
 
-# Quote GINKGO_ARGS so values with spaces are not word-split (avoids "flag after package list").
-$GINKGO ${GINKGO_ARGS:+"$GINKGO_ARGS"} --junit-report=junit.xml --json-report=e2e.json --output-dir="$ARTIFACTS" -v ./test/e2e/"${E2E_TARGET_FOLDER}"/...
+run_e2e_ginkgo --junit-report=junit.xml --json-report=e2e.json --output-dir="$ARTIFACTS" -v ./test/e2e/"${E2E_TARGET_FOLDER}"/...
 "$ROOT_DIR/bin/ginkgo-top" -i "$ARTIFACTS/e2e.json" > "$ARTIFACTS/e2e-top.yaml"

--- a/hack/testing/e2e-test.sh
+++ b/hack/testing/e2e-test.sh
@@ -68,7 +68,5 @@ if [ "$E2E_RUN_ONLY_ENV" = "true" ]; then
   exit 0
 fi
 
-# Quote GINKGO_ARGS so values with spaces (e.g. --focus='should ensure the eviction') are not
-# word-split; otherwise fragments get interpreted as packages and cause "flag after package list".
-$GINKGO ${GINKGO_ARGS:+"$GINKGO_ARGS"} --junit-report=junit.xml --json-report=e2e.json --output-dir="$ARTIFACTS" -v ./test/e2e/"${E2E_TARGET_FOLDER}"/...
+run_e2e_ginkgo --junit-report=junit.xml --json-report=e2e.json --output-dir="$ARTIFACTS" -v ./test/e2e/"${E2E_TARGET_FOLDER}"/...
 "$ROOT_DIR/bin/ginkgo-top" -i "$ARTIFACTS/e2e.json" > "$ARTIFACTS/e2e-top.yaml"


### PR DESCRIPTION

#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10087 

#### Special notes for your reviewer:

Fix assisted with llm

I checked experimentally this works well:

```sh
GINKGO_ARGS="--repeat=1 --label-filter=feature:kuberay" E2E_MODE=dev make test-e2e
```
if the focus is enabled on a test with `ginkgo.FIt(`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```