### PR TITLE
Add borrowWithinCohort LowerPriorityBorrowersOnly policy

### DIFF
--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -507,8 +507,9 @@ type ClusterQueuePreemption struct {
 type BorrowWithinCohortPolicy string
 
 const (
-	BorrowWithinCohortPolicyNever         BorrowWithinCohortPolicy = "Never"
-	BorrowWithinCohortPolicyLowerPriority BorrowWithinCohortPolicy = "LowerPriority"
+	BorrowWithinCohortPolicyNever                      BorrowWithinCohortPolicy = "Never"
+	BorrowWithinCohortPolicyLowerPriority              BorrowWithinCohortPolicy = "LowerPriority"
+	BorrowWithinCohortPolicyLowerPriorityBorrowersOnly BorrowWithinCohortPolicy = "LowerPriorityBorrowersOnly"
 )
 
 // BorrowWithinCohort contains configuration which allows to preempt workloads
@@ -522,9 +523,14 @@ type BorrowWithinCohort struct {
 	// - `LowerPriority`: allow preemption, in other ClusterQueues
 	//    within the cohort, for a borrowing workload, but only if
 	//    the preempted workloads are of lower priority.
+	// - `LowerPriorityBorrowersOnly`: like `LowerPriority`, but a workload in
+	//    another ClusterQueue is a valid target only if that ClusterQueue is
+	//    borrowing for the contested resources and removing the target workload
+	//    would not reduce that ClusterQueue's usage below its nominal quota
+	//    for those resources.
 	//
 	// +kubebuilder:default=Never
-	// +kubebuilder:validation:Enum=Never;LowerPriority
+	// +kubebuilder:validation:Enum=Never;LowerPriority;LowerPriorityBorrowersOnly
 	Policy BorrowWithinCohortPolicy `json:"policy,omitempty"`
 
 	// maxPriorityThreshold allows to restrict the set of workloads which

--- a/apis/kueue/v1beta2/clusterqueue_types.go
+++ b/apis/kueue/v1beta2/clusterqueue_types.go
@@ -501,8 +501,9 @@ type ClusterQueuePreemption struct {
 type BorrowWithinCohortPolicy string
 
 const (
-	BorrowWithinCohortPolicyNever         BorrowWithinCohortPolicy = "Never"
-	BorrowWithinCohortPolicyLowerPriority BorrowWithinCohortPolicy = "LowerPriority"
+	BorrowWithinCohortPolicyNever                      BorrowWithinCohortPolicy = "Never"
+	BorrowWithinCohortPolicyLowerPriority              BorrowWithinCohortPolicy = "LowerPriority"
+	BorrowWithinCohortPolicyLowerPriorityBorrowersOnly BorrowWithinCohortPolicy = "LowerPriorityBorrowersOnly"
 )
 
 // BorrowWithinCohort contains configuration which allows to preempt workloads
@@ -516,9 +517,14 @@ type BorrowWithinCohort struct {
 	// - `LowerPriority`: allow preemption, in other ClusterQueues
 	//    within the cohort, for a borrowing workload, but only if
 	//    the preempted workloads are of lower priority.
+	// - `LowerPriorityBorrowersOnly`: like `LowerPriority`, but a workload in
+	//    another ClusterQueue is a valid target only if that ClusterQueue is
+	//    borrowing for the contested resources and removing the target workload
+	//    would not reduce that ClusterQueue's usage below its nominal quota
+	//    for those resources.
 	//
 	// +kubebuilder:default=Never
-	// +kubebuilder:validation:Enum=Never;LowerPriority
+	// +kubebuilder:validation:Enum=Never;LowerPriority;LowerPriorityBorrowersOnly
 	// +optional
 	Policy BorrowWithinCohortPolicy `json:"policy,omitempty"`
 	// maxPriorityThreshold allows to restrict the set of workloads which

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -324,9 +324,15 @@ spec:
                             - `LowerPriority`: allow preemption, in other ClusterQueues
                                within the cohort, for a borrowing workload, but only if
                                the preempted workloads are of lower priority.
+                            - `LowerPriorityBorrowersOnly`: like `LowerPriority`, but a workload in
+                               another ClusterQueue is a valid target only if that ClusterQueue is
+                               borrowing for the contested resources and removing the target workload
+                               would not reduce that ClusterQueue's usage below its nominal quota
+                               for those resources.
                           enum:
                             - Never
                             - LowerPriority
+                            - LowerPriorityBorrowersOnly
                           type: string
                       type: object
                     reclaimWithinCohort:
@@ -1088,9 +1094,15 @@ spec:
                             - `LowerPriority`: allow preemption, in other ClusterQueues
                                within the cohort, for a borrowing workload, but only if
                                the preempted workloads are of lower priority.
+                            - `LowerPriorityBorrowersOnly`: like `LowerPriority`, but a workload in
+                               another ClusterQueue is a valid target only if that ClusterQueue is
+                               borrowing for the contested resources and removing the target workload
+                               would not reduce that ClusterQueue's usage below its nominal quota
+                               for those resources.
                           enum:
                             - Never
                             - LowerPriority
+                            - LowerPriorityBorrowersOnly
                           type: string
                       type: object
                     reclaimWithinCohort:

--- a/client-go/applyconfiguration/kueue/v1beta1/borrowwithincohort.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/borrowwithincohort.go
@@ -36,6 +36,11 @@ type BorrowWithinCohortApplyConfiguration struct {
 	// - `LowerPriority`: allow preemption, in other ClusterQueues
 	// within the cohort, for a borrowing workload, but only if
 	// the preempted workloads are of lower priority.
+	// - `LowerPriorityBorrowersOnly`: like `LowerPriority`, but a workload in
+	// another ClusterQueue is a valid target only if that ClusterQueue is
+	// borrowing for the contested resources and removing the target workload
+	// would not reduce that ClusterQueue's usage below its nominal quota
+	// for those resources.
 	Policy *kueuev1beta1.BorrowWithinCohortPolicy `json:"policy,omitempty"`
 	// maxPriorityThreshold allows to restrict the set of workloads which
 	// might be preempted by a borrowing workload, to only workloads with

--- a/client-go/applyconfiguration/kueue/v1beta2/borrowwithincohort.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/borrowwithincohort.go
@@ -36,6 +36,11 @@ type BorrowWithinCohortApplyConfiguration struct {
 	// - `LowerPriority`: allow preemption, in other ClusterQueues
 	// within the cohort, for a borrowing workload, but only if
 	// the preempted workloads are of lower priority.
+	// - `LowerPriorityBorrowersOnly`: like `LowerPriority`, but a workload in
+	// another ClusterQueue is a valid target only if that ClusterQueue is
+	// borrowing for the contested resources and removing the target workload
+	// would not reduce that ClusterQueue's usage below its nominal quota
+	// for those resources.
 	Policy *kueuev1beta2.BorrowWithinCohortPolicy `json:"policy,omitempty"`
 	// maxPriorityThreshold allows to restrict the set of workloads which
 	// might be preempted by a borrowing workload, to only workloads with

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -299,9 +299,15 @@ spec:
                           - `LowerPriority`: allow preemption, in other ClusterQueues
                              within the cohort, for a borrowing workload, but only if
                              the preempted workloads are of lower priority.
+                          - `LowerPriorityBorrowersOnly`: like `LowerPriority`, but a workload in
+                             another ClusterQueue is a valid target only if that ClusterQueue is
+                             borrowing for the contested resources and removing the target workload
+                             would not reduce that ClusterQueue's usage below its nominal quota
+                             for those resources.
                         enum:
                         - Never
                         - LowerPriority
+                        - LowerPriorityBorrowersOnly
                         type: string
                     type: object
                   reclaimWithinCohort:
@@ -1083,9 +1089,15 @@ spec:
                           - `LowerPriority`: allow preemption, in other ClusterQueues
                              within the cohort, for a borrowing workload, but only if
                              the preempted workloads are of lower priority.
+                          - `LowerPriorityBorrowersOnly`: like `LowerPriority`, but a workload in
+                             another ClusterQueue is a valid target only if that ClusterQueue is
+                             borrowing for the contested resources and removing the target workload
+                             would not reduce that ClusterQueue's usage below its nominal quota
+                             for those resources.
                         enum:
                         - Never
                         - LowerPriority
+                        - LowerPriorityBorrowersOnly
                         type: string
                     type: object
                   reclaimWithinCohort:

--- a/keps/10171-borrow-within-cohort-lower-priority-borrowers-only/README.md
+++ b/keps/10171-borrow-within-cohort-lower-priority-borrowers-only/README.md
@@ -1,0 +1,257 @@
+# KEP-10171: borrowWithinCohort `LowerPriorityBorrowersOnly` policy
+
+<!--
+This KEP extends [KEP-1337](https://github.com/kubernetes-sigs/kueue/tree/main/keps/1337-preempt-within-cohort-while-borrowing)
+(`borrowWithinCohort`) with an additional policy that protects other tenants’
+nominal quota when a workload preempts while borrowing. It accompanies
+[Issue #10171](https://github.com/kubernetes-sigs/kueue/issues/10171).
+-->
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User stories](#user-stories)
+  - [Risks and mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Relationship to KEP-1337](#relationship-to-kep-1337)
+  - [API](#api)
+  - [Semantics](#semantics)
+  - [Implementation sketch](#implementation-sketch)
+  - [Fair Sharing](#fair-sharing)
+  - [Test Plan](#test-plan)
+    - [Unit tests](#unit-tests)
+    - [Integration tests](#integration-tests)
+  - [Graduation Criteria](#graduation-criteria)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+<!-- /toc -->
+
+## Summary
+
+This KEP adds a new value `LowerPriorityBorrowersOnly` for
+`.spec.preemption.borrowWithinCohort.policy` on `ClusterQueue` (classical
+preemption only). It sits between `Never` and `LowerPriority`:
+
+- With **`LowerPriority`**, a borrowing preemptor may evict **any** eligible
+  lower-priority workload in another queue in the cohort, including workloads
+  whose resources are **entirely backed by that queue’s nominal quota**.
+- With **`LowerPriorityBorrowersOnly`**, a workload in another `ClusterQueue`
+  is a preemption target **only if** removing it would leave that queue **at or
+  above nominal** for every **contested** flavor-resource involved in the
+  preemption decision. Intuitively: the preemptor may reclaim **borrowed**
+  capacity from other queues, not capacity that is still **guaranteed** to the
+  victim queue under nominal quota.
+
+`maxPriorityThreshold` continues to apply: a candidate must satisfy the priority
+and threshold constraints **and** the nominal-remainder rule above.
+
+## Motivation
+
+In multi-tenant clusters, teams are often given **nominal quota** as a hard
+allocation. Borrowing from a cohort is understood as **best-effort** relative
+to that guarantee. Today, `borrowWithinCohort.policy: LowerPriority` does not
+distinguish borrowed usage from usage within nominal on the **victim**
+`ClusterQueue`. A high-priority borrowing workload can therefore preempt
+lower-priority workloads that are not “using borrowed headroom” in a precise
+sense—e.g. preemptions that would push the victim **below** nominal on a
+resource if the preempted workload were removed.
+
+Operators need a middle ground:
+
+- **`Never`**: no cross-queue preemption while borrowing (too strict for some).
+- **`LowerPriority`**: unrestricted (among priorities) preemption of lower
+  priority workloads (too aggressive for nominal guarantees).
+- **`LowerPriorityBorrowersOnly`**: allow reclaiming capacity that keeps the
+  victim at or above nominal after the removal, aligning preemption with the
+  idea that nominal quota should remain protected.
+
+### Goals
+
+- Add `LowerPriorityBorrowersOnly` to `BorrowWithinCohortPolicy`.
+- Define clear semantics for **per-candidate** validation against **nominal**
+  quota for **contested** flavor-resources (resources for which preemption is
+  being considered).
+- Preserve composition with `maxPriorityThreshold`.
+- Keep behavior scoped to **classical preemption**; do not extend
+  `borrowWithinCohort` to Fair Sharing (unchanged from KEP-1337).
+
+### Non-Goals
+
+- Changing `reclaimWithinCohort`, `withinClusterQueue`, or hierarchical reclaim
+  rules beyond what follows naturally from the new `borrowWithinCohort`
+  policy.
+- Introducing new Fair Sharing behavior for `borrowWithinCohort`.
+- Defining a different notion of “borrowing” than usage vs nominal already used
+  in the scheduler cache (see [Semantics](#semantics)).
+
+## Proposal
+
+Extend `BorrowWithinCohortPolicy` with one new enum value and document it in the
+API. No new fields are required on `BorrowWithinCohort`.
+
+### User stories
+
+1. **Tenant B** has nominal 10 GPUs and is using 13 (borrowed 3). **Tenant A**
+   submits a borrowing workload that needs to reclaim GPUs. Under
+   `LowerPriorityBorrowersOnly`, a workload in B that uses **2** GPUs may be
+   preempted (13 − 2 = 11 ≥ 10), but a workload that uses **5** GPUs may not
+   (13 − 5 = 8 &lt; 10).
+2. **Tenant C** is **not** borrowing (usage ≤ nominal on contested resources).
+   No workloads in C are considered for this preemption path when the cohort
+   logic already restricts to over-nominal queues (existing behavior);
+   `LowerPriorityBorrowersOnly` then adds the per-workload remainder check for
+   queues that *are* over nominal.
+
+### Risks and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Harder to schedule if fewer candidates qualify | Opt-in policy; clusters keep `LowerPriority` if they prefer the old behavior. |
+| Misunderstanding “contested” resources | Document that the check applies per flavor-resource in the set needing preemption for the incoming assignment. |
+| Interaction with multi-resource workloads | Require **all** contested flavor-resources to remain at or above nominal after subtracting the candidate’s usage on each. |
+
+## Design Details
+
+### Relationship to KEP-1337
+
+[KEP-1337](/keps/1337-preempt-within-cohort-while-borrowing) introduced
+`borrowWithinCohort` with `Never` and `LowerPriority`. This KEP **only** adds an
+enum value and refines which workloads are eligible when that policy is
+selected. Webhook rules (e.g. `reclaimWithinCohort` must not be `Never` when
+`borrowWithinCohort` is enabled) stay the same.
+
+### API
+
+```go
+type BorrowWithinCohortPolicy string
+
+const (
+	BorrowWithinCohortPolicyNever                      BorrowWithinCohortPolicy = "Never"
+	BorrowWithinCohortPolicyLowerPriority              BorrowWithinCohortPolicy = "LowerPriority"
+	BorrowWithinCohortPolicyLowerPriorityBorrowersOnly BorrowWithinCohortPolicy = "LowerPriorityBorrowersOnly"
+)
+
+type BorrowWithinCohort struct {
+	// policy ...
+	// - `LowerPriorityBorrowersOnly`: like `LowerPriority`, but a workload in
+	//    another ClusterQueue is a valid target only if that ClusterQueue is
+	//    borrowing for the contested resources and removing the target workload
+	//    would not reduce that ClusterQueue's usage below its nominal quota
+	//    for those resources.
+	//
+	// +kubebuilder:validation:Enum=Never;LowerPriority;LowerPriorityBorrowersOnly
+	Policy BorrowWithinCohortPolicy `json:"policy,omitempty"`
+	// maxPriorityThreshold unchanged
+	MaxPriorityThreshold *int32 `json:"maxPriorityThreshold,omitempty"`
+}
+```
+
+(CRD and both API versions `v1beta1` / `v1beta2` gain the same enum extension.)
+
+### Semantics
+
+Let:
+
+- `frs` = set of `(resource flavor, resource name)` pairs that need preemption
+  for the incoming workload’s assignment.
+- For a **candidate** workload `W` in **victim** `ClusterQueue` `Q`:
+  - `usage_Q(fr)` = current usage of `Q` for `fr`.
+  - `nominal_Q(fr)` = nominal quota of `Q` for `fr`.
+  - `usage_W(fr)` = usage of `W` for `fr` (from admitted assignment).
+
+**`LowerPriorityBorrowersOnly`** (in addition to KEP-1337 priority / threshold
+rules): `W` is **not** a valid target if there exists `fr ∈ frs` such that
+
+```text
+usage_Q(fr) − usage_W(fr) < nominal_Q(fr)
+```
+
+Equivalently, for all `fr ∈ frs`:
+
+```text
+usage_Q(fr) − usage_W(fr) ≥ nominal_Q(fr)
+```
+
+If `W` is invalid under this rule, it must **not** be selected as a preemption
+target for this preemptor (including when the scheduler tries “fit without
+borrowing” passes), so that nominal protection is not bypassed by a later
+attempt.
+
+**Note:** Queues that are not over nominal for `frs` are already excluded from
+the usual cohort candidate set; this policy tightens **which workloads** in an
+already-over-nominal queue can be preempted.
+
+### Implementation sketch
+
+1. When classifying a cross-queue candidate for “reclaim while borrowing” for
+   the preemptor’s `ClusterQueue`, if
+   `borrowWithinCohort.policy == LowerPriorityBorrowersOnly`, compute the
+   candidate’s flavor-resource usage and compare post-removal usage to nominal
+   for each `fr` in `frs`. If any check fails, treat the candidate as
+   **ineligible** (do not preempt it).
+2. Helper on the victim `ClusterQueue` snapshot (conceptually): given a map of
+   usage to subtract and `frs`, return whether
+   `usage[fr] - subtract[fr] >= nominal[fr]` for all `fr ∈ frs`.
+3. **`IsBorrowingWithinCohortForbidden`**: unchanged—`LowerPriorityBorrowersOnly`
+   is not `Never`, enabling borrow-within-cohort preemption like
+   `LowerPriority`.
+
+### Fair Sharing
+
+Unchanged: `borrowWithinCohort` applies only to **classical** preemption, not
+Fair Sharing (per KEP-1337).
+
+### Test Plan
+
+[x] Owners of involved components may require test updates before merge.
+
+#### Unit tests
+
+- `pkg/scheduler/preemption`: cohort with victim over nominal; multiple victim
+  workloads; assert `LowerPriorityBorrowersOnly` preempts only workloads whose
+  removal keeps victim ≥ nominal; assert `LowerPriority` can still preempt a
+  larger workload that fails the remainder check.
+- Cover interaction with `maxPriorityThreshold` (optional dedicated case).
+
+#### Integration tests
+
+- Webhook / API: create `ClusterQueue` with
+  `borrowWithinCohort.policy: LowerPriorityBorrowersOnly` and valid
+  `reclaimWithinCohort` (not `Never`); admission succeeds.
+- Scheduler integration (optional): end-to-end scenario matching user story (1).
+
+### Graduation Criteria
+
+**Alpha**
+
+- API and implementation merged behind normal API review.
+- Documented in ClusterQueue / preemption docs.
+
+**Beta / GA**
+
+- Follow subproject conventions for CRD stability; address user feedback and
+  bugs.
+
+## Implementation History
+
+- 2026-03-30: KEP drafted (Issue [#10171](https://github.com/kubernetes-sigs/kueue/issues/10171)).
+
+## Drawbacks
+
+- Slightly more complex preemption and API surface.
+- Schedules may fail more often when nominal protection removes large
+  victims from the candidate set; operators must tune policies and quotas.
+
+## Alternatives
+
+1. **Separate boolean** `protectVictimNominal: true` alongside `LowerPriority`
+   instead of a new enum value—rejected as harder to read and combinatorial with
+   future policies.
+2. **`OnlyBorrowedUsage` naming**—rejected in favor of the issue’s name
+   `LowerPriorityBorrowersOnly` for consistency with `LowerPriority`.
+3. **Global cluster policy** instead of `ClusterQueue`—rejected; KEP-1337 is
+   already per–ClusterQueue for the preemptor.

--- a/keps/10171-borrow-within-cohort-lower-priority-borrowers-only/kep.yaml
+++ b/keps/10171-borrow-within-cohort-lower-priority-borrowers-only/kep.yaml
@@ -1,27 +1,27 @@
-title: Preempt within cohort while borrowing
-kep-number: 1337
+title: borrowWithinCohort LowerPriorityBorrowersOnly policy
+kep-number: 10171
 authors:
-  - "@mimowo"
-status: implementable
-creation-date: 2023-12-05
+  - "@isumitsolanki"
+  - "@tskillian"
+status: provisional
+creation-date: 2026-03-30
 reviewers:
-  - "@yaroslava-serdiuk"
-  - "@mwielgus"
+  - TBD
 approvers:
-  - "@tenzen-y"
-  - "@alculquicondor"
+  - TBD
 
 see-also:
-  - "/keps/10171-borrow-within-cohort-lower-priority-borrowers-only"
+  - "/keps/1337-preempt-within-cohort-while-borrowing"
+  - "https://github.com/kubernetes-sigs/kueue/issues/10171"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: alpha
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.6"
+latest-milestone: TBD
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  beta: "v0.6"
+  alpha: TBD

--- a/keps/1337-preempt-within-cohort-while-borrowing/README.md
+++ b/keps/1337-preempt-within-cohort-while-borrowing/README.md
@@ -51,6 +51,11 @@ tags, and then generate with `hack/update-toc.sh`.
 This KEP introduces ClusterQueue-level API to support workload preemption
 to reclaim quota within cohort for a workload that requires borrowing.
 
+**See also:** [KEP-10171](../10171-borrow-within-cohort-lower-priority-borrowers-only/README.md)
+adds an optional `borrowWithinCohort.policy` value `LowerPriorityBorrowersOnly`
+that limits targets so a victim ClusterQueue stays at or above nominal quota
+for contested resources when reclaiming capacity while borrowing.
+
 <!--
 This section is incredibly important for producing high-quality, user-focused
 documentation such as release notes or a development roadmap. It should be

--- a/pkg/cache/scheduler/clusterqueue_snapshot.go
+++ b/pkg/cache/scheduler/clusterqueue_snapshot.go
@@ -147,6 +147,21 @@ func (c *ClusterQueueSnapshot) BorrowingWith(fr resources.FlavorResource, val in
 	return c.ResourceNode.Usage[fr]+val > c.QuotaFor(fr).Nominal
 }
 
+// UsageRemainsAtOrAboveNominalForFlavorResources reports whether subtracting remove from the
+// ClusterQueue's current usage leaves usage at or above nominal quota for every flavor in frs.
+func (c *ClusterQueueSnapshot) UsageRemainsAtOrAboveNominalForFlavorResources(
+	remove resources.FlavorResourceQuantities,
+	frs sets.Set[resources.FlavorResource],
+) bool {
+	for fr := range frs {
+		usedAfter := c.ResourceNode.Usage[fr] - remove[fr]
+		if usedAfter < c.QuotaFor(fr).Nominal {
+			return false
+		}
+	}
+	return true
+}
+
 // Available returns the current capacity available, before preempting
 // any workloads. Includes local capacity and capacity borrowed from
 // Cohort. When the ClusterQueue/Cohort is in debt, Available

--- a/pkg/scheduler/preemption/classical/hierarchical_preemption.go
+++ b/pkg/scheduler/preemption/classical/hierarchical_preemption.go
@@ -78,7 +78,7 @@ func IsBorrowingWithinCohortForbidden(cq *schdcache.ClusterQueueSnapshot) (bool,
 
 // classifyPreemptionVariant evaluates, based on config and priorities, the
 // preemption type for a given candidate
-func classifyPreemptionVariant(ctx *HierarchicalPreemptionCtx, wl *workload.Info, haveHierarchicalAdvantage bool) preemptionVariant {
+func classifyPreemptionVariant(ctx *HierarchicalPreemptionCtx, wl *workload.Info, candidateCQ *schdcache.ClusterQueueSnapshot, haveHierarchicalAdvantage bool) preemptionVariant {
 	if !WorkloadUsesResources(wl, ctx.FrsNeedPreemption) {
 		return Never
 	}
@@ -109,6 +109,11 @@ func classifyPreemptionVariant(ctx *HierarchicalPreemptionCtx, wl *workload.Info
 	if isAboveBorrowingThreshold(candidatePriority, incomingPriority, borrowWithinCohortThreshold) {
 		return ReclaimWithoutBorrowing
 	}
+	if ctx.Cq.Preemption.BorrowWithinCohort != nil &&
+		ctx.Cq.Preemption.BorrowWithinCohort.Policy == kueue.BorrowWithinCohortPolicyLowerPriorityBorrowersOnly &&
+		!candidateCQ.UsageRemainsAtOrAboveNominalForFlavorResources(wl.FlavorResourceUsage(), ctx.FrsNeedPreemption) {
+		return Never
+	}
 	return ReclaimWhileBorrowing
 }
 
@@ -132,7 +137,7 @@ func collectSameQueueCandidates(ctx *HierarchicalPreemptionCtx) []*candidateElem
 func getCandidatesFromCQ(cq *schdcache.ClusterQueueSnapshot, lca *schdcache.CohortSnapshot, ctx *HierarchicalPreemptionCtx, hasHiearchicalAdvantage bool) []*candidateElem {
 	candidates := []*candidateElem{}
 	for _, candidateWl := range cq.Workloads {
-		preemptionVariant := classifyPreemptionVariant(ctx, candidateWl, hasHiearchicalAdvantage)
+		preemptionVariant := classifyPreemptionVariant(ctx, candidateWl, cq, hasHiearchicalAdvantage)
 		if preemptionVariant == Never {
 			continue
 		}

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -276,6 +276,56 @@ func TestPreemption(t *testing.T) {
 				Obj(),
 			).
 			Obj(),
+		utiltestingapi.MakeClusterQueue("borrow_nom_shared").
+			Cohort("borrow_nom_prot").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+				Resource(corev1.ResourceCPU, "100").
+				Obj(),
+			).
+			Obj(),
+		utiltestingapi.MakeClusterQueue("a_borrowers_only").
+			Cohort("borrow_nom_prot").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "1000m", "50000m").
+					Obj(),
+			).
+			Preemption(kueue.ClusterQueuePreemption{
+				WithinClusterQueue:  kueue.PreemptionPolicyNever,
+				ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
+				BorrowWithinCohort: &kueue.BorrowWithinCohort{
+					Policy:               kueue.BorrowWithinCohortPolicyLowerPriorityBorrowersOnly,
+					MaxPriorityThreshold: ptr.To[int32](0),
+				},
+			}).
+			Obj(),
+		utiltestingapi.MakeClusterQueue("a_borrow_lower_nom").
+			Cohort("borrow_nom_prot").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "1000m", "50000m").
+					Obj(),
+			).
+			Preemption(kueue.ClusterQueuePreemption{
+				WithinClusterQueue:  kueue.PreemptionPolicyNever,
+				ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
+				BorrowWithinCohort: &kueue.BorrowWithinCohort{
+					Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
+					MaxPriorityThreshold: ptr.To[int32](0),
+				},
+			}).
+			Obj(),
+		utiltestingapi.MakeClusterQueue("b_victim_borrow_nom").
+			Cohort("borrow_nom_prot").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+				Resource(corev1.ResourceCPU, "10000m", "50000m").
+				Obj(),
+			).
+			Preemption(kueue.ClusterQueuePreemption{
+				WithinClusterQueue:  kueue.PreemptionPolicyNever,
+				ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
+			}).
+			Obj(),
 	}
 	baseIncomingWl := utiltestingapi.MakeWorkload("in", "").
 		UID("wl-in").
@@ -2511,6 +2561,218 @@ func TestPreemption(t *testing.T) {
 							Obj(),
 						now,
 					).
+					Obj(),
+			},
+		},
+		"LowerPriorityBorrowersOnly preempts workloads only when removal keeps victim at or above nominal": {
+			clusterQueues: defaultClusterQueues,
+			admitted: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("victim_w2", "").
+					Priority(-1).
+					Request(corev1.ResourceCPU, "2000m").
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("b_victim_borrow_nom").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
+						now,
+					).
+					Obj(),
+				*utiltestingapi.MakeWorkload("victim_w5", "").
+					Priority(-1).
+					Request(corev1.ResourceCPU, "5").
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("b_victim_borrow_nom").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "5").
+								Obj()).
+							Obj(),
+						now.Add(time.Second),
+					).
+					Obj(),
+				*utiltestingapi.MakeWorkload("victim_w6", "").
+					Priority(-1).
+					Request(corev1.ResourceCPU, "6").
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("b_victim_borrow_nom").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "6").
+								Obj()).
+							Obj(),
+						now.Add(2*time.Second),
+					).
+					Obj(),
+			},
+			incoming: baseIncomingWl.Clone().
+				Priority(1).
+				Request(corev1.ResourceCPU, "2000m").
+				Obj(),
+			targetCQ: "a_borrowers_only",
+			assignment: singlePodSetAssignment(flavorassigner.ResourceAssignment{
+				corev1.ResourceCPU: &flavorassigner.FlavorAssignment{
+					Name: "default",
+					Mode: flavorassigner.Preempt,
+				},
+			}),
+			wantPreempted: 1,
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("victim_w2", "").
+					Priority(-1).
+					Request(corev1.ResourceCPU, "2000m").
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("b_victim_borrow_nom").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
+						now,
+					).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to reclamation within the cohort while borrowing; preemptor path: /borrow_nom_prot/a_borrowers_only; preemptee path: /borrow_nom_prot/b_victim_borrow_nom",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InCohortReclaimWhileBorrowing",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to reclamation within the cohort while borrowing; preemptor path: /borrow_nom_prot/a_borrowers_only; preemptee path: /borrow_nom_prot/b_victim_borrow_nom",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("victim_w5", "").
+					Priority(-1).
+					Request(corev1.ResourceCPU, "5").
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("b_victim_borrow_nom").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "5").
+								Obj()).
+							Obj(),
+						now.Add(time.Second),
+					).
+					Obj(),
+				*utiltestingapi.MakeWorkload("victim_w6", "").
+					Priority(-1).
+					Request(corev1.ResourceCPU, "6").
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("b_victim_borrow_nom").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "6").
+								Obj()).
+							Obj(),
+						now.Add(2*time.Second),
+					).
+					Obj(),
+			},
+		},
+		"LowerPriority borrowWithinCohort preempts larger victim workloads that LowerPriorityBorrowersOnly skips": {
+			clusterQueues: defaultClusterQueues,
+			admitted: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("victim_w2", "").
+					Priority(-1).
+					Request(corev1.ResourceCPU, "2000m").
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("b_victim_borrow_nom").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
+						now,
+					).
+					Obj(),
+				*utiltestingapi.MakeWorkload("victim_w5", "").
+					Priority(-1).
+					Request(corev1.ResourceCPU, "5").
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("b_victim_borrow_nom").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "5").
+								Obj()).
+							Obj(),
+						now.Add(time.Second),
+					).
+					Obj(),
+				*utiltestingapi.MakeWorkload("victim_w6", "").
+					Priority(-1).
+					Request(corev1.ResourceCPU, "6").
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("b_victim_borrow_nom").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "6").
+								Obj()).
+							Obj(),
+						now.Add(2*time.Second),
+					).
+					Obj(),
+			},
+			incoming: baseIncomingWl.Clone().
+				Priority(1).
+				Request(corev1.ResourceCPU, "2000m").
+				Obj(),
+			targetCQ: "a_borrow_lower_nom",
+			assignment: singlePodSetAssignment(flavorassigner.ResourceAssignment{
+				corev1.ResourceCPU: &flavorassigner.FlavorAssignment{
+					Name: "default",
+					Mode: flavorassigner.Preempt,
+				},
+			}),
+			wantPreempted: 1,
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("victim_w2", "").
+					Priority(-1).
+					Request(corev1.ResourceCPU, "2000m").
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("b_victim_borrow_nom").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
+						now,
+					).
+					Obj(),
+				*utiltestingapi.MakeWorkload("victim_w5", "").
+					Priority(-1).
+					Request(corev1.ResourceCPU, "5").
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("b_victim_borrow_nom").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "5").
+								Obj()).
+							Obj(),
+						now.Add(time.Second),
+					).
+					Obj(),
+				*utiltestingapi.MakeWorkload("victim_w6", "").
+					Priority(-1).
+					Request(corev1.ResourceCPU, "6").
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("b_victim_borrow_nom").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "6").
+								Obj()).
+							Obj(),
+						now.Add(2*time.Second),
+					).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to reclamation within the cohort while borrowing; preemptor path: /borrow_nom_prot/a_borrow_lower_nom; preemptee path: /borrow_nom_prot/b_victim_borrow_nom",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InCohortReclaimWhileBorrowing",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to reclamation within the cohort while borrowing; preemptor path: /borrow_nom_prot/a_borrow_lower_nom; preemptee path: /borrow_nom_prot/b_victim_borrow_nom",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
 					Obj(),
 			},
 		},

--- a/test/integration/singlecluster/webhook/core/clusterqueue_test.go
+++ b/test/integration/singlecluster/webhook/core/clusterqueue_test.go
@@ -543,6 +543,21 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", ginkgo.Ordered, func() {
 					},
 				},
 				gomega.Succeed()),
+			ginkgo.Entry("Should allow to create clusterQueue with borrowWithinCohort LowerPriorityBorrowersOnly",
+				&kueue.ClusterQueue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster-queue",
+					},
+					Spec: kueue.ClusterQueueSpec{
+						Preemption: &kueue.ClusterQueuePreemption{
+							ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
+							BorrowWithinCohort: &kueue.BorrowWithinCohort{
+								Policy: kueue.BorrowWithinCohortPolicyLowerPriorityBorrowersOnly,
+							},
+						},
+					},
+				},
+				gomega.Succeed()),
 			ginkgo.Entry("Should allow to create clusterQueue with existing cluster queue created with older Kueue version that has a nil borrowWithinCohort field",
 				&kueue.ClusterQueue{
 					ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Introduce `BorrowWithinCohortPolicyLowerPriorityBorrowersOnly` for classical preemption. When the preemptor is borrowing, a workload in another `ClusterQueue` is only a candidate if removing it leaves that queue at or above nominal quota for every contested flavor-resource.

- Extend v1beta1/v1beta2 `ClusterQueue` API and regenerate CRDs, Helm chart, and client apply configs.
- Add `ClusterQueueSnapshot.UsageRemainsAtOrAboveNominalForFlavorResources` and use it in hierarchical preemption classification.
- Add scheduler unit tests and a webhook integration case.
- Add KEP-10171 and link it from KEP-1337 (README + `kep.yaml`).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind api-change
/kind kep

#### What this PR does / why we need it:

Adds `LowerPriorityBorrowersOnly` to `spec.preemption.borrowWithinCohort.policy` so clusters can let borrowing preemptors reclaim cohort capacity from **other** queues without evicting workloads that would push the victim **below** nominal on the resources involved in preemption. This matches multi-tenant expectations that nominal quota stays protected while borrowed capacity remains reclaimable.

`maxPriorityThreshold` still applies together with this policy. Behavior is **classical preemption only** (unchanged from existing `borrowWithinCohort` scope; Fair Sharing is unaffected).

#### Which issue(s) this PR fixes:

Fixes #10171

#### Special notes for your reviewer:

- KEP: `keps/10171-borrow-within-cohort-lower-priority-borrowers-only/`; cross-links added under KEP-1337.
- Implementation: candidates that fail the nominal-remainder check are dropped entirely (not only in the borrowing pass), so nominal protection is not bypassed when the scheduler tries a non-borrowing preemption attempt.
- Please confirm wording for user-facing docs (e.g. `site/` follow-up) if you want this PR to include them; this change set focuses on API, codegen, scheduler, tests, and KEP.

#### Does this PR introduce a user-facing change?

```release-note
ClusterQueue: new value `LowerPriorityBorrowersOnly` for `spec.preemption.borrowWithinCohort.policy`. When a workload needs to borrow, it may preempt lower-priority workloads in other cohort queues only if removing each candidate keeps that queue at or above nominal quota for the contested resources. Composes with `maxPriorityThreshold`. Classical preemption only.****