### PR TITLE
Automated cherry pick of #10330: Propagate LeaderWorkerSet PodTemplate metadata to PodSet

### DIFF
--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -250,7 +250,7 @@ func (r *Reconciler) constructWorkload(lws *leaderworkersetv1.LeaderWorkerSet, w
 	return createdWorkload, nil
 }
 
-func cleanMetadata(m map[string]string) {
+func dropLWSPrefixedKeys(m map[string]string) {
 	for k := range m {
 		if strings.HasPrefix(k, lwsDomainPrefix) && k != lwsNameLabel {
 			delete(m, k)
@@ -258,7 +258,7 @@ func cleanMetadata(m map[string]string) {
 	}
 }
 
-func clearTASAnnotations(annotations map[string]string) {
+func dropTASAnnotations(annotations map[string]string) {
 	keysToDelete := []string{
 		kueue.PodSetRequiredTopologyAnnotation,
 		kueue.PodSetPreferredTopologyAnnotation,
@@ -276,9 +276,9 @@ func newPodSet(name kueue.PodSetReference, count int32, template *corev1.PodTemp
 		Count:    count,
 		Template: *template.DeepCopy(),
 	}
-	cleanMetadata(podSet.Template.Labels)
-	cleanMetadata(podSet.Template.Annotations)
-	clearTASAnnotations(podSet.Template.Annotations)
+	dropLWSPrefixedKeys(podSet.Template.Labels)
+	dropLWSPrefixedKeys(podSet.Template.Annotations)
+	dropTASAnnotations(podSet.Template.Annotations)
 	jobframework.SanitizePodSet(podSet)
 	if features.Enabled(features.TopologyAwareScheduling) {
 		builder := jobframework.NewPodSetTopologyRequest(template.ObjectMeta.DeepCopy())

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -258,18 +258,6 @@ func dropLWSPrefixedKeys(m map[string]string) {
 	}
 }
 
-func dropTASAnnotations(annotations map[string]string) {
-	keysToDelete := []string{
-		kueue.PodSetRequiredTopologyAnnotation,
-		kueue.PodSetPreferredTopologyAnnotation,
-		kueue.PodSetSliceRequiredTopologyAnnotation,
-		kueue.PodSetSliceSizeAnnotation,
-	}
-	for _, k := range keysToDelete {
-		delete(annotations, k)
-	}
-}
-
 func newPodSet(name kueue.PodSetReference, count int32, template *corev1.PodTemplateSpec, podIndexLabel *string) (*kueue.PodSet, error) {
 	podSet := &kueue.PodSet{
 		Name:     name,
@@ -278,7 +266,6 @@ func newPodSet(name kueue.PodSetReference, count int32, template *corev1.PodTemp
 	}
 	dropLWSPrefixedKeys(podSet.Template.Labels)
 	dropLWSPrefixedKeys(podSet.Template.Annotations)
-	dropTASAnnotations(podSet.Template.Annotations)
 	jobframework.SanitizePodSet(podSet)
 	if features.Enabled(features.TopologyAwareScheduling) {
 		builder := jobframework.NewPodSetTopologyRequest(template.ObjectMeta.DeepCopy())

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"golang.org/x/sync/errgroup"
@@ -58,6 +59,8 @@ import (
 const (
 	leaderPodSetName = "leader"
 	workerPodSetName = "worker"
+	lwsDomainPrefix  = "leaderworkerset.sigs.k8s.io"
+	lwsNameLabel     = "leaderworkerset.sigs.k8s.io/name"
 )
 
 type Reconciler struct {
@@ -247,14 +250,35 @@ func (r *Reconciler) constructWorkload(lws *leaderworkersetv1.LeaderWorkerSet, w
 	return createdWorkload, nil
 }
 
+func cleanMetadata(m map[string]string) {
+	for k := range m {
+		if strings.HasPrefix(k, lwsDomainPrefix) && k != lwsNameLabel {
+			delete(m, k)
+		}
+	}
+}
+
+func clearTASAnnotations(annotations map[string]string) {
+	keysToDelete := []string{
+		kueue.PodSetRequiredTopologyAnnotation,
+		kueue.PodSetPreferredTopologyAnnotation,
+		kueue.PodSetSliceRequiredTopologyAnnotation,
+		kueue.PodSetSliceSizeAnnotation,
+	}
+	for _, k := range keysToDelete {
+		delete(annotations, k)
+	}
+}
+
 func newPodSet(name kueue.PodSetReference, count int32, template *corev1.PodTemplateSpec, podIndexLabel *string) (*kueue.PodSet, error) {
 	podSet := &kueue.PodSet{
-		Name:  name,
-		Count: count,
-		Template: corev1.PodTemplateSpec{
-			Spec: *template.Spec.DeepCopy(),
-		},
+		Name:     name,
+		Count:    count,
+		Template: *template.DeepCopy(),
 	}
+	cleanMetadata(podSet.Template.Labels)
+	cleanMetadata(podSet.Template.Annotations)
+	clearTASAnnotations(podSet.Template.Annotations)
 	jobframework.SanitizePodSet(podSet)
 	if features.Enabled(features.TopologyAwareScheduling) {
 		builder := jobframework.NewPodSetTopologyRequest(template.ObjectMeta.DeepCopy())

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -430,11 +430,13 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet(leaderPodSetName, 1).
 							RestartPolicy("").
 							Image("pause").
+							Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
 							RequiredTopologyRequest("cloud.com/block").
 							Obj(),
 						*utiltestingapi.MakePodSet(workerPodSetName, 2).
 							RestartPolicy("").
 							Image("pause").
+							Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
 							RequiredTopologyRequest("cloud.com/block").
 							PodIndexLabel(ptr.To(leaderworkersetv1.WorkerIndexLabelKey)).
 							Obj(),
@@ -455,7 +457,7 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		},
-		"should create prebuilt workload without required topology annotation is TAS is disabled": {
+		"should create prebuilt workload without topology request if TAS is disabled": {
 			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
 			},
@@ -525,10 +527,12 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet(leaderPodSetName, 1).
 							RestartPolicy("").
 							Image("pause").
+							Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
 							Obj(),
 						*utiltestingapi.MakePodSet(workerPodSetName, 2).
 							RestartPolicy("").
 							Image("pause").
+							Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
 							Obj(),
 					).
 					Priority(0).

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -245,6 +245,161 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		},
+		"should create prebuilt workload with custom annotations propagated to podsets": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling: false,
+			},
+			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
+				UID(testUID).
+				Replicas(2).
+				Size(3).
+				LeaderTemplate(corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"custom-leader-annotation":                  "leader-value",
+							"leaderworkerset.sigs.k8s.io/template-hash": "12345",
+						},
+						Labels: map[string]string{
+							"leaderworkerset.sigs.k8s.io/name":        testLWS,
+							"leaderworkerset.sigs.k8s.io/group-index": "1",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "c", Image: "pause"},
+						},
+					},
+				}).
+				WorkerTemplate(corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"custom-worker-annotation":                  "worker-value",
+							"leaderworkerset.sigs.k8s.io/template-hash": "12345",
+						},
+						Labels: map[string]string{
+							"leaderworkerset.sigs.k8s.io/name":        testLWS,
+							"leaderworkerset.sigs.k8s.io/group-index": "1",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "c", Image: "pause"},
+						},
+					},
+				}).
+				Obj(),
+			wantLeaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
+				UID(testUID).
+				Replicas(2).
+				Size(3).
+				LeaderTemplate(corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"custom-leader-annotation":                  "leader-value",
+							"leaderworkerset.sigs.k8s.io/template-hash": "12345",
+						},
+						Labels: map[string]string{
+							"leaderworkerset.sigs.k8s.io/name":        testLWS,
+							"leaderworkerset.sigs.k8s.io/group-index": "1",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "c", Image: "pause"},
+						},
+					},
+				}).
+				WorkerTemplate(corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"custom-worker-annotation":                  "worker-value",
+							"leaderworkerset.sigs.k8s.io/template-hash": "12345",
+						},
+						Labels: map[string]string{
+							"leaderworkerset.sigs.k8s.io/name":        testLWS,
+							"leaderworkerset.sigs.k8s.io/group-index": "1",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "c", Image: "pause"},
+						},
+					},
+				}).
+				Obj(),
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName(types.UID(testUID), testLWS, "0"), testNS).
+					JobUID(testUID).
+					OwnerReference(gvk, testLWS, testUID).
+					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet(leaderPodSetName, 1).
+							Annotations(map[string]string{"custom-leader-annotation": "leader-value"}).
+							Labels(map[string]string{"leaderworkerset.sigs.k8s.io/name": testLWS}).
+							RestartPolicy("").
+							Image("pause").
+							Obj(),
+						*utiltestingapi.MakePodSet(workerPodSetName, 2).
+							Annotations(map[string]string{"custom-worker-annotation": "worker-value"}).
+							Labels(map[string]string{"leaderworkerset.sigs.k8s.io/name": testLWS}).
+							RestartPolicy("").
+							Image("pause").
+							Obj(),
+					).
+					Priority(0).
+					Obj(),
+				*utiltestingapi.MakeWorkload(GetWorkloadName(types.UID(testUID), testLWS, "1"), testNS).
+					JobUID(testUID).
+					OwnerReference(gvk, testLWS, testUID).
+					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						func() kueue.PodSet {
+							ps := *utiltestingapi.MakePodSet(leaderPodSetName, 1).
+								RestartPolicy("").
+								Image("pause").
+								Obj()
+							ps.Template.Annotations = map[string]string{"custom-leader-annotation": "leader-value"}
+							ps.Template.Labels = map[string]string{"leaderworkerset.sigs.k8s.io/name": testLWS}
+							return ps
+						}(),
+						func() kueue.PodSet {
+							ps := *utiltestingapi.MakePodSet(workerPodSetName, 2).
+								RestartPolicy("").
+								Image("pause").
+								Obj()
+							ps.Template.Annotations = map[string]string{"custom-worker-annotation": "worker-value"}
+							ps.Template.Labels = map[string]string{"leaderworkerset.sigs.k8s.io/name": testLWS}
+							return ps
+						}(),
+					).
+					Priority(0).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: testLWS, Namespace: testNS},
+					EventType: corev1.EventTypeNormal,
+					Reason:    jobframework.ReasonCreatedWorkload,
+					Message: fmt.Sprintf(
+						"Created Workload: %s/%s",
+						testNS,
+						GetWorkloadName(types.UID(testUID), testLWS, "0"),
+					),
+				},
+				{
+					Key:       types.NamespacedName{Name: testLWS, Namespace: testNS},
+					EventType: corev1.EventTypeNormal,
+					Reason:    jobframework.ReasonCreatedWorkload,
+					Message: fmt.Sprintf(
+						"Created Workload: %s/%s",
+						testNS,
+						GetWorkloadName(types.UID(testUID), testLWS, "1"),
+					),
+				},
+			},
+		},
 		"should create prebuilt workload with required topology annotation": {
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
 				UID(testUID).

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -251,7 +251,7 @@ func TestReconciler(t *testing.T) {
 			},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
 				UID(testUID).
-				Replicas(2).
+				Replicas(1).
 				Size(3).
 				LeaderTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
@@ -290,7 +290,7 @@ func TestReconciler(t *testing.T) {
 				Obj(),
 			wantLeaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
 				UID(testUID).
-				Replicas(2).
+				Replicas(1).
 				Size(3).
 				LeaderTemplate(corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
@@ -349,33 +349,6 @@ func TestReconciler(t *testing.T) {
 					).
 					Priority(0).
 					Obj(),
-				*utiltestingapi.MakeWorkload(GetWorkloadName(types.UID(testUID), testLWS, "1"), testNS).
-					JobUID(testUID).
-					OwnerReference(gvk, testLWS, testUID).
-					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
-					Finalizers(kueue.ResourceInUseFinalizerName).
-					PodSets(
-						func() kueue.PodSet {
-							ps := *utiltestingapi.MakePodSet(leaderPodSetName, 1).
-								RestartPolicy("").
-								Image("pause").
-								Obj()
-							ps.Template.Annotations = map[string]string{"custom-leader-annotation": "leader-value"}
-							ps.Template.Labels = map[string]string{"leaderworkerset.sigs.k8s.io/name": testLWS}
-							return ps
-						}(),
-						func() kueue.PodSet {
-							ps := *utiltestingapi.MakePodSet(workerPodSetName, 2).
-								RestartPolicy("").
-								Image("pause").
-								Obj()
-							ps.Template.Annotations = map[string]string{"custom-worker-annotation": "worker-value"}
-							ps.Template.Labels = map[string]string{"leaderworkerset.sigs.k8s.io/name": testLWS}
-							return ps
-						}(),
-					).
-					Priority(0).
-					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
 				{
@@ -386,16 +359,6 @@ func TestReconciler(t *testing.T) {
 						"Created Workload: %s/%s",
 						testNS,
 						GetWorkloadName(types.UID(testUID), testLWS, "0"),
-					),
-				},
-				{
-					Key:       types.NamespacedName{Name: testLWS, Namespace: testNS},
-					EventType: corev1.EventTypeNormal,
-					Reason:    jobframework.ReasonCreatedWorkload,
-					Message: fmt.Sprintf(
-						"Created Workload: %s/%s",
-						testNS,
-						GetWorkloadName(types.UID(testUID), testLWS, "1"),
 					),
 				},
 			},


### PR DESCRIPTION
Cherry pick of #10330 on release-0.16.

#10330: Propagate LeaderWorkerSet PodTemplate metadata to PodSet

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
LeaderWorkerSet integration: fix the bug that the PodTemplate metadata wasn't propagated to the Workload's PodSets.
```