### PR TITLE
Make MultiKueue Orchestrated Preemption test timeouts longer

### DIFF
--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -2510,7 +2510,7 @@ app = HelloWorld.bind()`,
 					// Evicted workload is requeued and pending on worker 2
 					g.Expect(k8sWorker2Client.Get(ctx, evictedWlKey, evictedWl)).To(gomega.Succeed())
 					g.Expect(evictedWl.Status.Conditions).To(utiltesting.HaveConditionStatusFalse(kueue.WorkloadQuotaReserved))
-				}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
 	})

--- a/test/integration/multikueue/scheduler/scheduler_test.go
+++ b/test/integration/multikueue/scheduler/scheduler_test.go
@@ -678,7 +678,7 @@ var _ = ginkgo.Describe("MultiKueue with scheduler", ginkgo.Label("area:multikue
 					// Evicted workload is requeued and pending on worker 2
 					g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, evictedWlKey, evictedWl)).To(gomega.Succeed())
 					g.Expect(evictedWl.Status.Conditions).To(testing.HaveConditionStatusFalse(kueue.WorkloadQuotaReserved))
-				}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
 	})


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind flake
/area multikueue
/area testing

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
The `ConsistentDuration` was likely used by mistake, since that block was previously a `Consistently` block (visible in the diff of https://github.com/kubernetes-sigs/kueue/pull/9670).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```