### PR TITLE
Clean deleted workloads from non-leader cache

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -1084,9 +1084,15 @@ func (r *WorkloadReconciler) Delete(e event.TypedDeleteEvent[*kueue.Workload]) b
 	if !e.DeleteStateUnknown {
 		status = workload.Status(e.Object)
 	}
-	r.logger().V(2).Info("Workload delete event", "workload", klog.KObj(e.Object), "queue", e.Object.Spec.QueueName, "status", status)
-	r.preemptionExpectations.ObservedUID(r.logger(),
+	log := r.logger().WithValues("workload", klog.KObj(e.Object), "queue", e.Object.Spec.QueueName, "status", status)
+	log.V(2).Info("Workload delete event")
+	r.preemptionExpectations.ObservedUID(log,
 		client.ObjectKeyFromObject(e.Object), e.Object.UID)
+
+	// Clean workload from caches in all replicas
+	ctx := ctrl.LoggerInto(context.Background(), log)
+	r.deleteWorkloadFromCaches(ctx, e.Object.Namespace, e.Object.Name)
+
 	return true
 }
 

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -3070,6 +3071,7 @@ func TestWorkloadDeletion(t *testing.T) {
 		wlInQueueCache    *kueue.Workload
 		wlInSchedCache    *kueue.Workload
 		wantNotifications []notification
+		nonLeader bool
 	}{
 		"no workloads in either cache": {
 			wlInQueueCache:    nil,
@@ -3116,6 +3118,15 @@ func TestWorkloadDeletion(t *testing.T) {
 				},
 			},
 		},
+		"non-leader replica cleans up queue cache": {
+			wlInQueueCache: pendingWl,
+			wlInSchedCache: nil,
+			wantNotifications: []notification{{
+				Cq: "cq1",
+				Lq: "lq1",
+			}},
+			nonLeader: true,
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -3129,7 +3140,9 @@ func TestWorkloadDeletion(t *testing.T) {
 
 			mockWatcher := mockWorkloadUpdateWatcher(qManager)
 
-			reconciler := NewWorkloadReconciler(cl, qManager, cqCache, recorder)
+			reconciler := NewWorkloadReconciler(cl, qManager, cqCache, recorder,
+				WithPreemptionExpectations(preemptexpectations.New()),
+			)
 			reconciler.watchers = []WorkloadUpdateWatcher{mockWatcher}
 
 			ctxWithLogger, log := utiltesting.ContextWithLog(t)
@@ -3169,7 +3182,29 @@ func TestWorkloadDeletion(t *testing.T) {
 				}
 			}
 
-			reconciler.deleteWorkloadFromCaches(ctx, wlNs, wlName)
+			if tc.nonLeader {
+				reconciler.Delete(event.TypedDeleteEvent[*kueue.Workload]{
+					Object: tc.wlInQueueCache.DeepCopy(),
+				})
+				nonLeaderReconciler := &leaderAwareReconciler{
+					elected:         make(chan struct{}),
+					client:          cl,
+					delegate:        reconciler,
+					object:          &kueue.Workload{},
+					requeueDuration: 15 * time.Second,
+				}
+				result, err := nonLeaderReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: wlNs, Name: wlName},
+				})
+				if err != nil {
+					t.Fatalf("non-leader reconciler returned error: %v", err)
+				}
+				if result.RequeueAfter != 0 {
+					t.Errorf("Expected no requeue for deleted workload, got RequeueAfter=%v", result.RequeueAfter)
+				}
+			} else {
+				reconciler.deleteWorkloadFromCaches(ctx, wlNs, wlName)
+			}
 
 			if testError := stderrors.Join(mockWatcher.testErrors...); testError != nil {
 				t.Error(testError)


### PR DESCRIPTION
Ensure caches of non-leaders are cleaned on delete events.
With the current behaviour a delete event cleans only the leader's cache.

To reproduce the issue:
* create a workload and delete it before finishing
* check the cluster queue as documented in: docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand/#cluster-queue-visibility-via-curl

/kind bug

```release-note
Clean deleted workloads from non-leader cache.
```