### PR TITLE
metrics: consolidate gauge cleanup scopes

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -269,13 +269,32 @@ var (
 	CohortSubtreeAdmittedActiveWorkloads *prometheus.GaugeVec
 )
 
-func trackGaugeVec(g *prometheus.GaugeVec) *prometheus.GaugeVec {
-	allGaugeVecs = append(allGaugeVecs, g)
+type gaugeCleanupScope uint8
+
+const (
+	gaugeCleanupScopeRole gaugeCleanupScope = iota
+	gaugeCleanupScopeClusterQueue
+	gaugeCleanupScopeClusterQueueLabelChange
+	gaugeCleanupScopeClusterQueueCache
+	gaugeCleanupScopeClusterQueueResource
+	gaugeCleanupScopeLocalQueue
+	gaugeCleanupScopeLocalQueueCache
+	gaugeCleanupScopeLocalQueueResource
+	gaugeCleanupScopeCohort
+)
+
+var gaugeVecsByScope map[gaugeCleanupScope][]*prometheus.GaugeVec
+
+func trackGaugeVec(g *prometheus.GaugeVec, scopes ...gaugeCleanupScope) *prometheus.GaugeVec {
+	gaugeVecsByScope[gaugeCleanupScopeRole] = append(gaugeVecsByScope[gaugeCleanupScopeRole], g)
+	for _, scope := range scopes {
+		gaugeVecsByScope[scope] = append(gaugeVecsByScope[scope], g)
+	}
 	return g
 }
 
 func InitMetricVectors(extraLabels []string) {
-	allGaugeVecs = nil
+	gaugeVecsByScope = make(map[gaugeCleanupScope][]*prometheus.GaugeVec)
 
 	AdmissionAttemptsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -300,14 +319,15 @@ The label 'result' can have the following values:
 		}, []string{"result", "replica_role"},
 	)
 
-	AdmissionCyclePreemptionSkips = trackGaugeVec(prometheus.NewGaugeVec(
+	AdmissionCyclePreemptionSkips = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "admission_cycle_preemption_skips",
 			Help: "The number of Workloads in the ClusterQueue that got preemption candidates " +
 				"but had to be skipped because other ClusterQueues needed the same resources in the same cycle",
 		}, append([]string{"cluster_queue", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(AdmissionCyclePreemptionSkips, gaugeCleanupScopeClusterQueue)
 
 	buildInfo = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -320,7 +340,7 @@ The label 'result' can have the following values:
 	versionInfo := version.Get()
 	buildInfo.WithLabelValues(versionInfo.GitVersion, versionInfo.GitCommit, versionInfo.BuildDate, versionInfo.GoVersion, versionInfo.Compiler, versionInfo.Platform).Set(1)
 
-	PendingWorkloads = trackGaugeVec(prometheus.NewGaugeVec(
+	PendingWorkloads = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "pending_workloads",
@@ -329,9 +349,10 @@ The label 'result' can have the following values:
 - "active" means that the workloads are in the admission queue.
 - "inadmissible" means there was a failed admission attempt for these workloads and they won't be retried until cluster conditions, which could make this workload admissible, change`,
 		}, append([]string{"cluster_queue", "status", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(PendingWorkloads, gaugeCleanupScopeClusterQueue)
 
-	LocalQueuePendingWorkloads = trackGaugeVec(prometheus.NewGaugeVec(
+	LocalQueuePendingWorkloads = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_pending_workloads",
@@ -340,23 +361,26 @@ The label 'result' can have the following values:
 - "active" means that the workloads are in the admission queue.
 - "inadmissible" means there was a failed admission attempt for these workloads and they won't be retried until cluster conditions, which could make this workload admissible, change`,
 		}, append([]string{"name", "namespace", "status", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(LocalQueuePendingWorkloads, gaugeCleanupScopeLocalQueue)
 
-	FinishedWorkloads = trackGaugeVec(prometheus.NewGaugeVec(
+	FinishedWorkloads = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "finished_workloads",
 			Help:      `The number of finished workloads per 'cluster_queue'.`,
 		}, append([]string{"cluster_queue", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(FinishedWorkloads, gaugeCleanupScopeClusterQueue)
 
-	LocalQueueFinishedWorkloads = trackGaugeVec(prometheus.NewGaugeVec(
+	LocalQueueFinishedWorkloads = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_finished_workloads",
 			Help:      `The number of finished workloads, per 'local_queue'.`,
 		}, append([]string{"name", "namespace", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(LocalQueueFinishedWorkloads, gaugeCleanupScopeLocalQueue)
 
 	QuotaReservedWorkloadsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -604,113 +628,126 @@ The label 'reason' can have the following values:
 		}, append([]string{"preempting_cluster_queue", "reason", "replica_role"}, extraLabels...),
 	)
 
-	ReservingActiveWorkloads = trackGaugeVec(prometheus.NewGaugeVec(
+	ReservingActiveWorkloads = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "reserving_active_workloads",
 			Help:      "The number of Workloads that are reserving quota, per 'cluster_queue'",
 		}, append([]string{"cluster_queue", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(ReservingActiveWorkloads, gaugeCleanupScopeClusterQueueCache)
 
-	LocalQueueReservingActiveWorkloads = trackGaugeVec(prometheus.NewGaugeVec(
+	LocalQueueReservingActiveWorkloads = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_reserving_active_workloads",
 			Help:      "The number of Workloads that are reserving quota, per 'localQueue'",
 		}, append([]string{"name", "namespace", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(LocalQueueReservingActiveWorkloads, gaugeCleanupScopeLocalQueueCache)
 
-	AdmittedActiveWorkloads = trackGaugeVec(prometheus.NewGaugeVec(
+	AdmittedActiveWorkloads = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "admitted_active_workloads",
 			Help:      "The number of admitted Workloads that are active, per 'cluster_queue'",
 		}, append([]string{"cluster_queue", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(AdmittedActiveWorkloads, gaugeCleanupScopeClusterQueueCache)
 
-	LocalQueueAdmittedActiveWorkloads = trackGaugeVec(prometheus.NewGaugeVec(
+	LocalQueueAdmittedActiveWorkloads = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_admitted_active_workloads",
 			Help:      "The number of admitted Workloads that are active, per 'localQueue'",
 		}, append([]string{"name", "namespace", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(LocalQueueAdmittedActiveWorkloads, gaugeCleanupScopeLocalQueueCache)
 
-	ClusterQueueByStatus = trackGaugeVec(prometheus.NewGaugeVec(
+	ClusterQueueByStatus = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "cluster_queue_status",
 			Help: `Reports 'cluster_queue' with its 'status' (with possible values 'pending', 'active' or 'terminated').
 For a ClusterQueue, the metric only reports a value of 1 for one of the statuses.`,
 		}, append([]string{"cluster_queue", "status", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(ClusterQueueByStatus, gaugeCleanupScopeClusterQueueCache)
 
-	LocalQueueByStatus = trackGaugeVec(prometheus.NewGaugeVec(
+	LocalQueueByStatus = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_status",
 			Help: `Reports 'localQueue' with its 'active' status (with possible values 'True', 'False', or 'Unknown').
 For a LocalQueue, the metric only reports a value of 1 for one of the statuses.`,
 		}, append([]string{"name", "namespace", "active", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(LocalQueueByStatus, gaugeCleanupScopeLocalQueueCache)
 
-	ClusterQueueResourceReservations = trackGaugeVec(prometheus.NewGaugeVec(
+	ClusterQueueResourceReservations = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "cluster_queue_resource_reservation",
 			Help:      `Reports the cluster_queue's total resource reservation within all the flavors`,
 		}, append([]string{"cohort", "cluster_queue", "flavor", "resource", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(ClusterQueueResourceReservations, gaugeCleanupScopeClusterQueueResource)
 
-	ClusterQueueResourceUsage = trackGaugeVec(prometheus.NewGaugeVec(
+	ClusterQueueResourceUsage = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "cluster_queue_resource_usage",
 			Help:      `Reports the cluster_queue's total resource usage within all the flavors`,
 		}, append([]string{"cohort", "cluster_queue", "flavor", "resource", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(ClusterQueueResourceUsage, gaugeCleanupScopeClusterQueueResource)
 
-	LocalQueueResourceReservations = trackGaugeVec(prometheus.NewGaugeVec(
+	LocalQueueResourceReservations = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_resource_reservation",
 			Help:      `Reports the localQueue's total resource reservation within all the flavors`,
 		}, append([]string{"name", "namespace", "flavor", "resource", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(LocalQueueResourceReservations, gaugeCleanupScopeLocalQueueResource)
 
-	LocalQueueResourceUsage = trackGaugeVec(prometheus.NewGaugeVec(
+	LocalQueueResourceUsage = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_resource_usage",
 			Help:      `Reports the localQueue's total resource usage within all the flavors`,
 		}, append([]string{"name", "namespace", "flavor", "resource", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(LocalQueueResourceUsage, gaugeCleanupScopeLocalQueueResource)
 
-	ClusterQueueResourceNominalQuota = trackGaugeVec(prometheus.NewGaugeVec(
+	ClusterQueueResourceNominalQuota = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "cluster_queue_nominal_quota",
 			Help:      `Reports the cluster_queue's resource nominal quota within all the flavors`,
 		}, append([]string{"cohort", "cluster_queue", "flavor", "resource", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(ClusterQueueResourceNominalQuota, gaugeCleanupScopeClusterQueueResource)
 
-	ClusterQueueResourceBorrowingLimit = trackGaugeVec(prometheus.NewGaugeVec(
+	ClusterQueueResourceBorrowingLimit = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "cluster_queue_borrowing_limit",
 			Help:      `Reports the cluster_queue's resource borrowing limit within all the flavors`,
 		}, append([]string{"cohort", "cluster_queue", "flavor", "resource", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(ClusterQueueResourceBorrowingLimit, gaugeCleanupScopeClusterQueueResource)
 
-	ClusterQueueResourceLendingLimit = trackGaugeVec(prometheus.NewGaugeVec(
+	ClusterQueueResourceLendingLimit = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "cluster_queue_lending_limit",
 			Help:      `Reports the cluster_queue's resource lending limit within all the flavors`,
 		}, append([]string{"cohort", "cluster_queue", "flavor", "resource", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(ClusterQueueResourceLendingLimit, gaugeCleanupScopeClusterQueueResource)
 
-	ClusterQueueWeightedShare = trackGaugeVec(prometheus.NewGaugeVec(
+	ClusterQueueWeightedShare = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "cluster_queue_weighted_share",
@@ -720,9 +757,10 @@ the ClusterQueue, and divided by the weight.
 If zero, it means that the usage of the ClusterQueue is below the nominal quota.
 If the ClusterQueue has a weight of zero and is borrowing, this will return NaN.`,
 		}, append([]string{"cluster_queue", "cohort", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(ClusterQueueWeightedShare, gaugeCleanupScopeClusterQueueLabelChange)
 
-	CohortWeightedShare = trackGaugeVec(prometheus.NewGaugeVec(
+	CohortWeightedShare = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "cohort_weighted_share",
@@ -732,15 +770,17 @@ the Cohort, and divided by the weight.
 If zero, it means that the usage of the Cohort is below the nominal quota.
 If the Cohort has a weight of zero and is borrowing, this will return NaN.`,
 		}, append([]string{"cohort", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(CohortWeightedShare, gaugeCleanupScopeCohort)
 
-	CohortSubtreeQuota = trackGaugeVec(prometheus.NewGaugeVec(
+	CohortSubtreeQuota = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "cohort_subtree_quota",
 			Help:      `Reports the cohort's nominal quota aggregated within the cohort's subtree. The values are reported per resource and flavor`,
 		}, append([]string{"cohort", "flavor", "resource", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(CohortSubtreeQuota, gaugeCleanupScopeCohort)
 
 	CohortSubtreeAdmittedWorkloadsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -750,21 +790,23 @@ If the Cohort has a weight of zero and is borrowing, this will return NaN.`,
 		}, append([]string{"cohort", "priority_class", "replica_role"}, extraLabels...),
 	)
 
-	CohortSubtreeResourceReservations = trackGaugeVec(prometheus.NewGaugeVec(
+	CohortSubtreeResourceReservations = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "cohort_subtree_resource_reservations",
 			Help:      `Reports the cohort's resource reservations aggregated within the cohort's subtree. The values are reported per resource and flavor`,
 		}, append([]string{"cohort", "flavor", "resource", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(CohortSubtreeResourceReservations, gaugeCleanupScopeCohort)
 
-	CohortSubtreeAdmittedActiveWorkloads = trackGaugeVec(prometheus.NewGaugeVec(
+	CohortSubtreeAdmittedActiveWorkloads = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: constants.KueueName,
 			Name:      "cohort_subtree_admitted_active_workloads",
 			Help:      "The number of admitted Workloads that are active, per cohort's subtree",
 		}, append([]string{"cohort", "replica_role"}, extraLabels...),
-	))
+	)
+	trackGaugeVec(CohortSubtreeAdmittedActiveWorkloads)
 }
 
 func init() {
@@ -913,11 +955,9 @@ func LQRefFromWorkload(wl *kueue.Workload) LocalQueueReference {
 
 func ClearClusterQueueMetrics(cq kueue.ClusterQueueReference) {
 	cqName := string(cq)
-	AdmissionCyclePreemptionSkips.DeletePartialMatch(prometheus.Labels{"cluster_queue": cqName})
-	PendingWorkloads.DeletePartialMatch(prometheus.Labels{"cluster_queue": cqName})
+	clearScopedGaugeMetrics(gaugeCleanupScopeClusterQueue, prometheus.Labels{"cluster_queue": cqName})
 	QuotaReservedWorkloadsTotal.DeletePartialMatch(prometheus.Labels{"cluster_queue": cqName})
 	QuotaReservedWaitTime.DeletePartialMatch(prometheus.Labels{"cluster_queue": cqName})
-	FinishedWorkloads.DeletePartialMatch(prometheus.Labels{"cluster_queue": cqName})
 	FinishedWorkloadsTotal.DeletePartialMatch(prometheus.Labels{"cluster_queue": cqName})
 	PodsReadyToEvictedTimeSeconds.DeletePartialMatch(prometheus.Labels{"cluster_queue": cqName})
 	AdmittedWorkloadsTotal.DeletePartialMatch(prometheus.Labels{"cluster_queue": cqName})
@@ -933,27 +973,25 @@ func ClearClusterQueueMetrics(cq kueue.ClusterQueueReference) {
 func ClearClusterQueueMetricsOnLabelChange(cq kueue.ClusterQueueReference) {
 	cqName := string(cq)
 	ReplacedWorkloadSlicesTotal.DeletePartialMatch(prometheus.Labels{"cluster_queue": cqName})
-	ClusterQueueWeightedShare.DeletePartialMatch(prometheus.Labels{"cluster_queue": cqName})
+	clearScopedGaugeMetrics(gaugeCleanupScopeClusterQueueLabelChange, prometheus.Labels{"cluster_queue": cqName})
 }
 
 func ClearLocalQueueMetrics(lq LocalQueueReference) {
-	LocalQueuePendingWorkloads.DeletePartialMatch(prometheus.Labels{"name": string(lq.Name), "namespace": lq.Namespace})
-	LocalQueueQuotaReservedWorkloadsTotal.DeletePartialMatch(prometheus.Labels{"name": string(lq.Name), "namespace": lq.Namespace})
-	LocalQueueQuotaReservedWaitTime.DeletePartialMatch(prometheus.Labels{"name": string(lq.Name), "namespace": lq.Namespace})
-	LocalQueueFinishedWorkloads.DeletePartialMatch(prometheus.Labels{"name": string(lq.Name), "namespace": lq.Namespace})
-	LocalQueueFinishedWorkloadsTotal.DeletePartialMatch(prometheus.Labels{"name": string(lq.Name), "namespace": lq.Namespace})
-	LocalQueueAdmittedWorkloadsTotal.DeletePartialMatch(prometheus.Labels{"name": string(lq.Name), "namespace": lq.Namespace})
-	LocalQueueAdmissionWaitTime.DeletePartialMatch(prometheus.Labels{"name": string(lq.Name), "namespace": lq.Namespace})
-	LocalQueueAdmissionChecksWaitTime.DeletePartialMatch(prometheus.Labels{"name": string(lq.Name), "namespace": lq.Namespace})
-	LocalQueueQueuedUntilReadyWaitTime.DeletePartialMatch(prometheus.Labels{"name": string(lq.Name), "namespace": lq.Namespace})
-	LocalQueueAdmittedUntilReadyWaitTime.DeletePartialMatch(prometheus.Labels{"name": string(lq.Name), "namespace": lq.Namespace})
-	LocalQueueEvictedWorkloadsTotal.DeletePartialMatch(prometheus.Labels{"name": string(lq.Name), "namespace": lq.Namespace})
+	lbls := prometheus.Labels{"name": string(lq.Name), "namespace": lq.Namespace}
+	clearScopedGaugeMetrics(gaugeCleanupScopeLocalQueue, lbls)
+	LocalQueueQuotaReservedWorkloadsTotal.DeletePartialMatch(lbls)
+	LocalQueueQuotaReservedWaitTime.DeletePartialMatch(lbls)
+	LocalQueueFinishedWorkloadsTotal.DeletePartialMatch(lbls)
+	LocalQueueAdmittedWorkloadsTotal.DeletePartialMatch(lbls)
+	LocalQueueAdmissionWaitTime.DeletePartialMatch(lbls)
+	LocalQueueAdmissionChecksWaitTime.DeletePartialMatch(lbls)
+	LocalQueueQueuedUntilReadyWaitTime.DeletePartialMatch(lbls)
+	LocalQueueAdmittedUntilReadyWaitTime.DeletePartialMatch(lbls)
+	LocalQueueEvictedWorkloadsTotal.DeletePartialMatch(lbls)
 }
 
 func ClearCohortMetrics(cohortName kueue.CohortReference) {
-	CohortSubtreeQuota.DeletePartialMatch(prometheus.Labels{"cohort": string(cohortName)})
-	CohortWeightedShare.DeletePartialMatch(prometheus.Labels{"cohort": string(cohortName)})
-	CohortSubtreeResourceReservations.DeletePartialMatch(prometheus.Labels{"cohort": string(cohortName)})
+	clearScopedGaugeMetrics(gaugeCleanupScopeCohort, prometheus.Labels{"cohort": string(cohortName)})
 }
 
 func ClearCohortAdmittedWorkloadsMetrics(cohortName kueue.CohortReference) {
@@ -990,15 +1028,11 @@ func ReportLocalQueueStatus(lq LocalQueueReference, conditionStatus metav1.Condi
 }
 
 func ClearCacheMetrics(cqName string) {
-	ReservingActiveWorkloads.DeletePartialMatch(prometheus.Labels{"cluster_queue": cqName})
-	AdmittedActiveWorkloads.DeletePartialMatch(prometheus.Labels{"cluster_queue": cqName})
-	ClusterQueueByStatus.DeletePartialMatch(prometheus.Labels{"cluster_queue": cqName})
+	clearScopedGaugeMetrics(gaugeCleanupScopeClusterQueueCache, prometheus.Labels{"cluster_queue": cqName})
 }
 
 func ClearLocalQueueCacheMetrics(lq LocalQueueReference) {
-	LocalQueueReservingActiveWorkloads.DeletePartialMatch(prometheus.Labels{"name": string(lq.Name), "namespace": lq.Namespace})
-	LocalQueueAdmittedActiveWorkloads.DeletePartialMatch(prometheus.Labels{"name": string(lq.Name), "namespace": lq.Namespace})
-	LocalQueueByStatus.DeletePartialMatch(prometheus.Labels{"name": string(lq.Name), "namespace": lq.Namespace})
+	clearScopedGaugeMetrics(gaugeCleanupScopeLocalQueueCache, prometheus.Labels{"name": string(lq.Name), "namespace": lq.Namespace})
 }
 
 func ReportClusterQueueQuotas(cohort kueue.CohortReference, queue, flavor, resource string, nominal, borrowing, lending float64, customLabelValues []string, tracker *roletracker.RoleTracker) {
@@ -1109,36 +1143,28 @@ func ReportAdmissionCyclePreemptionSkips(cqName kueue.ClusterQueueReference, cou
 	AdmissionCyclePreemptionSkips.WithLabelValues(labels...).Set(float64(count))
 }
 
-var allGaugeVecs []*prometheus.GaugeVec
+func clearScopedGaugeMetrics(scope gaugeCleanupScope, lbls prometheus.Labels) {
+	for _, g := range gaugeVecsByScope[scope] {
+		g.DeletePartialMatch(lbls)
+	}
+}
 
 // ClearGaugeMetricsForRole deletes all gauge metric time series matching
 // replica_role=role. Called during HA role transitions to remove stale
 // time series reported under the old role.
 func ClearGaugeMetricsForRole(role string) {
-	lbls := prometheus.Labels{"replica_role": role}
-	for _, g := range allGaugeVecs {
-		g.DeletePartialMatch(lbls)
-	}
+	clearScopedGaugeMetrics(gaugeCleanupScopeRole, prometheus.Labels{"replica_role": role})
 }
 
 func ClearClusterQueueResourceMetrics(cqName string) {
-	lbls := prometheus.Labels{
-		"cluster_queue": cqName,
-	}
-	ClusterQueueResourceNominalQuota.DeletePartialMatch(lbls)
-	ClusterQueueResourceBorrowingLimit.DeletePartialMatch(lbls)
-	ClusterQueueResourceLendingLimit.DeletePartialMatch(lbls)
-	ClusterQueueResourceUsage.DeletePartialMatch(lbls)
-	ClusterQueueResourceReservations.DeletePartialMatch(lbls)
+	clearScopedGaugeMetrics(gaugeCleanupScopeClusterQueueResource, prometheus.Labels{"cluster_queue": cqName})
 }
 
 func ClearLocalQueueResourceMetrics(lq LocalQueueReference) {
-	lbls := prometheus.Labels{
+	clearScopedGaugeMetrics(gaugeCleanupScopeLocalQueueResource, prometheus.Labels{
 		"name":      string(lq.Name),
 		"namespace": lq.Namespace,
-	}
-	LocalQueueResourceReservations.DeletePartialMatch(lbls)
-	LocalQueueResourceUsage.DeletePartialMatch(lbls)
+	})
 }
 
 func ClearClusterQueueResourceQuotas(cqName, flavor, resource string) {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -241,12 +241,6 @@ func TestMetricsWithReplicaRoleLabel(t *testing.T) {
 }
 
 func TestStaleMetricsAfterRoleTransition(t *testing.T) {
-	savedGaugeVecs := allGaugeVecs
-	allGaugeVecs = append(allGaugeVecs, ClusterQueueResourceNominalQuota)
-	t.Cleanup(func() {
-		allGaugeVecs = savedGaugeVecs
-	})
-
 	followerTracker := roletracker.NewFakeRoleTracker(roletracker.RoleFollower)
 	leaderTracker := roletracker.NewFakeRoleTracker(roletracker.RoleLeader)
 
@@ -285,6 +279,104 @@ func TestMetricsWithDifferentRoles(t *testing.T) {
 	ClearClusterQueueMetrics("cq_follower")
 }
 
+func TestClearClusterQueueMetricsOnLabelChangeOnlyClearsScopedGaugeMetrics(t *testing.T) {
+	const cqName = "cq-label-change"
+
+	ReportPendingWorkloads(cqName, 3, 1, nil, nil)
+	ReportClusterQueueWeightedShare(cqName, "cohort", 7, nil, nil)
+	ReportReplacedWorkloadSlices(cqName, nil, nil)
+
+	expectFilteredMetricsCount(t, PendingWorkloads, 2, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, ClusterQueueWeightedShare, 1, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, ReplacedWorkloadSlicesTotal, 1, "cluster_queue", cqName)
+
+	ClearClusterQueueMetricsOnLabelChange(cqName)
+
+	expectFilteredMetricsCount(t, PendingWorkloads, 2, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, ClusterQueueWeightedShare, 0, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, ReplacedWorkloadSlicesTotal, 0, "cluster_queue", cqName)
+
+	ClearClusterQueueMetrics(cqName)
+}
+
+func TestClearCacheMetricsOnlyClearsCacheScopedGauges(t *testing.T) {
+	const cqName = "cq-cache-scope"
+
+	ReportClusterQueueStatus(cqName, CQStatusActive, nil, nil)
+	ReportAdmittedActiveWorkloads(cqName, 3, nil, nil)
+	ReportReservingActiveWorkloads(cqName, 1, nil, nil)
+	ReportClusterQueueQuotas("cohort", cqName, "flavor", "cpu", 10, 5, 3, nil, nil)
+	ReportPendingWorkloads(cqName, 4, 2, nil, nil)
+
+	expectFilteredMetricsCount(t, ClusterQueueByStatus, 3, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, AdmittedActiveWorkloads, 1, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, ReservingActiveWorkloads, 1, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, ClusterQueueResourceNominalQuota, 1, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, PendingWorkloads, 2, "cluster_queue", cqName)
+
+	ClearCacheMetrics(cqName)
+
+	expectFilteredMetricsCount(t, ClusterQueueByStatus, 0, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, AdmittedActiveWorkloads, 0, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, ReservingActiveWorkloads, 0, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, ClusterQueueResourceNominalQuota, 1, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, PendingWorkloads, 2, "cluster_queue", cqName)
+
+	ClearClusterQueueResourceMetrics(cqName)
+	ClearClusterQueueMetrics(cqName)
+}
+
+func TestClearClusterQueueResourceMetricsOnlyClearsResourceScopedGauges(t *testing.T) {
+	const cqName = "cq-resource-scope"
+
+	ReportClusterQueueQuotas("cohort", cqName, "flavor", "cpu", 10, 5, 3, nil, nil)
+	ReportClusterQueueResourceReservations("cohort", cqName, "flavor", "cpu", 7, nil, nil)
+	ReportClusterQueueResourceUsage("cohort", cqName, "flavor", "cpu", 6, nil, nil)
+	ReportClusterQueueStatus(cqName, CQStatusActive, nil, nil)
+
+	expectFilteredMetricsCount(t, ClusterQueueResourceNominalQuota, 1, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, ClusterQueueResourceBorrowingLimit, 1, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, ClusterQueueResourceLendingLimit, 1, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, ClusterQueueResourceReservations, 1, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, ClusterQueueResourceUsage, 1, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, ClusterQueueByStatus, 3, "cluster_queue", cqName)
+
+	ClearClusterQueueResourceMetrics(cqName)
+
+	expectFilteredMetricsCount(t, ClusterQueueResourceNominalQuota, 0, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, ClusterQueueResourceBorrowingLimit, 0, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, ClusterQueueResourceLendingLimit, 0, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, ClusterQueueResourceReservations, 0, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, ClusterQueueResourceUsage, 0, "cluster_queue", cqName)
+	expectFilteredMetricsCount(t, ClusterQueueByStatus, 3, "cluster_queue", cqName)
+
+	ClearCacheMetrics(cqName)
+}
+
+func TestClearLocalQueueResourceMetricsOnlyClearsResourceScopedGauges(t *testing.T) {
+	lq := LocalQueueReference{Name: "lq-resource-scope", Namespace: "ns-resource-scope"}
+
+	ReportLocalQueueResourceReservations(lq, "flavor", "cpu", 7, nil, nil)
+	ReportLocalQueueResourceUsage(lq, "flavor", "cpu", 6, nil, nil)
+	ReportLocalQueueStatus(lq, "True", nil, nil)
+	ReportLocalQueuePendingWorkloads(lq, 4, 2, nil, nil)
+
+	expectFilteredMetricsCount(t, LocalQueueResourceReservations, 1, "name", string(lq.Name), "namespace", lq.Namespace)
+	expectFilteredMetricsCount(t, LocalQueueResourceUsage, 1, "name", string(lq.Name), "namespace", lq.Namespace)
+	expectFilteredMetricsCount(t, LocalQueueByStatus, 3, "name", string(lq.Name), "namespace", lq.Namespace)
+	expectFilteredMetricsCount(t, LocalQueuePendingWorkloads, 2, "name", string(lq.Name), "namespace", lq.Namespace)
+
+	ClearLocalQueueResourceMetrics(lq)
+
+	expectFilteredMetricsCount(t, LocalQueueResourceReservations, 0, "name", string(lq.Name), "namespace", lq.Namespace)
+	expectFilteredMetricsCount(t, LocalQueueResourceUsage, 0, "name", string(lq.Name), "namespace", lq.Namespace)
+	expectFilteredMetricsCount(t, LocalQueueByStatus, 3, "name", string(lq.Name), "namespace", lq.Namespace)
+	expectFilteredMetricsCount(t, LocalQueuePendingWorkloads, 2, "name", string(lq.Name), "namespace", lq.Namespace)
+
+	ClearLocalQueueCacheMetrics(lq)
+	ClearLocalQueueMetrics(lq)
+}
+
 func TestCohortMetrics(t *testing.T) {
 	leaderTracker := roletracker.NewFakeRoleTracker(roletracker.RoleLeader)
 	followerTracker := roletracker.NewFakeRoleTracker(roletracker.RoleFollower)
@@ -320,4 +412,27 @@ func TestCohortMetrics(t *testing.T) {
 	ClearCohortMetrics("cohort_two")
 	expectFilteredMetricsCount(t, CohortSubtreeQuota, 0, "cohort", "cohort_two")
 	expectFilteredMetricsCount(t, CohortSubtreeResourceReservations, 0, "cohort", "cohort_two")
+}
+
+func TestClearCohortMetricsOnlyClearsScopedGauges(t *testing.T) {
+	const cohortName = "cohort-scope"
+
+	ReportCohortWeightedShare(cohortName, 7, nil, nil)
+	ReportCohortSubtreeQuota(cohortName, "flavor", "cpu", 10, nil, nil)
+	ReportCohortSubtreeResourceReservations(cohortName, "flavor", "cpu", 6, nil, nil)
+	ReportCohortSubtreeAdmittedActiveWorkloads(cohortName, 4, nil, nil)
+
+	expectFilteredMetricsCount(t, CohortWeightedShare, 1, "cohort", cohortName)
+	expectFilteredMetricsCount(t, CohortSubtreeQuota, 1, "cohort", cohortName)
+	expectFilteredMetricsCount(t, CohortSubtreeResourceReservations, 1, "cohort", cohortName)
+	expectFilteredMetricsCount(t, CohortSubtreeAdmittedActiveWorkloads, 1, "cohort", cohortName)
+
+	ClearCohortMetrics(cohortName)
+
+	expectFilteredMetricsCount(t, CohortWeightedShare, 0, "cohort", cohortName)
+	expectFilteredMetricsCount(t, CohortSubtreeQuota, 0, "cohort", cohortName)
+	expectFilteredMetricsCount(t, CohortSubtreeResourceReservations, 0, "cohort", cohortName)
+	expectFilteredMetricsCount(t, CohortSubtreeAdmittedActiveWorkloads, 1, "cohort", cohortName)
+
+	ClearCohortAdmittedWorkloadsMetrics(cohortName)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
This PR cleans up how Kueue removes old Prometheus gauge metrics.

Right now, Kueue has two different ways to clean up stale gauge metrics. This PR keeps both flows working the same way, but makes them use the same cleanup code.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially addresses #9854

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```