### PR TITLE
Add job to workload latency metric

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1588,6 +1588,17 @@ func (r *JobReconciler) handleJobWithNoWorkload(ctx context.Context, job Generic
 	}
 	r.record.Eventf(object, corev1.EventTypeNormal, ReasonCreatedWorkload,
 		"Created Workload: %v", workload.Key(wl))
+
+	creationTime := wl.CreationTimestamp.Time
+	if creationTime.IsZero() {
+		creationTime = r.clock.Now()
+	}
+	if !job.Object().GetCreationTimestamp().Time.IsZero() {
+		latency := creationTime.Sub(job.Object().GetCreationTimestamp().Time)
+		customLabelValues := r.customLabels.LQGet(utilqueue.KeyFromWorkload(wl))
+		metrics.ReportJobToWorkloadLatency(job.GVK().Kind, latency, customLabelValues, r.RoleTracker())
+	}
+
 	return nil
 }
 

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -61,6 +61,8 @@ import (
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 
 	_ "sigs.k8s.io/kueue/pkg/controller/jobs"
+	"sigs.k8s.io/kueue/pkg/metrics"
+	testingmetrics "sigs.k8s.io/kueue/pkg/util/testing/metrics"
 
 	. "sigs.k8s.io/kueue/pkg/controller/jobframework"
 )
@@ -1234,5 +1236,59 @@ func TestReconcileGenericJobWithWaitForPodsReady(t *testing.T) {
 				t.Errorf("unexpected reconcile error want %s got %s)", tc.wantError, err)
 			}
 		})
+	}
+}
+
+func TestReconcileJobToWorkloadLatencyMetric(t *testing.T) {
+	var (
+		testJobName        = "test-job"
+		testLocalQueueName = kueue.LocalQueueName("test-lq")
+	)
+
+	ctx, _ := utiltesting.ContextWithLog(t)
+	mockctrl := gomock.NewController(t)
+
+	jobCreationTime := time.Now().Add(-10 * time.Second)
+	job := testingjob.MakeJob(testJobName, metav1.NamespaceDefault).
+		UID(testJobName).
+		Queue(testLocalQueueName).
+		Obj()
+	job.CreationTimestamp = metav1.NewTime(jobCreationTime)
+
+	basePodSets := []kueue.PodSet{
+		*utiltestingapi.MakePodSet("main", 1).Obj(),
+	}
+
+	uniqueJobKind := "TestJobKind"
+	testGVKWithUniqueKind := batchv1.SchemeGroupVersion.WithKind(uniqueJobKind)
+
+	mgj := mocks.NewMockGenericJob(mockctrl)
+	mgj.EXPECT().Object().Return(job).AnyTimes()
+	mgj.EXPECT().GVK().Return(testGVKWithUniqueKind).AnyTimes()
+	mgj.EXPECT().IsSuspended().Return(false).AnyTimes()
+	mgj.EXPECT().IsActive().Return(false).AnyTimes()
+	mgj.EXPECT().Finished(gomock.Any()).Return("", false, false).AnyTimes()
+	mgj.EXPECT().PodSets(gomock.Any()).Return(basePodSets, nil).AnyTimes()
+	mgj.EXPECT().Suspend().AnyTimes()
+
+	cl := utiltesting.NewClientBuilder(batchv1.AddToScheme, kueue.AddToScheme).
+		WithObjects(utiltesting.MakeNamespace(metav1.NamespaceDefault)).
+		WithObjects(job).
+		WithIndex(&kueue.Workload{}, indexer.OwnerReferenceIndexKey(testGVKWithUniqueKind), indexer.WorkloadOwnerIndexFunc(testGVKWithUniqueKind)).
+		Build()
+
+	recorder := &utiltesting.EventRecorder{}
+	rec := NewReconciler(cl, recorder)
+
+	_, err := rec.ReconcileGenericJob(ctx, controllerruntime.Request{
+		NamespacedName: types.NamespacedName{Name: testJobName, Namespace: metav1.NamespaceDefault},
+	}, mgj)
+	if err != nil {
+		t.Fatalf("Failed to Reconcile GenericJob: %v", err)
+	}
+
+	all := testingmetrics.CollectFilteredGaugeVec(metrics.JobToWorkloadLatency, map[string]string{"job_kind": uniqueJobKind})
+	if len(all) != 1 {
+		t.Errorf("Expecting 1 metric got %d", len(all))
 	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -187,6 +187,10 @@ var (
 	// +metricsdoc:labels=preempting_cluster_queue="the ClusterQueue executing preemption",reason="eviction or preemption reason",replica_role="one of `leader`, `follower`, or `standalone`"
 	PreemptedWorkloadsTotal *prometheus.CounterVec
 
+	// +metricsdoc:group=job
+	// +metricsdoc:labels=job_kind="the kind of the job",replica_role="one of `leader`, `follower`, or `standalone`"
+	JobToWorkloadLatency *prometheus.HistogramVec
+
 	// Metrics tied to the cache.
 
 	// +metricsdoc:group=clusterqueue
@@ -509,6 +513,15 @@ The label 'underlying_cause' can have the following values:
 		}, append([]string{"name", "namespace", "priority_class", "replica_role"}, extraLabels...),
 	)
 
+	JobToWorkloadLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: constants.KueueName,
+			Name:      "job_to_workload_latency_seconds",
+			Help:      "The time between a job was created until its workload was created, per 'job_kind'",
+			Buckets:   generateExponentialBuckets(14),
+		}, append([]string{"job_kind", "replica_role"}, extraLabels...),
+	)
+
 	EvictedWorkloadsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: constants.KueueName,
@@ -754,6 +767,11 @@ func AdmissionAttempt(result AdmissionResult, duration time.Duration, tracker *r
 	role := roletracker.GetRole(tracker)
 	AdmissionAttemptsTotal.WithLabelValues(string(result), role).Inc()
 	admissionAttemptDuration.WithLabelValues(string(result), role).Observe(duration.Seconds())
+}
+
+func ReportJobToWorkloadLatency(jobKind string, latency time.Duration, customLabelValues []string, tracker *roletracker.RoleTracker) {
+	labels := append([]string{jobKind, roletracker.GetRole(tracker)}, customLabelValues...)
+	JobToWorkloadLatency.WithLabelValues(labels...).Observe(latency.Seconds())
 }
 
 func QuotaReservedWorkload(cqName kueue.ClusterQueueReference, priorityClass string, waitTime time.Duration, customLabelValues []string, tracker *roletracker.RoleTracker) {
@@ -1153,6 +1171,7 @@ func Register() {
 		EvictedWorkloadsTotal,
 		EvictedWorkloadsOnceTotal,
 		PreemptedWorkloadsTotal,
+		JobToWorkloadLatency,
 		ReservingActiveWorkloads,
 		AdmittedActiveWorkloads,
 		ClusterQueueByStatus,

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/prometheus/client_golang/prometheus"
@@ -193,6 +194,11 @@ func TestGitVersionMetric(t *testing.T) {
 	expectFilteredMetricsCount(t, buildInfo, 1, "go_version", versionInfo.GoVersion)
 	expectFilteredMetricsCount(t, buildInfo, 1, "compiler", versionInfo.Compiler)
 	expectFilteredMetricsCount(t, buildInfo, 1, "platform", versionInfo.Platform)
+}
+
+func TestReportJobToWorkloadLatency(t *testing.T) {
+	ReportJobToWorkloadLatency("Job", 5*time.Second, nil, nil)
+	expectFilteredMetricsCount(t, JobToWorkloadLatency, 1, "job_kind", "Job")
 }
 
 func TestReportLocalQueueAdmissionChecksWaitTimeHasPriorityLabel(t *testing.T) {

--- a/pkg/util/testing/metrics/metrics.go
+++ b/pkg/util/testing/metrics/metrics.go
@@ -85,6 +85,9 @@ func CollectFilteredGaugeVec(v prometheus.Collector, labels map[string]string) [
 				if dtoMetric.Counter != nil {
 					dp.Value = *dtoMetric.Counter.Value
 				}
+				if dtoMetric.Histogram != nil {
+					dp.Value = *dtoMetric.Histogram.SampleSum
+				}
 				ret = append(ret, dp)
 			}
 		}

--- a/site/content/en/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand.md
+++ b/site/content/en/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand.md
@@ -76,7 +76,7 @@ If you disable the feature, you also need to remove the associated `APIService` 
 
 If you need the embedded visibility server to run on a different port, you can use the Configuration API `visibilityServer.bindPort`.
 
-Alternatively, you can use the `--visibility-server-port` flag when running the Kueue controller manager. For example: `--visibility-server-port=8443`. Keep in mind, this option will be deprecated soon.
+Alternatively, you can use the `--visibility-server-port` flag when running the Kueue controller manager. For example: `--visibility-server-port=8443`. However, this option is deprecated as of 0.17 and will be removed in the future.
 
 {{% /alert %}}
 

--- a/site/content/en/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand.md
+++ b/site/content/en/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand.md
@@ -76,7 +76,7 @@ If you disable the feature, you also need to remove the associated `APIService` 
 
 If you need the embedded visibility server to run on a different port, you can use the Configuration API `visibilityServer.bindPort`.
 
-Alternatively, you can use the `--visibility-server-port` flag when running the Kueue controller manager. For example: `--visibility-server-port=8443`. However, this option is deprecated as of 0.17 and will be removed in the future.
+(Deprecated as of 0.17, to be removed in the future) Alternatively, you can use the `--visibility-server-port` flag when running the Kueue controller manager. For example: `--visibility-server-port=8443`.
 
 {{% /alert %}}
 

--- a/site/content/zh-CN/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand.md
+++ b/site/content/zh-CN/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand.md
@@ -76,7 +76,7 @@ If you disable the feature, you also need to remove the associated `APIService` 
 
 If you need the embedded visibility server to run on a different port, you can use the Configuration API `visibilityServer.bindPort`.
 
-Alternatively, you can use the `--visibility-server-port` flag when running the Kueue controller manager. For example: `--visibility-server-port=8443`. Keep in mind, this option will be deprecated soon.
+Alternatively, you can use the `--visibility-server-port` flag when running the Kueue controller manager. For example: `--visibility-server-port=8443`. However, this option is deprecated as of 0.17 and will be removed in the future.
 
 {{% /alert %}}
 

--- a/site/content/zh-CN/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand.md
+++ b/site/content/zh-CN/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand.md
@@ -76,7 +76,7 @@ If you disable the feature, you also need to remove the associated `APIService` 
 
 If you need the embedded visibility server to run on a different port, you can use the Configuration API `visibilityServer.bindPort`.
 
-Alternatively, you can use the `--visibility-server-port` flag when running the Kueue controller manager. For example: `--visibility-server-port=8443`. However, this option is deprecated as of 0.17 and will be removed in the future.
+(Deprecated as of 0.17, to be removed in the future) Alternatively, you can use the `--visibility-server-port` flag when running the Kueue controller manager. For example: `--visibility-server-port=8443`.
 
 {{% /alert %}}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces a new Prometheus histogram metric, job_to_workload_latency_seconds, to track the latency between when a job-like resource (e.g., Batch Job, JobSet, etc.) is created and when Kueue creates its corresponding Workload.

This metric is needed to help operators monitor the responsiveness of Kueue in acknowledging new jobs and to detect potential bottlenecks or delays in the reconciliation queue.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

- The metric is implemented as a Histogram to allow calculating percentiles (p50, p95, p99).
- It uses `job_kind and replica_role` as default labels, and also supports any user-configured extraLabels.
- Unit tests were added in `pkg/metrics/metrics_test.go` and`pkg/controller/jobframework/reconciler_test.go` to verify the metric recording.

#### Does this PR introduce a user-facing change?

```release-note
Added a new Prometheus metric `job_to_workload_latency_seconds` to track the time elapsed between a Job's creation and the creation of its corresponding Workload by Kueue.
```