### PR TITLE
Introduce ExpectWorkloadToFinishWithTimeout() to allow tests to speci…

### DIFF
--- a/test/e2e/dra/dra_test.go
+++ b/test/e2e/dra/dra_test.go
@@ -120,7 +120,7 @@ var _ = ginkgo.Describe("DRA", func() {
 			util.ExpectJobToBeCompleted(ctx, k8sClient, job)
 
 			ginkgo.By("Verifying workload finished successfully")
-			util.ExpectWorkloadToFinish(ctx, k8sClient, wlLookupKey)
+			util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
 		})
 
 		ginkgo.It("Should keep job suspended when DRA quota is exceeded", func() {
@@ -223,7 +223,7 @@ var _ = ginkgo.Describe("DRA", func() {
 					Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
 					Namespace: ns.Name,
 				}
-				util.ExpectWorkloadToFinish(ctx, k8sClient, wlLookupKey)
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
 			}
 		})
 
@@ -279,7 +279,7 @@ var _ = ginkgo.Describe("DRA", func() {
 				Name:      workloadjob.GetWorkloadNameForJob(job3.Name, job3.UID),
 				Namespace: ns.Name,
 			}
-			util.ExpectWorkloadToFinish(ctx, k8sClient, wlLookupKey3)
+			util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey3, util.LongTimeout)
 		})
 
 		ginkgo.It("Should correctly calculate DRA resources for multi-pod jobs", func() {
@@ -427,7 +427,7 @@ var _ = ginkgo.Describe("DRA", func() {
 			util.ExpectJobToBeCompleted(ctx, k8sClient, job)
 
 			ginkgo.By("Verifying workload finished successfully")
-			util.ExpectWorkloadToFinish(ctx, k8sClient, wlLookupKey)
+			util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
 		})
 
 		ginkgo.It("Should keep job suspended when extended resource DRA quota is exceeded", func() {

--- a/test/e2e/singlecluster/jaxjob_test.go
+++ b/test/e2e/singlecluster/jaxjob_test.go
@@ -135,7 +135,7 @@ var _ = ginkgo.Describe("JAX integration", ginkgo.Label("area:singlecluster", "f
 				// Wait for active pods and terminate them
 				util.WaitForActivePodsAndTerminate(ctx, k8sClient, restClient, cfg, ns.Name, 2, 0, client.InNamespace(ns.Name))
 
-				util.ExpectWorkloadToFinish(ctx, k8sClient, wlLookupKey)
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
 			})
 
 			ginkgo.By("Delete the JAX", func() {

--- a/test/e2e/singlecluster/pod_test.go
+++ b/test/e2e/singlecluster/pod_test.go
@@ -122,7 +122,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 					}
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-				util.ExpectWorkloadToFinish(ctx, k8sClient, gKey)
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, gKey, util.LongTimeout)
 			})
 
 			ginkgo.By("Deleting finished Pods", func() {
@@ -175,7 +175,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 					util.MustCreate(ctx, k8sClient, p.DeepCopy())
 				}
 
-				util.ExpectWorkloadToFinish(ctx, k8sClient, client.ObjectKey{Namespace: ns.Name, Name: "group"})
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, client.ObjectKey{Namespace: ns.Name, Name: "group"}, util.LongTimeout)
 			})
 		})
 
@@ -292,7 +292,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			util.ExpectWorkloadToFinish(ctx, k8sClient, client.ObjectKey{Namespace: ns.Name, Name: "group"})
+			util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, client.ObjectKey{Namespace: ns.Name, Name: "group"}, util.LongTimeout)
 		})
 
 		ginkgo.It("Unscheduled Pod which is deleted can be replaced in group", func() {
@@ -401,7 +401,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 			})
 
 			ginkgo.By("Group completes", func() {
-				util.ExpectWorkloadToFinish(ctx, k8sClient, client.ObjectKey{Namespace: ns.Name, Name: "group"})
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, client.ObjectKey{Namespace: ns.Name, Name: "group"}, util.LongTimeout)
 			})
 			ginkgo.By("Deleting finished Pods", func() {
 				for _, p := range group {
@@ -541,7 +541,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 			})
 
 			ginkgo.By("Verify the high priority group completes", func() {
-				util.ExpectWorkloadToFinish(ctx, k8sClient, highGroupKey)
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, highGroupKey, util.LongTimeout)
 			})
 
 			ginkgo.By("Await for the replacement pods to be ungated", func() {
@@ -565,7 +565,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 			})
 
 			ginkgo.By("Verify the default priority workload is finished", func() {
-				util.ExpectWorkloadToFinish(ctx, k8sClient, defaultGroupKey)
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, defaultGroupKey, util.LongTimeout)
 			})
 		})
 
@@ -624,7 +624,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 				gKey := client.ObjectKey{Namespace: ns.Name, Name: "test-group"}
-				util.ExpectWorkloadToFinish(ctx, k8sClient, gKey)
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, gKey, util.LongTimeout)
 			})
 
 			ginkgo.By("Ensure the pod is deleted", func() {

--- a/test/e2e/singlecluster/pytorchjob_test.go
+++ b/test/e2e/singlecluster/pytorchjob_test.go
@@ -134,7 +134,7 @@ var _ = ginkgo.Describe("PyTorch integration", ginkgo.Label("area:singlecluster"
 				// Wait for active pods and terminate them
 				util.WaitForActivePodsAndTerminate(ctx, k8sClient, restClient, cfg, ns.Name, 1, 0, client.InNamespace(ns.Name))
 
-				util.ExpectWorkloadToFinish(ctx, k8sClient, wlLookupKey)
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
 			})
 
 			ginkgo.By("Delete the PyTorch", func() {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -536,12 +536,18 @@ func expectWorkloadsWithPriority(
 	}, Timeout, Interval).Should(gomega.Succeed(), assertMsg("Workload priority does not match expected", createdWl))
 }
 
-func ExpectWorkloadToFinish(ctx context.Context, k8sClient client.Client, wlKey client.ObjectKey) {
+func ExpectWorkloadToFinishWithTimeout(ctx context.Context, k8sClient client.Client, wlKey client.ObjectKey, timeout time.Duration) {
+	ginkgo.GinkgoHelper()
 	var wl kueue.Workload
-	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
+	gomega.Eventually(func(g gomega.Gomega) {
 		g.Expect(k8sClient.Get(ctx, wlKey, &wl)).To(gomega.Succeed())
 		g.Expect(wl.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished), "it's finished")
-	}, LongTimeout, Interval).Should(gomega.Succeed(), assertMsg("Workload did not finish", &wl))
+	}, timeout, Interval).Should(gomega.Succeed(), assertMsg("Workload did not finish", &wl))
+}
+
+func ExpectWorkloadToFinish(ctx context.Context, k8sClient client.Client, wlKey client.ObjectKey) {
+	ginkgo.GinkgoHelper()
+	ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlKey, MediumTimeout)
 }
 
 func ExpectPodsReadyCondition(ctx context.Context, k8sClient client.Client, wlKey client.ObjectKey) {


### PR DESCRIPTION
…fy custom timeouts, update integration tests to use MediumTimeout

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Introduce ExpectWorkloadToFinishWithTimeout() to allow tests to specify custom timeouts, update integration tests to use MediumTimeout
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
https://github.com/kubernetes-sigs/kueue/pull/10430#discussion_r3077480161

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```