### PR TITLE
TAS: Use hierarchical LeastFreeCapacity for unconstrained workloads

### DIFF
--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -1561,8 +1561,9 @@ Without `TASHierarchicalUnconstrained`, the existing behavior is preserved: the 
 level for unconstrained workloads is resolved at the node level, and `LeastFreeCapacity`
 sorting occurs only within that level.
 
-This feature gate is alpha and disabled by default. It is not mutually exclusive with
-`TASProfileMixed` — it augments the unconstrained scheduling path when both are enabled.
+This feature gate is Beta and enabled by default in v0.18. It is planned to graduate to
+GA in v0.21. It is not mutually exclusive with `TASProfileMixed` — it augments the
+unconstrained scheduling path when both are enabled.
 
 ### Two-level Topology Aware scheduling
 In consideration of a [Story 5](#story-5) a two-level scheduling is introduced.

--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -53,6 +53,7 @@
     - [Selecting the algorithm](#selecting-the-algorithm)
       - [Until v0.14](#until-v014)
       - [Since v0.15](#since-v015)
+      - [Hierarchical LeastFreeCapacity for unconstrained workloads](#hierarchical-leastfreecapacity-for-unconstrained-workloads)
   - [Two-level Topology Aware scheduling](#two-level-topology-aware-scheduling)
     - [Example](#example-1)
   - [Multi-level Topology Aware scheduling](#multi-level-topology-aware-scheduling)
@@ -1541,10 +1542,27 @@ Since v0.15, the available feature gates are as follows:
 | TASProfileBestFit (deprecated)                   | BestFit           | BestFit           | BestFit           |
 | TASProfileLeastFreeCapacity (removed in v0.17)   | LeastFreeCapacity | LeastFreeCapacity | LeastFreeCapacity |
 | TASBalancedPlacement                             | BalancedPlacement | BestFit           | LeastFreeCapacity |
+| TASHierarchicalUnconstrained                     | BestFit           | BestFit           | LeastFreeCapacity (hierarchical) |
 
 Based on the user feedback, we decided to make `TASProfileMixed` default starting in v0.15. (The corresponding feature gate is hence obsolete; we formally keep it "deprecated" for backwards compatibility). It differs from the previous default only in the `unconstrained` case - in which Kueue should prioritize minimizing fragmentation which is provided by the `LeastFreeCapacity` algorithm.
 
 For users still preferring the "always BestFit" profile, we introduce the `TASProfileBestFit` feature gate, marking it as deprecated. We will remove it in v0.17 if we see no report indicating a need for that configuration.
+
+##### Hierarchical LeastFreeCapacity for unconstrained workloads
+
+When `TASHierarchicalUnconstrained` is enabled (alongside the default `TASProfileMixed`
+profile), the `LeastFreeCapacity` algorithm for `unconstrained` workloads resolves the
+topology level starting from the **highest level** in the hierarchy (e.g., rack) rather
+than the lowest level (host). This means the algorithm first identifies the busiest
+higher-level domain and then packs pods into the busiest nodes within that domain,
+resulting in hierarchical packing behavior.
+
+Without `TASHierarchicalUnconstrained`, the existing behavior is preserved: the topology
+level for unconstrained workloads is resolved at the node level, and `LeastFreeCapacity`
+sorting occurs only within that level.
+
+This feature gate is alpha and disabled by default. It is not mutually exclusive with
+`TASProfileMixed` — it augments the unconstrained scheduling path when both are enabled.
 
 ### Two-level Topology Aware scheduling
 In consideration of a [Story 5](#story-5) a two-level scheduling is introduced.

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -595,11 +595,68 @@ func TestFindTopologyAssignments(t *testing.T) {
 					Levels: defaultOneLevel,
 					Domains: []tas.TopologyDomainAssignment{
 						{Count: 1, Values: []string{"x1"}},
+						{Count: 1, Values: []string{"x3"}},
+						{Count: 1, Values: []string{"x5"}},
+						{Count: 1, Values: []string{"x2"}},
+						{Count: 2, Values: []string{"x6"}},
+					},
+				},
+			}},
+		},
+		// Topology: scatteredNodes (block → rack → host)
+		//   b1/r1: x3(4cpu), x5(1cpu), x1(1cpu) = 6cpu total
+		//   b2/r1: x6(2cpu), x2(1cpu) = 3cpu total
+		// With TASHierarchicalUnconstrained, LeastFreeCapacity sorts top-down:
+		// block b1 has more used capacity than b2, so b1 is chosen first, packing
+		// 6 pods into b1's nodes (x3:4, x5:1, x1:1) instead of scattering across blocks.
+		"unconstrained; 6 pods fit into hosts packed within rack; TASHierarchicalUnconstrained": {
+			nodes:  scatteredNodes,
+			levels: defaultThreeLevels,
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Unconstrained: ptr.To(true),
+				},
+				requests: resources.Requests{
+					corev1.ResourceCPU: 1000,
+				},
+				count: 6,
+				wantAssignment: &tas.TopologyAssignment{
+					Levels: defaultOneLevel,
+					Domains: []tas.TopologyDomainAssignment{
+						{Count: 1, Values: []string{"x1"}},
 						{Count: 4, Values: []string{"x3"}},
 						{Count: 1, Values: []string{"x5"}},
 					},
 				},
 			}},
+			featureGates: map[featuregate.Feature]bool{features.TASHierarchicalUnconstrained: true},
+		},
+		// Same topology as above but with TASHierarchicalUnconstrained disabled.
+		// Without hierarchical packing, pods are scattered across all nodes sorted
+		// by least free capacity at the node level only (no rack awareness).
+		"unconstrained; 6 pods fit into hosts scattered across blocks; TASHierarchicalUnconstrained disabled": {
+			nodes:  scatteredNodes,
+			levels: defaultThreeLevels,
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Unconstrained: ptr.To(true),
+				},
+				requests: resources.Requests{
+					corev1.ResourceCPU: 1000,
+				},
+				count: 6,
+				wantAssignment: &tas.TopologyAssignment{
+					Levels: defaultOneLevel,
+					Domains: []tas.TopologyDomainAssignment{
+						{Count: 1, Values: []string{"x1"}},
+						{Count: 1, Values: []string{"x3"}},
+						{Count: 1, Values: []string{"x5"}},
+						{Count: 1, Values: []string{"x2"}},
+						{Count: 2, Values: []string{"x6"}},
+					},
+				},
+			}},
+			featureGates: map[featuregate.Feature]bool{features.TASHierarchicalUnconstrained: false},
 		},
 		"unconstrained; a single pod fits into each host; BestFit": {
 			nodes:  defaultNodes,
@@ -618,14 +675,21 @@ func TestFindTopologyAssignments(t *testing.T) {
 						{
 							Count: 1,
 							Values: []string{
-								"x2",
+								"x3",
 							},
 						},
 					},
 				},
 			}},
 		},
-		"unconstrained; a single pod fits into each host; LeastFreeCapacity; TASProfileMixed": {
+		// Topology: defaultNodes (block → rack → host), all 1cpu except x4(2cpu)
+		//   b1/r1: x3(1cpu); b1/r2: x5(1cpu), x1(1cpu), x6(1cpu)
+		//   b2/r1: x2(1cpu); b2/r2: x4(2cpu)
+		// With TASHierarchicalUnconstrained enabled, the algorithm picks the
+		// tightest-fitting block first (b2: 3cpu total vs b1: 4cpu total), then
+		// the tightest host within b2 → x2(1cpu). Without this gate, the
+		// node-level-only sort picks x3 (least free at node level globally).
+		"unconstrained; a single pod fits into each host; LeastFreeCapacity; TASHierarchicalUnconstrained": {
 			nodes:  defaultNodes,
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
@@ -648,7 +712,32 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
-			featureGates: map[featuregate.Feature]bool{features.TASProfileMixed: true},
+			featureGates: map[featuregate.Feature]bool{features.TASHierarchicalUnconstrained: true},
+		},
+		"unconstrained; a single pod fits into each host; LeastFreeCapacity; TASProfileMixed and TASHierarchicalUnconstrained": {
+			nodes:  defaultNodes,
+			levels: defaultThreeLevels,
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Unconstrained: ptr.To(true),
+				},
+				requests: resources.Requests{
+					corev1.ResourceCPU: 1000,
+				},
+				count: 1,
+				wantAssignment: &tas.TopologyAssignment{
+					Levels: defaultOneLevel,
+					Domains: []tas.TopologyDomainAssignment{
+						{
+							Count: 1,
+							Values: []string{
+								"x2",
+							},
+						},
+					},
+				},
+			}},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileMixed: true, features.TASHierarchicalUnconstrained: true},
 		},
 		"block required; 4 pods fit into one host each; BestFit": {
 			nodes:  binaryTreesNodes,

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -602,6 +602,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
+			featureGates: map[featuregate.Feature]bool{features.TASHierarchicalUnconstrained: false},
 		},
 		// Topology: scatteredNodes (block → rack → host)
 		//   b1/r1: x3(4cpu), x5(1cpu), x1(1cpu) = 6cpu total
@@ -681,14 +682,37 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 				},
 			}},
+			featureGates: map[featuregate.Feature]bool{features.TASHierarchicalUnconstrained: false},
 		},
 		// Topology: defaultNodes (block → rack → host), all 1cpu except x4(2cpu)
-		//   b1/r1: x3(1cpu); b1/r2: x5(1cpu), x1(1cpu), x6(1cpu)
-		//   b2/r1: x2(1cpu); b2/r2: x4(2cpu)
-		// With TASHierarchicalUnconstrained enabled, the algorithm picks the
-		// tightest-fitting block first (b2: 3cpu total vs b1: 4cpu total), then
-		// the tightest host within b2 → x2(1cpu). Without this gate, the
-		// node-level-only sort picks x3 (least free at node level globally).
+		"unconstrained; a single pod fits into each host; LeastFreeCapacity; TASProfileMixed": {
+			nodes:  defaultNodes,
+			levels: defaultThreeLevels,
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Unconstrained: new(true),
+				},
+				requests: resources.Requests{
+					corev1.ResourceCPU: 1000,
+				},
+				count: 1,
+				wantAssignment: &tas.TopologyAssignment{
+					Levels: defaultOneLevel,
+					Domains: []tas.TopologyDomainAssignment{
+						{
+							Count: 1,
+							Values: []string{
+								"x3",
+							},
+						},
+					},
+				},
+			}},
+			featureGates: map[featuregate.Feature]bool{features.TASProfileMixed: true, features.TASHierarchicalUnconstrained: false},
+		},
+		// Same topology as above but with TASHierarchicalUnconstrained enabled.
+		// The algorithm picks the tightest-fitting block first (b2: 3cpu total
+		// vs b1: 4cpu total), then the tightest host within b2 → x2(1cpu).
 		"unconstrained; a single pod fits into each host; LeastFreeCapacity; TASHierarchicalUnconstrained": {
 			nodes:  defaultNodes,
 			levels: defaultThreeLevels,

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -595,10 +595,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 					Levels: defaultOneLevel,
 					Domains: []tas.TopologyDomainAssignment{
 						{Count: 1, Values: []string{"x1"}},
-						{Count: 1, Values: []string{"x3"}},
+						{Count: 4, Values: []string{"x3"}},
 						{Count: 1, Values: []string{"x5"}},
-						{Count: 1, Values: []string{"x2"}},
-						{Count: 2, Values: []string{"x6"}},
 					},
 				},
 			}},
@@ -620,7 +618,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 						{
 							Count: 1,
 							Values: []string{
-								"x3",
+								"x2",
 							},
 						},
 					},
@@ -644,7 +642,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 						{
 							Count: 1,
 							Values: []string{
-								"x3",
+								"x2",
 							},
 						},
 					},

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -614,7 +614,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Unconstrained: ptr.To(true),
+					Unconstrained: new(true),
 				},
 				requests: resources.Requests{
 					corev1.ResourceCPU: 1000,
@@ -639,7 +639,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Unconstrained: ptr.To(true),
+					Unconstrained: new(true),
 				},
 				requests: resources.Requests{
 					corev1.ResourceCPU: 1000,
@@ -719,7 +719,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Unconstrained: ptr.To(true),
+					Unconstrained: new(true),
 				},
 				requests: resources.Requests{
 					corev1.ResourceCPU: 1000,

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1131,6 +1131,9 @@ func (s *TASFlavorSnapshot) levelKey(topologyRequest *kueue.PodSetTopologyReques
 	case isSliceTopologyOnlyRequest(topologyRequest):
 		return new(s.highestLevel())
 	case ptr.Deref(topologyRequest.Unconstrained, false):
+		if features.Enabled(features.TASProfileMixed) {
+			return new(s.highestLevel())
+		}
 		return new(s.lowestLevel())
 	default:
 		return nil

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -847,6 +847,7 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	if topologyKey == nil {
 		return nil, "topology level not specified"
 	}
+	s.log.V(3).Info("resolved topology level key", "topologyKey", *topologyKey, "unconstrained", state.unconstrained)
 	requestedLevelIdx, found := s.resolveLevelIdx(*topologyKey)
 	if !found {
 		return nil, fmt.Sprintf("no requested topology level: %s", *topologyKey)
@@ -1131,7 +1132,7 @@ func (s *TASFlavorSnapshot) levelKey(topologyRequest *kueue.PodSetTopologyReques
 	case isSliceTopologyOnlyRequest(topologyRequest):
 		return new(s.highestLevel())
 	case ptr.Deref(topologyRequest.Unconstrained, false):
-		if features.Enabled(features.TASProfileMixed) {
+		if features.Enabled(features.TASHierarchicalUnconstrained) {
 			return new(s.highestLevel())
 		}
 		return new(s.lowestLevel())

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -115,6 +115,7 @@ const (
 	// When enabled alongside TASProfileMixed, makes LeastFreeCapacity for
 	// unconstrained workloads start from the highest topology level instead
 	// of the node level, enabling hierarchical packing to reduce rack fragmentation.
+	// Planned graduation: Beta in 0.18, GA in 0.21.
 	TASHierarchicalUnconstrained featuregate.Feature = "TASHierarchicalUnconstrained"
 
 	// owner: @mwielgus
@@ -440,7 +441,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.15"), Default: true, PreRelease: featuregate.Beta},
 	},
 	TASHierarchicalUnconstrained: {
-		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
 	},
 	HierarchicalCohorts: {
 		{Version: version.MustParse("0.11"), Default: true, PreRelease: featuregate.Beta},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -109,6 +109,14 @@ const (
 	// Enable to set use Mixed algorithm (BestFit or LeastFreeCapacity) for TAS which switch the algorithm based on TAS requirements level.
 	TASProfileMixed featuregate.Feature = "TASProfileMixed"
 
+	// owner: @abhi179
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-scheduling
+	//
+	// When enabled alongside TASProfileMixed, makes LeastFreeCapacity for
+	// unconstrained workloads start from the highest topology level instead
+	// of the node level, enabling hierarchical packing to reduce rack fragmentation.
+	TASHierarchicalUnconstrained featuregate.Feature = "TASHierarchicalUnconstrained"
+
 	// owner: @mwielgus
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/79-hierarchical-cohorts
 	//
@@ -430,6 +438,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	TASProfileMixed: {
 		{Version: version.MustParse("0.10"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("0.15"), Default: true, PreRelease: featuregate.Beta},
+	},
+	TASHierarchicalUnconstrained: {
+		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	HierarchicalCohorts: {
 		{Version: version.MustParse("0.11"), Default: true, PreRelease: featuregate.Beta},

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -363,6 +363,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.14"
+- name: TASHierarchicalUnconstrained
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.18"
 - name: TASMultiLayerTopology
   versionedSpecs:
   - default: false

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -365,9 +365,9 @@
     version: "0.14"
 - name: TASHierarchicalUnconstrained
   versionedSpecs:
-  - default: false
+  - default: true
     lockToDefault: false
-    preRelease: Alpha
+    preRelease: Beta
     version: "0.18"
 - name: TASMultiLayerTopology
   versionedSpecs:


### PR DESCRIPTION

### **TL;DR**
Fixes rack fragmentation for unconstrained workloads by making LeastFreeCapacity topology-aware. Instead of scheduling at node level only, the algorithm now packs workloads top-down (rack → node), preserving empty racks for large jobs (e.g., NVL72).


**What changed**

When TASProfileMixed is enabled and a workload uses unconstrained topology, LeastFreeCapacity now evaluates capacity hierarchically:

- Previously: scheduling was done only at node level (lowest level)
- Now: scheduling is done top-down across topology levels
    - Select the domain with least free capacity at the highest level (e.g., rack)
    - Recursively select the tightest-fitting child domain (e.g., node)


### **Detailed Description:**
**Title: LeastFreeCapacity for unconstrained workloads should consider higher topology levels to prevent rack fragmentation**

**Issue Description :**
On a large GPU cluster with GB200 NVL72 racks (~33 racks, ~18 nodes per rack, 4 GPUs per node), single-GPU inference workloads using unconstrained-topology: "true" are being scattered across many partially-filled racks instead of being consolidated into the fewest racks possible.

The cluster topology has two levels:

 apiVersion: kueue.x-k8s.io/v1beta2
 kind: Topology
 metadata:
   name: rack-topology
 spec:
   levels:
   - nodeLabel: nvidia.com/gpu.clique   # rack
   - nodeLabel: kubernetes.io/hostname   # node

With TASProfileMixed enabled (default since v0.15), unconstrained workloads use LeastFreeCapacity. However, the algorithm only operates at the hostname (lowest) level — it picks the globally busiest node without considering rack-level grouping. This causes
single-GPU pods to land on partially-used nodes across many different racks, creating widespread rack fragmentation.

**What should have been the expected behavior:**

LeastFreeCapacity should traverse the topology tree top-down for unconstrained workloads: first select the busiest rack (least free capacity at the rack level), then select the busiest node within that rack. This would consolidate single-GPU workloads into the fewest racks possible.

Why this matters (GB200/NVL72 use case):

GB200 NVL72 workloads require an entire rack (72 GPUs across 18 nodes connected via NVLink). When single-GPU inference pods (image-encoding, proxy, etc.) are scattered across many racks — each consuming just 1 GPU per rack — it becomes impossible to find a fully empty rack for NVL72 jobs. The goal is to pack unconstrained single-GPU workloads into the fewest racks possible, keeping maximum racks entirely free for large topology-constrained jobs.

**Reproduction:**

 1. Create a topology with two levels (rack → hostname)
 2. Deploy multiple single-GPU StatefulSets with kueue.x-k8s.io/podset-unconstrained-topology: "true"
 3. Observe pods scattered across many racks instead of consolidating into the fewest racks

**Evidence from production (Kueue v0.16.1):**

 - Pod deleted from a node landed back on the same rack instead of going to the busiest rack (LeastFree)
 - TopologyAssignment shows only levels: ["kubernetes.io/hostname"] — rack level absent
 - Rack utilization ranged from 1–72 GPUs across 33 racks, confirming no rack-level consolidation

**Root cause in code:**

pkg/cache/scheduler/tas_flavor_snapshot.go:

 1. levelKey() (line 1105): For unconstrained, returns s.lowestLevel() = kubernetes.io/hostname, skipping the rack level entirely
 2. findLevelWithFitDomains() (line 1250): Upward traversal to rack level is blocked by !unconstrained guard: if levelIdx > 0 && !unconstrained {
      return s.findLevelWithFitDomains(levelIdx-1, ...)
  }
 3. LeastFreeCapacity sorts hostname-level domains only — it never groups or scores by rack

Proposed behavior:
For unconstrained + LeastFreeCapacity with multi-level topologies, the algorithm should:

 1. Score capacity at each topology level (rack, then hostname)
 2. Select the rack with the least free capacity that can fit the workload
 3. Within that rack, select the node with the least free capacity

This preserves the "no hard placement constraint" semantics of unconstrained while enabling topology-aware bin-packing to reduce fragmentation.

Environment:

 - Kueue version: v0.16.1
 - Feature gates: TASProfileMixed=true (default)
 - Kubernetes: AKS with unmanaged GPU nodes
 - Topology: 2 levels (nvidia.com/gpu.clique → kubernetes.io/hostname)

```release-note
TAS: Introduce hierarchical LeastFreeCapacity for unconstrained workloads, gated by the TASHierarchicalUnconstrained feature gate (alpha, disabled by default). When enabled alongside TASProfileMixed, the algorithm resolves topology starting from the highest level (e.g., rack) instead of the node level, packing pods into the busiest racks first to reduce fragmentation.
```

