### PR TITLE
tas: strip stale topology nodeSelector keys on workload re-evaluation

### DIFF
--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -1655,6 +1655,36 @@ func TestFindTopologyAssignments(t *testing.T) {
 				wantReason: `topology "default" doesn't allow to fit any of 1 pod(s). Total nodes: 4; excluded: nodeSelector: 2, resource "cpu": 1, taint "key=value:NoSchedule": 1`,
 			}},
 		},
+		"stale topology nodeSelector from prior admission is stripped; pod still schedules": {
+			nodes: defaultNodes,
+			levels: defaultThreeLevels,
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Required: ptr.To(corev1.LabelHostname),
+				},
+				requests: resources.Requests{
+					corev1.ResourceCPU: 1000,
+				},
+				// Simulate stale nodeSelector from a prior TAS admission that
+				// injected kubernetes.io/hostname. This should be stripped by the
+				// scheduler so it does not constrain node filtering.
+				nodeSelector: map[string]string{
+					corev1.LabelHostname: "deleted-node",
+				},
+				count: 1,
+				wantAssignment: &tas.TopologyAssignment{
+					Levels: defaultOneLevel,
+					Domains: []tas.TopologyDomainAssignment{
+						{
+							Count: 1,
+							Values: []string{
+								"x3",
+							},
+						},
+					},
+				},
+			}},
+		},
 		"resource exclusion picks most restrictive resource": {
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("dual-shortage").

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -792,6 +792,17 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	}
 	podSetTolerations := info.Tolerations
 	podSetNodeSelectors := info.NodeSelector
+
+	// Strip any nodeSelector keys that match topology level keys. These may
+	// be stale values from a prior TAS admission (e.g., kubernetes.io/hostname
+	// injected by the topology ungater) that survived eviction because the
+	// PodSet template was rebuilt from live pods carrying the old nodeSelector.
+	// TAS will compute its own topology assignment, so these keys must not
+	// constrain node filtering.
+	for _, levelKey := range s.levelKeys {
+		delete(podSetNodeSelectors, levelKey)
+	}
+
 	count := workersTasPodSetRequests.Count
 
 	// If slice topology is not requested then we can assume that slice is a single pod


### PR DESCRIPTION
When a TAS workload is evicted (e.g., due to PodsReadyTimeout after a partial pod deletion by a cluster health manager), the surviving pods retain the kubernetes.io/hostname nodeSelector injected during the prior admission by the topology ungater. When the workload is re-queued, the pod group controller reconstructs the workload from the surviving pod's spec via DeepCopy, carrying the stale nodeSelector into the new PodSet template.

During TAS topology assignment evaluation, findTopologyAssignment() merges PodSet.NodeSelector with AdmissionCheck PodSetUpdates. The stale kubernetes.io/hostname constrains node filtering to a single node (the old assignment), causing the workload to be permanently stuck in Pending — it can never be re-admitted because the target node may no longer exist or have capacity.

Fix: After merging the combined nodeSelector, strip any keys that match TAS topology level keys (e.g., kubernetes.io/hostname, topology.kubernetes.io/zone). These keys are always recomputed by TAS during topology assignment, so prior values must not constrain node filtering. This allows evicted workloads to be re-admitted to any valid topology domain.

Observed in production: CHM NodeStatusUnknown repair action on GB200 clusters force-deleted individual pods from multi-pod GPU inference StatefulSets. 86% of affected workloads (6/7) became permanently stuck due to this bug.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

 /kind bug
 /area tas

#### What this PR does / why we need it:

When a TAS workload is evicted (e.g., due to PodsReadyTimeout after a partial pod deletion by a cluster health manager), the surviving pods retain the kubernetes.io/hostname nodeSelector injected during
prior admission by the topology ungater. When the workload is re-queued, the pod group controller reconstructs the workload from the surviving pod's spec via DeepCopy, carrying the stale nodeSelector into
the new PodSet template.

During TAS topology assignment evaluation, findTopologyAssignment() merges PodSet.NodeSelector with AdmissionCheck PodSetUpdates. The stale kubernetes.io/hostname constrains node filtering to a single node
(the old assignment), causing the workload to be permanently stuck in Pending — it can never be re-admitted because the target node may no longer exist or have capacity.

Fix: After merging the combined nodeSelector in findTopologyAssignment(), strip any keys that match TAS topology level keys (e.g., kubernetes.io/hostname, topology.kubernetes.io/zone). These keys are
always recomputed by TAS during topology assignment, so prior values must not constrain node filtering.

#### Which issue(s) this PR fixes:

(No upstream issue yet — discovered in production. Can file one if needed.)

#### Special notes for your reviewer:

 - Observed in production: CHM NodeStatusUnknown repair on GPU clusters force-deleted individual pods from multi-pod GPU inference StatefulSets managed by Kueue TAS. 86% of affected workloads (6/7) 
became permanently stuck.
 - The fix is minimal and safe: topology level keys are always recomputed by TAS during findTopologyAssignment(), so stripping them before node filtering has no effect on fresh admissions — only on 
re-admissions where stale data survived eviction.
 - Surviving ungated pods that are already running still retain the old nodeSelector — this is non-blocking since they're already scheduled and running on the correct node.

#### Does this PR introduce a user-facing change?

 TAS: Fix permanently stuck workloads after eviction by stripping stale topology nodeSelector keys (e.g., kubernetes.io/hostname) from PodSet templates during re-evaluation, allowing evicted workloads to 
be re-admitted to any valid topology domain.
```