### PR TITLE
Automated cherry pick of #10391: Pin GH Actions to SHA hashes for supply-chain protection

### DIFF
--- a/.github/workflows/krew-release.yml
+++ b/.github/workflows/krew-release.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Update new version in krew-index
-        uses: rajatjindal/krew-release-bot@v0.0.47
+        uses: rajatjindal/krew-release-bot@c970b8a8f6dbc2f2285a26e3ae160903b87002c3 # v0.0.51

--- a/.github/workflows/openvex.yaml
+++ b/.github/workflows/openvex.yaml
@@ -19,7 +19,7 @@ jobs:
           TAG=${{ github.event.inputs.tag }}
           echo "TAG=$TAG" >> "$GITHUB_ENV"
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: openvex/generate-vex@c59881b41451d7ccba5c3b74cd195382b8971fcd
         name: Run vexctl
         with:

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -15,13 +15,13 @@ jobs:
     name: Install bom and generate SBOM
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set tag name
         shell: bash
         run: |
           TAG=${{ github.event.inputs.tag }}
           echo "TAG=$TAG" >> "$GITHUB_ENV"
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           check-latest: true

--- a/.github/workflows/sync-dependabot.yaml
+++ b/.github/workflows/sync-dependabot.yaml
@@ -15,7 +15,7 @@ jobs:
           contents: write
 
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with: 
                 ref: ${{github.head_ref}}
             - name: Set git user from last commit


### PR DESCRIPTION
Cherry pick of #10391 on release-0.16.

#10391: Pin GH Actions to SHA hashes for supply-chain protection

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```