### PR TITLE
Fix adding a trailing space to `GINKGO_ARGS`

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -60,7 +60,12 @@ KIND_CLUSTER_NAME ?= kind
 # Number of processes to use during e2e tests.
 E2E_NPROCS ?= 1
 
-GINKGO_ARGS += $(if $(filter-out 1,$(E2E_NPROCS)),-procs=$(E2E_NPROCS))
+# Inject the number of procs into GINKGO_ARGS
+GINKGO_PROC_ARG := $(if $(filter-out 1,$(E2E_NPROCS)),-procs=$(E2E_NPROCS))
+# Check empty string to avoid adding a trailing space
+ifneq ($(GINKGO_PROC_ARG),)
+    GINKGO_ARGS += $(GINKGO_PROC_ARG)
+endif
 
 # For restricting to a specific directory
 GO_TEST_TARGET ?= .


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area testing

#### What this PR does / why we need it:
`+=` adds an implicit space in Makefile. So invocations like:
```
GINKGO_ARGS="--repeat=10" make test-multikueue-e2e
```
fail with:
```
invalid value "10 " for flag -repeat: parse error
```

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
Found by @Singularity23x0, but I'm also checking out a flake and I saw the issue so I'm posting a fix.

We can also consider using `strip`.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```