### PR TITLE
LeaderWorkerSet: Relax PodSpec validation to allow changing nodeSelector.

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1207,7 +1207,8 @@ func EquivalentToWorkload(ctx context.Context, c client.Client, job GenericJob, 
 	}
 	jobPodSets := clearMinCountsIfFeatureDisabled(getPodSets)
 
-	opts := make([]equality.ComparePodSetsOption, 0, 1)
+	opts := make([]equality.ComparePodSetsOption, 0, 2)
+	opts = append(opts, equality.WithIgnoreNodeSelector())
 	if workload.IsAdmitted(wl) {
 		opts = append(opts, equality.WithIgnoreTolerations())
 	}

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -207,7 +207,11 @@ func validateUpdateForMaxExecTime(oldJob, newJob GenericJob) field.ErrorList {
 // ValidateImmutablePodGroupPodSpec function is used for serving workloads to ensure no changes are allowed
 // to the PodSpec except fields that required for role-hash generation.
 func ValidateImmutablePodGroupPodSpec(newPodSpec *corev1.PodSpec, oldPodSpec *corev1.PodSpec, fieldPath *field.Path) field.ErrorList {
-	return validateImmutablePodGroupPodSpecPath(utilpod.SpecShape(newPodSpec), utilpod.SpecShape(oldPodSpec), fieldPath)
+	return validateImmutablePodGroupPodSpecPath(
+		ignoreNodeSelector(utilpod.SpecShape(newPodSpec)),
+		ignoreNodeSelector(utilpod.SpecShape(oldPodSpec)),
+		fieldPath,
+	)
 }
 
 func validateImmutablePodGroupPodSpecPath(newShape, oldShape map[string]any, fieldPath *field.Path) field.ErrorList {
@@ -241,6 +245,11 @@ func validateImmutablePodGroupPodSpecPath(newShape, oldShape map[string]any, fie
 	}
 
 	return allErrs
+}
+
+func ignoreNodeSelector(shape map[string]any) map[string]any {
+	shape["nodeSelector"] = nil
+	return shape
 }
 
 func IsWorkloadPriorityClassNameEmpty(obj client.Object) bool {

--- a/pkg/controller/jobframework/validation_test.go
+++ b/pkg/controller/jobframework/validation_test.go
@@ -149,16 +149,10 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 				},
 			},
 		},
-		"change nodeTemplate": {
+		"change nodeSelector": {
 			oldPodSpec: &corev1.PodSpec{},
 			newPodSpec: &corev1.PodSpec{
 				NodeSelector: map[string]string{"key": "value"},
-			},
-			wantErr: field.ErrorList{
-				&field.Error{
-					Type:  field.ErrorTypeInvalid,
-					Field: testPath.Child("nodeSelector").String(),
-				},
 			},
 		},
 		"add toleration": {

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -51,6 +51,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	podcontroller "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/util/equality"
 	"sigs.k8s.io/kueue/pkg/util/parallelize"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
@@ -141,30 +142,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	eg.Go(func() error {
 		return parallelize.Until(ctx, len(toCreate), func(i int) error {
-			return r.createPrebuiltWorkload(ctx, lws, toCreate[i].name, toCreate[i].index)
+			return r.createWorkload(ctx, lws, toCreate[i].name, toCreate[i].index)
 		})
 	})
 
 	eg.Go(func() error {
 		return parallelize.Until(ctx, len(toUpdate), func(i int) error {
-			if features.Enabled(features.AdmissionGatedBy) {
-				if err := jobframework.UpdateAdmissionGatedBy(ctx, r.client, r.record, lws, toUpdate[i]); err != nil {
-					return err
-				}
-			}
-
-			return jobframework.UpdateWorkloadPriority(ctx, r.client, r.record, lws, toUpdate[i], nil)
+			return r.updateWorkload(ctx, lws, toUpdate[i])
 		})
 	})
 
 	eg.Go(func() error {
 		return parallelize.Until(ctx, len(toDelete), func(i int) error {
-			// Remove the finalizer before deleting to ensure prompt cleanup,
-			// consistent with how the job framework reconciler deletes workloads.
-			if err := workload.RemoveFinalizer(ctx, r.client, toDelete[i]); err != nil && !apierrors.IsNotFound(err) {
-				return err
-			}
-			return r.client.Delete(ctx, toDelete[i])
+			return r.deleteWorkload(ctx, toDelete[i])
 		})
 	})
 
@@ -226,7 +216,7 @@ func isRollingUpdateWithSurge(lws *leaderworkersetv1.LeaderWorkerSet) bool {
 	return maxSurge > 0 && lws.Status.UpdatedReplicas < ptr.Deref(lws.Spec.Replicas, 1)
 }
 
-func (r *Reconciler) createPrebuiltWorkload(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, workloadName string, index int) error {
+func (r *Reconciler) createWorkload(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, workloadName string, index int) error {
 	createdWorkload, err := r.constructWorkload(lws, workloadName, index)
 	if err != nil {
 		return err
@@ -341,6 +331,31 @@ func podSets(lws *leaderworkersetv1.LeaderWorkerSet) ([]kueue.PodSet, error) {
 	podSets = append(podSets, *workerPodSet)
 
 	return podSets, nil
+}
+
+func (r *Reconciler) updateWorkload(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, wl *kueue.Workload) error {
+	podSets, err := podSets(lws)
+	if err != nil {
+		return err
+	}
+	if !equality.ComparePodSetSlices(podSets, wl.Spec.PodSets) {
+		return r.deleteWorkload(ctx, wl)
+	}
+	if features.Enabled(features.AdmissionGatedBy) {
+		if err := jobframework.UpdateAdmissionGatedBy(ctx, r.client, r.record, lws, wl); err != nil {
+			return err
+		}
+	}
+	return jobframework.UpdateWorkloadPriority(ctx, r.client, r.record, lws, wl, nil)
+}
+
+func (r *Reconciler) deleteWorkload(ctx context.Context, wl *kueue.Workload) error {
+	// Remove the finalizer before deleting to ensure prompt cleanup,
+	// consistent with how the job framework reconciler deletes workloads.
+	if err := workload.RemoveFinalizer(ctx, r.client, wl); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return r.client.Delete(ctx, wl)
 }
 
 var _ predicate.Predicate = (*Reconciler)(nil)

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
@@ -1260,6 +1260,38 @@ func TestValidateUpdate(t *testing.T) {
 				},
 			}.ToAggregate(),
 		},
+		"change nodeSelector": {
+			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						NodeSelector: map[string]string{},
+					},
+				}).
+				WorkerTemplate(corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						NodeSelector: map[string]string{},
+					},
+				}).
+				Queue("test-queue").
+				LeaderTemplateSpecAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+				WorkerTemplateSpecAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+				Obj(),
+			newObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						NodeSelector: map[string]string{"test": "test"},
+					},
+				}).
+				WorkerTemplate(corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						NodeSelector: map[string]string{"test": "test"},
+					},
+				}).
+				Queue("test-queue").
+				LeaderTemplateSpecAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+				WorkerTemplateSpecAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+				Obj(),
+		},
 		"set valid topology request": {
 			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				LeaderTemplate(corev1.PodTemplateSpec{}).

--- a/pkg/util/equality/podset.go
+++ b/pkg/util/equality/podset.go
@@ -25,7 +25,8 @@ import (
 )
 
 type ComparePodSetsOptions struct {
-	ignoreTolerations bool
+	ignoreTolerations  bool
+	ignoreNodeSelector bool
 }
 
 type ComparePodSetsOption func(*ComparePodSetsOptions)
@@ -33,6 +34,12 @@ type ComparePodSetsOption func(*ComparePodSetsOptions)
 func WithIgnoreTolerations() ComparePodSetsOption {
 	return func(options *ComparePodSetsOptions) {
 		options.ignoreTolerations = true
+	}
+}
+
+func WithIgnoreNodeSelector() ComparePodSetsOption {
+	return func(options *ComparePodSetsOptions) {
+		options.ignoreNodeSelector = true
 	}
 }
 
@@ -44,6 +51,9 @@ func comparePodTemplate(a, b *corev1.PodSpec, options ...ComparePodSetsOption) b
 		opt(opts)
 	}
 	if !opts.ignoreTolerations && !equality.Semantic.DeepEqual(a.Tolerations, b.Tolerations) {
+		return false
+	}
+	if !opts.ignoreNodeSelector && !equality.Semantic.DeepEqual(a.NodeSelector, b.NodeSelector) {
 		return false
 	}
 	if !equality.Semantic.DeepEqual(a.InitContainers, b.InitContainers) {

--- a/pkg/util/equality/podset_test.go
+++ b/pkg/util/equality/podset_test.go
@@ -28,10 +28,11 @@ import (
 
 func TestComparePodSetSlices(t *testing.T) {
 	cases := map[string]struct {
-		a                 []kueue.PodSet
-		b                 []kueue.PodSet
-		ignoreTolerations bool
-		wantEquivalent    bool
+		a                  []kueue.PodSet
+		b                  []kueue.PodSet
+		ignoreTolerations  bool
+		ignoreNodeSelector bool
+		wantEquivalent     bool
 	}{
 		"different name": {
 			a:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
@@ -46,7 +47,13 @@ func TestComparePodSetSlices(t *testing.T) {
 		"different node selector": {
 			a:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
 			b:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(5).NodeSelector(map[string]string{"key": "val"}).Obj()},
-			wantEquivalent: true,
+			wantEquivalent: false,
+		},
+		"different node selector with ignoreNodeSelector": {
+			a:                  []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
+			b:                  []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(5).NodeSelector(map[string]string{"key": "val"}).Obj()},
+			ignoreNodeSelector: true,
+			wantEquivalent:     true,
 		},
 		"different requests": {
 			a:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(5).Request("res", "1").Obj()},
@@ -134,7 +141,23 @@ func TestComparePodSetSlices(t *testing.T) {
 					NodeSelector(map[string]string{"key": "val2"}).
 					Obj(),
 			},
-			wantEquivalent: true,
+			wantEquivalent: false,
+		},
+		"different requests in node selector with ignoreNodeSelector": {
+			a: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("ps", 10).
+					SetMinimumCount(5).
+					NodeSelector(map[string]string{"key": "val"}).
+					Obj(),
+			},
+			b: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("ps", 10).
+					SetMinimumCount(5).
+					NodeSelector(map[string]string{"key": "val2"}).
+					Obj(),
+			},
+			ignoreNodeSelector: true,
+			wantEquivalent:     true,
 		},
 	}
 	for name, tc := range cases {
@@ -142,6 +165,9 @@ func TestComparePodSetSlices(t *testing.T) {
 			options := make([]ComparePodSetsOption, 0, 1)
 			if tc.ignoreTolerations {
 				options = append(options, WithIgnoreTolerations())
+			}
+			if tc.ignoreNodeSelector {
+				options = append(options, WithIgnoreNodeSelector())
 			}
 			got := ComparePodSetSlices(tc.a, tc.b, options...)
 			if got != tc.wantEquivalent {

--- a/test/e2e/singlecluster/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/leaderworkerset_test.go
@@ -135,6 +135,69 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 			})
 		})
 
+		ginkgo.It("should allow to mutate nodeSelector", func() {
+			lws := leaderworkersettesting.MakeLeaderWorkerSet("lws", ns.Name).
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				Size(1).
+				Replicas(1).
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				TerminationGracePeriod(1).
+				Queue(lq.Name).
+				Obj()
+
+			ginkgo.By("Create a LeaderWorkerSet", func() {
+				util.MustCreate(ctx, k8sClient, lws)
+			})
+
+			wlKey := util.WorkloadKeyForLeaderWorkerSet(lws, "0")
+
+			ginkgo.By("Waiting for replicas to be ready", func() {
+				createdLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
+					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
+					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(utiltesting.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			createdWorkload := &kueue.Workload{}
+			ginkgo.By("Check workload is created and has JobUID label", func() {
+				gomega.Expect(k8sClient.Get(ctx, wlKey, createdWorkload)).To(gomega.Succeed())
+				gomega.Expect(createdWorkload.Labels[ctrlconstants.JobUIDLabel]).To(gomega.Equal(string(lws.UID)))
+			})
+
+			oldUID := createdWorkload.UID
+
+			ginkgo.By("Updating nodeSelector", func() {
+				createdLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
+					createdLeaderWorkerSet.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.NodeSelector = map[string]string{"instance-type": "on-demand"}
+					g.Expect(k8sClient.Update(ctx, createdLeaderWorkerSet)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking that workload recreated", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, createdWorkload)).To(gomega.Succeed())
+					g.Expect(createdWorkload.UID).ToNot(gomega.Equal(oldUID))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking that workload is admitted", func() {
+				util.ExpectWorkloadsToBeAdmittedByKeys(ctx, k8sClient, wlKey)
+			})
+
+			ginkgo.By("Waiting for replicas to be ready", func() {
+				createdLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
+					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
+					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(utiltesting.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
 		ginkgo.It("should admit group with leader and workers", func() {
 			lws := leaderworkersettesting.MakeLeaderWorkerSet("lws", ns.Name).
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
LeaderWorkerSet: Relax PodSpec validation to allow changing nodeSelector.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10178

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```