### PR TITLE
add aggregate-to-view label to read-only cluster roles

### DIFF
--- a/charts/kueue/templates/rbac/clusterqueue_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/clusterqueue_viewer_role.yaml
@@ -23,6 +23,9 @@ metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - kueue.x-k8s.io

--- a/charts/kueue/templates/rbac/cohort_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/cohort_viewer_role.yaml
@@ -23,6 +23,9 @@ metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - kueue.x-k8s.io

--- a/charts/kueue/templates/rbac/jaxjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/jaxjob_viewer_role.yaml
@@ -24,6 +24,9 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - kubeflow.org

--- a/charts/kueue/templates/rbac/job_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/job_viewer_role.yaml
@@ -24,6 +24,9 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - batch

--- a/charts/kueue/templates/rbac/jobset_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/jobset_viewer_role.yaml
@@ -24,6 +24,9 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - jobset.x-k8s.io

--- a/charts/kueue/templates/rbac/leaderworkerset_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/leaderworkerset_viewer_role.yaml
@@ -24,6 +24,9 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - leaderworkerset.x-k8s.io

--- a/charts/kueue/templates/rbac/localqueue_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/localqueue_viewer_role.yaml
@@ -24,6 +24,9 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - kueue.x-k8s.io

--- a/charts/kueue/templates/rbac/mpijob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/mpijob_viewer_role.yaml
@@ -24,6 +24,9 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - kubeflow.org

--- a/charts/kueue/templates/rbac/paddlejob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/paddlejob_viewer_role.yaml
@@ -24,6 +24,9 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - kubeflow.org

--- a/charts/kueue/templates/rbac/pending_workloads_cq_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/pending_workloads_cq_viewer_role.yaml
@@ -23,6 +23,9 @@ metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - visibility.kueue.x-k8s.io

--- a/charts/kueue/templates/rbac/pending_workloads_lq_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/pending_workloads_lq_viewer_role.yaml
@@ -24,6 +24,9 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - visibility.kueue.x-k8s.io

--- a/charts/kueue/templates/rbac/pytorchjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/pytorchjob_viewer_role.yaml
@@ -24,6 +24,9 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - kubeflow.org

--- a/charts/kueue/templates/rbac/raycluster_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/raycluster_viewer_role.yaml
@@ -23,6 +23,9 @@ metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - ray.io

--- a/charts/kueue/templates/rbac/rayjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/rayjob_viewer_role.yaml
@@ -24,6 +24,9 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - ray.io

--- a/charts/kueue/templates/rbac/rayservice_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/rayservice_viewer_role.yaml
@@ -23,6 +23,9 @@ metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - ray.io

--- a/charts/kueue/templates/rbac/resourceflavor_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/resourceflavor_viewer_role.yaml
@@ -23,6 +23,9 @@ metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - kueue.x-k8s.io

--- a/charts/kueue/templates/rbac/sparkapplication_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/sparkapplication_viewer_role.yaml
@@ -24,6 +24,9 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - sparkoperator.k8s.io

--- a/charts/kueue/templates/rbac/tfjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/tfjob_viewer_role.yaml
@@ -24,6 +24,9 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - kubeflow.org

--- a/charts/kueue/templates/rbac/topology_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/topology_viewer_role.yaml
@@ -23,6 +23,9 @@ metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - kueue.x-k8s.io

--- a/charts/kueue/templates/rbac/trainjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/trainjob_viewer_role.yaml
@@ -24,6 +24,9 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - trainer.kubeflow.org

--- a/charts/kueue/templates/rbac/workload_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/workload_viewer_role.yaml
@@ -24,6 +24,9 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - kueue.x-k8s.io

--- a/charts/kueue/templates/rbac/xgboostjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/xgboostjob_viewer_role.yaml
@@ -24,6 +24,9 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - kubeflow.org

--- a/config/components/rbac/clusterqueue_viewer_role.yaml
+++ b/config/components/rbac/clusterqueue_viewer_role.yaml
@@ -5,6 +5,9 @@ metadata:
   name: clusterqueue-viewer-role
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - kueue.x-k8s.io

--- a/config/components/rbac/cohort_viewer_role.yaml
+++ b/config/components/rbac/cohort_viewer_role.yaml
@@ -5,6 +5,9 @@ metadata:
   name: cohort-viewer-role
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - kueue.x-k8s.io

--- a/config/components/rbac/jaxjob_viewer_role.yaml
+++ b/config/components/rbac/jaxjob_viewer_role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - kubeflow.org

--- a/config/components/rbac/job_viewer_role.yaml
+++ b/config/components/rbac/job_viewer_role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - batch

--- a/config/components/rbac/jobset_viewer_role.yaml
+++ b/config/components/rbac/jobset_viewer_role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - jobset.x-k8s.io

--- a/config/components/rbac/leaderworkerset_viewer_role.yaml
+++ b/config/components/rbac/leaderworkerset_viewer_role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - leaderworkerset.x-k8s.io

--- a/config/components/rbac/localqueue_viewer_role.yaml
+++ b/config/components/rbac/localqueue_viewer_role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - kueue.x-k8s.io

--- a/config/components/rbac/mpijob_viewer_role.yaml
+++ b/config/components/rbac/mpijob_viewer_role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - kubeflow.org

--- a/config/components/rbac/paddlejob_viewer_role.yaml
+++ b/config/components/rbac/paddlejob_viewer_role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - kubeflow.org

--- a/config/components/rbac/pending_workloads_cq_viewer_role.yaml
+++ b/config/components/rbac/pending_workloads_cq_viewer_role.yaml
@@ -5,6 +5,9 @@ metadata:
   name: pending-workloads-cq-viewer-role
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - visibility.kueue.x-k8s.io

--- a/config/components/rbac/pending_workloads_lq_viewer_role.yaml
+++ b/config/components/rbac/pending_workloads_lq_viewer_role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - visibility.kueue.x-k8s.io

--- a/config/components/rbac/pytorchjob_viewer_role.yaml
+++ b/config/components/rbac/pytorchjob_viewer_role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - kubeflow.org

--- a/config/components/rbac/raycluster_viewer_role.yaml
+++ b/config/components/rbac/raycluster_viewer_role.yaml
@@ -5,6 +5,9 @@ metadata:
   name: raycluster-viewer-role
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - ray.io

--- a/config/components/rbac/rayjob_viewer_role.yaml
+++ b/config/components/rbac/rayjob_viewer_role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - ray.io

--- a/config/components/rbac/rayservice_viewer_role.yaml
+++ b/config/components/rbac/rayservice_viewer_role.yaml
@@ -5,6 +5,9 @@ metadata:
   name: rayservice-viewer-role
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - ray.io

--- a/config/components/rbac/resourceflavor_viewer_role.yaml
+++ b/config/components/rbac/resourceflavor_viewer_role.yaml
@@ -5,6 +5,9 @@ metadata:
   name: resourceflavor-viewer-role
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - kueue.x-k8s.io

--- a/config/components/rbac/sparkapplication_viewer_role.yaml
+++ b/config/components/rbac/sparkapplication_viewer_role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - sparkoperator.k8s.io

--- a/config/components/rbac/tfjob_viewer_role.yaml
+++ b/config/components/rbac/tfjob_viewer_role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - kubeflow.org

--- a/config/components/rbac/topology_viewer_role.yaml
+++ b/config/components/rbac/topology_viewer_role.yaml
@@ -4,6 +4,9 @@ metadata:
   name: topology-viewer-role
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - kueue.x-k8s.io

--- a/config/components/rbac/trainjob_viewer_role.yaml
+++ b/config/components/rbac/trainjob_viewer_role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - trainer.kubeflow.org

--- a/config/components/rbac/workload_viewer_role.yaml
+++ b/config/components/rbac/workload_viewer_role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - kueue.x-k8s.io

--- a/config/components/rbac/xgboostjob_viewer_role.yaml
+++ b/config/components/rbac/xgboostjob_viewer_role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - kubeflow.org


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup 
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Add 
- `rbac.authorization.k8s.io/aggregate-to-view: "true"`
- `rbac.authorization.k8s.io/aggregate-to-admin: "true"`
- `rbac.authorization.k8s.io/aggregate-to-edit: "true"` 

labels to Kueue ClusterRoles. This allows Kueue CRDs read-only permissions to be aggregated to the default k8s `view`, `admin`, and `edit` roles that's provided with each k8s release.

Getting access for Kueue CRDs is out of band vs just aggregating it to the existing view only k8s role that comes with each k8s release: https://github.com/kubernetes/kubernetes/blob/v1.35.3/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L1428

You can also see other sig projects with similar practices: https://github.com/kubernetes-sigs/metrics-server/blob/master/charts/metrics-server/templates/clusterrole-aggregated-reader.yaml

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10481

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Aggregate Kueue CRD read-only clusterRoles to k8s default view clusterRole
```