### PR TITLE
Manual cherrypick of: Fix stale workload accumulation after PodsReady timeout eviction [0.17]

### DIFF
--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -1092,6 +1092,10 @@ const (
 
 	// WorkloadFinishedReasonOutOfSync indicates that the prebuilt workload is not in sync with its parent job.
 	WorkloadFinishedReasonOutOfSync = "OutOfSync"
+
+	// WorkloadFinishedReasonOwnerNotFound indicates that the workload's owner
+	// no longer exists (e.g., a pod deleted after PodsReady timeout eviction).
+	WorkloadFinishedReasonOwnerNotFound = "OwnerNotFound"
 )
 
 // +genclient

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -213,6 +213,24 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	// Finish orphaned workloads whose controller owner no longer exists.
+	// The ownerReference still points to a non-existent object (e.g., a
+	// Deployment-owned pod deleted after PodsReady timeout eviction).
+	if features.Enabled(features.FinishOrphanedWorkloads) && wl.DeletionTimestamp.IsZero() {
+		if ownerGone, err := r.isControllerOwnerGone(ctx, &wl); err != nil {
+			return ctrl.Result{}, err
+		} else if ownerGone {
+			log.V(2).Info("Workload is orphaned, finishing to release quota")
+			if err := workload.Finish(ctx, r.client, &wl, kueue.WorkloadFinishedReasonOwnerNotFound, "The workload's owner no longer exists", r.clock); err != nil {
+				return ctrl.Result{}, client.IgnoreNotFound(err)
+			}
+			if err := workload.RemoveFinalizer(ctx, r.client, &wl); err != nil {
+				return ctrl.Result{}, client.IgnoreNotFound(err)
+			}
+			return ctrl.Result{}, nil
+		}
+	}
+
 	if features.Enabled(features.MultiKueueOrchestratedPreemption) {
 		updateErr := workload.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
 			updated := r.syncPreemptionGateStates(wl)
@@ -1288,16 +1306,36 @@ func (r *WorkloadReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.Conf
 		Complete(WithLeadingManager(mgr, r, &kueue.Workload{}, cfg))
 }
 
-// admittedNotReadyWorkload checks if a workload counts toward the PodsReady timeout
-// and calculates the remaining timeout duration.
-//
-// It returns two values:
-//  1. A underlyingCause that complements information carried by kueue.WorkloadEvictedByPodsReadyTimeout
-//
-// (e.g., WaitForStart, WaitForRecovery, or empty if not applicable).
-//
-//  2. The remaining time (in seconds) until the timeout is exceeded, based on
-//     the maximum of the LastTransitionTime for the Admitted and PodsReady conditions.
+// isControllerOwnerGone checks whether the controller owner of the workload
+// still exists. Returns true if the controller owner reference points to an
+// object that no longer exists (NotFound) or whose UID no longer matches.
+// This is used to detect stale workloads whose owning pod was deleted
+// (e.g., by eviction) and replaced by a new pod from a Deployment.
+func (r *WorkloadReconciler) isControllerOwnerGone(ctx context.Context, wl *kueue.Workload) (bool, error) {
+	ref := metav1.GetControllerOf(wl)
+	if ref == nil {
+		return false, nil
+	}
+	obj := &metav1.PartialObjectMetadata{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: ref.APIVersion,
+			Kind:       ref.Kind,
+		},
+	}
+	key := client.ObjectKey{Namespace: wl.Namespace, Name: ref.Name}
+	if err := r.client.Get(ctx, key, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	// A different UID means the original owner was deleted and a new object
+	// with the same name was created.
+	return obj.UID != ref.UID, nil
+}
+
+// admittedNotReadyWorkload returns the underlying cause and remaining time for
+// a workload that is admitted but not yet in PodsReady condition.
 //
 // If the workload is not admitted, PodsReady is true, or no timeout is configured,
 // it returns an empty underlyingCause and zero duration.

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -408,6 +408,7 @@ func TestReconcile(t *testing.T) {
 		featureGates map[featuregate.Feature]bool
 
 		workload                  *kueue.Workload
+		additionalObjects         []client.Object
 		cq                        *kueue.ClusterQueue
 		lq                        *kueue.LocalQueue
 		resourceClaims            []*resourcev1.ResourceClaim
@@ -2807,6 +2808,51 @@ func TestReconcile(t *testing.T) {
 				Obj(),
 			reconcilerOpts: []Option{},
 		},
+
+		"workload with existing controller owner should not be finished": {
+			featureGates: map[featuregate.Feature]bool{
+				features.FinishOrphanedWorkloads: true,
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "ownername", "owneruid").
+				Obj(),
+			additionalObjects: []client.Object{
+				&batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ownername",
+						Namespace: "ns",
+						UID:       "owneruid",
+					},
+				},
+			},
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "ownername", "owneruid").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadInadmissible,
+					Message: "LocalQueue  doesn't exist",
+				}).
+				Obj(),
+		},
+
+		"workload with gone controller owner should be finished": {
+			featureGates: map[featuregate.Feature]bool{
+				features.FinishOrphanedWorkloads: true,
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "deleted-job", "gone-uid").
+				Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "deleted-job", "gone-uid").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadFinished,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueue.WorkloadFinishedReasonOwnerNotFound,
+					Message: "The workload's owner no longer exists",
+				}).
+				Obj(),
+		},
 	}
 	for name, tc := range cases {
 		for _, enabled := range []bool{false, true} {
@@ -2817,12 +2863,27 @@ func TestReconcile(t *testing.T) {
 
 				testWl := tc.workload.DeepCopy()
 				objs := []client.Object{testWl}
+				objs = append(objs, tc.additionalObjects...)
 				for _, rc := range tc.resourceClaims {
 					objs = append(objs, rc)
 				}
 
 				for _, rct := range tc.resourceClaimTemplates {
 					objs = append(objs, rct)
+				}
+
+				// Create a stub owner object so that the FinishOrphanedWorkloads
+				// check does not incorrectly mark them as orphaned. Skip when
+				// the test explicitly enables the feature gate (those tests
+				// provide their own additionalObjects to control ownership).
+				if ref := metav1.GetControllerOf(testWl); ref != nil && !tc.featureGates[features.FinishOrphanedWorkloads] {
+					objs = append(objs, &batchv1.Job{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      ref.Name,
+							Namespace: testWl.Namespace,
+							UID:       ref.UID,
+						},
+					})
 				}
 
 				clientBuilder := utiltesting.NewClientBuilder().

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -359,6 +359,14 @@ const (
 	// Enables rejecting updates to ClusterQueues with invalid
 	// AdmissionCheckStrategy.OnFlavors references.
 	RejectUpdatesToCQWithInvalidOnFlavors featuregate.Feature = "RejectUpdatesToCQWithInvalidOnFlavors"
+
+	// owner: @sebest
+	//
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/1789
+	// Finish workloads whose controller owner no longer exists, preventing
+	// stale workload accumulation (e.g., after PodsReady timeout eviction
+	// deletes a Deployment-owned pod).
+	FinishOrphanedWorkloads featuregate.Feature = "FinishOrphanedWorkloads"
 )
 
 func init() {
@@ -552,6 +560,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	RejectUpdatesToCQWithInvalidOnFlavors: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	FinishOrphanedWorkloads: {
+		{Version: version.MustParse("0.17"), Default: true, PreRelease: featuregate.Beta},
 	},
 }
 

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -77,6 +77,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.17"
+- name: FinishOrphanedWorkloads
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.17"
 - name: FlavorFungibility
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -77,6 +77,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.17"
+- name: FinishOrphanedWorkloads
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.17"
 - name: FlavorFungibility
   versionedSpecs:
   - default: true

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -2657,5 +2658,133 @@ var _ = ginkgo.Describe("Pod controller with TASReplaceNodeOnPodTermination", gi
 				g.Expect(nodeNames[0]).ShouldNot(gomega.Equal(nodeName))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
+	})
+})
+
+var _ = ginkgo.Describe("Pod controller with deployment-owned pods and waitForPodsReady", ginkgo.Label("job:pod", "area:jobs"), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+	var (
+		ns *corev1.Namespace
+		fl *kueue.ResourceFlavor
+		cq *kueue.ClusterQueue
+		lq *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeAll(func() {
+		waitForPodsReady := &configapi.WaitForPodsReady{
+			Timeout:        metav1.Duration{Duration: 3 * time.Second},
+			BlockAdmission: ptr.To(false),
+			RequeuingStrategy: &configapi.RequeuingStrategy{
+				Timestamp:          ptr.To(configapi.EvictionTimestamp),
+				BackoffBaseSeconds: ptr.To[int32](1),
+				BackoffMaxSeconds:  ptr.To[int32](5),
+			},
+		}
+		nsSelector := &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      corev1.LabelMetadataName,
+					Operator: metav1.LabelSelectorOpNotIn,
+					Values:   []string{"kube-system", "kueue-system"},
+				},
+			},
+		}
+		mjnsSelector, err := metav1.LabelSelectorAsSelector(nsSelector)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		fwk.StartManager(ctx, cfg, managerSetup(
+			false,
+			true, // enable scheduler so pods get auto-admitted
+			&configapi.Configuration{WaitForPodsReady: waitForPodsReady},
+			jobframework.WithManageJobsWithoutQueueName(false),
+			jobframework.WithManagedJobsNamespaceSelector(mjnsSelector),
+			jobframework.WithKubeServerVersion(serverVersionFetcher),
+			jobframework.WithEnabledFrameworks([]string{"pod"}),
+		))
+	})
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "deploy-pod-")
+
+		fl = utiltestingapi.MakeResourceFlavor("fl").Obj()
+		util.MustCreate(ctx, k8sClient, fl)
+
+		cq = utiltestingapi.MakeClusterQueue("cq").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(fl.Name).
+				Resource(corev1.ResourceCPU, "9").
+				Obj()).
+			Obj()
+		util.MustCreate(ctx, k8sClient, cq)
+
+		lq = utiltestingapi.MakeLocalQueue("lq", ns.Name).ClusterQueue(cq.Name).Obj()
+		util.MustCreate(ctx, k8sClient, lq)
+
+		util.ExpectClusterQueuesToBeActive(ctx, k8sClient, cq)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, fl, true)
+	})
+
+	ginkgo.It("should not requeue stale workloads after pod is deleted and replaced", framework.SlowSpec, func() {
+		ginkgo.By("creating pod-1")
+		pod1 := testingpod.MakePod("pod-1", ns.Name).
+			Queue(lq.Name).
+			Request(corev1.ResourceCPU, "1").
+			Obj()
+		util.MustCreate(ctx, k8sClient, pod1)
+
+		ginkgo.By("waiting for pod-1 to be created and getting its UID")
+		createdPod1 := &corev1.Pod{}
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod1), createdPod1)).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		wl1Key := types.NamespacedName{
+			Name:      podcontroller.GetWorkloadNameForPod(pod1.Name, createdPod1.UID),
+			Namespace: ns.Name,
+		}
+
+		ginkgo.By("waiting for workload-1 to be admitted")
+		util.ExpectWorkloadsToBeAdmittedByKeys(ctx, k8sClient, wl1Key)
+		wl1 := &kueue.Workload{}
+		gomega.Expect(k8sClient.Get(ctx, wl1Key, wl1)).To(gomega.Succeed())
+
+		ginkgo.By("waiting for PodsReady timeout to trigger eviction of workload-1")
+		util.AwaitWorkloadEvictionByPodsReadyTimeout(ctx, k8sClient, wl1Key, 3*time.Second)
+		util.FinishEvictionForWorkloads(ctx, k8sClient, wl1)
+
+		ginkgo.By("waiting for pod-1 to be finalized or gone")
+		util.ExpectPodsFinalizedOrGone(ctx, k8sClient, client.ObjectKeyFromObject(pod1))
+
+		ginkgo.By("creating pod-2 as a replacement (simulating Deployment creating a new pod)")
+		pod2 := testingpod.MakePod("pod-2", ns.Name).
+			Queue(lq.Name).
+			Request(corev1.ResourceCPU, "1").
+			Obj()
+		util.MustCreate(ctx, k8sClient, pod2)
+
+		ginkgo.By("waiting for pod-2 to be created and getting its UID")
+		createdPod2 := &corev1.Pod{}
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod2), createdPod2)).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		wl2Key := types.NamespacedName{
+			Name:      podcontroller.GetWorkloadNameForPod(pod2.Name, createdPod2.UID),
+			Namespace: ns.Name,
+		}
+
+		ginkgo.By("waiting for workload-2 to be admitted")
+		util.ExpectWorkloadsToBeAdmittedByKeys(ctx, k8sClient, wl2Key)
+
+		ginkgo.By("asserting workload-1 is finished as stale (owner pod-1 was deleted)")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wl1Key, wl1)).To(gomega.Succeed())
+			g.Expect(wl1.Status.Conditions).Should(utiltesting.HaveConditionStatusTrueAndReason(kueue.WorkloadFinished, kueue.WorkloadFinishedReasonOwnerNotFound))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 })


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

CP for https://github.com/kubernetes-sigs/kueue/issues/10407

Manual cherrypick of https://github.com/kubernetes-sigs/kueue/pull/10274


#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix handling of orphaned workloads which could result in the accumulation of stale workloads
after PodsReady timeout eviction for Deployment-owned pods.
```