### PR TITLE
TAS: Handle cordoned nodes as immediate failures for workload replacement

### DIFF
--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -145,6 +145,21 @@ func (r *nodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		readyCondition = utiltas.GetNodeCondition(&node, corev1.NodeReady)
 	}
 
+	// Cordoned (Unschedulable) — mark unhealthy immediately.
+	if nodeExists && node.Spec.Unschedulable {
+		log.V(3).Info("Node is cordoned (Unschedulable), marking as failed")
+		nodeSelectorPodsByWorkload, err := r.listPodsAssignedByNodeSelector(ctx, req.Name)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		affectedWorkloads, err := r.getWorkloadsOnNode(ctx, req.Name, nodeSelectorPodsByWorkload)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		_, err = r.handleUnhealthyNode(ctx, req.Name, affectedWorkloads)
+		return ctrl.Result{}, err
+	}
+
 	var timerExpired bool
 	if readyCondition != nil && readyCondition.Status != corev1.ConditionTrue {
 		timeSinceNotReady := r.clock.Now().Sub(readyCondition.LastTransitionTime.Time)
@@ -212,6 +227,11 @@ func (r *nodeReconciler) Update(e event.TypedUpdateEvent[*corev1.Node]) bool {
 	oldReady := utiltas.IsNodeStatusConditionTrue(e.ObjectOld.Status.Conditions, corev1.NodeReady)
 	if oldReady != newReady {
 		r.logger().V(4).Info("Node Ready status changed, triggering reconcile", "node", klog.KObj(e.ObjectNew), "oldReady", oldReady, "newReady", newReady)
+		return true
+	}
+	// Also trigger when node is cordoned/uncordoned.
+	if e.ObjectOld.Spec.Unschedulable != e.ObjectNew.Spec.Unschedulable {
+		r.logger().V(4).Info("Node Unschedulable changed, triggering reconcile", "node", klog.KObj(e.ObjectNew), "unschedulable", e.ObjectNew.Spec.Unschedulable)
 		return true
 	}
 	if features.Enabled(features.TASReplaceNodeOnNodeTaints) && !equality.Semantic.DeepEqual(e.ObjectOld.Spec.Taints, e.ObjectNew.Spec.Taints) {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area tas

#### What this PR does / why we need it:

This PR enhances TAS node failure handling to immediately mark cordoned (unschedulable) nodes as failed, triggering workload replacement without waiting for the `NodeFailureDelay` timer.

Changes:
- add an early check for `node.Spec.Unschedulable` before the not-ready timer logic. When a node is cordoned, it is immediately treated as unhealthy and affected workloads are handled right away.

Previously, cordoning a node would only be detected if the node also became not-ready, and even then it would be subject to the `NodeFailureDelay` wait. With this change, cordoned nodes are handled as an explicit, immediate failure signal.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

The unschedulable check is placed before the not-ready timer block so that a cordoned-but-not-ready node doesn't unnecessarily wait for the delay to expire.

Let me know if you think this feature is ok to go or need more discussion — I will add tests and documentation after proposal accepted.

#### Does this PR introduce a user-facing change?

```release-note
TAS: Immediately mark cordoned (unschedulable) nodes as failed and trigger workload replacement without waiting for NodeFailureDelay.
```