### PR TITLE
Fix stale follower workload cache cleanup on NotFound reconciles

### DIFF
--- a/pkg/controller/core/leader_aware_reconciler.go
+++ b/pkg/controller/core/leader_aware_reconciler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -77,8 +78,12 @@ func (r *leaderAwareReconciler) Reconcile(ctx context.Context, request reconcile
 		return r.delegate.Reconcile(ctx, request)
 	default:
 		if err := r.client.Get(ctx, request.NamespacedName, r.object); err != nil {
-			// Discard request if not found, to prevent from re-enqueueing indefinitely.
-			return ctrl.Result{}, client.IgnoreNotFound(err)
+			if apierrors.IsNotFound(err) {
+				// Delegate not found requests so reconcilers can clean up in-memory state
+				// after delete events while this replica is still a follower.
+				return r.delegate.Reconcile(ctx, request)
+			}
+			return ctrl.Result{}, err
 		}
 		// The manager hasn't been elected leader yet, requeue the reconciliation request
 		// to prevent against any missed / discarded events over the period it takes

--- a/pkg/controller/core/leader_aware_reconciler_test.go
+++ b/pkg/controller/core/leader_aware_reconciler_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+type stubReconciler struct {
+	calls  int
+	result ctrl.Result
+	err    error
+}
+
+func (r *stubReconciler) Reconcile(context.Context, ctrl.Request) (ctrl.Result, error) {
+	r.calls++
+	return r.result, r.err
+}
+
+func newFollowerLeaderAwareReconciler(cl client.Client, delegate reconcile.Reconciler, requeueAfter time.Duration) *leaderAwareReconciler {
+	return &leaderAwareReconciler{
+		elected:         make(chan struct{}),
+		client:          cl,
+		delegate:        delegate,
+		object:          &kueue.Workload{},
+		requeueDuration: requeueAfter,
+	}
+}
+
+func TestLeaderAwareReconcilerRequeuesWhileFollowerForExistingObject(t *testing.T) {
+	workloadObj := utiltestingapi.MakeWorkload("wl", "ns").Obj()
+	cl := utiltesting.NewClientBuilder().WithObjects(workloadObj).Build()
+	delegate := &stubReconciler{}
+	requeueAfter := time.Minute
+
+	r := newFollowerLeaderAwareReconciler(cl, delegate, requeueAfter)
+
+	gotResult, gotErr := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(workloadObj),
+	})
+
+	if gotErr != nil {
+		t.Fatalf("Reconcile() error = %v, want nil", gotErr)
+	}
+	if diff := cmp.Diff(ctrl.Result{RequeueAfter: requeueAfter}, gotResult); diff != "" {
+		t.Fatalf("Reconcile() result mismatch (-want,+got):\n%s", diff)
+	}
+	if delegate.calls != 0 {
+		t.Fatalf("delegate calls = %d, want 0", delegate.calls)
+	}
+}
+
+func TestLeaderAwareReconcilerDelegatesNotFoundToWorkloadCleanup(t *testing.T) {
+	clientBuilder := utiltesting.NewClientBuilder().
+		WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
+	cl := clientBuilder.Build()
+	recorder := &utiltesting.EventRecorder{}
+	cqCache := schdcache.New(cl)
+	queueOptions := []qcache.Option{qcache.WithPreemptionExpectations(preemptexpectations.New())}
+	qManager := qcache.NewManagerForUnitTests(cl, cqCache, queueOptions...)
+	reconciler := NewWorkloadReconciler(cl, qManager, cqCache, recorder)
+
+	ctx, log := utiltesting.ContextWithLog(t)
+
+	cq := utiltestingapi.MakeClusterQueue("cq").Obj()
+	lq := utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj()
+	if err := errors.Join(cqCache.AddClusterQueue(ctx, cq.DeepCopy()), qManager.AddClusterQueue(ctx, cq.DeepCopy())); err != nil {
+		t.Fatalf("add ClusterQueue: %v", err)
+	}
+	if err := errors.Join(cqCache.AddLocalQueue(lq.DeepCopy()), qManager.AddLocalQueue(ctx, lq.DeepCopy())); err != nil {
+		t.Fatalf("add LocalQueue: %v", err)
+	}
+
+	pendingWL := utiltestingapi.MakeWorkload("wl", "ns").Queue("lq").Obj()
+	if err := qManager.AddOrUpdateWorkload(log, pendingWL.DeepCopy()); err != nil {
+		t.Fatalf("add queue workload: %v", err)
+	}
+
+	admittedWL := utiltestingapi.MakeWorkload("wl", "ns").
+		Queue("lq").
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), time.Now()).
+		Obj()
+	if !cqCache.AddOrUpdateWorkload(log, admittedWL.DeepCopy()) {
+		t.Fatal("add scheduler workload returned false")
+	}
+
+	wlKey := workload.Key(admittedWL)
+	if qManager.GetWorkloadFromCache(wlKey) == nil {
+		t.Fatal("workload missing from queue cache before reconcile")
+	}
+	if cqCache.GetWorkloadFromCache(wlKey) == nil {
+		t.Fatal("workload missing from scheduler cache before reconcile")
+	}
+
+	r := newFollowerLeaderAwareReconciler(cl, reconciler, time.Minute)
+
+	gotResult, gotErr := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(admittedWL),
+	})
+
+	if gotErr != nil {
+		t.Fatalf("Reconcile() error = %v, want nil", gotErr)
+	}
+	if diff := cmp.Diff(ctrl.Result{}, gotResult); diff != "" {
+		t.Fatalf("Reconcile() result mismatch (-want,+got):\n%s", diff)
+	}
+	if qManager.GetWorkloadFromCache(wlKey) != nil {
+		t.Fatal("workload still present in queue cache after reconcile")
+	}
+	if cqCache.GetWorkloadFromCache(wlKey) != nil {
+		t.Fatal("workload still present in scheduler cache after reconcile")
+	}
+}

--- a/pkg/controller/core/leader_aware_reconciler_test.go
+++ b/pkg/controller/core/leader_aware_reconciler_test.go
@@ -66,7 +66,7 @@ func TestLeaderAwareReconcilerRequeuesWhileFollowerForExistingObject(t *testing.
 
 	r := newFollowerLeaderAwareReconciler(cl, delegate, requeueAfter)
 
-	gotResult, gotErr := r.Reconcile(context.Background(), reconcile.Request{
+	gotResult, gotErr := r.Reconcile(t.Context(), reconcile.Request{
 		NamespacedName: client.ObjectKeyFromObject(workloadObj),
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

/kind bug
/kind regression

#### What this PR does / why we need it:

This PR fixes a stale cache issue on follower replicas in HA controller-manager deployments.

A recent workload delete handling change #8655 relies on the delegated workload reconciler to clean up queue and scheduler caches when `Reconcile` sees `Get(...)=NotFound`. However, `leaderAwareReconciler` returned early on `NotFound` for follower replicas and did not delegate the request.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/10495

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a regression in HA controller-manager deployments where a follower replica could keep stale workload cache state after workload deletion.
```