### PR TITLE
TAS: incremental per-node usage aggregation in nonTasUsageCache

### DIFF
--- a/pkg/cache/scheduler/tas_cache.go
+++ b/pkg/cache/scheduler/tas_cache.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/resources"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 )
 
@@ -48,8 +49,9 @@ func NewTASCache(client client.Client) tasCache {
 		topologies:  make(map[kueue.TopologyReference]topologyInformation),
 		flavorCache: make(map[kueue.ResourceFlavorReference]*TASFlavorCache),
 		nonTasUsageCache: &nonTasUsageCache{
-			podUsage: make(map[types.NamespacedName]podUsageValue),
-			lock:     sync.RWMutex{},
+			podUsage:  make(map[types.NamespacedName]podUsageValue),
+			nodeUsage: make(map[string]resources.Requests),
+			lock:      sync.RWMutex{},
 		},
 		nodesCache: newNodesCache(),
 	}
@@ -126,8 +128,8 @@ func (t *tasCache) Update(pod *corev1.Pod, log logr.Logger) {
 	t.nonTasUsageCache.update(pod, log)
 }
 
-func (t *tasCache) DeletePodByKey(key client.ObjectKey) {
-	t.nonTasUsageCache.delete(key)
+func (t *tasCache) DeletePodByKey(key client.ObjectKey, log logr.Logger) {
+	t.nonTasUsageCache.delete(key, log)
 }
 
 func (t *tasCache) SyncNode(node *corev1.Node) {

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache.go
@@ -31,8 +31,9 @@ import (
 // nonTasUsageCache caches pod usage, to avoid
 // the hot path documented in kueue#8449.
 type nonTasUsageCache struct {
-	podUsage map[types.NamespacedName]podUsageValue
-	lock     sync.RWMutex
+	podUsage  map[types.NamespacedName]podUsageValue
+	nodeUsage map[string]resources.Requests // pre-aggregated per-node totals
+	lock      sync.RWMutex
 }
 
 type podUsageValue struct {
@@ -46,37 +47,74 @@ func (n *nonTasUsageCache) update(pod *corev1.Pod, log logr.Logger) {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 
+	key := client.ObjectKeyFromObject(pod)
+
 	// delete terminated pods as they no longer use any capacity.
 	if utilpod.IsTerminated(pod) {
 		log.V(5).Info("Deleting terminated pod from the cache")
-		delete(n.podUsage, client.ObjectKeyFromObject(pod))
+		if old, found := n.podUsage[key]; found {
+			n.removeNodeUsage(old.node, old.usage, log)
+		}
+		delete(n.podUsage, key)
 		return
+	}
+
+	// Remove old entry if pod already exists (handles node migration, resource resize).
+	if old, found := n.podUsage[key]; found {
+		n.removeNodeUsage(old.node, old.usage, log)
 	}
 
 	log.V(5).Info("Adding non-TAS pod to the cache")
 	requests := resources.NewRequestsFromPodSpec(&pod.Spec)
-	n.podUsage[client.ObjectKeyFromObject(pod)] = podUsageValue{
+	n.podUsage[key] = podUsageValue{
 		node:  pod.Spec.NodeName,
 		usage: requests,
 	}
+	n.addNodeUsage(pod.Spec.NodeName, requests)
 }
 
-func (n *nonTasUsageCache) delete(key client.ObjectKey) {
+func (n *nonTasUsageCache) delete(key client.ObjectKey, log logr.Logger) {
 	n.lock.Lock()
 	defer n.lock.Unlock()
+	if old, found := n.podUsage[key]; found {
+		n.removeNodeUsage(old.node, old.usage, log)
+	}
 	delete(n.podUsage, key)
 }
 
 func (n *nonTasUsageCache) usagePerNode() map[string]resources.Requests {
 	n.lock.RLock()
 	defer n.lock.RUnlock()
-	usage := make(map[string]resources.Requests)
-	for _, podUsage := range n.podUsage {
-		if _, found := usage[podUsage.node]; !found {
-			usage[podUsage.node] = resources.Requests{}
-		}
-		usage[podUsage.node].Add(podUsage.usage)
-		usage[podUsage.node].Add(resources.Requests{corev1.ResourcePods: 1})
+	usage := make(map[string]resources.Requests, len(n.nodeUsage))
+	for node, reqs := range n.nodeUsage {
+		usage[node] = reqs.Clone()
 	}
 	return usage
+}
+
+// addNodeUsage increments the pre-aggregated per-node usage.
+// Must be called under write lock.
+func (n *nonTasUsageCache) addNodeUsage(node string, usage resources.Requests) {
+	if _, found := n.nodeUsage[node]; !found {
+		n.nodeUsage[node] = resources.Requests{}
+	}
+	n.nodeUsage[node].Add(usage)
+	n.nodeUsage[node][corev1.ResourcePods]++
+}
+
+// removeNodeUsage decrements the pre-aggregated per-node usage.
+// Must be called under write lock.
+func (n *nonTasUsageCache) removeNodeUsage(node string, usage resources.Requests, log logr.Logger) {
+	existing, found := n.nodeUsage[node]
+	if !found {
+		return
+	}
+	existing.Sub(usage)
+	existing[corev1.ResourcePods]--
+	if pods := existing[corev1.ResourcePods]; pods <= 0 {
+		if pods < 0 {
+			log.V(0).Info("Unexpected negative pod count in nodeUsage", "node", node, "podCount", pods)
+		}
+		delete(n.nodeUsage, node)
+	}
 }

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/kueue/pkg/resources"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+)
+
+// verifyNodeUsageConsistency recomputes usage from podUsage (old O(pods) algorithm)
+// and verifies it matches the incremental nodeUsage.
+func verifyNodeUsageConsistency(t *testing.T, cache *nonTasUsageCache) {
+	t.Helper()
+	expected := make(map[string]resources.Requests)
+	for _, pv := range cache.podUsage {
+		if _, found := expected[pv.node]; !found {
+			expected[pv.node] = resources.Requests{}
+		}
+		expected[pv.node].Add(pv.usage)
+		expected[pv.node][corev1.ResourcePods]++
+	}
+	got := cache.usagePerNode()
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Errorf("nodeUsage inconsistent with podUsage (-recomputed +nodeUsage):\n%s", diff)
+	}
+}
+
+func makePod(name, namespace, node string, cpu string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: corev1.PodSpec{
+			NodeName: node,
+			Containers: []corev1.Container{{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse(cpu),
+					},
+				},
+			}},
+		},
+	}
+}
+
+func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
+	testCases := map[string]struct {
+		initialPods []*corev1.Pod
+		// podsUpdate, when set, mutates the initialPods in place after they
+		// are first applied to the cache. Each mutated pod is then re-applied
+		// via cache.update — exercising in-place transitions like a pod
+		// moving between nodes or transitioning to PodSucceeded.
+		podsUpdate func(pods []*corev1.Pod)
+		// podsDelete is the set of pod keys to delete from the cache after
+		// initialPods are applied (and after podsUpdate, if any).
+		podsDelete    []client.ObjectKey
+		wantNodeUsage map[string]resources.Requests
+	}{
+		"add then delete same pod": {
+			initialPods: []*corev1.Pod{makePod("pod1", "ns", "node-a", "2")},
+			podsDelete:  []client.ObjectKey{{Namespace: "ns", Name: "pod1"}},
+		},
+		"multiple pods on same node": {
+			initialPods: []*corev1.Pod{
+				makePod("pod1", "ns", "node-a", "1"),
+				makePod("pod2", "ns", "node-a", "2"),
+			},
+			wantNodeUsage: map[string]resources.Requests{
+				"node-a": {corev1.ResourceCPU: 3000, corev1.ResourcePods: 2},
+			},
+		},
+		"pod moves between nodes cleans up source node": {
+			initialPods: []*corev1.Pod{makePod("pod1", "ns", "node-a", "4")},
+			podsUpdate: func(pods []*corev1.Pod) {
+				pods[0].Spec.NodeName = "node-b"
+			},
+			wantNodeUsage: map[string]resources.Requests{
+				"node-b": {corev1.ResourceCPU: 4000, corev1.ResourcePods: 1},
+			},
+		},
+		"pod resize on same node updates usage to new requests": {
+			initialPods: []*corev1.Pod{makePod("pod1", "ns", "node-a", "1")},
+			podsUpdate: func(pods []*corev1.Pod) {
+				pods[0].Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("4")
+			},
+			wantNodeUsage: map[string]resources.Requests{
+				"node-a": {corev1.ResourceCPU: 4000, corev1.ResourcePods: 1},
+			},
+		},
+		"resize one of two pods on same node updates only that pod's contribution": {
+			initialPods: []*corev1.Pod{
+				makePod("pod1", "ns", "node-a", "1"),
+				makePod("pod2", "ns", "node-a", "2"),
+			},
+			podsUpdate: func(pods []*corev1.Pod) {
+				pods[0].Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("3")
+			},
+			wantNodeUsage: map[string]resources.Requests{
+				"node-a": {corev1.ResourceCPU: 5000, corev1.ResourcePods: 2},
+			},
+		},
+		"terminated pod removes usage": {
+			initialPods: []*corev1.Pod{makePod("pod1", "ns", "node-a", "2")},
+			podsUpdate: func(pods []*corev1.Pod) {
+				pods[0].Status.Phase = corev1.PodSucceeded
+			},
+		},
+		"delete non-existent key is no-op": {
+			podsDelete: []client.ObjectKey{{Namespace: "ns", Name: "ghost"}},
+		},
+		"removing one of two pods leaves node entry": {
+			initialPods: []*corev1.Pod{
+				makePod("pod1", "ns", "node-a", "1"),
+				makePod("pod2", "ns", "node-a", "1"),
+			},
+			podsDelete: []client.ObjectKey{{Namespace: "ns", Name: "pod1"}},
+			wantNodeUsage: map[string]resources.Requests{
+				"node-a": {corev1.ResourceCPU: 1000, corev1.ResourcePods: 1},
+			},
+		},
+		"removing last pod cleans up node entry": {
+			initialPods: []*corev1.Pod{
+				makePod("pod1", "ns", "node-a", "1"),
+				makePod("pod2", "ns", "node-a", "1"),
+			},
+			podsDelete: []client.ObjectKey{
+				{Namespace: "ns", Name: "pod1"},
+				{Namespace: "ns", Name: "pod2"},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
+			cache := &nonTasUsageCache{
+				podUsage:  make(map[types.NamespacedName]podUsageValue),
+				nodeUsage: make(map[string]resources.Requests),
+			}
+
+			for _, pod := range tc.initialPods {
+				cache.update(pod, log)
+			}
+			if tc.podsUpdate != nil {
+				tc.podsUpdate(tc.initialPods)
+				for _, pod := range tc.initialPods {
+					cache.update(pod, log)
+				}
+			}
+			for _, key := range tc.podsDelete {
+				cache.delete(key, log)
+			}
+
+			verifyNodeUsageConsistency(t, cache)
+
+			wantUsage := tc.wantNodeUsage
+			if wantUsage == nil {
+				wantUsage = map[string]resources.Requests{}
+			}
+			if diff := cmp.Diff(wantUsage, cache.usagePerNode()); diff != "" {
+				t.Errorf("usagePerNode() mismatch (-want +got):\n%s", diff)
+			}
+
+			// Explicitly verify the internal nodeUsage map has no leftover
+			// entries — a missing delete() in removeNodeUsage would leave
+			// zeroed Requests behind and leak memory as nodes turn over.
+			if len(cache.nodeUsage) != len(wantUsage) {
+				t.Errorf("len(cache.nodeUsage)=%d, want %d (zeroed entries must be removed to avoid memory leak)",
+					len(cache.nodeUsage), len(wantUsage))
+			}
+			for node := range wantUsage {
+				if _, found := cache.nodeUsage[node]; !found {
+					t.Errorf("cache.nodeUsage missing expected entry for node %q", node)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/tas/non_tas_usage_controller.go
+++ b/pkg/controller/tas/non_tas_usage_controller.go
@@ -67,14 +67,14 @@ func (r *NonTasUsageReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{}, err
 		}
 		log.V(5).Info("Idempotently deleting not found pod")
-		r.cache.TASCache().DeletePodByKey(req.NamespacedName)
+		r.cache.TASCache().DeletePodByKey(req.NamespacedName, log)
 		return ctrl.Result{}, nil
 	}
 
 	if belongsToNonTASCache(&pod) {
 		r.cache.TASCache().Update(&pod, log)
 	} else {
-		r.cache.TASCache().DeletePodByKey(req.NamespacedName)
+		r.cache.TASCache().DeletePodByKey(req.NamespacedName, log)
 	}
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
/kind feature


Please also consider setting the area:
/area tas

#### What this PR does / why we need it:
Replace the full scan in usagePerNode() with an incrementally maintained nodeUsage map. update() and delete() now maintain pre-aggregated per-node totals, reducing usagePerNode() to O(nodes) making the TAS snapshot cheaper for clusters with large number of non TAS pods per node

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
```release-note
TAS: optimize performance of building the snapshot by pre-aggregating the node usage coming from non-TAS Pods.
```