### PR TITLE
docs: add details related to spark application integration (#10483)

### DIFF
--- a/site/content/en/docs/tasks/run/kubeflow/sparkapplications.md
+++ b/site/content/en/docs/tasks/run/kubeflow/sparkapplications.md
@@ -8,23 +8,26 @@ description: >
 
 {{< feature-state state="alpha" for_version="v0.17" >}}
 
-{{% alert title="Note" color="primary" %}}
-`SparkApplicationIntegration` is currently an alpha feature and is disabled by default.
-
-You can enable it by editing the `SparkApplicationIntegration` feature gate. Check the [Installation](/docs/installation/#change-the-feature-gates-configuration) guide for details on feature gate configuration.
-{{% /alert %}}
-
 This page shows how to leverage Kueue's scheduling and resource management capabilities when running [Spark Operator](https://github.com/kubeflow/spark-operator) SparkApplication.
 
 This guide is for [batch users](/docs/tasks#batch-user) that have a basic understanding of Kueue. For more information, see [Kueue's overview](/docs/overview).
 
+{{% alert title="Note" color="primary" %}}
+`SparkApplicationIntegration` is currently an alpha feature and is disabled by default.
+
+To enable it, the `SparkApplicationIntegration` feature gate needs to be activated, and `sparkoperator.k8s.io/sparkapplication` must be added as an allowed workload.
+
+{{% /alert %}}
+
 ## Before you begin
+
+Enable SparkApplication integration in Kueue. You can [modify Kueue configurations from installed releases](/docs/installation#install-a-custom-configured-released-version) to include `sparkoperator.k8s.io/sparkapplication` as an allowed workload.
+
+Enable the `SparkApplicationIntegration` feature gate. Check the [installation](/docs/installation/#change-the-feature-gates-configuration) guide for details on feature gate configuration.
 
 Check [administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) for details on the initial cluster setup.
 
 Check [the Spark Operator installation guide](https://www.kubeflow.org/docs/components/spark-operator/getting-started/#installation).
-
-You can [modify kueue configurations from installed releases](/docs/installation#install-a-custom-configured-released-version) to include SparkApplication as an allowed workload.
 
 {{% alert title="Note" color="primary" %}}
 In order to use SparkApplication integration, you must install [Spark Operator](https://github.com/kubeflow/spark-operator) [v2.4.0](https://github.com/kubeflow/spark-operator/releases/tag/v2.4.0) or above.


### PR DESCRIPTION
Mention that sparkoperator.k8s.io/sparkapplication must also be added to integrations.frameworks in the configmap named kueue-manager-config for the spark application integration to work properly.

#### What type of PR is this?

/kind documentation
/area integrations

#### What this PR does / why we need it:

The existing documentation is missing a prerequisites for spark integration to work properly.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-sigs/kueue/issues/10483

#### Special notes for your reviewer:

In the future, as the spark integration leaves the alpha state, it may be enabled by default, in which case we will probably want to revert this PR. Maybe there is a checklist somewhere where this action can be added so that we remember that the documentation should be removed once it becomes obsolete, to not confuse spark application queue users?

Also I'm not sure if documentation is considered a user-facing change ? For now, I'm assuming it's not, but if that's the case, is a release note required?

I changed only the english documentation, is there automated translation for other languages ?
#### Does this PR introduce a user-facing change?

```release-note
NONE
```