### PR TITLE
TAS: filter irrelevant non-TAS pod updates

### DIFF
--- a/pkg/controller/tas/non_tas_usage_controller.go
+++ b/pkg/controller/tas/non_tas_usage_controller.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 )
@@ -71,30 +72,45 @@ func (r *NonTasUsageReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
-	r.cache.TASCache().Update(&pod, log)
+	if belongsToNonTASCache(&pod) {
+		r.cache.TASCache().Update(&pod, log)
+	} else {
+		r.cache.TASCache().DeletePodByKey(req.NamespacedName)
+	}
 	return ctrl.Result{}, nil
 }
 
-func filterPod(pod *corev1.Pod) bool {
+func belongsToNonTASCache(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
 	if utiltas.IsTAS(pod) {
 		return false
-	} else if len(pod.Spec.NodeName) == 0 {
-		// skip unscheduled pods as they don't use any capacity.
+	}
+	if len(pod.Spec.NodeName) == 0 {
+		// Skip unscheduled pods as they don't use any capacity.
+		return false
+	}
+	if utilpod.IsTerminated(pod) {
 		return false
 	}
 	return true
 }
 
 func (r *NonTasUsageReconciler) Create(e event.TypedCreateEvent[*corev1.Pod]) bool {
-	return filterPod(e.Object)
+	return belongsToNonTASCache(e.Object)
+}
+
+func shouldReconcilePodUpdate(oldPod, newPod *corev1.Pod) bool {
+	return belongsToNonTASCache(oldPod) != belongsToNonTASCache(newPod)
 }
 
 func (r *NonTasUsageReconciler) Update(e event.TypedUpdateEvent[*corev1.Pod]) bool {
-	return filterPod(e.ObjectNew)
+	return shouldReconcilePodUpdate(e.ObjectOld, e.ObjectNew)
 }
 
 func (r *NonTasUsageReconciler) Delete(e event.TypedDeleteEvent[*corev1.Pod]) bool {
-	return filterPod(e.Object)
+	return belongsToNonTASCache(e.Object)
 }
 
 func (r *NonTasUsageReconciler) Generic(event.TypedGenericEvent[*corev1.Pod]) bool {

--- a/pkg/controller/tas/non_tas_usage_controller_test.go
+++ b/pkg/controller/tas/non_tas_usage_controller_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tas
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+)
+
+func TestBelongsToNonTASCache(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{
+			name: "nil pod",
+			pod:  nil,
+			want: false,
+		},
+		{
+			name: "scheduled non-TAS pod",
+			pod:  testingpod.MakePod("pod", "ns").NodeName("node-a").Obj(),
+			want: true,
+		},
+		{
+			name: "unscheduled pod",
+			pod:  testingpod.MakePod("pod", "ns").Obj(),
+			want: false,
+		},
+		{
+			name: "scheduled TAS pod",
+			pod: testingpod.MakePod("pod", "ns").
+				NodeName("node-a").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, "rack").
+				Obj(),
+			want: false,
+		},
+		{
+			name: "scheduled succeeded non-TAS pod",
+			pod:  testingpod.MakePod("pod", "ns").NodeName("node-a").StatusPhase(corev1.PodSucceeded).Obj(),
+			want: false,
+		},
+		{
+			name: "scheduled failed non-TAS pod",
+			pod:  testingpod.MakePod("pod", "ns").NodeName("node-a").StatusPhase(corev1.PodFailed).Obj(),
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := belongsToNonTASCache(tc.pod); got != tc.want {
+				t.Errorf("belongsToNonTASCache() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNonTasUsageReconcilerCreateDelete(t *testing.T) {
+	reconciler := &NonTasUsageReconciler{}
+
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{
+			name: "scheduled non-TAS pod",
+			pod:  testingpod.MakePod("pod", "ns").NodeName("node-a").Obj(),
+			want: true,
+		},
+		{
+			name: "unscheduled pod",
+			pod:  testingpod.MakePod("pod", "ns").Obj(),
+			want: false,
+		},
+		{
+			name: "scheduled TAS pod",
+			pod: testingpod.MakePod("pod", "ns").
+				NodeName("node-a").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, "rack").
+				Obj(),
+			want: false,
+		},
+		{
+			name: "terminated scheduled non-TAS pod",
+			pod:  testingpod.MakePod("pod", "ns").NodeName("node-a").StatusPhase(corev1.PodSucceeded).Obj(),
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := reconciler.Create(event.TypedCreateEvent[*corev1.Pod]{Object: tc.pod}); got != tc.want {
+				t.Errorf("Create() = %v, want %v", got, tc.want)
+			}
+			if got := reconciler.Delete(event.TypedDeleteEvent[*corev1.Pod]{Object: tc.pod}); got != tc.want {
+				t.Errorf("Delete() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestShouldReconcilePodUpdate(t *testing.T) {
+	tests := []struct {
+		name   string
+		oldPod *corev1.Pod
+		newPod *corev1.Pod
+		want   bool
+	}{
+		{
+			name:   "ignores status-only churn for scheduled non-TAS pod",
+			oldPod: testingpod.MakePod("pod", "ns").NodeName("node-a").StatusPhase(corev1.PodPending).Obj(),
+			newPod: testingpod.MakePod("pod", "ns").NodeName("node-a").StatusPhase(corev1.PodRunning).Obj(),
+			want:   false,
+		},
+		{
+			name:   "reconciles when non-TAS pod gets scheduled",
+			oldPod: testingpod.MakePod("pod", "ns").StatusPhase(corev1.PodPending).Obj(),
+			newPod: testingpod.MakePod("pod", "ns").NodeName("node-a").StatusPhase(corev1.PodPending).Obj(),
+			want:   true,
+		},
+		{
+			name:   "reconciles when scheduled non-TAS pod terminates",
+			oldPod: testingpod.MakePod("pod", "ns").NodeName("node-a").StatusPhase(corev1.PodRunning).Obj(),
+			newPod: testingpod.MakePod("pod", "ns").NodeName("node-a").StatusPhase(corev1.PodSucceeded).Obj(),
+			want:   true,
+		},
+		{
+			name: "reconciles when scheduled non-TAS pod becomes TAS",
+			oldPod: testingpod.MakePod("pod", "ns").
+				NodeName("node-a").
+				StatusPhase(corev1.PodRunning).
+				Obj(),
+			newPod: testingpod.MakePod("pod", "ns").
+				NodeName("node-a").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, "rack").
+				StatusPhase(corev1.PodRunning).
+				Obj(),
+			want: true,
+		},
+		{
+			name:   "reconciles when scheduled non-TAS pod becomes unscheduled",
+			oldPod: testingpod.MakePod("pod", "ns").NodeName("node-a").StatusPhase(corev1.PodRunning).Obj(),
+			newPod: testingpod.MakePod("pod", "ns").StatusPhase(corev1.PodRunning).Obj(),
+			want:   true,
+		},
+		{
+			name: "reconciles when TAS pod becomes scheduled non-TAS",
+			oldPod: testingpod.MakePod("pod", "ns").
+				NodeName("node-a").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, "rack").
+				StatusPhase(corev1.PodRunning).
+				Obj(),
+			newPod: testingpod.MakePod("pod", "ns").
+				NodeName("node-a").
+				StatusPhase(corev1.PodRunning).
+				Obj(),
+			want: true,
+		},
+		{
+			name: "ignores TAS pod status-only churn",
+			oldPod: testingpod.MakePod("pod", "ns").
+				NodeName("node-a").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, "rack").
+				StatusPhase(corev1.PodPending).
+				Obj(),
+			newPod: testingpod.MakePod("pod", "ns").
+				NodeName("node-a").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, "rack").
+				StatusPhase(corev1.PodRunning).
+				Obj(),
+			want: false,
+		},
+		{
+			name:   "ignores unscheduled non-TAS update",
+			oldPod: testingpod.MakePod("pod", "ns").StatusPhase(corev1.PodPending).Obj(),
+			newPod: testingpod.MakePod("pod", "ns").StatusPhase(corev1.PodPending).Obj(),
+			want:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldReconcilePodUpdate(tc.oldPod, tc.newPod)
+			if got != tc.want {
+				t.Errorf("shouldReconcilePodUpdate() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNonTasUsageReconcilerUpdate(t *testing.T) {
+	reconciler := &NonTasUsageReconciler{}
+	oldPod := testingpod.MakePod("pod", "ns").NodeName("node-a").StatusPhase(corev1.PodRunning).Obj()
+	newPod := testingpod.MakePod("pod", "ns").NodeName("node-a").StatusPhase(corev1.PodSucceeded).Obj()
+
+	got := reconciler.Update(event.TypedUpdateEvent[*corev1.Pod]{
+		ObjectOld: oldPod,
+		ObjectNew: newPod,
+	})
+	if !got {
+		t.Errorf("Update() = %v, want %v", got, true)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/area tas
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Filters Pod updates that do not matter in NonTasUsageReconciler.

Before this change, the controller reconciled every update for scheduled non-TAS Pods. Now it only reconciles when a non-TAS Pod gets scheduled, moves to a different node, or finishes. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10269

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: reduce the churn on the TAS-enabled controller, called NonTasUsageReconciler, by skipping triggering
of the Reconcile on Pod changes which are irrelevant from the controller point-of-view.
```