### PR TITLE
FailureRecovery: Decouple a compacted predicates based on event types.

### DIFF
--- a/pkg/controller/failurerecovery/pod_termination_controller.go
+++ b/pkg/controller/failurerecovery/pod_termination_controller.go
@@ -249,22 +249,25 @@ func (r *TerminatingPodReconciler) mapNodeToPods(ctx context.Context, node *core
 	return requests
 }
 
-func (r *TerminatingPodReconciler) nodeEventsPredicate() predicate.TypedPredicate[*corev1.Node] {
-	return predicate.TypedFuncs[*corev1.Node]{
-		CreateFunc: func(e event.TypedCreateEvent[*corev1.Node]) bool {
-			return utiltaints.TaintKeyExists(e.Object.Spec.Taints, corev1.TaintNodeUnreachable)
-		},
-		UpdateFunc: func(e event.TypedUpdateEvent[*corev1.Node]) bool {
-			return !utiltaints.TaintKeyExists(e.ObjectOld.Spec.Taints, corev1.TaintNodeUnreachable) &&
-				utiltaints.TaintKeyExists(e.ObjectNew.Spec.Taints, corev1.TaintNodeUnreachable)
-		},
-		DeleteFunc: func(e event.TypedDeleteEvent[*corev1.Node]) bool {
-			return false
-		},
-		GenericFunc: func(e event.TypedGenericEvent[*corev1.Node]) bool {
-			return false
-		},
-	}
+type nodeEventsPredicate struct{}
+
+var _ predicate.TypedPredicate[*corev1.Node] = (*nodeEventsPredicate)(nil)
+
+func (p *nodeEventsPredicate) Create(e event.TypedCreateEvent[*corev1.Node]) bool {
+	return utiltaints.TaintKeyExists(e.Object.Spec.Taints, corev1.TaintNodeUnreachable)
+}
+
+func (p *nodeEventsPredicate) Update(e event.TypedUpdateEvent[*corev1.Node]) bool {
+	return !utiltaints.TaintKeyExists(e.ObjectOld.Spec.Taints, corev1.TaintNodeUnreachable) &&
+		utiltaints.TaintKeyExists(e.ObjectNew.Spec.Taints, corev1.TaintNodeUnreachable)
+}
+
+func (p *nodeEventsPredicate) Delete(event.TypedDeleteEvent[*corev1.Node]) bool {
+	return false
+}
+
+func (p *nodeEventsPredicate) Generic(event.TypedGenericEvent[*corev1.Node]) bool {
+	return false
 }
 
 const ControllerName = "failure-recovery-pod-termination-controller"
@@ -282,7 +285,7 @@ func (r *TerminatingPodReconciler) SetupWithManager(mgr ctrl.Manager, cfg *confi
 			mgr.GetCache(),
 			&corev1.Node{},
 			handler.TypedEnqueueRequestsFromMapFunc(r.mapNodeToPods),
-			r.nodeEventsPredicate(),
+			&nodeEventsPredicate{},
 		)).
 		WithOptions(controller.Options{
 			NeedLeaderElection:      ptr.To(false),

--- a/pkg/controller/failurerecovery/pod_termination_controller_test.go
+++ b/pkg/controller/failurerecovery/pod_termination_controller_test.go
@@ -143,6 +143,141 @@ func TestUpdateEventFilter(t *testing.T) {
 	}
 }
 
+func TestNodeEventsPredicateCreate(t *testing.T) {
+	cases := map[string]struct {
+		node       *corev1.Node
+		wantResult bool
+	}{
+		"node has unreachable taint": {
+			node: testingnode.MakeNode("node").
+				Taints(corev1.Taint{Key: corev1.TaintNodeUnreachable}).
+				Obj(),
+			wantResult: true,
+		},
+		"node has no taints": {
+			node:       testingnode.MakeNode("node").Obj(),
+			wantResult: false,
+		},
+		"node has an unrelated taint only": {
+			node: testingnode.MakeNode("node").
+				Taints(corev1.Taint{Key: corev1.TaintNodeNotReady}).
+				Obj(),
+			wantResult: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			p := &nodeEventsPredicate{}
+			gotResult := p.Create(event.TypedCreateEvent[*corev1.Node]{Object: tc.node})
+
+			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
+				t.Errorf("unexpected predicate result (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNodeEventsPredicateUpdate(t *testing.T) {
+	nodeWithoutTaint := testingnode.MakeNode("node").
+		Obj()
+	nodeWithUnreachableTaint := testingnode.MakeNode("node").
+		Taints(corev1.Taint{Key: corev1.TaintNodeUnreachable}).
+		Obj()
+
+	cases := map[string]struct {
+		oldNode    *corev1.Node
+		newNode    *corev1.Node
+		wantResult bool
+	}{
+		"no taint to no taint": {
+			oldNode:    nodeWithoutTaint,
+			newNode:    nodeWithoutTaint,
+			wantResult: false,
+		},
+		"no taint to unreachable taint": {
+			oldNode:    nodeWithoutTaint,
+			newNode:    nodeWithUnreachableTaint,
+			wantResult: true,
+		},
+		"unreachable taint to unreachable taint": {
+			oldNode:    nodeWithUnreachableTaint,
+			newNode:    nodeWithUnreachableTaint,
+			wantResult: false,
+		},
+		"unreachable taint to no taint": {
+			oldNode:    nodeWithUnreachableTaint,
+			newNode:    nodeWithoutTaint,
+			wantResult: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			p := &nodeEventsPredicate{}
+			gotResult := p.Update(event.TypedUpdateEvent[*corev1.Node]{ObjectOld: tc.oldNode, ObjectNew: tc.newNode})
+
+			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
+				t.Errorf("unexpected predicate result (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNodeEventsPredicateDelete(t *testing.T) {
+	cases := map[string]struct {
+		node       *corev1.Node
+		wantResult bool
+	}{
+		"node has unreachable taint": {
+			node: testingnode.MakeNode("node").
+				Taints(corev1.Taint{Key: corev1.TaintNodeUnreachable}).
+				Obj(),
+			wantResult: false,
+		},
+		"node has no taints": {
+			node:       testingnode.MakeNode("node").Obj(),
+			wantResult: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			p := &nodeEventsPredicate{}
+			gotResult := p.Delete(event.TypedDeleteEvent[*corev1.Node]{Object: tc.node})
+
+			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
+				t.Errorf("unexpected predicate result (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNodeEventsPredicateGeneric(t *testing.T) {
+	cases := map[string]struct {
+		node       *corev1.Node
+		wantResult bool
+	}{
+		"node has unreachable taint": {
+			node: testingnode.MakeNode("node").
+				Taints(corev1.Taint{Key: corev1.TaintNodeUnreachable}).
+				Obj(),
+			wantResult: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			p := &nodeEventsPredicate{}
+			gotResult := p.Generic(event.TypedGenericEvent[*corev1.Node]{Object: tc.node})
+
+			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
+				t.Errorf("unexpected predicate result (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestReconciler(t *testing.T) {
 	now := time.Now()
 	nowSecondPrecision := metav1.NewTime(now).Rfc3339Copy()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

I decoupled a compacted nodeEventsPredicate for each event type so that we can have fine-grained UTs for predicates. The fine-grained predicate UTs contribute to helping us when debugging Kueue behavior and identifying the bug root cause.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```