### PR TITLE
[Fix] Avoid multiprocess run on MacOS

### DIFF
--- a/hack/testing/get-build-logs.sh
+++ b/hack/testing/get-build-logs.sh
@@ -18,6 +18,8 @@
 # It transforms a given URL copied from the CI into a format compatible with the gcloud storage cp command.
 # It ensures that the gcloud CLI is installed and that given URL is in fact pointing to Kueue related GCS bucket.
 # Second command line argument is optional and allows to define output directory, which by default is located in build_logs at project direcotry level.
+# On macOS, gsutil multiprocess mode is disabled by default to avoid fork-related Python crashes.
+# Set ENABLE_MULTIPROCESSING=1 to opt back into gsutil multiprocess mode.
 
 set -o errexit
 set -o nounset
@@ -54,5 +56,15 @@ transformed_url=$(transform_url "$1")
 root_dir="$(cd "$(dirname "$0")/.." && pwd)"
 output_dir=${2:-"$root_dir/build_logs"}
 mkdir -p "$output_dir"
-gsutil -m cp -r "$transformed_url" "$output_dir"
 
+gsutil_args=(-m)
+
+# macOS frameworks are generally not fork-safe after threaded startup.
+# To avoid nondeterministic gsutil child crashes, default to a single process
+# while preserving multithreaded transfers.
+# Set ENABLE_MULTIPROCESSING=1 to opt in to gsutil multiprocess mode.
+if [[ "$(uname -s)" == "Darwin" ]] && [[ "${ENABLE_MULTIPROCESSING:-0}" != "1" ]]; then
+    gsutil_args+=("-o" "GSUtil:parallel_process_count=1")
+fi
+
+gsutil "${gsutil_args[@]}" cp -r "$transformed_url" "$output_dir"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/area testing
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
We tracked the crash to gsutil running with Python on macOS in multiprocess mode, where forked child processes can segfault in system networking/framework code.
To prevent that we force GSUtil:parallel_process_count=1 on macOS, so downloads still use threads without spawning extra worker processes.
An opt-in override remains: set ENABLE_MULTIPROCESSING=1 if you explicitly want the old multiprocess behavior.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```