### PR TITLE
Automated cherry pick of #10238: Update main with the latest v0.17.0

### DIFF
--- a/SECURITY-INSIGHTS.yaml
+++ b/SECURITY-INSIGHTS.yaml
@@ -1,11 +1,11 @@
 header:
   schema-version: 1.0.0
   expiration-date: '2024-09-28T01:00:00.000Z'
-  last-updated: '2026-03-19'
-  last-reviewed: '2026-03-19'
-  commit-hash: "70c6a0150f579ffa3d865ac106915b5951d798df"
+  last-updated: '2026-03-31'
+  last-reviewed: '2026-03-31'
+  commit-hash: "4d5f7ffc7bdc5f88c723678cdacb89c05158dd36"
   project-url: 'https://github.com/kubernetes-sigs/kueue'
-  project-release: "0.16.4"
+  project-release: "0.17.0"
   changelog: 'https://github.com/kubernetes-sigs/kueue/tree/main/CHANGELOG'
   license: 'https://github.com/kubernetes-sigs/kueue/blob/main/LICENSE'
 project-lifecycle:
@@ -28,7 +28,7 @@ documentation:
   - 'https://kueue.sigs.k8s.io/docs/'
 distribution-points:
   - >-
-    https://github.com/kubernetes-sigs/kueue/releases/download/v0.16.4/manifests.yaml
+    https://github.com/kubernetes-sigs/kueue/releases/download/v0.17.0/manifests.yaml
 security-artifacts:
   threat-model:
     threat-model-created: false
@@ -62,5 +62,5 @@ dependencies:
   dependencies-lists:
     - 'https://github.com/kubernetes-sigs/kueue/blob/main/go.mod'
   sbom:
-    - sbom-file: https://github.com/kubernetes-sigs/kueue/releases/download/v0.16.4/kueue-v0.16.4.spdx.json
+    - sbom-file: https://github.com/kubernetes-sigs/kueue/releases/download/v0.17.0/kueue-v0.17.0.spdx.json
       sbom-format: SPDX


### PR DESCRIPTION
Cherry pick of #10238 on website.

#10238: Update main with the latest v0.17.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```