### PR TITLE
Automated cherry pick of #10530: Update main with the latest v0.17.1

### DIFF
--- a/CHANGELOG/CHANGELOG-0.17.md
+++ b/CHANGELOG/CHANGELOG-0.17.md
@@ -1,3 +1,46 @@
+## v0.17.1
+
+Changes since `v0.17.0`:
+
+## Urgent Upgrade Notes 
+
+### (No, really, you MUST read this before you upgrade)
+
+- AdmissionChecks: Add the alpha `RejectUpdatesToCQWithInvalidOnFlavors` feature gate (disabled by default) to reject updates to existing ClusterQueues with invalid `AdmissionCheckStrategy.OnFlavors` references. 
+  when enabling this feature gate, fix any existing invalid `OnFlavors` references before updating the affected ClusterQueues. (#10512, @tenzen-y)
+ 
+## Changes by Kind
+
+### Bug or Regression
+
+- AdmissionChecks: ClusterQueue validation now checks that the flavors specified in `AdmissionCheckStrategy.OnFlavors` are listed in quota. (#10369, @ShaanveerS)
+- AdmissionChecks: fix the bug that on backoff admission checks which are spanning all ResourceFlavors, such as MultiKueue, may be missing in the Workload’s status. 
+  
+  For MultiKueue that manifested with a bug, when aside from the MultiKueue admission check there was another non-MultiKueue admission check. In the scenario when eviction on the management cluster happened the manager that had temporarily lost connection to a worker, the remote workload would keep running on the reconnected worker, despite the workload staying without reservation on the manager cluster. (#9359, @Singularity23x0)
+- AdmissionFairSharing: Fixed a bug in entry penalties by reducing them when workload is admitted and also clearing them up if all the resources on the admission entry penalty have value zero. (#10455, @MaysaMacedo)
+- ElasticJobs: Fix a bug where pods stay gated after scale-up by allowing finished workloads to ungate their own pods. (#10364, @sohankunkerkar)
+- FailureRecoveryPolicy: Fixed an issue where pods could remain stuck terminating if their node became unreachable only after the force-termination timeout had already elapsed. (#10500, @kshalot)
+- Fix a bug in HA mode that caused follower replicas to retain stale workload caches after deletion. (#10521, @Ladicle)
+- Fix a bug where the batch/v1 Job mutating webhook could still run even when the batch/job integration was disabled. (#10328, @Ladicle)
+- Fix handling of orphaned workloads which could result in the accumulation of stale workloads
+  after PodsReady timeout eviction for Deployment-owned pods. (#10274, @sebest)
+- LeaderWorkerSet integration: fix the bug that the PodTemplate metadata wasn't propagated to the Workload's PodSets. (#10399, @pajakd)
+- MultiKueue: Fixes the bug where a job, after being dispatched to a worker, would not sync correctly after being evicted there. This would also cause its workload to be incorrectly labeled as admitted.
+  
+  Now the workload and the manager job instance will correctly reflect the evicted state and MultiKueue will perform a fallback, then dispatch remote workloads to all eligible workers again after being evicted from the Worker it was successfully admitted to before. An example of such a case is if the remote instance got preempted on the worker. (#10340, @Singularity23x0)
+- MultiKueue: fix the bug that when custom admission checks are configured on the manager cluster, other than
+  the MultiKueue admission check, then the Job may start running on the selected worker before the other admission
+  checks are satisfied (Ready). We fix the issue by deferring the dispatching of workload until all non-MultiKueue AdmissionChecks become Ready. (#10398, @mszadkow)
+- Observability: Fix a bug where kueue_cohort_subtree_admitted_workloads_total and kueue_cohort_subtree_admitted_active_workloads metrics could include results for an implicit root Cohort after deletion of a child Cohort or ClusterQueue. (#10395, @mbobrovskyi)
+- Observability: Fix excessive memory overhead in hot code paths by reusing the named logger in NewLogConstructor and avoiding unnecessary logger cloning. (#10393, @MatteoFari)
+- Observability: avoid logging update failures as "error" when they are caused by concurrent object modifications, especially when multiple errors are present.
+  
+  Example log message: "failed to update MultiKueueCluster status: Operation cannot be fulfilled on multikueueclusters.kueue.x-k8s.io \"testing-cluster\": the object has been modified; please apply your changes to the latest version and try again after failing to load client config: open /tmp/kubeconfig no such file or directory" (#10348, @mbobrovskyi)
+- TAS: Fix empty slices for count=0 podSets causing infinite scheduling loop (#10502, @jzhaojieh)
+- TAS: fix the bug that Pods which only contain the `kueue.x-k8s.io/podset-slice-required-topology` or `kueue.x-k8s.io/podset-slice-required-topology-constraints` as the TAS annotation are not ungated. (#10442, @tg123)
+- TAS: reduce the churn on the TAS-enabled controller, called NonTasUsageReconciler, by skipping triggering
+  of the Reconcile on Pod changes which are irrelevant from the controller point-of-view. (#10508, @MatteoFari)
+
 ## v0.17.0
 
 Changes since `v0.16.0`:

--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,8 @@ LD_FLAGS += -X '$(version_pkg).BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)'
 
 # Update these variables when preparing a new release or a release branch.
 # Then run `make prepare-release-branch`
-RELEASE_VERSION=v0.17.0
-RELEASE_BRANCH=release-0.17
+RELEASE_VERSION=v0.17.1
+RELEASE_BRANCH=main
 # Application version for Helm and npm (strips leading 'v' from RELEASE_VERSION)
 APP_VERSION := $(shell echo $(RELEASE_VERSION) | cut -c2-)
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Read the [overview](https://kueue.sigs.k8s.io/docs/overview/) and watch the Kueu
 To install the latest release of Kueue in your cluster, run the following command:
 
 ```shell
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.17.0/manifests.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.17.1/manifests.yaml
 ```
 
 The controller runs in the `kueue-system` namespace.

--- a/SECURITY-INSIGHTS.yaml
+++ b/SECURITY-INSIGHTS.yaml
@@ -1,11 +1,11 @@
 header:
   schema-version: 1.0.0
   expiration-date: '2024-09-28T01:00:00.000Z'
-  last-updated: '2026-03-31'
-  last-reviewed: '2026-03-31'
-  commit-hash: "4d5f7ffc7bdc5f88c723678cdacb89c05158dd36"
+  last-updated: '2026-04-16'
+  last-reviewed: '2026-04-16'
+  commit-hash: "6fcc132c0121b3f5e8b49246fc13e2e66c6f0620"
   project-url: 'https://github.com/kubernetes-sigs/kueue'
-  project-release: "0.17.0"
+  project-release: "0.17.1"
   changelog: 'https://github.com/kubernetes-sigs/kueue/tree/main/CHANGELOG'
   license: 'https://github.com/kubernetes-sigs/kueue/blob/main/LICENSE'
 project-lifecycle:
@@ -28,7 +28,7 @@ documentation:
   - 'https://kueue.sigs.k8s.io/docs/'
 distribution-points:
   - >-
-    https://github.com/kubernetes-sigs/kueue/releases/download/v0.17.0/manifests.yaml
+    https://github.com/kubernetes-sigs/kueue/releases/download/v0.17.1/manifests.yaml
 security-artifacts:
   threat-model:
     threat-model-created: false
@@ -62,5 +62,5 @@ dependencies:
   dependencies-lists:
     - 'https://github.com/kubernetes-sigs/kueue/blob/main/go.mod'
   sbom:
-    - sbom-file: https://github.com/kubernetes-sigs/kueue/releases/download/v0.17.0/kueue-v0.17.0.spdx.json
+    - sbom-file: https://github.com/kubernetes-sigs/kueue/releases/download/v0.17.1/kueue-v0.17.1.spdx.json
       sbom-format: SPDX

--- a/charts/kueue/Chart.yaml
+++ b/charts/kueue/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # NOTE: Do not modify manually. In Kueue, the version and appVersion are
 # overridden to GIT_TAG when building the artifacts, including the helm charts,
 # via Makefile.
-version: 0.17.0
+version: 0.17.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.17.0"
+appVersion: "v0.17.1"

--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -1,6 +1,6 @@
 # kueue
 
-![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.17.0](https://img.shields.io/badge/AppVersion-v0.17.0-informational?style=flat-square)
+![Version: 0.17.1](https://img.shields.io/badge/Version-0.17.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.17.1](https://img.shields.io/badge/AppVersion-v0.17.1-informational?style=flat-square)
 
 Kueue is a set of APIs and controllers for job queueing. It is a job-level manager that decides when a job should be admitted to start (as in pods can be created) and when it should stop (as in active pods should be deleted).
 
@@ -28,7 +28,7 @@ $ helm install kueue kueue/ --create-namespace --namespace kueue-system
 Or use the charts pushed to `oci://registry.k8s.io/kueue/charts/kueue`:
 
 ```bash
-helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.17.0" --create-namespace --namespace=kueue-system
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.17.1" --create-namespace --namespace=kueue-system
 ```
 
 For more advanced parametrization of Kueue, we recommend using a local overrides file, passed via the `--values` flag. For example:
@@ -50,7 +50,7 @@ controllerManager:
 ```
 
 ```bash
-helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.17.0" \
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.17.1" \
   --create-namespace --namespace=kueue-system \
   --values overrides.yaml
 ```
@@ -58,7 +58,7 @@ helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.17.0" \
 You can also use the `--set` flag. For example, to enable a feature gate (e.g., `TopologyAwareScheduling`):
 
 ```bash
-helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.17.0" \
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.17.1" \
   --create-namespace --namespace=kueue-system \
   --set "controllerManager.featureGates[0].name=TopologyAwareScheduling" \
   --set "controllerManager.featureGates[0].enabled=true"

--- a/charts/kueue/README.md.gotmpl
+++ b/charts/kueue/README.md.gotmpl
@@ -30,7 +30,7 @@ $ helm install kueue kueue/ --create-namespace --namespace kueue-system
 Or use the charts pushed to `oci://registry.k8s.io/kueue/charts/kueue`:
 
 ```bash
-helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.17.0" --create-namespace --namespace=kueue-system
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.17.1" --create-namespace --namespace=kueue-system
 ```
 
 For more advanced parametrization of Kueue, we recommend using a local overrides file, passed via the `--values` flag. For example:
@@ -52,7 +52,7 @@ controllerManager:
 ```
 
 ```bash
-helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.17.0" \
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.17.1" \
   --create-namespace --namespace=kueue-system \
   --values overrides.yaml
 ```
@@ -60,7 +60,7 @@ helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.17.0" \
 You can also use the `--set` flag. For example, to enable a feature gate (e.g., `TopologyAwareScheduling`):
 
 ```bash
-helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.17.0" \
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.17.1" \
   --create-namespace --namespace=kueue-system \
   --set "controllerManager.featureGates[0].name=TopologyAwareScheduling" \
   --set "controllerManager.featureGates[0].enabled=true"

--- a/cmd/experimental/kueue-populator/README.md
+++ b/cmd/experimental/kueue-populator/README.md
@@ -41,7 +41,7 @@ You can also install the `kueue-populator` using the provided Helm chart.
 
 ```bash
 helm install kueue-populator oci://registry.k8s.io/kueue/charts/kueue-populator \
-  --version 0.17.0 \
+  --version 0.17.1 \
   --namespace kueue-system \
   --create-namespace \
   --wait

--- a/cmd/experimental/kueue-populator/charts/kueue-populator/Chart.yaml
+++ b/cmd/experimental/kueue-populator/charts/kueue-populator/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: kueue-populator
 description: A Helm chart for Kueue Populator setup including Kueue, LocalQueue Creator, and default resources.
 type: application
-version: 0.17.0
-appVersion: "v0.17.0"
+version: 0.17.1
+appVersion: "v0.17.1"
 dependencies:
   - name: kueue
-    version: "~0.17.0"
+    version: "~0.17.1"
     repository: "file://../../../../../charts/kueue"
     condition: kueue.enabled

--- a/cmd/experimental/kueue-populator/charts/kueue-populator/README.md
+++ b/cmd/experimental/kueue-populator/charts/kueue-populator/README.md
@@ -34,7 +34,7 @@ You can install the chart directly from the OCI registry:
 
 ```bash
 helm install kueue-populator oci://registry.k8s.io/kueue/charts/kueue-populator \
-  --version 0.17.0 \
+  --version 0.17.1 \
   --namespace kueue-system \
   --create-namespace \
   --wait
@@ -112,7 +112,7 @@ kueuePopulator:
 
 ```bash
 helm install kueue-populator oci://registry.k8s.io/kueue/charts/kueue-populator \
-  --version 0.17.0 \
+  --version 0.17.1 \
   --namespace kueue-system \
   --create-namespace \
   --wait \
@@ -125,7 +125,7 @@ For simple configuration you may also use the minimalistic command:
 
 ```bash
 helm install kueue-populator oci://registry.k8s.io/kueue/charts/kueue-populator \
-  --version 0.17.0 \
+  --version 0.17.1 \
   --namespace kueue-system \
   --create-namespace \
   --wait \

--- a/cmd/kueueviz/INSTALL.md
+++ b/cmd/kueueviz/INSTALL.md
@@ -3,7 +3,7 @@
 KueueViz can be installed using `kubectl` with the following command:
 
 ```
-kubectl create -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.17.0/kueueviz.yaml
+kubectl create -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.17.1/kueueviz.yaml
 ```
 If you are using `kind` and that you don't have an `ingress` controller, you can use `port-forward` to 
 configure and run `KueueViz`.
@@ -60,7 +60,7 @@ by ensuring that `enableKueueViz` is set to `true`:
 
 ```
 helm upgrade --install kueue oci://registry.k8s.io/kueue/charts/kueue \
-  --version="0.17.0" \
+  --version="0.17.1" \
   --namespace kueue-system \
   --set enableKueueViz=true \
   --create-namespace
@@ -81,7 +81,7 @@ kind create cluster
 kind get kubeconfig > kubeconfig
 export KUBECONFIG=$PWD/kubeconfig
 helm install kueue oci://us-central1-docker.pkg.dev/k8s-staging-images/charts/kueue \
-            --version="0.17.0" --create-namespace --namespace=kueue-system
+            --version="0.17.1" --create-namespace --namespace=kueue-system
 ```
 
 ## Build

--- a/cmd/kueueviz/frontend/package-lock.json
+++ b/cmd/kueueviz/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kueueviz-frontend",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kueueviz-frontend",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "Apache 2.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/cmd/kueueviz/frontend/package.json
+++ b/cmd/kueueviz/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kueueviz-frontend",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "private": true,
   "description": "Frontend dashboard for visualizing Kueue status",
   "main": "src/index.jsx",

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -99,10 +99,10 @@ ignoreFiles = []
   # The major.minor version tag for the version of the docs represented in this
   # branch of the repository. Used in the "version-banner" partial to display a
   # version number for this doc set.
-  version = "v0.17.0"
+  version = "v0.17.1"
 
   # Version of Kueue without the leading "v", as used for Helm charts.
-  chart_version = "0.17.0"
+  chart_version = "0.17.1"
 
   # Flag used in the "version-banner" partial to decide whether to display a
   # banner on every page indicating that this is an archived version of the docs.

--- a/test/e2e/kueueviz/package-lock.json
+++ b/test/e2e/kueueviz/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kueueviz-frontend-tests",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kueueviz-frontend-tests",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "devDependencies": {
         "@testing-library/cypress": "^10.1.0",
         "cypress": "^15.13.0",

--- a/test/e2e/kueueviz/package.json
+++ b/test/e2e/kueueviz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kueueviz-frontend-tests",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "scripts": {
     "cypress:run": "cypress run --headless",
     "check-unused": "depcheck"


### PR DESCRIPTION
Cherry pick of #10530 on website.

#10530: Update main with the latest v0.17.1

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```