### PR TITLE
Finish orphaned workloads using stored owner metadata

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -210,11 +210,12 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// Finish orphaned workloads whose controller owner no longer exists.
-	// The ownerReference still points to a non-existent object (e.g., a
-	// Deployment-owned pod deleted after PodsReady timeout eviction).
+	// Finish orphaned workloads whose owner no longer exists.
+	// Prefer the controller ownerReference when it is still present, and fall
+	// back to the stored owner metadata after orphan propagation removes owner
+	// references from the workload.
 	if features.Enabled(features.FinishOrphanedWorkloads) && wl.DeletionTimestamp.IsZero() {
-		if ownerGone, err := r.isControllerOwnerGone(ctx, &wl); err != nil {
+		if ownerGone, err := workload.IsOwnerGone(ctx, r.client, &wl); err != nil {
 			return ctrl.Result{}, err
 		} else if ownerGone {
 			log.V(2).Info("Workload is orphaned, finishing to release quota")
@@ -1286,34 +1287,6 @@ func (r *WorkloadReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.Conf
 		Watches(&kueue.ClusterQueue{}, wqh).
 		Watches(&kueue.LocalQueue{}, wqh).
 		Complete(WithLeadingManager(mgr, r, &kueue.Workload{}, cfg))
-}
-
-// isControllerOwnerGone checks whether the controller owner of the workload
-// still exists. Returns true if the controller owner reference points to an
-// object that no longer exists (NotFound) or whose UID no longer matches.
-// This is used to detect stale workloads whose owning pod was deleted
-// (e.g., by eviction) and replaced by a new pod from a Deployment.
-func (r *WorkloadReconciler) isControllerOwnerGone(ctx context.Context, wl *kueue.Workload) (bool, error) {
-	ref := metav1.GetControllerOf(wl)
-	if ref == nil {
-		return false, nil
-	}
-	obj := &metav1.PartialObjectMetadata{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: ref.APIVersion,
-			Kind:       ref.Kind,
-		},
-	}
-	key := client.ObjectKey{Namespace: wl.Namespace, Name: ref.Name}
-	if err := r.client.Get(ctx, key, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return true, nil
-		}
-		return false, err
-	}
-	// A different UID means the original owner was deleted and a new object
-	// with the same name was created.
-	return obj.UID != ref.UID, nil
 }
 
 // admittedNotReadyWorkload returns the underlying cause and remaining time for

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -45,6 +45,7 @@ import (
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/constants"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/dra"
 	"sigs.k8s.io/kueue/pkg/features"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
@@ -2849,6 +2850,138 @@ func TestReconcile(t *testing.T) {
 					Status:  metav1.ConditionTrue,
 					Reason:  kueue.WorkloadFinishedReasonOwnerNotFound,
 					Message: "The workload's owner no longer exists",
+				}).
+				Obj(),
+		},
+		"workload with fallback owner metadata and existing owner should not be finished": {
+			featureGates: map[featuregate.Feature]bool{
+				features.FinishOrphanedWorkloads: true,
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				JobUID("owneruid").
+				Annotation(controllerconstants.JobOwnerGVKAnnotation, batchv1.SchemeGroupVersion.WithKind("Job").String()).
+				Annotation(controllerconstants.JobOwnerNameAnnotation, "ownername").
+				Obj(),
+			additionalObjects: []client.Object{
+				&batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ownername",
+						Namespace: "ns",
+						UID:       "owneruid",
+					},
+				},
+			},
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				JobUID("owneruid").
+				Annotation(controllerconstants.JobOwnerGVKAnnotation, batchv1.SchemeGroupVersion.WithKind("Job").String()).
+				Annotation(controllerconstants.JobOwnerNameAnnotation, "ownername").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadInadmissible,
+					Message: "LocalQueue  doesn't exist",
+				}).
+				Obj(),
+		},
+		"workload with fallback owner metadata and deleting owner should be finished": {
+			featureGates: map[featuregate.Feature]bool{
+				features.FinishOrphanedWorkloads: true,
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				JobUID("owneruid").
+				Annotation(controllerconstants.JobOwnerGVKAnnotation, batchv1.SchemeGroupVersion.WithKind("Job").String()).
+				Annotation(controllerconstants.JobOwnerNameAnnotation, "ownername").
+				Obj(),
+			additionalObjects: []client.Object{
+				&batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "ownername",
+						Namespace:         "ns",
+						UID:               "owneruid",
+						Finalizers:        []string{"test-finalizer"},
+						DeletionTimestamp: ptr.To(metav1.Now()),
+					},
+				},
+			},
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				JobUID("owneruid").
+				Annotation(controllerconstants.JobOwnerGVKAnnotation, batchv1.SchemeGroupVersion.WithKind("Job").String()).
+				Annotation(controllerconstants.JobOwnerNameAnnotation, "ownername").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadFinished,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueue.WorkloadFinishedReasonOwnerNotFound,
+					Message: "The workload's owner no longer exists",
+				}).
+				Obj(),
+		},
+		"workload with fallback owner metadata and missing owner should be finished": {
+			featureGates: map[featuregate.Feature]bool{
+				features.FinishOrphanedWorkloads: true,
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				JobUID("gone-uid").
+				Annotation(controllerconstants.JobOwnerGVKAnnotation, batchv1.SchemeGroupVersion.WithKind("Job").String()).
+				Annotation(controllerconstants.JobOwnerNameAnnotation, "deleted-job").
+				Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				JobUID("gone-uid").
+				Annotation(controllerconstants.JobOwnerGVKAnnotation, batchv1.SchemeGroupVersion.WithKind("Job").String()).
+				Annotation(controllerconstants.JobOwnerNameAnnotation, "deleted-job").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadFinished,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueue.WorkloadFinishedReasonOwnerNotFound,
+					Message: "The workload's owner no longer exists",
+				}).
+				Obj(),
+		},
+		"workload with fallback owner metadata and recreated owner should be finished": {
+			featureGates: map[featuregate.Feature]bool{
+				features.FinishOrphanedWorkloads: true,
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				JobUID("gone-uid").
+				Annotation(controllerconstants.JobOwnerGVKAnnotation, batchv1.SchemeGroupVersion.WithKind("Job").String()).
+				Annotation(controllerconstants.JobOwnerNameAnnotation, "ownername").
+				Obj(),
+			additionalObjects: []client.Object{
+				&batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ownername",
+						Namespace: "ns",
+						UID:       "replacement-uid",
+					},
+				},
+			},
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				JobUID("gone-uid").
+				Annotation(controllerconstants.JobOwnerGVKAnnotation, batchv1.SchemeGroupVersion.WithKind("Job").String()).
+				Annotation(controllerconstants.JobOwnerNameAnnotation, "ownername").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadFinished,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueue.WorkloadFinishedReasonOwnerNotFound,
+					Message: "The workload's owner no longer exists",
+				}).
+				Obj(),
+		},
+		"workload with incomplete fallback owner metadata should not be finished": {
+			featureGates: map[featuregate.Feature]bool{
+				features.FinishOrphanedWorkloads: true,
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Annotation(controllerconstants.JobOwnerGVKAnnotation, batchv1.SchemeGroupVersion.WithKind("Job").String()).
+				Annotation(controllerconstants.JobOwnerNameAnnotation, "ownername").
+				Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Annotation(controllerconstants.JobOwnerGVKAnnotation, batchv1.SchemeGroupVersion.WithKind("Job").String()).
+				Annotation(controllerconstants.JobOwnerNameAnnotation, "ownername").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadInadmissible,
+					Message: "LocalQueue  doesn't exist",
 				}).
 				Obj(),
 		},

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1114,18 +1114,28 @@ func FindMatchingWorkloads(ctx context.Context, c client.Client, job GenericJob)
 }
 
 func EnsurePrebuiltWorkloadOwnership(ctx context.Context, c client.Client, wl *kueue.Workload, object client.Object) error {
+	shouldUpdate := false
+
 	if !metav1.IsControlledBy(wl, object) {
 		if err := ctrl.SetControllerReference(object, wl, c.Scheme()); err != nil {
 			return err
 		}
+		shouldUpdate = true
+	}
 
-		if errs := content.IsLabelValue(string(object.GetUID())); len(errs) == 0 {
-			if wl.Labels == nil {
-				wl.Labels = make(map[string]string, 1)
-			}
-			wl.Labels[controllerconsts.JobUIDLabel] = string(object.GetUID())
-		}
+	prevJobUID := wl.Labels[controllerconsts.JobUIDLabel]
+	prevOwnerGVK := wl.Annotations[controllerconsts.JobOwnerGVKAnnotation]
+	prevOwnerName := wl.Annotations[controllerconsts.JobOwnerNameAnnotation]
+	if err := workload.SetOwnerMetadata(wl, object, c); err != nil {
+		return err
+	}
+	if wl.Labels[controllerconsts.JobUIDLabel] != prevJobUID ||
+		wl.Annotations[controllerconsts.JobOwnerGVKAnnotation] != prevOwnerGVK ||
+		wl.Annotations[controllerconsts.JobOwnerNameAnnotation] != prevOwnerName {
+		shouldUpdate = true
+	}
 
+	if shouldUpdate {
 		if err := c.Update(ctx, wl); err != nil {
 			return err
 		}
@@ -1394,6 +1404,10 @@ func ConstructWorkload(ctx context.Context, c client.Client, job GenericJob, lab
 			"ValidationErrors", errs,
 			"LabelValue", jobUID,
 		)
+	}
+
+	if err := workload.SetOwnerMetadata(wl, object, c); err != nil {
+		return nil, err
 	}
 
 	if err := ctrl.SetControllerReference(object, wl, c.Scheme()); err != nil {

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -82,6 +82,8 @@ func TestReconcileGenericJob(t *testing.T) {
 		ResourceVersion("1").
 		Finalizers(kueue.ResourceInUseFinalizerName).
 		Label(constants.JobUIDLabel, testJobName).
+		Annotation(constants.JobOwnerGVKAnnotation, testGVK.String()).
+		Annotation(constants.JobOwnerNameAnnotation, testJobName).
 		ControllerReference(testGVK, testJobName, testJobName).
 		Queue(testLocalQueueName).
 		PodSets(basePodSets...).
@@ -136,6 +138,8 @@ func TestReconcileGenericJob(t *testing.T) {
 				*baseWl.Clone().Name("job-test-job-3991b").
 					Annotations(map[string]string{
 						workloadslicing.EnabledAnnotationKey: workloadslicing.EnabledAnnotationValue,
+						constants.JobOwnerGVKAnnotation:      testGVK.String(),
+						constants.JobOwnerNameAnnotation:     testJobName,
 						kueue.WorkloadSliceNameAnnotation:    "job-test-job-3991b",
 					}).
 					Obj(),
@@ -399,6 +403,8 @@ func TestReconcileGenericJobWithCustomWorkloadActivation(t *testing.T) {
 		ResourceVersion("1").
 		Finalizers(kueue.ResourceInUseFinalizerName).
 		Label(constants.JobUIDLabel, testJobName).
+		Annotation(constants.JobOwnerGVKAnnotation, testGVK.String()).
+		Annotation(constants.JobOwnerNameAnnotation, testJobName).
 		ControllerReference(testGVK, testJobName, testJobName).
 		Queue(testLocalQueueName).
 		PodSets(basePodSets...).

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -557,6 +557,17 @@ var (
 	}
 )
 
+func jobWorkloadAnnotations(name string, extra map[string]string) map[string]string {
+	annotations := map[string]string{
+		controllerconsts.JobOwnerGVKAnnotation:  batchv1.SchemeGroupVersion.WithKind("Job").String(),
+		controllerconsts.JobOwnerNameAnnotation: name,
+	}
+	for key, value := range extra {
+		annotations[key] = value
+	}
+	return annotations
+}
+
 func TestReconciler(t *testing.T) {
 	// the clock is primarily used with second rounded times
 	// use the current time trimmed.
@@ -1105,7 +1116,9 @@ func TestReconciler(t *testing.T) {
 				Obj(),
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("job", "ns").
-					Annotations(map[string]string{controllerconsts.ProvReqAnnotationPrefix + "test-annotation": "test-val"}).
+					Annotations(jobWorkloadAnnotations("job", map[string]string{
+						controllerconsts.ProvReqAnnotationPrefix + "test-annotation": "test-val",
+					})).
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
 					Queue(localQueueName).
@@ -1152,6 +1165,7 @@ func TestReconciler(t *testing.T) {
 					Labels(map[string]string{
 						controllerconsts.JobUIDLabel: "test-uid",
 						"toCopyKey":                  "toCopyValue"}).
+					Annotations(jobWorkloadAnnotations("job", nil)).
 					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
@@ -2887,6 +2901,7 @@ func TestReconciler(t *testing.T) {
 					Labels(map[string]string{
 						controllerconsts.JobUIDLabel: "test-uid",
 					}).
+					Annotations(jobWorkloadAnnotations("job", nil)).
 					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
@@ -3066,6 +3081,7 @@ func TestReconciler(t *testing.T) {
 					Queue("test-queue").
 					Priority(0).
 					Labels(map[string]string{}).
+					Annotations(jobWorkloadAnnotations("job", nil)).
 					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
@@ -3540,6 +3556,7 @@ func TestReconciler(t *testing.T) {
 					Labels(map[string]string{
 						controllerconsts.JobUIDLabel: "test-uid",
 					}).
+					Annotations(jobWorkloadAnnotations("job", nil)).
 					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
@@ -3589,6 +3606,7 @@ func TestReconciler(t *testing.T) {
 					Labels(map[string]string{
 						controllerconsts.JobUIDLabel: "test-uid",
 					}).
+					Annotations(jobWorkloadAnnotations("job", nil)).
 					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
@@ -3640,6 +3658,7 @@ func TestReconciler(t *testing.T) {
 					Labels(map[string]string{
 						controllerconsts.JobUIDLabel: "test-uid",
 					}).
+					Annotations(jobWorkloadAnnotations("job", nil)).
 					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
@@ -3735,6 +3754,7 @@ func TestReconciler(t *testing.T) {
 					Labels(map[string]string{
 						controllerconsts.JobUIDLabel: "test-uid",
 					}).
+					Annotations(jobWorkloadAnnotations("job", nil)).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job", "test-uid").
 					Obj(),
 			},
@@ -3830,6 +3850,7 @@ func TestReconciler(t *testing.T) {
 					Labels(map[string]string{
 						controllerconsts.JobUIDLabel: "test-uid",
 					}).
+					Annotations(jobWorkloadAnnotations("job", nil)).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job", "test-uid").
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadFinished,
@@ -4192,6 +4213,7 @@ func TestReconciler(t *testing.T) {
 					Queue(localQueueName).
 					Priority(0).
 					Labels(map[string]string{controllerconsts.JobUIDLabel: string(baseJobWrapper.GetUID())}).
+					Annotations(jobWorkloadAnnotations("job", nil)).
 					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
@@ -4303,6 +4325,7 @@ func TestReconciler(t *testing.T) {
 					Labels(map[string]string{
 						controllerconsts.JobUIDLabel: "test-uid",
 					}).
+					Annotations(jobWorkloadAnnotations("job", nil)).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -251,6 +251,17 @@ var (
 	}
 )
 
+func podWorkloadAnnotations(name string, extra map[string]string) map[string]string {
+	annotations := map[string]string{
+		controllerconsts.JobOwnerGVKAnnotation:  corev1.SchemeGroupVersion.WithKind("Pod").String(),
+		controllerconsts.JobOwnerNameAnnotation: name,
+	}
+	for key, value := range extra {
+		annotations[key] = value
+	}
+	return annotations
+}
+
 func TestReconciler(t *testing.T) {
 	// the clock is primarily used with second rounded times
 	// use the current time trimmed.
@@ -410,6 +421,7 @@ func TestReconciler(t *testing.T) {
 					Labels(map[string]string{
 						controllerconsts.JobUIDLabel: "test-uid",
 					}).
+					Annotations(podWorkloadAnnotations("pod", nil)).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
@@ -653,7 +665,9 @@ func TestReconciler(t *testing.T) {
 			},
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("wl", "ns").
-					Annotations(map[string]string{controllerconsts.ProvReqAnnotationPrefix + "test-annotation": "test-val"}).
+					Annotations(podWorkloadAnnotations("pod", map[string]string{
+						controllerconsts.ProvReqAnnotationPrefix + "test-annotation": "test-val",
+					})).
 					Obj(),
 			},
 			workloadCmpOpts: cmp.Options{
@@ -4186,6 +4200,7 @@ func TestReconciler(t *testing.T) {
 						controllerconsts.JobUIDLabel: "test-uid",
 						"toCopyKey":                  "toCopyValue",
 					}).
+					Annotations(podWorkloadAnnotations("pod", nil)).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -29,8 +29,12 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/validate/content"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	resourcehelpers "k8s.io/component-helpers/resource"
@@ -38,6 +42,7 @@ import (
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -45,6 +50,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	queueafs "sigs.k8s.io/kueue/pkg/cache/queue/afs"
 	"sigs.k8s.io/kueue/pkg/constants"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/resources"
@@ -543,6 +549,100 @@ func CanBePartiallyAdmitted(wl *kueue.Workload) bool {
 
 func Key(w *kueue.Workload) Reference {
 	return NewReference(w.Namespace, w.Name)
+}
+
+// SetOwnerMetadata records the owner identity so the owner can still be
+// resolved after orphan propagation removes owner references from the
+// workload.
+func SetOwnerMetadata(wl *kueue.Workload, object client.Object, c client.Client) error {
+	gvk, err := apiutil.GVKForObject(object, c.Scheme())
+	if err != nil {
+		return err
+	}
+
+	if wl.Annotations == nil {
+		wl.Annotations = make(map[string]string, 2)
+	}
+	wl.Annotations[controllerconstants.JobOwnerGVKAnnotation] = gvk.String()
+	wl.Annotations[controllerconstants.JobOwnerNameAnnotation] = object.GetName()
+
+	jobUID := string(object.GetUID())
+	if errs := content.IsLabelValue(jobUID); len(errs) == 0 {
+		if wl.Labels == nil {
+			wl.Labels = make(map[string]string, 1)
+		}
+		wl.Labels[controllerconstants.JobUIDLabel] = jobUID
+	}
+
+	return nil
+}
+
+// IsOwnerGone checks whether the workload owner still exists.
+// It first resolves the controller owner reference, then falls back to the
+// stored owner metadata when the controller owner reference is unavailable.
+func IsOwnerGone(ctx context.Context, c client.Client, wl *kueue.Workload) (bool, error) {
+	if ref := metav1.GetControllerOf(wl); ref != nil {
+		return isOwnerReferenceGone(ctx, c, wl.Namespace, ref, false)
+	}
+
+	ref, ok := ownerReferenceFromMetadata(wl)
+	if !ok {
+		return false, nil
+	}
+	return isOwnerReferenceGone(ctx, c, wl.Namespace, ref, true)
+}
+
+func ownerReferenceFromMetadata(wl *kueue.Workload) (*metav1.OwnerReference, bool) {
+	ownerGVK := wl.Annotations[controllerconstants.JobOwnerGVKAnnotation]
+	ownerName := wl.Annotations[controllerconstants.JobOwnerNameAnnotation]
+	ownerUID := wl.Labels[controllerconstants.JobUIDLabel]
+	if ownerGVK == "" || ownerName == "" || ownerUID == "" {
+		return nil, false
+	}
+
+	apiVersion, kind, ok := strings.Cut(ownerGVK, ", Kind=")
+	if !ok || kind == "" {
+		return nil, false
+	}
+
+	gv, err := schema.ParseGroupVersion(apiVersion)
+	if err != nil {
+		return nil, false
+	}
+
+	return &metav1.OwnerReference{
+		APIVersion: gv.String(),
+		Kind:       kind,
+		Name:       ownerName,
+		UID:        types.UID(ownerUID),
+	}, true
+}
+
+func isOwnerReferenceGone(ctx context.Context, c client.Client, namespace string, ref *metav1.OwnerReference, treatDeletingAsGone bool) (bool, error) {
+	obj := &metav1.PartialObjectMetadata{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: ref.APIVersion,
+			Kind:       ref.Kind,
+		},
+	}
+	key := client.ObjectKey{Namespace: namespace, Name: ref.Name}
+	if err := c.Get(ctx, key, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	if treatDeletingAsGone && !obj.GetDeletionTimestamp().IsZero() {
+		return true, nil
+	}
+	return obj.UID != ref.UID, nil
+}
+
+func GetLocalQueue(wl *kueue.Workload) kueue.LocalQueueName {
+	if wl == nil {
+		return ""
+	}
+	return wl.Spec.QueueName
 }
 
 func reclaimableCounts(wl *kueue.Workload) map[kueue.PodSetReference]int32 {

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -920,6 +920,117 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:batch", "area:jobs")
 	})
 })
 
+var _ = ginkgo.Describe("Job controller with orphaned workload cleanup", ginkgo.Label("job:batch", "area:jobs"), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+	var (
+		ns *corev1.Namespace
+		fl *kueue.ResourceFlavor
+		cq *kueue.ClusterQueue
+		lq *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeAll(func() {
+		fwk.StartManager(ctx, cfg, managerAndControllersSetup(false, true, nil))
+	})
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "orphan-job-")
+
+		fl = utiltestingapi.MakeResourceFlavor("fl").Obj()
+		util.MustCreate(ctx, k8sClient, fl)
+
+		cq = utiltestingapi.MakeClusterQueue("cq").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(fl.Name).
+				Resource(corev1.ResourceCPU, "1").
+				Obj()).
+			Obj()
+		util.MustCreate(ctx, k8sClient, cq)
+
+		lq = utiltestingapi.MakeLocalQueue("lq", ns.Name).ClusterQueue(cq.Name).Obj()
+		util.MustCreate(ctx, k8sClient, lq)
+
+		util.ExpectClusterQueuesToBeActive(ctx, k8sClient, cq)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, fl, true)
+	})
+
+	ginkgo.It("should finish orphaned workload and release quota when owner Job is deleted with orphan propagation", func() {
+		ginkgo.By("creating and admitting job-a")
+		jobA := testingjob.MakeJob("job-a", ns.Name).
+			Queue(kueue.LocalQueueName(lq.Name)).
+			Request(corev1.ResourceCPU, "1").
+			Obj()
+		util.MustCreate(ctx, k8sClient, jobA)
+
+		wlAKey := types.NamespacedName{
+			Name:      workloadjob.GetWorkloadNameForJob(jobA.Name, jobA.UID),
+			Namespace: ns.Name,
+		}
+		util.ExpectWorkloadsToBeAdmittedByKeys(ctx, k8sClient, wlAKey)
+
+		ginkgo.By("verifying workload-a recorded owner metadata")
+		wlA := &kueue.Workload{}
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlAKey, wlA)).To(gomega.Succeed())
+			g.Expect(wlA.Annotations).To(gomega.HaveKeyWithValue(constants.JobOwnerGVKAnnotation, batchv1.SchemeGroupVersion.WithKind("Job").String()))
+			g.Expect(wlA.Annotations).To(gomega.HaveKeyWithValue(constants.JobOwnerNameAnnotation, jobA.Name))
+			g.Expect(wlA.Labels).To(gomega.HaveKeyWithValue(constants.JobUIDLabel, string(jobA.UID)))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("creating job-b, which should remain pending while job-a holds quota")
+		jobB := testingjob.MakeJob("job-b", ns.Name).
+			Queue(kueue.LocalQueueName(lq.Name)).
+			Request(corev1.ResourceCPU, "1").
+			Obj()
+		util.MustCreate(ctx, k8sClient, jobB)
+
+		wlBKey := types.NamespacedName{
+			Name:      workloadjob.GetWorkloadNameForJob(jobB.Name, jobB.UID),
+			Namespace: ns.Name,
+		}
+		wlB := &kueue.Workload{}
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlBKey, wlB)).To(gomega.Succeed())
+			g.Expect(workload.IsAdmitted(wlB)).To(gomega.BeFalse())
+			g.Expect(wlB.Status.Conditions).To(utiltesting.HaveConditionStatusFalseAndReason(kueue.WorkloadQuotaReserved, "Pending"))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("deleting job-a with orphan propagation")
+		gomega.Expect(k8sClient.Delete(ctx, jobA, client.PropagationPolicy(metav1.DeletePropagationOrphan))).To(gomega.Succeed())
+
+		ginkgo.By("verifying job-b still cannot use the quota before orphan cleanup runs")
+		gomega.Consistently(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlBKey, wlB)).To(gomega.Succeed())
+			g.Expect(workload.IsAdmitted(wlB)).To(gomega.BeFalse())
+		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+
+		ginkgo.By("simulating orphan propagation by removing workload-a owner references")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlAKey, wlA)).To(gomega.Succeed())
+			if len(wlA.OwnerReferences) == 0 {
+				return
+			}
+			wlA.OwnerReferences = nil
+			g.Expect(k8sClient.Update(ctx, wlA)).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("asserting workload-a is finished with OwnerNotFound")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlAKey, wlA)).To(gomega.Succeed())
+			g.Expect(wlA.Status.Conditions).Should(utiltesting.HaveConditionStatusTrueAndReason(kueue.WorkloadFinished, kueue.WorkloadFinishedReasonOwnerNotFound))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("asserting job-b is admitted after workload-a releases quota")
+		util.ExpectWorkloadsToBeAdmittedByKeys(ctx, k8sClient, wlBKey)
+	})
+})
+
 var _ = ginkgo.Describe("When waitForPodsReady enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	type podsReadyTestSpec struct {
 		beforeJobStatus *batchv1.JobStatus


### PR DESCRIPTION
## Summary
Addresses #1789 by making orphan cleanup rely on workload-stored owner metadata instead of Job-side orphan handling.

- record owner GVK, owner name, and owner UID on created and prebuilt workloads
- finish orphaned workloads from the workload controller after orphan propagation removes owner references, including the window where the owner object is already deleting
- update job and pod controller expectations and add focused unit/integration coverage for orphaned and stale workload behavior

## Testing
- go test ./pkg/controller/core -run TestReconcile -count=1
- go test ./pkg/controller/jobframework -run 'TestReconcileGenericJob|TestReconcileGenericJobWithCustomWorkloadActivation|TestReconcileGenericJobWithWaitForPodsReady' -count=1
- go test ./pkg/controller/jobs/job -run TestReconcile -count=1
- go test ./pkg/controller/jobs/pod -run TestReconcile -count=1
- go test ./test/integration/singlecluster/controller/jobs/job -run TestAPIs -ginkgo.focus='orphaned workload cleanup' -count=1
- go test ./test/integration/singlecluster/controller/jobs/pod -run TestAPIs -ginkgo.focus='should not requeue stale workloads after pod is deleted and replaced' -count=1
