### PR TITLE
docs: clarify borrowWithinCohort only targets workloads above nominal quota

### DIFF
--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -443,7 +443,8 @@ The fields above do the following:
     priority.
 
 - `borrowWithinCohort` determines whether a pending Workload can preempt
-  Workloads from other ClusterQueues if the workload requires borrowing.
+  Workloads from other ClusterQueues that are using more than their nominal
+  quota, if the workload requires borrowing.
   May only be configured with Classical Preemption, and __not__ with Fair Sharing.
   This field requires to specify `policy` sub-field with possible values:
   - `Never` (default): do not preempt Workloads in the cohort if borrowing is required.


### PR DESCRIPTION
## Summary
Docs currently read like borrowWithinCohort with "lowerPriority" may evict workloads within other cluster queues' nominal quota. The preemption documentation declares this impossible, but I think it's confusing when ou're reading about the borrowWithinCohort documentation. This PR clarifies that `borrowWithinCohort` preemption only targets workloads in ClusterQueues that are using more than their nominal quota. 

Clarifies and closes https://github.com/kubernetes-sigs/kueue/issues/10171

## Test plan
- Documentation-only change, no behavioral impact