### PR TITLE
Add feature gate for invalid ClusterQueue onFlavors updates

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -352,6 +352,13 @@ const (
 	// Pod integration's IsActive() check, allowing quota to be released immediately
 	// when preempted pods begin terminating rather than waiting for the grace period.
 	FastQuotaReleaseInPodIntegration featuregate.Feature = "FastQuotaReleaseInPodIntegration"
+
+	// owner: @ShaanveerS
+	//
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/7259
+	// Enables rejecting updates to ClusterQueues with invalid
+	// AdmissionCheckStrategy.OnFlavors references.
+	RejectUpdatesToCQWithInvalidOnFlavors featuregate.Feature = "RejectUpdatesToCQWithInvalidOnFlavors"
 )
 
 func init() {
@@ -542,6 +549,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	FastQuotaReleaseInPodIntegration: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	RejectUpdatesToCQWithInvalidOnFlavors: {
+		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }
 

--- a/pkg/webhooks/clusterqueue_webhook.go
+++ b/pkg/webhooks/clusterqueue_webhook.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 )
@@ -133,12 +134,15 @@ func validateAdmissionCheckOnFlavors(cq *kueue.ClusterQueue) field.ErrorList {
 
 func validateAdmissionCheckOnFlavorsUpdate(oldCQ, newCQ *kueue.ClusterQueue) field.ErrorList {
 	oldOnFlavorsByName := map[kueue.AdmissionCheckReference]sets.Set[kueue.ResourceFlavorReference]{}
-	newFlavors := utilqueue.AllFlavors(newCQ.Spec.ResourceGroups)
-	if oldStrategy := oldCQ.Spec.AdmissionChecksStrategy; oldStrategy != nil &&
-		utilqueue.AllFlavors(oldCQ.Spec.ResourceGroups).Equal(newFlavors) {
-		oldOnFlavorsByName = make(map[kueue.AdmissionCheckReference]sets.Set[kueue.ResourceFlavorReference], len(oldStrategy.AdmissionChecks))
-		for _, check := range oldStrategy.AdmissionChecks {
-			oldOnFlavorsByName[check.Name] = sets.New(check.OnFlavors...)
+
+	if !features.Enabled(features.RejectUpdatesToCQWithInvalidOnFlavors) {
+		newFlavors := utilqueue.AllFlavors(newCQ.Spec.ResourceGroups)
+		if oldStrategy := oldCQ.Spec.AdmissionChecksStrategy; oldStrategy != nil &&
+			utilqueue.AllFlavors(oldCQ.Spec.ResourceGroups).Equal(newFlavors) {
+			oldOnFlavorsByName = make(map[kueue.AdmissionCheckReference]sets.Set[kueue.ResourceFlavorReference], len(oldStrategy.AdmissionChecks))
+			for _, check := range oldStrategy.AdmissionChecks {
+				oldOnFlavorsByName[check.Name] = sets.New(check.OnFlavors...)
+			}
 		}
 	}
 
@@ -156,7 +160,9 @@ func validateAdmissionCheckOnFlavorsWithOld(cq *kueue.ClusterQueue, oldOnFlavors
 
 	var allErrs field.ErrorList
 	for i, check := range strategy.AdmissionChecks {
-		// allow unrelated updates for pre-existing ClusterQueues with invalid onFlavors
+		// When the RejectUpdatesToCQWithInvalidOnFlavors feature gate is
+		// disabled, allow unrelated updates for legacy ClusterQueues that were
+		// already persisted with invalid onFlavors.
 		if oldOnFlavors, found := oldOnFlavorsByName[check.Name]; found && oldOnFlavors.Equal(sets.New(check.OnFlavors...)) {
 			continue
 		}

--- a/pkg/webhooks/clusterqueue_webhook_test.go
+++ b/pkg/webhooks/clusterqueue_webhook_test.go
@@ -26,9 +26,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 )
 
@@ -413,6 +415,7 @@ func TestValidateClusterQueueUpdate(t *testing.T) {
 		name            string
 		oldClusterQueue *kueue.ClusterQueue
 		newClusterQueue *kueue.ClusterQueue
+		featureGates    map[featuregate.Feature]bool
 		wantErr         field.ErrorList
 	}{
 		{
@@ -428,7 +431,7 @@ func TestValidateClusterQueueUpdate(t *testing.T) {
 			wantErr:         nil,
 		},
 		{
-			name: "legacy cluster queue with invalid onFlavors allows unrelated updates",
+			name: "legacy cluster queue with invalid onFlavors allows unrelated updates when the feature gate is disabled",
 			oldClusterQueue: utiltestingapi.MakeClusterQueue("cluster-queue").
 				QueueingStrategy("StrictFIFO").
 				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("alpha").Resource("cpu", "1").Obj()).
@@ -439,7 +442,29 @@ func TestValidateClusterQueueUpdate(t *testing.T) {
 				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("alpha").Resource("cpu", "1").Obj()).
 				AdmissionCheckStrategy(*utiltestingapi.MakeAdmissionCheckStrategyRule("ac1", "ghost").Obj()).
 				Obj(),
+			featureGates: map[featuregate.Feature]bool{
+				features.RejectUpdatesToCQWithInvalidOnFlavors: false,
+			},
 			wantErr: nil,
+		},
+		{
+			name: "legacy cluster queue with invalid onFlavors rejects unrelated updates when the feature gate is enabled",
+			oldClusterQueue: utiltestingapi.MakeClusterQueue("cluster-queue").
+				QueueingStrategy("StrictFIFO").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("alpha").Resource("cpu", "1").Obj()).
+				AdmissionCheckStrategy(*utiltestingapi.MakeAdmissionCheckStrategyRule("ac1", "ghost").Obj()).
+				Obj(),
+			newClusterQueue: utiltestingapi.MakeClusterQueue("cluster-queue").
+				QueueingStrategy("BestEffortFIFO").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("alpha").Resource("cpu", "1").Obj()).
+				AdmissionCheckStrategy(*utiltestingapi.MakeAdmissionCheckStrategyRule("ac1", "ghost").Obj()).
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{
+				features.RejectUpdatesToCQWithInvalidOnFlavors: true,
+			},
+			wantErr: field.ErrorList{
+				field.NotSupported(admissionCheckFlavorPath, kueue.ResourceFlavorReference("ghost"), []string{"alpha"}),
+			},
 		},
 		{
 			name: "valid admissionCheckStrategy can be added when the old cluster queue has no strategy",
@@ -511,6 +536,9 @@ func TestValidateClusterQueueUpdate(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.featureGates != nil {
+				features.SetFeatureGatesDuringTest(t, tc.featureGates)
+			}
 			gotErr := ValidateClusterQueueUpdate(tc.oldClusterQueue, tc.newClusterQueue)
 			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.IgnoreFields(field.Error{}, "Detail", "BadValue")); diff != "" {
 				t.Errorf("ValidateResources() mismatch (-want +got):\n%s", diff)

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -261,6 +261,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.15"
+- name: RejectUpdatesToCQWithInvalidOnFlavors
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.18"
 - name: RemoveFinalizersWithStrictPatch
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -261,6 +261,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.15"
+- name: RejectUpdatesToCQWithInvalidOnFlavors
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.18"
 - name: RemoveFinalizersWithStrictPatch
   versionedSpecs:
   - default: true


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
#### What this PR does / why we need it:
Introduce the `RejectUpdatesToCQWithInvalidOnFlavors` feature gate.
When the feature gate is disabled, updates to legacy ClusterQueues that already contain invalid `AdmissionCheckStrategy.OnFlavors` references are still allowed as long as those entries are unchanged.
When enabled, updates to such ClusterQueues are rejected until the invalid flavor references are fixed.

#### Which issue(s) this PR fixes:
Follow up to https://github.com/kubernetes-sigs/kueue/pull/10336

#### Does this PR introduce a user-facing change?
```release-note
AdmissionChecks: Add the alpha `RejectUpdatesToCQWithInvalidOnFlavors` feature gate (disabled by default) to reject updates to existing ClusterQueues with invalid `AdmissionCheckStrategy.OnFlavors` references. 
action required: when enabling this feature gate, fix any existing invalid `OnFlavors` references before updating the affected ClusterQueues.
```