### PR TITLE
Automated cherry pick of #10493: Introduce ExpectWorkloadToFinishWithTimeout() to allow tests to speci…

### DIFF
--- a/test/e2e/dra/dra_test.go
+++ b/test/e2e/dra/dra_test.go
@@ -118,7 +118,7 @@ var _ = ginkgo.Describe("DRA", func() {
 			util.ExpectJobToBeCompleted(ctx, k8sClient, job)
 
 			ginkgo.By("Verifying workload finished successfully")
-			util.ExpectWorkloadToFinish(ctx, k8sClient, wlLookupKey)
+			util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
 		})
 
 		ginkgo.It("Should keep job suspended when DRA quota is exceeded", func() {
@@ -221,7 +221,7 @@ var _ = ginkgo.Describe("DRA", func() {
 					Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
 					Namespace: ns.Name,
 				}
-				util.ExpectWorkloadToFinish(ctx, k8sClient, wlLookupKey)
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
 			}
 		})
 
@@ -277,7 +277,7 @@ var _ = ginkgo.Describe("DRA", func() {
 				Name:      workloadjob.GetWorkloadNameForJob(job3.Name, job3.UID),
 				Namespace: ns.Name,
 			}
-			util.ExpectWorkloadToFinish(ctx, k8sClient, wlLookupKey3)
+			util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey3, util.LongTimeout)
 		})
 
 		ginkgo.It("Should correctly calculate DRA resources for multi-pod jobs", func() {

--- a/test/e2e/singlecluster/jaxjob_test.go
+++ b/test/e2e/singlecluster/jaxjob_test.go
@@ -135,7 +135,7 @@ var _ = ginkgo.Describe("JAX integration", ginkgo.Label("area:singlecluster", "f
 				// Wait for active pods and terminate them
 				util.WaitForActivePodsAndTerminate(ctx, k8sClient, restClient, cfg, ns.Name, 2, 0, client.InNamespace(ns.Name))
 
-				util.ExpectWorkloadToFinish(ctx, k8sClient, wlLookupKey)
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
 			})
 
 			ginkgo.By("Delete the JAX", func() {

--- a/test/e2e/singlecluster/pod_test.go
+++ b/test/e2e/singlecluster/pod_test.go
@@ -122,7 +122,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 					}
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-				util.ExpectWorkloadToFinish(ctx, k8sClient, gKey)
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, gKey, util.LongTimeout)
 			})
 
 			ginkgo.By("Deleting finished Pods", func() {
@@ -175,7 +175,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 					util.MustCreate(ctx, k8sClient, p.DeepCopy())
 				}
 
-				util.ExpectWorkloadToFinish(ctx, k8sClient, client.ObjectKey{Namespace: ns.Name, Name: "group"})
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, client.ObjectKey{Namespace: ns.Name, Name: "group"}, util.LongTimeout)
 			})
 		})
 
@@ -292,7 +292,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			util.ExpectWorkloadToFinish(ctx, k8sClient, client.ObjectKey{Namespace: ns.Name, Name: "group"})
+			util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, client.ObjectKey{Namespace: ns.Name, Name: "group"}, util.LongTimeout)
 		})
 
 		ginkgo.It("Unscheduled Pod which is deleted can be replaced in group", func() {
@@ -401,7 +401,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 			})
 
 			ginkgo.By("Group completes", func() {
-				util.ExpectWorkloadToFinish(ctx, k8sClient, client.ObjectKey{Namespace: ns.Name, Name: "group"})
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, client.ObjectKey{Namespace: ns.Name, Name: "group"}, util.LongTimeout)
 			})
 			ginkgo.By("Deleting finished Pods", func() {
 				for _, p := range group {
@@ -541,7 +541,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 			})
 
 			ginkgo.By("Verify the high priority group completes", func() {
-				util.ExpectWorkloadToFinish(ctx, k8sClient, highGroupKey)
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, highGroupKey, util.LongTimeout)
 			})
 
 			ginkgo.By("Await for the replacement pods to be ungated", func() {
@@ -565,7 +565,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 			})
 
 			ginkgo.By("Verify the default priority workload is finished", func() {
-				util.ExpectWorkloadToFinish(ctx, k8sClient, defaultGroupKey)
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, defaultGroupKey, util.LongTimeout)
 			})
 		})
 
@@ -614,7 +614,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 				gKey := client.ObjectKey{Namespace: ns.Name, Name: "test-group"}
-				util.ExpectWorkloadToFinish(ctx, k8sClient, gKey)
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, gKey, util.LongTimeout)
 			})
 
 			ginkgo.By("Ensure the pod is deleted", func() {

--- a/test/e2e/singlecluster/pytorchjob_test.go
+++ b/test/e2e/singlecluster/pytorchjob_test.go
@@ -134,7 +134,7 @@ var _ = ginkgo.Describe("PyTorch integration", ginkgo.Label("area:singlecluster"
 				// Wait for active pods and terminate them
 				util.WaitForActivePodsAndTerminate(ctx, k8sClient, restClient, cfg, ns.Name, 1, 0, client.InNamespace(ns.Name))
 
-				util.ExpectWorkloadToFinish(ctx, k8sClient, wlLookupKey)
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
 			})
 
 			ginkgo.By("Delete the PyTorch", func() {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -525,12 +525,18 @@ func expectWorkloadsWithPriority(
 	}, Timeout, Interval).Should(gomega.Succeed(), assertMsg("Workload priority does not match expected", createdWl))
 }
 
-func ExpectWorkloadToFinish(ctx context.Context, k8sClient client.Client, wlKey client.ObjectKey) {
+func ExpectWorkloadToFinishWithTimeout(ctx context.Context, k8sClient client.Client, wlKey client.ObjectKey, timeout time.Duration) {
+	ginkgo.GinkgoHelper()
 	var wl kueue.Workload
-	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
+	gomega.Eventually(func(g gomega.Gomega) {
 		g.Expect(k8sClient.Get(ctx, wlKey, &wl)).To(gomega.Succeed())
 		g.Expect(wl.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished), "it's finished")
-	}, LongTimeout, Interval).Should(gomega.Succeed(), assertMsg("Workload did not finish", &wl))
+	}, timeout, Interval).Should(gomega.Succeed(), assertMsg("Workload did not finish", &wl))
+}
+
+func ExpectWorkloadToFinish(ctx context.Context, k8sClient client.Client, wlKey client.ObjectKey) {
+	ginkgo.GinkgoHelper()
+	ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlKey, MediumTimeout)
 }
 
 func ExpectPodsReadyCondition(ctx context.Context, k8sClient client.Client, wlKey client.ObjectKey) {


### PR DESCRIPTION
Cherry pick of #10493 on release-0.16.

#10493: Introduce ExpectWorkloadToFinishWithTimeout() to allow tests to speci…

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```