### PR TITLE
Pin GH Actions to SHA hashes for supply-chain protection

### DIFF
--- a/.github/workflows/krew-release.yml
+++ b/.github/workflows/krew-release.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Update new version in krew-index
-        uses: rajatjindal/krew-release-bot@v0.0.51
+        uses: rajatjindal/krew-release-bot@c970b8a8f6dbc2f2285a26e3ae160903b87002c3 # v0.0.51

--- a/.github/workflows/openvex.yaml
+++ b/.github/workflows/openvex.yaml
@@ -19,7 +19,7 @@ jobs:
           TAG=${{ github.event.inputs.tag }}
           echo "TAG=$TAG" >> "$GITHUB_ENV"
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: openvex/generate-vex@c59881b41451d7ccba5c3b74cd195382b8971fcd
         name: Run vexctl
         with:

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -15,13 +15,13 @@ jobs:
     name: Install bom and generate SBOM
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set tag name
         shell: bash
         run: |
           TAG=${{ github.event.inputs.tag }}
           echo "TAG=$TAG" >> "$GITHUB_ENV"
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           check-latest: true

--- a/.github/workflows/sync-dependabot.yaml
+++ b/.github/workflows/sync-dependabot.yaml
@@ -15,7 +15,7 @@ jobs:
           contents: write
 
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with: 
                 ref: ${{github.head_ref}}
             - name: Set git user from last commit


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Pins all GitHub Action references to commit SHAs with version comments
to prevent supply-chain attacks via tag manipulation. Tags can be
overwritten by compromised upstream repos, but commit SHAs are immutable.
The version comments (e.g. `# v6.0.2`) allow Dependabot to still
propose automated updates.

#### Which issue(s) this PR fixes:

Fixes #10377

#### Special notes for your reviewer:

All SHAs were verified against their upstream repos via the GitHub API:

- actions/checkout: v6.0.2 tag resolves to de0fac2e4500dabe0009e67214ff5f5447ce83dd
- actions/setup-go: v6.4.0 tag resolves to 4a3601121dd01d1626a1e23e37211e3254c1c06c
- rajatjindal/krew-release-bot: v0.0.51 tag resolves to c970b8a8f6dbc2f2285a26e3ae160903b87002c3
- kubernetes-sigs/release-actions (setup-bom): v0.4.3 annotated tag dereferences to 8753ea6bdadb814d779c6ec34eaca689dbfb492b (pre-existing, unchanged)
- openvex/generate-vex: c59881b41451d7ccba5c3b74cd195382b8971fcd confirmed as latest commit (no version tags exist in this repo)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

---
> **AI Assistance Disclosure**: This pull request was created with the assistance of AI (Claude Code by Anthropic).