### PR TITLE
Add support of []runtime.Object to formatK8sObject in test/util

### DIFF
--- a/test/util/util.go
+++ b/test/util/util.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -90,15 +91,33 @@ func init() {
 }
 
 func formatK8sObject(value any) (string, bool) {
-	obj, ok := value.(client.Object)
-	if !ok {
+	if value == nil {
 		return "", false
 	}
-	objYAML, err := yaml.Marshal(obj)
+	_, isObject := value.(runtime.Object)
+	if !isObject && !isRuntimeObjectSlice(value) {
+		return "", false
+	}
+	objYAML, err := yaml.Marshal(value)
 	if err != nil {
 		return "", false
 	}
 	return string(objYAML), true
+}
+
+func isRuntimeObjectSlice(value any) bool {
+	if value == nil {
+		return false
+	}
+	val := reflect.ValueOf(value)
+	if val.Kind() == reflect.Slice {
+		k8sInterfaceType := reflect.TypeFor[runtime.Object]()
+		sliceElemType := val.Type().Elem()
+		if sliceElemType.Implements(k8sInterfaceType) || reflect.PointerTo(sliceElemType).Implements(k8sInterfaceType) {
+			return true
+		}
+	}
+	return false
 }
 
 var SetupLogger = sync.OnceFunc(func() {
@@ -323,7 +342,7 @@ func ExpectAllPodsInNamespaceDeleted(ctx context.Context, c client.Client, ns *c
 	gomega.Eventually(func(g gomega.Gomega) {
 		g.Expect(c.List(ctx, &pods, client.InNamespace(ns.Name))).Should(gomega.Succeed())
 		g.Expect(pods.Items).Should(gomega.BeEmpty())
-	}, LongTimeout, Interval).Should(gomega.Succeed(), assertMsgObjList(fmt.Sprintf("Pods still exist in namespace %s", ns.Name), &pods))
+	}, LongTimeout, Interval).Should(gomega.Succeed())
 }
 
 func DeleteWorkloadsInNamespace(ctx context.Context, c client.Client, ns *corev1.Namespace) error {
@@ -1290,7 +1309,7 @@ func ExpectWorkloadsInNamespace(ctx context.Context, k8sClient client.Client, na
 	gomega.Eventually(func(g gomega.Gomega) {
 		g.Expect(k8sClient.List(ctx, list, client.InNamespace(namespace))).To(gomega.Succeed())
 		g.Expect(list.Items).Should(gomega.HaveLen(count))
-	}, Timeout, Interval).Should(gomega.Succeed(), assertMsgObjList(fmt.Sprintf("Expected %d workloads in namespace %q", count, namespace), list))
+	}, Timeout, Interval).Should(gomega.Succeed())
 	return list.Items
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Format all objects to YAML format in test/util

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10443 

#### Special notes for your reviewer:
The reason here https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_kueue/10082/pull-kueue-test-e2e-multikueue-main/2036403536677310464 we have a big output log is because we have this comparison that logs expected value and actual value. I tinkered with `formatK8sObject`, now it converts all objects into YAML
```
g.Expect(pods.Items).Should(gomega.BeEmpty())
```

Now the expect logs look like this 
```
 The function passed to Eventually failed at /home/user1/Projects/kueue/test/util/util.go:660 with:
  Expected
      <[]v1.Pod | len:2, cap:2>: - metadata:
              annotations:
                kueue.x-k8s.io/workload: job-high-job-88ad5
                kueue.x-k8s.io/workload-slice-name: job-high-job-88ad5
              creationTimestamp: "2026-03-24T11:41:40Z"
              deletionGracePeriodSeconds: 30
              deletionTimestamp: "2026-03-24T11:42:11Z"
              generateName: high-job-
              generation: 2
              labels:
                batch.kubernetes.io/controller-uid: 6436daa8-5ff0-4736-b479-376ff3ed11c3
                batch.kubernetes.io/job-name: high-job
                controller-uid: 6436daa8-5ff0-4736-b479-376ff3ed11c3
                job-name: high-job
                kueue.x-k8s.io/cluster-queue-name: q1
                kueue.x-k8s.io/local-queue-name: q1
                kueue.x-k8s.io/podset: main
              managedFields:
              - apiVersion: v1
                fieldsType: FieldsV1
                fieldsV1:
                  f:metadata:
                    f:annotations:
                      .: {}
                      f:kueue.x-k8s.io/workload: {}
                      f:kueue.x-k8s.io/workload-slice-name: {}
                    f:generateName: {}
                    f:labels:
                      .: {}
                      f:batch.kubernetes.io/controller-uid: {}
                      f:batch.kubernetes.io/job-name: {}
                      f:controller-uid: {}
                      f:job-name: {}
                      f:kueue.x-k8s.io/cluster-queue-name: {}
                      f:kueue.x-k8s.io/local-queue-name: {}
                      f:kueue.x-k8s.io/podset: {}
                    f:ownerReferences:
                      .: {}
                      k:{"uid":"6436daa8-5ff0-4736-b479-376ff3ed11c3"}: {}
                  f:spec:
                    f:containers:
                      k:{"name":"c"}:
                        .: {}
                        f:args: {}
                        f:image: {}
                        f:imagePullPolicy: {}
                        f:name: {}
                        f:resources:
                          .: {}
                          f:limits:
                            .: {}
                            f:cpu: {}
                            f:memory: {}
                          f:requests:
                            .: {}
                            f:cpu: {}
                            f:memory: {}
                        f:terminationMessagePath: {}
                        f:terminationMessagePolicy: {}
                    f:dnsPolicy: {}
                    f:enableServiceLinks: {}
                    f:restartPolicy: {}
                    f:schedulerName: {}
                    f:securityContext: {}
                    f:terminationGracePeriodSeconds: {}
                manager: kube-controller-manager
                operation: Update
                time: "2026-03-24T11:41:40Z"
              - apiVersion: v1
                fieldsType: FieldsV1
                fieldsV1:
                  f:status:
                    f:conditions:
                      k:{"type":"ContainersReady"}:
                        .: {}
                        f:lastProbeTime: {}
                        f:lastTransitionTime: {}
                        f:observedGeneration: {}
                        f:status: {}
                        f:type: {}
                      k:{"type":"Initialized"}:
                        .: {}
                        f:lastProbeTime: {}
                        f:lastTransitionTime: {}
                        f:observedGeneration: {}
                        f:status: {}
                        f:type: {}
                      k:{"type":"PodReadyToStartContainers"}:
                        .: {}
                        f:lastProbeTime: {}
                        f:lastTransitionTime: {}
                        f:observedGeneration: {}
                        f:status: {}
                        f:type: {}
                      k:{"type":"PodScheduled"}:
                        f:observedGeneration: {}
                      k:{"type":"Ready"}:
                        .: {}
                        f:lastProbeTime: {}
                        f:lastTransitionTime: {}
                        f:observedGeneration: {}
                        f:status: {}
                        f:type: {}
                    f:containerStatuses: {}
                    f:hostIP: {}
                    f:hostIPs: {}
                    f:observedGeneration: {}
                    f:phase: {}
                    f:podIP: {}
                    f:podIPs:
                      .: {}
                      k:{"ip":"10.244.1.25"}:
                        .: {}
                        f:ip: {}
                    f:startTime: {}
                manager: kubelet
                operation: Update
                subresource: status
                time: "2026-03-24T11:41:43Z"
              name: high-job-jc7zz
              namespace: multikueue-2kv6p
              ownerReferences:
              - apiVersion: batch/v1
                blockOwnerDeletion: true
                controller: true
                kind: Job
                name: high-job
                uid: 6436daa8-5ff0-4736-b479-376ff3ed11c3
              resourceVersion: "4505"
              uid: 225c280e-a878-4f78-9747-f6c3347a7791
            spec:
              containers:
              - args:
                - netexec
                image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
                imagePullPolicy: IfNotPresent
                name: c
                resources:
                  limits:
                    cpu: "2"
                    memory: 1G
                  requests:
                    cpu: "2"
                    memory: 1G
                terminationMessagePath: /dev/termination-log
                terminationMessagePolicy: File
                volumeMounts:
                - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
                  name: kube-api-access-vm6mc
                  readOnly: true
              dnsPolicy: ClusterFirst
              enableServiceLinks: true
              nodeName: kind-worker1-worker
              preemptionPolicy: PreemptLowerPriority
              priority: 0
              restartPolicy: Never
              schedulerName: default-scheduler
              securityContext: {}
              serviceAccount: default
              serviceAccountName: default
              terminationGracePeriodSeconds: 30
              tolerations:
              - effect: NoExecute
                key: node.kubernetes.io/not-ready
                operator: Exists
                tolerationSeconds: 300
              - effect: NoExecute
                key: node.kubernetes.io/unreachable
                operator: Exists
                tolerationSeconds: 300
              volumes:
              - name: kube-api-access-vm6mc
                projected:
                  defaultMode: 420
                  sources:
                  - serviceAccountToken:
                      path: token
                  - configMap:
                      name: kube-root-ca.crt
                  - downwardAPI:
                      items:
                      - fieldRef:
                          apiVersion: v1
                          fieldPath: metadata.namespace
                        path: namespace
            status:
              conditions:
              - lastProbeTime: null
                lastTransitionTime: "2026-03-24T11:41:43Z"
                observedGeneration: 2
                status: "True"
                type: PodReadyToStartContainers
              - lastProbeTime: null
                lastTransitionTime: "2026-03-24T11:41:41Z"
                observedGeneration: 2
                status: "True"
                type: Initialized
              - lastProbeTime: null
                lastTransitionTime: "2026-03-24T11:41:43Z"
                observedGeneration: 2
                status: "True"
                type: Ready
              - lastProbeTime: null
                lastTransitionTime: "2026-03-24T11:41:43Z"
                observedGeneration: 2
                status: "True"
                type: ContainersReady
              - lastProbeTime: null
                lastTransitionTime: "2026-03-24T11:41:40Z"
                observedGeneration: 2
                status: "True"
                type: PodScheduled
              containerStatuses:
              - allocatedResources:
                  cpu: "2"
                  memory: 1G
                containerID: containerd://61ebb60e1e1e6595c2af68d07b55b1ced40b798fa16ad8060d8429c251603bb5
                image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
                imageID: sha256:c9f5d8950c9708ecd87ab2f90056fb06ba2ecc65b24f52bae819ef2c0c7a78ad
                lastState: {}
                name: c
                ready: true
                resources:
                  limits:
                    cpu: "2"
                    memory: 1G
                  requests:
                    cpu: "2"
                    memory: 1G
                restartCount: 0
                started: true
                state:
                  running:
                    startedAt: "2026-03-24T11:41:43Z"
                volumeMounts:
                - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
                  name: kube-api-access-vm6mc
                  readOnly: true
                  recursiveReadOnly: Disabled
              hostIP: 172.18.0.6
              hostIPs:
              - ip: 172.18.0.6
              phase: Running
              podIP: 10.244.1.25
              podIPs:
              - ip: 10.244.1.25
              qosClass: Guaranteed
              startTime: "2026-03-24T11:41:41Z"
          - metadata:
              annotations:
                kueue.x-k8s.io/workload: job-low-job-d8e5e
                kueue.x-k8s.io/workload-slice-name: job-low-job-d8e5e
              creationTimestamp: "2026-03-24T11:41:38Z"
              deletionGracePeriodSeconds: 30
              deletionTimestamp: "2026-03-24T11:42:08Z"
              generateName: low-job-
              generation: 2
              labels:
                batch.kubernetes.io/controller-uid: 5c004e63-ab22-4790-baaa-aff32d90471e
                batch.kubernetes.io/job-name: low-job
                controller-uid: 5c004e63-ab22-4790-baaa-aff32d90471e
                job-name: low-job
                kueue.x-k8s.io/cluster-queue-name: q1
                kueue.x-k8s.io/local-queue-name: q1
                kueue.x-k8s.io/podset: main
              managedFields:
              - apiVersion: v1
                fieldsType: FieldsV1
                fieldsV1:
                  f:metadata:
                    f:annotations:
                      .: {}
                      f:kueue.x-k8s.io/workload: {}
                      f:kueue.x-k8s.io/workload-slice-name: {}
                    f:generateName: {}
                    f:labels:
                      .: {}
                      f:batch.kubernetes.io/controller-uid: {}
                      f:batch.kubernetes.io/job-name: {}
                      f:controller-uid: {}
                      f:job-name: {}
                      f:kueue.x-k8s.io/cluster-queue-name: {}
                      f:kueue.x-k8s.io/local-queue-name: {}
                      f:kueue.x-k8s.io/podset: {}
                    f:ownerReferences:
                      .: {}
                      k:{"uid":"5c004e63-ab22-4790-baaa-aff32d90471e"}: {}
                  f:spec:
                    f:containers:
                      k:{"name":"c"}:
                        .: {}
                        f:args: {}
                        f:image: {}
                        f:imagePullPolicy: {}
                        f:name: {}
                        f:resources:
                          .: {}
                          f:limits:
                            .: {}
                            f:cpu: {}
                            f:memory: {}
                          f:requests:
                            .: {}
                            f:cpu: {}
                            f:memory: {}
                        f:terminationMessagePath: {}
                        f:terminationMessagePolicy: {}
                    f:dnsPolicy: {}
                    f:enableServiceLinks: {}
                    f:restartPolicy: {}
                    f:schedulerName: {}
                    f:securityContext: {}
                    f:terminationGracePeriodSeconds: {}
                manager: kube-controller-manager
                operation: Update
                time: "2026-03-24T11:41:38Z"
              - apiVersion: v1
                fieldsType: FieldsV1
                fieldsV1:
                  f:status:
                    f:conditions:
                      k:{"type":"ContainersReady"}:
                        .: {}
                        f:lastProbeTime: {}
                        f:lastTransitionTime: {}
                        f:observedGeneration: {}
                        f:status: {}
                        f:type: {}
                      k:{"type":"Initialized"}:
                        .: {}
                        f:lastProbeTime: {}
                        f:lastTransitionTime: {}
                        f:observedGeneration: {}
                        f:status: {}
                        f:type: {}
                      k:{"type":"PodReadyToStartContainers"}:
                        .: {}
                        f:lastProbeTime: {}
                        f:lastTransitionTime: {}
                        f:observedGeneration: {}
                        f:status: {}
                        f:type: {}
                      k:{"type":"PodScheduled"}:
                        f:observedGeneration: {}
                      k:{"type":"Ready"}:
                        .: {}
                        f:lastProbeTime: {}
                        f:lastTransitionTime: {}
                        f:observedGeneration: {}
                        f:status: {}
                        f:type: {}
                    f:containerStatuses: {}
                    f:hostIP: {}
                    f:hostIPs: {}
                    f:observedGeneration: {}
                    f:phase: {}
                    f:podIP: {}
                    f:podIPs:
                      .: {}
                      k:{"ip":"10.244.1.24"}:
                        .: {}
                        f:ip: {}
                    f:startTime: {}
                manager: kubelet
                operation: Update
                subresource: status
                time: "2026-03-24T11:41:39Z"
              name: low-job-bwfft
              namespace: multikueue-2kv6p
              ownerReferences:
              - apiVersion: batch/v1
                blockOwnerDeletion: true
                controller: true
                kind: Job
                name: low-job
                uid: 5c004e63-ab22-4790-baaa-aff32d90471e
              resourceVersion: "4449"
              uid: fc1a7ea2-6e53-483e-aa2b-83f245e89713
            spec:
              containers:
              - args:
                - netexec
                image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
                imagePullPolicy: IfNotPresent
                name: c
                resources:
                  limits:
                    cpu: "2"
                    memory: 1G
                  requests:
                    cpu: "2"
                    memory: 1G
                terminationMessagePath: /dev/termination-log
                terminationMessagePolicy: File
                volumeMounts:
                - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
                  name: kube-api-access-f6xfz
                  readOnly: true
              dnsPolicy: ClusterFirst
              enableServiceLinks: true
              nodeName: kind-worker1-worker
              preemptionPolicy: PreemptLowerPriority
              priority: 0
              restartPolicy: Never
              schedulerName: default-scheduler
              securityContext: {}
              serviceAccount: default
              serviceAccountName: default
              terminationGracePeriodSeconds: 30
              tolerations:
              - effect: NoExecute
                key: node.kubernetes.io/not-ready
                operator: Exists
                tolerationSeconds: 300
              - effect: NoExecute
                key: node.kubernetes.io/unreachable
                operator: Exists
                tolerationSeconds: 300
              volumes:
              - name: kube-api-access-f6xfz
                projected:
                  defaultMode: 420
                  sources:
                  - serviceAccountToken:
                      path: token
                  - configMap:
                      name: kube-root-ca.crt
                  - downwardAPI:
                      items:
                      - fieldRef:
                          apiVersion: v1
                          fieldPath: metadata.namespace
                        path: namespace
            status:
              conditions:
              - lastProbeTime: null
                lastTransitionTime: "2026-03-24T11:41:39Z"
                observedGeneration: 2
                status: "True"
                type: PodReadyToStartContainers
              - lastProbeTime: null
                lastTransitionTime: "2026-03-24T11:41:38Z"
                observedGeneration: 2
                status: "True"
                type: Initialized
              - lastProbeTime: null
                lastTransitionTime: "2026-03-24T11:41:39Z"
                observedGeneration: 2
                status: "True"
                type: Ready
              - lastProbeTime: null
                lastTransitionTime: "2026-03-24T11:41:39Z"
                observedGeneration: 2
                status: "True"
                type: ContainersReady
              - lastProbeTime: null
                lastTransitionTime: "2026-03-24T11:41:38Z"
                observedGeneration: 2
                status: "True"
                type: PodScheduled
              containerStatuses:
              - allocatedResources:
                  cpu: "2"
                  memory: 1G
                containerID: containerd://b2f51f14c271dc52684b376a0c2eb2d87594e46f255c6db9675375e667e45dab
                image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
                imageID: sha256:c9f5d8950c9708ecd87ab2f90056fb06ba2ecc65b24f52bae819ef2c0c7a78ad
                lastState: {}
                name: c
                ready: true
                resources:
                  limits:
                    cpu: "2"
                    memory: 1G
                  requests:
                    cpu: "2"
                    memory: 1G
                restartCount: 0
                started: true
                state:
                  running:
                    startedAt: "2026-03-24T11:41:39Z"
                volumeMounts:
                - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
                  name: kube-api-access-f6xfz
                  readOnly: true
                  recursiveReadOnly: Disabled
              hostIP: 172.18.0.6
              hostIPs:
              - ip: 172.18.0.6
              phase: Running
              podIP: 10.244.1.24
              podIPs:
              - ip: 10.244.1.24
              qosClass: Guaranteed
              startTime: "2026-03-24T11:41:38Z"
          
  to be empty
```

IMPORTANT: I have broken the tests, to see the bad output in CI CD 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```