### PR TITLE
KEP-2941: Add partitionable devices support

### DIFF
--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -33,6 +33,7 @@ tags, and then generate with `hack/update-toc.sh`.
     - [Story 2](#story-2)
     - [Story 3](#story-3)
     - [Story 4](#story-4)
+    - [Story 5](#story-5)
   - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
@@ -54,6 +55,14 @@ tags, and then generate with `hack/update-toc.sh`.
     - [DeviceClass Resolution via Field Indexer](#deviceclass-resolution-via-field-indexer)
     - [DeviceClass Lifecycle Scenarios](#deviceclass-lifecycle-scenarios)
     - [Late DeviceClass Creation](#late-deviceclass-creation)
+  - [Partitionable Devices](#partitionable-devices)
+    - [ResourceSlice Structure](#resourceslice-structure)
+    - [User Workload](#user-workload)
+    - [Configuration](#configuration-1)
+    - [Processing Flow](#processing-flow-1)
+    - [Path Interactions](#path-interactions)
+    - [Counter Lifecycle Scenarios](#counter-lifecycle-scenarios)
+    - [Validation](#validation)
   - [Architecture Details](#architecture-details)
     - [Queue Manager Extensions](#queue-manager-extensions)
   - [Integration with Admission Fair Sharing](#integration-with-admission-fair-sharing)
@@ -67,6 +76,7 @@ tags, and then generate with `hack/update-toc.sh`.
     - [Alpha](#alpha)
       - [KueueDRAIntegration (v0.14)](#kueuedraintegration-v014)
       - [KueueDRAIntegrationExtendedResource (v0.17)](#kueuedraintegrationextendedresource-v017)
+      - [KueueDRAIntegrationPartitionableDevices (v0.18)](#kueuedraintegrationpartitionabledevices-v018)
     - [Beta](#beta)
       - [KueueDRAIntegration (v0.18)](#kueuedraintegration-v018)
       - [KueueDRAIntegrationExtendedResource](#kueuedraintegrationextendedresource)
@@ -82,6 +92,12 @@ tags, and then generate with `hack/update-toc.sh`.
   - [Defining DeviceClass mapping in ClusterQuota](#defining-deviceclass-mapping-in-clusterquota)
   - [Using ResourceFlavor for DeviceClass Mapping](#using-resourceflavor-for-deviceclass-mapping)
   - [Creating a new CRD for device class mapping](#creating-a-new-crd-for-device-class-mapping)
+  - [User Annotation as Primary Counter Consumption Mechanism](#user-annotation-as-primary-counter-consumption-mechanism)
+  - [Separate counterMappings Struct](#separate-countermappings-struct)
+  - [Device-Count Quota with Dual Tracking](#device-count-quota-with-dual-tracking)
+  - [Auto-discovery of Counters Without Configuration](#auto-discovery-of-counters-without-configuration)
+- [Appendix](#appendix)
+  - [Consumable Capacity Compatibility](#consumable-capacity-compatibility)
 <!-- /toc -->
 
 ## Summary
@@ -89,9 +105,13 @@ tags, and then generate with `hack/update-toc.sh`.
 [Dynamic Resource Allocation (DRA)](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/)
 is a major effort to improve device support in Kubernetes. It changes how one can request resources in a myriad of ways.
 
-This KEP supports two approaches for DRA integration with Kueue:
+This KEP supports three approaches for DRA integration with Kueue:
 1. **ResourceClaimTemplates**: Pods explicitly reference ResourceClaimTemplates that specify device requests.
 2. **Extended Resources**: Pods request DRA devices via standard `resources.requests` (e.g., `example.com/gpu: 1`), and kube-scheduler automatically creates ResourceClaims when the DeviceClass has an `extendedResourceName` field set.
+3. **Partitionable Devices**: Counter-based quota for devices that can be dynamically
+   partitioned (e.g., NVIDIA MIG). Instead of counting devices, Kueue tracks counter
+   consumption (e.g., GPU memory) from the `SharedCounters` and `ConsumesCounters` fields
+   defined by [KEP-4815](https://github.com/kubernetes/enhancements/issues/4815).
 
 ## Motivation
 
@@ -191,13 +211,22 @@ a simple device class named `gpu.example.com`. This will be the way to enforce q
 - Users can submit workloads using extended resource requests (e.g., `example.com/gpu: 1`) and
   Kueue can account for quota when the DeviceClass has `extendedResourceName` set.
 - Admins can enforce the quota for number of devices for a given DeviceClass.
+- Admins can enforce counter-based quota for partitionable devices (e.g., GPU memory quota
+  instead of device count quota for MIG profiles).
 
 ### Non-Goals
 
 - Quota-aware handling of DRAAdminAccess and DRAPrioritizedLists (beta, default enabled in K8s 1.35)
   is not included in Kueue's alpha. See [Risks and Mitigations](#risks-and-mitigations) for the
   planned approach.
-- Support for alpha DRA features like DRADeviceTaints and DRAPartitionableDevices will not be included.
+- Support for DRA features like DRADeviceTaints is not included.
+- Multi-host partitionable devices (e.g., NVLink fabrics spanning multiple nodes) are not
+  supported.
+- Support for DRAConsumableCapacity (alpha in K8s 1.34, beta targeting K8s 1.36) is not
+  included. Consumable capacity enables software-level device sharing (e.g., MPS, time-slicing)
+  where multiple claims share one device. This requires different quota semantics as Kueue
+  would need to read the cost from the claim's capacity request rather than the device's
+  counters. No GPU driver ships consumable capacity yet.
 - This design does not work with Topology Aware Scheduling feature of Kueue. It is a significant
   amount of work, will be addressed in the future with a separate body of work.
 
@@ -214,6 +243,10 @@ scheduling. This includes:
 4. Allowing admins to define quota for DRA resources in ClusterQueues using the logical resource names from device class
    mappings
 5. Implementing validation to prevent device class conflicts and ensure predictable quota behavior
+6. Extending `deviceClassMappings` with a `sources` field to support counter-based quota for
+   partitionable devices (requires Kubernetes `DRAPartitionableDevices` feature gate, beta in
+   K8s 1.36). This builds on CEL expression support which adds ResourceSlice access and
+   device matching to Kueue.
 
 More details are documented in [Design Details](#design-details)
 
@@ -239,6 +272,13 @@ As a Kueue user, I want to request DRA devices using standard resource requests 
 instead of ResourceClaimTemplates, so my existing workloads can benefit from DRA without modification when the cluster
 administrator configures DeviceClasses with `extendedResourceName`.
 
+#### Story 5
+
+As a cluster administrator, I want to enforce GPU memory quota for MIG partitions so that teams
+sharing a pool of partitionable GPUs get fair access based on counter consumption, not
+just device counts. A team requesting a 1g.10gb MIG profile should consume about 9856Mi of
+GPU memory quota, while a team requesting a 7g.80gb profile should consume 80Gi.
+
 ### Notes/Constraints/Caveats (Optional)
 
 - The `ResourceClaims` and `ResourceClaimTemplates` APIs for DRA in k8s are immutable.
@@ -247,9 +287,13 @@ administrator configures DeviceClasses with `extendedResourceName`.
 - Device class uniqueness is enforced - each device class can only map to one resource name to prevent quota ambiguity.
 - Configuration-based approach - device class mappings are configured through the Kueue Configuration API
 - This design does not work with Kueue's Topology Aware Scheduling feature and will be addressed in future work.
+- DRA resource preprocessing is not scoped by ResourceFlavor node constraints. Counter
+  charges and device matching are computed globally before flavor assignment.
 - Quota-aware handling of DRAAdminAccess and DRAPrioritizedLists (beta in K8s 1.35) is deferred
-  to beta graduation. Alpha DRA features like DRADeviceTaints and DRAPartitionableDevices are
-  not supported.
+  to beta graduation. DRADeviceTaints is not supported in alpha.
+- **Single-node partitionable devices (e.g., MIG) are supported** via counter-based
+  quota. See [Partitionable Devices](#partitionable-devices). Multi-host partitionable
+  devices are not supported.
 - **Extended Resources** requires DeviceClasses to have `spec.extendedResourceName` set.
   This depends on the Kubernetes `DRAExtendedResource` feature gate (alpha in k8s 1.35).
   When enabled, kube-scheduler automatically creates ResourceClaims for pods requesting extended resources.
@@ -266,7 +310,6 @@ administrator configures DeviceClasses with `extendedResourceName`.
   With structured parameters, GPU sharing is supported via ResourceClaimTemplates where
   containers within the same pod share a GPU. Cross-pod sharing via direct ResourceClaims
   is not supported.
-
 - **Kueue does not validate DeviceClass existence at config load time.** Admins should
   create DeviceClasses before submitting workloads but strict ordering is not enforced.
 
@@ -278,12 +321,12 @@ administrator configures DeviceClasses with `extendedResourceName`.
   time on a best-effort basis. Workloads with CEL selectors that match fewer devices than requested are rejected
   to prevent quota leaks. This validation uses the upstream DRA CEL compiler from [`k8s.io/dynamic-resource-allocation/cel`](https://github.com/kubernetes/dynamic-resource-allocation/tree/master/cel).
   On the other hand, devices can be allocated between Kueue's check and scheduling, and new ResourceSlices published after
-  validation can make previously-unsatisfiable workloads. `WaitForPodsReady` serves as the safety net for cases where
-  the validation state diverges from actual device availability at scheduling time.
-
-- **Kueue does not have any informers on ResourceSlice changes.** CEL expression evalulation
-requires that the ResourceSlices are fetched from the apiserver. If a driver publishes new capacity and the workload was rejected, there is no
-resubmission of the workload once ResourceSlices changes. Evaluating this for beta is important.
+  validation can make previously-unsatisfiable workloads satisfiable. Kueue does not
+  currently have a ResourceSlice informer. Inadmissible workloads are only re-evaluated
+  when the ClusterQueue is notified through other events such as quota changes. Adding
+  event-driven requeuing on ResourceSlice changes is an Alpha graduation criterion.
+  `WaitForPodsReady` serves as the safety net for cases where the validation state
+  diverges from actual device availability at scheduling time.
 
 ### Risks and Mitigations
 
@@ -295,9 +338,8 @@ See [Workload Rejection When DRA Is Disabled](#workload-rejection-when-dra-is-di
 
 With DRAAdminAccess and DRAPrioritizedLists (both beta, default enabled in K8s 1.35), there is a
 risk that effective tallying of resources will not be available until after allocation of these
-resources by kube-scheduler.
-
-In order to mitigate this risk, Kueue can take the following approach:
+resources by kube-scheduler. Support for these is deferred to Beta but the mitigation approach
+is documented here:
 1. For DRAPrioritizedLists: all the mentioned device classes in the request will be counted against the quota
 2. For DRAAdminAccess: This feature can only be enabled in admin namespace, therefore it should be skipped for being
    counted against ClusterQuota. This is a different stance than Kubernetes ResourceQuota because kubernetes
@@ -336,6 +378,10 @@ Three feature gates control DRA support in Kueue:
 - `DRAExtendedResources`: gates extended resources support, including DeviceClass
   auto-discovery via `extendedResourceName`. Does not use `deviceClassMappings`.
   Requires `DynamicResourceAllocation` to also be enabled.
+- `KueueDRAIntegrationPartitionableDevices`: gates counter-based quota for partitionable
+  devices. Enables the `sources` field on `deviceClassMappings` entries. Requires
+  `DynamicResourceAllocation` to also be enabled. Also requires the Kubernetes
+  `DRAPartitionableDevices` feature gate (beta in K8s 1.36).
 - `KueueDRARejectWorkloadsWhenDRADisabled` (default: enabled, Beta since v0.18): rejects workloads that
   use DRA resources (ResourceClaimTemplates or ResourceClaims) when the
   `DynamicResourceAllocation` feature gate is disabled. Without this gate, DRA workloads
@@ -437,7 +483,7 @@ spec:
 
 The above ClusterQueue is an example configuration of a queue, with half quota configured for single allocation of
 example
-GPUs, and half quota configured for GPUs that are shared by workloads. Similarly, when DRAPartitionableDevices feature
+GPUs, and half quota configured for GPUs that are shared by workloads. Similarly, when KueueDRAIntegrationPartitionableDevices feature
 is supported in kubernetes, GPUs partitions can be represented by a single device class.
 
 ### Device Class Resolution and Conflict Prevention
@@ -521,7 +567,8 @@ rules:
 **Required Permissions:**
 - `resourceclaims`: Read access to validate ResourceClaim references (though not supported for quota)
 - `resourceclaimtemplates`: Read access to process ResourceClaimTemplates and extract device class information
-- `resourceslices`: Read access to list cluster devices for CEL selector validation
+- `resourceslices`: Read access to list cluster devices for CEL selector validation and `consumesCounters` reading.
+  Kueue only reads device attributes for CEL matching and counter values for quota.
 - `deviceclasses`: Read access to resolve DeviceClass selectors for device pre-filtering during CEL evaluation
 
 **Security Considerations:**
@@ -774,7 +821,9 @@ An extended resource can be identified by verifying that qualified resource name
 
 The extended resources path does not require `deviceClassMappings`. Kueue auto-discovers
 DeviceClasses via a field indexer on `spec.extendedResourceName` and uses the
-`extendedResourceName` directly as the quota key in ClusterQueue.
+`extendedResourceName` as the default quota key. If the DeviceClass is also in
+`deviceClassMappings`, Kueue uses the mapped logical name instead to unify quota
+with the ResourceClaimTemplate path.
 
 DeviceClass with `extendedResourceName` (DeviceClass API is v1/GA, but the `extendedResourceName`
 field requires the Kubernetes `DRAExtendedResource` feature gate):
@@ -809,14 +858,16 @@ continues to use `deviceClassMappings`.
 
 #### Path Separation
 
-The two DRA paths have independent quota resolution:
+The two DRA paths resolve quota independently:
 1. **Extended resources** (`DRAExtendedResources` gate): auto-discovers DeviceClass via
-   field indexer, uses `extendedResourceName` as quota key. No `deviceClassMappings` needed.
+   field indexer. Uses `extendedResourceName` as the default quota key. If the resolved
+   DeviceClass is also present in `deviceClassMappings`, Kueue uses the mapped logical
+   name instead to unify quota with the ResourceClaimTemplate path. If the mapping has
+   counter sources configured, the workload is marked inadmissible because extended resources
+   do not carry the profile-level information needed for counter-based charging.
 2. **ResourceClaimTemplates** (`DynamicResourceAllocation` gate): uses `deviceClassMappings`
-   to map DeviceClass names to logical resource names. No auto-discovery.
-
-There is no precedence or fallback between the two paths. Each path has exactly one resolution
-mechanism.
+   to map DeviceClass names to logical resource names. When the mapping has counter sources
+   configured, charges counter units instead of device count.
 
 #### Processing Flow
 
@@ -824,10 +875,14 @@ mechanism.
 2. Looks up DeviceClass by `extendedResourceName` by field indexer
 3. If no matching DeviceClass is found, the resource is not DRA-backed and Kueue
    processes it through the standard resource quota path (counted via `node.Status.Allocatable`)
-4. If a matching DeviceClass is found, uses the `extendedResourceName` as the quota key
-5. Removes original extended resource from the workload's effective resource requests
+4. If a matching DeviceClass is found, resolves the quota key. If the DeviceClass is also
+   in `deviceClassMappings`, uses the mapped logical name. Otherwise uses `extendedResourceName`.
+5. If the mapping has counter sources configured, the workload is marked inadmissible.
+   Extended resources do not carry profile-level information for counter-based charging.
+   Otherwise charges device count.
+6. Removes original extended resource from the workload's effective resource requests
    (tracked internally per PodSet) to avoid double-counting
-6. Admits workload against the quota for the `extendedResourceName`
+7. Admits workload against the resolved quota key
 
 The extended resource translation reads directly from the workload spec before
 `excludeResourcePrefixes` filtering is applied. The processing order:
@@ -913,6 +968,382 @@ is treated as a normal (non-DRA) extended resource. A subsequent reconciliation 
 (e.g., triggered by other workload or queue events) re-evaluates the workload after the
 DeviceClass is created. Event-driven re-reconciliation on DeviceClass creation will be
 evaluated as a Beta graduation criterion.
+
+### Partitionable Devices
+
+This section is gated behind the `KueueDRAIntegrationPartitionableDevices` Kueue feature gate.
+
+Kueue supports counter-based quota for partitionable DRA devices as defined by
+Kubernetes [KEP-4815](https://github.com/kubernetes/enhancements/issues/4815). Instead of
+counting devices, Kueue tracks counter consumption (e.g., GPU memory) from the
+`SharedCounters` and `ConsumesCounters` fields on ResourceSlices.
+
+Counter-based resources fit into Kueue's existing (Flavor, Resource) quota model.
+Borrowing, lending, cohorts, preemption, and fair sharing work with counter resources.
+The `deviceSelector` ensures accurate charging by narrowing the accounting
+domain. See [Processing Flow](#processing-flow-1) for details.
+
+#### ResourceSlice Structure
+
+Starting in K8s 1.35, `SharedCounters` and `Devices` are mutually exclusive in a single
+ResourceSlice (`+zeroOrOneOf=ResourceSliceType`). Drivers must split them into separate
+slices in the same pool. On K8s 1.34 (where partitionable devices are alpha) this
+validation does not apply and some drivers put both in one slice
+(`resourceSliceCount: 1`). Pool completeness checks `len(slices) == resourceSliceCount`
+so both layouts work.
+
+The example below shows the separate-slice layout. Only the `memory` counter is shown.
+The driver also
+publishes `multiprocessors` and `memory-slice-0` through `memory-slice-7` which the
+kube-scheduler uses for MIG placement but Kueue does not need for quota:
+
+```yaml
+# ResourceSlice 1: SharedCounters (total capacity for this GPU)
+spec:
+  driver: gpu.nvidia.com
+  pool:
+    name: node1-gpu0
+    generation: 1
+    resourceSliceCount: 2
+  sharedCounters:
+  - name: gpu-0-counter-set
+    counters:
+      memory:
+        value: 80Gi
+      # Driver also publishes multiprocessors, memory-slice-0 through
+      # memory-slice-7 - used by kube-scheduler, not by Kueue.
+---
+# ResourceSlice 2: Devices with ConsumesCounters
+spec:
+  driver: gpu.nvidia.com
+  pool:
+    name: node1-gpu0
+    generation: 1
+    resourceSliceCount: 2
+  nodeName: node1
+  devices:
+  - name: gpu-0-mig-1g.10gb-0
+    attributes:
+      gpu.nvidia.com/profile:
+        string: "1g.10gb"
+    consumesCounters:
+    - counterSet: gpu-0-counter-set
+      counters:
+        memory:
+          value: 9856Mi
+  - name: gpu-0-mig-7g.80gb-0
+    attributes:
+      gpu.nvidia.com/profile:
+        string: "7g.80gb"
+    consumesCounters:
+    - counterSet: gpu-0-counter-set
+      counters:
+        memory:
+          value: 80Gi
+```
+
+#### User Workload
+
+Users request MIG profiles via CEL selectors on ResourceClaimTemplates. Counter tracking
+is transparent to the user:
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: mig-1g-10gb
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: mig.nvidia.com
+          selectors:
+          - cel:
+              expression: "device.attributes['gpu.nvidia.com'].profile == '1g.10gb'"
+```
+
+#### Configuration
+
+The existing `DeviceClassMapping` struct is extended with an optional `sources` field.
+When a counter source is present, Kueue tracks quota in counter units (e.g., GPU memory)
+instead of device count. This can allow whole-GPU and MIG DeviceClasses to share a single
+quota pool. See [Path Interactions](#path-interactions) for caveats on unified pool charging.
+
+The `DeviceClassMapping` struct is extended:
+
+```golang
+type DeviceClassMapping struct {
+    // ...existing fields (Name, DeviceClassNames)...
+
+    // Sources configures resource accounting sources for this mapping.
+    // Each source defines how quota is tracked for this DeviceClass.
+    // Currently only counter sources are supported (for partitionable devices).
+    // Extended resource requests that resolve to a DeviceClass with sources
+    // configured are marked inadmissible.
+    // Requires the KueueDRAIntegrationPartitionableDevices feature gate.
+    // +optional
+    Sources []DeviceClassSourceConfig `json:"sources,omitempty"`
+}
+
+// DeviceClassSourceConfig defines a resource accounting source for a DeviceClassMapping.
+// Exactly one of the source types must be set.
+type DeviceClassSourceConfig struct {
+    // Counter configures counter-based quota for partitionable devices.
+    // Maps a DRA driver counter to the parent DeviceClassMapping's Kueue quota resource.
+    // +optional
+    Counter *DeviceClassCounterSource `json:"counter,omitempty"`
+}
+
+// DeviceClassCounterSource identifies where to read counter data from and which counter to track.
+type DeviceClassCounterSource struct {
+    // Name is the counter name within the device's consumesCounters
+    // entries to track for quota. Must match a counter name published by
+    // the driver in ResourceSlice devices' consumesCounters field.
+    // Counter set names are per-device identifiers (e.g., gpu-0-counter-set,
+    // gpu-1-counter-set), so name matches across all counter sets
+    // for a given driver without requiring one mapping per device.
+    // +required
+    Name string `json:"name"`
+
+    // Driver is the DRA driver name used to filter relevant ResourceSlices.
+    // Must match the spec.driver field on ResourceSlice objects.
+    // +required
+    Driver string `json:"driver"`
+
+    // DeviceSelector scopes which devices are eligible for counter-based
+    // quota accounting. Typically matches a GPU model (e.g., productName)
+    // so all partition profiles on that model share one quota pool.
+    // Per-workload charging is determined by the workload's own
+    // ResourceClaimTemplate selector, which narrows to the requested profile.
+    // The selector is compiled at config load time using the upstream dracel
+    // compiler.
+    // +required
+    DeviceSelector resourcev1.DeviceSelector `json:"deviceSelector"`
+}
+```
+
+Multi-profile MIG setup sharing a single `gpu.memory` quota pool. The
+`deviceSelector` scopes the accounting domain to devices from the configured
+driver. Per-workload charging comes from the workload's own ResourceClaimTemplate selector, which narrows
+to the requested profile:
+
+```yaml
+# Kueue Configuration
+apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+featureGates:
+  KueueDRAIntegration: true
+  KueueDRAIntegrationPartitionableDevices: true
+resources:
+  deviceClassMappings:
+  - name: gpu.memory
+    deviceClassNames: [mig.nvidia.com]
+    sources:
+    - counter:
+        name: memory
+        driver: gpu.nvidia.com
+        deviceSelector:
+          cel:
+            expression: "device.driver == 'gpu.nvidia.com'"
+---
+# ClusterQueue: 10 A100 GPUs worth of memory
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: gpu-queue
+spec:
+  resourceGroups:
+  - coveredResources: ["gpu.memory"]
+    flavors:
+    - name: a100-pool
+      resources:
+      - name: gpu.memory
+        nominalQuota: "800Gi"
+```
+
+Workloads requesting different MIG profiles share the same `gpu.memory` quota. Kueue
+matches devices using both the DeviceClass selectors and the workload's ResourceClaimTemplate selectors
+(step 4 in [Processing Flow](#processing-flow-1)), then reads `consumesCounters.memory`
+from the matched devices:
+
+```yaml
+# Workload A: requests 1g.10gb profile
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: mig-small
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: mig.nvidia.com
+          count: 1
+          selectors:
+          - cel:
+              expression: "device.attributes['gpu.nvidia.com'].profile == '1g.10gb'"
+---
+# Workload B: requests 7g.80gb profile
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: mig-large
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: mig.nvidia.com
+          count: 1
+          selectors:
+          - cel:
+              expression: "device.attributes['gpu.nvidia.com'].profile == '7g.80gb'"
+```
+
+Resulting quota usage against `gpu.memory: 800Gi`:
+
+| Workload | ResourceClaimTemplate selector | consumesCounters.memory | Charge |
+|----------|-------------|------------------------|--------|
+| A | `profile == '1g.10gb'` | 9856Mi | `gpu.memory: 9856Mi` |
+| B | `profile == '7g.80gb'` | 80Gi | `gpu.memory: 80Gi` |
+
+The `deviceSelector` does not select the MIG profile. It scopes which devices
+are eligible for counter-based accounting. The workload's own ResourceClaimTemplate selector narrows to the
+requested profile. Different profiles produce different charges against the same quota
+because Kueue reads the actual `consumesCounters` value from the matched devices. When a
+workload uses a broad ResourceClaimTemplate selector matching multiple profiles, Kueue charges conservatively
+using the maximum `consumesCounters` value across matched devices.
+
+`deviceSelector` is required when a counter source is configured. Single-profile
+DeviceClasses that match devices with identical counter values do not need counter-based
+quota and can use device-count quota instead.
+
+When `sources` is absent on a mapping, the mapping behaves exactly as today (device-count
+quota). This is backward compatible and covers non-GPU DRA devices where device count is
+the appropriate unit.
+
+Counter names are driver-specific, so the counter source's `name` maps them to the Kueue
+quota resource name. The admin chooses which counters to track for quota.
+
+#### Processing Flow
+
+Partitionable devices reuses the upstream `dracel` compiler from the CEL expression
+support but performs its own
+ResourceSlice listing with pool-aware processing, since the CEL validation path does not
+return matched device objects or do pool grouping:
+
+1. Kueue looks up the ResourceClaimTemplate's DeviceClass in `deviceClassMappings`
+2. If the mapping has counter sources configured, enters the counter-based path
+3. Lists ResourceSlices for the configured driver, groups them by pool and checks completeness
+4. Filters devices by `deviceSelector` to narrow the candidate pool
+5. From filtered devices, matches using DeviceClass selectors and the workload's
+   ResourceClaimTemplate request selectors using the `dracel` compiler
+6. For each matched device, resolves the counter charge:
+   - Device has `consumesCounters` containing the configured `name`: uses the
+     actual value (e.g., 9856Mi for a 1g.10gb MIG profile)
+   - Device has `consumesCounters` but `name` is not found: workload is
+     marked inadmissible
+   - Device has no `consumesCounters`: workload is marked inadmissible
+7. Uses the maximum consumption across matched devices as the per-device counter charge
+8. For requests with `count > 1`, multiplies per-device consumption by count
+
+Counter resources are injected through the existing `WithPreprocessedDRAResources` path.
+
+In Alpha, partitionable devices performs its own ResourceSlice listing independently from
+the CEL validation path because the two have different requirements: CEL validation only
+needs a match count, while counter processing needs matched device objects and pool-aware
+grouping. In Beta, these can be consolidated into a shared ResourceSlice listing layer.
+
+The workload is marked inadmissible if the matching device count is less than the
+requested count, or if ResourceSlice data is unavailable. Workloads are never admitted
+with zero counter charge when counter sources are configured. For each pool, Kueue only
+considers ResourceSlices with the latest generation. If a pool's slice count is less
+than its `resourceSliceCount`, the pool is incomplete and its devices are excluded from
+matching.
+
+For `count > 1`, the per-device consumption is multiplied by count.
+
+The Kubernetes API limits each device to 2 `consumesCounters` entries
+(`ResourceSliceMaxDeviceCounterConsumptionsPerDevice`), each referencing a different counter
+set. In Alpha, only single-node partitionable devices are supported where each device
+consumes from a single local counter set. Multi-counter-set semantics (e.g., a device
+consuming from both a local GPU pool and a shared NVLink fabric pool) will be addressed
+with multi-host support in future work.
+
+#### Path Interactions
+
+A `deviceClassMappings` entry uses either device-count or source-based quota, determined
+by whether `sources` is set. A DeviceClass appears in exactly one mapping entry.
+
+When a counter source is set, the charge comes from the matched device's `consumesCounters`.
+If the device has no `consumesCounters`, the workload is marked inadmissible.
+
+**Extended resources and counter sources are not supported together:**
+
+If an extended resource request resolves to a DeviceClass whose mapping has counter sources
+configured, the workload is marked inadmissible. Extended resources carry only a device
+count (e.g., `nvidia.com/gpu: 1`) without profile-level CEL selectors, so Kueue cannot
+determine an accurate counter charge. Workloads requiring counter-based quota should use
+ResourceClaimTemplates with CEL selectors.
+
+**Unified quota pools:**
+
+Whole-GPU and MIG DeviceClasses can share one mapping entry with counter sources configured.
+The `deviceSelector` must be compatible with both request shapes for unified
+charging to work. Workloads that need both a whole GPU and a MIG slice from the same
+counter pool should use ResourceClaimTemplates for both.
+
+**Cohort and borrowing:**
+
+Counter resources participate in Cohort borrowing and lending like any other resource.
+`nominalQuota`, `borrowingLimit`, and `lendingLimit` are all in counter units. A
+ClusterQueue with `nominalQuota: "0"` borrows counter capacity from other ClusterQueues
+or the Cohort. Counter resources use a distinct resource name (e.g., `gpu.memory`) so
+borrowing only operates within the same resource.
+
+#### Counter Lifecycle Scenarios
+
+1. **No counter data on matched devices**: the driver published devices without
+   `consumesCounters` entries. The workload is marked inadmissible. Drivers using
+   partitionable devices must publish `consumesCounters` on all devices for counter-based
+   quota to work.
+
+2. **Non-existent counter name**: the configured `name` does not match any entry in
+   matched devices' `consumesCounters`. The workload is marked inadmissible.
+
+3. **ResourceSlice changes after admission**: Kueue does not re-evaluate admitted workloads.
+   If ResourceSlices change and the scheduler cannot find a matching device, the pod stays
+   pending and `waitForPodsReady` evicts the workload. If the scheduler allocates a smaller
+   partition than what Kueue charged, the pod runs fine but quota stays over-reserved until
+   the workload finishes.
+
+4. **Driver restart**: ResourceSlices may temporarily disappear. Workloads submitted during
+   this window are marked inadmissible. Kueue does not currently have a ResourceSlice
+   informer, so inadmissible workloads are only re-evaluated when the ClusterQueue is
+   notified through other events. Event-driven requeuing on ResourceSlice changes is an
+   Alpha graduation criterion.
+
+#### Validation
+
+- At config load time: when `sources` is present on a `deviceClassMappings` entry, the
+  `KueueDRAIntegrationPartitionableDevices` feature gate must be enabled. `sources` must have exactly
+  one entry in Alpha, and it must be a counter source. Each counter source is validated for
+  required fields (`name`, `driver`, `deviceSelector`). The `deviceSelector` CEL expression
+  is compiled at config load time using the upstream `dracel` compiler to catch syntax
+  and type errors early. Exactly one source type must be set per entry.
+- Duplicate `(driver, name)` tuples within a single mapping's `sources` are
+  rejected. Across different mappings, the same `(driver, name)` is allowed
+  since DeviceClass uniqueness already prevents double-counting. This supports separate
+  quota for GPU models that share a driver and counter name (e.g., A100 vs H100).
+- At runtime: no cross-validation between `name` and actual ResourceSlice counter
+  names. This is consistent with how `deviceClassMappings` does not validate DeviceClass
+  existence at config load time.
+- `KueueDRAIntegrationPartitionableDevices` requires `KueueDRAIntegration` to be enabled. Validated
+  at startup in `pkg/config/validation.go`.
 
 ### Architecture Details
 
@@ -1036,10 +1467,30 @@ using mock ResourceClaimTemplates and DeviceClasses to simulate DRA workloads. K
 - DRA disabled rejection: Testing that workloads with ResourceClaimTemplates or ResourceClaims are
   rejected as inadmissible when `DynamicResourceAllocation` is off and `KueueDRARejectWorkloadsWhenDRADisabled` is on,
   and that non-DRA workloads are still admitted normally
+- Partitionable devices: Testing `sources` config validation on `deviceClassMappings`
+  (required fields, duplicate driver+name tuples, device selector CEL compilation
+  at config load time, exactly one source type set)
+- Extended resources with counter sources rejection: extended resource request resolved to a
+  DeviceClass with counter sources is marked inadmissible
+- Counter consumption: Verifying counter charge from matched devices' `consumesCounters`,
+  device selector-based pre-filtering,
+  maximum consumption across matched devices, count multiplication for `count > 1`
+- Unified quota: Whole-GPU and MIG DeviceClasses sharing one quota pool via single
+  `deviceClassMappings` entry with counter sources
+- Counter inadmissibility: Workload inadmissible when ResourceSlice data is unavailable,
+  pool is incomplete, configured `name` has no match in devices, or device has no
+  `consumesCounters` not present on matched device
+- ResourceSlice handling: Pool completeness via generation and resourceSliceCount,
+  correct filtering by driver name
 
 #### E2E Test
 
-Use existing dra-example-driver or Kubernetes test driver for e2e testing.
+Use existing dra-example-driver or Kubernetes test driver for e2e testing. For partitionable
+devices, integration tests create ResourceSlice objects directly via the API since no test
+driver publishes `SharedCounters` yet
+([kubernetes-sigs/dra-example-driver#150](https://github.com/kubernetes-sigs/dra-example-driver/pull/150)
+tracks adding this). This follows the same pattern as upstream K8s integration tests in
+`test/integration/dra/`.
 
 ### Graduation Criteria
 
@@ -1057,6 +1508,12 @@ Use existing dra-example-driver or Kubernetes test driver for e2e testing.
 - extended resource detection and resource translation
 - double-counting prevention with `deviceClassMappings`
 
+##### KueueDRAIntegrationPartitionableDevices (v0.18)
+
+- support for partitionable devices via counter-based quota (KEP-4815, beta in k8s 1.36)
+- CEL expression validation against ResourceSlice devices
+- event-driven requeuing of inadmissible workloads on ResourceSlice changes
+
 #### Beta
 
 ##### KueueDRAIntegration (v0.18)
@@ -1072,14 +1529,21 @@ Use existing dra-example-driver or Kubernetes test driver for e2e testing.
 - re-evaluate event-driven DeviceClass tracking for late DeviceClass creation
 - re-evaluate post-scheduling quota reconciliation for DeviceClass drift
 - re-evaluate the need for indexing of resourceSlices for CEL performance lookups
-- re-evaluate event-driven ResourceSlice tracking for late ResourceSlice creation
+- re-evaluate pool-aware flavor assignment for counter resources
+- re-evaluate caching `deviceSelector` evaluation results to avoid repeated ResourceSlice
+  evaluation
+- re-evaluate consolidating ResourceSlice listing between CEL validation and counter
+  processing into a shared layer
+- re-evaluate multi-counter tracking (e.g., memory and compute as separate quota resources
+  for the same DeviceClass) by relaxing the DeviceClass uniqueness constraint when mappings
+  have different counter sources configured
 
 #### GA
 
 ##### KueueDRAIntegration
 
 - the feature gate in stable
-- integration with TopologyAwareScheduling
+- TAS + DRA integration and testing
 
 ## Implementation History
 
@@ -1088,11 +1552,12 @@ Use existing dra-example-driver or Kubernetes test driver for e2e testing.
 - Design evolution from standalone CRD to Configuration API approach: October 2024
 - Alpha implementation completed: December 2024
 - KEP updated to reflect actual implementation: September 2025 by @alaypatel07
-- Extended Resources implementation: January 2026
+- Extended Resources implementation: January 2026 by @sohankunkerkar
 - Integration with Admission Fair Sharing: April 2026 — added integration tests and documentation
   confirming DRA logical resources work with existing `AdmissionFairSharing.ResourceWeights`
 - CEL expression validation support added: April 2026 by @kannon92
 - Promoted KueueDRAIntegration to Beta: May 2026 by @sohankunkerkar
+- Partitionable devices support: May 2026 by @sohankunkerkar
 - `KueueDRARejectWorkloadsWhenDRADisabled` feature gate added: May 2026 by @kannon92 — rejects DRA workloads
   when the `DynamicResourceAllocation` feature gate is disabled to prevent silent quota bypass
   (see [#10504](https://github.com/kubernetes-sigs/kueue/issues/10504))
@@ -1339,3 +1804,46 @@ type DynamicResource struct {
 }
 ```
 However, this approach was introducing a significant amount of complexity in implementing the feature so it was rejected.
+
+### User Annotation as Primary Counter Consumption Mechanism
+
+Users could declare counter consumption via a pod annotation like
+`kueue.x-k8s.io/counter-requests: '{"gpu.memory": "20Gi"}'`. Kueue trusts the annotation,
+scheduler handles actual allocation. The problem is the annotation can drift from the CEL
+selectors. If the CEL matches a 7g.80gb profile but the annotation says 20Gi, quota is
+undercharged. Reading `consumesCounters` from matched devices avoids this because it stays
+in sync with what the CEL actually selects.
+
+### Separate counterMappings Struct
+
+Counter config could be a separate top-level `counterMappings` struct alongside
+`deviceClassMappings`. This aligns the config surface with data sources (DeviceClasses vs
+ResourceSlices) but creates two independent quota pools for the same physical hardware.
+Whole-GPU and MIG workloads end up in separate quota dimensions with no way to borrow,
+fair-share, or preempt across them.
+
+### Device-Count Quota with Dual Tracking
+
+Quota in device units with Kueue maintaining both device count and counter budget as two
+coupled dimensions at runtime. A MIG workload would consume a fractional device (e.g.,
+0.25) and a counter value simultaneously, requiring borrowing, preemption, and fair
+sharing to reason about both dimensions. The adopted approach uses counter-unit
+`nominalQuota` directly, tracking only counter units internally.
+
+### Auto-discovery of Counters Without Configuration
+
+Kueue could read counter names directly from ResourceSlices without needing any
+counter config. But counter names are driver-specific (NVIDIA uses `memory`,
+others might use `gpu-mem`) and there is no way to connect them to the admin-chosen quota
+resource names in the ClusterQueue (e.g., `gpu.memory`) without an explicit mapping.
+
+## Appendix
+
+### Consumable Capacity Compatibility
+
+[KEP-5075 (Consumable Capacity)](https://github.com/kubernetes/enhancements/issues/5075)
+enables software-level device sharing where multiple ResourceClaims share one physical
+device. Kueue's `(Flavor, Resource)` quota model supports adding Consumable Capacity in
+the future. Both partitionable devices and consumable capacity produce a
+`resource.Quantity` charge that fits the existing quota tracking, borrowing, preemption,
+and fair sharing without changes.

--- a/keps/2941-DRA/kep.yaml
+++ b/keps/2941-DRA/kep.yaml
@@ -15,6 +15,7 @@ approvers:
 see-also:
   - "https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/4381-dra-structured-parameters/README.md"
   - "https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5004-dra-extended-resource"
+  - "https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4815-dra-partitionable-devices"
 replaces:
   - "https://github.com/kubernetes-sigs/kueue/pull/3071"
 
@@ -37,6 +38,7 @@ milestone:
 feature-gates:
   - name: KueueDRAIntegration
   - name: KueueDRAIntegrationExtendedResource
+  - name: KueueDRAIntegrationPartitionableDevices
   - name: KueueDRARejectWorkloadsWhenDRADisabled
 disable-supported: true
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially fixes https://github.com/kubernetes-sigs/kueue/issues/10108

#### Special notes for your reviewer:
<details>
<summary>1. ResourceSlice published by NVIDIA DRA driver</summary>

```sh
$ kubectl get resourceslice gcp-a100-test-gfn26-worker-f-gz764-gpu.nvidia.com-tt5gs \
    -o jsonpath='{.spec.sharedCounters[0]}'
gpu-0-counter-set: memory=40320Mi

$ kubectl get resourceslice gcp-a100-test-gfn26-worker-f-gz764-gpu.nvidia.com-tt5gs \
    -o jsonpath='{range .spec.devices[*]}{.name}: {.consumesCounters[0].counters.memory.value}{"\n"}{end}' \
    | grep 'mig-1g\|mig-7g'
gpu-0-mig-1g10gb-15-0: 9984Mi
gpu-0-mig-7g40gb-0-0: 40320Mi
```

</details>

<details>
<summary>2. Kueue config</summary>

```yaml
counterMappings:
- name: gpu.memory
  driver: gpu.nvidia.com
  counterName: memory
```

</details>

<details>
<summary>3. ClusterQueue with counter quota</summary>

```sh
$ kubectl get clusterqueue pd-test-cq \
    -o jsonpath='{range .spec.resourceGroups[0].flavors[0].resources[*]}{.name}: {.nominalQuota}{"\n"}{end}'
cpu: 100
memory: 200Gi
gpu.memory: 40Gi
```

</details>

<details>
<summary>4. Workload admitted with counter-based charge</summary>

```sh
$ kubectl get workload job-mig-1g-test-8be29 -n pd-test \
    -o jsonpath='{.status.admission.podSetAssignments[0].resourceUsage}'
{"cpu":"100m","gpu.memory":"9984Mi","memory":"256Mi"}
```

`1g.10gb` charges `9984Mi` and `7g.40gb` would charge `40320Mi`. Without counter-based quota, both would charge "1 GPU" via `deviceClassMappings` despite `7g.40gb` using 4x the memory.

</details>


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```