### PR TITLE
Added an integration test for AdmittedActiveWorkloads.

### DIFF
--- a/test/integration/singlecluster/scheduler/fairsharing/metrics_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/metrics_test.go
@@ -528,6 +528,9 @@ var _ = ginkgo.Describe("Cohorts", func() {
 			})
 
 			ginkgo.By("Checking that only cq2 Workloads admitted", func() {
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric("cq1", 0)
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric("cq2", numWorkloadsForCQ2)
+
 				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root", "", numWorkloadsForCQ2)
 				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("ch1", "", 0)
 				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("ch2", "", numWorkloadsForCQ2)
@@ -549,6 +552,9 @@ var _ = ginkgo.Describe("Cohorts", func() {
 			})
 
 			ginkgo.By("Checking that all Workloads admitted", func() {
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric("cq1", numWorkloadsForCQ1)
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric("cq2", numWorkloadsForCQ2)
+
 				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root", "", numWorkloadsForCQ1+numWorkloadsForCQ2)
 				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("ch1", "", numWorkloadsForCQ1)
 				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("ch2", "", numWorkloadsForCQ2)
@@ -621,6 +627,9 @@ var _ = ginkgo.Describe("Cohorts", func() {
 			})
 
 			ginkgo.By("Checking that only cq2 Workloads admitted", func() {
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric("cq1", numWorkloadsForCQ1)
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric("cq2", numWorkloadsForCQ2)
+
 				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root", "high", numWorkloadsForCQ1)
 				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("root", "low", numWorkloadsForCQ2)
 				util.ExpectCohortSubtreeAdmittedWorkloadsTotalMetric("ch1", "high", numWorkloadsForCQ1)

--- a/test/util/metrics.go
+++ b/test/util/metrics.go
@@ -328,3 +328,9 @@ func ExpectCohortSubtreeResourceReservationsGaugeMetricCleaned(cohortName, flavo
 	ginkgo.GinkgoHelper()
 	ExpectCohortSubtreeResourceReservationsGaugeMetric(cohortName, flavor, resource, 0)
 }
+
+func ExpectAdmittedActiveWorkloadsGaugeMetric(clusterQueue kueue.ClusterQueueReference, count float64) {
+	ginkgo.GinkgoHelper()
+	lvs := []string{string(clusterQueue), roletracker.RoleStandalone}
+	expectGaugeMetric(metrics.AdmittedActiveWorkloads, lvs, gomega.Equal(count))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Added an integration test for AdmittedActiveWorkloads.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```