### PR TITLE
fix Missing Workload status accumulatedPastExecutionTimeSeconds

### DIFF
--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -1679,7 +1679,17 @@ func Finish(ctx context.Context, c client.Client, wl *kueue.Workload, reason, ms
 		return nil
 	}
 	err := PatchAdmissionStatus(ctx, c, wl, clock, func(wl *kueue.Workload) (bool, error) {
-		return SetFinishedCondition(wl, clock.Now(), reason, msg), nil
+		// Sync Admitted condition to ensure accumulatedPastExecutionTimeSeconds is updated
+		syncChanged := SyncAdmittedCondition(wl, clock.Now())
+		// Set Finished condition
+		finishedChanged := SetFinishedCondition(wl, clock.Now(), reason, msg)
+		// Clear admission to ensure Admitted condition becomes False
+		if wl.Status.Admission != nil {
+			wl.Status.Admission = nil
+			// Re-sync Admitted condition after clearing admission
+			SyncAdmittedCondition(wl, clock.Now())
+		}
+		return syncChanged || finishedChanged, nil
 	})
 	if err != nil {
 		return err

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1759,6 +1759,70 @@ func TestWithPreprocessedDRAResources(t *testing.T) {
 	}
 }
 
+func TestFinishUpdatesAccumulatedPastExecutionTimeSeconds(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	twoSecondsLater := now.Add(2 * time.Second)
+
+	cases := map[string]struct {
+		workload            *kueue.Workload
+		finishTime          time.Time
+		wantAccumulatedTime *int32
+	}{
+		"admitted workload finishes and updates accumulated time": {
+			workload: utiltestingapi.MakeWorkload("test-wl", "default").
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), now).
+				AdmittedAt(true, now).
+				Obj(),
+			finishTime:          twoSecondsLater,
+			wantAccumulatedTime: ptr.To(int32(2)),
+		},
+		"workload with existing accumulated time finishes and adds to it": {
+			workload: func() *kueue.Workload {
+				wl := utiltestingapi.MakeWorkload("test-wl", "default").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), now).
+					AdmittedAt(true, now).
+					Obj()
+				wl.Status.AccumulatedPastExecutionTimeSeconds = ptr.To(int32(5))
+				return wl
+			}(),
+			finishTime:          twoSecondsLater,
+			wantAccumulatedTime: ptr.To(int32(7)),
+		},
+		"non-admitted workload finishes without updating accumulated time": {
+			workload: utiltestingapi.MakeWorkload("test-wl", "default").
+				Obj(),
+			finishTime:          twoSecondsLater,
+			wantAccumulatedTime: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			fakeClock := testingclock.NewFakeClock(tc.finishTime)
+
+			cl := utiltesting.NewClientBuilder().
+				WithObjects(tc.workload).
+				WithStatusSubresource(&kueue.Workload{}).
+				Build()
+
+			err := Finish(ctx, cl, tc.workload, "TestReason", "TestMessage", fakeClock)
+			if err != nil {
+				t.Fatalf("Finish() failed: %v", err)
+			}
+
+			var updatedWl kueue.Workload
+			if err := cl.Get(ctx, client.ObjectKeyFromObject(tc.workload), &updatedWl); err != nil {
+				t.Fatalf("Failed to get updated workload: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.wantAccumulatedTime, updatedWl.Status.AccumulatedPastExecutionTimeSeconds); diff != "" {
+				t.Errorf("Unexpected AccumulatedPastExecutionTimeSeconds (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestWithPreprocessedDRAResourcesReplacesExtendedResources(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.DynamicResourceAllocation, true)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/10437

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix missing Workload status (`workload.status.accumulatedPastExecutionTimeSeconds`) in MultiKueue environment.
```