### PR TITLE
[release-0.16] TAS: recognize PodSetSliceRequiredTopologyAnnotation in IsTAS()

### DIFF
--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -2669,12 +2669,6 @@ func TestIsTAS(t *testing.T) {
 				Obj(),
 			want: true,
 		},
-		"PodSetRequiredTopologyAnnotation": {
-			pod: testingpod.MakePod("pod", "ns").
-				Annotation(kueue.PodSetRequiredTopologyAnnotation, tasRackLabel).
-				Obj(),
-			want: true,
-		},
 		"PodSetSliceRequiredTopologyAnnotation": {
 			pod: testingpod.MakePod("pod", "ns").
 				Annotation(kueue.PodSetSliceRequiredTopologyAnnotation, tasBlockLabel).

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -2653,3 +2653,59 @@ func TestReconcile(t *testing.T) {
 		})
 	}
 }
+
+func TestIsTAS(t *testing.T) {
+	cases := map[string]struct {
+		pod  *corev1.Pod
+		want bool
+	}{
+		"no annotations": {
+			pod:  testingpod.MakePod("pod", "ns").Obj(),
+			want: false,
+		},
+		"PodSetPreferredTopologyAnnotation": {
+			pod: testingpod.MakePod("pod", "ns").
+				Annotation(kueue.PodSetPreferredTopologyAnnotation, tasBlockLabel).
+				Obj(),
+			want: true,
+		},
+		"PodSetRequiredTopologyAnnotation": {
+			pod: testingpod.MakePod("pod", "ns").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, tasRackLabel).
+				Obj(),
+			want: true,
+		},
+		"PodSetSliceRequiredTopologyAnnotation": {
+			pod: testingpod.MakePod("pod", "ns").
+				Annotation(kueue.PodSetSliceRequiredTopologyAnnotation, tasBlockLabel).
+				Obj(),
+			want: true,
+		},
+		"PodSetSliceRequiredTopologyConstraintsAnnotation": {
+			pod: testingpod.MakePod("pod", "ns").
+				Annotation(kueue.PodSetSliceRequiredTopologyConstraintsAnnotation, `[{"topology":"cloud.com/rack","size":2}]`).
+				Obj(),
+			want: true,
+		},
+		"PodSetUnconstrainedTopologyAnnotation": {
+			pod: testingpod.MakePod("pod", "ns").
+				Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
+				Obj(),
+			want: true,
+		},
+		"unrelated annotation": {
+			pod: testingpod.MakePod("pod", "ns").
+				Annotation("foo", "bar").
+				Obj(),
+			want: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := tas.IsTAS(tc.pod)
+			if got != tc.want {
+				t.Errorf("IsTAS() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -2681,12 +2681,6 @@ func TestIsTAS(t *testing.T) {
 				Obj(),
 			want: true,
 		},
-		"PodSetSliceRequiredTopologyConstraintsAnnotation": {
-			pod: testingpod.MakePod("pod", "ns").
-				Annotation(kueue.PodSetSliceRequiredTopologyConstraintsAnnotation, `[{"topology":"cloud.com/rack","size":2}]`).
-				Obj(),
-			want: true,
-		},
 		"PodSetUnconstrainedTopologyAnnotation": {
 			pod: testingpod.MakePod("pod", "ns").
 				Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").

--- a/pkg/util/tas/tas.go
+++ b/pkg/util/tas/tas.go
@@ -51,6 +51,12 @@ func IsExplicitTAS(annots map[string]string) bool {
 	if _, ok := annots[kueue.PodSetRequiredTopologyAnnotation]; ok {
 		return true
 	}
+	if _, ok := annots[kueue.PodSetSliceRequiredTopologyAnnotation]; ok {
+		return true
+	}
+	if _, ok := annots[kueue.PodSetSliceRequiredTopologyConstraintsAnnotation]; ok {
+		return true
+	}
 	return false
 }
 

--- a/pkg/util/tas/tas.go
+++ b/pkg/util/tas/tas.go
@@ -54,9 +54,6 @@ func IsExplicitTAS(annots map[string]string) bool {
 	if _, ok := annots[kueue.PodSetSliceRequiredTopologyAnnotation]; ok {
 		return true
 	}
-	if _, ok := annots[kueue.PodSetSliceRequiredTopologyConstraintsAnnotation]; ok {
-		return true
-	}
 	return false
 }
 


### PR DESCRIPTION
This is a cherry-pick of https://github.com/kubernetes-sigs/kueue/pull/10282


fix missing PodSetSliceRequiredTopologyConstraintsAnnotation for 0.16, #10441

/assign tenzen-y


```release-note
TAS: fix a bug that Pods which only contain the `kueue.x-k8s.io/podset-slice-required-topology` as the TAS annotation are not ungated.
```