### PR TITLE
[trainjob] use wrappers pattern for the RuntimePatches

### DIFF
--- a/pkg/controller/jobs/trainjob/trainjob_controller_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller_test.go
@@ -93,15 +93,11 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 	}{
 		"should add to the TrainJob the config specified in the PodSet info": {
 			trainJob: testTrainJob.Clone().
-				RuntimePatches([]kftrainerapi.RuntimePatch{{
-					Manager: runtimePatchManagerName,
-					TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-						Template: &kftrainerapi.JobSetTemplatePatch{
-							Metadata: &metav1.ObjectMeta{},
-							Spec:     &kftrainerapi.JobSetSpecPatch{},
-						},
-					},
-				}}).Obj(),
+				RuntimePatches([]kftrainerapi.RuntimePatch{
+					testingtrainjob.MakeRuntimePatchWrapper(runtimePatchManagerName).
+						EmptyMetadata().
+						Obj(),
+				}).Obj(),
 			podsetsInfo: []podset.PodSetInfo{
 				{
 					Name: "node",
@@ -119,39 +115,19 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 			},
 			wantTrainJob: testTrainJob.Clone().
 				RuntimePatches([]kftrainerapi.RuntimePatch{
-					{
-						Manager: runtimePatchManagerName,
-						TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-							Template: &kftrainerapi.JobSetTemplatePatch{
-								Metadata: &metav1.ObjectMeta{},
-								Spec: &kftrainerapi.JobSetSpecPatch{
-									ReplicatedJobs: []kftrainerapi.ReplicatedJobPatch{
-										{
-											Name: "node",
-											Template: &kftrainerapi.JobTemplatePatch{Spec: &kftrainerapi.JobSpecPatch{
-												Template: &kftrainerapi.PodTemplatePatch{
-													Metadata: &metav1.ObjectMeta{
-														Annotations: map[string]string{
-															"test-annotation": "test",
-														},
-														Labels: map[string]string{
-															constants.PodSetLabel: "node",
-															"test-label":          "label",
-														},
-													},
-													Spec: &kftrainerapi.PodSpecPatch{
-														NodeSelector:    map[string]string{"disktype": "ssd"},
-														Tolerations:     []corev1.Toleration{*toleration1.DeepCopy()},
-														SchedulingGates: []corev1.PodSchedulingGate{{Name: "test-scheduling-gate-1"}},
-													},
-												},
-											}},
-										},
-									},
-								},
-							},
-						},
-					},
+					testingtrainjob.MakeRuntimePatchWrapper(runtimePatchManagerName).
+						EmptyMetadata().
+						ReplicatedJobs(
+							testingtrainjob.MakeReplicatedJobPatchWrapper("node").
+								PodAnnotation("test-annotation", "test").
+								PodLabel(constants.PodSetLabel, "node").
+								PodLabel("test-label", "label").
+								NodeSelector("disktype", "ssd").
+								Toleration(*toleration1.DeepCopy()).
+								SchedulingGate("test-scheduling-gate-1").
+								Obj(),
+						).
+						Obj(),
 				}).
 				Suspend(false).
 				Obj(),
@@ -160,36 +136,18 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 		"should respect user provided RuntimePatches when adding PodSet info config to the trainjob": {
 			trainJob: testTrainJob.Clone().
 				RuntimePatches([]kftrainerapi.RuntimePatch{
-					{
-						Manager: "user-manager",
-						TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-							Template: &kftrainerapi.JobSetTemplatePatch{Spec: &kftrainerapi.JobSetSpecPatch{
-								ReplicatedJobs: []kftrainerapi.ReplicatedJobPatch{
-									{
-										Name: "node",
-										Template: &kftrainerapi.JobTemplatePatch{Spec: &kftrainerapi.JobSpecPatch{
-											Template: &kftrainerapi.PodTemplatePatch{
-												Spec: &kftrainerapi.PodSpecPatch{
-													NodeSelector:    map[string]string{"disktype": "sdd"},
-													Tolerations:     []corev1.Toleration{*toleration1.DeepCopy()},
-													SchedulingGates: []corev1.PodSchedulingGate{{Name: "test-scheduling-gate-4"}},
-												},
-											},
-										}},
-									},
-								},
-							}},
-						},
-					},
-					{
-						Manager: runtimePatchManagerName,
-						TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-							Template: &kftrainerapi.JobSetTemplatePatch{
-								Metadata: &metav1.ObjectMeta{},
-								Spec:     &kftrainerapi.JobSetSpecPatch{},
-							},
-						},
-					},
+					testingtrainjob.MakeRuntimePatchWrapper("user-manager").
+						ReplicatedJobs(
+							testingtrainjob.MakeReplicatedJobPatchWrapper("node").
+								NodeSelector("disktype", "sdd").
+								Toleration(*toleration1.DeepCopy()).
+								SchedulingGate("test-scheduling-gate-4").
+								Obj(),
+						).
+						Obj(),
+					testingtrainjob.MakeRuntimePatchWrapper(runtimePatchManagerName).
+						EmptyMetadata().
+						Obj(),
 				}).Obj(),
 			podsetsInfo: []podset.PodSetInfo{
 				{
@@ -208,60 +166,28 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 			},
 			wantTrainJob: testTrainJob.Clone().
 				RuntimePatches([]kftrainerapi.RuntimePatch{
-					{
-						Manager: "user-manager",
-						TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-							Template: &kftrainerapi.JobSetTemplatePatch{Spec: &kftrainerapi.JobSetSpecPatch{
-								ReplicatedJobs: []kftrainerapi.ReplicatedJobPatch{
-									{
-										Name: "node",
-										Template: &kftrainerapi.JobTemplatePatch{Spec: &kftrainerapi.JobSpecPatch{
-											Template: &kftrainerapi.PodTemplatePatch{
-												Spec: &kftrainerapi.PodSpecPatch{
-													NodeSelector:    map[string]string{"disktype": "sdd"},
-													Tolerations:     []corev1.Toleration{*toleration1.DeepCopy()},
-													SchedulingGates: []corev1.PodSchedulingGate{{Name: "test-scheduling-gate-4"}},
-												},
-											},
-										}},
-									},
-								},
-							}},
-						},
-					},
-					{
-						Manager: runtimePatchManagerName,
-						TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-							Template: &kftrainerapi.JobSetTemplatePatch{
-								Metadata: &metav1.ObjectMeta{},
-								Spec: &kftrainerapi.JobSetSpecPatch{
-									ReplicatedJobs: []kftrainerapi.ReplicatedJobPatch{
-										{
-											Name: "node",
-											Template: &kftrainerapi.JobTemplatePatch{Spec: &kftrainerapi.JobSpecPatch{
-												Template: &kftrainerapi.PodTemplatePatch{
-													Metadata: &metav1.ObjectMeta{
-														Annotations: map[string]string{
-															"test-annotation": "test",
-														},
-														Labels: map[string]string{
-															constants.PodSetLabel: "node",
-															"test-label":          "label",
-														},
-													},
-													Spec: &kftrainerapi.PodSpecPatch{
-														NodeSelector:    map[string]string{"gpu": "nvidia"},
-														Tolerations:     []corev1.Toleration{*toleration2.DeepCopy()},
-														SchedulingGates: []corev1.PodSchedulingGate{{Name: "test-scheduling-gate-2"}},
-													},
-												},
-											}},
-										},
-									},
-								},
-							},
-						},
-					},
+					testingtrainjob.MakeRuntimePatchWrapper("user-manager").
+						ReplicatedJobs(
+							testingtrainjob.MakeReplicatedJobPatchWrapper("node").
+								NodeSelector("disktype", "sdd").
+								Toleration(*toleration1.DeepCopy()).
+								SchedulingGate("test-scheduling-gate-4").
+								Obj(),
+						).
+						Obj(),
+					testingtrainjob.MakeRuntimePatchWrapper(runtimePatchManagerName).
+						EmptyMetadata().
+						ReplicatedJobs(
+							testingtrainjob.MakeReplicatedJobPatchWrapper("node").
+								PodAnnotation("test-annotation", "test").
+								PodLabel(constants.PodSetLabel, "node").
+								PodLabel("test-label", "label").
+								NodeSelector("gpu", "nvidia").
+								Toleration(*toleration2.DeepCopy()).
+								SchedulingGate("test-scheduling-gate-2").
+								Obj(),
+						).
+						Obj(),
 				}).
 				Suspend(false).
 				Obj(),
@@ -293,51 +219,23 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 		"should replace existing Kueue overrides (idempotency)": {
 			trainJob: testTrainJob.Clone().
 				RuntimePatches([]kftrainerapi.RuntimePatch{
-					{
-						Manager: "user-manager",
-						TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-							Template: &kftrainerapi.JobSetTemplatePatch{Spec: &kftrainerapi.JobSetSpecPatch{
-								ReplicatedJobs: []kftrainerapi.ReplicatedJobPatch{
-									{
-										Name: "user-provided",
-										Template: &kftrainerapi.JobTemplatePatch{Spec: &kftrainerapi.JobSpecPatch{
-											Template: &kftrainerapi.PodTemplatePatch{
-												Spec: &kftrainerapi.PodSpecPatch{
-													NodeSelector: map[string]string{"disktype": "sdd"},
-												},
-											},
-										}},
-									},
-								},
-							}},
-						},
-					},
-					{
-						Manager: runtimePatchManagerName,
-						TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-							Template: &kftrainerapi.JobSetTemplatePatch{
-								Metadata: &metav1.ObjectMeta{},
-								Spec: &kftrainerapi.JobSetSpecPatch{
-									ReplicatedJobs: []kftrainerapi.ReplicatedJobPatch{
-										{
-											Name: "node",
-											Template: &kftrainerapi.JobTemplatePatch{Spec: &kftrainerapi.JobSpecPatch{
-												Template: &kftrainerapi.PodTemplatePatch{
-													Metadata: &metav1.ObjectMeta{
-														Annotations: map[string]string{"test-annotation": "old-value"},
-														Labels:      map[string]string{constants.PodSetLabel: "node"},
-													},
-													Spec: &kftrainerapi.PodSpecPatch{
-														NodeSelector: map[string]string{"old-selector": "value"},
-													},
-												},
-											}},
-										},
-									},
-								},
-							},
-						},
-					},
+					testingtrainjob.MakeRuntimePatchWrapper("user-manager").
+						ReplicatedJobs(
+							testingtrainjob.MakeReplicatedJobPatchWrapper("user-provided").
+								NodeSelector("disktype", "sdd").
+								Obj(),
+						).
+						Obj(),
+					testingtrainjob.MakeRuntimePatchWrapper(runtimePatchManagerName).
+						EmptyMetadata().
+						ReplicatedJobs(
+							testingtrainjob.MakeReplicatedJobPatchWrapper("node").
+								PodAnnotation("test-annotation", "old-value").
+								PodLabel(constants.PodSetLabel, "node").
+								NodeSelector("old-selector", "value").
+								Obj(),
+						).
+						Obj(),
 				}).
 				Obj(),
 			podsetsInfo: []podset.PodSetInfo{
@@ -354,51 +252,23 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 			},
 			wantTrainJob: testTrainJob.Clone().
 				RuntimePatches([]kftrainerapi.RuntimePatch{
-					{
-						Manager: "user-manager",
-						TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-							Template: &kftrainerapi.JobSetTemplatePatch{Spec: &kftrainerapi.JobSetSpecPatch{
-								ReplicatedJobs: []kftrainerapi.ReplicatedJobPatch{
-									{
-										Name: "user-provided",
-										Template: &kftrainerapi.JobTemplatePatch{Spec: &kftrainerapi.JobSpecPatch{
-											Template: &kftrainerapi.PodTemplatePatch{
-												Spec: &kftrainerapi.PodSpecPatch{
-													NodeSelector: map[string]string{"disktype": "sdd"},
-												},
-											},
-										}},
-									},
-								},
-							}},
-						},
-					},
-					{
-						Manager: runtimePatchManagerName,
-						TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-							Template: &kftrainerapi.JobSetTemplatePatch{
-								Metadata: &metav1.ObjectMeta{},
-								Spec: &kftrainerapi.JobSetSpecPatch{
-									ReplicatedJobs: []kftrainerapi.ReplicatedJobPatch{
-										{
-											Name: "node",
-											Template: &kftrainerapi.JobTemplatePatch{Spec: &kftrainerapi.JobSpecPatch{
-												Template: &kftrainerapi.PodTemplatePatch{
-													Metadata: &metav1.ObjectMeta{
-														Annotations: map[string]string{"test-annotation": "new-value"},
-														Labels:      map[string]string{constants.PodSetLabel: "node"},
-													},
-													Spec: &kftrainerapi.PodSpecPatch{
-														NodeSelector: map[string]string{"new-selector": "value"},
-													},
-												},
-											}},
-										},
-									},
-								},
-							},
-						},
-					},
+					testingtrainjob.MakeRuntimePatchWrapper("user-manager").
+						ReplicatedJobs(
+							testingtrainjob.MakeReplicatedJobPatchWrapper("user-provided").
+								NodeSelector("disktype", "sdd").
+								Obj(),
+						).
+						Obj(),
+					testingtrainjob.MakeRuntimePatchWrapper(runtimePatchManagerName).
+						EmptyMetadata().
+						ReplicatedJobs(
+							testingtrainjob.MakeReplicatedJobPatchWrapper("node").
+								PodAnnotation("test-annotation", "new-value").
+								PodLabel(constants.PodSetLabel, "node").
+								NodeSelector("new-selector", "value").
+								Obj(),
+						).
+						Obj(),
 				}).
 				Suspend(false).
 				Obj(),
@@ -452,55 +322,32 @@ func TestRestorePodSetsInfo(t *testing.T) {
 		"should clear replicated job patches from the kueue RuntimePatch": {
 			trainJob: testTrainJob.Clone().
 				RuntimePatches([]kftrainerapi.RuntimePatch{
-					{
-						Manager: "user-manager",
-						TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-							Template: &kftrainerapi.JobSetTemplatePatch{Spec: &kftrainerapi.JobSetSpecPatch{
-								ReplicatedJobs: []kftrainerapi.ReplicatedJobPatch{
-									{Name: "user-provided-1"},
-									{Name: "user-provided-2"},
-								},
-							}},
-						},
-					},
-					{
-						Manager: runtimePatchManagerName,
-						TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-							Template: &kftrainerapi.JobSetTemplatePatch{
-								Metadata: &metav1.ObjectMeta{},
-								Spec: &kftrainerapi.JobSetSpecPatch{
-									ReplicatedJobs: []kftrainerapi.ReplicatedJobPatch{
-										{Name: "kueue-provided-1"},
-										{Name: "kueue-provided-2"},
-									},
-								},
-							},
-						},
-					},
+					testingtrainjob.MakeRuntimePatchWrapper("user-manager").
+						ReplicatedJobs(
+							testingtrainjob.MakeReplicatedJobPatchWrapper("user-provided-1").Obj(),
+							testingtrainjob.MakeReplicatedJobPatchWrapper("user-provided-2").Obj(),
+						).
+						Obj(),
+					testingtrainjob.MakeRuntimePatchWrapper(runtimePatchManagerName).
+						EmptyMetadata().
+						ReplicatedJobs(
+							testingtrainjob.MakeReplicatedJobPatchWrapper("kueue-provided-1").Obj(),
+							testingtrainjob.MakeReplicatedJobPatchWrapper("kueue-provided-2").Obj(),
+						).
+						Obj(),
 				}).
 				Obj(),
 			wantTrainJob: testTrainJob.Clone().
 				RuntimePatches([]kftrainerapi.RuntimePatch{
-					{
-						Manager: "user-manager",
-						TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-							Template: &kftrainerapi.JobSetTemplatePatch{Spec: &kftrainerapi.JobSetSpecPatch{
-								ReplicatedJobs: []kftrainerapi.ReplicatedJobPatch{
-									{Name: "user-provided-1"},
-									{Name: "user-provided-2"},
-								},
-							}},
-						},
-					},
-					{
-						Manager: runtimePatchManagerName,
-						TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-							Template: &kftrainerapi.JobSetTemplatePatch{
-								Metadata: &metav1.ObjectMeta{},
-								Spec:     &kftrainerapi.JobSetSpecPatch{},
-							},
-						},
-					},
+					testingtrainjob.MakeRuntimePatchWrapper("user-manager").
+						ReplicatedJobs(
+							testingtrainjob.MakeReplicatedJobPatchWrapper("user-provided-1").Obj(),
+							testingtrainjob.MakeReplicatedJobPatchWrapper("user-provided-2").Obj(),
+						).
+						Obj(),
+					testingtrainjob.MakeRuntimePatchWrapper(runtimePatchManagerName).
+						EmptyMetadata().
+						Obj(),
 				}).
 				Obj(),
 			wantReturn: true,

--- a/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter_test.go
@@ -82,14 +82,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			managersTrainJobs: []kftrainerapi.TrainJob{
 				*baseTrainJobManagedByKueueBuilder.Clone().
 					RuntimePatches([]kftrainerapi.RuntimePatch{
-						{
-							Manager: runtimePatchManagerName,
-							TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-								Template: &kftrainerapi.JobSetTemplatePatch{
-									Spec: &kftrainerapi.JobSetSpecPatch{},
-								},
-							},
-						},
+						testingtrainjob.MakeRuntimePatchWrapper(runtimePatchManagerName).Obj(),
 					}).
 					Obj(),
 			},
@@ -100,14 +93,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			wantManagersTrainJobs: []kftrainerapi.TrainJob{
 				*baseTrainJobManagedByKueueBuilder.Clone().
 					RuntimePatches([]kftrainerapi.RuntimePatch{
-						{
-							Manager: runtimePatchManagerName,
-							TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-								Template: &kftrainerapi.JobSetTemplatePatch{
-									Spec: &kftrainerapi.JobSetSpecPatch{},
-								},
-							},
-						},
+						testingtrainjob.MakeRuntimePatchWrapper(runtimePatchManagerName).Obj(),
 					}).
 					Obj(),
 			},

--- a/pkg/controller/jobs/trainjob/trainjob_webhook_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_webhook_test.go
@@ -84,27 +84,13 @@ func TestValidateCreate(t *testing.T) {
 		"valid topology request in RuntimePatch": {
 			clusterTrainingRuntime: testCtr,
 			trainJob: testTrainJob.Clone().RuntimePatches([]kftrainerapi.RuntimePatch{
-				{
-					Manager: runtimePatchManagerName,
-					TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-						Template: &kftrainerapi.JobSetTemplatePatch{Spec: &kftrainerapi.JobSetSpecPatch{
-							ReplicatedJobs: []kftrainerapi.ReplicatedJobPatch{
-								{
-									Name: "node",
-									Template: &kftrainerapi.JobTemplatePatch{Spec: &kftrainerapi.JobSpecPatch{
-										Template: &kftrainerapi.PodTemplatePatch{
-											Metadata: &metav1.ObjectMeta{
-												Annotations: map[string]string{
-													kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
-												},
-											},
-										},
-									}},
-								},
-							},
-						}},
-					},
-				},
+				testingtrainjob.MakeRuntimePatchWrapper(runtimePatchManagerName).
+					ReplicatedJobs(
+						testingtrainjob.MakeReplicatedJobPatchWrapper("node").
+							PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+							Obj(),
+					).
+					Obj(),
 			}).Obj(),
 			topologyAwareScheduling: true,
 		},
@@ -123,28 +109,14 @@ func TestValidateCreate(t *testing.T) {
 		"invalid topology request in TrainJob": {
 			clusterTrainingRuntime: testCtr,
 			trainJob: testTrainJob.Clone().RuntimePatches([]kftrainerapi.RuntimePatch{
-				{
-					Manager: runtimePatchManagerName,
-					TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-						Template: &kftrainerapi.JobSetTemplatePatch{Spec: &kftrainerapi.JobSetSpecPatch{
-							ReplicatedJobs: []kftrainerapi.ReplicatedJobPatch{
-								{
-									Name: "node",
-									Template: &kftrainerapi.JobTemplatePatch{Spec: &kftrainerapi.JobSpecPatch{
-										Template: &kftrainerapi.PodTemplatePatch{
-											Metadata: &metav1.ObjectMeta{
-												Annotations: map[string]string{
-													kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block",
-													kueue.PodSetRequiredTopologyAnnotation:  "cloud.com/block",
-												},
-											},
-										},
-									}},
-								},
-							},
-						}},
-					},
-				},
+				testingtrainjob.MakeRuntimePatchWrapper(runtimePatchManagerName).
+					ReplicatedJobs(
+						testingtrainjob.MakeReplicatedJobPatchWrapper("node").
+							PodAnnotation(kueue.PodSetPreferredTopologyAnnotation, "cloud.com/block").
+							PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+							Obj(),
+					).
+					Obj(),
 			}).Obj(),
 			wantErr: field.ErrorList{field.Invalid(field.NewPath("job[node].annotations"),
 				field.OmitValueType{}, `must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
@@ -174,29 +146,15 @@ func TestValidateCreate(t *testing.T) {
 		"invalid slice topology request - slice size larger than number of podsets": {
 			clusterTrainingRuntime: testCtr,
 			trainJob: testTrainJob.Clone().RuntimePatches([]kftrainerapi.RuntimePatch{
-				{
-					Manager: runtimePatchManagerName,
-					TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-						Template: &kftrainerapi.JobSetTemplatePatch{Spec: &kftrainerapi.JobSetSpecPatch{
-							ReplicatedJobs: []kftrainerapi.ReplicatedJobPatch{
-								{
-									Name: "node",
-									Template: &kftrainerapi.JobTemplatePatch{Spec: &kftrainerapi.JobSpecPatch{
-										Template: &kftrainerapi.PodTemplatePatch{
-											Metadata: &metav1.ObjectMeta{
-												Annotations: map[string]string{
-													kueue.PodSetRequiredTopologyAnnotation:      "cloud.com/block",
-													kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/block",
-													kueue.PodSetSliceSizeAnnotation:             "20",
-												},
-											},
-										},
-									}},
-								},
-							},
-						}},
-					},
-				},
+				testingtrainjob.MakeRuntimePatchWrapper(runtimePatchManagerName).
+					ReplicatedJobs(
+						testingtrainjob.MakeReplicatedJobPatchWrapper("node").
+							PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+							PodAnnotation(kueue.PodSetSliceRequiredTopologyAnnotation, "cloud.com/block").
+							PodAnnotation(kueue.PodSetSliceSizeAnnotation, "20").
+							Obj(),
+					).
+					Obj(),
 			}).Obj(),
 			wantErr: field.ErrorList{
 				field.Invalid(field.NewPath("job[node].annotations").
@@ -234,14 +192,7 @@ func TestDefault(t *testing.T) {
 	testLocalQueue := utiltestingapi.MakeLocalQueue("local-queue", testNamespace.Name).ClusterQueue(testClusterQueue.Name)
 	testTrainJob := testingtrainjob.MakeTrainJob("trainjob", testNamespace.Name).Suspend(false)
 	testExpectedTrainJob := testTrainJob.Clone().RuntimePatches([]kftrainerapi.RuntimePatch{
-		{
-			Manager: runtimePatchManagerName,
-			TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-				Template: &kftrainerapi.JobSetTemplatePatch{
-					Spec: &kftrainerapi.JobSetSpecPatch{},
-				},
-			},
-		},
+		testingtrainjob.MakeRuntimePatchWrapper(runtimePatchManagerName).Obj(),
 	})
 	testCases := map[string]struct {
 		trainJob                     *kftrainerapi.TrainJob

--- a/pkg/util/testingjobs/trainjob/wrappers.go
+++ b/pkg/util/testingjobs/trainjob/wrappers.go
@@ -27,6 +27,9 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 )
 
+// KueueRuntimePatchManager is the manager name used for Kueue-owned TrainJob runtime patches.
+const KueueRuntimePatchManager = "kueue.x-k8s.io/manager"
+
 type TrainJobWrapper struct{ kftrainerapi.TrainJob }
 
 // MakeTrainJob creates a wrapper for a suspended TrainJob
@@ -105,31 +108,21 @@ func (t *TrainJobWrapper) Label(key, value string) *TrainJobWrapper {
 
 // JobSetLabel sets a label on the child JobSet via RuntimePatches
 func (t *TrainJobWrapper) JobSetLabel(key, value string) *TrainJobWrapper {
-	for i := range t.Spec.RuntimePatches {
-		if t.Spec.RuntimePatches[i].Manager == "kueue.x-k8s.io/manager" {
-			metadata := t.Spec.RuntimePatches[i].TrainingRuntimeSpec.Template.Metadata
-			if metadata == nil {
-				metadata = &metav1.ObjectMeta{}
-			}
-			if metadata.Labels == nil {
-				metadata.Labels = make(map[string]string)
-			}
-			metadata.Labels[key] = value
-			t.Spec.RuntimePatches[i].TrainingRuntimeSpec.Template.Metadata = metadata
-			return t
+	if kueueRuntimePatch := KueueRuntimePatch(t.Obj()); kueueRuntimePatch != nil {
+		metadata := kueueRuntimePatch.TrainingRuntimeSpec.Template.Metadata
+		if metadata == nil {
+			metadata = &metav1.ObjectMeta{}
 		}
+		if metadata.Labels == nil {
+			metadata.Labels = make(map[string]string)
+		}
+		metadata.Labels[key] = value
+		kueueRuntimePatch.TrainingRuntimeSpec.Template.Metadata = metadata
+		return t
 	}
-	return t.RuntimePatches(append(t.Spec.RuntimePatches, kftrainerapi.RuntimePatch{
-		Manager: "kueue.x-k8s.io/manager",
-		TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-			Template: &kftrainerapi.JobSetTemplatePatch{
-				Metadata: &metav1.ObjectMeta{
-					Labels: map[string]string{key: value},
-				},
-				Spec: &kftrainerapi.JobSetSpecPatch{},
-			},
-		},
-	}))
+	return t.RuntimePatches(append(t.Spec.RuntimePatches, MakeRuntimePatchWrapper(KueueRuntimePatchManager).
+		Label(key, value).
+		Obj()))
 }
 
 // Obj returns the inner TrainJob.
@@ -168,6 +161,188 @@ func (t *TrainJobWrapper) TrainerRequest(r corev1.ResourceName, v string) *Train
 func (t *TrainJobWrapper) JobsStatus(statuses ...kftrainerapi.JobStatus) *TrainJobWrapper {
 	t.Status.JobsStatus = statuses
 	return t
+}
+
+type RuntimePatchWrapper struct{ kftrainerapi.RuntimePatch }
+
+// MakeRuntimePatchWrapper creates a wrapper for a TrainJob RuntimePatch.
+func MakeRuntimePatchWrapper(manager string) *RuntimePatchWrapper {
+	return &RuntimePatchWrapper{RuntimePatch: kftrainerapi.RuntimePatch{
+		Manager: manager,
+		TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
+			Template: &kftrainerapi.JobSetTemplatePatch{
+				Spec: &kftrainerapi.JobSetSpecPatch{},
+			},
+		},
+	}}
+}
+
+// Obj returns the inner RuntimePatch.
+func (r *RuntimePatchWrapper) Obj() kftrainerapi.RuntimePatch {
+	return r.RuntimePatch
+}
+
+func (r *RuntimePatchWrapper) EmptyMetadata() *RuntimePatchWrapper {
+	r.ensureTemplate().Metadata = &metav1.ObjectMeta{}
+	return r
+}
+
+func (r *RuntimePatchWrapper) Annotation(key, value string) *RuntimePatchWrapper {
+	metadata := r.ensureMetadata()
+	if metadata.Annotations == nil {
+		metadata.Annotations = make(map[string]string)
+	}
+	metadata.Annotations[key] = value
+	return r
+}
+
+func (r *RuntimePatchWrapper) Label(key, value string) *RuntimePatchWrapper {
+	metadata := r.ensureMetadata()
+	if metadata.Labels == nil {
+		metadata.Labels = make(map[string]string)
+	}
+	metadata.Labels[key] = value
+	return r
+}
+
+func (r *RuntimePatchWrapper) ReplicatedJobs(replicatedJobs ...kftrainerapi.ReplicatedJobPatch) *RuntimePatchWrapper {
+	r.ensureTemplateSpec().ReplicatedJobs = replicatedJobs
+	return r
+}
+
+func (r *RuntimePatchWrapper) ensureTrainingRuntimeSpec() *kftrainerapi.TrainingRuntimeSpecPatch {
+	if r.TrainingRuntimeSpec == nil {
+		r.TrainingRuntimeSpec = &kftrainerapi.TrainingRuntimeSpecPatch{}
+	}
+	return r.TrainingRuntimeSpec
+}
+
+func (r *RuntimePatchWrapper) ensureTemplate() *kftrainerapi.JobSetTemplatePatch {
+	trainingRuntimeSpec := r.ensureTrainingRuntimeSpec()
+	if trainingRuntimeSpec.Template == nil {
+		trainingRuntimeSpec.Template = &kftrainerapi.JobSetTemplatePatch{}
+	}
+	return trainingRuntimeSpec.Template
+}
+
+func (r *RuntimePatchWrapper) ensureTemplateSpec() *kftrainerapi.JobSetSpecPatch {
+	template := r.ensureTemplate()
+	if template.Spec == nil {
+		template.Spec = &kftrainerapi.JobSetSpecPatch{}
+	}
+	return template.Spec
+}
+
+func (r *RuntimePatchWrapper) ensureMetadata() *metav1.ObjectMeta {
+	template := r.ensureTemplate()
+	if template.Metadata == nil {
+		template.Metadata = &metav1.ObjectMeta{}
+	}
+	return template.Metadata
+}
+
+type ReplicatedJobPatchWrapper struct {
+	kftrainerapi.ReplicatedJobPatch
+}
+
+// MakeReplicatedJobPatchWrapper creates a wrapper for a TrainJob ReplicatedJobPatch.
+func MakeReplicatedJobPatchWrapper(name string) *ReplicatedJobPatchWrapper {
+	return &ReplicatedJobPatchWrapper{ReplicatedJobPatch: kftrainerapi.ReplicatedJobPatch{
+		Name: name,
+	}}
+}
+
+// Obj returns the inner ReplicatedJobPatch.
+func (r *ReplicatedJobPatchWrapper) Obj() kftrainerapi.ReplicatedJobPatch {
+	return r.ReplicatedJobPatch
+}
+
+func (r *ReplicatedJobPatchWrapper) PodAnnotation(key, value string) *ReplicatedJobPatchWrapper {
+	metadata := r.ensurePodMetadata()
+	if metadata.Annotations == nil {
+		metadata.Annotations = make(map[string]string)
+	}
+	metadata.Annotations[key] = value
+	return r
+}
+
+func (r *ReplicatedJobPatchWrapper) PodLabel(key, value string) *ReplicatedJobPatchWrapper {
+	metadata := r.ensurePodMetadata()
+	if metadata.Labels == nil {
+		metadata.Labels = make(map[string]string)
+	}
+	metadata.Labels[key] = value
+	return r
+}
+
+func (r *ReplicatedJobPatchWrapper) NodeSelector(key, value string) *ReplicatedJobPatchWrapper {
+	spec := r.ensurePodSpec()
+	if spec.NodeSelector == nil {
+		spec.NodeSelector = make(map[string]string)
+	}
+	spec.NodeSelector[key] = value
+	return r
+}
+
+func (r *ReplicatedJobPatchWrapper) Toleration(toleration corev1.Toleration) *ReplicatedJobPatchWrapper {
+	spec := r.ensurePodSpec()
+	spec.Tolerations = append(spec.Tolerations, toleration)
+	return r
+}
+
+func (r *ReplicatedJobPatchWrapper) SchedulingGate(name string) *ReplicatedJobPatchWrapper {
+	spec := r.ensurePodSpec()
+	spec.SchedulingGates = append(spec.SchedulingGates, corev1.PodSchedulingGate{Name: name})
+	return r
+}
+
+func (r *ReplicatedJobPatchWrapper) ensureJobTemplate() *kftrainerapi.JobTemplatePatch {
+	if r.Template == nil {
+		r.Template = &kftrainerapi.JobTemplatePatch{}
+	}
+	return r.Template
+}
+
+func (r *ReplicatedJobPatchWrapper) ensureJobSpec() *kftrainerapi.JobSpecPatch {
+	template := r.ensureJobTemplate()
+	if template.Spec == nil {
+		template.Spec = &kftrainerapi.JobSpecPatch{}
+	}
+	return template.Spec
+}
+
+func (r *ReplicatedJobPatchWrapper) ensurePodTemplate() *kftrainerapi.PodTemplatePatch {
+	jobSpec := r.ensureJobSpec()
+	if jobSpec.Template == nil {
+		jobSpec.Template = &kftrainerapi.PodTemplatePatch{}
+	}
+	return jobSpec.Template
+}
+
+func (r *ReplicatedJobPatchWrapper) ensurePodMetadata() *metav1.ObjectMeta {
+	podTemplate := r.ensurePodTemplate()
+	if podTemplate.Metadata == nil {
+		podTemplate.Metadata = &metav1.ObjectMeta{}
+	}
+	return podTemplate.Metadata
+}
+
+func (r *ReplicatedJobPatchWrapper) ensurePodSpec() *kftrainerapi.PodSpecPatch {
+	podTemplate := r.ensurePodTemplate()
+	if podTemplate.Spec == nil {
+		podTemplate.Spec = &kftrainerapi.PodSpecPatch{}
+	}
+	return podTemplate.Spec
+}
+
+// KueueRuntimePatch returns the Kueue-managed RuntimePatch, if present.
+func KueueRuntimePatch(trainJob *kftrainerapi.TrainJob) *kftrainerapi.RuntimePatch {
+	for i := range trainJob.Spec.RuntimePatches {
+		if trainJob.Spec.RuntimePatches[i].Manager == KueueRuntimePatchManager {
+			return &trainJob.Spec.RuntimePatches[i]
+		}
+	}
+	return nil
 }
 
 // MakeClusterTrainingRuntime creates a ClusterTrainingRuntime with the jobsetSpec provided

--- a/test/e2e/singlecluster/tas_test.go
+++ b/test/e2e/singlecluster/tas_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -494,25 +493,13 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", ginkgo.Label("area:singleclus
 				TrainerRequest(corev1.ResourceCPU, "500m").
 				TrainerRequest(corev1.ResourceMemory, "200Mi").
 				RuntimePatches([]kftrainerapi.RuntimePatch{
-					{
-						Manager: "test-e2e/tas",
-						TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-							Template: &kftrainerapi.JobSetTemplatePatch{Spec: &kftrainerapi.JobSetSpecPatch{
-								ReplicatedJobs: []kftrainerapi.ReplicatedJobPatch{
-									{
-										Name: "node",
-										Template: &kftrainerapi.JobTemplatePatch{Spec: &kftrainerapi.JobSpecPatch{
-											Template: &kftrainerapi.PodTemplatePatch{
-												Metadata: &metav1.ObjectMeta{
-													Annotations: map[string]string{kueue.PodSetRequiredTopologyAnnotation: corev1.LabelHostname},
-												},
-											},
-										}},
-									},
-								},
-							}},
-						},
-					},
+					testingtrainjob.MakeRuntimePatchWrapper("test-e2e/tas").
+						ReplicatedJobs(
+							testingtrainjob.MakeReplicatedJobPatchWrapper("node").
+								PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, corev1.LabelHostname).
+								Obj(),
+						).
+						Obj(),
 				}).
 				Obj()
 
@@ -528,18 +515,9 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", ginkgo.Label("area:singleclus
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			var kueueRuntimePatch *kftrainerapi.RuntimePatch
 			ginkgo.By("Verify that the trainjob has a runtime patch from kueue", func() {
-				for _, p := range trainjob.Spec.RuntimePatches {
-					if p.Manager == "kueue.x-k8s.io/manager" {
-						kueueRuntimePatch = &p
-						break
-					}
-				}
+				kueueRuntimePatch := testingtrainjob.KueueRuntimePatch(trainjob)
 				gomega.Expect(kueueRuntimePatch).ToNot(gomega.BeNil())
-			})
-
-			ginkgo.By("Verify the trainjob has nodeSelector set", func() {
 				rJobs := kueueRuntimePatch.TrainingRuntimeSpec.Template.Spec.ReplicatedJobs
 				gomega.Expect(rJobs).To(gomega.HaveLen(1))
 				gomega.Expect(rJobs[0].Template.Spec.Template.Spec.NodeSelector).To(gomega.Equal(

--- a/test/e2e/singlecluster/trainjob_test.go
+++ b/test/e2e/singlecluster/trainjob_test.go
@@ -185,12 +185,11 @@ var _ = ginkgo.Describe("TrainJob", ginkgo.Label("area:singlecluster", "feature:
 			})
 
 			ginkgo.By("Verify that the trainjob has a runtime patch from kueue", func() {
-				gomega.Expect(trainjob.Spec.RuntimePatches).To(gomega.HaveLen(1))
-				gomega.Expect(trainjob.Spec.RuntimePatches[0].Manager).To(gomega.Equal("kueue.x-k8s.io/manager"))
+				gomega.Expect(testingtrainjob.KueueRuntimePatch(trainjob)).ToNot(gomega.BeNil())
 			})
 
 			ginkgo.By("Verify the trainjob has nodeSelector set", func() {
-				rJobs := trainjob.Spec.RuntimePatches[0].TrainingRuntimeSpec.Template.Spec.ReplicatedJobs
+				rJobs := testingtrainjob.KueueRuntimePatch(trainjob).TrainingRuntimeSpec.Template.Spec.ReplicatedJobs
 				gomega.Expect(rJobs).To(gomega.HaveLen(1))
 				gomega.Expect(rJobs[0].Template.Spec.Template.Spec.NodeSelector).To(gomega.Equal(
 					map[string]string{

--- a/test/integration/singlecluster/controller/jobs/trainjob/trainjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/trainjob/trainjob_controller_test.go
@@ -456,14 +456,7 @@ var _ = ginkgo.Describe("TrainJob controller interacting with scheduler", ginkgo
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: trainJob.Name, Namespace: ns.Name}, createdTrainJob)).Should(gomega.Succeed())
 			g.Expect(*createdTrainJob.Spec.Suspend).Should(gomega.BeFalse())
-			// Find the Kueue RuntimePatch and verify replicated job patches
-			var kueuePatch *kftrainerapi.RuntimePatch
-			for i := range createdTrainJob.Spec.RuntimePatches {
-				if createdTrainJob.Spec.RuntimePatches[i].Manager == "kueue.x-k8s.io/manager" {
-					kueuePatch = &createdTrainJob.Spec.RuntimePatches[i]
-					break
-				}
-			}
+			kueuePatch := testingtrainjob.KueueRuntimePatch(createdTrainJob)
 			g.Expect(kueuePatch).ShouldNot(gomega.BeNil())
 			rJobs := kueuePatch.TrainingRuntimeSpec.Template.Spec.ReplicatedJobs
 			g.Expect(rJobs).To(gomega.HaveLen(2))

--- a/test/integration/singlecluster/webhook/jobs/trainjob_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/trainjob_webhook_test.go
@@ -89,13 +89,7 @@ var _ = ginkgo.Describe("Trainjob Webhook", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: trainJob.Name, Namespace: ns.Name}, &createdTrainJob)).Should(gomega.Succeed())
 					g.Expect(ptr.Deref(createdTrainJob.Spec.Suspend, false)).Should(gomega.BeTrue())
-					var kueueRuntimePatch *kftrainerapi.RuntimePatch
-					for i := range createdTrainJob.Spec.RuntimePatches {
-						if createdTrainJob.Spec.RuntimePatches[i].Manager == "kueue.x-k8s.io/manager" {
-							kueueRuntimePatch = &createdTrainJob.Spec.RuntimePatches[i]
-							break
-						}
-					}
+					kueueRuntimePatch := testingtrainjob.KueueRuntimePatch(&createdTrainJob)
 					g.Expect(kueueRuntimePatch).ShouldNot(gomega.BeNil())
 					g.Expect(kueueRuntimePatch.TrainingRuntimeSpec.Template.Metadata.Labels).To(gomega.HaveKeyWithValue(controllerconstants.QueueLabel, "queue"))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it:
Refactors TrainJob tests to use shared `RuntimePatch` wrappers and helpers instead of verbose inline patch literals and repeated manual lookup logic.

#### Which issue(s) this PR fixes:
Fixes #10148

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```