### PR TITLE
Automated cherry pick of #10090: featureGates unit tests cleanup

### DIFF
--- a/pkg/cache/queue/inadmissible_workloads_test.go
+++ b/pkg/cache/queue/inadmissible_workloads_test.go
@@ -31,8 +31,8 @@ import (
 
 func TestNewRequeuer(t *testing.T) {
 	type args struct {
-		features map[featuregate.Feature]bool
-		opts     []RequeuerOption
+		featureGates map[featuregate.Feature]bool
+		opts         []RequeuerOption
 	}
 
 	type want struct {
@@ -45,7 +45,7 @@ func TestNewRequeuer(t *testing.T) {
 	}{
 		"SchedulerLongRequeueInterval feature disabled": {
 			args: args{
-				features: map[featuregate.Feature]bool{
+				featureGates: map[featuregate.Feature]bool{
 					features.SchedulerLongRequeueInterval: false,
 				},
 			},
@@ -55,7 +55,7 @@ func TestNewRequeuer(t *testing.T) {
 		},
 		"SchedulerLongRequeueInterval feature enabled": {
 			args: args{
-				features: map[featuregate.Feature]bool{
+				featureGates: map[featuregate.Feature]bool{
 					features.SchedulerLongRequeueInterval: true,
 				},
 			},
@@ -76,9 +76,7 @@ func TestNewRequeuer(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			for feature, enabled := range tc.args.features {
-				features.SetFeatureGateDuringTest(t, feature, enabled)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.args.featureGates)
 			requeuer := NewRequeuer(tc.args.opts...)
 			if diff := cmp.Diff(tc.want.batchPeriod, requeuer.batchPeriod); len(diff) != 0 {
 				t.Errorf("Unexpected requeue batch period (-want,+got):\n%s", diff)

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -99,12 +100,12 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		return nil
 	}
 	cases := []struct {
-		name                string
-		operation           func(log logr.Logger, cache *Cache) error
-		clientObjects       []client.Object
-		wantClusterQueues   map[kueue.ClusterQueueReference]*clusterQueue
-		wantCohorts         map[kueue.CohortReference]sets.Set[kueue.ClusterQueueReference]
-		disableLendingLimit bool
+		name              string
+		featureGates      map[featuregate.Feature]bool
+		operation         func(log logr.Logger, cache *Cache) error
+		clientObjects     []client.Object
+		wantClusterQueues map[kueue.ClusterQueueReference]*clusterQueue
+		wantCohorts       map[kueue.CohortReference]sets.Set[kueue.ClusterQueueReference]
 	}{
 		{
 			name: "add",
@@ -1009,8 +1010,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			},
 		},
 		{
-			name:                "should not populate the fields with lendingLimit when feature disabled",
-			disableLendingLimit: true,
+			name:         "should not populate the fields with lendingLimit when feature disabled",
+			featureGates: map[featuregate.Feature]bool{features.LendingLimit: false},
 			operation: func(log logr.Logger, cache *Cache) error {
 				cq := utiltestingapi.MakeClusterQueue("foo").
 					ResourceGroup(
@@ -1123,9 +1124,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
-			if tc.disableLendingLimit {
-				features.SetFeatureGateDuringTest(t, features.LendingLimit, false)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			cache := New(utiltesting.NewFakeClient(tc.clientObjects...))
 			if err := tc.operation(log, cache); err != nil {
 				t.Errorf("Unexpected error during test operation: %s", err)

--- a/pkg/cache/scheduler/snapshot_test.go
+++ b/pkg/cache/scheduler/snapshot_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -47,12 +48,12 @@ var snapCmpOpts = cmp.Options{
 
 func TestSnapshot(t *testing.T) {
 	testCases := map[string]struct {
-		cqs                 []*kueue.ClusterQueue
-		cohorts             []*kueue.Cohort
-		rfs                 []*kueue.ResourceFlavor
-		wls                 []*kueue.Workload
-		wantSnapshot        Snapshot
-		disableLendingLimit bool
+		cqs          []*kueue.ClusterQueue
+		cohorts      []*kueue.Cohort
+		rfs          []*kueue.ResourceFlavor
+		wls          []*kueue.Workload
+		wantSnapshot Snapshot
+		featureGates map[featuregate.Feature]bool
 	}{
 		"empty": {},
 		"independent clusterQueues": {
@@ -596,7 +597,7 @@ func TestSnapshot(t *testing.T) {
 			}(),
 		},
 		"should not populate the snapshot with lendingLimit when feature disabled": {
-			disableLendingLimit: true,
+			featureGates: map[featuregate.Feature]bool{features.LendingLimit: false},
 			cqs: []*kueue.ClusterQueue{
 				utiltestingapi.MakeClusterQueue("a").
 					Cohort("lending").
@@ -945,9 +946,7 @@ func TestSnapshot(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctx, log := utiltesting.ContextWithLog(t)
-			if tc.disableLendingLimit {
-				features.SetFeatureGateDuringTest(t, features.LendingLimit, false)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			cache := New(utiltesting.NewFakeClient())
 			for _, cq := range tc.cqs {
 				// Purposely do not make a copy of clusterQueues. Clones of necessary fields are

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -376,12 +376,12 @@ func TestFindTopologyAssignments(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		enableFeatureGates []featuregate.Feature
-		nodes              []corev1.Node
-		pods               []corev1.Pod
-		levels             []string
-		nodeLabels         map[string]string
-		podSets            []PodSetTestCase
+		featureGates map[featuregate.Feature]bool
+		nodes        []corev1.Node
+		pods         []corev1.Pod
+		levels       []string
+		nodeLabels   map[string]string
+		podSets      []PodSetTestCase
 	}{
 		"minimize the number of used racks before optimizing the number of nodes; BestFit": {
 			// Solution by optimizing the number of racks then nodes: [r3]: [x1,x6,x2,x4]
@@ -494,7 +494,6 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{},
 		},
 		"minimize resource fragmentation; LeastFreeCapacityFit": {
 			//        b1
@@ -562,7 +561,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileLeastFreeCapacity: true},
 		},
 		"choose the node that can accommodate all Pods": {
 			//        b1
@@ -647,7 +646,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileLeastFreeCapacity: true},
 		},
 		"no annotation; implied default to unconstrained; 6 pods fit into hosts scattered across the whole datacenter even they could fit into single rack; BestFit": {
 			nodes:  scatteredNodes,
@@ -739,7 +738,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileLeastFreeCapacity: true},
 		},
 		"unconstrained; a single pod fits into each host; LeastFreeCapacity; TASProfileMixed": {
 			nodes:  defaultNodes,
@@ -764,7 +763,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMixed},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileMixed: true},
 		},
 		"block required; 4 pods fit into one host each; BestFit": {
 			nodes:  binaryTreesNodes,
@@ -831,7 +830,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileLeastFreeCapacity: true},
 		},
 		"host required; single Pod fits in the host; BestFit": {
 			nodes:  defaultNodes,
@@ -880,7 +879,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMixed},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileMixed: true},
 		},
 		"host required; single Pod fits in the largest host; LeastFreeCapacityFit": {
 			nodes:  defaultNodes,
@@ -905,7 +904,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileLeastFreeCapacity: true},
 		},
 		"host preferred; single Pod fits in the largest host; LeastFreeCapacityFit": {
 			nodes:  defaultNodes,
@@ -930,7 +929,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileLeastFreeCapacity: true},
 		},
 		"host required; no single host fits all pods, expect notFitMessage; LeastFreeCapacityFit": {
 			nodes:  defaultNodes,
@@ -945,7 +944,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				count:      3,
 				wantReason: `topology "default" allows to fit only 2 out of 3 pod(s)`,
 			}},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileLeastFreeCapacity: true},
 		},
 		"host preferred; single Pod fits in the host; BestFit; TASProfileMixed": {
 			nodes:  defaultNodes,
@@ -970,7 +969,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMixed},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileMixed: true},
 		},
 		"rack required; single Pod fits in a rack; BestFit": {
 			nodes:  defaultNodes,
@@ -1020,7 +1019,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileLeastFreeCapacity: true},
 		},
 		"rack preferred; multiple Pods fits in multiple racks; LeastFreeCapacityFit": {
 			nodes:  defaultNodes,
@@ -1046,7 +1045,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileLeastFreeCapacity: true},
 		},
 		"rack required; multiple Pods fit in a rack; BestFit": {
 			nodes:  defaultNodes,
@@ -1190,7 +1189,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileLeastFreeCapacity: true},
 		},
 		"block required; two Pods fits in a block; LeastFreeCapacityFit": {
 			nodes:  defaultNodes,
@@ -1221,7 +1220,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileLeastFreeCapacity: true},
 		},
 		"block required; single Pod fits in a block and a single rack; BestFit": {
 			nodes:  defaultNodes,
@@ -2719,7 +2718,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileLeastFreeCapacity: true},
 		},
 		"block preferred for podset; host required for slices; LeastFreeCapacity": {
 			//nolint:dupword // suppress duplicate r1 word
@@ -2816,7 +2815,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileLeastFreeCapacity: true},
 		},
 		"block preferred for podset; host required for slices; 2 blocks with unbalanced subdomains; BestFit": {
 			//nolint:dupword // suppress duplicate r1 word
@@ -2912,7 +2911,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// request: 25
 		// expected outcome: x1:13, x2:12
 		"balanced placement; basic": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -2967,7 +2966,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// request: 23
 		// expected outcome: x1:12, x2:11
 		"balanced placement; select optmial set of domains": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -3033,7 +3032,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// sliceSize: 5
 		// expected outcome: x2:15, x3:10
 		"balanced placement; select optmial set of domains; with slices": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -3100,7 +3099,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// request: 22
 		// expected outcome: x3:11, x4:11
 		"balanced placement; select correct block": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -3176,7 +3175,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// request: 25
 		// expected outcome: x1:14, x2:11
 		"balanced placement; cannot chose domains from different blocks": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -3253,7 +3252,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// sizeSize: 5
 		// expected outcome: x3:15, x4:10
 		"balanced placement; select correct block; prefer blocks with single rack; with slices": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -3333,7 +3332,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// sliceSize: 2
 		// expected outcome: x3:10, x4:8, x5:2
 		"balanced placement; four level topology; slice two levels below balanced level": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-sb1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -3431,7 +3430,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// request: 20
 		// expected outcome: x3:10, x4:3, x5:7
 		"balanced placement; four level topology; slice one level below balanced level": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-sb1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -3530,7 +3529,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// sliceSize: 2
 		// expected outcome: x3:10, x4:10
 		"balanced placement; four level topology; balance on rack level; slice not on the lowest level": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-sb1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -3612,7 +3611,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// sliceSize: 2
 		// expected outcome: x2:12, x3:10
 		"balanced placement; three level topology; balance on the same level as slice": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -3699,7 +3698,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// request: 22
 		// expected outcome: x3:11, x4:11
 		"balanced placement; three level topology; balance on the lowest level": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -3786,7 +3785,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// leaders: 1
 		// expected outcome: x2:15, x3:10 + leader
 		"balanced placement; leader worker set": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -3878,7 +3877,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// request: 15
 		// expected outcome: x3:5, x4:5, x5:5
 		"balanced placement; prioritize (using entropy) balanced domains; second rack wins": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -3967,7 +3966,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// request: 24
 		// expected outcome: x1:8, x2:8, x3:8
 		"balanced placement; prioritize (using entropy) balanced domains; first rack wins": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -4054,7 +4053,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// request: 23
 		// expected outcome: x1:12, x3:11
 		"balanced placement; two level topology; balance on the highest level": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("r1-x1").
 					Label(tasRackLabel, "r1").
@@ -4134,7 +4133,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// request: 20
 		// expected outcome: x1:5, x2:5, x3:5, x4:5
 		"balanced placement; select correct block taking into account pruning": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -4278,7 +4277,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		// leaders: 1
 		// expected outcome: x1:5 + leader, x2:5
 		"balanced placement; should not prune domain": {
-			enableFeatureGates: []featuregate.Feature{features.TASBalancedPlacement},
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -5481,11 +5480,10 @@ func TestFindTopologyAssignments(t *testing.T) {
 				},
 			},
 		},
-
 		"multiple podsets: block required for one, unconstrained for another; LeastFreeCapacity": {
-			nodes:              multipodNodeset,
-			levels:             defaultThreeLevels,
-			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+			nodes:        multipodNodeset,
+			levels:       defaultThreeLevels,
+			featureGates: map[featuregate.Feature]bool{features.TASProfileMixed: true},
 			podSets: []PodSetTestCase{
 				{
 					podSetName: "podset1",
@@ -5523,9 +5521,9 @@ func TestFindTopologyAssignments(t *testing.T) {
 		},
 
 		"multiple podsets: rack required for both, different resource requests; LeastFreeCapacity": {
-			nodes:              multipodNodeset,
-			levels:             defaultTwoLevels,
-			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+			nodes:        multipodNodeset,
+			levels:       defaultTwoLevels,
+			featureGates: map[featuregate.Feature]bool{features.TASProfileLeastFreeCapacity: true},
 			podSets: []PodSetTestCase{
 				{
 					podSetName: "podset1",
@@ -5564,9 +5562,9 @@ func TestFindTopologyAssignments(t *testing.T) {
 		},
 
 		"multiple podsets: one podset fits, one does not due to insufficient capacity; LeastFreeCapacity": {
-			nodes:              multipodNodeset,
-			levels:             defaultTwoLevels,
-			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+			nodes:        multipodNodeset,
+			levels:       defaultTwoLevels,
+			featureGates: map[featuregate.Feature]bool{features.TASProfileLeastFreeCapacity: true},
 			podSets: []PodSetTestCase{
 				{
 					podSetName: "podset1",
@@ -5604,9 +5602,9 @@ func TestFindTopologyAssignments(t *testing.T) {
 		},
 
 		"multiple podsets: block required for one, unconstrained for another; TASProfileMixed": {
-			nodes:              multipodNodeset,
-			levels:             defaultThreeLevels,
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMixed},
+			nodes:        multipodNodeset,
+			levels:       defaultThreeLevels,
+			featureGates: map[featuregate.Feature]bool{features.TASProfileMixed: true},
 			podSets: []PodSetTestCase{
 				{
 					podSetName: "podset1",
@@ -5698,10 +5696,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ctx, log := utiltesting.ContextWithLog(t)
-			// TODO: remove after dropping the TAS profiles feature gates
-			for _, gate := range tc.enableFeatureGates {
-				features.SetFeatureGateDuringTest(t, gate, true)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			initialObjects := make([]client.Object, 0)
 			for i := range tc.nodes {

--- a/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter_test.go
+++ b/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -35,12 +36,12 @@ import (
 
 func TestAdapter_IsJobManagedByKueue(t *testing.T) {
 	tests := []struct {
-		name           string
-		object         *unstructured.Unstructured
-		featureEnabled bool
-		want           bool
-		wantReason     string
-		wantErr        error
+		name         string
+		object       *unstructured.Unstructured
+		featureGates map[featuregate.Feature]bool
+		want         bool
+		wantReason   string
+		wantErr      error
 	}{
 		{
 			name: "feature gate disabled",
@@ -51,10 +52,10 @@ func TestAdapter_IsJobManagedByKueue(t *testing.T) {
 					},
 				},
 			},
-			featureEnabled: false,
-			want:           false,
-			wantReason:     "MultiKueueAdaptersForCustomJobs feature gate is disabled",
-			wantErr:        nil,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueAdaptersForCustomJobs: false},
+			want:         false,
+			wantReason:   "MultiKueueAdaptersForCustomJobs feature gate is disabled",
+			wantErr:      nil,
 		},
 		{
 			name: "managed by kueue with default path",
@@ -65,10 +66,10 @@ func TestAdapter_IsJobManagedByKueue(t *testing.T) {
 					},
 				},
 			},
-			featureEnabled: true,
-			want:           true,
-			wantReason:     "",
-			wantErr:        nil,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueAdaptersForCustomJobs: true},
+			want:         true,
+			wantReason:   "",
+			wantErr:      nil,
 		},
 		{
 			name: "not managed by kueue",
@@ -79,10 +80,10 @@ func TestAdapter_IsJobManagedByKueue(t *testing.T) {
 					},
 				},
 			},
-			featureEnabled: true,
-			want:           false,
-			wantReason:     "Expecting .spec.managedBy to be \"kueue.x-k8s.io/multikueue\" not \"other-controller\"",
-			wantErr:        nil,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueAdaptersForCustomJobs: true},
+			want:         false,
+			wantReason:   "Expecting .spec.managedBy to be \"kueue.x-k8s.io/multikueue\" not \"other-controller\"",
+			wantErr:      nil,
 		},
 		{
 			name: "managedBy field not found",
@@ -93,10 +94,10 @@ func TestAdapter_IsJobManagedByKueue(t *testing.T) {
 					},
 				},
 			},
-			featureEnabled: true,
-			want:           false,
-			wantReason:     "Expecting .spec.managedBy to be \"kueue.x-k8s.io/multikueue\" not \"\"",
-			wantErr:        nil,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueAdaptersForCustomJobs: true},
+			want:         false,
+			wantReason:   "Expecting .spec.managedBy to be \"kueue.x-k8s.io/multikueue\" not \"\"",
+			wantErr:      nil,
 		},
 		{
 			name: "managedBy value is not a string",
@@ -107,16 +108,16 @@ func TestAdapter_IsJobManagedByKueue(t *testing.T) {
 					},
 				},
 			},
-			featureEnabled: true,
-			want:           false,
-			wantReason:     "Expecting .spec.managedBy to be \"kueue.x-k8s.io/multikueue\" not \"not-a-string\"",
-			wantErr:        nil,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueAdaptersForCustomJobs: true},
+			want:         false,
+			wantReason:   "Expecting .spec.managedBy to be \"kueue.x-k8s.io/multikueue\" not \"not-a-string\"",
+			wantErr:      nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.MultiKueueAdaptersForCustomJobs, tt.featureEnabled)
+			features.SetFeatureGatesDuringTest(t, tt.featureGates)
 
 			adapter := &Adapter{
 				gvk: schema.GroupVersionKind{

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	inventoryv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -186,12 +187,12 @@ func TestUpdateConfig(t *testing.T) {
 		clusterprofiles []inventoryv1alpha1.ClusterProfile
 		cpCreds         clusterProfileCreds
 
-		wantRemoteClients      map[string]*remoteClient
-		wantClusters           []kueue.MultiKueueCluster
-		wantRequeueAfter       time.Duration
-		wantCancelCalled       int
-		wantErr                error
-		skipInsecureKubeconfig bool
+		wantRemoteClients map[string]*remoteClient
+		wantClusters      []kueue.MultiKueueCluster
+		wantRequeueAfter  time.Duration
+		wantCancelCalled  int
+		wantErr           error
+		featureGates      map[featuregate.Feature]bool
 	}{
 		"new valid client is added": {
 			reconcileFor: "worker1",
@@ -521,7 +522,7 @@ func TestUpdateConfig(t *testing.T) {
 					},
 				},
 			},
-			skipInsecureKubeconfig: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueAllowInsecureKubeconfigs: true},
 		},
 		"use cluster profile": {
 			reconcileFor: "worker1",
@@ -672,10 +673,7 @@ func TestUpdateConfig(t *testing.T) {
 			}
 			reconciler.builderOverride = fakeClientBuilder(ctx)
 
-			if tc.skipInsecureKubeconfig {
-				features.SetFeatureGateDuringTest(t, features.MultiKueueAllowInsecureKubeconfigs, true)
-			}
-
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			if len(tc.clusterprofiles) > 0 {
 				features.SetFeatureGateDuringTest(t, features.MultiKueueClusterProfile, true)
 			}

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -74,7 +74,7 @@ func TestWlReconcile(t *testing.T) {
 	baseJobManagedByKueueBuilder := baseJobBuilder.Clone().ManagedBy(kueue.MultiKueueControllerName)
 
 	cases := map[string]struct {
-		features map[featuregate.Feature]bool
+		featureGates map[featuregate.Feature]bool
 
 		reconcileFor             string
 		managersWorkloads        []kueue.Workload
@@ -212,7 +212,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"unmanaged wl (job not managed by multikueue) is rejected": {
-			features:     map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
 			reconcileFor: "wl1",
 			managersJobs: []batchv1.Job{
 				*baseJobBuilder.Clone().Obj(),
@@ -299,7 +299,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"wl without reservation, clears the workload objects (withoutJobManagedBy)": {
-			features:     map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: false},
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: false},
 			reconcileFor: "wl1",
 			managersJobs: []batchv1.Job{*baseJobBuilder.Clone().Obj()},
 			managersWorkloads: []kueue.Workload{
@@ -389,7 +389,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"remote wl with reservation, unable to delete the second worker's workload": {
-			features:     map[featuregate.Feature]bool{features.MultiKueueWaitForWorkloadAdmitted: false},
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueWaitForWorkloadAdmitted: false},
 			reconcileFor: "wl1",
 			managersWorkloads: []kueue.Workload{
 				*baseWorkloadBuilder.Clone().
@@ -438,7 +438,7 @@ func TestWlReconcile(t *testing.T) {
 			wantError: errFake,
 		},
 		"remote wl with reservation": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueBatchJobWithManagedBy:   true,
 				features.MultiKueueWaitForWorkloadAdmitted: false,
 			},
@@ -506,7 +506,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"remote wl with reservation but not admitted, feature gate enabled - other workers not deleted": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueBatchJobWithManagedBy:   true,
 				features.MultiKueueWaitForWorkloadAdmitted: true,
 			},
@@ -557,7 +557,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"remote wl admitted, feature gate enabled - other workers deleted": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueBatchJobWithManagedBy:   true,
 				features.MultiKueueWaitForWorkloadAdmitted: true,
 			},
@@ -631,7 +631,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"remote wl evicted": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueBatchJobWithManagedBy:   true,
 				features.MultiKueueWaitForWorkloadAdmitted: false,
 			},
@@ -704,7 +704,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"handle workload evicted on manager cluster": {
-			features:     map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
 			reconcileFor: "wl1",
 			managersWorkloads: []kueue.Workload{
 				*baseWorkloadBuilder.Clone().
@@ -784,7 +784,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"remote wl with reservation (withoutJobManagedBy)": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueBatchJobWithManagedBy:   false,
 				features.MultiKueueWaitForWorkloadAdmitted: false,
 			},
@@ -852,7 +852,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"remote wl with reservation (withoutJobManagedBy, MultiKueueDispatcherModeIncremental)": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueBatchJobWithManagedBy:   false,
 				features.MultiKueueWaitForWorkloadAdmitted: false,
 			},
@@ -921,7 +921,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"remote job is changing status the local Job is updated ": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueBatchJobWithManagedBy:   true,
 				features.MultiKueueWaitForWorkloadAdmitted: false,
 			},
@@ -996,7 +996,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"remote job is changing status, the local job is not updated (withoutJobManagedBy)": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueBatchJobWithManagedBy:   false,
 				features.MultiKueueWaitForWorkloadAdmitted: false,
 			},
@@ -1133,7 +1133,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"remote wl is finished, the local workload and Job are marked completed (withoutJobManagedBy)": {
-			features:     map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: false},
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: false},
 			reconcileFor: "wl1",
 			managersWorkloads: []kueue.Workload{
 				*baseWorkloadBuilder.Clone().
@@ -1345,7 +1345,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"worker reconnects after the local workload is requeued and got reservation on a second worker": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueBatchJobWithManagedBy:   true,
 				features.MultiKueueWaitForWorkloadAdmitted: false,
 			},
@@ -1427,7 +1427,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"elastic job finished local workload via replacement is ignored": {
-			features:     map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			reconcileFor: "wl1",
 
 			managersWorkloads: []kueue.Workload{
@@ -1499,7 +1499,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"elastic job local workload without quota reservation": {
-			features:     map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			reconcileFor: "wl1",
 
 			managersWorkloads: []kueue.Workload{
@@ -1548,7 +1548,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"elastic job local scaled-up workload slice without quota reservation": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.ElasticJobsViaWorkloadSlices:    true,
 				features.MultiKueueBatchJobWithManagedBy: true,
 			},
@@ -1613,7 +1613,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"elastic job local workload out-of-sync other than scaled-down": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.ElasticJobsViaWorkloadSlices:    true,
 				features.MultiKueueBatchJobWithManagedBy: true,
 			},
@@ -1669,7 +1669,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"elastic job local workload out-of-sync scaled-down": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.ElasticJobsViaWorkloadSlices:      true,
 				features.MultiKueueBatchJobWithManagedBy:   true,
 				features.MultiKueueWaitForWorkloadAdmitted: false,
@@ -1749,10 +1749,7 @@ func TestWlReconcile(t *testing.T) {
 		for _, useMergePatch := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s when the WorkloadRequestUseMergePatch feature is %t", name, useMergePatch), func(t *testing.T) {
 				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, useMergePatch)
-
-				for feature, enabled := range tc.features {
-					features.SetFeatureGateDuringTest(t, feature, enabled)
-				}
+				features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 				ctx, _ := utiltesting.ContextWithLog(t)
 				managerBuilder := getClientBuilder(ctx)

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -401,8 +402,7 @@ func TestReconcile(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(testStartTime)
 
 	cases := map[string]struct {
-		enableObjectRetentionPolicies bool
-		enableDRAFeature              bool
+		featureGates map[featuregate.Feature]bool
 
 		workload                  *kueue.Workload
 		cq                        *kueue.ClusterQueue
@@ -420,7 +420,7 @@ func TestReconcile(t *testing.T) {
 		reconcilerOpts            []Option
 	}{
 		"reconcile DRA ResourceClaim should be rejected as inadmissible": {
-			enableDRAFeature: true,
+			featureGates: map[featuregate.Feature]bool{features.DynamicResourceAllocation: true},
 			workload: utiltestingapi.MakeWorkload("wlWithDRAResourceClaim", "ns").
 				Queue("lq").
 				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
@@ -459,7 +459,7 @@ func TestReconcile(t *testing.T) {
 			wantEvents: nil,
 		},
 		"reconcile DRA ResourceClaimTemplate should be pre-processed and queued": {
-			enableDRAFeature:     true,
+			featureGates:         map[featuregate.Feature]bool{features.DynamicResourceAllocation: true},
 			wantDRAResourceTotal: ptr.To(int64(1)),
 			wantWorkloadsInQueue: ptr.To(1),
 			workload: utiltestingapi.MakeWorkload("wlWithDRAResourceClaimTemplate", "ns").
@@ -494,7 +494,7 @@ func TestReconcile(t *testing.T) {
 			wantEvents: nil,
 		},
 		"reconcile DRA ResourceClaimTemplate multi-pod should be pre-processed and queued": {
-			enableDRAFeature:     true,
+			featureGates:         map[featuregate.Feature]bool{features.DynamicResourceAllocation: true},
 			wantDRAResourceTotal: ptr.To(int64(6)),
 			wantWorkloadsInQueue: ptr.To(1),
 			workload: utiltestingapi.MakeWorkload("wlMultiPodDRA", "ns").
@@ -529,7 +529,7 @@ func TestReconcile(t *testing.T) {
 			wantEvents: nil,
 		},
 		"reconcile DRA ResourceClaimTemplate with unmapped device class": {
-			enableDRAFeature: true,
+			featureGates: map[featuregate.Feature]bool{features.DynamicResourceAllocation: true},
 			workload: utiltestingapi.MakeWorkload("wlUnmappedDRA", "ns").
 				Queue("lq").
 				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
@@ -578,7 +578,7 @@ func TestReconcile(t *testing.T) {
 			wantEvents:   nil,
 		},
 		"reconcile DRA ResourceClaimTemplate not found should return error": {
-			enableDRAFeature: true,
+			featureGates: map[featuregate.Feature]bool{features.DynamicResourceAllocation: true},
 			workload: utiltestingapi.MakeWorkload("wlMissingTemplate", "ns").
 				Queue("lq").
 				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
@@ -2312,7 +2312,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"shouldn't delete the workload because, object retention not configured": {
-			enableObjectRetentionPolicies: true,
+			featureGates: map[featuregate.Feature]bool{features.ObjectRetentionPolicies: true},
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				Condition(metav1.Condition{
 					Type:   kueue.WorkloadFinished,
@@ -2331,7 +2331,7 @@ func TestReconcile(t *testing.T) {
 			wantError: nil,
 		},
 		"shouldn't try to delete the workload (no event emitted) because it is already being deleted by kubernetes, object retention configured": {
-			enableObjectRetentionPolicies: true,
+			featureGates: map[featuregate.Feature]bool{features.ObjectRetentionPolicies: true},
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				Condition(metav1.Condition{
 					Type:   kueue.WorkloadFinished,
@@ -2354,7 +2354,7 @@ func TestReconcile(t *testing.T) {
 			wantError:    nil,
 		},
 		"shouldn't try to delete the workload because the retention period hasn't elapsed yet, object retention configured": {
-			enableObjectRetentionPolicies: true,
+			featureGates: map[featuregate.Feature]bool{features.ObjectRetentionPolicies: true},
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				Condition(metav1.Condition{
 					Type:               kueue.WorkloadFinished,
@@ -2382,7 +2382,7 @@ func TestReconcile(t *testing.T) {
 			wantError: nil,
 		},
 		"should delete the workload because the retention period has elapsed, object retention configured": {
-			enableObjectRetentionPolicies: true,
+			featureGates: map[featuregate.Feature]bool{features.ObjectRetentionPolicies: true},
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				Condition(metav1.Condition{
 					Type:               kueue.WorkloadFinished,
@@ -2569,8 +2569,7 @@ func TestReconcile(t *testing.T) {
 	for name, tc := range cases {
 		for _, enabled := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", name, enabled), func(t *testing.T) {
-				features.SetFeatureGateDuringTest(t, features.ObjectRetentionPolicies, tc.enableObjectRetentionPolicies)
-				features.SetFeatureGateDuringTest(t, features.DynamicResourceAllocation, tc.enableDRAFeature)
+				features.SetFeatureGatesDuringTest(t, tc.featureGates)
 				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, enabled)
 
 				testWl := tc.workload.DeepCopy()
@@ -2682,7 +2681,7 @@ func TestReconcile(t *testing.T) {
 				}
 
 				// For DRA tests, verify that workloads are properly queued/cached
-				if tc.enableDRAFeature && testWl != nil &&
+				if tc.featureGates[features.DynamicResourceAllocation] && testWl != nil &&
 					len(testWl.Spec.PodSets) > 0 &&
 					len(testWl.Spec.PodSets[0].Template.Spec.ResourceClaims) > 0 {
 					workloadKey := client.ObjectKeyFromObject(testWl)

--- a/pkg/controller/jobframework/base_webhook_test.go
+++ b/pkg/controller/jobframework/base_webhook_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -44,9 +45,8 @@ import (
 func TestBaseWebhookDefault(t *testing.T) {
 	testcases := map[string]struct {
 		manageJobsWithoutQueueName bool
-		localQueueDefaulting       bool
 		defaultLqExist             bool
-		enableMultiKueue           bool
+		featureGates               map[featuregate.Feature]bool
 		job                        *batchv1.Job
 		want                       *batchv1.Job
 	}{
@@ -60,24 +60,24 @@ func TestBaseWebhookDefault(t *testing.T) {
 			want:                       utiljob.MakeJob("job", metav1.NamespaceDefault).Queue("queue").Suspend(true).Obj(),
 		},
 		"LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			job:                  utiljob.MakeJob("job", metav1.NamespaceDefault).Obj(),
+			defaultLqExist: true,
+			job:            utiljob.MakeJob("job", metav1.NamespaceDefault).Obj(),
 			want: utiljob.MakeJob("job", metav1.NamespaceDefault).
 				Label(constants.QueueLabel, "default").
 				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
 		},
 		"LocalQueueDefaulting enabled, default lq is created, job has queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			job:                  utiljob.MakeJob("job", metav1.NamespaceDefault).Queue("queue").Obj(),
-			want:                 utiljob.MakeJob("job", metav1.NamespaceDefault).Queue("queue").Obj(),
+			defaultLqExist: true,
+			job:            utiljob.MakeJob("job", metav1.NamespaceDefault).Queue("queue").Obj(),
+			want:           utiljob.MakeJob("job", metav1.NamespaceDefault).Queue("queue").Obj(),
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
 		},
 		"LocalQueueDefaulting enabled, default lq isn't created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       false,
-			job:                  utiljob.MakeJob("job", metav1.NamespaceDefault).Obj(),
-			want:                 utiljob.MakeJob("job", metav1.NamespaceDefault).Obj(),
+			defaultLqExist: false,
+			job:            utiljob.MakeJob("job", metav1.NamespaceDefault).Obj(),
+			want:           utiljob.MakeJob("job", metav1.NamespaceDefault).Obj(),
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
 		},
 		"ManagedByDefaulting, targeting multikueue local queue": {
 			job: utiljob.MakeJob("job", metav1.NamespaceDefault).Queue("multikueue").Obj(),
@@ -85,7 +85,7 @@ func TestBaseWebhookDefault(t *testing.T) {
 				Queue("multikueue").
 				ManagedBy(kueue.MultiKueueControllerName).
 				Obj(),
-			enableMultiKueue: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueue: true},
 		},
 		"ManagedByDefaulting, targeting multikueue local queue but already managaed by someone else": {
 			job: utiljob.MakeJob("job", metav1.NamespaceDefault).
@@ -96,7 +96,7 @@ func TestBaseWebhookDefault(t *testing.T) {
 				Queue("multikueue").
 				ManagedBy("someone-else").
 				Obj(),
-			enableMultiKueue: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueue: true},
 		},
 		"ManagedByDefaulting, targeting non-multikueue local queue": {
 			job: utiljob.MakeJob("job", metav1.NamespaceDefault).
@@ -105,14 +105,13 @@ func TestBaseWebhookDefault(t *testing.T) {
 			want: utiljob.MakeJob("job", metav1.NamespaceDefault).
 				Queue("queue").
 				Obj(),
-			enableMultiKueue: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueue: true},
 		},
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			ctx, log := utiltesting.ContextWithLog(t)
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
-			features.SetFeatureGateDuringTest(t, features.MultiKueue, tc.enableMultiKueue)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			clientBuilder := utiltesting.NewClientBuilder().
 				WithObjects(
 					utiltesting.MakeNamespace(metav1.NamespaceDefault),
@@ -126,7 +125,7 @@ func TestBaseWebhookDefault(t *testing.T) {
 					t.Fatalf("failed to create default local queue: %s", err)
 				}
 			}
-			if tc.enableMultiKueue {
+			if tc.featureGates[features.MultiKueue] {
 				if err := queueManager.AddLocalQueue(ctx, utiltestingapi.MakeLocalQueue("multikueue", metav1.NamespaceDefault).
 					ClusterQueue("cluster-queue").Obj()); err != nil {
 					t.Fatalf("failed to create default local queue: %s", err)

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -33,6 +33,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
@@ -85,25 +86,25 @@ func TestReconcileGenericJob(t *testing.T) {
 		Priority(0)
 
 	testCases := map[string]struct {
-		elasticJobsViaWorkloadSlicesEnabled bool
-		req                                 types.NamespacedName
-		job                                 *batchv1.Job
-		podSets                             []kueue.PodSet
-		objs                                []client.Object
-		wantWorkloads                       []kueue.Workload
+		featureGates  map[featuregate.Feature]bool
+		req           types.NamespacedName
+		job           *batchv1.Job
+		podSets       []kueue.PodSet
+		objs          []client.Object
+		wantWorkloads []kueue.Workload
 	}{
 		"handle job with no workload (elasticJobsViaWorkloadSlicesEnabled = false)": {
-			elasticJobsViaWorkloadSlicesEnabled: false,
-			req:                                 baseReq,
-			job:                                 baseJob.DeepCopy(),
-			podSets:                             basePodSets,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: false},
+			req:          baseReq,
+			job:          baseJob.DeepCopy(),
+			podSets:      basePodSets,
 			wantWorkloads: []kueue.Workload{
 				*baseWl.Clone().Name("job-test-job-ce737").Obj(),
 			},
 		},
 		"handle job with no workload (elasticJobsViaWorkloadSlicesEnabled = false and elastic job annotation)": {
-			elasticJobsViaWorkloadSlicesEnabled: false,
-			req:                                 baseReq,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: false},
+			req:          baseReq,
 			job: baseJob.Clone().
 				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 				Obj(),
@@ -113,17 +114,17 @@ func TestReconcileGenericJob(t *testing.T) {
 			},
 		},
 		"handle job with no workload (elasticJobsViaWorkloadSlicesEnabled = true)": {
-			elasticJobsViaWorkloadSlicesEnabled: true,
-			req:                                 baseReq,
-			job:                                 baseJob.DeepCopy(),
-			podSets:                             basePodSets,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			req:          baseReq,
+			job:          baseJob.DeepCopy(),
+			podSets:      basePodSets,
 			wantWorkloads: []kueue.Workload{
 				*baseWl.Clone().Name("job-test-job-ce737").Obj(),
 			},
 		},
 		"handle job with no workload (elasticJobsViaWorkloadSlicesEnabled = true and elastic job annotation)": {
-			elasticJobsViaWorkloadSlicesEnabled: true,
-			req:                                 baseReq,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			req:          baseReq,
 			job: baseJob.Clone().
 				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 				Obj(),
@@ -138,8 +139,8 @@ func TestReconcileGenericJob(t *testing.T) {
 			},
 		},
 		"update workload to match job (one existing workload)": {
-			elasticJobsViaWorkloadSlicesEnabled: true,
-			req:                                 baseReq,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			req:          baseReq,
 			job: baseJob.Clone().
 				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 				Obj(),
@@ -208,7 +209,7 @@ func TestReconcileGenericJob(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, tc.elasticJobsViaWorkloadSlicesEnabled)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			ctx, _ := utiltesting.ContextWithLog(t)
 			mockctrl := gomock.NewController(t)

--- a/pkg/controller/jobframework/utils_test.go
+++ b/pkg/controller/jobframework/utils_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/component-base/featuregate"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -31,12 +32,12 @@ import (
 func TestSanitizePodSets(t *testing.T) {
 	testCases := map[string]struct {
 		podSets         []kueue.PodSet
-		featureEnabled  bool
+		featureGates    map[featuregate.Feature]bool
 		expectedPodSets []kueue.PodSet
 	}{
 
 		"disabled feature gate": {
-			featureEnabled: false,
+			featureGates: map[featuregate.Feature]bool{features.SanitizePodSets: false},
 			podSets: []kueue.PodSet{
 				*utiltestingapi.MakePodSet("test", 1).
 					Containers(*utiltesting.MakeContainer().
@@ -57,7 +58,7 @@ func TestSanitizePodSets(t *testing.T) {
 			},
 		},
 		"enabled feature gate, init containers and containers": {
-			featureEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.SanitizePodSets: true},
 			podSets: []kueue.PodSet{
 				*utiltestingapi.MakePodSet("test", 1).
 					Containers(*utiltesting.MakeContainer().
@@ -86,7 +87,7 @@ func TestSanitizePodSets(t *testing.T) {
 			},
 		},
 		"enabled feature gate, containers only": {
-			featureEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.SanitizePodSets: true},
 			podSets: []kueue.PodSet{
 				*utiltestingapi.MakePodSet("test", 1).
 					Containers(*utiltesting.MakeContainer().
@@ -106,7 +107,7 @@ func TestSanitizePodSets(t *testing.T) {
 			},
 		},
 		"empty podsets": {
-			featureEnabled:  true,
+			featureGates:    map[featuregate.Feature]bool{features.SanitizePodSets: true},
 			podSets:         []kueue.PodSet{},
 			expectedPodSets: []kueue.PodSet{},
 		},
@@ -114,8 +115,7 @@ func TestSanitizePodSets(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.SanitizePodSets, tc.featureEnabled)
-
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			SanitizePodSets(tc.podSets)
 
 			if diff := cmp.Diff(tc.expectedPodSets, tc.podSets); diff != "" {

--- a/pkg/controller/jobframework/validation_test.go
+++ b/pkg/controller/jobframework/validation_test.go
@@ -328,9 +328,7 @@ func TestValidateJobOnUpdate(t *testing.T) {
 
 	for tcName, tc := range testCases {
 		t.Run(tcName, func(t *testing.T) {
-			for feature, enabled := range tc.featureGates {
-				features.SetFeatureGateDuringTest(t, feature, enabled)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			mockctrl := gomock.NewController(t)
 

--- a/pkg/controller/jobframework/workload_names_test.go
+++ b/pkg/controller/jobframework/workload_names_test.go
@@ -112,9 +112,7 @@ func TestGenerateWorkloadNameWithExtra(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			for fg, enabled := range tc.featureGates {
-				features.SetFeatureGateDuringTest(t, fg, enabled)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			got := GenerateWorkloadNameWithExtra(tc.ownerName, tc.ownerUID, tc.ownerGVK, tc.extra)
 			if tc.want != "" {
 				if diff := cmp.Diff(tc.want, got); len(diff) != 0 {

--- a/pkg/controller/jobs/appwrapper/appwrapper_controller_test.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_controller_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -89,9 +90,9 @@ func TestPodSets(t *testing.T) {
 		Obj()
 
 	testCases := map[string]struct {
-		job                           *awv1beta2.AppWrapper
-		wantPodSets                   []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		job          *awv1beta2.AppWrapper
+		wantPodSets  []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingappwrapper.MakeAppWrapper("aw", "ns").
@@ -109,7 +110,7 @@ func TestPodSets(t *testing.T) {
 					PodSpec(batchJob.Spec.Template.Spec).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required and preferred topology annotation": {
 			job: testingappwrapper.MakeAppWrapper("aw", "ns").
@@ -131,7 +132,7 @@ func TestPodSets(t *testing.T) {
 					Obj(),
 			},
 
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"without required and preferred topology annotation if TAS is disabled": {
 			job: testingappwrapper.MakeAppWrapper("aw", "ns").
@@ -149,13 +150,13 @@ func TestPodSets(t *testing.T) {
 					Obj(),
 			},
 
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := fromObject(tc.job).PodSets(ctx)
 			if err != nil {

--- a/pkg/controller/jobs/deployment/deployment_webhook_test.go
+++ b/pkg/controller/jobs/deployment/deployment_webhook_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
@@ -38,10 +39,10 @@ import (
 
 func TestDefault(t *testing.T) {
 	testCases := map[string]struct {
-		deployment           *appsv1.Deployment
-		localQueueDefaulting bool
-		defaultLqExist       bool
-		want                 *appsv1.Deployment
+		deployment     *appsv1.Deployment
+		featureGates   map[featuregate.Feature]bool
+		defaultLqExist bool
+		want           *appsv1.Deployment
 	}{
 		"deployment without queue": {
 			deployment: testingdeployment.MakeDeployment("test-pod", "").Obj(),
@@ -75,9 +76,9 @@ func TestDefault(t *testing.T) {
 			want:       testingdeployment.MakeDeployment("test-pod", "").PodTemplateSpecQueue("test-queue").Obj(),
 		},
 		"LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			deployment:           testingdeployment.MakeDeployment("test-pod", "default").Obj(),
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: true,
+			deployment:     testingdeployment.MakeDeployment("test-pod", "default").Obj(),
 			want: testingdeployment.MakeDeployment("test-pod", "default").
 				PodTemplateSpecManagedByKueue().
 				Queue("default").
@@ -86,9 +87,9 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, default lq is created, job has queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			deployment:           testingdeployment.MakeDeployment("test-pod", "").Queue("test-queue").Obj(),
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: true,
+			deployment:     testingdeployment.MakeDeployment("test-pod", "").Queue("test-queue").Obj(),
 			want: testingdeployment.MakeDeployment("test-pod", "").
 				PodTemplateSpecManagedByKueue().
 				Queue("test-queue").
@@ -97,9 +98,9 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, default lq isn't created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       false,
-			deployment:           testingdeployment.MakeDeployment("test-pod", "").Obj(),
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: false,
+			deployment:     testingdeployment.MakeDeployment("test-pod", "").Obj(),
 			want: testingdeployment.MakeDeployment("test-pod", "").
 				Obj(),
 		},
@@ -148,7 +149,7 @@ func TestDefault(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			t.Cleanup(jobframework.EnableIntegrationsForTest(t, "pod"))
 			builder := utiltesting.NewClientBuilder()
 			client := builder.Build()

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -334,20 +335,21 @@ func TestPodSets(t *testing.T) {
 	jobTemplate := utiltestingjob.MakeJob("job", "ns")
 
 	cases := map[string]struct {
-		job                           *Job
-		wantPodSets                   []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		featureGates map[featuregate.Feature]bool
+		job          *Job
+		wantPodSets  []kueue.PodSet
 	}{
 		"no partial admission": {
-			job: (*Job)(jobTemplate.Clone().Parallelism(3).Obj()),
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			job:          (*Job)(jobTemplate.Clone().Parallelism(3).Obj()),
 			wantPodSets: []kueue.PodSet{
 				*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).
 					PodSpec(*jobTemplate.Clone().Spec.Template.Spec.DeepCopy()).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: false,
 		},
 		"partial admission": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			job: (*Job)(
 				jobTemplate.Clone().
 					Parallelism(3).
@@ -360,9 +362,9 @@ func TestPodSets(t *testing.T) {
 					SetMinimumCount(2).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: false,
 		},
 		"with required topology annotation": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			job: (*Job)(
 				jobTemplate.Clone().
 					Parallelism(3).
@@ -377,9 +379,9 @@ func TestPodSets(t *testing.T) {
 					PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: true,
 		},
 		"with preferred topology annotation": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			job: (*Job)(
 				jobTemplate.Clone().
 					Parallelism(3).
@@ -394,9 +396,9 @@ func TestPodSets(t *testing.T) {
 					PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: true,
 		},
 		"with slice-only topology": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			job: (*Job)(
 				jobTemplate.Clone().
 					Parallelism(3).
@@ -416,9 +418,9 @@ func TestPodSets(t *testing.T) {
 					SliceSizeTopologyRequest(1).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: true,
 		},
 		"with slice-only topology if TAS is disabled": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			job: (*Job)(
 				jobTemplate.Clone().
 					Parallelism(3).
@@ -435,9 +437,9 @@ func TestPodSets(t *testing.T) {
 					}).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: false,
 		},
 		"with slice-only topology – only podset slice required topology annotation": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			job: (*Job)(
 				jobTemplate.Clone().
 					Parallelism(3).
@@ -453,9 +455,9 @@ func TestPodSets(t *testing.T) {
 					PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: true,
 		},
 		"with slice-only topology – only podset slice size annotation": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			job: (*Job)(
 				jobTemplate.Clone().
 					Parallelism(3).
@@ -471,9 +473,9 @@ func TestPodSets(t *testing.T) {
 					PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: true,
 		},
 		"without preferred topology annotation if TAS is disabled": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			job: (*Job)(
 				jobTemplate.Clone().
 					Parallelism(3).
@@ -486,9 +488,9 @@ func TestPodSets(t *testing.T) {
 					Annotations(map[string]string{kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: false,
 		},
 		"without required topology annotation if TAS is disabled": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			job: (*Job)(
 				jobTemplate.Clone().
 					Parallelism(3).
@@ -501,12 +503,11 @@ func TestPodSets(t *testing.T) {
 					Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: false,
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := tc.job.PodSets(ctx)
 			if err != nil {
@@ -587,9 +588,7 @@ func TestReconciler(t *testing.T) {
 	baseWaitForPodsReadyConf := &configapi.WaitForPodsReady{}
 
 	cases := map[string]struct {
-		enableObjectRetentionPolicies                     bool
-		enableTopologyAwareScheduling                     bool
-		enableManagedJobsNamespaceSelectorAlwaysRespected bool
+		featureGates map[featuregate.Feature]bool
 
 		reconcilerOptions []jobframework.Option
 		job               batchv1.Job
@@ -602,6 +601,10 @@ func TestReconciler(t *testing.T) {
 		wantErr           error
 	}{
 		"PodsReady is set to False before Workload is Admitted": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -623,6 +626,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodsReady is set to False after Workload is Admitted but not all Pods reached readiness": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -644,6 +651,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodsReady is set to False after Workload is Admitted, some Pods became ready but not all Pods reached readiness": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -679,6 +690,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodsReady is set to True after Workload is Admitted and all Pods reached readiness": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -710,6 +725,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodsReady is set to True after Workload is Admitted and all Pods reached readiness without previous PodsReady condition": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -735,6 +754,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodsReady is set to False after Workload is running and one pod failed": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -768,6 +791,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodsReady continues to be False after a pod failed and workload is still recovering": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -803,6 +830,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodsReady is set to True after failing pod recovered": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -834,6 +865,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodsReady=False has the new Reason if there was the old one before (pre v0.11.0)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -861,6 +896,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodsReady=True has the new Reason if there was the old one before (pre v0.11.0)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -892,6 +931,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodsReady is set to False if there's an invalid Reason (pre v0.11.0)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
@@ -919,7 +962,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"PodSet label and Workload annotation are set when Job is starting; TopologyAwareScheduling enabled": {
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     true,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
@@ -950,6 +996,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is created, it has its owner ProvReq annotations": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				SetAnnotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
 				SetAnnotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
@@ -982,6 +1032,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is created, it has correct labels set": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Label("toCopyKey", "toCopyValue").
 				Label("dontCopyKey", "dontCopyValue").
@@ -1017,6 +1071,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is admitted the PodSetUpdates are propagated to job": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -1068,6 +1126,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is evicted due to spec.active field being false, job gets suspended and quota is unset": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
@@ -1150,7 +1212,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is active after deactivation; objectRetentionPolicies.workloads.afterDeactivatedByKueue=0; should not delete the job": {
-			enableObjectRetentionPolicies: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithObjectRetentionPolicies(&configapi.ObjectRetentionPolicies{
 					Workloads: &configapi.WorkloadRetentionPolicy{
@@ -1241,7 +1306,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is manually deactivated; objectRetentionPolicies.workloads.afterDeactivatedByKueue=0; should not delete the job": {
-			enableObjectRetentionPolicies: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithObjectRetentionPolicies(&configapi.ObjectRetentionPolicies{
 					Workloads: &configapi.WorkloadRetentionPolicy{
@@ -1332,7 +1400,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is deactivated by kueue; objectRetentionPolicies.workloads.afterDeactivatedByKueue=0; should delete the job": {
-			enableObjectRetentionPolicies: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithObjectRetentionPolicies(&configapi.ObjectRetentionPolicies{
 					Workloads: &configapi.WorkloadRetentionPolicy{
@@ -1426,7 +1497,11 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is deactivated by kueue; objectRetentionPolicies.workloads.afterDeactivatedByKueue=60; retention period has not expired": {
-			enableObjectRetentionPolicies: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.ObjectRetentionPolicies:                     true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithObjectRetentionPolicies(&configapi.ObjectRetentionPolicies{
 					Workloads: &configapi.WorkloadRetentionPolicy{
@@ -1517,7 +1592,12 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is deactivated by kueue; objectRetentionPolicies.workloads.afterDeactivatedByKueue=60; retention period has expired": {
-			enableObjectRetentionPolicies: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+
+				features.ObjectRetentionPolicies: true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithObjectRetentionPolicies(&configapi.ObjectRetentionPolicies{
 					Workloads: &configapi.WorkloadRetentionPolicy{
@@ -1611,6 +1691,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is evicted due to pods ready timeout, job gets suspended and quota is unset": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
@@ -1667,6 +1751,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is evicted due to admission check, job gets suspended": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
@@ -1747,6 +1835,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is evicted due to cluster queue stopped, job gets suspended": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
@@ -1827,6 +1919,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is evicted due to local queue stopped, job gets suspended": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
@@ -1907,6 +2003,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is evicted due to preemption, job gets suspended": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
@@ -1988,6 +2088,10 @@ func TestReconciler(t *testing.T) {
 		},
 		"when job is initially suspended, the Workload has active=false and it's not admitted, " +
 			"it should not get an evicted condition, but the job should remain suspended": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(true).
 				Obj(),
@@ -2058,6 +2162,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is admitted and PodSetUpdates conflict between admission checks on labels, the workload is finished with failure": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2129,6 +2237,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is admitted and PodSetUpdates conflict between admission checks on annotations, the workload is finished with failure": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2200,6 +2312,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is admitted and PodSetUpdates conflict between admission checks on nodeSelector, the workload is finished with failure": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2271,6 +2387,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is admitted and PodSetUpdates conflict between admission check nodeSelector and current node selector, the workload is finished with failure": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				NodeSelector("provisioning", "spot").
 				Obj(),
@@ -2320,6 +2440,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is admitted the PodSetUpdates values matching for key": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2427,6 +2551,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"suspended job with matching admitted workload is unsuspended": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
@@ -2456,6 +2584,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"non-matching admitted workload is deleted": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
@@ -2479,6 +2611,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"non-matching non-admitted workload is updated": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
@@ -2510,6 +2646,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"suspended job with partial admission and admitted workload is unsuspended": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
@@ -2554,6 +2694,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"unsuspended job with partial admission and non-matching admitted workload is suspended and workload is deleted": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
@@ -2595,6 +2739,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload is created when queue name is set": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -2633,6 +2781,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload is updated when queue name has changed for suspended job": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(true).
@@ -2668,6 +2820,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload is updated when priority class has changed for suspended job": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(true).
@@ -2716,6 +2872,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"shouldn't update workload when priority class no changes": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(true).
@@ -2756,6 +2916,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload without uid label is created when job's uid is longer than 63 characters": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -2792,6 +2956,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload is not created when queue name is not set": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *utiltestingjob.MakeJob("job", "ns").
 				Suspend(false).
 				Obj(),
@@ -2800,6 +2968,10 @@ func TestReconciler(t *testing.T) {
 				Obj(),
 		},
 		"non-standalone job is suspended if its parent workload is not found": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				OwnerReference("parent", batchv1.SchemeGroupVersion.WithKind("Job")).
@@ -2828,6 +3000,10 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
 			job: *baseJobWrapper.
 				Clone().
@@ -2863,6 +3039,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"non-standalone job is suspended if its parent workload is found and not admitted": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
@@ -2906,6 +3086,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"non-standalone job is not suspended if its parent workload is admitted and queue name is set": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -2944,6 +3128,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"checking a second non-matching workload is deleted": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
@@ -3026,6 +3214,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is evicted but suspended, reset startTime and restore node affinity": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(true).
 				StartTime(now).
@@ -3056,6 +3248,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is evicted, suspended and startTime is reset, restore node affinity": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(true).
 				NodeSelector("provisioning", "spot").
@@ -3085,6 +3281,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when job completes, workload is marked as finished": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Condition(batchv1.JobCondition{
 					Type:    batchv1.JobComplete,
@@ -3128,6 +3328,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when the workload is finished, its finalizer is removed": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().Obj(),
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("a", "ns").
@@ -3167,6 +3371,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload is created when queue name is set, with workloadPriorityClass": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -3211,6 +3419,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload is created when queue name is set, with PriorityClass": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -3255,6 +3467,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload is created when queue name is set, with workloadPriorityClass and PriorityClass": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -3301,6 +3517,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload shouldn't be recreated for the completed job": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
 				Obj(),
@@ -3311,6 +3531,10 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{},
 		},
 		"when the prebuilt workload is missing, no new one is created, the job is suspended and prebuilt workload not found error is returned": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -3333,6 +3557,10 @@ func TestReconciler(t *testing.T) {
 			wantErr: jobframework.ErrPrebuiltWorkloadNotFound,
 		},
 		"when the prebuilt workload exists its owner info is updated": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -3376,6 +3604,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when the prebuilt workload is owned by another object": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -3418,6 +3650,10 @@ func TestReconciler(t *testing.T) {
 			wantErr: jobframework.ErrPrebuiltWorkloadNotFound,
 		},
 		"when the prebuilt workload is not equivalent to the job": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -3468,6 +3704,10 @@ func TestReconciler(t *testing.T) {
 			wantErr: jobframework.ErrPrebuiltWorkloadNotFound,
 		},
 		"the workload is not admitted, tolerations and node selector change": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
 				Operator: corev1.TolerationOpExists,
@@ -3532,6 +3772,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload is admitted, tolerations and node selector change": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
 				Operator: corev1.TolerationOpExists,
@@ -3606,6 +3850,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload is admitted, job still suspended and tolerations change": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
 				Operator: corev1.TolerationOpExists,
@@ -3656,6 +3904,10 @@ func TestReconciler(t *testing.T) {
 			wantErr: jobframework.ErrNoMatchingWorkloads,
 		},
 		"admission check message is emitted as event for job": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(true).
 				Obj(),
@@ -3706,6 +3958,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"multiple admission check messages are emitted as a single event for job": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Suspend(true).
 				Obj(),
@@ -3766,6 +4022,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the maximum execution time is passed to the created workload": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 				Obj(),
@@ -3792,6 +4052,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the maximum execution time is updated in the workload": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+			},
 			job: *baseJobWrapper.Clone().
 				Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 				Obj(),
@@ -3828,7 +4092,10 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"job with queue name is not reconciled in unlabelled namespace when AlwaysRespected is enabled": {
-			enableManagedJobsNamespaceSelectorAlwaysRespected: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManagedJobsNamespaceSelector(labels.SelectorFromSet(map[string]string{
 					"managed-by-kueue": "true",
@@ -3847,7 +4114,10 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: nil,
 		},
 		"job with queue name is reconciled in labelled namespace when AlwaysRespected is enabled": {
-			enableManagedJobsNamespaceSelectorAlwaysRespected: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: true,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManagedJobsNamespaceSelector(labels.SelectorFromSet(map[string]string{
 					"managed-by-kueue": "true",
@@ -3896,9 +4166,7 @@ func TestReconciler(t *testing.T) {
 	for name, tc := range cases {
 		for _, enabled := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", name, enabled), func(t *testing.T) {
-				features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
-				features.SetFeatureGateDuringTest(t, features.ObjectRetentionPolicies, tc.enableObjectRetentionPolicies)
-				features.SetFeatureGateDuringTest(t, features.ManagedJobsNamespaceSelectorAlwaysRespected, tc.enableManagedJobsNamespaceSelectorAlwaysRespected)
+				features.SetFeatureGatesDuringTest(t, tc.featureGates)
 				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, enabled)
 
 				ctx, _ := utiltesting.ContextWithLog(t)
@@ -3993,12 +4261,12 @@ func TestReconciler(t *testing.T) {
 
 func TestCleanLabels(t *testing.T) {
 	cases := map[string]struct {
-		featureEnabled bool
-		labels         map[string]string
-		wantLabels     map[string]string
+		featureGates map[featuregate.Feature]bool
+		labels       map[string]string
+		wantLabels   map[string]string
 	}{
 		"feature disabled": {
-			featureEnabled: false,
+			featureGates: map[featuregate.Feature]bool{features.PropagateBatchJobLabelsToWorkload: false},
 			labels: map[string]string{
 				"foo":                      "bar",
 				batchv1.JobNameLabel:       "job-name",
@@ -4010,7 +4278,7 @@ func TestCleanLabels(t *testing.T) {
 			},
 		},
 		"feature enabled": {
-			featureEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.PropagateBatchJobLabelsToWorkload: true},
 			labels: map[string]string{
 				"foo":                      "bar",
 				batchv1.JobNameLabel:       "job-name",
@@ -4027,7 +4295,7 @@ func TestCleanLabels(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			print(tc.labels)
-			features.SetFeatureGateDuringTest(t, features.PropagateBatchJobLabelsToWorkload, tc.featureEnabled)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			pt := &corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: tc.labels,

--- a/pkg/controller/jobs/job/job_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter_test.go
@@ -58,9 +58,9 @@ func TestMultiKueueAdapter(t *testing.T) {
 	baseJobManagedByKueueBuilder := baseJobBuilder.Clone().ManagedBy(kueue.MultiKueueControllerName)
 
 	cases := map[string]struct {
-		managersJobs        []batchv1.Job
-		workerJobs          []batchv1.Job
-		withoutJobManagedBy bool
+		managersJobs []batchv1.Job
+		workerJobs   []batchv1.Job
+		featureGates map[featuregate.Feature]bool
 
 		operation func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error
 
@@ -182,7 +182,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Active(2).
 					Obj(),
 			},
-			withoutJobManagedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: false},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
 				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, "wl1", "origin1")
 			},
@@ -209,7 +209,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
 					Obj(),
 			},
-			withoutJobManagedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: false},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
 				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, "wl1", "origin1")
 			},
@@ -279,7 +279,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			managersJobs: []batchv1.Job{
 				*baseJobBuilder.Clone().Obj(),
 			},
-			withoutJobManagedBy: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: false},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
 				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}); !isManged {
 					return errors.New("expecting true")
@@ -293,7 +293,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.MultiKueueBatchJobWithManagedBy, !tc.withoutJobManagedBy)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			managerBuilder := utiltesting.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 			managerBuilder = managerBuilder.WithLists(&batchv1.JobList{Items: tc.managersJobs})
@@ -337,7 +337,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 
 func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 	type fields struct {
-		features map[featuregate.Feature]bool
+		featureGates map[featuregate.Feature]bool
 	}
 	type args struct {
 		localClient  client.Client
@@ -395,7 +395,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"RemoteJobNotFound": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: false},
+				featureGates: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: false},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
@@ -413,7 +413,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"RemoteJobNotFound_ResetManagedBy": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
+				featureGates: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
@@ -430,7 +430,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"RemoteJobInProgress_LocalIsManagedButStillSuspended": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
+				featureGates: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().Obj()).Build(),
@@ -448,7 +448,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"RemoteJobInProgress_LocalIsManagedAndUnsuspended": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
+				featureGates: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().Suspend(false).Obj()).Build(),
@@ -485,7 +485,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"RemoteJobFinished_Completed_MultiKueueBatchJobWithManagedBy_Disabled": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: false},
+				featureGates: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: false},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().Suspend(false).Obj()).Build(),
@@ -511,7 +511,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"RemoteJobFinished_Completed_MultiKueueBatchJobWithManagedBy_Enabled": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
+				featureGates: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().Suspend(false).Obj()).Build(),
@@ -536,7 +536,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"RemoteJobFinished_Failed_MultiKueueBatchJobManagedBy_Disabled": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: false},
+				featureGates: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: false},
 			},
 
 			args: args{
@@ -563,7 +563,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"RemoteJobFinished_Failed_MultiKueueBatchJobManagedBy_Enabled": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
+				featureGates: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
 			},
 
 			args: args{
@@ -590,7 +590,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"ElasticJob_RemoteInSync": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+				featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
@@ -619,7 +619,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"ElasticJob_LocalIsStale": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+				featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
@@ -650,7 +650,10 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"ElasticJob_WorkloadNameOnlyChange_EdgeCase_MultiKueueBatchJobWithManagedBy_Disabled": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true, features.MultiKueueBatchJobWithManagedBy: false},
+				featureGates: map[featuregate.Feature]bool{
+					features.ElasticJobsViaWorkloadSlices:    true,
+					features.MultiKueueBatchJobWithManagedBy: false,
+				},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
@@ -679,7 +682,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"ElasticJob_WorkloadNameOnlyChange_EdgeCase_MultiKueueBatchJobWithManagedBy_Enabled": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true, features.MultiKueueBatchJobWithManagedBy: true},
+				featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true, features.MultiKueueBatchJobWithManagedBy: true},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
@@ -707,7 +710,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"ElasticJob_RemoteOutOfSync_MultiKueueBatchJobWithManagedBy_Disabled": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true, features.MultiKueueBatchJobWithManagedBy: false},
+				featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true, features.MultiKueueBatchJobWithManagedBy: false},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
@@ -740,7 +743,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"ElasticJob_RemoteOutOfSync_MultiKueueBatchJobWithManagedBy_Enabled": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true, features.MultiKueueBatchJobWithManagedBy: true},
+				featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true, features.MultiKueueBatchJobWithManagedBy: true},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
@@ -773,7 +776,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"ElasticJob_RemoteOutOfSync_PatchFailure_MultiKueueBatchJobManagedBy_Disabled": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true, features.MultiKueueBatchJobWithManagedBy: false},
+				featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true, features.MultiKueueBatchJobWithManagedBy: false},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
@@ -810,7 +813,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"ElasticJob_RemoteOutOfSync_PatchFailure_MultiKueueBatchJobManagedBy_Enabled": {
 			fields: fields{
-				features: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true, features.MultiKueueBatchJobWithManagedBy: true},
+				featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true, features.MultiKueueBatchJobWithManagedBy: true},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
@@ -848,9 +851,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			// Setup feature gates if any provided.
-			for featureName, enabled := range tt.fields.features {
-				features.SetFeatureGateDuringTest(t, featureName, enabled)
-			}
+			features.SetFeatureGatesDuringTest(t, tt.fields.featureGates)
 
 			adapter := &multiKueueAdapter{}
 			ctx, _ := utiltesting.ContextWithLog(t)

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	jobsetapi "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
@@ -64,11 +65,11 @@ var (
 
 func TestValidateCreate(t *testing.T) {
 	testcases := []struct {
-		name                    string
-		job                     *batchv1.Job
-		wantValidationErrs      field.ErrorList
-		wantErr                 error
-		topologyAwareScheduling bool
+		featureGates       map[featuregate.Feature]bool
+		name               string
+		job                *batchv1.Job
+		wantValidationErrs field.ErrorList
+		wantErr            error
 	}{
 		{
 			name:               "simple",
@@ -240,8 +241,8 @@ func TestValidateCreate(t *testing.T) {
 			job: testingutil.MakeJob("job", "default").
 				PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				Obj(),
-			wantValidationErrs:      nil,
-			topologyAwareScheduling: true,
+			wantValidationErrs: nil,
+			featureGates:       map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid topology request - both annotations",
@@ -254,7 +255,7 @@ func TestValidateCreate(t *testing.T) {
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid topology request - invalid required",
@@ -265,7 +266,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(replicaMetaPath.Child("annotations").Key("kueue.x-k8s.io/podset-required-topology"), "some required value",
 					invalidLabelKeyMessage).WithOrigin("labelKey"),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid topology request - invalid preferred",
@@ -276,7 +277,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(replicaMetaPath.Child("annotations").Key("kueue.x-k8s.io/podset-preferred-topology"), "some preferred value",
 					invalidLabelKeyMessage).WithOrigin("labelKey"),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "valid slice topology request",
@@ -285,8 +286,8 @@ func TestValidateCreate(t *testing.T) {
 				PodAnnotation(kueue.PodSetSliceRequiredTopologyAnnotation, "cloud.com/block").
 				PodAnnotation(kueue.PodSetSliceSizeAnnotation, "1").
 				Obj(),
-			wantValidationErrs:      nil,
-			topologyAwareScheduling: true,
+			wantValidationErrs: nil,
+			featureGates:       map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "valid topology request - slice-only topology - unconstrained with slices defined",
@@ -295,8 +296,8 @@ func TestValidateCreate(t *testing.T) {
 				PodAnnotation(kueue.PodSetSliceRequiredTopologyAnnotation, "cloud.com/block").
 				PodAnnotation(kueue.PodSetSliceSizeAnnotation, "1").
 				Obj(),
-			wantValidationErrs:      nil,
-			topologyAwareScheduling: true,
+			wantValidationErrs: nil,
+			featureGates:       map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid topology request - slice requested without slice size",
@@ -307,7 +308,7 @@ func TestValidateCreate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.Required(replicaMetaPath.Child("annotations").Key("kueue.x-k8s.io/podset-slice-size"), "must be set when 'kueue.x-k8s.io/podset-slice-required-topology' is specified"),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid topology request - slice size is not a number",
@@ -319,7 +320,7 @@ func TestValidateCreate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.Invalid(replicaMetaPath.Child("annotations").Key("kueue.x-k8s.io/podset-slice-size"), "not a number", "must be a numeric value"),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid topology request - slice size is negative",
@@ -331,7 +332,7 @@ func TestValidateCreate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.Invalid(replicaMetaPath.Child("annotations").Key("kueue.x-k8s.io/podset-slice-size"), "-1", "must be greater than or equal to 1"),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid topology request - slice size is zero",
@@ -343,7 +344,7 @@ func TestValidateCreate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.Invalid(replicaMetaPath.Child("annotations").Key("kueue.x-k8s.io/podset-slice-size"), "0", "must be greater than or equal to 1"),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid topology request - slice size provided without slice topology",
@@ -354,7 +355,7 @@ func TestValidateCreate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.Forbidden(replicaMetaPath.Child("annotations").Key("kueue.x-k8s.io/podset-slice-size"), "may not be set when 'kueue.x-k8s.io/podset-slice-required-topology' is not specified"),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "valid topology request - slice-only topology",
@@ -362,8 +363,8 @@ func TestValidateCreate(t *testing.T) {
 				PodAnnotation(kueue.PodSetSliceRequiredTopologyAnnotation, "cloud.com/block").
 				PodAnnotation(kueue.PodSetSliceSizeAnnotation, "1").
 				Obj(),
-			wantValidationErrs:      nil,
-			topologyAwareScheduling: true,
+			wantValidationErrs: nil,
+			featureGates:       map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid slice topology request - slice size larger than number of podsets",
@@ -377,13 +378,13 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(replicaMetaPath.Child("annotations").
 					Key("kueue.x-k8s.io/podset-slice-size"), "20", "must not be greater than pod set count 4"),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			jw := &JobWebhook{}
 
@@ -403,12 +404,12 @@ func TestValidateCreate(t *testing.T) {
 
 func TestValidateUpdate(t *testing.T) {
 	testcases := []struct {
-		name                    string
-		oldJob                  *batchv1.Job
-		newJob                  *batchv1.Job
-		wantValidationErrs      field.ErrorList
-		wantErr                 error
-		topologyAwareScheduling bool
+		name               string
+		oldJob             *batchv1.Job
+		newJob             *batchv1.Job
+		wantValidationErrs field.ErrorList
+		wantErr            error
+		featureGates       map[featuregate.Feature]bool
 	}{
 		{
 			name:               "normal update",
@@ -658,7 +659,7 @@ func TestValidateUpdate(t *testing.T) {
 			newJob: testingutil.MakeJob("job", "default").
 				PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "attempt to set invalid TAS request",
@@ -672,7 +673,7 @@ func TestValidateUpdate(t *testing.T) {
 				field.Invalid(replicaMetaPath.Child("annotations"), field.OmitValueType{},
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`)},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "valid slice topology request",
@@ -683,7 +684,7 @@ func TestValidateUpdate(t *testing.T) {
 				PodAnnotation(kueue.PodSetSliceRequiredTopologyAnnotation, "cloud.com/block").
 				PodAnnotation(kueue.PodSetSliceSizeAnnotation, "1").
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "attempt to set invalid slice topology request",
@@ -696,13 +697,13 @@ func TestValidateUpdate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.Required(replicaMetaPath.Child("annotations").Key("kueue.x-k8s.io/podset-slice-size"), "must be set when 'kueue.x-k8s.io/podset-slice-required-topology' is specified"),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotValidationErrs, gotErr := new(JobWebhook).validateUpdate(ctx, (*Job)(tc.oldJob), (*Job)(tc.newJob))
 			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.IgnoreFields(field.Error{})); diff != "" {
@@ -717,19 +718,17 @@ func TestValidateUpdate(t *testing.T) {
 
 func TestDefault(t *testing.T) {
 	testcases := map[string]struct {
-		job                                    *batchv1.Job
-		objs                                   []runtime.Object
-		queues                                 []kueue.LocalQueue
-		clusterQueues                          []kueue.ClusterQueue
-		admissionCheck                         *kueue.AdmissionCheck
-		manageJobsWithoutQueueName             bool
-		multiKueueEnabled                      bool
-		multiKueueBatchJobWithManagedByEnabled bool
-		localQueueDefaulting                   bool
-		defaultLqExist                         bool
-		enableIntegrations                     []string
-		want                                   *batchv1.Job
-		wantErr                                error
+		job                        *batchv1.Job
+		objs                       []runtime.Object
+		queues                     []kueue.LocalQueue
+		clusterQueues              []kueue.ClusterQueue
+		admissionCheck             *kueue.AdmissionCheck
+		manageJobsWithoutQueueName bool
+		featureGates               map[featuregate.Feature]bool
+		defaultLqExist             bool
+		enableIntegrations         []string
+		want                       *batchv1.Job
+		wantErr                    error
 	}{
 		"update the suspend field with 'manageJobsWithoutQueueName=false'": {
 			job:  testingutil.MakeJob("job", "default").Queue("queue").Suspend(false).Obj(),
@@ -741,14 +740,14 @@ func TestDefault(t *testing.T) {
 			want:                       testingutil.MakeJob("job", "default").Obj(),
 		},
 		"no change in managed by: features.MultiKueueBatchJobWithManagedBy disabled": {
-			job:                                    testingutil.MakeJob("job", "default").Queue("queue").Suspend(false).Obj(),
-			multiKueueBatchJobWithManagedByEnabled: false,
-			want:                                   testingutil.MakeJob("job", "default").Queue("queue").Obj(),
+			job:          testingutil.MakeJob("job", "default").Queue("queue").Suspend(false).Obj(),
+			featureGates: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: false},
+			want:         testingutil.MakeJob("job", "default").Queue("queue").Obj(),
 		},
 		"no change in managed by: features.MultiKueue disabled": {
-			job:               testingutil.MakeJob("job", "default").Queue("queue").Suspend(false).Obj(),
-			multiKueueEnabled: false,
-			want:              testingutil.MakeJob("job", "default").Queue("queue").Obj(),
+			job:          testingutil.MakeJob("job", "default").Queue("queue").Suspend(false).Obj(),
+			featureGates: map[featuregate.Feature]bool{features.MultiKueue: false},
+			want:         testingutil.MakeJob("job", "default").Queue("queue").Obj(),
 		},
 		"managed by is defaulted: queue label was set": {
 			job: testingutil.MakeJob("job", "default").
@@ -773,8 +772,10 @@ func TestDefault(t *testing.T) {
 				Queue("local-queue").
 				ManagedBy(kueue.MultiKueueControllerName).
 				Obj(),
-			multiKueueEnabled:                      true,
-			multiKueueBatchJobWithManagedByEnabled: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueue:                      true,
+				features.MultiKueueBatchJobWithManagedBy: true,
+			},
 		},
 		"no change in managed by: user specified managed by": {
 			job: testingutil.MakeJob("job", "default").
@@ -800,8 +801,10 @@ func TestDefault(t *testing.T) {
 				Queue("local-queue").
 				ManagedBy("example.com/foo").
 				Obj(),
-			multiKueueEnabled:                      true,
-			multiKueueBatchJobWithManagedByEnabled: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueue:                      true,
+				features.MultiKueueBatchJobWithManagedBy: true,
+			},
 		},
 		"invalid queue name": {
 			job: testingutil.MakeJob("job", "default").
@@ -811,35 +814,37 @@ func TestDefault(t *testing.T) {
 			want: testingutil.MakeJob("job", "default").
 				Queue("invalid-local-queue").
 				Obj(),
-			multiKueueEnabled:                      true,
-			multiKueueBatchJobWithManagedByEnabled: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueue:                      true,
+				features.MultiKueueBatchJobWithManagedBy: true,
+			},
 		},
 		"LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			job:                  testingutil.MakeJob("test-job", "default").Obj(),
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: true,
+			job:            testingutil.MakeJob("test-job", "default").Obj(),
 			want: testingutil.MakeJob("test-job", "default").
 				Queue("default").
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, default lq is created, job has queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			job:                  testingutil.MakeJob("test-job", "").Queue("test-queue").Obj(),
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: true,
+			job:            testingutil.MakeJob("test-job", "").Queue("test-queue").Obj(),
 			want: testingutil.MakeJob("test-job", "").
 				Queue("test-queue").
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, default lq isn't created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       false,
-			job:                  testingutil.MakeJob("test-job", "").Obj(),
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: false,
+			job:            testingutil.MakeJob("test-job", "").Obj(),
 			want: testingutil.MakeJob("test-job", "").
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, job is managed by Kueue managed owner, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: true,
 			// MPIJob callBackFunction is registered as integrations since we initialize MPIJob integration package.
 			enableIntegrations: []string{"kubeflow.org/mpijob"},
 			job: testingutil.MakeJob("test-job", metav1.NamespaceDefault).
@@ -853,8 +858,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, job is managed by non Kueue managed owner, job has queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: true,
 			job: testingutil.MakeJob("test-job", metav1.NamespaceDefault).
 				OwnerReference("owner", jobsetapi.SchemeGroupVersion.WithKind("JobSet")).
 				Obj(),
@@ -866,9 +871,7 @@ func TestDefault(t *testing.T) {
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.MultiKueue, tc.multiKueueEnabled)
-			features.SetFeatureGateDuringTest(t, features.MultiKueueBatchJobWithManagedBy, tc.multiKueueBatchJobWithManagedByEnabled)
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			ctx, log := utiltesting.ContextWithLog(t)
 
@@ -928,9 +931,9 @@ func Test_applyWorkloadSliceSchedulingGate(t *testing.T) {
 	//   - WorkloadSlice feature enabled: true or false
 	//   - Job opt-in via annotation: present or absent
 	tests := map[string]struct {
-		featureEnabled bool
-		args           args
-		want           []corev1.PodSchedulingGate
+		featureGates map[featuregate.Feature]bool
+		args         args
+		want         []corev1.PodSchedulingGate
 	}{
 		"FeatureDisabledAndNotOptIn": {
 			args: args{job: &Job{}},
@@ -947,11 +950,11 @@ func Test_applyWorkloadSliceSchedulingGate(t *testing.T) {
 			},
 		},
 		"FeatureEnabledButNotOptIn": {
-			featureEnabled: true,
-			args:           args{job: &Job{}},
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			args:         args{job: &Job{}},
 		},
 		"FeatureEnabledAndOptIn": {
-			featureEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			args: args{
 				job: &Job{
 					ObjectMeta: metav1.ObjectMeta{
@@ -977,7 +980,7 @@ func Test_applyWorkloadSliceSchedulingGate(t *testing.T) {
 			},
 		},
 		"FeatureEnabledAndOptIn_SpecAlreadyContainsWorkloadSliceGate": {
-			featureEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			args: args{
 				job: &Job{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1003,7 +1006,7 @@ func Test_applyWorkloadSliceSchedulingGate(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, tt.featureEnabled)
+			features.SetFeatureGatesDuringTest(t, tt.featureGates)
 			applyWorkloadSliceSchedulingGate(tt.args.job)
 			if diff := cmp.Diff(tt.args.job.Spec.Template.Spec.SchedulingGates, tt.want); diff != "" {
 				t.Errorf("applyWorkloadSliceSchedulingGate() got(-),want(+): %s", diff)

--- a/pkg/controller/jobs/jobset/jobset_controller_test.go
+++ b/pkg/controller/jobs/jobset/jobset_controller_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -206,9 +207,9 @@ func TestPodSets(t *testing.T) {
 	jobSetTemplate := testingjobset.MakeJobSet("jobset", "ns")
 
 	testCases := map[string]struct {
-		jobSet                        *JobSet
-		wantPodSets                   func(jobSet *JobSet) []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		jobSet       *JobSet
+		wantPodSets  func(jobSet *JobSet) []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			jobSet: (*JobSet)(jobSetTemplate.Clone().
@@ -227,7 +228,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required topology annotation": {
 			jobSet: (*JobSet)(jobSetTemplate.Clone().
@@ -262,7 +263,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"with preferred topology annotation": {
 			jobSet: (*JobSet)(jobSetTemplate.Clone().
@@ -297,7 +298,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"without required and preferred topology annotation if TAS is disabled": {
 			jobSet: (*JobSet)(jobSetTemplate.Clone().
@@ -338,12 +339,12 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := tc.jobSet.PodSets(ctx)
 			if err != nil {

--- a/pkg/controller/jobs/jobset/jobset_webhook_test.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
@@ -48,10 +49,10 @@ var (
 
 func TestValidateCreate(t *testing.T) {
 	testcases := []struct {
-		name                    string
-		job                     *jobset.JobSet
-		wantErr                 error
-		topologyAwareScheduling bool
+		name         string
+		job          *jobset.JobSet
+		wantErr      error
+		featureGates map[featuregate.Feature]bool
 	}{
 		{
 			name:    "simple",
@@ -81,7 +82,7 @@ func TestValidateCreate(t *testing.T) {
 					kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 				},
 			}).Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid topology request",
@@ -100,7 +101,7 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{field.Invalid(field.NewPath("spec.replicatedJobs[1].template.spec.template.metadata.annotations"),
 				field.OmitValueType{}, `must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 					`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`)}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid slice topology request - slice size larger than number of podsets",
@@ -117,7 +118,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.replicatedJobs[0].template.spec.template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-slice-size"), "20", "must not be greater than pod set count 2"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "valid PodSet grouping request",
@@ -134,7 +135,7 @@ func TestValidateCreate(t *testing.T) {
 					kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 				},
 			}).Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid PodSet grouping request - groups of size other than 2",
@@ -176,7 +177,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.replicatedJobs[3].template.spec.template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-group-name"), "3podsets", "can only define groups of exactly 2 pod sets, got: 3 pod set(s)"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid PodSet grouping request - no leader in group",
@@ -202,7 +203,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.replicatedJobs[1].template.spec.template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-group-name"), "groupname", "can only define groups where at least one pod set has only 1 replica, got: 2 replica(s) and 3 replica(s) in the group"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid PodSet grouping request - required topology does not match",
@@ -226,7 +227,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.replicatedJobs[0].template.spec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.replicatedJobs[1].template.spec.template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.replicatedJobs[1].template.spec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.replicatedJobs[0].template.spec.template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid PodSet grouping request - preferred topology does not match",
@@ -250,7 +251,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.replicatedJobs[0].template.spec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.replicatedJobs[1].template.spec.template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.replicatedJobs[1].template.spec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.replicatedJobs[0].template.spec.template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid PodSet grouping request - different topology annotations within group",
@@ -274,13 +275,13 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.replicatedJobs[0].template.spec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.replicatedJobs[1].template.spec.template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.replicatedJobs[1].template.spec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.replicatedJobs[0].template.spec.template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			jsw := &JobSetWebhook{}
 			ctx, _ := utiltesting.ContextWithLog(t)
@@ -295,12 +296,12 @@ func TestValidateCreate(t *testing.T) {
 
 func TestValidateUpdate(t *testing.T) {
 	testcases := []struct {
-		name                    string
-		oldJob                  *jobset.JobSet
-		newJob                  *jobset.JobSet
-		wantValidationErrs      field.ErrorList
-		wantErr                 error
-		topologyAwareScheduling bool
+		name               string
+		oldJob             *jobset.JobSet
+		newJob             *jobset.JobSet
+		wantValidationErrs field.ErrorList
+		wantErr            error
+		featureGates       map[featuregate.Feature]bool
 	}{
 		{
 			name: "set valid topology request",
@@ -314,7 +315,7 @@ func TestValidateUpdate(t *testing.T) {
 					kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block",
 				},
 			}).Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "attempt to set invalid topology request",
@@ -332,13 +333,13 @@ func TestValidateUpdate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{field.Invalid(field.NewPath("spec.replicatedJobs[0].template.spec.template.metadata.annotations"),
 				field.OmitValueType{}, `must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 					`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`)},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotValidationErrs, gotErr := new(JobSetWebhook).validateUpdate(ctx, (*JobSet)(tc.oldJob), (*JobSet)(tc.newJob))
 			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.IgnoreFields(field.Error{})); diff != "" {
@@ -353,17 +354,16 @@ func TestValidateUpdate(t *testing.T) {
 
 func TestDefault(t *testing.T) {
 	testCases := []struct {
-		name                 string
-		jobSet               *jobset.JobSet
-		queues               []kueue.LocalQueue
-		clusterQueues        []kueue.ClusterQueue
-		admissionCheck       *kueue.AdmissionCheck
-		multiKueueEnabled    bool
-		localQueueDefaulting bool
-		defaultLqExist       bool
-		want                 *jobset.JobSet
-		wantManagedBy        *string
-		wantErr              error
+		name           string
+		jobSet         *jobset.JobSet
+		queues         []kueue.LocalQueue
+		clusterQueues  []kueue.ClusterQueue
+		admissionCheck *kueue.AdmissionCheck
+		featureGates   map[featuregate.Feature]bool
+		defaultLqExist bool
+		want           *jobset.JobSet
+		wantManagedBy  *string
+		wantErr        error
 	}{
 		{
 			name: "TestDefault_JobSetManagedBy_jobsetapi.JobSetControllerName",
@@ -392,8 +392,8 @@ func TestDefault(t *testing.T) {
 				ControllerName(kueue.MultiKueueControllerName).
 				Active(metav1.ConditionTrue).
 				Obj(),
-			multiKueueEnabled: true,
-			wantManagedBy:     ptr.To(kueue.MultiKueueControllerName),
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: ptr.To(kueue.MultiKueueControllerName),
 		},
 		{
 			name: "TestDefault_WithQueueLabel",
@@ -419,16 +419,16 @@ func TestDefault(t *testing.T) {
 				ControllerName(kueue.MultiKueueControllerName).
 				Active(metav1.ConditionTrue).
 				Obj(),
-			multiKueueEnabled: true,
-			wantManagedBy:     ptr.To(kueue.MultiKueueControllerName),
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: ptr.To(kueue.MultiKueueControllerName),
 		},
 		{
 			name: "TestDefault_WithoutQueueLabel",
 			jobSet: &jobset.JobSet{
 				ObjectMeta: ctrl.ObjectMeta{Namespace: "default"},
 			},
-			multiKueueEnabled: true,
-			wantManagedBy:     nil,
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: nil,
 		},
 		{
 			name: "TestDefault_InvalidQueueName",
@@ -438,7 +438,7 @@ func TestDefault(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			multiKueueEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueue: true},
 		},
 		{
 			name: "TestDefault_QueueNotFound",
@@ -450,7 +450,7 @@ func TestDefault(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			multiKueueEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueue: true},
 		},
 		{
 			name: "TestDefault_AdmissionCheckNotFound",
@@ -472,8 +472,8 @@ func TestDefault(t *testing.T) {
 					AdmissionChecks("non-existent-admission-check").
 					Obj(),
 			},
-			multiKueueEnabled: true,
-			wantManagedBy:     nil,
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: nil,
 		},
 		{
 			name: "TestDefault_MultiKueueFeatureDisabled",
@@ -499,8 +499,8 @@ func TestDefault(t *testing.T) {
 				ControllerName(kueue.MultiKueueControllerName).
 				Active(metav1.ConditionTrue).
 				Obj(),
-			multiKueueEnabled: false,
-			wantManagedBy:     nil,
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: false},
+			wantManagedBy: nil,
 		},
 		{
 			name: "TestDefault_UserSpecifiedManagedBy",
@@ -529,8 +529,8 @@ func TestDefault(t *testing.T) {
 				ControllerName(kueue.MultiKueueControllerName).
 				Active(metav1.ConditionTrue).
 				Obj(),
-			multiKueueEnabled: true,
-			wantManagedBy:     ptr.To("example.com/foo"),
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: ptr.To("example.com/foo"),
 		},
 		{
 			name: "TestDefault_ClusterQueueWithoutAdmissionCheck",
@@ -551,36 +551,35 @@ func TestDefault(t *testing.T) {
 				*utiltestingapi.MakeClusterQueue("cluster-queue").
 					Obj(),
 			},
-			multiKueueEnabled: true,
-			wantManagedBy:     nil,
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: nil,
 		},
 		{
-			name:                 "LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label",
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			jobSet:               testingutil.MakeJobSet("test-js", "default").Obj(),
-			want:                 testingutil.MakeJobSet("test-js", "default").Queue("default").Obj(),
+			name:           "LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label",
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: true,
+			jobSet:         testingutil.MakeJobSet("test-js", "default").Obj(),
+			want:           testingutil.MakeJobSet("test-js", "default").Queue("default").Obj(),
 		},
 		{
-			name:                 "LocalQueueDefaulting enabled, default lq is created, job has queue label",
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			jobSet:               testingutil.MakeJobSet("test-js", "default").Queue("queue").Obj(),
-			want:                 testingutil.MakeJobSet("test-js", "default").Queue("queue").Obj(),
+			name:           "LocalQueueDefaulting enabled, default lq is created, job has queue label",
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: true,
+			jobSet:         testingutil.MakeJobSet("test-js", "default").Queue("queue").Obj(),
+			want:           testingutil.MakeJobSet("test-js", "default").Queue("queue").Obj(),
 		},
 		{
-			name:                 "LocalQueueDefaulting enabled, default lq isn't created, job doesn't have queue label",
-			localQueueDefaulting: true,
-			defaultLqExist:       false,
-			jobSet:               testingutil.MakeJobSet("test-js", "default").Obj(),
-			want:                 testingutil.MakeJobSet("test-js", "default").Obj(),
+			name:           "LocalQueueDefaulting enabled, default lq isn't created, job doesn't have queue label",
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: false,
+			jobSet:         testingutil.MakeJobSet("test-js", "default").Obj(),
+			want:           testingutil.MakeJobSet("test-js", "default").Obj(),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.MultiKueue, tc.multiKueueEnabled)
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			ctx, log := utiltesting.ContextWithLog(t)
 

--- a/pkg/controller/jobs/kubeflow/jobs/jaxjob/jaxjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/jaxjob/jaxjob_controller_test.go
@@ -111,9 +111,9 @@ func TestOrderedReplicaTypes(t *testing.T) {
 
 func TestPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		job                *kftraining.JAXJob
-		wantPodSets        func(job *kftraining.JAXJob) []kueue.PodSet
-		enableFeatureGates []featuregate.Feature
+		job          *kftraining.JAXJob
+		wantPodSets  func(job *kftraining.JAXJob) []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingJAXjob.MakeJAXJob("JAXjob", "ns").
@@ -155,16 +155,12 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableFeatureGates: []featuregate.Feature{
-				features.TopologyAwareScheduling,
-			},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			for _, gate := range tc.enableFeatureGates {
-				features.SetFeatureGateDuringTest(t, gate, true)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := fromObject(tc.job).PodSets(ctx)
 			if err != nil {
@@ -179,10 +175,10 @@ func TestPodSets(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	testCases := map[string]struct {
-		job                     *kftraining.JAXJob
-		wantValidationErrs      field.ErrorList
-		wantErr                 error
-		topologyAwareScheduling bool
+		job                *kftraining.JAXJob
+		wantValidationErrs field.ErrorList
+		wantErr            error
+		featureGates       map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingJAXjob.MakeJAXJob("JAXjob", "ns").
@@ -206,7 +202,7 @@ func TestValidate(t *testing.T) {
 					},
 				).
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid TAS request": {
 			job: testingJAXjob.MakeJAXJob("JAXjob", "ns").
@@ -230,7 +226,7 @@ func TestValidate(t *testing.T) {
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid slice topology request - slice size larger than number of podsets": {
 			job: testingJAXjob.MakeJAXJob("JAXjob", "ns").
@@ -255,13 +251,12 @@ func TestValidate(t *testing.T) {
 					"20", "must not be greater than pod set count 3",
 				),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
-
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotValidationErrs, gotErr := fromObject(tc.job).ValidateOnCreate(ctx)
 			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {

--- a/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -235,9 +236,9 @@ func TestOrderedReplicaTypes(t *testing.T) {
 
 func TestPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		job                           *kftraining.PaddleJob
-		wantPodSets                   func(job *kftraining.PaddleJob) []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		job          *kftraining.PaddleJob
+		wantPodSets  func(job *kftraining.PaddleJob) []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingpaddlejob.MakePaddleJob("paddlejob", "ns").
@@ -262,7 +263,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required and preferred topology annotation": {
 			job: testingpaddlejob.MakePaddleJob("paddlejob", "ns").
@@ -299,7 +300,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"without required and preferred topology annotation if TAS is disabled": {
 			job: testingpaddlejob.MakePaddleJob("paddlejob", "ns").
@@ -332,12 +333,12 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := fromObject(tc.job).PodSets(ctx)
 			if err != nil {
@@ -352,10 +353,10 @@ func TestPodSets(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	testCases := map[string]struct {
-		job                     *kftraining.PaddleJob
-		wantValidationErrs      field.ErrorList
-		wantErr                 error
-		topologyAwareScheduling bool
+		job                *kftraining.PaddleJob
+		wantValidationErrs field.ErrorList
+		wantErr            error
+		featureGates       map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingpaddlejob.MakePaddleJob("paddlejob", "ns").PaddleReplicaSpecsDefault().Obj(),
@@ -379,7 +380,7 @@ func TestValidate(t *testing.T) {
 					},
 				).
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid TAS request": {
 			job: testingpaddlejob.MakePaddleJob("paddlejob", "ns").
@@ -418,7 +419,7 @@ func TestValidate(t *testing.T) {
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid slice topology request - slice size larger than number of podsets": {
 			job: testingpaddlejob.MakePaddleJob("paddlejob", "ns").
@@ -459,13 +460,12 @@ func TestValidate(t *testing.T) {
 					"20", "must not be greater than pod set count 10",
 				),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
-
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotValidationErrs, gotErr := fromObject(tc.job).ValidateOnCreate(ctx)
 			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {

--- a/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller_test.go
@@ -23,6 +23,7 @@ import (
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -226,9 +227,9 @@ func TestOrderedReplicaTypes(t *testing.T) {
 
 func TestPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		job                           *kftraining.PyTorchJob
-		wantPodSets                   func(job *kftraining.PyTorchJob) []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		job          *kftraining.PyTorchJob
+		wantPodSets  func(job *kftraining.PyTorchJob) []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingpytorchjob.MakePyTorchJob("pytorchjob", "ns").
@@ -253,7 +254,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required and preferred topology annotation": {
 			job: testingpytorchjob.MakePyTorchJob("pytorchjob", "ns").
@@ -290,7 +291,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"without required and preferred topology annotation if TAS is disabled": {
 			job: testingpytorchjob.MakePyTorchJob("pytorchjob", "ns").
@@ -323,12 +324,12 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := fromObject(tc.job).PodSets(ctx)
 			if err != nil {
@@ -343,10 +344,10 @@ func TestPodSets(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	testCases := map[string]struct {
-		job                     *kftraining.PyTorchJob
-		wantValidationErrs      field.ErrorList
-		wantErr                 error
-		topologyAwareScheduling bool
+		job                *kftraining.PyTorchJob
+		wantValidationErrs field.ErrorList
+		wantErr            error
+		featureGates       map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingpytorchjob.MakePyTorchJob("pytorchjob", "ns").
@@ -381,7 +382,7 @@ func TestValidate(t *testing.T) {
 					},
 				).
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid TAS request": {
 			job: testingpytorchjob.MakePyTorchJob("pytorchjob", "ns").
@@ -420,7 +421,7 @@ func TestValidate(t *testing.T) {
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid slice topology request - slice size larger than number of podsets": {
 			job: testingpytorchjob.MakePyTorchJob("pytorchjob", "ns").
@@ -461,13 +462,12 @@ func TestValidate(t *testing.T) {
 					"20", "must not be greater than pod set count 10",
 				),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
-
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotValidationErrs, gotErr := fromObject(tc.job).ValidateOnCreate(ctx)
 			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {

--- a/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_controller_test.go
@@ -23,6 +23,7 @@ import (
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -244,9 +245,9 @@ func TestOrderedReplicaTypes(t *testing.T) {
 
 func TestPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		job                           *kftraining.TFJob
-		wantPodSets                   func(job *kftraining.TFJob) []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		job          *kftraining.TFJob
+		wantPodSets  func(job *kftraining.TFJob) []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingtfjob.MakeTFJob("tfjob", "ns").TFReplicaSpecsDefault().Obj(),
@@ -263,7 +264,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required and preferred topology annotation": {
 			job: testingtfjob.MakeTFJob("tfjob", "ns").
@@ -308,7 +309,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"without required and preferred topology annotation if TAS is disabled": {
 			job: testingtfjob.MakeTFJob("tfjob", "ns").
@@ -348,12 +349,12 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := fromObject(tc.job).PodSets(ctx)
 			if err != nil {
@@ -368,10 +369,10 @@ func TestPodSets(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	testCases := map[string]struct {
-		job                     *kftraining.TFJob
-		wantValidationErrs      field.ErrorList
-		wantErr                 error
-		topologyAwareScheduling bool
+		job                *kftraining.TFJob
+		wantValidationErrs field.ErrorList
+		wantErr            error
+		featureGates       map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingtfjob.MakeTFJob("tfjob", "ns").TFReplicaSpecsDefault().Obj(),
@@ -399,7 +400,7 @@ func TestValidate(t *testing.T) {
 					},
 				).
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid TAS request": {
 			job: testingtfjob.MakeTFJob("tfjob", "ns").
@@ -445,7 +446,7 @@ func TestValidate(t *testing.T) {
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid slice topology request - slice size larger than number of podsets": {
 			job: testingtfjob.MakeTFJob("tfjob", "ns").
@@ -502,13 +503,12 @@ func TestValidate(t *testing.T) {
 					"20", "must not be greater than pod set count 10",
 				),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
-
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotValidationErrs, gotErr := fromObject(tc.job).ValidateOnCreate(ctx)
 			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {

--- a/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -233,9 +234,9 @@ func TestOrderedReplicaTypes(t *testing.T) {
 
 func TestPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		job                           *kftraining.XGBoostJob
-		wantPodSets                   func(job *kftraining.XGBoostJob) []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		job          *kftraining.XGBoostJob
+		wantPodSets  func(job *kftraining.XGBoostJob) []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingxgboostjob.MakeXGBoostJob("xgboostjob", "ns").
@@ -260,7 +261,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required and preferred topology annotation": {
 			job: testingxgboostjob.MakeXGBoostJob("xgboostjob", "ns").
@@ -297,7 +298,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"without required and preferred topology annotation if TAS is disabled": {
 			job: testingxgboostjob.MakeXGBoostJob("xgboostjob", "ns").
@@ -330,12 +331,12 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := fromObject(tc.job).PodSets(ctx)
 			if err != nil {
@@ -350,10 +351,10 @@ func TestPodSets(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	testCases := map[string]struct {
-		job                     *kftraining.XGBoostJob
-		wantValidationErrs      field.ErrorList
-		wantErr                 error
-		topologyAwareScheduling bool
+		job                *kftraining.XGBoostJob
+		wantValidationErrs field.ErrorList
+		wantErr            error
+		featureGates       map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: testingxgboostjob.MakeXGBoostJob("xgboostjob", "ns").
@@ -388,7 +389,7 @@ func TestValidate(t *testing.T) {
 					},
 				).
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid TAS request": {
 			job: testingxgboostjob.MakeXGBoostJob("xgboostjob", "ns").
@@ -427,7 +428,7 @@ func TestValidate(t *testing.T) {
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid slice topology request - slice size larger than number of podsets": {
 			job: testingxgboostjob.MakeXGBoostJob("xgboostjob", "ns").
@@ -468,13 +469,12 @@ func TestValidate(t *testing.T) {
 					"20", "must not be greater than pod set count 10",
 				),
 			},
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
-
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotValidationErrs, gotErr := fromObject(tc.job).ValidateOnCreate(ctx)
 			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -57,7 +57,7 @@ var (
 
 func TestReconciler(t *testing.T) {
 	cases := map[string]struct {
-		features                map[featuregate.Feature]bool
+		featureGates            map[featuregate.Feature]bool
 		labelKeysToCopy         []string
 		leaderWorkerSet         *leaderworkersetv1.LeaderWorkerSet
 		workloads               []kueue.Workload
@@ -68,7 +68,7 @@ func TestReconciler(t *testing.T) {
 		wantErr                 error
 	}{
 		"should create prebuilt workload": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
 			},
 			leaderWorkerSet:     leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testUID).Obj(),
@@ -109,7 +109,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should create prebuilt workload with leader template": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
 			},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
@@ -183,7 +183,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should create prebuilt workloads with leader template": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
 			},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
@@ -412,7 +412,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should create prebuilt workload without required topology annotation is TAS is disabled": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
 			},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
@@ -518,7 +518,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should create prebuilt workload with workload priority": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
 			},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
@@ -574,7 +574,7 @@ func TestReconciler(t *testing.T) {
 		// maxSurge > 0 alone would cause filterWorkloads to use stale status.Replicas, keeping the
 		// excess workload in toUpdate instead of toDelete.
 		"should delete excess workload on scale down with maxSurge configured but no active rolling update": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
 			},
 			leaderWorkerSet: func() *leaderworkersetv1.LeaderWorkerSet {
@@ -637,7 +637,7 @@ func TestReconciler(t *testing.T) {
 		// must be kept. This, paired with the test above, proves that maxSurge > 0 alone is
 		// not sufficient — the UpdatedReplicas check is needed to distinguish the two cases.
 		"should keep surge workloads during active rolling update with maxSurge": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
 			},
 			leaderWorkerSet: func() *leaderworkersetv1.LeaderWorkerSet {
@@ -730,7 +730,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should delete LeaderWorkerSet ownerReference from the redundant prebuilt workload": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
 			},
 			leaderWorkerSet:     leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testUID).Obj(),
@@ -799,9 +799,7 @@ func TestReconciler(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			for feature, enable := range tc.features {
-				features.SetFeatureGateDuringTest(t, feature, enable)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			clientBuilder := utiltesting.NewClientBuilder(leaderworkersetv1.AddToScheme)
 			indexer := utiltesting.AsIndexer(clientBuilder)

--- a/pkg/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -196,9 +197,9 @@ func TestPodSets(t *testing.T) {
 	)
 
 	testCases := map[string]struct {
-		job                           *MPIJob
-		wantPodSets                   []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		job          *MPIJob
+		wantPodSets  []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			job: (*MPIJob)(jobTemplate.DeepCopy()),
@@ -210,7 +211,7 @@ func TestPodSets(t *testing.T) {
 					PodSpec(jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker].Template.Spec).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required topology annotation": {
 			job: (*MPIJob)(jobTemplate.Clone().
@@ -240,7 +241,7 @@ func TestPodSets(t *testing.T) {
 					PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"with preferred topology annotation": {
 			job: (*MPIJob)(jobTemplate.Clone().
@@ -270,7 +271,7 @@ func TestPodSets(t *testing.T) {
 					PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"without required and preferred topology annotation if TAS is disabled": {
 			job: (*MPIJob)(jobTemplate.Clone().
@@ -296,7 +297,7 @@ func TestPodSets(t *testing.T) {
 					Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"without preferred topology annotation if TAS is disabled": {
 			job: (*MPIJob)(jobTemplate.Clone().
@@ -322,12 +323,12 @@ func TestPodSets(t *testing.T) {
 					Annotations(map[string]string{kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 					Obj(),
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := tc.job.PodSets(ctx)
 			if err != nil {

--- a/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -48,10 +49,10 @@ var (
 
 func TestValidateCreate(t *testing.T) {
 	testcases := []struct {
-		name                    string
-		job                     *v2beta1.MPIJob
-		wantErr                 error
-		topologyAwareScheduling bool
+		name         string
+		job          *v2beta1.MPIJob
+		wantErr      error
+		featureGates map[featuregate.Feature]bool
 	}{
 		{
 			name:    "simple",
@@ -85,7 +86,7 @@ func TestValidateCreate(t *testing.T) {
 				PodAnnotation(v2beta1.MPIReplicaTypeLauncher, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid topology request",
@@ -118,7 +119,7 @@ func TestValidateCreate(t *testing.T) {
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid slice topology request - slice size larger than number of podsets",
@@ -147,7 +148,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.mpiReplicaSpecs[Worker].template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-slice-size"), "20", "must not be greater than pod set count 3"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "valid PodSet grouping request",
@@ -168,7 +169,7 @@ func TestValidateCreate(t *testing.T) {
 				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetGroupName, "groupname").
 				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid PodSet grouping request - groups of size other than 2",
@@ -195,7 +196,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.mpiReplicaSpecs[Worker].template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-group-name"), "groupname2", "can only define groups of exactly 2 pod sets, got: 1 pod set(s)"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid PodSet grouping request - no leader in group",
@@ -222,7 +223,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.mpiReplicaSpecs[Worker].template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-group-name"), "groupname", "can only define groups where at least one pod set has only 1 replica, got: 2 replica(s) and 3 replica(s) in the group"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid PodSet grouping request - required topology does not match",
@@ -247,7 +248,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.mpiReplicaSpecs[Launcher].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.mpiReplicaSpecs[Worker].template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.mpiReplicaSpecs[Worker].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.mpiReplicaSpecs[Launcher].template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid PodSet grouping request - preferred topology does not match",
@@ -272,7 +273,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.mpiReplicaSpecs[Launcher].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.mpiReplicaSpecs[Worker].template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.mpiReplicaSpecs[Worker].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.mpiReplicaSpecs[Launcher].template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
 			name: "invalid PodSet grouping request - different topology annotations within group",
@@ -297,13 +298,13 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.mpiReplicaSpecs[Launcher].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.mpiReplicaSpecs[Worker].template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.mpiReplicaSpecs[Worker].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.mpiReplicaSpecs[Launcher].template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			jsw := &MpiJobWebhook{}
 			ctx, _ := utiltesting.ContextWithLog(t)
@@ -318,18 +319,16 @@ func TestValidateCreate(t *testing.T) {
 
 func TestDefault(t *testing.T) {
 	testCases := []struct {
-		name                    string
-		mpiJob                  *v2beta1.MPIJob
-		queues                  []kueue.LocalQueue
-		clusterQueues           []kueue.ClusterQueue
-		admissionCheck          *kueue.AdmissionCheck
-		multiKueueEnabled       bool
-		localQueueDefaulting    bool
-		topologyAwareScheduling bool
-		defaultLqExist          bool
-		want                    *v2beta1.MPIJob
-		wantManagedBy           *string
-		wantErr                 error
+		name           string
+		mpiJob         *v2beta1.MPIJob
+		queues         []kueue.LocalQueue
+		clusterQueues  []kueue.ClusterQueue
+		admissionCheck *kueue.AdmissionCheck
+		featureGates   map[featuregate.Feature]bool
+		defaultLqExist bool
+		want           *v2beta1.MPIJob
+		wantManagedBy  *string
+		wantErr        error
 	}{
 		{
 			name: "TestDefault_MPIJobManagedBy_mpijobapi.MPIJobControllerName",
@@ -360,8 +359,8 @@ func TestDefault(t *testing.T) {
 				ControllerName(kueue.MultiKueueControllerName).
 				Active(metav1.ConditionTrue).
 				Obj(),
-			multiKueueEnabled: true,
-			wantManagedBy:     ptr.To(kueue.MultiKueueControllerName),
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: ptr.To(kueue.MultiKueueControllerName),
 		},
 		{
 			name: "TestDefault_WithQueueLabel",
@@ -387,16 +386,16 @@ func TestDefault(t *testing.T) {
 				ControllerName(kueue.MultiKueueControllerName).
 				Active(metav1.ConditionTrue).
 				Obj(),
-			multiKueueEnabled: true,
-			wantManagedBy:     ptr.To(kueue.MultiKueueControllerName),
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: ptr.To(kueue.MultiKueueControllerName),
 		},
 		{
 			name: "TestDefault_WithoutQueueLabel",
 			mpiJob: &v2beta1.MPIJob{
 				ObjectMeta: ctrl.ObjectMeta{Namespace: "default"},
 			},
-			multiKueueEnabled: true,
-			wantManagedBy:     nil,
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: nil,
 		},
 		{
 			name: "TestDefault_InvalidQueueName",
@@ -406,7 +405,7 @@ func TestDefault(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			multiKueueEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueue: true},
 		},
 		{
 			name: "TestDefault_QueueNotFound",
@@ -418,7 +417,7 @@ func TestDefault(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			multiKueueEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.MultiKueue: true},
 		},
 		{
 			name: "TestDefault_AdmissionCheckNotFound",
@@ -440,8 +439,8 @@ func TestDefault(t *testing.T) {
 					AdmissionChecks("non-existent-admission-check").
 					Obj(),
 			},
-			multiKueueEnabled: true,
-			wantManagedBy:     nil,
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: nil,
 		},
 		{
 			name: "TestDefault_MultiKueueFeatureDisabled",
@@ -467,8 +466,8 @@ func TestDefault(t *testing.T) {
 				ControllerName(kueue.MultiKueueControllerName).
 				Active(metav1.ConditionTrue).
 				Obj(),
-			multiKueueEnabled: false,
-			wantManagedBy:     nil,
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: false},
+			wantManagedBy: nil,
 		},
 		{
 			name: "TestDefault_UserSpecifiedManagedBy",
@@ -499,8 +498,8 @@ func TestDefault(t *testing.T) {
 				ControllerName(kueue.MultiKueueControllerName).
 				Active(metav1.ConditionTrue).
 				Obj(),
-			multiKueueEnabled: true,
-			wantManagedBy:     ptr.To("example.com/foo"),
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: ptr.To("example.com/foo"),
 		},
 		{
 			name: "TestDefault_ClusterQueueWithoutAdmissionCheck",
@@ -521,33 +520,33 @@ func TestDefault(t *testing.T) {
 				*utiltestingapi.MakeClusterQueue("cluster-queue").
 					Obj(),
 			},
-			multiKueueEnabled: true,
-			wantManagedBy:     nil,
+			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
+			wantManagedBy: nil,
 		},
 		{
-			name:                 "LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label",
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			mpiJob:               testingutil.MakeMPIJob("job", "default").Obj(),
-			want:                 testingutil.MakeMPIJob("job", "default").Queue("default").Obj(),
+			name:           "LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label",
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: true,
+			mpiJob:         testingutil.MakeMPIJob("job", "default").Obj(),
+			want:           testingutil.MakeMPIJob("job", "default").Queue("default").Obj(),
 		},
 		{
-			name:                 "LocalQueueDefaulting enabled, default lq is created, job has queue label",
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			mpiJob:               testingutil.MakeMPIJob("job", "default").Queue("queue").Obj(),
-			want:                 testingutil.MakeMPIJob("job", "default").Queue("queue").Obj(),
+			name:           "LocalQueueDefaulting enabled, default lq is created, job has queue label",
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: true,
+			mpiJob:         testingutil.MakeMPIJob("job", "default").Queue("queue").Obj(),
+			want:           testingutil.MakeMPIJob("job", "default").Queue("queue").Obj(),
 		},
 		{
-			name:                 "LocalQueueDefaulting enabled, default lq isn't created, job doesn't have queue label",
-			localQueueDefaulting: true,
-			defaultLqExist:       false,
-			mpiJob:               testingutil.MakeMPIJob("job", "default").Obj(),
-			want:                 testingutil.MakeMPIJob("job", "default").Obj(),
+			name:           "LocalQueueDefaulting enabled, default lq isn't created, job doesn't have queue label",
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: false,
+			mpiJob:         testingutil.MakeMPIJob("job", "default").Obj(),
+			want:           testingutil.MakeMPIJob("job", "default").Obj(),
 		},
 		{
-			name:                    "TAS enabled, RunLauncherAsWorker true with 2 replica specs",
-			topologyAwareScheduling: true,
+			name:         "TAS enabled, RunLauncherAsWorker true with 2 replica specs",
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			mpiJob: testingutil.MakeMPIJob("job", "default").
 				Queue("queue").
 				MPIJobReplicaSpecs(
@@ -579,8 +578,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		{
-			name:                    "TAS enabled, RunLauncherAsWorker false",
-			topologyAwareScheduling: true,
+			name:         "TAS enabled, RunLauncherAsWorker false",
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			mpiJob: testingutil.MakeMPIJob("job", "default").
 				Queue("queue").
 				MPIJobReplicaSpecs(
@@ -611,8 +610,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		{
-			name:                    "TAS enabled, RunLauncherAsWorker nil",
-			topologyAwareScheduling: true,
+			name:         "TAS enabled, RunLauncherAsWorker nil",
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			mpiJob: testingutil.MakeMPIJob("job", "default").
 				Queue("queue").
 				MPIJobReplicaSpecs(
@@ -641,8 +640,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		{
-			name:                    "TAS disabled, RunLauncherAsWorker true",
-			topologyAwareScheduling: false,
+			name:         "TAS disabled, RunLauncherAsWorker true",
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			mpiJob: testingutil.MakeMPIJob("job", "default").
 				Queue("queue").
 				MPIJobReplicaSpecs(
@@ -673,8 +672,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		{
-			name:                    "TAS enabled, RunLauncherAsWorker true, only Launcher replica",
-			topologyAwareScheduling: true,
+			name:         "TAS enabled, RunLauncherAsWorker true, only Launcher replica",
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			mpiJob: testingutil.MakeMPIJob("job", "default").
 				Queue("queue").
 				GenericLauncher().
@@ -687,8 +686,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		{
-			name:                    "TAS enabled, RunLauncherAsWorker true, Worker has existing annotations",
-			topologyAwareScheduling: true,
+			name:         "TAS enabled, RunLauncherAsWorker true, Worker has existing annotations",
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			mpiJob: testingutil.MakeMPIJob("job", "default").
 				Queue("queue").
 				MPIJobReplicaSpecs(
@@ -722,8 +721,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		{
-			name:                    "TAS enabled, RunLauncherAsWorker true, Launcher has PodSetGroupName annotation",
-			topologyAwareScheduling: true,
+			name:         "TAS enabled, RunLauncherAsWorker true, Launcher has PodSetGroupName annotation",
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			mpiJob: testingutil.MakeMPIJob("job", "default").
 				Queue("queue").
 				MPIJobReplicaSpecs(
@@ -759,9 +758,7 @@ func TestDefault(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.MultiKueue, tc.multiKueueEnabled)
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			ctx, log := utiltesting.ContextWithLog(t)
 

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -135,9 +136,9 @@ func TestRun(t *testing.T) {
 
 func TestPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		pod                           *Pod
-		wantPodSets                   func(pod *Pod) []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		pod          *Pod
+		wantPodSets  func(pod *Pod) []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			pod: FromObject(testingpod.MakePod("pod", "ns").Obj()),
@@ -148,7 +149,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required topology annotation": {
 			pod: FromObject(testingpod.MakePod("pod", "ns").
@@ -164,7 +165,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"with required topology preferred": {
 			pod: FromObject(testingpod.MakePod("pod", "ns").
@@ -180,7 +181,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"without required topology annotation if TAS is disabled": {
 			pod: FromObject(testingpod.MakePod("pod", "ns").
@@ -194,7 +195,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"without preferred topology annotation if TAS is disabled": {
 			pod: FromObject(testingpod.MakePod("pod", "ns").
@@ -208,12 +209,13 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := tc.pod.PodSets(ctx)
 			if err != nil {
@@ -263,7 +265,7 @@ func TestReconciler(t *testing.T) {
 	podUID := "dc85db45"
 
 	testCases := map[string]struct {
-		enableObjectRetentionPolicies bool
+		featureGates map[featuregate.Feature]bool
 
 		reconcileKey           *types.NamespacedName
 		initObjects            []client.Object
@@ -5489,7 +5491,8 @@ func TestReconciler(t *testing.T) {
 			wantErr:         jobframework.ErrPrebuiltWorkloadNotFound,
 		},
 		"when workload is deactivated by kueue; objectRetentionPolicies.workloads.afterDeactivatedByKueue=0; should delete the job": {
-			enableObjectRetentionPolicies: true,
+			featureGates: map[featuregate.Feature]bool{features.ObjectRetentionPolicies: true},
+
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithObjectRetentionPolicies(&configapi.ObjectRetentionPolicies{
 					Workloads: &configapi.WorkloadRetentionPolicy{
@@ -5586,7 +5589,7 @@ func TestReconciler(t *testing.T) {
 	for name, tc := range testCases {
 		for _, enabled := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", name, enabled), func(t *testing.T) {
-				features.SetFeatureGateDuringTest(t, features.ObjectRetentionPolicies, tc.enableObjectRetentionPolicies)
+				features.SetFeatureGatesDuringTest(t, tc.featureGates)
 				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, enabled)
 
 				ctx, log := utiltesting.ContextWithLog(t)

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -84,12 +84,9 @@ func TestDefault(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		enableTopologyAwareScheduling bool
-
-		features                     map[featuregate.Feature]bool
+		featureGates                 map[featuregate.Feature]bool
 		initObjects                  []client.Object
 		pod                          *corev1.Pod
-		localQueueDefaulting         bool
 		defaultLqExist               bool
 		manageJobsWithoutQueueName   bool
 		managedJobsNamespaceSelector labels.Selector
@@ -100,7 +97,8 @@ func TestDefault(t *testing.T) {
 		wantErr                      error
 	}{
 		"pod with suspend by parent annotation shouldn't skip finalizer when SkipFinalizersForPodsSuspendedByParent disabled": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                false,
 				features.SkipFinalizersForPodsSuspendedByParent: false,
 			},
 			initObjects: []client.Object{defaultNamespace},
@@ -117,7 +115,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with suspend by parent annotation should skip finalizer when SkipFinalizersForPodsSuspendedByParent enabled": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                false,
 				features.SkipFinalizersForPodsSuspendedByParent: true,
 			},
 			initObjects: []client.Object{defaultNamespace},
@@ -133,7 +132,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with queue nil ns selector": {
-			initObjects: []client.Object{defaultNamespace},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			initObjects:  []client.Object{defaultNamespace},
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
 				Obj(),
@@ -146,7 +146,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with queue matching ns selector": {
-			initObjects: []client.Object{defaultNamespace},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			initObjects:  []client.Object{defaultNamespace},
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
 				Obj(),
@@ -161,7 +162,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod without queue matching ns selector manage jobs without queue name": {
-			initObjects: []client.Object{defaultNamespace},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			initObjects:  []client.Object{defaultNamespace},
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Obj(),
 			manageJobsWithoutQueueName: true,
@@ -175,6 +177,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with owner managed by kueue (Job) while not enabled": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects: []client.Object{
 				defaultNamespace,
 				testingjob.MakeJob("parent-job", defaultNamespace.Name).UID("parent-job").Queue("test-queue").Obj(),
@@ -195,6 +198,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with owner managed by kueue (Job)": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects: []client.Object{
 				defaultNamespace,
 				testingjob.MakeJob("parent-job", defaultNamespace.Name).UID("parent-job").Queue("test-queue").Obj(),
@@ -212,6 +216,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with owner managed by kueue (RayCluster)": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects: []client.Object{
 				defaultNamespace,
 				&rayv1.RayCluster{
@@ -238,6 +243,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with owner managed by kueue (MPIJob)": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects: []client.Object{
 				defaultNamespace,
 				testingmpijob.MakeMPIJob("parent-mpi-job", defaultNamespace.Name).UID("parent-mpi-job").Queue("test-queue").Obj(),
@@ -261,6 +267,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with owner managed by kueue (PyTorchJob)": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects: []client.Object{
 				defaultNamespace,
 				testingpytorchjob.MakePyTorchJob("parent-pytorch-job", defaultNamespace.Name).UID("parent-pytorch-job").Queue("test-queue").Obj(),
@@ -284,6 +291,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with owner managed by kueue (TFJob)": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects: []client.Object{
 				defaultNamespace,
 				testingtfjob.MakeTFJob("parent-tf-job", defaultNamespace.Name).UID("parent-tf-job").Queue("test-queue").Obj(),
@@ -307,6 +315,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with owner managed by kueue (XGBoostJob)": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects: []client.Object{
 				defaultNamespace,
 				testingxgboostjob.MakeXGBoostJob("parent-xgboost-job", defaultNamespace.Name).UID("parent-xgboost-job").Queue("test-queue").Obj(),
@@ -330,6 +339,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with owner managed by kueue (PaddleJob)": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects: []client.Object{
 				defaultNamespace,
 				paddlejob.MakePaddleJob("parent-paddle-job", defaultNamespace.Name).UID("parent-paddle-job").Queue("test-queue").Obj(),
@@ -353,6 +363,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with a group name label, but without group total count label": {
+			featureGates:      map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects:       []client.Object{defaultNamespace},
 			podSelector:       &metav1.LabelSelector{},
 			namespaceSelector: defaultNamespaceSelector,
@@ -370,6 +381,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with a group name label": {
+			featureGates:      map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects:       []client.Object{defaultNamespace},
 			podSelector:       &metav1.LabelSelector{},
 			namespaceSelector: defaultNamespaceSelector,
@@ -387,10 +399,10 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with TAS": {
-			enableTopologyAwareScheduling: true,
-			initObjects:                   []client.Object{defaultNamespace},
-			podSelector:                   &metav1.LabelSelector{},
-			namespaceSelector:             defaultNamespaceSelector,
+			featureGates:      map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+			initObjects:       []client.Object{defaultNamespace},
+			podSelector:       &metav1.LabelSelector{},
+			namespaceSelector: defaultNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
 				Annotation(kueue.PodSetRequiredTopologyAnnotation, "block").
@@ -406,10 +418,10 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"pod with TAS and PodGroupPodIndexLabelAnnotation": {
-			enableTopologyAwareScheduling: true,
-			initObjects:                   []client.Object{defaultNamespace},
-			podSelector:                   &metav1.LabelSelector{},
-			namespaceSelector:             defaultNamespaceSelector,
+			featureGates:      map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+			initObjects:       []client.Object{defaultNamespace},
+			podSelector:       &metav1.LabelSelector{},
+			namespaceSelector: defaultNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
 				Label("test-label", "test-value").
@@ -430,11 +442,14 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, default queue is created, pod has no queue label": {
-			initObjects:          []client.Object{defaultNamespace},
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			podSelector:          &metav1.LabelSelector{},
-			namespaceSelector:    defaultNamespaceSelector,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling: false,
+				features.LocalQueueDefaulting:    true,
+			},
+			initObjects:       []client.Object{defaultNamespace},
+			defaultLqExist:    true,
+			podSelector:       &metav1.LabelSelector{},
+			namespaceSelector: defaultNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Obj(),
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
@@ -446,22 +461,28 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, default queue isn't created, pod has no queue label": {
-			initObjects:          []client.Object{defaultNamespace},
-			localQueueDefaulting: true,
-			defaultLqExist:       false,
-			podSelector:          &metav1.LabelSelector{},
-			namespaceSelector:    defaultNamespaceSelector,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling: false,
+				features.LocalQueueDefaulting:    true,
+			},
+			initObjects:       []client.Object{defaultNamespace},
+			defaultLqExist:    false,
+			podSelector:       &metav1.LabelSelector{},
+			namespaceSelector: defaultNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Obj(),
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, default queue is created, pod has queue label": {
-			initObjects:          []client.Object{defaultNamespace},
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			podSelector:          &metav1.LabelSelector{},
-			namespaceSelector:    defaultNamespaceSelector,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling: false,
+				features.LocalQueueDefaulting:    true,
+			},
+			initObjects:       []client.Object{defaultNamespace},
+			defaultLqExist:    true,
+			podSelector:       &metav1.LabelSelector{},
+			namespaceSelector: defaultNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("queue").
 				Obj(),
@@ -474,6 +495,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"the namespace matches the selector": {
+			featureGates:                 map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects:                  []client.Object{defaultNamespace},
 			managedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
@@ -488,6 +510,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"doesn’t match the managedJobsNamespaceSelector": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects: []client.Object{
 				utiltesting.MakeNamespaceWrapper("kube-system").Label(corev1.LabelMetadataName, "kube-system").Obj(),
 			},
@@ -500,6 +523,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"the namespace matches the namespace selector": {
+			featureGates:      map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects:       []client.Object{defaultNamespace},
 			namespaceSelector: defaultNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
@@ -514,6 +538,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"the namespace doesn't match the namespace selector": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects: []client.Object{
 				utiltesting.MakeNamespaceWrapper("kube-system").Label(corev1.LabelMetadataName, "kube-system").Obj(),
 			},
@@ -526,8 +551,9 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"the pod matches the pod selector": {
-			initObjects: []client.Object{defaultNamespace},
-			podSelector: defaultPodSelector,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			initObjects:  []client.Object{defaultNamespace},
+			podSelector:  defaultPodSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Label(corev1.LabelMetadataName, "test-pod").
 				Queue("queue").
@@ -542,8 +568,9 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"the pod doesn't match the pod selector": {
-			initObjects: []client.Object{defaultNamespace},
-			podSelector: defaultPodSelector,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			initObjects:  []client.Object{defaultNamespace},
+			podSelector:  defaultPodSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Label(corev1.LabelMetadataName, "kube-system").
 				Queue("queue").
@@ -557,11 +584,7 @@ func TestDefault(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			for feature, enabled := range tc.features {
-				features.SetFeatureGateDuringTest(t, feature, enabled)
-			}
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			t.Cleanup(jobframework.EnableIntegrationsForTest(t, tc.enableIntegrations...))
 			builder := utiltesting.NewClientBuilder(rayv1.AddToScheme, kfmpi.AddToScheme, kftraining.AddToScheme, appsv1.AddToScheme)
 			builder = builder.WithObjects(tc.initObjects...)

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -45,10 +45,9 @@ import (
 
 func TestBuildPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		rayClusterSpec                *rayv1.RayClusterSpec
-		wantPodSets                   []kueue.PodSet
-		enableTopologyAwareScheduling bool
-		wantErr                       bool
+		rayClusterSpec *rayv1.RayClusterSpec
+		wantPodSets    []kueue.PodSet
+		wantErr        bool
 	}{
 		"basic spec with head and single worker group": {
 			rayClusterSpec: &rayv1.RayClusterSpec{
@@ -204,8 +203,6 @@ func TestBuildPodSets(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
-
 			gotPodSets, err := BuildPodSets(tc.rayClusterSpec)
 
 			if tc.wantErr {

--- a/pkg/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -60,9 +61,9 @@ var (
 
 func TestPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		rayCluster                    *RayCluster
-		wantPodSets                   func(rayJob *RayCluster) []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		rayCluster   *RayCluster
+		wantPodSets  func(rayJob *RayCluster) []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			rayCluster: (*RayCluster)(testingrayutil.MakeCluster("raycluster", "ns").
@@ -102,7 +103,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required topology annotation": {
 			rayCluster: (*RayCluster)(testingrayutil.MakeCluster("raycluster", "ns").
@@ -156,7 +157,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"with preferred topology annotation": {
 			rayCluster: (*RayCluster)(testingrayutil.MakeCluster("raycluster", "ns").
@@ -210,7 +211,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"without required and preferred topology annotation if TAS is disabled": {
 			rayCluster: (*RayCluster)(testingrayutil.MakeCluster("raycluster", "ns").
@@ -278,12 +279,12 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := tc.rayCluster.PodSets(ctx)
 			if err != nil {

--- a/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
@@ -26,6 +26,7 @@ import (
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -40,11 +41,11 @@ import (
 
 func TestValidateDefault(t *testing.T) {
 	testcases := map[string]struct {
-		oldJob               *rayv1.RayCluster
-		newJob               *rayv1.RayCluster
-		manageAll            bool
-		localQueueDefaulting bool
-		defaultLqExist       bool
+		oldJob         *rayv1.RayCluster
+		newJob         *rayv1.RayCluster
+		manageAll      bool
+		featureGates   map[featuregate.Feature]bool
+		defaultLqExist bool
 	}{
 		"unmanaged": {
 			oldJob: testingrayutil.MakeCluster("job", "ns").
@@ -74,25 +75,25 @@ func TestValidateDefault(t *testing.T) {
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			oldJob:               testingrayutil.MakeCluster("test-job", "default").Obj(),
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: true,
+			oldJob:         testingrayutil.MakeCluster("test-job", "default").Obj(),
 			newJob: testingrayutil.MakeCluster("test-job", "default").
 				Queue("default").
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, default lq is created, job has queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			oldJob:               testingrayutil.MakeCluster("test-job", "").Queue("test-queue").Obj(),
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: true,
+			oldJob:         testingrayutil.MakeCluster("test-job", "").Queue("test-queue").Obj(),
 			newJob: testingrayutil.MakeCluster("test-job", "").
 				Queue("test-queue").
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, default lq isn't created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       false,
-			oldJob:               testingrayutil.MakeCluster("test-job", "").Obj(),
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: false,
+			oldJob:         testingrayutil.MakeCluster("test-job", "").Obj(),
 			newJob: testingrayutil.MakeCluster("test-job", "").
 				Obj(),
 		},
@@ -100,7 +101,7 @@ func TestValidateDefault(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			builder := utiltesting.NewClientBuilder()
 			cli := builder.Build()
@@ -134,10 +135,10 @@ func TestValidateCreate(t *testing.T) {
 	bigWorkerGroup := []rayv1.WorkerGroupSpec{worker, worker, worker, worker, worker, worker, worker, worker}
 
 	testcases := map[string]struct {
-		job                     *rayv1.RayCluster
-		manageAll               bool
-		wantErr                 error
-		topologyAwareScheduling bool
+		job          *rayv1.RayCluster
+		manageAll    bool
+		wantErr      error
+		featureGates map[featuregate.Feature]bool
 	}{
 		"invalid unmanaged": {
 			job: testingrayutil.MakeCluster("job", "ns").
@@ -205,7 +206,7 @@ func TestValidateCreate(t *testing.T) {
 					rayv1.WorkerGroupSpec{GroupName: "wg3"},
 				).
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid topology request": {
 			job: testingrayutil.MakeCluster("raycluster", "ns").Queue("queue").
@@ -245,7 +246,7 @@ func TestValidateCreate(t *testing.T) {
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid slice topology request - slice size larger than number of podsets": {
 			job: testingrayutil.MakeCluster("raycluster", "ns").Queue("queue").
@@ -297,7 +298,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.workerGroupSpecs[1].template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-slice-size"), "20", "must not be greater than pod set count 10"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"valid PodSet grouping request": {
 			job: testingrayutil.MakeCluster("raycluster", "ns").Queue("queue").
@@ -325,7 +326,7 @@ func TestValidateCreate(t *testing.T) {
 					},
 				).
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid PodSet grouping request - groups of size other than 2": {
 			job: testingrayutil.MakeCluster("rayjob", "ns").Queue("queue").
@@ -388,7 +389,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.workerGroupSpecs[2].template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-group-name"), "3podsets", "can only define groups of exactly 2 pod sets, got: 3 pod set(s)"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid PodSet grouping request - no leader in group": {
 			job: testingrayutil.MakeCluster("rayjob", "ns").Queue("queue").
@@ -425,7 +426,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.workerGroupSpecs[1].template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-group-name"), "groupname", "can only define groups where at least one pod set has only 1 replica, got: 5 replica(s) and 10 replica(s) in the group"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid PodSet grouping request - required topology does not match": {
 			job: testingrayutil.MakeCluster("rayjob", "ns").Queue("queue").
@@ -458,7 +459,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.headGroupSpec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.workerGroupSpecs[0].template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.workerGroupSpecs[0].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.headGroupSpec.template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid PodSet grouping request - preferred topology does not match": {
 			job: testingrayutil.MakeCluster("rayjob", "ns").Queue("queue").
@@ -491,7 +492,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.headGroupSpec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.workerGroupSpecs[0].template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.workerGroupSpecs[0].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.headGroupSpec.template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid PodSet grouping request - different topology annotations within group": {
 			job: testingrayutil.MakeCluster("rayjob", "ns").Queue("queue").
@@ -524,13 +525,13 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.headGroupSpec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.workerGroupSpecs[0].template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.workerGroupSpecs[0].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.headGroupSpec.template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			wh := &RayClusterWebhook{
 				manageJobsWithoutQueueName: tc.manageAll,
 			}

--- a/pkg/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -40,9 +41,9 @@ import (
 
 func TestPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		rayJob                        *RayJob
-		wantPodSets                   func(rayJob *RayJob) []kueue.PodSet
-		enableTopologyAwareScheduling bool
+		rayJob       *RayJob
+		wantPodSets  func(rayJob *RayJob) []kueue.PodSet
+		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
 			rayJob: (*RayJob)(testingrayutil.MakeJob("rayjob", "ns").
@@ -82,7 +83,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with required topology annotation": {
 			rayJob: (*RayJob)(testingrayutil.MakeJob("rayjob", "ns").
@@ -136,7 +137,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"with preferred topology annotation": {
 			rayJob: (*RayJob)(testingrayutil.MakeJob("rayjob", "ns").
@@ -190,7 +191,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"without required and preferred topology annotation if TAS is disabled": {
 			rayJob: (*RayJob)(testingrayutil.MakeJob("rayjob", "ns").
@@ -248,7 +249,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with submitter topology annotation not specified": {
 			rayJob: (*RayJob)(testingrayutil.MakeJob("rayjob", "ns").
@@ -297,7 +298,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"with submitter topology annotation specified": {
 			rayJob: (*RayJob)(testingrayutil.MakeJob("rayjob", "ns").
@@ -363,7 +364,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"with NumOfHosts > 1": {
 			rayJob: (*RayJob)(testingrayutil.MakeJob("rayjob", "ns").
@@ -405,7 +406,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with default job submitter": {
 			rayJob: (*RayJob)(testingrayutil.MakeJob("rayjob", "ns").
@@ -449,7 +450,7 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 		"with submitter job pod template override": {
 			rayJob: (*RayJob)(testingrayutil.MakeJob("rayjob", "ns").
@@ -518,12 +519,12 @@ func TestPodSets(t *testing.T) {
 						Obj(),
 				}
 			},
-			enableTopologyAwareScheduling: false,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			gotPodSets, err := tc.rayJob.PodSets(ctx)
 			if err != nil {

--- a/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
@@ -26,6 +26,7 @@ import (
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -41,11 +42,11 @@ import (
 
 func TestDefault(t *testing.T) {
 	testcases := map[string]struct {
-		oldJob               *rayv1.RayJob
-		newJob               *rayv1.RayJob
-		manageAll            bool
-		localQueueDefaulting bool
-		defaultLqExist       bool
+		featureGates   map[featuregate.Feature]bool
+		oldJob         *rayv1.RayJob
+		newJob         *rayv1.RayJob
+		manageAll      bool
+		defaultLqExist bool
 	}{
 		"unmanaged": {
 			oldJob: testingrayutil.MakeJob("job", "ns").
@@ -75,25 +76,25 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			oldJob:               testingrayutil.MakeJob("test-job", "default").Obj(),
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: true,
+			oldJob:         testingrayutil.MakeJob("test-job", "default").Obj(),
 			newJob: testingrayutil.MakeJob("test-job", "default").
 				Queue("default").
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, default lq is created, job has queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			oldJob:               testingrayutil.MakeJob("test-job", "").Queue("test-queue").Obj(),
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: true,
+			oldJob:         testingrayutil.MakeJob("test-job", "").Queue("test-queue").Obj(),
 			newJob: testingrayutil.MakeJob("test-job", "").
 				Queue("test-queue").
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, default lq isn't created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       false,
-			oldJob:               testingrayutil.MakeJob("test-job", "").Obj(),
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: false,
+			oldJob:         testingrayutil.MakeJob("test-job", "").Obj(),
 			newJob: testingrayutil.MakeJob("test-job", "").
 				Obj(),
 		},
@@ -101,7 +102,7 @@ func TestDefault(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			builder := utiltesting.NewClientBuilder()
 			cli := builder.Build()
@@ -134,12 +135,10 @@ func TestValidateCreate(t *testing.T) {
 	bigWorkerGroup := []rayv1.WorkerGroupSpec{worker, worker, worker, worker, worker, worker, worker, worker}
 
 	testcases := map[string]struct {
-		job                          *rayv1.RayJob
-		manageAll                    bool
-		wantErr                      error
-		localQueueDefaulting         bool
-		topologyAwareScheduling      bool
-		elasticJobsViaWorkloadSlices bool
+		job          *rayv1.RayJob
+		manageAll    bool
+		wantErr      error
+		featureGates map[featuregate.Feature]bool
 	}{
 		"invalid unmanaged": {
 			job: testingrayutil.MakeJob("job", "ns").
@@ -155,8 +154,8 @@ func TestValidateCreate(t *testing.T) {
 				}).
 				RayClusterSpec(nil).
 				Obj(),
-			localQueueDefaulting: false,
-			wantErr:              nil,
+			featureGates: map[featuregate.Feature]bool{features.LocalQueueDefaulting: false},
+			wantErr:      nil,
 		},
 		"invalid managed - no cluster selector and no RayClusterSpec": {
 			job: testingrayutil.MakeJob("job", "ns").Queue("queue").
@@ -170,8 +169,8 @@ func TestValidateCreate(t *testing.T) {
 			job: testingrayutil.MakeJob("job", "ns").
 				ShutdownAfterJobFinishes(false).
 				Obj(),
-			localQueueDefaulting: true,
-			wantErr:              nil,
+			featureGates: map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			wantErr:      nil,
 		},
 		"invalid managed - by config": {
 			job: testingrayutil.MakeJob("job", "ns").
@@ -205,8 +204,8 @@ func TestValidateCreate(t *testing.T) {
 				WithEnableAutoscaling(ptr.To(true)).
 				Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 				Obj(),
-			elasticJobsViaWorkloadSlices: true,
-			wantErr:                      nil,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			wantErr:      nil,
 		},
 		"invalid managed - too many worker groups": {
 			job: testingrayutil.MakeJob("job", "ns").Queue("queue").
@@ -261,7 +260,7 @@ func TestValidateCreate(t *testing.T) {
 					rayv1.WorkerGroupSpec{GroupName: "wg3"},
 				).
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid topology request": {
 			job: testingrayutil.MakeJob("rayjob", "ns").Queue("queue").
@@ -301,7 +300,7 @@ func TestValidateCreate(t *testing.T) {
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid slice topology request - slice size larger than number of podsets": {
 			job: testingrayutil.MakeJob("rayjob", "ns").Queue("queue").
@@ -352,7 +351,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.rayClusterSpec.workerGroupSpecs[1].template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-slice-size"), "20", "must not be greater than pod set count 10"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"valid PodSet grouping request": {
 			job: testingrayutil.MakeJob("rayjob", "ns").Queue("queue").
@@ -380,7 +379,7 @@ func TestValidateCreate(t *testing.T) {
 					},
 				).
 				Obj(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid PodSet grouping request - groups of size other than 2": {
 			job: testingrayutil.MakeJob("rayjob", "ns").Queue("queue").
@@ -443,7 +442,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.rayClusterSpec.workerGroupSpecs[2].template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-group-name"), "3podsets", "can only define groups of exactly 2 pod sets, got: 3 pod set(s)"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid PodSet grouping request - no leader in group": {
 			job: testingrayutil.MakeJob("rayjob", "ns").Queue("queue").
@@ -480,7 +479,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.rayClusterSpec.workerGroupSpecs[1].template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-group-name"), "groupname", "can only define groups where at least one pod set has only 1 replica, got: 5 replica(s) and 10 replica(s) in the group"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid PodSet grouping request - required topology does not match": {
 			job: testingrayutil.MakeJob("rayjob", "ns").Queue("queue").
@@ -513,7 +512,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.rayClusterSpec.headGroupSpec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.rayClusterSpec.workerGroupSpecs[0].template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.rayClusterSpec.workerGroupSpecs[0].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.rayClusterSpec.headGroupSpec.template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid PodSet grouping request - preferred topology does not match": {
 			job: testingrayutil.MakeJob("rayjob", "ns").Queue("queue").
@@ -546,7 +545,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.rayClusterSpec.headGroupSpec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.rayClusterSpec.workerGroupSpecs[0].template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.rayClusterSpec.workerGroupSpecs[0].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.rayClusterSpec.headGroupSpec.template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		"invalid PodSet grouping request - different topology annotations within group": {
 			job: testingrayutil.MakeJob("rayjob", "ns").Queue("queue").
@@ -579,7 +578,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(field.NewPath("spec.rayClusterSpec.headGroupSpec.template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.rayClusterSpec.workerGroupSpecs[0].template.metadata.annotations' in group 'groupname'"),
 				field.Invalid(field.NewPath("spec.rayClusterSpec.workerGroupSpecs[0].template.metadata.annotations"), field.OmitValueType{}, "must specify 'kueue.x-k8s.io/podset-required-topology' or 'kueue.x-k8s.io/podset-preferred-topology' topology consistent with 'spec.rayClusterSpec.headGroupSpec.template.metadata.annotations' in group 'groupname'"),
 			}.ToAggregate(),
-			topologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 	}
 
@@ -588,9 +587,7 @@ func TestValidateCreate(t *testing.T) {
 			wh := &RayJobWebhook{
 				manageJobsWithoutQueueName: tc.manageAll,
 			}
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.topologyAwareScheduling)
-			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, tc.elasticJobsViaWorkloadSlices)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			_, result := wh.ValidateCreate(ctx, tc.job)
 			if diff := cmp.Diff(tc.wantErr, result); diff != "" {

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -50,7 +51,7 @@ var (
 func TestReconciler(t *testing.T) {
 	now := time.Now()
 	cases := map[string]struct {
-		enableTAS       bool
+		featureGates    map[featuregate.Feature]bool
 		stsKey          client.ObjectKey
 		statefulSet     *appsv1.StatefulSet
 		pods            []corev1.Pod
@@ -61,10 +62,12 @@ func TestReconciler(t *testing.T) {
 		wantErr         error
 	}{
 		"statefulset not found": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 		},
 		"statefulset with finished pods": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Replicas(0).
@@ -110,7 +113,8 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"statefulset with update revision": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("lq").
@@ -175,7 +179,8 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should add StatefulSet to Workload owner references if replicas > 0": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("lq").
@@ -196,7 +201,8 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"shouldn't add StatefulSet to Workload owner references if replicas = 0": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("lq").
@@ -217,7 +223,8 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should remove StatefulSet from Workload owner references if replicas = 0": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("lq").
@@ -239,7 +246,8 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should create workload when replicas > 0 and workload doesn't exist": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("lq").
@@ -267,8 +275,8 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should create workload with TAS topology request when TAS enabled": {
-			enableTAS: true,
-			stsKey:    client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("lq").
@@ -302,7 +310,8 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should not create workload when replicas == 0": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Replicas(0).
@@ -315,7 +324,8 @@ func TestReconciler(t *testing.T) {
 				DeepCopy(),
 		},
 		"should not create workload when queue name is empty": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Obj(),
@@ -324,7 +334,8 @@ func TestReconciler(t *testing.T) {
 				DeepCopy(),
 		},
 		"should adopt legacy workload instead of creating duplicate": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("lq").
@@ -356,7 +367,8 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should list pods by legacy workload name": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Replicas(0).
@@ -391,7 +403,8 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should finalize deleted pod": {
-			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Replicas(0).
@@ -415,7 +428,7 @@ func TestReconciler(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTAS)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			clientBuilder := utiltesting.NewClientBuilder()
 			indexer := utiltesting.AsIndexer(clientBuilder)

--- a/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -54,7 +55,7 @@ func TestDefault(t *testing.T) {
 		initObjs                   []client.Object
 		statefulset                *appsv1.StatefulSet
 		manageJobsWithoutQueueName bool
-		localQueueDefaulting       bool
+		featureGates               map[featuregate.Feature]bool
 		defaultLqExist             bool
 		enableIntegrations         []string
 		want                       *appsv1.StatefulSet
@@ -125,9 +126,9 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			statefulset:          testingstatefulset.MakeStatefulSet("test-pod", "default").Obj(),
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: true,
+			statefulset:    testingstatefulset.MakeStatefulSet("test-pod", "default").Obj(),
 			want: testingstatefulset.MakeStatefulSet("test-pod", "default").
 				Queue("default").
 				PodTemplateAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
@@ -135,9 +136,9 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, default lq is created, job has queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       true,
-			statefulset:          testingstatefulset.MakeStatefulSet("test-pod", "").Queue("test-queue").Obj(),
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: true,
+			statefulset:    testingstatefulset.MakeStatefulSet("test-pod", "").Queue("test-queue").Obj(),
 			want: testingstatefulset.MakeStatefulSet("test-pod", "").
 				Queue("test-queue").
 				PodTemplateAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
@@ -145,16 +146,16 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"LocalQueueDefaulting enabled, default lq isn't created, job doesn't have queue label": {
-			localQueueDefaulting: true,
-			defaultLqExist:       false,
-			statefulset:          testingstatefulset.MakeStatefulSet("test-pod", "").Obj(),
-			want:                 testingstatefulset.MakeStatefulSet("test-pod", "").Obj(),
+			featureGates:   map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			defaultLqExist: false,
+			statefulset:    testingstatefulset.MakeStatefulSet("test-pod", "").Obj(),
+			want:           testingstatefulset.MakeStatefulSet("test-pod", "").Obj(),
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			t.Cleanup(jobframework.EnableIntegrationsForTest(t, tc.enableIntegrations...))
 			ctx, _ := utiltesting.ContextWithLog(t)
 

--- a/pkg/controller/jobs/trainjob/trainjob_webhook_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_webhook_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	jobsetapi "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
@@ -205,11 +206,10 @@ func TestDefault(t *testing.T) {
 	testCases := map[string]struct {
 		trainJob                     *kftrainerapi.TrainJob
 		defaultQueue                 *kueue.LocalQueue
-		localQueueDefaultingEnabled  bool
 		manageJobsWithoutQueueName   bool
 		withMultiKueueAdmissionCheck bool
 		withDefaultLocalQueue        bool
-		multiKueueEnabled            bool
+		featureGates                 map[featuregate.Feature]bool
 		wantTrainJob                 *kftrainerapi.TrainJob
 		wantErr                      error
 	}{
@@ -238,14 +238,14 @@ func TestDefault(t *testing.T) {
 				Queue(string(controllerconstants.DefaultLocalQueueName)).
 				JobSetLabel(controllerconstants.QueueLabel, string(controllerconstants.DefaultLocalQueueName)).
 				Obj(),
-			localQueueDefaultingEnabled: true,
-			withDefaultLocalQueue:       true,
+			featureGates:          map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			withDefaultLocalQueue: true,
 		},
 		"should not set the default local queue if doesn't exists": {
-			trainJob:                    testTrainJob.Clone().Obj(),
-			wantTrainJob:                testTrainJob.Clone().Obj(),
-			localQueueDefaultingEnabled: true,
-			withDefaultLocalQueue:       false,
+			trainJob:              testTrainJob.Clone().Obj(),
+			wantTrainJob:          testTrainJob.Clone().Obj(),
+			featureGates:          map[featuregate.Feature]bool{features.LocalQueueDefaulting: true},
+			withDefaultLocalQueue: false,
 		},
 		"should set managedBy to multiKueue if the user didn't specify any": {
 			trainJob: testTrainJob.Clone().Queue(testLocalQueue.Name).Obj(),
@@ -254,7 +254,7 @@ func TestDefault(t *testing.T) {
 				JobSetLabel(controllerconstants.QueueLabel, testLocalQueue.Name).
 				ManagedBy(kueue.MultiKueueControllerName).
 				Obj(),
-			multiKueueEnabled:            true,
+			featureGates:                 map[featuregate.Feature]bool{features.MultiKueue: true},
 			withMultiKueueAdmissionCheck: true,
 		},
 		"should not set managedBy to multiKueue if already specified by the user": {
@@ -264,7 +264,7 @@ func TestDefault(t *testing.T) {
 				JobSetLabel(controllerconstants.QueueLabel, testLocalQueue.Name).
 				ManagedBy("user").
 				Obj(),
-			multiKueueEnabled:            true,
+			featureGates:                 map[featuregate.Feature]bool{features.MultiKueue: true},
 			withMultiKueueAdmissionCheck: true,
 		},
 		"should not set managedBy to multiKueue if the selected clusterQueue doesn't have the corresponding admissionCheck": {
@@ -273,16 +273,14 @@ func TestDefault(t *testing.T) {
 				Suspend(true).
 				JobSetLabel(controllerconstants.QueueLabel, testLocalQueue.Name).
 				Obj(),
-			multiKueueEnabled:            true,
+			featureGates:                 map[featuregate.Feature]bool{features.MultiKueue: true},
 			withMultiKueueAdmissionCheck: false,
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.MultiKueue, tc.multiKueueEnabled)
-			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaultingEnabled)
-
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, log := utiltesting.ContextWithLog(t)
 
 			kClient := utiltesting.NewClientBuilder().WithObjects(testNamespace.Obj()).Build()

--- a/pkg/controller/tas/node_controller_test.go
+++ b/pkg/controller/tas/node_controller_test.go
@@ -893,9 +893,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 	for name, tc := range tests {
 		fakeClock.SetTime(testStartTime)
 		t.Run(name, func(t *testing.T) {
-			for fg, enable := range tc.featureGates {
-				features.SetFeatureGateDuringTest(t, fg, enable)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			fakeClock.SetTime(testStartTime)
 
 			clientBuilder := utiltesting.NewClientBuilder().
@@ -1076,9 +1074,7 @@ func TestGetWorkloadStatus(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			for fg, enable := range tc.featureGates {
-				features.SetFeatureGateDuringTest(t, fg, enable)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			clientBuilder := utiltesting.NewClientBuilder().WithObjects(tc.initObjs...)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			if err := indexer.SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder)); err != nil {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -458,6 +458,12 @@ func SetFeatureGateDuringTest(tb testing.TB, f featuregate.Feature, value bool) 
 	featuregatetesting.SetFeatureGateDuringTest(tb, utilfeature.DefaultFeatureGate, f, value)
 }
 
+func SetFeatureGatesDuringTest(tb testing.TB, featureGates map[featuregate.Feature]bool) {
+	for fg, enable := range featureGates {
+		featuregatetesting.SetFeatureGateDuringTest(tb, utilfeature.DefaultFeatureGate, fg, enable)
+	}
+}
+
 // Enabled is helper for `utilfeature.DefaultFeatureGate.Enabled()`
 func Enabled(f featuregate.Feature) bool {
 	return utilfeature.DefaultFeatureGate.Enabled(f)

--- a/pkg/podset/podset_test.go
+++ b/pkg/podset/podset_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -66,7 +67,7 @@ func TestFromAssignment(t *testing.T) {
 		Obj()
 
 	cases := map[string]struct {
-		enableTopologyAwareScheduling bool
+		featureGates map[featuregate.Feature]bool
 
 		assignment   *kueue.PodSetAssignment
 		defaultCount int32
@@ -169,7 +170,7 @@ func TestFromAssignment(t *testing.T) {
 			},
 		},
 		"with topology assignment; TopologyAwareScheduling enabled - scheduling gate added": {
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			assignment: &kueue.PodSetAssignment{
 				Name: "name",
 				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
@@ -206,6 +207,7 @@ func TestFromAssignment(t *testing.T) {
 			},
 		},
 		"with topology assignment; TopologyAwareScheduling disabled - no scheduling gate added": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			assignment: &kueue.PodSetAssignment{
 				Name: "name",
 				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
@@ -237,7 +239,7 @@ func TestFromAssignment(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			client := utiltesting.NewClientBuilder().WithLists(&kueue.ResourceFlavorList{Items: tc.flavors}).Build()
 
 			podSet := kueue.PodSet{

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -198,12 +198,10 @@ func TestAssignFlavors(t *testing.T) {
 		secondaryClusterQueueUsage          resources.FlavorResourceQuantities
 		wantRepMode                         FlavorAssignmentMode
 		wantAssignment                      Assignment
-		disableLendingLimit                 bool
 		enableFairSharing                   bool
 		simulationResult                    map[resources.FlavorResource]simulationResultForFlavor
 		elasticJobsViaWorkloadSlicesEnabled bool
 		preemptWorkloadSlice                *workload.Info
-		enableImplicitPreferenceDefault     bool
 		featureGates                        map[featuregate.Feature]bool
 	}{
 		"single flavor, fits": {
@@ -3080,7 +3078,7 @@ func TestAssignFlavors(t *testing.T) {
 			},
 		},
 		"workload slice preemption fits in the original workload resource flavor": {
-			elasticJobsViaWorkloadSlicesEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			wlPods: []kueue.PodSet{
 				*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 					Request(corev1.ResourceCPU, "3").
@@ -3145,7 +3143,7 @@ func TestAssignFlavors(t *testing.T) {
 			},
 		},
 		"workload slice preemption does not fit in the original workload resource flavor": {
-			elasticJobsViaWorkloadSlicesEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			wlPods: []kueue.PodSet{
 				*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 					Request(corev1.ResourceCPU, "3").
@@ -3209,7 +3207,7 @@ func TestAssignFlavors(t *testing.T) {
 			},
 		},
 		"preferPreemption; preempt without borrowing is preferred over fit with borrowing; preempt within cohort": {
-			enableImplicitPreferenceDefault: true,
+			featureGates: map[featuregate.Feature]bool{features.FlavorFungibilityImplicitPreferenceDefault: true},
 			wlPods: []kueue.PodSet{
 				*utiltestingapi.MakePodSet("main", 1).
 					Request(corev1.ResourceCPU, "10").
@@ -3271,7 +3269,7 @@ func TestAssignFlavors(t *testing.T) {
 			},
 		},
 		"preferPreemption; preempt without borrowing is preferred over fit with borrowing; preempt in own CQ": {
-			enableImplicitPreferenceDefault: true,
+			featureGates: map[featuregate.Feature]bool{features.FlavorFungibilityImplicitPreferenceDefault: true},
 			wlPods: []kueue.PodSet{
 				*utiltestingapi.MakePodSet("main", 1).
 					Request(corev1.ResourceCPU, "10").
@@ -3333,7 +3331,7 @@ func TestAssignFlavors(t *testing.T) {
 			},
 		},
 		"preferPreemption; fit without borrowing is preferred over fit with borrowing": {
-			enableImplicitPreferenceDefault: true,
+			featureGates: map[featuregate.Feature]bool{features.FlavorFungibilityImplicitPreferenceDefault: true},
 			wlPods: []kueue.PodSet{
 				*utiltestingapi.MakePodSet("main", 1).
 					Request(corev1.ResourceCPU, "10").
@@ -3390,15 +3388,7 @@ func TestAssignFlavors(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ctx, log := utiltesting.ContextWithLog(t)
-			if tc.disableLendingLimit {
-				features.SetFeatureGateDuringTest(t, features.LendingLimit, false)
-			}
-			if tc.enableImplicitPreferenceDefault {
-				features.SetFeatureGateDuringTest(t, features.FlavorFungibilityImplicitPreferenceDefault, true)
-			}
-			for fg, enabled := range tc.featureGates {
-				features.SetFeatureGateDuringTest(t, fg, enabled)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			wlInfo := workload.NewInfo(&kueue.Workload{
 				Spec: kueue.WorkloadSpec{
 					PodSets: tc.wlPods,
@@ -3444,10 +3434,6 @@ func TestAssignFlavors(t *testing.T) {
 					t.Fatalf("Failed to create secondary CQ snapshot")
 				}
 				secondaryClusterQueue.AddUsage(workload.Usage{Quota: tc.secondaryClusterQueueUsage})
-			}
-
-			if tc.elasticJobsViaWorkloadSlicesEnabled {
-				features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
 			}
 
 			flvAssigner := New(wlInfo, clusterQueue, resourceFlavors, tc.enableFairSharing, &testOracle{simulationResult: tc.simulationResult}, tc.preemptWorkloadSlice)
@@ -3981,7 +3967,7 @@ func TestIsPreferred(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		enableGate    bool
+		featureGates  map[featuregate.Feature]bool
 		a             granularMode
 		b             granularMode
 		config        kueue.FlavorFungibility
@@ -3997,9 +3983,9 @@ func TestIsPreferred(t *testing.T) {
 			wantPreferred: true,
 		},
 		"both policies try default to borrowing preference": {
-			enableGate: true,
-			a:          granularMode{preemptionMode: preempt, borrowingLevel: 1},
-			b:          granularMode{preemptionMode: fit, borrowingLevel: 2},
+			featureGates: map[featuregate.Feature]bool{features.FlavorFungibilityImplicitPreferenceDefault: true},
+			a:            granularMode{preemptionMode: preempt, borrowingLevel: 1},
+			b:            granularMode{preemptionMode: fit, borrowingLevel: 2},
 			config: kueue.FlavorFungibility{
 				WhenCanBorrow:  kueue.TryNextFlavor,
 				WhenCanPreempt: kueue.TryNextFlavor,
@@ -4007,9 +3993,9 @@ func TestIsPreferred(t *testing.T) {
 			wantPreferred: true,
 		},
 		"mismatched policies default to preemption preference": {
-			enableGate: true,
-			a:          granularMode{preemptionMode: preempt, borrowingLevel: 0},
-			b:          granularMode{preemptionMode: fit, borrowingLevel: 1},
+			featureGates: map[featuregate.Feature]bool{features.FlavorFungibilityImplicitPreferenceDefault: true},
+			a:            granularMode{preemptionMode: preempt, borrowingLevel: 0},
+			b:            granularMode{preemptionMode: fit, borrowingLevel: 1},
 			config: kueue.FlavorFungibility{
 				WhenCanBorrow:  kueue.MayStopSearch,
 				WhenCanPreempt: kueue.TryNextFlavor,
@@ -4017,9 +4003,9 @@ func TestIsPreferred(t *testing.T) {
 			wantPreferred: false,
 		},
 		"explicit BorrowingOverPreemption prioritises borrowing distance": {
-			enableGate: false,
-			a:          granularMode{preemptionMode: preempt, borrowingLevel: 1},
-			b:          granularMode{preemptionMode: fit, borrowingLevel: 2},
+			featureGates: map[featuregate.Feature]bool{features.FlavorFungibilityImplicitPreferenceDefault: false},
+			a:            granularMode{preemptionMode: preempt, borrowingLevel: 1},
+			b:            granularMode{preemptionMode: fit, borrowingLevel: 2},
 			config: kueue.FlavorFungibility{
 				WhenCanBorrow:  kueue.TryNextFlavor,
 				WhenCanPreempt: kueue.TryNextFlavor,
@@ -4028,9 +4014,9 @@ func TestIsPreferred(t *testing.T) {
 			wantPreferred: true,
 		},
 		"explicit PreemptionOverBorrowing prioritises lower preemption": {
-			enableGate: false,
-			a:          granularMode{preemptionMode: preempt, borrowingLevel: 1},
-			b:          granularMode{preemptionMode: fit, borrowingLevel: 2},
+			featureGates: map[featuregate.Feature]bool{features.FlavorFungibilityImplicitPreferenceDefault: false},
+			a:            granularMode{preemptionMode: preempt, borrowingLevel: 1},
+			b:            granularMode{preemptionMode: fit, borrowingLevel: 2},
 			config: kueue.FlavorFungibility{
 				WhenCanBorrow:  kueue.TryNextFlavor,
 				WhenCanPreempt: kueue.TryNextFlavor,
@@ -4039,9 +4025,9 @@ func TestIsPreferred(t *testing.T) {
 			wantPreferred: false,
 		},
 		"explicit PreemptionOverBorrowing breaks borrowing ties with preemption": {
-			enableGate: false,
-			a:          granularMode{preemptionMode: preempt, borrowingLevel: 1},
-			b:          granularMode{preemptionMode: fit, borrowingLevel: 1},
+			featureGates: map[featuregate.Feature]bool{features.FlavorFungibilityImplicitPreferenceDefault: false},
+			a:            granularMode{preemptionMode: preempt, borrowingLevel: 1},
+			b:            granularMode{preemptionMode: fit, borrowingLevel: 1},
 			config: kueue.FlavorFungibility{
 				WhenCanBorrow:  kueue.TryNextFlavor,
 				WhenCanPreempt: kueue.TryNextFlavor,
@@ -4053,7 +4039,7 @@ func TestIsPreferred(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.FlavorFungibilityImplicitPreferenceDefault, tc.enableGate)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			if got := isPreferred(tc.a, tc.b, tc.config); got != tc.wantPreferred {
 				t.Fatalf("isPreferred(%+v, %+v, %+v)=%t, want %t", tc.a, tc.b, tc.config, got, tc.wantPreferred)

--- a/pkg/scheduler/preemption/common/preemption_policy_test.go
+++ b/pkg/scheduler/preemption/common/preemption_policy_test.go
@@ -38,11 +38,11 @@ func TestSatisfiesPreemptionPolicy(t *testing.T) {
 	candidate := utiltestingapi.MakeWorkload("candidate", metav1.NamespaceDefault)
 
 	testCases := map[string]struct {
-		features  map[featuregate.Feature]bool
-		preemptor *kueue.Workload
-		candidate *kueue.Workload
-		policy    kueue.PreemptionPolicy
-		want      bool
+		featureGates map[featuregate.Feature]bool
+		preemptor    *kueue.Workload
+		candidate    *kueue.Workload
+		policy       kueue.PreemptionPolicy
+		want         bool
 	}{
 		"LowerPriority: preemptor has higher priority": {
 			preemptor: preemptor.Clone().Priority(10).Obj(),
@@ -75,7 +75,7 @@ func TestSatisfiesPreemptionPolicy(t *testing.T) {
 			want:      true, // candidate is newer
 		},
 		"LowerOrNewerEqualPriority with SchedulerTimestampPreemptionBuffer: preemptor has same priority, older timestamp (within 5min buffer)": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.SchedulerTimestampPreemptionBuffer: true,
 			},
 			preemptor: preemptor.Clone().Priority(10).Creation(now).Obj(),
@@ -84,7 +84,7 @@ func TestSatisfiesPreemptionPolicy(t *testing.T) {
 			want:      false, // candidate is newer but within buffer
 		},
 		"LowerOrNewerEqualPriority with SchedulerTimestampPreemptionBuffer: preemptor has same priority, older timestamp (outside 5min buffer)": {
-			features: map[featuregate.Feature]bool{
+			featureGates: map[featuregate.Feature]bool{
 				features.SchedulerTimestampPreemptionBuffer: true,
 			},
 			preemptor: preemptor.Clone().Priority(10).Creation(now).Obj(),
@@ -108,9 +108,7 @@ func TestSatisfiesPreemptionPolicy(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			for feature, enabled := range tc.features {
-				features.SetFeatureGateDuringTest(t, feature, enabled)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ordering := workload.Ordering{}
 			got := SatisfiesPreemptionPolicy(tc.preemptor, tc.candidate, ordering, tc.policy)
 			if got != tc.want {

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	clocktesting "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -280,15 +281,14 @@ func TestPreemption(t *testing.T) {
 		Label(controllerconstants.JobUIDLabel, "job-in")
 
 	cases := map[string]struct {
-		clusterQueues       []*kueue.ClusterQueue
-		cohorts             []*kueue.Cohort
-		admitted            []kueue.Workload
-		incoming            *kueue.Workload
-		targetCQ            kueue.ClusterQueueReference
-		assignment          flavorassigner.Assignment
-		wantPreempted       int
-		wantWorkloads       []kueue.Workload
-		disableLendingLimit bool
+		clusterQueues []*kueue.ClusterQueue
+		cohorts       []*kueue.Cohort
+		admitted      []kueue.Workload
+		incoming      *kueue.Workload
+		targetCQ      kueue.ClusterQueueReference
+		assignment    flavorassigner.Assignment
+		wantPreempted int
+		wantWorkloads []kueue.Workload
 	}{
 		"preempt lowest priority": {
 			clusterQueues: defaultClusterQueues,
@@ -4104,10 +4104,6 @@ func TestPreemption(t *testing.T) {
 		for _, useMergePatch := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s when the WorkloadRequestUseMergePatch feature is %t", name, useMergePatch), func(t *testing.T) {
 				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, useMergePatch)
-
-				if tc.disableLendingLimit {
-					features.SetFeatureGateDuringTest(t, features.LendingLimit, false)
-				}
 				ctx, log := utiltesting.ContextWithLog(t)
 				cl := utiltesting.NewClientBuilder().
 					WithLists(&kueue.WorkloadList{Items: tc.admitted}).
@@ -4553,9 +4549,9 @@ func TestCandidatesOrdering(t *testing.T) {
 	wlHighUsageLqDifCQ.LocalQueueFSUsage = ptr.To(1.0)
 
 	cases := map[string]struct {
-		candidates                  []workload.Info
-		wantCandidates              []workload.Reference
-		admissionFairSharingEnabled bool
+		candidates     []workload.Info
+		wantCandidates []workload.Reference
+		featureGates   map[featuregate.Feature]bool
 	}{
 		"workloads sorted by priority": {
 			candidates: []workload.Info{
@@ -4618,23 +4614,23 @@ func TestCandidatesOrdering(t *testing.T) {
 				*wlLowUsageLq,
 				*wlMidUsageLq,
 			},
-			wantCandidates:              []workload.Reference{"mid_lq_usage", "low_lq_usage"},
-			admissionFairSharingEnabled: true,
+			wantCandidates: []workload.Reference{"mid_lq_usage", "low_lq_usage"},
+			featureGates:   map[featuregate.Feature]bool{features.AdmissionFairSharing: true},
 		},
 		"workloads from different CQ are sorted based on priority and timestamp": {
 			candidates: []workload.Info{
 				*wlMidUsageLq,
 				*wlHighUsageLqDifCQ,
 			},
-			wantCandidates:              []workload.Reference{"high_lq_usage_different_cq", "mid_lq_usage"},
-			admissionFairSharingEnabled: true,
+			wantCandidates: []workload.Reference{"high_lq_usage_different_cq", "mid_lq_usage"},
+			featureGates:   map[featuregate.Feature]bool{features.AdmissionFairSharing: true},
 		}}
 
 	_, log := utiltesting.ContextWithLog(t)
 	for _, tc := range cases {
-		features.SetFeatureGateDuringTest(t, features.AdmissionFairSharing, tc.admissionFairSharingEnabled)
+		features.SetFeatureGatesDuringTest(t, tc.featureGates)
 		slices.SortFunc(tc.candidates, func(a, b workload.Info) int {
-			return preemptioncommon.CandidatesOrdering(log, tc.admissionFairSharingEnabled, &a, &b, kueue.ClusterQueueReference(preemptorCq), now)
+			return preemptioncommon.CandidatesOrdering(log, tc.featureGates[features.AdmissionFairSharing], &a, &b, kueue.ClusterQueueReference(preemptorCq), now)
 		})
 		got := utilslices.Map(tc.candidates, func(c *workload.Info) workload.Reference {
 			return workload.Reference(c.Obj.Name)

--- a/pkg/scheduler/scheduler_afs_test.go
+++ b/pkg/scheduler/scheduler_afs_test.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -78,13 +79,13 @@ func TestScheduleForAFS(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		enableFairSharing bool
-		initialUsage      map[string]corev1.ResourceList
-		workloads         []kueue.Workload
-		wantWorkloads     []kueue.Workload
+		featureGates  map[featuregate.Feature]bool
+		initialUsage  map[string]corev1.ResourceList
+		workloads     []kueue.Workload
+		wantWorkloads []kueue.Workload
 	}{
 		"admits workload from less active localqueue": {
-			enableFairSharing: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionFairSharing: true},
 			initialUsage: map[string]corev1.ResourceList{
 				"lq-a": {corev1.ResourceCPU: resource.MustParse("8")},
 				"lq-b": {corev1.ResourceCPU: resource.MustParse("2")},
@@ -160,7 +161,7 @@ func TestScheduleForAFS(t *testing.T) {
 			},
 		},
 		"without AFS: classic admission decision ignores queue usage": {
-			enableFairSharing: false,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionFairSharing: false},
 			initialUsage: map[string]corev1.ResourceList{
 				"lq-a": {corev1.ResourceCPU: resource.MustParse("8")},
 				"lq-b": {corev1.ResourceCPU: resource.MustParse("2")},
@@ -236,7 +237,7 @@ func TestScheduleForAFS(t *testing.T) {
 			},
 		},
 		"admits one workload from each localqueue when quota is limited": {
-			enableFairSharing: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionFairSharing: true},
 			initialUsage: map[string]corev1.ResourceList{
 				"lq-a": {corev1.ResourceCPU: resource.MustParse("4")},
 				"lq-b": {corev1.ResourceCPU: resource.MustParse("4")},
@@ -377,7 +378,7 @@ func TestScheduleForAFS(t *testing.T) {
 			},
 		},
 		"schedules normally when queues have equal usage": {
-			enableFairSharing: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionFairSharing: true},
 			initialUsage: map[string]corev1.ResourceList{
 				"lq-a": {corev1.ResourceCPU: resource.MustParse("2")},
 				"lq-b": {corev1.ResourceCPU: resource.MustParse("2")},
@@ -497,7 +498,7 @@ func TestScheduleForAFS(t *testing.T) {
 			},
 		},
 		"admits workload from lq-b with uninitialized cache": {
-			enableFairSharing: true,
+			featureGates: map[featuregate.Feature]bool{features.AdmissionFairSharing: true},
 			initialUsage: map[string]corev1.ResourceList{
 				"lq-a": {corev1.ResourceCPU: resource.MustParse("8")},
 			},
@@ -577,7 +578,7 @@ func TestScheduleForAFS(t *testing.T) {
 		for _, enabled := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", name, enabled), func(t *testing.T) {
 				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, enabled)
-				features.SetFeatureGateDuringTest(t, features.AdmissionFairSharing, tc.enableFairSharing)
+				features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 				clientBuilder := utiltesting.NewClientBuilder().
 					WithLists(
@@ -591,7 +592,7 @@ func TestScheduleForAFS(t *testing.T) {
 					WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 				cl := clientBuilder.Build()
 
-				cqCache := schdcache.New(cl, schdcache.WithFairSharing(tc.enableFairSharing), schdcache.WithAdmissionFairSharing(afsConfig))
+				cqCache := schdcache.New(cl, schdcache.WithFairSharing(tc.featureGates[features.AdmissionFairSharing]), schdcache.WithAdmissionFairSharing(afsConfig))
 				qManager := qcache.NewManagerForUnitTests(cl, cqCache, qcache.WithAdmissionFairSharing(afsConfig))
 
 				ctx, log := utiltesting.ContextWithLog(t)
@@ -617,7 +618,7 @@ func TestScheduleForAFS(t *testing.T) {
 				}
 				recorder := &utiltesting.EventRecorder{}
 				var preemptionFairSharing *config.FairSharing
-				if tc.enableFairSharing {
+				if tc.featureGates[features.AdmissionFairSharing] {
 					preemptionFairSharing = &config.FairSharing{}
 				}
 				scheduler := New(qManager, cqCache, cl, recorder,

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -2845,9 +2845,7 @@ func TestScheduleForTAS(t *testing.T) {
 		for _, enabled := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", name, enabled), func(t *testing.T) {
 				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, enabled)
-				for fg, enable := range tc.featureGates {
-					features.SetFeatureGateDuringTest(t, fg, enable)
-				}
+				features.SetFeatureGatesDuringTest(t, tc.featureGates)
 				ctx, log := utiltesting.ContextWithLog(t)
 				testWls := make([]kueue.Workload, 0, len(tc.workloads))
 				for _, wl := range tc.workloads {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/component-base/metrics/testutil"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
@@ -173,11 +174,8 @@ func TestSchedule(t *testing.T) {
 	}
 	cases := map[string]struct {
 		// Features
-		disableLendingLimit                        bool
-		disablePartialAdmission                    bool
-		enableFairSharing                          bool
-		enableElasticJobsViaWorkloadSlice          bool
-		flavorFungibilityImplicitPreferenceDefault bool
+		featureGates      map[featuregate.Feature]bool
+		enableFairSharing bool
 
 		workloads      []kueue.Workload
 		objects        []client.Object
@@ -207,6 +205,7 @@ func TestSchedule(t *testing.T) {
 		wantSkippedPreemptions map[string]int
 	}{
 		"use second flavor when the first has no preemption candidates; WhenCanPreempt: MayStopSearch": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			additionalClusterQueues: []kueue.ClusterQueue{
 				*utiltestingapi.MakeClusterQueue("other-alpha").
 					Preemption(kueue.ClusterQueuePreemption{
@@ -295,6 +294,7 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"workload fits in single clusterQueue, with check state ready": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("foo", "sales").
 					Queue("main").
@@ -363,6 +363,7 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"skip workload with missing or deleted ClusterQueue (NoFit)": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("missing-cq-workload", "sales").
 					Queue("non-existent-queue").
@@ -387,6 +388,7 @@ func TestSchedule(t *testing.T) {
 			eventCmpOpts: ignoreEventMessageCmpOpts,
 		},
 		"workload fits in single clusterQueue, with check state pending": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("foo", "sales").
 					Queue("main").
@@ -443,6 +445,7 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"error during admission": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("foo", "sales").
 					Queue("main").
@@ -465,6 +468,7 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"single clusterQueue full": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("new", "sales").
 					Queue("main").
@@ -536,6 +540,7 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"failed to match clusterQueue selector": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("new", "sales").
 					Queue("blocked").
@@ -570,6 +575,7 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"admit in different cohorts": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("new", "sales").
 					Queue("main").
@@ -663,6 +669,7 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"admit in same cohort with no borrowing": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("new", "eng-alpha").
 					Queue("main").
@@ -757,6 +764,7 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"assign multiple resources and flavors": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("new", "eng-beta").
 					Queue("main").
@@ -1169,7 +1177,7 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"lendingLimit should not affect assignments when feature disabled": {
-			disableLendingLimit: true,
+			featureGates: map[featuregate.Feature]bool{features.LendingLimit: false},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("a", "lend").
 					Request(corev1.ResourceCPU, "2").
@@ -2215,7 +2223,7 @@ func TestSchedule(t *testing.T) {
 			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"sales": {"sales/new"},
 			},
-			disablePartialAdmission: true,
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: false},
 		},
 		"two workloads can borrow different resources from the same flavor in the same cycle": {
 			additionalClusterQueues: func() []kueue.ClusterQueue {
@@ -6941,7 +6949,7 @@ func TestSchedule(t *testing.T) {
 		},
 		// Workload-slice scheduling test case.
 		"workload-slice fits in single clusterQueue": {
-			enableElasticJobsViaWorkloadSlice: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			// workloads that will be returned by the fake.client.
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("foo-1", "sales").
@@ -7299,8 +7307,8 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"preempt within CQ in flavor with most local capacity": {
-			enableFairSharing:                          true,
-			flavorFungibilityImplicitPreferenceDefault: true,
+			enableFairSharing: true,
+			featureGates:      map[featuregate.Feature]bool{features.FlavorFungibilityImplicitPreferenceDefault: true},
 			cohorts: []kueue.Cohort{
 				*utiltestingapi.MakeCohort("root-cohort").
 					ResourceGroup(
@@ -7408,8 +7416,8 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		"preempt within Cohort in flavor with most local capacity": {
-			enableFairSharing:                          true,
-			flavorFungibilityImplicitPreferenceDefault: true,
+			enableFairSharing: true,
+			featureGates:      map[featuregate.Feature]bool{features.FlavorFungibilityImplicitPreferenceDefault: true},
 			cohorts: []kueue.Cohort{
 				*utiltestingapi.MakeCohort("root-cohort").
 					ResourceGroup(
@@ -7592,14 +7600,7 @@ func TestSchedule(t *testing.T) {
 			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", name, enabled), func(t *testing.T) {
 				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, enabled)
 				metrics.AdmissionCyclePreemptionSkips.Reset()
-				if tc.disableLendingLimit {
-					features.SetFeatureGateDuringTest(t, features.LendingLimit, false)
-				}
-				if tc.disablePartialAdmission {
-					features.SetFeatureGateDuringTest(t, features.PartialAdmission, false)
-				}
-				features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, tc.enableElasticJobsViaWorkloadSlice)
-				features.SetFeatureGateDuringTest(t, features.FlavorFungibilityImplicitPreferenceDefault, tc.flavorFungibilityImplicitPreferenceDefault)
+				features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 				ctx, log := utiltesting.ContextWithLog(t)
 
@@ -7960,42 +7961,42 @@ func TestEntryOrdering(t *testing.T) {
 	for _, tc := range []struct {
 		name             string
 		input            []entry
-		prioritySorting  bool
+		featureGates     map[featuregate.Feature]bool
 		workloadOrdering workload.Ordering
 		wantOrder        []string
 	}{
 		{
 			name:             "Priority sorting is enabled (default) using pods-ready Eviction timestamp (default)",
 			input:            input,
-			prioritySorting:  true,
+			featureGates:     map[featuregate.Feature]bool{features.PrioritySortingWithinCohort: true},
 			workloadOrdering: workload.Ordering{PodsReadyRequeuingTimestamp: config.EvictionTimestamp},
 			wantOrder:        []string{"new_high_pri", "old", "recently_evicted", "new", "high_pri_borrowing", "old_borrowing", "evicted_borrowing", "new_borrowing", "high_pri_borrowing_more"},
 		},
 		{
 			name:             "Priority sorting is enabled (default) using pods-ready Creation timestamp",
 			input:            input,
-			prioritySorting:  true,
+			featureGates:     map[featuregate.Feature]bool{features.PrioritySortingWithinCohort: true},
 			workloadOrdering: workload.Ordering{PodsReadyRequeuingTimestamp: config.CreationTimestamp},
 			wantOrder:        []string{"new_high_pri", "recently_evicted", "old", "new", "high_pri_borrowing", "old_borrowing", "evicted_borrowing", "new_borrowing", "high_pri_borrowing_more"},
 		},
 		{
 			name:             "Priority sorting is disabled using pods-ready Eviction timestamp",
 			input:            input,
-			prioritySorting:  false,
+			featureGates:     map[featuregate.Feature]bool{features.PrioritySortingWithinCohort: false},
 			workloadOrdering: workload.Ordering{PodsReadyRequeuingTimestamp: config.EvictionTimestamp},
 			wantOrder:        []string{"old", "recently_evicted", "new", "new_high_pri", "old_borrowing", "evicted_borrowing", "high_pri_borrowing", "new_borrowing", "high_pri_borrowing_more"},
 		},
 		{
 			name:             "Priority sorting is disabled using pods-ready Creation timestamp",
 			input:            input,
-			prioritySorting:  false,
+			featureGates:     map[featuregate.Feature]bool{features.PrioritySortingWithinCohort: false},
 			workloadOrdering: workload.Ordering{PodsReadyRequeuingTimestamp: config.CreationTimestamp},
 			wantOrder:        []string{"recently_evicted", "old", "new", "new_high_pri", "old_borrowing", "evicted_borrowing", "high_pri_borrowing", "new_borrowing", "high_pri_borrowing_more"},
 		},
 		{
-			name:            "Some workloads are preempted; Priority sorting is disabled",
-			input:           inputForOrderingPreemptedWorkloads,
-			prioritySorting: false,
+			name:         "Some workloads are preempted; Priority sorting is disabled",
+			input:        inputForOrderingPreemptedWorkloads,
+			featureGates: map[featuregate.Feature]bool{features.PrioritySortingWithinCohort: false},
 			wantOrder: []string{
 				"old-mid-recently-preempted-in-queue",
 				"old-mid-not-preempted-yet",
@@ -8005,9 +8006,9 @@ func TestEntryOrdering(t *testing.T) {
 			},
 		},
 		{
-			name:            "Some workloads are preempted; Priority sorting is enabled",
-			input:           inputForOrderingPreemptedWorkloads,
-			prioritySorting: true,
+			name:         "Some workloads are preempted; Priority sorting is enabled",
+			input:        inputForOrderingPreemptedWorkloads,
+			featureGates: map[featuregate.Feature]bool{features.PrioritySortingWithinCohort: true},
 			wantOrder: []string{
 				"preemptor",
 				"old-mid-recently-preempted-in-queue",
@@ -8018,7 +8019,7 @@ func TestEntryOrdering(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.PrioritySortingWithinCohort, tc.prioritySorting)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			iter := makeIterator(ctx, tc.input, tc.workloadOrdering, false)
 			order := make([]string, len(tc.input))

--- a/pkg/webhooks/clusterqueue_webhook_test.go
+++ b/pkg/webhooks/clusterqueue_webhook_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -38,12 +39,12 @@ func TestValidateClusterQueue(t *testing.T) {
 	resourceGroupsPath := specPath.Child("resourceGroups")
 
 	testcases := []struct {
-		name                string
-		clusterQueue        *kueue.ClusterQueue
-		wantErr             field.ErrorList
-		disableLendingLimit bool
-		wantDetail          string
-		wantBadValue        string
+		name         string
+		clusterQueue *kueue.ClusterQueue
+		wantErr      field.ErrorList
+		wantDetail   string
+		wantBadValue string
+		featureGates map[featuregate.Feature]bool
 	}{
 		{
 			name: "built-in resources with qualified names",
@@ -166,8 +167,8 @@ func TestValidateClusterQueue(t *testing.T) {
 			},
 		},
 		{
-			name:                "flavor quota with lendingLimit and empty cohort, but feature disabled",
-			disableLendingLimit: true,
+			name:         "flavor quota with lendingLimit and empty cohort, but feature disabled",
+			featureGates: map[featuregate.Feature]bool{features.LendingLimit: false},
 			clusterQueue: utiltestingapi.MakeClusterQueue("cluster-queue").
 				ResourceGroup(
 					*utiltestingapi.MakeFlavorQuotas("x86").Resource("cpu", "1", "", "1").Obj()).
@@ -383,9 +384,7 @@ func TestValidateClusterQueue(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.disableLendingLimit {
-				features.SetFeatureGateDuringTest(t, features.LendingLimit, false)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			gotErr := ValidateClusterQueue(tc.clusterQueue)
 			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.IgnoreFields(field.Error{}, "Detail", "BadValue")); diff != "" {
 				t.Errorf("ValidateResources() mismatch (-want +got):\n%s", diff)

--- a/pkg/webhooks/cohort_webhook_test.go
+++ b/pkg/webhooks/cohort_webhook_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/features"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 )
 
@@ -33,10 +32,9 @@ func TestValidateCohort(t *testing.T) {
 	resourceGroupsPath := specPath.Child("resourceGroups")
 
 	testcases := []struct {
-		name                string
-		cohort              *kueue.Cohort
-		wantErr             field.ErrorList
-		disableLendingLimit bool
+		name    string
+		cohort  *kueue.Cohort
+		wantErr field.ErrorList
 	}{
 		{
 			name: "flavor quota with lendingLimit and empty parent",
@@ -52,9 +50,6 @@ func TestValidateCohort(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.disableLendingLimit {
-				features.SetFeatureGateDuringTest(t, features.LendingLimit, false)
-			}
 			gotErr := validateCohort(tc.cohort)
 			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.IgnoreFields(field.Error{}, "BadValue")); diff != "" {
 				t.Errorf("ValidateResources() mismatch (-want +got):\n%s", diff)

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -236,8 +237,7 @@ func TestValidateWorkload(t *testing.T) {
 
 func TestValidateWorkloadUpdate(t *testing.T) {
 	testCases := map[string]struct {
-		enableTopologyAwareScheduling bool
-		enableElasticJobsFeature      bool
+		featureGates map[featuregate.Feature]bool
 
 		before, after *kueue.Workload
 		wantErr       field.ErrorList
@@ -382,7 +382,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 			}).Obj(),
 		},
 		"TopologyAssignment can be mutated": {
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				PodSets(
 					*utiltestingapi.MakePodSet("ps1", 3).Obj(),
@@ -428,7 +428,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 			wantErr: nil,
 		},
 		"PodSets cannot be removed from admission": {
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				PodSets(
 					*utiltestingapi.MakePodSet("ps1", 3).Obj(),
@@ -463,7 +463,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 			},
 		},
 		"PodSets cannot be added to admission": {
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				PodSets(
 					*utiltestingapi.MakePodSet("ps1", 3).Obj(),
@@ -518,7 +518,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 			},
 		},
 		"workload.podSets[].count is mutable with ElasticJobs feature gate": {
-			enableElasticJobsFeature: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				PodSets(
 					*utiltestingapi.MakePodSet("ps1", 3).Obj(),
@@ -535,7 +535,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 					kueue.PodSetAssignment{Name: "ps2"}).Obj()).Obj(),
 		},
 		"ClusterName doesn't have to be one of the nominatedClusterNames with ElasticJobs feature gate": {
-			enableElasticJobsFeature: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				PodSets(
 					*utiltestingapi.MakePodSet("ps1", 3).Obj(),
@@ -555,8 +555,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, tc.enableElasticJobsFeature)
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			errList := ValidateWorkloadUpdate(tc.after, tc.before)
 			if diff := cmp.Diff(tc.wantErr, errList, cmpopts.IgnoreFields(field.Error{}, "Detail", "BadValue")); diff != "" {
 				t.Errorf("ValidateWorkloadUpdate() mismatch (-want +got):\n%s", diff)

--- a/pkg/workload/admissionchecks_test.go
+++ b/pkg/workload/admissionchecks_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 
@@ -36,7 +37,7 @@ import (
 func TestSyncAdmittedCondition(t *testing.T) {
 	testTime := time.Now().Truncate(time.Second)
 	cases := map[string]struct {
-		enableTopologyAwareScheduling bool
+		featureGates map[featuregate.Feature]bool
 
 		admission        *kueue.Admission
 		checkStates      []kueue.AdmissionCheckState
@@ -258,7 +259,7 @@ func TestSyncAdmittedCondition(t *testing.T) {
 			wantAdmittedTime: 2,
 		},
 		"pending delayed topology request; flip from Admitted=true": {
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			admission: &kueue.Admission{
 				PodSetAssignments: []kueue.PodSetAssignment{
 					{
@@ -299,7 +300,7 @@ func TestSyncAdmittedCondition(t *testing.T) {
 			wantChange: true,
 		},
 		"pending delayed topology request; already Admitted=false": {
-			enableTopologyAwareScheduling: true,
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			admission: &kueue.Admission{
 				PodSetAssignments: []kueue.PodSetAssignment{
 					{
@@ -343,7 +344,7 @@ func TestSyncAdmittedCondition(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			builder := utiltestingapi.MakeWorkload("foo", "bar").
 				Admission(tc.admission).
 				AdmissionChecks(tc.checkStates...).

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -440,9 +440,7 @@ func TestNewInfo(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			for fg, enabled := range tc.featureGates {
-				features.SetFeatureGateDuringTest(t, fg, enabled)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			info := NewInfo(&tc.workload, tc.infoOptions...)
 			if diff := cmp.Diff(info, &tc.wantInfo, cmpopts.IgnoreFields(Info{}, "Obj", "SchedulingHash")); diff != "" {
 				t.Errorf("NewInfo(_) = (-want,+got):\n%s", diff)
@@ -1975,9 +1973,7 @@ func TestSchedulingHash(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			for fg, enable := range tc.featureGates {
-				features.SetFeatureGateDuringTest(t, fg, enable)
-			}
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			info1 := NewInfo(tc.wl1)
 			info1.UpdateSchedulingHash(logr.Discard())
 			info2 := NewInfo(tc.wl2)

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -1200,29 +1201,31 @@ func TestReplacedWorkloadSlice(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		featureEnabled bool
-		args           args
-		want           want
+		featureGates map[featuregate.Feature]bool
+		args         args
+		want         want
 	}{
-		"FeatureNotEnabled": {},
+		"FeatureNotEnabled": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: false},
+		},
 		"EdgeCase_WorkloadIsNil": {
-			featureEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 		},
 		"EdgeCase_SnapshotIsNil": {
-			featureEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			args: args{
 				wl: workload.NewInfo(utiltestingapi.MakeWorkload("test", "default").Obj()),
 			},
 		},
 		"WorkloadWithoutReplacementAnnotation": {
-			featureEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			args: args{
 				wl:   workload.NewInfo(utiltestingapi.MakeWorkload("test", "default").Obj()),
 				snap: &schdcache.Snapshot{},
 			},
 		},
 		"ReplacedWorkloadIsNotFound_MissingClusterQueue": {
-			featureEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			args: args{
 				wl: workload.NewInfo(utiltestingapi.MakeWorkload("test-new", "default").
 					Annotation(WorkloadSliceReplacementFor, "test-old").
@@ -1235,7 +1238,7 @@ func TestReplacedWorkloadSlice(t *testing.T) {
 			},
 		},
 		"EdgeCase_ReplacedWorkloadIsNotFound_NotInClusterQueue": {
-			featureEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			args: args{
 				wl: workload.NewInfo(utiltestingapi.MakeWorkload("test-new", "default").
 					Annotation(WorkloadSliceReplacementFor, "test-old").
@@ -1251,7 +1254,7 @@ func TestReplacedWorkloadSlice(t *testing.T) {
 			},
 		},
 		"ReplacedWorkloadIsFound": {
-			featureEnabled: true,
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			args: args{
 				wl: workload.NewInfo(utiltestingapi.MakeWorkload("test-new", "default").
 					Annotation(WorkloadSliceReplacementFor, "test-old").
@@ -1279,7 +1282,7 @@ func TestReplacedWorkloadSlice(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, tt.featureEnabled)
+			features.SetFeatureGatesDuringTest(t, tt.featureGates)
 			targets, wl := ReplacedWorkloadSlice(tt.args.wl, tt.args.snap)
 			if diff := cmp.Diff(tt.want.targets, targets); diff != "" {
 				t.Errorf("ReplacedWorkloadSlice() targets (+want,-got):\n%s", diff)


### PR DESCRIPTION
Cherry pick of #10090 on release-0.15.

#10090: featureGates unit tests cleanup

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```