### PR TITLE
Trigger failure recovery reconciliations for unreachable nodes

### DIFF
--- a/pkg/controller/failurerecovery/pod_termination_controller.go
+++ b/pkg/controller/failurerecovery/pod_termination_controller.go
@@ -241,6 +241,9 @@ func (r *TerminatingPodReconciler) mapNodeToPods(ctx context.Context, node *core
 			})
 		}
 	}
+
+	log.V(4).Info("Reconciling pods affected by unreachable node", "pod_count", len(requests))
+
 	return requests
 }
 

--- a/pkg/controller/failurerecovery/pod_termination_controller.go
+++ b/pkg/controller/failurerecovery/pod_termination_controller.go
@@ -242,7 +242,9 @@ func (r *TerminatingPodReconciler) mapNodeToPods(ctx context.Context, node *core
 		}
 	}
 
-	log.V(4).Info("Reconciling pods affected by unreachable node", "pod_count", len(requests))
+	if len(requests) > 0 {
+		log.V(4).Info("Reconciling pods affected by unreachable node", "pod_count", len(requests))
+	}
 
 	return requests
 }

--- a/pkg/controller/failurerecovery/pod_termination_controller.go
+++ b/pkg/controller/failurerecovery/pod_termination_controller.go
@@ -250,7 +250,8 @@ func (r *TerminatingPodReconciler) nodeEventsPredicate() predicate.TypedPredicat
 			return utiltaints.TaintKeyExists(e.Object.Spec.Taints, corev1.TaintNodeUnreachable)
 		},
 		UpdateFunc: func(e event.TypedUpdateEvent[*corev1.Node]) bool {
-			return utiltaints.TaintKeyExists(e.ObjectNew.Spec.Taints, corev1.TaintNodeUnreachable)
+			return !utiltaints.TaintKeyExists(e.ObjectOld.Spec.Taints, corev1.TaintNodeUnreachable) &&
+				utiltaints.TaintKeyExists(e.ObjectNew.Spec.Taints, corev1.TaintNodeUnreachable)
 		},
 		DeleteFunc: func(e event.TypedDeleteEvent[*corev1.Node]) bool {
 			return false

--- a/pkg/controller/failurerecovery/pod_termination_controller.go
+++ b/pkg/controller/failurerecovery/pod_termination_controller.go
@@ -33,11 +33,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core"
+	"sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	utilclient "sigs.k8s.io/kueue/pkg/util/client"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
@@ -123,16 +125,7 @@ func (r *TerminatingPodReconciler) Create(e event.TypedCreateEvent[*corev1.Pod])
 }
 
 func (r *TerminatingPodReconciler) Update(u event.TypedUpdateEvent[*corev1.Pod]) bool {
-	if !podEligibleForTermination(u.ObjectNew) {
-		return false
-	}
-
-	// Pod was not marked for deletion in the update
-	if !u.ObjectOld.DeletionTimestamp.IsZero() || u.ObjectNew.DeletionTimestamp.IsZero() {
-		return false
-	}
-
-	return true
+	return podEligibleForTermination(u.ObjectNew)
 }
 
 func (r *TerminatingPodReconciler) Delete(event.TypedDeleteEvent[*corev1.Pod]) bool {
@@ -228,6 +221,46 @@ func isPodPartiallyForcefullyTerminated(p *corev1.Pod) bool {
 	})
 }
 
+func (r *TerminatingPodReconciler) mapNodeToPods(ctx context.Context, node *corev1.Node) []ctrl.Request {
+	log := log.FromContext(ctx)
+
+	pods := &corev1.PodList{}
+	if err := r.client.List(ctx, pods, client.MatchingFields{indexer.PodNodeNameKey: node.Name}); err != nil {
+		log.Error(err, "Failed to list pods for node", "node", klog.KObj(node))
+		return nil
+	}
+
+	var requests []ctrl.Request
+	for _, pod := range pods.Items {
+		if podEligibleForTermination(&pod) {
+			requests = append(requests, ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: pod.Namespace,
+					Name:      pod.Name,
+				},
+			})
+		}
+	}
+	return requests
+}
+
+func (r *TerminatingPodReconciler) nodeEventsPredicate() predicate.TypedPredicate[*corev1.Node] {
+	return predicate.TypedFuncs[*corev1.Node]{
+		CreateFunc: func(e event.TypedCreateEvent[*corev1.Node]) bool {
+			return utiltaints.TaintKeyExists(e.Object.Spec.Taints, corev1.TaintNodeUnreachable)
+		},
+		UpdateFunc: func(e event.TypedUpdateEvent[*corev1.Node]) bool {
+			return utiltaints.TaintKeyExists(e.ObjectNew.Spec.Taints, corev1.TaintNodeUnreachable)
+		},
+		DeleteFunc: func(e event.TypedDeleteEvent[*corev1.Node]) bool {
+			return false
+		},
+		GenericFunc: func(e event.TypedGenericEvent[*corev1.Node]) bool {
+			return false
+		},
+	}
+}
+
 const ControllerName = "failure-recovery-pod-termination-controller"
 
 func (r *TerminatingPodReconciler) SetupWithManager(mgr ctrl.Manager, cfg *configapi.Configuration) (string, error) {
@@ -238,6 +271,12 @@ func (r *TerminatingPodReconciler) SetupWithManager(mgr ctrl.Manager, cfg *confi
 			&corev1.Pod{},
 			&handler.TypedEnqueueRequestForObject[*corev1.Pod]{},
 			r,
+		)).
+		WatchesRawSource(source.TypedKind(
+			mgr.GetCache(),
+			&corev1.Node{},
+			handler.TypedEnqueueRequestsFromMapFunc(r.mapNodeToPods),
+			r.nodeEventsPredicate(),
 		)).
 		WithOptions(controller.Options{
 			NeedLeaderElection:      ptr.To(false),

--- a/pkg/controller/failurerecovery/pod_termination_controller.go
+++ b/pkg/controller/failurerecovery/pod_termination_controller.go
@@ -125,7 +125,7 @@ func (r *TerminatingPodReconciler) Create(e event.TypedCreateEvent[*corev1.Pod])
 }
 
 func (r *TerminatingPodReconciler) Update(u event.TypedUpdateEvent[*corev1.Pod]) bool {
-	return podEligibleForTermination(u.ObjectNew)
+	return !podEligibleForTermination(u.ObjectOld) && podEligibleForTermination(u.ObjectNew)
 }
 
 func (r *TerminatingPodReconciler) Delete(event.TypedDeleteEvent[*corev1.Pod]) bool {

--- a/pkg/controller/failurerecovery/pod_termination_controller_test.go
+++ b/pkg/controller/failurerecovery/pod_termination_controller_test.go
@@ -120,7 +120,7 @@ func TestUpdateEventFilter(t *testing.T) {
 		"pod was already deleted": {
 			oldPod:     oldPod.Clone().DeletionTimestamp(now).Obj(),
 			newPod:     newPodToReconcile.Obj(),
-			wantResult: false,
+			wantResult: true,
 		},
 		"updated object is not annotated": {
 			oldPod: oldPod.Obj(),

--- a/pkg/controller/failurerecovery/pod_termination_controller_test.go
+++ b/pkg/controller/failurerecovery/pod_termination_controller_test.go
@@ -120,7 +120,7 @@ func TestUpdateEventFilter(t *testing.T) {
 		"pod was already deleted": {
 			oldPod:     oldPod.Clone().DeletionTimestamp(now).Obj(),
 			newPod:     newPodToReconcile.Obj(),
-			wantResult: true,
+			wantResult: false,
 		},
 		"updated object is not annotated": {
 			oldPod: oldPod.Obj(),

--- a/test/integration/singlecluster/controller/failurerecovery/pod_termination_controller_test.go
+++ b/test/integration/singlecluster/controller/failurerecovery/pod_termination_controller_test.go
@@ -61,7 +61,7 @@ var _ = ginkgo.Describe("Pod termination controller", ginkgo.Ordered, ginkgo.Con
 			Annotation(constants.SafeToForcefullyDeleteAnnotationKey, constants.SafeToForcefullyDeleteAnnotationValue)
 	})
 
-	ginkgo.It("forcefully terminates pods that opt-in, scheduled on unreachable nodes", func() {
+	ginkgo.It("should forcefully terminate pods that opt-in, scheduled on unreachable nodes", func() {
 		matchingPod := matchingPodWrapper.Clone().Obj()
 		util.MustCreate(ctx, k8sClient, matchingPod)
 		gomega.Expect(k8sClient.Delete(ctx, matchingPod)).To(gomega.Succeed())
@@ -72,7 +72,7 @@ var _ = ginkgo.Describe("Pod termination controller", ginkgo.Ordered, ginkgo.Con
 		}, forcefulTerminationCheckTimeout, util.Interval).Should(gomega.Succeed())
 	})
 
-	ginkgo.It("triggers reconciliation when the node becomes unreachable", func() {
+	ginkgo.It("should trigger reconciliation when the node becomes unreachable", func() {
 		var pod *corev1.Pod
 		ginkgo.By("creating the pod on a reachable node", func() {
 			pod = matchingPodWrapper.Clone().NodeName(reachableNodeName).Obj()
@@ -105,7 +105,7 @@ var _ = ginkgo.Describe("Pod termination controller", ginkgo.Ordered, ginkgo.Con
 		})
 	})
 
-	ginkgo.It("does not forcefully terminate matching pods that did not opt-in or are running on healthy nodes", func() {
+	ginkgo.It("should not forcefully terminate matching pods that did not opt-in or are running on healthy nodes", func() {
 		nonMatchingPod := matchingPodWrapper.
 			Clone().
 			Name("non-matching-pod").

--- a/test/integration/singlecluster/controller/failurerecovery/pod_termination_controller_test.go
+++ b/test/integration/singlecluster/controller/failurerecovery/pod_termination_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package failurerecovery
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -40,21 +39,17 @@ var _ = ginkgo.Describe("Pod termination controller", func() {
 	var ns *corev1.Namespace
 	var matchingPodWrapper *testingpod.PodWrapper
 
-	namespacedNodeName := func(nodeName string) string {
-		return fmt.Sprintf("%s-%s", ns.Name, nodeName)
-	}
+	matchingPodWrapper = testingpod.MakePod("matching-pod", ns.Name).
+		StatusPhase(corev1.PodPending).
+		TerminationGracePeriod(1).
+		Annotation(constants.SafeToForcefullyDeleteAnnotationKey, constants.SafeToForcefullyDeleteAnnotationValue)
 
 	ginkgo.BeforeEach(func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "pod-fr-namespace-")
-
-		matchingPodWrapper = testingpod.MakePod("matching-pod", ns.Name).
-			StatusPhase(corev1.PodPending).
-			TerminationGracePeriod(1).
-			Annotation(constants.SafeToForcefullyDeleteAnnotationKey, constants.SafeToForcefullyDeleteAnnotationValue)
 	})
 
 	ginkgo.It("should forcefully terminate pods that opt-in, scheduled on unreachable nodes", func() {
-		unreachableNode := testingnode.MakeNode(namespacedNodeName("unreachable-node")).
+		unreachableNode := testingnode.MakeNode("unreachable-node").
 			NotReady().
 			Taints(corev1.Taint{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule}).
 			Obj()
@@ -74,7 +69,7 @@ var _ = ginkgo.Describe("Pod termination controller", func() {
 	})
 
 	ginkgo.It("should trigger reconciliation when the node becomes unreachable", func() {
-		thrashingNode := testingnode.MakeNode(namespacedNodeName("thrashing-node")).
+		thrashingNode := testingnode.MakeNode("thrashing-node").
 			Ready().
 			Obj()
 		util.MustCreate(ctx, k8sClient, thrashingNode)
@@ -110,7 +105,7 @@ var _ = ginkgo.Describe("Pod termination controller", func() {
 		})
 	})
 	ginkgo.It("should trigger reconciliation when the node becomes unreachable", func() {
-		thrashingNode := testingnode.MakeNode(namespacedNodeName("thrashing-node")).
+		thrashingNode := testingnode.MakeNode("thrashing-node").
 			Ready().
 			Obj()
 		util.MustCreate(ctx, k8sClient, thrashingNode)
@@ -147,7 +142,7 @@ var _ = ginkgo.Describe("Pod termination controller", func() {
 	})
 
 	ginkgo.It("should not forcefully terminate matching pods that did not opt-in or are running on healthy nodes", func() {
-		unhealthyNode := testingnode.MakeNode(namespacedNodeName("unhealthy-node")).
+		unhealthyNode := testingnode.MakeNode("unhealthy-node").
 			NotReady().
 			Taints(corev1.Taint{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule}).
 			Obj()
@@ -164,7 +159,7 @@ var _ = ginkgo.Describe("Pod termination controller", func() {
 		util.MustCreate(ctx, k8sClient, nonMatchingPod)
 		gomega.Expect(k8sClient.Delete(ctx, nonMatchingPod)).To(gomega.Succeed())
 
-		healthyNode := testingnode.MakeNode(namespacedNodeName("healthy-node")).
+		healthyNode := testingnode.MakeNode("healthy-node").
 			Ready().
 			Obj()
 		util.MustCreate(ctx, k8sClient, healthyNode)

--- a/test/integration/singlecluster/controller/failurerecovery/pod_termination_controller_test.go
+++ b/test/integration/singlecluster/controller/failurerecovery/pod_termination_controller_test.go
@@ -37,15 +37,16 @@ const (
 
 var _ = ginkgo.Describe("Pod termination controller", func() {
 	var ns *corev1.Namespace
-	var matchingPodWrapper *testingpod.PodWrapper
 
-	matchingPodWrapper = testingpod.MakePod("matching-pod", ns.Name).
-		StatusPhase(corev1.PodPending).
-		TerminationGracePeriod(1).
-		Annotation(constants.SafeToForcefullyDeleteAnnotationKey, constants.SafeToForcefullyDeleteAnnotationValue)
+	var matchingPodWrapper *testingpod.PodWrapper
 
 	ginkgo.BeforeEach(func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "pod-fr-namespace-")
+
+		matchingPodWrapper = testingpod.MakePod("matching-pod", ns.Name).
+			StatusPhase(corev1.PodPending).
+			TerminationGracePeriod(1).
+			Annotation(constants.SafeToForcefullyDeleteAnnotationKey, constants.SafeToForcefullyDeleteAnnotationValue)
 	})
 
 	ginkgo.It("should forcefully terminate pods that opt-in, scheduled on unreachable nodes", func() {

--- a/test/integration/singlecluster/controller/failurerecovery/pod_termination_controller_test.go
+++ b/test/integration/singlecluster/controller/failurerecovery/pod_termination_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package failurerecovery
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -35,11 +36,15 @@ const (
 	forcefulTerminationCheckTimeout = 2 * time.Second
 )
 
-var _ = ginkgo.Describe("Pod termination controller", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("Pod termination controller", func() {
 	var ns *corev1.Namespace
 	var matchingPodWrapper *testingpod.PodWrapper
 
-	ginkgo.BeforeAll(func() {
+	namespacedNodeName := func(nodeName string) string {
+		return fmt.Sprintf("%s-%s", ns.Name, nodeName)
+	}
+
+	ginkgo.BeforeEach(func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "pod-fr-namespace-")
 
 		matchingPodWrapper = testingpod.MakePod("matching-pod", ns.Name).
@@ -49,7 +54,7 @@ var _ = ginkgo.Describe("Pod termination controller", ginkgo.Ordered, ginkgo.Con
 	})
 
 	ginkgo.It("should forcefully terminate pods that opt-in, scheduled on unreachable nodes", func() {
-		unreachableNode := testingnode.MakeNode("unreachable-node").
+		unreachableNode := testingnode.MakeNode(namespacedNodeName("unreachable-node")).
 			NotReady().
 			Taints(corev1.Taint{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule}).
 			Obj()
@@ -69,7 +74,43 @@ var _ = ginkgo.Describe("Pod termination controller", ginkgo.Ordered, ginkgo.Con
 	})
 
 	ginkgo.It("should trigger reconciliation when the node becomes unreachable", func() {
-		thrashingNode := testingnode.MakeNode("thrashing-node").
+		thrashingNode := testingnode.MakeNode(namespacedNodeName("thrashing-node")).
+			Ready().
+			Obj()
+		util.MustCreate(ctx, k8sClient, thrashingNode)
+		ginkgo.DeferCleanup(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, thrashingNode, true)
+		})
+
+		var pod *corev1.Pod
+
+		ginkgo.By("creating the pod on a reachable node", func() {
+			pod = matchingPodWrapper.Clone().NodeName(thrashingNode.Name).Obj()
+			util.MustCreate(ctx, k8sClient, pod)
+		})
+
+		ginkgo.By("marking the pod for deletion and verifying that it's not forcefully terminated", func() {
+			gomega.Expect(k8sClient.Delete(ctx, pod)).To(gomega.Succeed())
+			gomega.Consistently(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, pod)).To(gomega.Succeed())
+			}, forcefulTerminationCheckTimeout, util.ShortInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("tainting the previously reachable node as unreachable", func() {
+			gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: thrashingNode.Name}, thrashingNode)).To(gomega.Succeed())
+			thrashingNode.Spec.Taints = append(thrashingNode.Spec.Taints, corev1.Taint{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule})
+			gomega.Expect(k8sClient.Update(ctx, thrashingNode)).To(gomega.Succeed())
+		})
+
+		ginkgo.By("verifying that the pod is forcefully terminated after the timeout elapses", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, pod)).
+					To(utiltesting.BeNotFoundError())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+	ginkgo.It("should trigger reconciliation when the node becomes unreachable", func() {
+		thrashingNode := testingnode.MakeNode(namespacedNodeName("thrashing-node")).
 			Ready().
 			Obj()
 		util.MustCreate(ctx, k8sClient, thrashingNode)
@@ -106,7 +147,7 @@ var _ = ginkgo.Describe("Pod termination controller", ginkgo.Ordered, ginkgo.Con
 	})
 
 	ginkgo.It("should not forcefully terminate matching pods that did not opt-in or are running on healthy nodes", func() {
-		unhealthyNode := testingnode.MakeNode("unhealthy-node").
+		unhealthyNode := testingnode.MakeNode(namespacedNodeName("unhealthy-node")).
 			NotReady().
 			Taints(corev1.Taint{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule}).
 			Obj()
@@ -123,7 +164,7 @@ var _ = ginkgo.Describe("Pod termination controller", ginkgo.Ordered, ginkgo.Con
 		util.MustCreate(ctx, k8sClient, nonMatchingPod)
 		gomega.Expect(k8sClient.Delete(ctx, nonMatchingPod)).To(gomega.Succeed())
 
-		healthyNode := testingnode.MakeNode("healthy-node").
+		healthyNode := testingnode.MakeNode(namespacedNodeName("healthy-node")).
 			Ready().
 			Obj()
 		util.MustCreate(ctx, k8sClient, healthyNode)

--- a/test/integration/singlecluster/controller/failurerecovery/pod_termination_controller_test.go
+++ b/test/integration/singlecluster/controller/failurerecovery/pod_termination_controller_test.go
@@ -142,6 +142,44 @@ var _ = ginkgo.Describe("Pod termination controller", func() {
 		})
 	})
 
+	ginkgo.It("should resume forceful termination if the controller restarts", func() {
+		node := testingnode.MakeNode("restart-node").
+			Ready().
+			Obj()
+		util.MustCreate(ctx, k8sClient, node)
+		ginkgo.DeferCleanup(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, node, true)
+		})
+
+		pod := matchingPodWrapper.Clone().NodeName(node.Name).Obj()
+		util.MustCreate(ctx, k8sClient, pod)
+
+		ginkgo.By("stopping the controller manager", func() {
+			fwk.StopManager(ctx)
+		})
+
+		ginkgo.By("mutating state while the controller is down", func() {
+			// Mark pod for deletion (it will hang because there's no Kubelet)
+			gomega.Expect(k8sClient.Delete(ctx, pod)).To(gomega.Succeed())
+
+			// Taint the node as unreachable
+			gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, node)).To(gomega.Succeed())
+			node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule})
+			gomega.Expect(k8sClient.Update(ctx, node)).To(gomega.Succeed())
+		})
+
+		ginkgo.By("restarting the controller manager", func() {
+			fwk.StartManager(ctx, cfg, managerSetup)
+		})
+
+		ginkgo.By("verifying the pod is forcefully terminated upon restart", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, pod)).
+					To(utiltesting.BeNotFoundError())
+			}, forcefulTerminationCheckTimeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
 	ginkgo.It("should not forcefully terminate matching pods that did not opt-in or are running on healthy nodes", func() {
 		unhealthyNode := testingnode.MakeNode("unhealthy-node").
 			NotReady().

--- a/test/integration/singlecluster/controller/failurerecovery/pod_termination_controller_test.go
+++ b/test/integration/singlecluster/controller/failurerecovery/pod_termination_controller_test.go
@@ -72,6 +72,39 @@ var _ = ginkgo.Describe("Pod termination controller", ginkgo.Ordered, ginkgo.Con
 		}, forcefulTerminationCheckTimeout, util.Interval).Should(gomega.Succeed())
 	})
 
+	ginkgo.It("triggers reconciliation when the node becomes unreachable", func() {
+		var pod *corev1.Pod
+		ginkgo.By("creating the pod on a reachable node", func() {
+			pod = matchingPodWrapper.Clone().NodeName(reachableNodeName).Obj()
+			util.MustCreate(ctx, k8sClient, pod)
+		})
+		ginkgo.By("marking the pod for deletion and verifying that it's not forcefully terminated", func() {
+			gomega.Expect(k8sClient.Delete(ctx, pod)).To(gomega.Succeed())
+			gomega.Consistently(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, pod)).To(gomega.Succeed())
+			}, forcefulTerminationCheckTimeout, util.ShortInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("tainting the previously reachable node as unreachable", func() {
+			node := &corev1.Node{}
+			gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: reachableNodeName}, node)).To(gomega.Succeed())
+			node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule})
+			gomega.Expect(k8sClient.Update(ctx, node)).To(gomega.Succeed())
+		})
+		ginkgo.By("verifying that the pod is forcefully terminated after the timeout elapses", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, pod)).
+					To(utiltesting.BeNotFoundError())
+			}, forcefulTerminationCheckTimeout, util.Interval).Should(gomega.Succeed())
+		})
+		ginkgo.By("removing the unreachable taint from the node", func() {
+			node := &corev1.Node{}
+			gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: reachableNodeName}, node)).To(gomega.Succeed())
+			node.Spec.Taints = nil
+			gomega.Expect(k8sClient.Update(ctx, node)).To(gomega.Succeed())
+		})
+	})
+
 	ginkgo.It("does not forcefully terminate matching pods that did not opt-in or are running on healthy nodes", func() {
 		nonMatchingPod := matchingPodWrapper.
 			Clone().

--- a/test/integration/singlecluster/controller/failurerecovery/pod_termination_controller_test.go
+++ b/test/integration/singlecluster/controller/failurerecovery/pod_termination_controller_test.go
@@ -32,8 +32,6 @@ import (
 )
 
 const (
-	unreachableNodeName             = "unreachable-node"
-	reachableNodeName               = "reachable-node"
 	forcefulTerminationCheckTimeout = 2 * time.Second
 )
 
@@ -43,26 +41,24 @@ var _ = ginkgo.Describe("Pod termination controller", ginkgo.Ordered, ginkgo.Con
 
 	ginkgo.BeforeAll(func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "pod-fr-namespace-")
-		nodes := []corev1.Node{
-			*testingnode.MakeNode(unreachableNodeName).
-				NotReady().
-				Taints(corev1.Taint{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule}).
-				Obj(),
-			*testingnode.MakeNode(reachableNodeName).
-				Ready().
-				Obj(),
-		}
-		util.CreateNodesWithStatus(ctx, k8sClient, nodes)
 
 		matchingPodWrapper = testingpod.MakePod("matching-pod", ns.Name).
 			StatusPhase(corev1.PodPending).
 			TerminationGracePeriod(1).
-			NodeName(unreachableNodeName).
 			Annotation(constants.SafeToForcefullyDeleteAnnotationKey, constants.SafeToForcefullyDeleteAnnotationValue)
 	})
 
 	ginkgo.It("should forcefully terminate pods that opt-in, scheduled on unreachable nodes", func() {
-		matchingPod := matchingPodWrapper.Clone().Obj()
+		unreachableNode := testingnode.MakeNode("unreachable-node").
+			NotReady().
+			Taints(corev1.Taint{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule}).
+			Obj()
+		util.MustCreate(ctx, k8sClient, unreachableNode)
+		ginkgo.DeferCleanup(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, unreachableNode, true)
+		})
+
+		matchingPod := matchingPodWrapper.Clone().NodeName(unreachableNode.Name).Obj()
 		util.MustCreate(ctx, k8sClient, matchingPod)
 		gomega.Expect(k8sClient.Delete(ctx, matchingPod)).To(gomega.Succeed())
 
@@ -73,11 +69,21 @@ var _ = ginkgo.Describe("Pod termination controller", ginkgo.Ordered, ginkgo.Con
 	})
 
 	ginkgo.It("should trigger reconciliation when the node becomes unreachable", func() {
+		thrashingNode := testingnode.MakeNode("thrashing-node").
+			Ready().
+			Obj()
+		util.MustCreate(ctx, k8sClient, thrashingNode)
+		ginkgo.DeferCleanup(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, thrashingNode, true)
+		})
+
 		var pod *corev1.Pod
+
 		ginkgo.By("creating the pod on a reachable node", func() {
-			pod = matchingPodWrapper.Clone().NodeName(reachableNodeName).Obj()
+			pod = matchingPodWrapper.Clone().NodeName(thrashingNode.Name).Obj()
 			util.MustCreate(ctx, k8sClient, pod)
 		})
+
 		ginkgo.By("marking the pod for deletion and verifying that it's not forcefully terminated", func() {
 			gomega.Expect(k8sClient.Delete(ctx, pod)).To(gomega.Succeed())
 			gomega.Consistently(func(g gomega.Gomega) {
@@ -86,35 +92,45 @@ var _ = ginkgo.Describe("Pod termination controller", ginkgo.Ordered, ginkgo.Con
 		})
 
 		ginkgo.By("tainting the previously reachable node as unreachable", func() {
-			node := &corev1.Node{}
-			gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: reachableNodeName}, node)).To(gomega.Succeed())
-			node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule})
-			gomega.Expect(k8sClient.Update(ctx, node)).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: thrashingNode.Name}, thrashingNode)).To(gomega.Succeed())
+			thrashingNode.Spec.Taints = append(thrashingNode.Spec.Taints, corev1.Taint{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule})
+			gomega.Expect(k8sClient.Update(ctx, thrashingNode)).To(gomega.Succeed())
 		})
+
 		ginkgo.By("verifying that the pod is forcefully terminated after the timeout elapses", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, pod)).
 					To(utiltesting.BeNotFoundError())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
-		ginkgo.By("removing the unreachable taint from the node", func() {
-			node := &corev1.Node{}
-			gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: reachableNodeName}, node)).To(gomega.Succeed())
-			node.Spec.Taints = nil
-			gomega.Expect(k8sClient.Update(ctx, node)).To(gomega.Succeed())
-		})
 	})
 
 	ginkgo.It("should not forcefully terminate matching pods that did not opt-in or are running on healthy nodes", func() {
+		unhealthyNode := testingnode.MakeNode("unhealthy-node").
+			NotReady().
+			Taints(corev1.Taint{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule}).
+			Obj()
+		util.MustCreate(ctx, k8sClient, unhealthyNode)
+		ginkgo.DeferCleanup(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, unhealthyNode, true)
+		})
 		nonMatchingPod := matchingPodWrapper.
 			Clone().
 			Name("non-matching-pod").
+			NodeName(unhealthyNode.Name).
 			Annotation(constants.SafeToForcefullyDeleteAnnotationKey, "false").
 			Obj()
 		util.MustCreate(ctx, k8sClient, nonMatchingPod)
 		gomega.Expect(k8sClient.Delete(ctx, nonMatchingPod)).To(gomega.Succeed())
 
-		podOnHealthyNode := matchingPodWrapper.Clone().Name("healthy-pod").NodeName(reachableNodeName).Obj()
+		healthyNode := testingnode.MakeNode("healthy-node").
+			Ready().
+			Obj()
+		util.MustCreate(ctx, k8sClient, healthyNode)
+		ginkgo.DeferCleanup(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, healthyNode, true)
+		})
+		podOnHealthyNode := matchingPodWrapper.Clone().Name("healthy-pod").NodeName(healthyNode.Name).Obj()
 		util.MustCreate(ctx, k8sClient, podOnHealthyNode)
 		gomega.Expect(k8sClient.Delete(ctx, podOnHealthyNode)).To(gomega.Succeed())
 

--- a/test/integration/singlecluster/controller/failurerecovery/pod_termination_controller_test.go
+++ b/test/integration/singlecluster/controller/failurerecovery/pod_termination_controller_test.go
@@ -95,7 +95,7 @@ var _ = ginkgo.Describe("Pod termination controller", ginkgo.Ordered, ginkgo.Con
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, pod)).
 					To(utiltesting.BeNotFoundError())
-			}, forcefulTerminationCheckTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 		ginkgo.By("removing the unreachable taint from the node", func() {
 			node := &corev1.Node{}

--- a/test/integration/singlecluster/controller/failurerecovery/suite_test.go
+++ b/test/integration/singlecluster/controller/failurerecovery/suite_test.go
@@ -30,6 +30,7 @@ import (
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/failurerecovery"
+	"sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
 	"sigs.k8s.io/kueue/test/util"
@@ -66,14 +67,17 @@ var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Repo
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
-func managerSetup(_ context.Context, mgr manager.Manager) {
+func managerSetup(ctx context.Context, mgr manager.Manager) {
+	err := indexer.SetupIndexes(ctx, mgr.GetFieldIndexer())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 	terminatingPodReconciler := failurerecovery.NewTerminatingPodReconciler(
 		mgr.GetClient(),
 		mgr.GetEventRecorderFor(constants.PodTerminationControllerName),
 		failurerecovery.WithForcefulTerminationGracePeriod(time.Millisecond),
 	)
 
-	_, err := terminatingPodReconciler.SetupWithManager(mgr, &configapi.Configuration{})
+	_, err = terminatingPodReconciler.SetupWithManager(mgr, &configapi.Configuration{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	failedWebhook, err := webhooks.Setup(mgr, nil)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
If the node is not tainted at the moment the timeout elapses, the pod won't be forcefully terminated and the reconcile will never be queued again, leading to the pod being stuck.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
FailureRecoveryPolicy: Fixed an issue where pods could remain stuck terminating if their node became unreachable only after the force-termination timeout had already elapsed.
```