### PR TITLE
Automated cherry pick of #10478: Fix TAS empty slices for count=0 podSets causing infinite scheduling loop

### DIFF
--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -694,7 +694,7 @@ func (a *FlavorAssigner) assignFlavors(log logr.Logger, counts []int32) Assignme
 	}
 
 	if features.Enabled(features.TopologyAwareScheduling) {
-		tasRequests := assignment.WorkloadsTopologyRequests(a.wl, a.cq)
+		tasRequests := assignment.WorkloadsTopologyRequests(log, a.wl, a.cq)
 		if assignment.RepresentativeMode() == Fit {
 			result := a.cq.FindTopologyAssignmentsForWorkload(tasRequests, schdcache.WithWorkload(a.wl.Obj))
 			if failure := result.Failure(); failure != nil {

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4064,7 +4064,7 @@ func TestWorkloadsTopologyRequests_ErrorBranches(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			tasReqs := tc.assignment.WorkloadsTopologyRequests(&tc.workload, &tc.cq)
+			tasReqs := tc.assignment.WorkloadsTopologyRequests(testr.New(t), &tc.workload, &tc.cq)
 			if len(tasReqs) != 0 {
 				t.Errorf("expected no TAS requests, got: %+v", tasReqs)
 			}
@@ -4327,6 +4327,100 @@ func TestAssignment_RequiresBorrowing(t *testing.T) {
 			a := &Assignment{Borrowing: tc.borrowing}
 			if got := a.RequiresBorrowing(); got != tc.want {
 				t.Errorf("RequiresBorrowing() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWorkloadsTopologyRequests_ZeroCountPodSetSkipped verifies that count=0
+// podSets (completed/reclaimable after preemption) are skipped in TAS request
+// generation, preventing empty TopologyAssignment slices that cause CRD
+// validation errors and infinite scheduling loops.
+func TestWorkloadsTopologyRequests_ZeroCountPodSetSkipped(t *testing.T) {
+	tasFlavor := &schdcache.TASFlavorSnapshot{}
+
+	cases := map[string]struct {
+		podSets        []PodSetAssignment
+		wlPodSets      []kueue.PodSet
+		wantTASPodSets []string // names of podSets that should have TAS requests
+	}{
+		"mixed: 1 completed (count=0) + 1 running (count=1)": {
+			podSets: []PodSetAssignment{
+				{Name: "completed-job", Flavors: ResourceAssignment{corev1.ResourceCPU: {Name: "tas", Mode: Fit, TriedFlavorIdx: -1}}, Count: 0, Status: *NewStatus()},
+				{Name: "running-job", Flavors: ResourceAssignment{corev1.ResourceCPU: {Name: "tas", Mode: Fit, TriedFlavorIdx: -1}}, Count: 1, Status: *NewStatus()},
+			},
+			wlPodSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("completed-job", 1).Request(corev1.ResourceCPU, "1").RequiredTopologyRequest(corev1.LabelHostname).Obj(),
+				*utiltestingapi.MakePodSet("running-job", 1).Request(corev1.ResourceCPU, "1").RequiredTopologyRequest(corev1.LabelHostname).Obj(),
+			},
+			wantTASPodSets: []string{"running-job"},
+		},
+		"all completed (count=0): no TAS requests": {
+			podSets: []PodSetAssignment{
+				{Name: "sampler-0", Flavors: ResourceAssignment{corev1.ResourceCPU: {Name: "tas", Mode: Fit, TriedFlavorIdx: -1}}, Count: 0, Status: *NewStatus()},
+				{Name: "controller", Flavors: ResourceAssignment{corev1.ResourceCPU: {Name: "tas", Mode: Fit, TriedFlavorIdx: -1}}, Count: 0, Status: *NewStatus()},
+			},
+			wlPodSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("sampler-0", 1).Request(corev1.ResourceCPU, "1").RequiredTopologyRequest(corev1.LabelHostname).Obj(),
+				*utiltestingapi.MakePodSet("controller", 1).Request(corev1.ResourceCPU, "1").RequiredTopologyRequest(corev1.LabelHostname).Obj(),
+			},
+			wantTASPodSets: nil,
+		},
+		"3 podSets: 2 completed + 1 running": {
+			podSets: []PodSetAssignment{
+				{Name: "sampler-0", Flavors: ResourceAssignment{corev1.ResourceCPU: {Name: "tas", Mode: Fit, TriedFlavorIdx: -1}}, Count: 0, Status: *NewStatus()},
+				{Name: "sampler-1", Flavors: ResourceAssignment{corev1.ResourceCPU: {Name: "tas", Mode: Fit, TriedFlavorIdx: -1}}, Count: 1, Status: *NewStatus()},
+				{Name: "controller", Flavors: ResourceAssignment{corev1.ResourceCPU: {Name: "tas", Mode: Fit, TriedFlavorIdx: -1}}, Count: 0, Status: *NewStatus()},
+			},
+			wlPodSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("sampler-0", 1).Request(corev1.ResourceCPU, "1").RequiredTopologyRequest(corev1.LabelHostname).Obj(),
+				*utiltestingapi.MakePodSet("sampler-1", 1).Request(corev1.ResourceCPU, "1").RequiredTopologyRequest(corev1.LabelHostname).Obj(),
+				*utiltestingapi.MakePodSet("controller", 1).Request(corev1.ResourceCPU, "1").RequiredTopologyRequest(corev1.LabelHostname).Obj(),
+			},
+			wantTASPodSets: []string{"sampler-1"},
+		},
+		"all running: all get TAS requests": {
+			podSets: []PodSetAssignment{
+				{Name: "worker-0", Flavors: ResourceAssignment{corev1.ResourceCPU: {Name: "tas", Mode: Fit, TriedFlavorIdx: -1}}, Count: 2, Status: *NewStatus()},
+				{Name: "worker-1", Flavors: ResourceAssignment{corev1.ResourceCPU: {Name: "tas", Mode: Fit, TriedFlavorIdx: -1}}, Count: 3, Status: *NewStatus()},
+			},
+			wlPodSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("worker-0", 2).Request(corev1.ResourceCPU, "1").RequiredTopologyRequest(corev1.LabelHostname).Obj(),
+				*utiltestingapi.MakePodSet("worker-1", 3).Request(corev1.ResourceCPU, "1").RequiredTopologyRequest(corev1.LabelHostname).Obj(),
+			},
+			wantTASPodSets: []string{"worker-0", "worker-1"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			cq := schdcache.ClusterQueueSnapshot{
+				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{"tas": tasFlavor},
+			}
+			assignment := Assignment{PodSets: tc.podSets}
+			wl := workload.NewInfo(&kueue.Workload{
+				Spec: kueue.WorkloadSpec{PodSets: tc.wlPodSets},
+			})
+
+			tasReqs := assignment.WorkloadsTopologyRequests(testr.New(t), wl, &cq)
+
+			// Collect which podSets got TAS requests
+			var gotPodSets []string
+			for _, flavorReqs := range tasReqs {
+				for _, req := range flavorReqs {
+					gotPodSets = append(gotPodSets, string(req.PodSet.Name))
+				}
+			}
+
+			if diff := cmp.Diff(tc.wantTASPodSets, gotPodSets, cmpopts.SortSlices(func(a, b string) bool { return a < b }), cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("TAS request podSets mismatch (-want +got):\n%s", diff)
+			}
+
+			// Verify no errors on count=0 podSets
+			for _, ps := range assignment.PodSets {
+				if ps.Count == 0 && ps.Status.IsError() {
+					t.Errorf("count=0 podSet %q should not have error, got: %v", ps.Name, ps.Status.err)
+				}
 			}
 		})
 	}

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
@@ -35,13 +36,17 @@ import (
 )
 
 // WorkloadsTopologyRequests - returns the TopologyRequests of the workload
-func (a *Assignment) WorkloadsTopologyRequests(wl *workload.Info, cq *schdcache.ClusterQueueSnapshot) schdcache.WorkloadTASRequests {
+func (a *Assignment) WorkloadsTopologyRequests(log logr.Logger, wl *workload.Info, cq *schdcache.ClusterQueueSnapshot) schdcache.WorkloadTASRequests {
 	tasRequests := make(schdcache.WorkloadTASRequests)
 	for i, podSet := range wl.Obj.Spec.PodSets {
 		if isTASRequested(&podSet, cq) {
 			psAssignment := a.podSetAssignmentByName(podSet.Name)
 			if psAssignment.Status.IsError() {
 				// There is no resource quota assignment for the PodSet - no need to check TAS.
+				continue
+			}
+			if psAssignment.Count == 0 {
+				log.V(3).Info("Skipping TAS for count=0 podSet", "podSet", podSet.Name)
 				continue
 			}
 			if psAssignment.TopologyAssignment != nil && !psAssignment.HasUnhealthyNode(wl) {

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -124,7 +124,7 @@ func (p *Preemptor) GetTargets(log logr.Logger, wl workload.Info, assignment fla
 	cq := snapshot.ClusterQueue(wl.ClusterQueue)
 	var tasRequests schdcache.WorkloadTASRequests
 	if features.Enabled(features.TopologyAwareScheduling) {
-		tasRequests = assignment.WorkloadsTopologyRequests(&wl, cq)
+		tasRequests = assignment.WorkloadsTopologyRequests(log, &wl, cq)
 	}
 	return p.getTargets(&preemptionCtx{
 		clock:             p.clock,

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -539,7 +539,7 @@ type partialAssignment struct {
 func (s *Scheduler) getAssignments(log logr.Logger, wl *workload.Info, snap *schdcache.Snapshot) (flavorassigner.Assignment, []*preemption.Target) {
 	assignment, targets := s.getInitialAssignments(log, wl, snap)
 	cq := snap.ClusterQueue(wl.ClusterQueue)
-	updateAssignmentForTAS(snap, cq, wl, &assignment, targets)
+	updateAssignmentForTAS(log, snap, cq, wl, &assignment, targets)
 	return assignment, targets
 }
 
@@ -622,10 +622,10 @@ func (s *Scheduler) evictWorkloadAfterFailedTASReplacement(ctx context.Context, 
 	return nil
 }
 
-func updateAssignmentForTAS(snapshot *schdcache.Snapshot, cq *schdcache.ClusterQueueSnapshot, wl *workload.Info, assignment *flavorassigner.Assignment, targets []*preemption.Target) {
+func updateAssignmentForTAS(log logr.Logger, snapshot *schdcache.Snapshot, cq *schdcache.ClusterQueueSnapshot, wl *workload.Info, assignment *flavorassigner.Assignment, targets []*preemption.Target) {
 	if features.Enabled(features.TopologyAwareScheduling) && assignment.RepresentativeMode() == flavorassigner.Preempt &&
 		(workload.IsExplicitlyRequestingTAS(wl.Obj.Spec.PodSets...) || cq.IsTASOnly()) && !workload.HasTopologyAssignmentWithUnhealthyNode(wl.Obj) {
-		tasRequests := assignment.WorkloadsTopologyRequests(wl, cq)
+		tasRequests := assignment.WorkloadsTopologyRequests(log, wl, cq)
 		var tasResult schdcache.TASAssignmentsResult
 		if len(targets) > 0 {
 			var targetWorkloads []*workload.Info

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -371,7 +371,6 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltestingapi.MakePodSetAssignment("worker").
 							Assignment(corev1.ResourceCPU, "tas-default", "0").
 							Count(0).
-							TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).Obj()).
 							Obj(),
 					).
 					Obj(),

--- a/test/integration/singlecluster/controller/jobs/jobset/jobset_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/jobset/jobset_controller_test.go
@@ -1298,4 +1298,136 @@ var _ = ginkgo.Describe("JobSet controller with TopologyAwareScheduling", ginkgo
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
+
+	ginkgo.It("should re-admit jobset with completed podSets after preemption without infinite loop", framework.SlowSpec, func() {
+		jobSet := testingjobset.MakeJobSet("tas-preempt-jobset", ns.Name).
+			Queue(localQueue.Name).
+			ReplicatedJobs(
+				testingjobset.ReplicatedJobRequirements{
+					Name:        "job-a",
+					Replicas:    1,
+					Parallelism: 1,
+					Completions: 1,
+					PodAnnotations: map[string]string{
+						kueue.PodSetRequiredTopologyAnnotation: utiltesting.DefaultBlockTopologyLevel,
+					},
+				},
+				testingjobset.ReplicatedJobRequirements{
+					Name:        "job-b",
+					Replicas:    1,
+					Parallelism: 1,
+					Completions: 1,
+					PodAnnotations: map[string]string{
+						kueue.PodSetRequiredTopologyAnnotation: utiltesting.DefaultBlockTopologyLevel,
+					},
+				},
+			).
+			Request("job-a", corev1.ResourceCPU, "100m").
+			Request("job-b", corev1.ResourceCPU, "100m").
+			Obj()
+
+		wl := &kueue.Workload{}
+		var wlLookupKey types.NamespacedName
+
+		ginkgo.By("creating the JobSet", func() {
+			util.MustCreate(ctx, k8sClient, jobSet)
+			wlLookupKey = types.NamespacedName{
+				Name:      workloadjobset.GetWorkloadNameForJobSet(jobSet.Name, jobSet.UID),
+				Namespace: ns.Name,
+			}
+		})
+
+		ginkgo.By("verify the workload is admitted with TAS assignments for both podSets", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, wl)).Should(gomega.Succeed())
+				g.Expect(wl.Status.Admission).ShouldNot(gomega.BeNil())
+				g.Expect(wl.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(2))
+				g.Expect(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment).ShouldNot(gomega.BeNil())
+				g.Expect(wl.Status.Admission.PodSetAssignments[1].TopologyAssignment).ShouldNot(gomega.BeNil())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("wait for the jobset to be unsuspended", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: jobSet.Name, Namespace: ns.Name}, jobSet)).Should(gomega.Succeed())
+				g.Expect(ptr.Deref(jobSet.Spec.Suspend, false)).Should(gomega.BeFalse())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("mark the jobset as active and job-a as completed", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(jobSet), jobSet)).To(gomega.Succeed())
+				jobSet = (&testingjobset.JobSetWrapper{JobSet: *jobSet}).JobsStatus(
+					jobsetapi.ReplicatedJobStatus{
+						Name:      "job-a",
+						Succeeded: 1,
+					},
+					jobsetapi.ReplicatedJobStatus{
+						Name:   "job-b",
+						Active: 1,
+					},
+				).Obj()
+				g.Expect(k8sClient.Status().Update(ctx, jobSet)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("verify the workload has reclaimable pods for job-a", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, wl)).Should(gomega.Succeed())
+				g.Expect(wl.Status.ReclaimablePods).Should(gomega.BeComparableTo([]kueue.ReclaimablePod{
+					{
+						Name:  "job-a",
+						Count: 1,
+					},
+				}))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("preempt the workload", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, wl)).To(gomega.Succeed())
+				g.Expect(workload.SetConditionAndUpdate(ctx, k8sClient, wl, kueue.WorkloadEvicted, metav1.ConditionTrue, kueue.WorkloadEvictedByPreemption, "By test", "evict", util.RealClock)).
+					To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("mark the jobset as inactive so eviction can complete", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(jobSet), jobSet)).To(gomega.Succeed())
+				jobSet = (&testingjobset.JobSetWrapper{JobSet: *jobSet}).JobsStatus(
+					jobsetapi.ReplicatedJobStatus{
+						Name:      "job-a",
+						Succeeded: 1,
+					},
+					jobsetapi.ReplicatedJobStatus{
+						Name:   "job-b",
+						Active: 0,
+					},
+				).Obj()
+				g.Expect(k8sClient.Status().Update(ctx, jobSet)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("finish eviction", func() {
+			util.FinishEvictionForWorkloads(ctx, k8sClient, wl)
+		})
+
+		ginkgo.By("verify the workload is re-admitted", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, wl)).Should(gomega.Succeed())
+				g.Expect(wl.Status.Admission).ShouldNot(gomega.BeNil())
+				g.Expect(wl.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(2))
+
+				// job-a (completed, count=0) should have no topology assignment
+				g.Expect(wl.Status.Admission.PodSetAssignments[0].Name).Should(gomega.Equal(kueue.NewPodSetReference("job-a")))
+				g.Expect(wl.Status.Admission.PodSetAssignments[0].Count).Should(gomega.Equal(ptr.To[int32](0)))
+				g.Expect(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeNil())
+
+				// job-b (still running, count=1) should have a valid topology assignment
+				g.Expect(wl.Status.Admission.PodSetAssignments[1].Name).Should(gomega.Equal(kueue.NewPodSetReference("job-b")))
+				g.Expect(wl.Status.Admission.PodSetAssignments[1].Count).Should(gomega.Equal(ptr.To[int32](1)))
+				g.Expect(wl.Status.Admission.PodSetAssignments[1].TopologyAssignment).ShouldNot(gomega.BeNil())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
 })


### PR DESCRIPTION
Cherry pick of #10478 on release-0.16.

#10478: Fix TAS empty slices for count=0 podSets causing infinite scheduling loop

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
TAS: Fix empty slices for count=0 podSets causing infinite scheduling loop
```