### PR TITLE
Update gcr.io/k8s-staging-test-infra/gcb-docker-gcloud version

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ timeout: 3000s
 # For each build step, cloudbuild executes a docker container.
 steps:
   # see https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260127-c1affcc8de'
     entrypoint: make
     args:
       - image-push


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

The previous `gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079` was removed, then all main branch Jobs failed.

```
Pulling image: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079
Error response from daemon: manifest for gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079 not found: manifest unknown: Failed to fetch "v20250513-9264efb079"
```

<img width="633" height="498" alt="Screenshot 2026-04-13 at 13 51 24" src="https://github.com/user-attachments/assets/6ca64d7d-c22d-412a-966f-a5346a7bd11f" />

<img width="703" height="410" alt="Screenshot 2026-04-13 at 13 51 43" src="https://github.com/user-attachments/assets/29e61d0b-8a23-4228-bb42-f7d8117ab0e7" />

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```