### PR TITLE
fix: optimize NewLogConstructor logging

### DIFF
--- a/pkg/util/roletracker/logger.go
+++ b/pkg/util/roletracker/logger.go
@@ -38,8 +38,10 @@ func withRequestContext(log logr.Logger, namespace, name string) logr.Logger {
 
 // NewLogConstructor creates a controller LogConstructor with replica-role and request context.
 func NewLogConstructor(tracker *RoleTracker, baseName string) func(*reconcile.Request) logr.Logger {
+	namedLog := ctrl.Log.WithName(baseName)
+
 	return func(req *reconcile.Request) logr.Logger {
-		log := ctrl.Log.WithName(baseName).WithValues("replica-role", GetRole(tracker))
+		log := WithReplicaRole(namedLog, tracker)
 		if req == nil {
 			return log
 		}

--- a/pkg/util/roletracker/logger_test.go
+++ b/pkg/util/roletracker/logger_test.go
@@ -17,10 +17,15 @@ limitations under the License.
 package roletracker
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func TestWithReplicaRole(t *testing.T) {
@@ -53,58 +58,165 @@ func TestWithReplicaRole(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			baseLogger := funcr.New(func(prefix, args string) {
-			}, funcr.Options{})
+			capture, baseLogger := newJSONLoggerCapture()
 
 			logger := WithReplicaRole(baseLogger, tc.tracker)
+			logger.Info("test")
 
-			if logger == (logr.Logger{}) {
-				t.Error("WithReplicaRole returned zero-value logger")
-			}
-
-			role := GetRole(tc.tracker)
-			if role != tc.expected {
-				t.Errorf("Expected role %q, got %q", tc.expected, role)
+			entry := capture.requireSingleEntry(t)
+			if got := entry["replica-role"]; got != tc.expected {
+				t.Errorf("Expected replica-role %q, got %v", tc.expected, got)
 			}
 		})
 	}
 }
 
 func TestNewLogConstructor(t *testing.T) {
+	type logCall struct {
+		request  *reconcile.Request
+		nextRole string
+	}
+
 	tests := []struct {
-		name     string
-		tracker  *RoleTracker
-		expected string
+		name        string
+		tracker     *RoleTracker
+		calls       []logCall
+		wantEntries []map[string]any
 	}{
 		{
-			name:     "nil tracker",
-			tracker:  nil,
-			expected: RoleStandalone,
+			name:    "nil tracker emits standalone role",
+			tracker: nil,
+			calls: []logCall{
+				{},
+			},
+			wantEntries: []map[string]any{
+				{"replica-role": RoleStandalone},
+			},
 		},
 		{
-			name:     "leader tracker",
-			tracker:  NewFakeRoleTracker(RoleLeader),
-			expected: RoleLeader,
+			name:    "follower tracker emits follower role",
+			tracker: NewFakeRoleTracker(RoleFollower),
+			calls: []logCall{
+				{},
+			},
+			wantEntries: []map[string]any{
+				{"replica-role": RoleFollower},
+			},
 		},
 		{
-			name:     "follower tracker",
-			tracker:  NewFakeRoleTracker(RoleFollower),
-			expected: RoleFollower,
+			name:    "role changes are reflected across calls",
+			tracker: NewFakeRoleTracker(RoleFollower),
+			calls: []logCall{
+				{nextRole: RoleLeader},
+				{},
+			},
+			wantEntries: []map[string]any{
+				{"replica-role": RoleFollower},
+				{"replica-role": RoleLeader},
+			},
+		},
+		{
+			name:    "request context adds namespace and name for namespaced requests",
+			tracker: nil,
+			calls: []logCall{
+				{
+					request: &reconcile.Request{
+						NamespacedName: types.NamespacedName{Namespace: "test-ns", Name: "test-name"},
+					},
+				},
+			},
+			wantEntries: []map[string]any{
+				{"replica-role": RoleStandalone, "namespace": "test-ns", "name": "test-name"},
+			},
+		},
+		{
+			name:    "request context adds only name for cluster-scoped requests",
+			tracker: nil,
+			calls: []logCall{
+				{
+					request: &reconcile.Request{
+						NamespacedName: types.NamespacedName{Name: "cluster-name"},
+					},
+				},
+			},
+			wantEntries: []map[string]any{
+				{"replica-role": RoleStandalone, "name": "cluster-name"},
+			},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			constructor := NewLogConstructor(tc.tracker, "test-controller")
+			capture, logger := newJSONLoggerCapture()
+			previousLogger := ctrl.Log
+			ctrl.Log = logger
+			t.Cleanup(func() {
+				ctrl.Log = previousLogger
+			})
 
-			if constructor == nil {
-				t.Fatal("NewLogConstructor returned nil")
+			constructor := NewLogConstructor(tc.tracker, "test-controller")
+			for _, call := range tc.calls {
+				constructor(call.request).Info("test")
+				if call.nextRole != "" && tc.tracker != nil {
+					tc.tracker.role.Store(call.nextRole)
+				}
 			}
 
-			logger := constructor(nil)
-			if logger == (logr.Logger{}) {
-				t.Error("LogConstructor returned zero-value logger")
+			gotEntries := selectedLogEntries(capture.requireEntries(t, len(tc.wantEntries)))
+			if diff := cmp.Diff(tc.wantEntries, gotEntries); diff != "" {
+				t.Errorf("Unexpected log entries (-want,+got):\n%s", diff)
 			}
 		})
 	}
+}
+
+type jsonLogCapture struct {
+	entries  []map[string]any
+	parseErr error
+}
+
+func newJSONLoggerCapture() (*jsonLogCapture, logr.Logger) {
+	capture := &jsonLogCapture{}
+	logger := funcr.NewJSON(func(obj string) {
+		entry := make(map[string]any)
+		if err := json.Unmarshal([]byte(obj), &entry); err != nil {
+			capture.parseErr = err
+			return
+		}
+		capture.entries = append(capture.entries, entry)
+	}, funcr.Options{})
+	return capture, logger
+}
+
+func (c *jsonLogCapture) requireSingleEntry(t *testing.T) map[string]any {
+	t.Helper()
+	return c.requireEntries(t, 1)[0]
+}
+
+func (c *jsonLogCapture) requireEntries(t *testing.T, want int) []map[string]any {
+	t.Helper()
+	if c.parseErr != nil {
+		t.Fatalf("Failed to parse log entry: %v", c.parseErr)
+	}
+	if len(c.entries) != want {
+		t.Fatalf("Expected %d log entries, got %d", want, len(c.entries))
+	}
+	return c.entries
+}
+
+func selectedLogEntries(entries []map[string]any) []map[string]any {
+	selected := make([]map[string]any, 0, len(entries))
+	for _, entry := range entries {
+		selectedEntry := map[string]any{
+			"replica-role": entry["replica-role"],
+		}
+		if namespace, found := entry["namespace"]; found {
+			selectedEntry["namespace"] = namespace
+		}
+		if name, found := entry["name"]; found {
+			selectedEntry["name"] = name
+		}
+		selected = append(selected, selectedEntry)
+	}
+	return selected
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Improves roletracker.NewLogConstructor by creating the named controller logger once and reusing it for later reconcile calls.

It's still safe because replica-role is still updated on each call, namespace and name are still added for each reconcile request.

This is the first part of the work discussed in #10269 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially addresses #10269

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Observability: Fix excessive memory overhead in hot code paths by reusing the named logger in NewLogConstructor and avoiding unnecessary logger cloning.
```