### PR TITLE
docs: clarify ProvisioningRequestConfigPodSetMergePolicy enum values

### DIFF
--- a/apis/kueue/v1beta1/provisioningrequestconfig_types.go
+++ b/apis/kueue/v1beta1/provisioningrequestconfig_types.go
@@ -21,11 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ProvisioningRequestConfigPodSetMergePolicy specifies the policy for merging PodSets.
-//
-// Valid values are:
-// - `IdenticalPodTemplates`: Merges only identical PodTemplates.
-// - `IdenticalWorkloadSchedulingRequirements`: Merges PodTemplates which have identical fields which are considered for defining the workload scheduling requirements.
 type ProvisioningRequestConfigPodSetMergePolicy string
 
 const (
@@ -89,6 +84,10 @@ type ProvisioningRequestConfigSpec struct {
 
 	// podSetMergePolicy specifies the policy for merging PodSets before being passed
 	// to the cluster autoscaler.
+	//
+	// The possible policies are:
+	// - `IdenticalPodTemplates`: Merges only identical PodTemplates.
+	// - `IdenticalWorkloadSchedulingRequirements`: Merges PodTemplates with identical fields that are considered when defining the workload scheduling requirements.
 	//
 	// +optional
 	// +kubebuilder:validation:Enum=IdenticalPodTemplates;IdenticalWorkloadSchedulingRequirements

--- a/apis/kueue/v1beta1/provisioningrequestconfig_types.go
+++ b/apis/kueue/v1beta1/provisioningrequestconfig_types.go
@@ -21,6 +21,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// ProvisioningRequestConfigPodSetMergePolicy specifies the policy for merging PodSets.
+//
+// Valid values are:
+// - `IdenticalPodTemplates`: Merges only identical PodTemplates.
+// - `IdenticalWorkloadSchedulingRequirements`: Merges PodTemplates which have identical fields which are considered for defining the workload scheduling requirements.
 type ProvisioningRequestConfigPodSetMergePolicy string
 
 const (

--- a/apis/kueue/v1beta2/provisioningrequestconfig_types.go
+++ b/apis/kueue/v1beta2/provisioningrequestconfig_types.go
@@ -21,11 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ProvisioningRequestConfigPodSetMergePolicy specifies the policy for merging PodSets.
-//
-// Valid values are:
-// - `IdenticalPodTemplates`: Merges only identical PodTemplates.
-// - `IdenticalWorkloadSchedulingRequirements`: Merges PodTemplates which have identical fields which are considered for defining the workload scheduling requirements.
 type ProvisioningRequestConfigPodSetMergePolicy string
 
 const (
@@ -90,6 +85,10 @@ type ProvisioningRequestConfigSpec struct {
 
 	// podSetMergePolicy specifies the policy for merging PodSets before being passed
 	// to the cluster autoscaler.
+	//
+	// The possible policies are:
+	// - `IdenticalPodTemplates`: Merges only identical PodTemplates.
+	// - `IdenticalWorkloadSchedulingRequirements`: Merges PodTemplates with identical fields that are considered when defining the workload scheduling requirements.
 	//
 	// +optional
 	// +kubebuilder:validation:Enum=IdenticalPodTemplates;IdenticalWorkloadSchedulingRequirements

--- a/apis/kueue/v1beta2/provisioningrequestconfig_types.go
+++ b/apis/kueue/v1beta2/provisioningrequestconfig_types.go
@@ -21,6 +21,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// ProvisioningRequestConfigPodSetMergePolicy specifies the policy for merging PodSets.
+//
+// Valid values are:
+// - `IdenticalPodTemplates`: Merges only identical PodTemplates.
+// - `IdenticalWorkloadSchedulingRequirements`: Merges PodTemplates which have identical fields which are considered for defining the workload scheduling requirements.
 type ProvisioningRequestConfigPodSetMergePolicy string
 
 const (

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_provisioningrequestconfigs.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_provisioningrequestconfigs.yaml
@@ -92,6 +92,10 @@ spec:
                   description: |-
                     podSetMergePolicy specifies the policy for merging PodSets before being passed
                     to the cluster autoscaler.
+
+                    The possible policies are:
+                    - `IdenticalPodTemplates`: Merges only identical PodTemplates.
+                    - `IdenticalWorkloadSchedulingRequirements`: Merges PodTemplates with identical fields that are considered when defining the workload scheduling requirements.
                   enum:
                     - IdenticalPodTemplates
                     - IdenticalWorkloadSchedulingRequirements
@@ -243,6 +247,10 @@ spec:
                   description: |-
                     podSetMergePolicy specifies the policy for merging PodSets before being passed
                     to the cluster autoscaler.
+
+                    The possible policies are:
+                    - `IdenticalPodTemplates`: Merges only identical PodTemplates.
+                    - `IdenticalWorkloadSchedulingRequirements`: Merges PodTemplates with identical fields that are considered when defining the workload scheduling requirements.
                   enum:
                     - IdenticalPodTemplates
                     - IdenticalWorkloadSchedulingRequirements

--- a/client-go/applyconfiguration/kueue/v1beta1/provisioningrequestconfigspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/provisioningrequestconfigspec.go
@@ -57,6 +57,10 @@ type ProvisioningRequestConfigSpecApplyConfiguration struct {
 	PodSetUpdates *ProvisioningRequestPodSetUpdatesApplyConfiguration `json:"podSetUpdates,omitempty"`
 	// podSetMergePolicy specifies the policy for merging PodSets before being passed
 	// to the cluster autoscaler.
+	//
+	// The possible policies are:
+	// - `IdenticalPodTemplates`: Merges only identical PodTemplates.
+	// - `IdenticalWorkloadSchedulingRequirements`: Merges PodTemplates with identical fields that are considered when defining the workload scheduling requirements.
 	PodSetMergePolicy *kueuev1beta1.ProvisioningRequestConfigPodSetMergePolicy `json:"podSetMergePolicy,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/provisioningrequestconfigspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/provisioningrequestconfigspec.go
@@ -57,6 +57,10 @@ type ProvisioningRequestConfigSpecApplyConfiguration struct {
 	PodSetUpdates *ProvisioningRequestPodSetUpdatesApplyConfiguration `json:"podSetUpdates,omitempty"`
 	// podSetMergePolicy specifies the policy for merging PodSets before being passed
 	// to the cluster autoscaler.
+	//
+	// The possible policies are:
+	// - `IdenticalPodTemplates`: Merges only identical PodTemplates.
+	// - `IdenticalWorkloadSchedulingRequirements`: Merges PodTemplates with identical fields that are considered when defining the workload scheduling requirements.
 	PodSetMergePolicy *kueuev1beta2.ProvisioningRequestConfigPodSetMergePolicy `json:"podSetMergePolicy,omitempty"`
 }
 

--- a/config/components/crd/bases/kueue.x-k8s.io_provisioningrequestconfigs.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_provisioningrequestconfigs.yaml
@@ -73,6 +73,10 @@ spec:
                 description: |-
                   podSetMergePolicy specifies the policy for merging PodSets before being passed
                   to the cluster autoscaler.
+
+                  The possible policies are:
+                  - `IdenticalPodTemplates`: Merges only identical PodTemplates.
+                  - `IdenticalWorkloadSchedulingRequirements`: Merges PodTemplates with identical fields that are considered when defining the workload scheduling requirements.
                 enum:
                 - IdenticalPodTemplates
                 - IdenticalWorkloadSchedulingRequirements
@@ -228,6 +232,10 @@ spec:
                 description: |-
                   podSetMergePolicy specifies the policy for merging PodSets before being passed
                   to the cluster autoscaler.
+
+                  The possible policies are:
+                  - `IdenticalPodTemplates`: Merges only identical PodTemplates.
+                  - `IdenticalWorkloadSchedulingRequirements`: Merges PodTemplates with identical fields that are considered when defining the workload scheduling requirements.
                 enum:
                 - IdenticalPodTemplates
                 - IdenticalWorkloadSchedulingRequirements

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -2443,6 +2443,13 @@ result in failure during workload admission.</p>
 - [ProvisioningRequestConfigSpec](#kueue-x-k8s-io-v1beta1-ProvisioningRequestConfigSpec)
 
 
+<p>ProvisioningRequestConfigPodSetMergePolicy specifies the policy for merging PodSets.</p>
+<p>Valid values are:</p>
+<ul>
+<li><code>IdenticalPodTemplates</code>: Merges only identical PodTemplates.</li>
+<li><code>IdenticalWorkloadSchedulingRequirements</code>: Merges PodTemplates which have identical fields which are considered for defining the workload scheduling requirements.</li>
+</ul>
+
 
 
 

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -2443,13 +2443,6 @@ result in failure during workload admission.</p>
 - [ProvisioningRequestConfigSpec](#kueue-x-k8s-io-v1beta1-ProvisioningRequestConfigSpec)
 
 
-<p>ProvisioningRequestConfigPodSetMergePolicy specifies the policy for merging PodSets.</p>
-<p>Valid values are:</p>
-<ul>
-<li><code>IdenticalPodTemplates</code>: Merges only identical PodTemplates.</li>
-<li><code>IdenticalWorkloadSchedulingRequirements</code>: Merges PodTemplates which have identical fields which are considered for defining the workload scheduling requirements.</li>
-</ul>
-
 
 
 
@@ -2523,6 +2516,11 @@ are used to target the provisioned nodes.</p>
 <td>
    <p>podSetMergePolicy specifies the policy for merging PodSets before being passed
 to the cluster autoscaler.</p>
+<p>The possible policies are:</p>
+<ul>
+<li><code>IdenticalPodTemplates</code>: Merges only identical PodTemplates.</li>
+<li><code>IdenticalWorkloadSchedulingRequirements</code>: Merges PodTemplates with identical fields that are considered when defining the workload scheduling requirements.</li>
+</ul>
 </td>
 </tr>
 </tbody>

--- a/site/content/en/docs/reference/kueue.v1beta2.md
+++ b/site/content/en/docs/reference/kueue.v1beta2.md
@@ -2634,6 +2634,13 @@ priority will be default or zero if there is no default.</p>
 - [ProvisioningRequestConfigSpec](#kueue-x-k8s-io-v1beta2-ProvisioningRequestConfigSpec)
 
 
+<p>ProvisioningRequestConfigPodSetMergePolicy specifies the policy for merging PodSets.</p>
+<p>Valid values are:</p>
+<ul>
+<li><code>IdenticalPodTemplates</code>: Merges only identical PodTemplates.</li>
+<li><code>IdenticalWorkloadSchedulingRequirements</code>: Merges PodTemplates which have identical fields which are considered for defining the workload scheduling requirements.</li>
+</ul>
+
 
 
 

--- a/site/content/en/docs/reference/kueue.v1beta2.md
+++ b/site/content/en/docs/reference/kueue.v1beta2.md
@@ -2634,13 +2634,6 @@ priority will be default or zero if there is no default.</p>
 - [ProvisioningRequestConfigSpec](#kueue-x-k8s-io-v1beta2-ProvisioningRequestConfigSpec)
 
 
-<p>ProvisioningRequestConfigPodSetMergePolicy specifies the policy for merging PodSets.</p>
-<p>Valid values are:</p>
-<ul>
-<li><code>IdenticalPodTemplates</code>: Merges only identical PodTemplates.</li>
-<li><code>IdenticalWorkloadSchedulingRequirements</code>: Merges PodTemplates which have identical fields which are considered for defining the workload scheduling requirements.</li>
-</ul>
-
 
 
 
@@ -2714,6 +2707,11 @@ are used to target the provisioned nodes.</p>
 <td>
    <p>podSetMergePolicy specifies the policy for merging PodSets before being passed
 to the cluster autoscaler.</p>
+<p>The possible policies are:</p>
+<ul>
+<li><code>IdenticalPodTemplates</code>: Merges only identical PodTemplates.</li>
+<li><code>IdenticalWorkloadSchedulingRequirements</code>: Merges PodTemplates with identical fields that are considered when defining the workload scheduling requirements.</li>
+</ul>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Clarifies the available enum values for `ProvisioningRequestConfigPodSetMergePolicy` in the generated API reference documentation.

The API reference currently does not make the valid values for `ProvisioningRequestConfigPodSetMergePolicy` obvious enough, which can make it harder for users to understand how to configure `podSetMergePolicy`. Defined enums can also be found in CRD:

https://github.com/kubernetes-sigs/kueue/blob/90375d4a3e8c363f7187512c8f5ad4145d041610/charts/kueue/templates/crd/kueue.x-k8s.io_provisioningrequestconfigs.yaml#L91-L98

Changes:
- Added a more complete type comment for `ProvisioningRequestConfigPodSetMergePolicy` in `v1beta1` and `v1beta2` comments.
- Regenerated API reference docs with `make generate-apiref`


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10457

#### Special notes for your reviewer:

The generated docs seems doesn't direct support showing as Field + Description for constants, hence added comments should improve user to understand existing values while maintaining readability for the code itself.

Doc preview/Screenshot
<img width="940" height="368" alt="image" src="https://github.com/user-attachments/assets/0d045366-c900-49bc-8673-7fc3c171bd49" />


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```