### PR TITLE
Fix Job and co-scheduling incompatibility after partial success on readmission 

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -52,6 +53,7 @@ import (
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/constants"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
@@ -583,6 +585,13 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, err
 		}
 		if workload.HasQuotaReservation(wl) {
+			// Delete any child gang indexed Jobs with stale CompletedIndexes so
+			// the parent controller (e.g., JobSet) recreates them with clean state
+			// on re-admission. Gated on HasQuotaReservation to avoid redundant
+			// List calls on subsequent reconciles after admission is cleared.
+			if err := r.deleteStaleGangChildJobs(ctx, object); err != nil {
+				return ctrl.Result{}, err
+			}
 			if !job.IsActive() {
 				log.V(6).Info("The job is no longer active, clear the workloads admission")
 				err := workload.PatchAdmissionStatus(ctx, r.client, wl, r.clock, func(wl *kueue.Workload) (bool, error) {
@@ -1770,4 +1779,60 @@ func mergeAnnotations(job GenericJob, customAnnotations map[string]string) (map[
 		}
 	}
 	return merged, changed
+}
+
+
+// hasStaleGangCompletions returns true if a gang indexed Job has stale
+// CompletedIndexes (Succeeded > 0 in a gang where parallelism == completions).
+func hasStaleGangCompletions(batchJob *batchv1.Job) bool {
+	parallelism := ptr.Deref(batchJob.Spec.Parallelism, 1)
+	if parallelism <= 1 {
+		// Single-pod Jobs (parallelism=1) are effectively complete when Succeeded=1,
+		// so the stale CompletedIndexes problem doesn't cause a gang deadlock.
+		return false
+	}
+	completions := ptr.Deref(batchJob.Spec.Completions, parallelism)
+	if parallelism != completions {
+		return false
+	}
+	if batchJob.Spec.CompletionMode == nil || *batchJob.Spec.CompletionMode != batchv1.IndexedCompletion {
+		return false
+	}
+	return batchJob.Status.Succeeded > 0
+}
+
+// deleteStaleGangChildJobs lists child batch Jobs of a parent object (e.g., JobSet)
+// and deletes any that have stale CompletedIndexes. The parent controller will
+// recreate them with clean state on re-admission. Uses foreground propagation to
+// ensure stale Succeeded pods are deleted before the Job object is removed,
+// preventing the k8s Job controller from re-adopting them on recreation.
+//
+// This runs for all GenericJob types during eviction. For non-parent types
+// (e.g., standalone batch/v1 Job), the List returns empty and is a no-op.
+// For parent types with children (JobSet, MPIJob, etc.), only gang indexed
+// child Jobs with Succeeded > 0 are deleted — non-gang and non-indexed
+// children are unaffected.
+func (r *JobReconciler) deleteStaleGangChildJobs(ctx context.Context, parent client.Object) error {
+	log := ctrl.LoggerFrom(ctx)
+	var childJobs batchv1.JobList
+	if err := r.client.List(ctx, &childJobs,
+		client.InNamespace(parent.GetNamespace()),
+		client.MatchingFields{indexer.OwnerReferenceUID: string(parent.GetUID())},
+	); err != nil {
+		return fmt.Errorf("listing child jobs for stale gang cleanup: %w", err)
+	}
+	for i := range childJobs.Items {
+		childJob := &childJobs.Items[i]
+		if hasStaleGangCompletions(childJob) {
+			log.V(2).Info("Deleting gang child Job with stale completedIndexes for clean recreation",
+				"job", klog.KObj(childJob),
+				"succeeded", childJob.Status.Succeeded,
+				"completedIndexes", childJob.Status.CompletedIndexes)
+			if err := r.client.Delete(ctx, childJob,
+				client.PropagationPolicy(metav1.DeletePropagationForeground)); client.IgnoreNotFound(err) != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/controller/jobframework/utils_test.go
+++ b/pkg/controller/jobframework/utils_test.go
@@ -17,12 +17,23 @@ limitations under the License.
 package jobframework
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 )
@@ -91,6 +102,199 @@ func TestSanitizePodSets(t *testing.T) {
 
 			if diff := cmp.Diff(tc.expectedPodSets, tc.podSets); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestHasStaleGangCompletions(t *testing.T) {
+	cases := map[string]struct {
+		job  *batchv1.Job
+		want bool
+	}{
+		"gang indexed, succeeded>0: stale": {
+			job: &batchv1.Job{
+				Spec: batchv1.JobSpec{
+					Parallelism:    ptr.To[int32](10),
+					Completions:    ptr.To[int32](10),
+					CompletionMode: ptr.To(batchv1.IndexedCompletion),
+				},
+				Status: batchv1.JobStatus{Succeeded: 2},
+			},
+			want: true,
+		},
+		"gang indexed, succeeded=0: not stale": {
+			job: &batchv1.Job{
+				Spec: batchv1.JobSpec{
+					Parallelism:    ptr.To[int32](10),
+					Completions:    ptr.To[int32](10),
+					CompletionMode: ptr.To(batchv1.IndexedCompletion),
+				},
+				Status: batchv1.JobStatus{Succeeded: 0},
+			},
+			want: false,
+		},
+		"non-gang (parallelism < completions): not stale": {
+			job: &batchv1.Job{
+				Spec: batchv1.JobSpec{
+					Parallelism:    ptr.To[int32](5),
+					Completions:    ptr.To[int32](100),
+					CompletionMode: ptr.To(batchv1.IndexedCompletion),
+				},
+				Status: batchv1.JobStatus{Succeeded: 50},
+			},
+			want: false,
+		},
+		"non-indexed gang: not stale": {
+			job: &batchv1.Job{
+				Spec: batchv1.JobSpec{
+					Parallelism: ptr.To[int32](10),
+					Completions: ptr.To[int32](10),
+				},
+				Status: batchv1.JobStatus{Succeeded: 2},
+			},
+			want: false,
+		},
+		"single pod: not stale": {
+			job: &batchv1.Job{
+				Spec: batchv1.JobSpec{
+					Parallelism:    ptr.To[int32](1),
+					Completions:    ptr.To[int32](1),
+					CompletionMode: ptr.To(batchv1.IndexedCompletion),
+				},
+				Status: batchv1.JobStatus{Succeeded: 1},
+			},
+			want: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := hasStaleGangCompletions(tc.job); got != tc.want {
+				t.Errorf("hasStaleGangCompletions() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func newFakeClientWithJobIndex(objs ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(&batchv1.Job{}).
+		WithIndex(&batchv1.Job{}, indexer.OwnerReferenceUID, indexer.IndexOwnerUID).
+		Build()
+}
+
+func TestDeleteStaleGangChildJobs(t *testing.T) {
+	parentUID := types.UID("parent-uid-123")
+	parent := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake-parent",
+			Namespace: "default",
+			UID:       parentUID,
+		},
+	}
+	ownerRef := []metav1.OwnerReference{{
+		APIVersion: "jobset.x-k8s.io/v1alpha2",
+		Kind:       "JobSet",
+		Name:       "fake-parent",
+		UID:        parentUID,
+		Controller: ptr.To(true),
+	}}
+
+	makeChildJob := func(name string, parallelism, completions, succeeded int32, indexed bool) *batchv1.Job {
+		job := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            name,
+				Namespace:       "default",
+				OwnerReferences: ownerRef,
+			},
+			Spec: batchv1.JobSpec{
+				Parallelism: ptr.To(parallelism),
+				Completions: ptr.To(completions),
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						RestartPolicy: corev1.RestartPolicyNever,
+						Containers:    []corev1.Container{{Name: "c", Image: "pause"}},
+					},
+				},
+			},
+		}
+		if indexed {
+			job.Spec.CompletionMode = ptr.To(batchv1.IndexedCompletion)
+		}
+		job.Status.Succeeded = succeeded
+		return job
+	}
+
+	cases := map[string]struct {
+		childJobs     []*batchv1.Job
+		wantRemaining []string
+	}{
+		"stale gang child deleted": {
+			childJobs:     []*batchv1.Job{makeChildJob("stale-job", 10, 10, 2, true)},
+			wantRemaining: nil,
+		},
+		"clean gang child not deleted": {
+			childJobs:     []*batchv1.Job{makeChildJob("clean-job", 10, 10, 0, true)},
+			wantRemaining: []string{"clean-job"},
+		},
+		"non-gang child not deleted": {
+			childJobs:     []*batchv1.Job{makeChildJob("batch-job", 5, 100, 50, true)},
+			wantRemaining: []string{"batch-job"},
+		},
+		"non-indexed child not deleted": {
+			childJobs:     []*batchv1.Job{makeChildJob("non-indexed", 10, 10, 2, false)},
+			wantRemaining: []string{"non-indexed"},
+		},
+		"mixed: only stale deleted": {
+			childJobs: []*batchv1.Job{
+				makeChildJob("stale-worker", 10, 10, 2, true),
+				makeChildJob("clean-worker", 10, 10, 0, true),
+			},
+			wantRemaining: []string{"clean-worker"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			objs := make([]client.Object, len(tc.childJobs))
+			for i, j := range tc.childJobs {
+				objs[i] = j
+			}
+			cl := newFakeClientWithJobIndex(objs...)
+			r := &JobReconciler{client: cl}
+
+			if err := r.deleteStaleGangChildJobs(ctx, parent); err != nil {
+				t.Fatalf("deleteStaleGangChildJobs() error: %v", err)
+			}
+
+			var remaining batchv1.JobList
+			if err := cl.List(ctx, &remaining, client.InNamespace("default")); err != nil {
+				t.Fatalf("List: %v", err)
+			}
+
+			gotSet := make(map[string]bool)
+			for _, j := range remaining.Items {
+				gotSet[j.Name] = true
+			}
+			wantSet := make(map[string]bool)
+			for _, n := range tc.wantRemaining {
+				wantSet[n] = true
+			}
+
+			for _, n := range tc.wantRemaining {
+				if !gotSet[n] {
+					t.Errorf("expected Job %q to remain, but it was deleted", n)
+				}
+			}
+			for n := range gotSet {
+				if !wantSet[n] {
+					t.Errorf("expected Job %q to be deleted, but it remains", n)
+				}
 			}
 		})
 	}

--- a/test/integration/singlecluster/controller/jobs/jobset/jobset_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/jobset/jobset_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1133,6 +1134,132 @@ var _ = ginkgo.Describe("JobSet controller interacting with scheduler", ginkgo.L
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 2)
+		})
+	})
+
+	ginkgo.It("Should delete gang child Job with stale completedIndexes on eviction", framework.SlowSpec, func() {
+		ginkgo.By("creating localQueue")
+		localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+		util.MustCreate(ctx, k8sClient, localQueue)
+
+		jobSet := testingjobset.MakeJobSet(jobSetName, ns.Name).ReplicatedJobs(
+			testingjobset.ReplicatedJobRequirements{
+				Name:        "worker",
+				Replicas:    1,
+				Parallelism: 10,
+				Completions: 10,
+			},
+		).Queue(localQueue.Name).
+			Request("worker", corev1.ResourceCPU, "100m").
+			Obj()
+
+		createdWorkload := &kueue.Workload{}
+		var wlLookupKey types.NamespacedName
+
+		ginkgo.By("create the jobset and admit the workload", func() {
+			util.MustCreate(ctx, k8sClient, jobSet)
+			wlLookupKey = types.NamespacedName{Name: workloadjobset.GetWorkloadNameForJobSet(jobSet.Name, jobSet.UID), Namespace: ns.Name}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			admission := utiltestingapi.MakeAdmission(localQueue.Name).PodSets(
+				kueue.PodSetAssignment{
+					Name: createdWorkload.Spec.PodSets[0].Name,
+					Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+						corev1.ResourceCPU: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+					},
+				},
+			).Obj()
+			util.SetQuotaReservation(ctx, k8sClient, wlLookupKey, admission)
+			util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+		})
+
+		ginkgo.By("wait for the jobset to be unsuspended", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(jobSet), jobSet)).Should(gomega.Succeed())
+				g.Expect(ptr.Deref(jobSet.Spec.Suspend, false)).Should(gomega.BeFalse())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("create a child Job with stale completedIndexes (simulating pods that exited 0 during node failure)", func() {
+			childJob := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      jobSet.Name + "-worker-0",
+					Namespace: ns.Name,
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: "jobset.x-k8s.io/v1alpha2",
+						Kind:       "JobSet",
+						Name:       jobSet.Name,
+						UID:        jobSet.UID,
+						Controller: ptr.To(true),
+					}},
+				},
+				Spec: batchv1.JobSpec{
+					Parallelism:    ptr.To[int32](10),
+					Completions:    ptr.To[int32](10),
+					CompletionMode: ptr.To(batchv1.IndexedCompletion),
+					Suspend:        ptr.To(false),
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							RestartPolicy: corev1.RestartPolicyNever,
+							Containers: []corev1.Container{{
+								Name:  "worker",
+								Image: "pause",
+							}},
+						},
+					},
+				},
+			}
+			util.MustCreate(ctx, k8sClient, childJob)
+
+			// Set stale status: 2 pods "succeeded" during node failure
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(childJob), childJob)).To(gomega.Succeed())
+				childJob.Status.Succeeded = 2
+				childJob.Status.CompletedIndexes = "0,1"
+				g.Expect(k8sClient.Status().Update(ctx, childJob)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("mark the jobset as active", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(jobSet), jobSet)).To(gomega.Succeed())
+				jobSet.Status.ReplicatedJobsStatus = []jobsetapi.ReplicatedJobStatus{{
+					Name:   "worker",
+					Active: 8,
+				}}
+				g.Expect(k8sClient.Status().Update(ctx, jobSet)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("evict the workload (simulating preemption)", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				g.Expect(workload.SetConditionAndUpdate(ctx, k8sClient, createdWorkload,
+					kueue.WorkloadEvicted, metav1.ConditionTrue,
+					kueue.WorkloadEvictedByPreemption, "By test", "evict", util.RealClock)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("verify the child Job with stale completedIndexes is deleted", func() {
+			childJobKey := types.NamespacedName{Name: jobSet.Name + "-worker-0", Namespace: ns.Name}
+			// First confirm the child Job exists before eviction
+			childJob := &batchv1.Job{}
+			gomega.Expect(k8sClient.Get(ctx, childJobKey, childJob)).To(gomega.Succeed(),
+				"child Job should exist before eviction")
+			gomega.Expect(childJob.Status.Succeeded).To(gomega.Equal(int32(2)),
+				"child Job should have stale Succeeded=2")
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				childJob := &batchv1.Job{}
+				err := k8sClient.Get(ctx, childJobKey, childJob)
+				if apierrors.IsNotFound(err) {
+					return // deleted — success
+				}
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(childJob.DeletionTimestamp).NotTo(gomega.BeNil(),
+					"child Job should be marked for deletion")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area integrations


#### What this PR does / why we need it:

When nodes fail, containers catching SIGTERM may exit 0, causing kubelet to report pods
as Succeeded. The k8s Job controller persists these indices in `CompletedIndexes`, which
survives suspend/resume. On re-admission after eviction, the Job controller skips
"completed" indices, creating fewer pods than the gang requires — leading to an infinite
PodsReadyTimeout loop since all pods are not created.


**Root cause sequence:**
1. JobSet with gang indexed Job (parallelism=completions=10) is running, all 10 pods active
2. Pods at indices 0,1 finish successfully — k8s Job controller sets
   `CompletedIndexes="0,1"` and `Succeeded=2` on the child Job
3. Higher-priority workload arrives → Kueue preempts and evicts this workload
4. Kueue suspends the JobSet → child Job suspended, but `CompletedIndexes="0,1"`
   and `Succeeded=2` persist 
5. Kueue re-admits workload → child Job unsuspended → k8s Job controller reads
   CompletedIndexes, creates only 8 pods (indices 2-9), skips 0 and 1
6. Co-scheduling plugin needs 10 pods (minMember=10), sees only 8 →
   PodsReadyTimeout → evict → re-admit → same 8 pods → infinite loop

#### Which issue(s) this PR fixes:

During eviction (`stopJob` path), list child batch Jobs owned by the parent
(e.g., JobSet) and delete any gang indexed Jobs with stale `CompletedIndexes`
(`Succeeded > 0` with `parallelism == completions`). To cleanup any stale completed indexes from the previous attempt
and ensure all pods are created after readmission


#### Does this PR introduce a user-facing change?
N/A

-->
```release-note
Fix Job and co-scheduling incompatibility after partial success on readmission 
```