### PR TITLE
e2e dev mode - add an option to skip image reload #10094

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -37,6 +37,10 @@ export E2E_ENFORCE_OPERATOR_UPDATE="${E2E_ENFORCE_OPERATOR_UPDATE:-false}"
 # When set to value "true", skip Kueue re-install in E2E_MODE=dev if the controller deployment already exists.
 export E2E_SKIP_REINSTALL="${E2E_SKIP_REINSTALL:-false}"
 
+# When set to a truthy value with E2E_MODE=dev, skip docker pull and kind image import for dependency images
+# when they already exist locally / on kind worker nodes. CI mode always pulls and loads.
+export E2E_SKIP_IMAGE_RELOAD="${E2E_SKIP_IMAGE_RELOAD:-false}"
+
 export KIND_VERSION="${E2E_KIND_VERSION/"kindest/node:v"/}"
 
 function e2e_is_truthy {
@@ -46,13 +50,14 @@ function e2e_is_truthy {
     esac
 }
 
-# In dev mode, skip docker pull when the image already exists locally. In CI, always pull.
+# $1 image reference
 function e2e_docker_pull_if_needed {
-    if [[ "${E2E_MODE}" == "dev" ]] && docker image inspect "$1" > /dev/null 2>&1; then
-        echo "Image '$1' already cached locally; skipping pull (E2E_MODE=dev)"
+    local image="$1"
+    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_SKIP_IMAGE_RELOAD:-}" && docker image inspect "$image" > /dev/null 2>&1; then
+        echo "Image '$image' already cached locally; skipping pull (E2E_MODE=dev, E2E_SKIP_IMAGE_RELOAD set)"
         return 0
     fi
-    docker pull "$1"
+    docker pull "$image"
 }
 
 function e2e_deployment_exists {
@@ -419,21 +424,22 @@ function prepare_docker_images {
 
 # $1 cluster
 function cluster_kind_load {
-    cluster_kind_load_image "$1" "${E2E_TEST_AGNHOST_IMAGE_OLD}"
-    cluster_kind_load_image "$1" "${E2E_TEST_AGNHOST_IMAGE}"
+    local cluster="$1"
+    cluster_kind_load_image "$cluster" "${E2E_TEST_AGNHOST_IMAGE_OLD}"
+    cluster_kind_load_image "$cluster" "${E2E_TEST_AGNHOST_IMAGE}"
 
     if [[ "${E2E_MODE}" == "dev" && "${E2E_SKIP_REINSTALL}" == "true" ]]; then
-        cluster_kind_load_image "$1" "$IMAGE_TAG"
+        cluster_kind_load_image "$cluster" "$IMAGE_TAG"
     else
-        # Kueue image may have been rebuilt locally with the same tag; always reload unless skipping reinstall.
-        cluster_kind_load_image_force "$1" "$IMAGE_TAG"
+        # Bypass dev-mode existence check: Kueue image may have been rebuilt locally with the same tag; always re-import unless skipping reinstall.
+        cluster_kind_load_image_impl "$cluster" "$IMAGE_TAG"
     fi
 
     if [[ -n ${KUEUE_UPGRADE_FROM_VERSION:-} ]]; then
-        cluster_kind_load_image "$1" "${KUEUE_OLD_VERSION_IMAGE}"
+        cluster_kind_load_image "$cluster" "${KUEUE_OLD_VERSION_IMAGE}"
     fi
     if [[ -n "${CLUSTERPROFILE_VERSION:-}" ]]; then
-        cluster_kind_load_image "$1" "${CLUSTERPROFILE_PLUGIN_IMAGE}"
+        cluster_kind_load_image "$cluster" "${CLUSTERPROFILE_PLUGIN_IMAGE}"
     fi
 }
 
@@ -491,10 +497,12 @@ function kind_load {
 # $1 cluster name
 # $2 image reference (must match how the image appears in ctr images ls -q on workers)
 function cluster_kind_image_exists {
+    local cluster="$1"
+    local image="$2"
     local first_worker
-    first_worker=$($KIND get nodes --name "$1" | grep -v 'control-plane' | head -1)
+    first_worker=$($KIND get nodes --name "$cluster" | grep -v 'control-plane' | head -1)
     [[ -n "$first_worker" ]] && \
-        docker exec "$first_worker" ctr --namespace=k8s.io images ls -q 2>/dev/null | grep -qF "$2"
+        docker exec "$first_worker" ctr --namespace=k8s.io images ls -q 2>/dev/null | grep -qF "$image"
 }
 
 # Save image to a temp file once, then load into all worker nodes in parallel.
@@ -547,16 +555,13 @@ function cluster_kind_load_image_impl {
 }
 
 function cluster_kind_load_image {
-    # In dev mode, skip if the image is already in the cluster
-    if [[ "${E2E_MODE}" == "dev" ]] && cluster_kind_image_exists "$1" "$2"; then
-        echo "Image '$2' already loaded in cluster '$1'; skipping (E2E_MODE=dev)"
+    local cluster="$1"
+    local image="$2"
+    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_SKIP_IMAGE_RELOAD:-}" && cluster_kind_image_exists "$cluster" "$image"; then
+        echo "Image '$image' already loaded in cluster '$cluster'; skipping (E2E_MODE=dev, E2E_SKIP_IMAGE_RELOAD set)"
         return 0
     fi
-    cluster_kind_load_image_impl "$1" "$2"
-}
-
-function cluster_kind_load_image_force {
-    cluster_kind_load_image_impl "$1" "$2"
+    cluster_kind_load_image_impl "$cluster" "$image"
 }
 
 # $1 kubeconfig

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -45,15 +45,15 @@ export KIND_VERSION="${E2E_KIND_VERSION/"kindest/node:v"/}"
 
 function e2e_is_truthy {
     case "${1:-}" in
-        1|true|TRUE|True|yes|YES|Yes|y|Y|on|ON|On) return 0 ;;
-        *) return 1 ;;
+        1|true|TRUE|True|yes|YES|Yes|y|Y|on|ON|On) return 1 ;;
+        *) return 0 ;;
     esac
 }
 
 # $1 image reference
 function e2e_docker_pull_if_needed {
     local image="$1"
-    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_SKIP_IMAGE_RELOAD:-}" && docker image inspect "$image" > /dev/null 2>&1; then
+    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_SKIP_IMAGE_RELOAD:-}" && docker image inspect "$image" > /dev/null 2>&1; then
         echo "Image '$image' already cached locally; skipping pull (E2E_MODE=dev, E2E_SKIP_IMAGE_RELOAD=true)"
         return 0
     fi
@@ -428,7 +428,7 @@ function cluster_kind_load {
     cluster_kind_load_image "$cluster" "${E2E_TEST_AGNHOST_IMAGE_OLD}"
     cluster_kind_load_image "$cluster" "${E2E_TEST_AGNHOST_IMAGE}"
 
-    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_SKIP_REINSTALL:-}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_SKIP_REINSTALL:-}"; then
         cluster_kind_load_image "$cluster" "$IMAGE_TAG"
     else
         # Bypass dev-mode existence check: Kueue image may have been rebuilt locally with the same tag; always re-import unless skipping reinstall.
@@ -557,7 +557,7 @@ function cluster_kind_load_image_impl {
 function cluster_kind_load_image {
     local cluster="$1"
     local image="$2"
-    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_SKIP_IMAGE_RELOAD:-}" && cluster_kind_image_exists "$cluster" "$image"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_SKIP_IMAGE_RELOAD:-}" && cluster_kind_image_exists "$cluster" "$image"; then
         echo "Image '$image' already loaded in cluster '$cluster'; skipping (E2E_MODE=dev, E2E_SKIP_IMAGE_RELOAD=true)"
         return 0
     fi
@@ -606,7 +606,7 @@ function cluster_kueue_deploy {
         return
     fi
 
-    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_SKIP_REINSTALL:-}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_SKIP_REINSTALL:-}"; then
         if e2e_deployment_exists "$1" "${KUEUE_NAMESPACE}" "${KUEUE_DEPLOYMENT_NAME}"; then
             echo "Kueue controller already exists in namespace '${KUEUE_NAMESPACE}', skipping reinstall"
             return
@@ -675,7 +675,7 @@ function install_appwrapper {
     local deployment_name="${APPWRAPPER_CONTROLLER_MANAGER_DEPLOYMENT:-appwrapper-controller-manager}"
     local expected_version="${APPWRAPPER_VERSION:-}"
 
-    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if e2e_deployment_exists "${kubeconfig}" "${ns}" "${deployment_name}"; then
             local installed_version=""
             local img=""
@@ -710,7 +710,7 @@ function install_jobset {
     local deployment_name="${JOBSET_CONTROLLER_MANAGER_DEPLOYMENT:-jobset-controller-manager}"
     local expected_version="${JOBSET_VERSION:-}"
 
-    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if e2e_deployment_exists "${kubeconfig}" "${ns}" "${deployment_name}"; then
             local installed_version=""
             local images=""
@@ -751,7 +751,7 @@ function install_kubeflow {
     local deployment_name="${KUBEFLOW_TRAINING_OPERATOR_DEPLOYMENT:-training-operator}"
     local expected_version="${KUBEFLOW_IMAGE_VERSION:-}"
 
-    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if e2e_deployment_exists "${kubeconfig}" "${ns}" "${deployment_name}"; then
             local installed_version=""
             local img=""
@@ -786,7 +786,7 @@ function install_kubeflow_trainer {
     local deployment_name="${KUBEFLOW_TRAINER_DEPLOYMENT:-kubeflow-trainer-controller-manager}"
     local expected_version="${KF_TRAINER_IMAGE_VERSION:-}"
 
-    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if e2e_deployment_exists "${kubeconfig}" "${ns}" "${deployment_name}"; then
             local installed_version=""
             local img=""
@@ -833,7 +833,7 @@ function install_mpi {
     local deployment_name="${KUBEFLOW_MPI_OPERATOR_DEPLOYMENT:-mpi-operator}"
     local expected_version="${KUBEFLOW_MPI_VERSION:-}"
 
-    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if e2e_deployment_exists "${kubeconfig}" "${ns}" "${deployment_name}"; then
             local installed_version=""
             local images=""
@@ -880,7 +880,7 @@ function install_kuberay {
         kubectl_args+=(--kubeconfig="${kubeconfig}")
     fi
 
-    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if e2e_deployment_exists "${kubeconfig}" "${ns}" "${deployment_name}"; then
             local installed_version=""
             local img=""
@@ -909,7 +909,7 @@ function install_kuberay {
     # "kubectl create -k" is used instead of apply (https://github.com/ray-project/kuberay/issues/504),
     # but it is not idempotent: it exits non-zero if any objects already exist.
 
-    if ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}" || ! e2e_is_truthy "${force_reinstall}"; then
+    if e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}" || e2e_is_truthy "${force_reinstall}"; then
         kubectl ${kubectl_args[@]+"${kubectl_args[@]}"} delete -k "${KUBERAY_MANIFEST}" --ignore-not-found=true
     fi
     kubectl ${kubectl_args[@]+"${kubectl_args[@]}"} create -k "${KUBERAY_MANIFEST}"
@@ -925,7 +925,7 @@ function install_lws {
     local deployment_name="${LEADERWORKERSET_DEPLOYMENT:-lws-controller-manager}"
     local expected_version="${LEADERWORKERSET_VERSION:-}"
 
-    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if e2e_deployment_exists "${kubeconfig}" "${ns}" "${deployment_name}"; then
             local installed_version=""
             local images=""
@@ -971,7 +971,7 @@ function install_sparkoperator {
 
     ${HELM} repo add --force-update spark-operator https://kubeflow.github.io/spark-operator
 
-    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if helm list --namespace "${ns}" | grep -q "${helm_release_name}"; then
             local installed_version=""
             installed_version=$(helm get values --namespace="${ns}" "${helm_release_name}" -o json | jq -r '.image.tag')
@@ -1007,7 +1007,7 @@ function install_cert_manager {
     local deployment_name="${CERTMANAGER_DEPLOYMENT:-cert-manager}"
     local expected_version="${CERTMANAGER_VERSION:-}"
 
-    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if e2e_deployment_exists "${kubeconfig}" "${ns}" "${deployment_name}"; then
             local installed_version=""
             local img=""
@@ -1046,7 +1046,7 @@ function install_prometheus_operator {
     local deployment_name="prometheus-operator"
     local expected_version="${PROMETHEUS_OPERATOR_VERSION:-}"
 
-    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if e2e_deployment_exists "${kubeconfig}" "${ns}" "${deployment_name}"; then
             local installed_version=""
             local img=""
@@ -1084,7 +1084,7 @@ function deploy_kueue_prometheus_config {
 # $1 kubeconfig option
 function install_multicluster {
     local kubeconfig=${1:-}
-    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if e2e_crd_exists "${kubeconfig}" "clusterprofiles.multicluster.x-k8s.io"; then
             echo "ClusterProfile CRD already installed; skipping install (E2E_MODE=dev)."
             return 0
@@ -1101,7 +1101,7 @@ function install_dra_example_driver {
     local kubeconfig=${2:-}
     local expected_version="${DRA_EXAMPLE_DRIVER_VERSION:-}"
 
-    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         local installed_version=""
         local images=""
         images=$(kubectl --kubeconfig="${kubeconfig}" -n dra-example-driver get deployments \

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -45,16 +45,16 @@ export KIND_VERSION="${E2E_KIND_VERSION/"kindest/node:v"/}"
 
 function e2e_is_truthy {
     case "${1:-}" in
-        1|true|TRUE|True|yes|YES|Yes|y|Y|on|ON|On) return 1 ;;
-        *) return 0 ;;
+        1|true|TRUE|True|yes|YES|Yes|y|Y|on|ON|On) return 0 ;;
+        *) return 1 ;;
     esac
 }
 
 # $1 image reference
 function e2e_docker_pull_if_needed {
     local image="$1"
-    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_SKIP_IMAGE_RELOAD:-}" && docker image inspect "$image" > /dev/null 2>&1; then
-        echo "Image '$image' already cached locally; skipping pull (E2E_MODE=dev, E2E_SKIP_IMAGE_RELOAD set)"
+    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_SKIP_IMAGE_RELOAD:-}" && docker image inspect "$image" > /dev/null 2>&1; then
+        echo "Image '$image' already cached locally; skipping pull (E2E_MODE=dev, E2E_SKIP_IMAGE_RELOAD=true)"
         return 0
     fi
     docker pull "$image"
@@ -428,7 +428,7 @@ function cluster_kind_load {
     cluster_kind_load_image "$cluster" "${E2E_TEST_AGNHOST_IMAGE_OLD}"
     cluster_kind_load_image "$cluster" "${E2E_TEST_AGNHOST_IMAGE}"
 
-    if [[ "${E2E_MODE}" == "dev" && "${E2E_SKIP_REINSTALL}" == "true" ]]; then
+    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_SKIP_REINSTALL:-}"; then
         cluster_kind_load_image "$cluster" "$IMAGE_TAG"
     else
         # Bypass dev-mode existence check: Kueue image may have been rebuilt locally with the same tag; always re-import unless skipping reinstall.
@@ -557,8 +557,8 @@ function cluster_kind_load_image_impl {
 function cluster_kind_load_image {
     local cluster="$1"
     local image="$2"
-    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_SKIP_IMAGE_RELOAD:-}" && cluster_kind_image_exists "$cluster" "$image"; then
-        echo "Image '$image' already loaded in cluster '$cluster'; skipping (E2E_MODE=dev, E2E_SKIP_IMAGE_RELOAD set)"
+    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_SKIP_IMAGE_RELOAD:-}" && cluster_kind_image_exists "$cluster" "$image"; then
+        echo "Image '$image' already loaded in cluster '$cluster'; skipping (E2E_MODE=dev, E2E_SKIP_IMAGE_RELOAD=true)"
         return 0
     fi
     cluster_kind_load_image_impl "$cluster" "$image"
@@ -606,7 +606,7 @@ function cluster_kueue_deploy {
         return
     fi
 
-    if [[ "${E2E_MODE}" == "dev" && "${E2E_SKIP_REINSTALL}" == "true" ]]; then
+    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_SKIP_REINSTALL:-}"; then
         if e2e_deployment_exists "$1" "${KUEUE_NAMESPACE}" "${KUEUE_DEPLOYMENT_NAME}"; then
             echo "Kueue controller already exists in namespace '${KUEUE_NAMESPACE}', skipping reinstall"
             return
@@ -675,7 +675,7 @@ function install_appwrapper {
     local deployment_name="${APPWRAPPER_CONTROLLER_MANAGER_DEPLOYMENT:-appwrapper-controller-manager}"
     local expected_version="${APPWRAPPER_VERSION:-}"
 
-    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if e2e_deployment_exists "${kubeconfig}" "${ns}" "${deployment_name}"; then
             local installed_version=""
             local img=""
@@ -710,7 +710,7 @@ function install_jobset {
     local deployment_name="${JOBSET_CONTROLLER_MANAGER_DEPLOYMENT:-jobset-controller-manager}"
     local expected_version="${JOBSET_VERSION:-}"
 
-    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if e2e_deployment_exists "${kubeconfig}" "${ns}" "${deployment_name}"; then
             local installed_version=""
             local images=""
@@ -751,7 +751,7 @@ function install_kubeflow {
     local deployment_name="${KUBEFLOW_TRAINING_OPERATOR_DEPLOYMENT:-training-operator}"
     local expected_version="${KUBEFLOW_IMAGE_VERSION:-}"
 
-    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if e2e_deployment_exists "${kubeconfig}" "${ns}" "${deployment_name}"; then
             local installed_version=""
             local img=""
@@ -786,7 +786,7 @@ function install_kubeflow_trainer {
     local deployment_name="${KUBEFLOW_TRAINER_DEPLOYMENT:-kubeflow-trainer-controller-manager}"
     local expected_version="${KF_TRAINER_IMAGE_VERSION:-}"
 
-    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if e2e_deployment_exists "${kubeconfig}" "${ns}" "${deployment_name}"; then
             local installed_version=""
             local img=""
@@ -833,7 +833,7 @@ function install_mpi {
     local deployment_name="${KUBEFLOW_MPI_OPERATOR_DEPLOYMENT:-mpi-operator}"
     local expected_version="${KUBEFLOW_MPI_VERSION:-}"
 
-    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if e2e_deployment_exists "${kubeconfig}" "${ns}" "${deployment_name}"; then
             local installed_version=""
             local images=""
@@ -880,7 +880,7 @@ function install_kuberay {
         kubectl_args+=(--kubeconfig="${kubeconfig}")
     fi
 
-    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if e2e_deployment_exists "${kubeconfig}" "${ns}" "${deployment_name}"; then
             local installed_version=""
             local img=""
@@ -909,7 +909,7 @@ function install_kuberay {
     # "kubectl create -k" is used instead of apply (https://github.com/ray-project/kuberay/issues/504),
     # but it is not idempotent: it exits non-zero if any objects already exist.
 
-    if e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}" || e2e_is_truthy "${force_reinstall}"; then
+    if ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}" || ! e2e_is_truthy "${force_reinstall}"; then
         kubectl ${kubectl_args[@]+"${kubectl_args[@]}"} delete -k "${KUBERAY_MANIFEST}" --ignore-not-found=true
     fi
     kubectl ${kubectl_args[@]+"${kubectl_args[@]}"} create -k "${KUBERAY_MANIFEST}"
@@ -925,7 +925,7 @@ function install_lws {
     local deployment_name="${LEADERWORKERSET_DEPLOYMENT:-lws-controller-manager}"
     local expected_version="${LEADERWORKERSET_VERSION:-}"
 
-    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if e2e_deployment_exists "${kubeconfig}" "${ns}" "${deployment_name}"; then
             local installed_version=""
             local images=""
@@ -971,7 +971,7 @@ function install_sparkoperator {
 
     ${HELM} repo add --force-update spark-operator https://kubeflow.github.io/spark-operator
 
-    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}" ; then
+    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if helm list --namespace "${ns}" | grep -q "${helm_release_name}"; then
             local installed_version=""
             installed_version=$(helm get values --namespace="${ns}" "${helm_release_name}" -o json | jq -r '.image.tag')
@@ -1007,7 +1007,7 @@ function install_cert_manager {
     local deployment_name="${CERTMANAGER_DEPLOYMENT:-cert-manager}"
     local expected_version="${CERTMANAGER_VERSION:-}"
 
-    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if e2e_deployment_exists "${kubeconfig}" "${ns}" "${deployment_name}"; then
             local installed_version=""
             local img=""
@@ -1046,7 +1046,7 @@ function install_prometheus_operator {
     local deployment_name="prometheus-operator"
     local expected_version="${PROMETHEUS_OPERATOR_VERSION:-}"
 
-    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if e2e_deployment_exists "${kubeconfig}" "${ns}" "${deployment_name}"; then
             local installed_version=""
             local img=""
@@ -1084,7 +1084,7 @@ function deploy_kueue_prometheus_config {
 # $1 kubeconfig option
 function install_multicluster {
     local kubeconfig=${1:-}
-    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if e2e_crd_exists "${kubeconfig}" "clusterprofiles.multicluster.x-k8s.io"; then
             echo "ClusterProfile CRD already installed; skipping install (E2E_MODE=dev)."
             return 0
@@ -1101,7 +1101,7 @@ function install_dra_example_driver {
     local kubeconfig=${2:-}
     local expected_version="${DRA_EXAMPLE_DRIVER_VERSION:-}"
 
-    if [[ "${E2E_MODE}" == "dev" ]] && e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
+    if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         local installed_version=""
         local images=""
         images=$(kubectl --kubeconfig="${kubeconfig}" -n dra-example-driver get deployments \

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -46,6 +46,15 @@ function e2e_is_truthy {
     esac
 }
 
+# In dev mode, skip docker pull when the image already exists locally. In CI, always pull.
+function e2e_docker_pull_if_needed {
+    if [[ "${E2E_MODE}" == "dev" ]] && docker image inspect "$1" > /dev/null 2>&1; then
+        echo "Image '$1' already cached locally; skipping pull (E2E_MODE=dev)"
+        return 0
+    fi
+    docker pull "$1"
+}
+
 function e2e_deployment_exists {
     local kubeconfig=${1:-}
     local ns=$2
@@ -365,8 +374,8 @@ function cluster_create {
 }
 
 function prepare_docker_images {
-    docker pull "$E2E_TEST_AGNHOST_IMAGE_OLD_WITH_SHA"
-    docker pull "$E2E_TEST_AGNHOST_IMAGE_WITH_SHA"
+    e2e_docker_pull_if_needed "$E2E_TEST_AGNHOST_IMAGE_OLD_WITH_SHA"
+    e2e_docker_pull_if_needed "$E2E_TEST_AGNHOST_IMAGE_WITH_SHA"
 
     # We can load image by a digest but we cannot reference it by the digest that we pulled.
     # For more information https://github.com/kubernetes-sigs/kind/issues/2394#issuecomment-888713831.
@@ -375,36 +384,36 @@ function prepare_docker_images {
     docker tag "$E2E_TEST_AGNHOST_IMAGE_WITH_SHA" "$E2E_TEST_AGNHOST_IMAGE"
 
     if [[ -n ${APPWRAPPER_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(appwrapper|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
-        docker pull "${APPWRAPPER_IMAGE}"
+        e2e_docker_pull_if_needed "${APPWRAPPER_IMAGE}"
     fi
     if [[ -n ${JOBSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(jobset|tas|trainjob|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
-        docker pull "${JOBSET_IMAGE}"
+        e2e_docker_pull_if_needed "${JOBSET_IMAGE}"
     fi
     if [[ -n ${KUBEFLOW_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(jaxjob|pytorchjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
-        docker pull "${KUBEFLOW_IMAGE}"
+        e2e_docker_pull_if_needed "${KUBEFLOW_IMAGE}"
     fi
     if [[ -n ${KUBEFLOW_TRAINER_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(tas|trainjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
-        docker pull "${KF_TRAINER_IMAGE}"
+        e2e_docker_pull_if_needed "${KF_TRAINER_IMAGE}"
     fi
 
     if [[ -n ${KUBEFLOW_MPI_VERSION:-} ]]; then
-        docker pull "${KUBEFLOW_MPI_IMAGE}"
+        e2e_docker_pull_if_needed "${KUBEFLOW_MPI_IMAGE}"
     fi
     if [[ -n ${KUBERAY_VERSION:-} && ("$GINKGO_ARGS" =~ feature:kuberay || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
-        docker pull "${KUBERAY_IMAGE}"
+        e2e_docker_pull_if_needed "${KUBERAY_IMAGE}"
         determine_kuberay_ray_image
         if [[ ${USE_RAY_FOR_TESTS:-} == "ray" ]]; then
-            docker pull "${KUBERAY_RAY_IMAGE}"
+            e2e_docker_pull_if_needed "${KUBERAY_RAY_IMAGE}"
         fi
     fi
     if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
-        docker pull "${LEADERWORKERSET_IMAGE}"
+        e2e_docker_pull_if_needed "${LEADERWORKERSET_IMAGE}"
     fi
     if [[ -n ${KUEUE_UPGRADE_FROM_VERSION:-} ]]; then
-        docker pull "${KUEUE_OLD_VERSION_IMAGE}"
+        e2e_docker_pull_if_needed "${KUEUE_OLD_VERSION_IMAGE}"
     fi
     if [[ -n ${SPARKOPERATOR_VERSION:-} && ("$GINKGO_ARGS" =~ feature:spark || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
-        docker pull "${SPARKOPERATOR_IMAGE}"
+        e2e_docker_pull_if_needed "${SPARKOPERATOR_IMAGE}"
     fi
 }
 
@@ -412,7 +421,14 @@ function prepare_docker_images {
 function cluster_kind_load {
     cluster_kind_load_image "$1" "${E2E_TEST_AGNHOST_IMAGE_OLD}"
     cluster_kind_load_image "$1" "${E2E_TEST_AGNHOST_IMAGE}"
-    cluster_kind_load_image "$1" "$IMAGE_TAG"
+
+    if [[ "${E2E_MODE}" == "dev" && "${E2E_SKIP_REINSTALL}" == "true" ]]; then
+        cluster_kind_load_image "$1" "$IMAGE_TAG"
+    else
+        # Kueue image may have been rebuilt locally with the same tag; always reload unless skipping reinstall.
+        cluster_kind_load_image_force "$1" "$IMAGE_TAG"
+    fi
+
     if [[ -n ${KUEUE_UPGRADE_FROM_VERSION:-} ]]; then
         cluster_kind_load_image "$1" "${KUEUE_OLD_VERSION_IMAGE}"
     fi
@@ -472,17 +488,29 @@ function kind_load {
     fi
 }
 
+# $1 cluster name
+# $2 image reference (must match how the image appears in ctr images ls -q on workers)
+function cluster_kind_image_exists {
+    local first_worker
+    first_worker=$($KIND get nodes --name "$1" | grep -v 'control-plane' | head -1)
+    [[ -n "$first_worker" ]] && \
+        docker exec "$first_worker" ctr --namespace=k8s.io images ls -q 2>/dev/null | grep -qF "$2"
+}
+
 # Save image to a temp file once, then load into all worker nodes in parallel.
 # Using docker save + ctr import directly to avoid the --all-platforms
 # issue with multi-arch images in DinD environments.
 # See: https://github.com/kubernetes-sigs/kind/issues/3795
 # $1 cluster
 # $2 image
-function cluster_kind_load_image {
+function cluster_kind_load_image_impl {
+    local cluster="$1"
+    local image="$2"
     # filter out 'control-plane' node, use only worker nodes to load image
-    worker_nodes=$($KIND get nodes --name "$1" | grep -v 'control-plane')
+    local worker_nodes
+    worker_nodes=$($KIND get nodes --name "$cluster" | grep -v 'control-plane')
     if [[ -z "$worker_nodes" ]]; then
-        echo "No worker nodes found for cluster '$1'"
+        echo "No worker nodes found for cluster '$cluster'"
         return 1
     fi
 
@@ -491,13 +519,13 @@ function cluster_kind_load_image {
     trap '[ -d "${tmp_dir:-}" ] && rm -rf "$tmp_dir"' RETURN
     local tmp_image="$tmp_dir/image.tar"
 
-    echo "Saving image '$2'..."
-    if ! docker save "$2" -o "$tmp_image"; then
-        echo "Failed to save image '$2'"
+    echo "Saving image '${image}'..."
+    if ! docker save "$image" -o "$tmp_image"; then
+        echo "Failed to save image '${image}'"
         return 1
     fi
 
-    echo "Loading image '$2' to cluster '$1' (parallel)"
+    echo "Loading image '${image}' to cluster '${cluster}' (parallel)"
     local pids=()
     local nodes=()
     while IFS= read -r node; do
@@ -511,11 +539,24 @@ function cluster_kind_load_image {
     local failed=0
     for i in "${!pids[@]}"; do
         if ! wait "${pids[$i]}"; then
-            echo "Failed to load image '$2' to node '${nodes[$i]}'"
+            echo "Failed to load image '${image}' to node '${nodes[$i]}'"
             failed=1
         fi
     done
     return "$failed"
+}
+
+function cluster_kind_load_image {
+    # In dev mode, skip if the image is already in the cluster
+    if [[ "${E2E_MODE}" == "dev" ]] && cluster_kind_image_exists "$1" "$2"; then
+        echo "Image '$2' already loaded in cluster '$1'; skipping (E2E_MODE=dev)"
+        return 0
+    fi
+    cluster_kind_load_image_impl "$1" "$2"
+}
+
+function cluster_kind_load_image_force {
+    cluster_kind_load_image_impl "$1" "$2"
 }
 
 # $1 kubeconfig

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -43,7 +43,6 @@ export E2E_SKIP_IMAGE_RELOAD="${E2E_SKIP_IMAGE_RELOAD:-false}"
 
 export KIND_VERSION="${E2E_KIND_VERSION/"kindest/node:v"/}"
 
-# Returns 0 (true) if the input value is a common representation of "true", otherwise returns 1 (false).
 function e2e_is_truthy {
     case "${1:-}" in
         1|true|TRUE|True|yes|YES|Yes|y|Y|on|ON|On) return 1 ;;

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -43,6 +43,7 @@ export E2E_SKIP_IMAGE_RELOAD="${E2E_SKIP_IMAGE_RELOAD:-false}"
 
 export KIND_VERSION="${E2E_KIND_VERSION/"kindest/node:v"/}"
 
+# Returns 0 (true) if the input value is a common representation of "true", otherwise returns 1 (false).
 function e2e_is_truthy {
     case "${1:-}" in
         1|true|TRUE|True|yes|YES|Yes|y|Y|on|ON|On) return 1 ;;

--- a/site/content/en/docs/contribution_guidelines/testing.md
+++ b/site/content/en/docs/contribution_guidelines/testing.md
@@ -141,6 +141,8 @@ E2E_MODE=dev E2E_SKIP_REINSTALL=true make kind-image-build test-multikueue-e2e
 {{% alert title="Note" color="primary" %}}
 When reusing a kept cluster in `E2E_MODE=dev`, external operators (MPI, KubeRay, etc.) are installed only once.
 To force re-installing them on every run, set `E2E_ENFORCE_OPERATOR_UPDATE=true`.
+
+In dev mode, e2e setup skips `docker pull` for dependency images that are already in your local Docker cache, and skips loading an image into kind worker nodes when that image reference is already present in the node containerd store. That makes repeat runs much faster, especially on multi-node clusters. The Kueue controller image is always reloaded into the cluster unless `E2E_SKIP_REINSTALL=true`, because you may rebuild it with `make kind-image-build` under the same tag.
 {{% /alert %}}
 
 To delete the kept cluster(s) afterwards:

--- a/site/content/en/docs/contribution_guidelines/testing.md
+++ b/site/content/en/docs/contribution_guidelines/testing.md
@@ -136,13 +136,22 @@ E2E_MODE=dev GINKGO_ARGS="--until-it-fails" make kind-image-build  test-e2e
 # Skip reinstallation of kueue (works only in dev mode)
 E2E_MODE=dev E2E_SKIP_REINSTALL=true make kind-image-build test-e2e
 E2E_MODE=dev E2E_SKIP_REINSTALL=true make kind-image-build test-multikueue-e2e
+
+# Skip re-pulling dependency images and re-importing them into kind when already present (dev mode only)
+E2E_MODE=dev E2E_SKIP_IMAGE_RELOAD=true make kind-image-build test-e2e
 ```
 
 {{% alert title="Note" color="primary" %}}
 When reusing a kept cluster in `E2E_MODE=dev`, external operators (MPI, KubeRay, etc.) are installed only once.
 To force re-installing them on every run, set `E2E_ENFORCE_OPERATOR_UPDATE=true`.
 
-In dev mode, e2e setup skips `docker pull` for dependency images that are already in your local Docker cache, and skips loading an image into kind worker nodes when that image reference is already present in the node containerd store. That makes repeat runs much faster, especially on multi-node clusters. The Kueue controller image is always reloaded into the cluster unless `E2E_SKIP_REINSTALL=true`, because you may rebuild it with `make kind-image-build` under the same tag.
+Set `E2E_SKIP_IMAGE_RELOAD` to a truthy value (for example `true`) to skip `docker pull` for dependency images
+that are already in your local Docker cache, and to skip loading an image into kind worker nodes when that
+image reference is already present in the node containerd store.
+That makes repeat runs faster, especially on multi-node clusters.
+
+The Kueue controller image is always reloaded into the cluster unless `E2E_SKIP_REINSTALL=true`, because you may
+rebuild it with `make kind-image-build` under the same tag.
 {{% /alert %}}
 
 To delete the kept cluster(s) afterwards:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area testing

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Adds an option to skip image re-load.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10094

#### Special notes for your reviewer:
Verification:
```bash
# First run -- creates cluster, pulls images, loads everything
time E2E_MODE=dev E2E_RUN_ONLY_ENV=true \
  GINKGO_ARGS='--label-filter=feature:kuberay' \
  make kind-image-build test-e2e
# E2E_MODE=dev E2E_RUN_ONLY_ENV=true GINKGO_ARGS= make kind-image-build test-e2  172.28s user 38.88s system 66% cpu 5:19.49 total  

# Second run -- should be much faster (images cached and loaded)
time E2E_MODE=dev E2E_RUN_ONLY_ENV=true E2E_SKIP_REINSTALL=true E2E_SKIP_IMAGE_RELOAD=true \
  GINKGO_ARGS='--label-filter=feature:kuberay' \
  make test-e2e
# E2E_MODE=dev E2E_RUN_ONLY_ENV=true E2E_SKIP_REINSTALL=true GINKGO_ARGS= make   5.72s user 5.59s system 36% cpu 31.227 total
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```