### PR TITLE
Automated cherry pick of #10424: [Cleanup] Deduplicate e2e util functions

### DIFF
--- a/test/e2e/dra/suite_test.go
+++ b/test/e2e/dra/suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package dra
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"os"
@@ -25,8 +26,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/kueue/test/util"
@@ -58,9 +57,11 @@ var _ = ginkgo.BeforeSuite(func() {
 
 	waitForAvailableStart := time.Now()
 	util.WaitForKueueAvailability(ctx, k8sClient)
-	waitForDRAExampleDriverAvailability(ctx, k8sClient)
+	clusterName := cmp.Or(os.Getenv("KIND_CLUSTER_NAME"), "kind")
+	util.WaitForDRAExampleDriverAvailability(ctx, k8sClient, clusterName)
 	ginkgo.GinkgoLogr.Info(
 		"Kueue and DRA example driver are available in the cluster",
+		"clusterName", clusterName,
 		"waitingTime", time.Since(waitForAvailableStart),
 	)
 })
@@ -69,16 +70,3 @@ var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Repo
 	err := util.ConfigureSuiteReporting(report)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
-
-func waitForDRAExampleDriverAvailability(ctx context.Context, k8sClient client.Client) {
-	dsKey := types.NamespacedName{Namespace: "dra-example-driver", Name: "dra-example-driver-kubeletplugin"}
-	daemonset := &appsv1.DaemonSet{}
-	waitForAvailableStart := time.Now()
-	ginkgo.By(fmt.Sprintf("Waiting for availability of daemonset: %q", dsKey))
-	gomega.Eventually(func(g gomega.Gomega) {
-		g.Expect(k8sClient.Get(ctx, dsKey, daemonset)).To(gomega.Succeed())
-		g.Expect(daemonset.Status.DesiredNumberScheduled).To(gomega.BeNumerically(">", 0))
-		g.Expect(daemonset.Status.DesiredNumberScheduled).To(gomega.Equal(daemonset.Status.NumberAvailable))
-	}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
-	ginkgo.GinkgoLogr.Info("DaemonSet is available in the cluster", "daemonset", dsKey, "waitingTime", time.Since(waitForAvailableStart))
-}

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -452,7 +452,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				Namespace: managerNs.Name,
 			}
 
-			waitForJobAdmitted(wlLookupKey, multiKueueAc.Name, "worker1")
+			util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker1", k8sManagerClient)
 
 			ginkgo.By("Waiting for StatefulSet to be synced to worker cluster", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -770,8 +770,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			})
 
 			ginkgo.By("Checking no objects are left in the worker clusters and the job is completed", func() {
-				expectObjectToBeDeletedOnWorkerClusters(ctx, createdLeaderWorkload)
-				expectObjectToBeDeletedOnWorkerClusters(ctx, job)
+				util.ExpectObjectToBeDeletedOnClusters(ctx, createdLeaderWorkload, k8sWorker1Client, k8sWorker2Client)
+				util.ExpectObjectToBeDeletedOnClusters(ctx, job, k8sWorker1Client, k8sWorker2Client)
 
 				createdJob := &batchv1.Job{}
 				gomega.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(job), createdJob)).To(gomega.Succeed())
@@ -1325,7 +1325,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			createdLeaderWorkload := &kueue.Workload{}
 			wlLookupKey := types.NamespacedName{Name: workloadjobset.GetWorkloadNameForJobSet(jobSet.Name, jobSet.UID), Namespace: managerNs.Name}
 			// the execution should be given to the worker1
-			waitForJobAdmitted(wlLookupKey, multiKueueAc.Name, "worker1")
+			util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker1", k8sManagerClient)
 
 			ginkgo.By("Waiting for the jobSet to get status updates", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -1361,8 +1361,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			})
 
 			ginkgo.By("Checking no objects are left in the worker clusters and the jobSet is completed", func() {
-				expectObjectToBeDeletedOnWorkerClusters(ctx, createdLeaderWorkload)
-				expectObjectToBeDeletedOnWorkerClusters(ctx, jobSet)
+				util.ExpectObjectToBeDeletedOnClusters(ctx, createdLeaderWorkload, k8sWorker1Client, k8sWorker2Client)
+				util.ExpectObjectToBeDeletedOnClusters(ctx, jobSet, k8sWorker1Client, k8sWorker2Client)
 
 				createdJobSet := &jobset.JobSet{}
 				gomega.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(jobSet), createdJobSet)).To(gomega.Succeed())
@@ -1399,11 +1399,10 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				util.MustCreate(ctx, k8sManagerClient, aw)
 			})
 
-			createdWorkload := &kueue.Workload{}
 			wlLookupKey := types.NamespacedName{Name: workloadaw.GetWorkloadNameForAppWrapper(aw.Name, aw.UID), Namespace: managerNs.Name}
 
 			// the execution should be given to worker 1
-			waitForJobAdmitted(wlLookupKey, multiKueueAc.Name, "worker1")
+			util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker1", k8sManagerClient)
 
 			ginkgo.By("Waiting for the appwrapper to get status updates", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -1419,21 +1418,14 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			})
 
 			ginkgo.By("Waiting for the appwrapper to finish", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
-
-					g.Expect(apimeta.FindStatusCondition(createdWorkload.Status.Conditions, kueue.WorkloadFinished)).To(gomega.BeComparableTo(&metav1.Condition{
-						Type:    kueue.WorkloadFinished,
-						Status:  metav1.ConditionTrue,
-						Reason:  kueue.WorkloadFinishedReasonSucceeded,
-						Message: "AppWrapper finished successfully",
-					}, util.IgnoreConditionTimestampsAndObservedGeneration))
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+				util.ExpectWorkloadToFinish(ctx, k8sManagerClient, wlLookupKey)
 			})
 
 			ginkgo.By("Checking no objects are left in the worker clusters and the appwrapper is completed", func() {
-				expectObjectToBeDeletedOnWorkerClusters(ctx, createdWorkload)
-				expectObjectToBeDeletedOnWorkerClusters(ctx, aw)
+				createdWorkload := &kueue.Workload{}
+				gomega.Expect(k8sManagerClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				util.ExpectObjectToBeDeletedOnClusters(ctx, createdWorkload, k8sWorker1Client, k8sWorker2Client)
+				util.ExpectObjectToBeDeletedOnClusters(ctx, aw, k8sWorker1Client, k8sWorker2Client)
 
 				createdAppWrapper := &awv1beta2.AppWrapper{}
 				gomega.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(aw), createdAppWrapper)).To(gomega.Succeed())
@@ -1467,7 +1459,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			wlLookupKey := types.NamespacedName{Name: workloadpytorchjob.GetWorkloadNameForPyTorchJob(pyTorchJob.Name, pyTorchJob.UID), Namespace: managerNs.Name}
 
 			// the execution should be given to the worker 2
-			waitForJobAdmitted(wlLookupKey, multiKueueAc.Name, "worker2")
+			util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker2", k8sManagerClient)
 
 			ginkgo.By("Waiting for the PyTorchJob to finish", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -1483,10 +1475,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 							),
 						},
 					))
-
-					finishReasonMessage := fmt.Sprintf("PyTorchJob %s is successfully completed.", pyTorchJob.Name)
-					checkFinishStatusCondition(g, wlLookupKey, finishReasonMessage)
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+				util.ExpectWorkloadToFinish(ctx, k8sManagerClient, wlLookupKey)
 			})
 
 			ginkgo.By("Checking no objects are left in the worker clusters and the PyTorchJob is completed", func() {
@@ -1496,8 +1486,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 						Namespace: wlLookupKey.Namespace,
 					},
 				}
-				expectObjectToBeDeletedOnWorkerClusters(ctx, wl)
-				expectObjectToBeDeletedOnWorkerClusters(ctx, pyTorchJob)
+				util.ExpectObjectToBeDeletedOnClusters(ctx, wl, k8sWorker1Client, k8sWorker2Client)
+				util.ExpectObjectToBeDeletedOnClusters(ctx, pyTorchJob, k8sWorker1Client, k8sWorker2Client)
 			})
 		})
 
@@ -1535,7 +1525,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			wlLookupKey := types.NamespacedName{Name: workloadmpijob.GetWorkloadNameForMPIJob(mpijob.Name, mpijob.UID), Namespace: managerNs.Name}
 
 			// the execution should be given to the worker1
-			waitForJobAdmitted(wlLookupKey, multiKueueAc.Name, "worker1")
+			util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker1", k8sManagerClient)
 
 			ginkgo.By("Waiting for the MPIJob to finish", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -1547,10 +1537,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 							Succeeded: 1,
 						},
 					))
-
-					finishReasonMessage := fmt.Sprintf("MPIJob %s successfully completed.", client.ObjectKeyFromObject(mpijob).String())
-					checkFinishStatusCondition(g, wlLookupKey, finishReasonMessage)
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+				util.ExpectWorkloadToFinish(ctx, k8sManagerClient, wlLookupKey)
 			})
 
 			ginkgo.By("Checking no objects are left in the worker clusters and the MPIJob is completed", func() {
@@ -1560,8 +1548,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 						Namespace: wlLookupKey.Namespace,
 					},
 				}
-				expectObjectToBeDeletedOnWorkerClusters(ctx, wl)
-				expectObjectToBeDeletedOnWorkerClusters(ctx, mpijob)
+				util.ExpectObjectToBeDeletedOnClusters(ctx, wl, k8sWorker1Client, k8sWorker2Client)
+				util.ExpectObjectToBeDeletedOnClusters(ctx, mpijob, k8sWorker1Client, k8sWorker2Client)
 			})
 		})
 
@@ -1585,16 +1573,15 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 
 			wlLookupKey := types.NamespacedName{Name: workloadrayjob.GetWorkloadNameForRayJob(rayjob.Name, rayjob.UID), Namespace: managerNs.Name}
 			// the execution should be given to the worker1
-			waitForJobAdmitted(wlLookupKey, multiKueueAc.Name, "worker1")
+			util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker1", k8sManagerClient)
 
 			ginkgo.By("Waiting for the RayJob to finish", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdRayJob := &rayv1.RayJob{}
 					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(rayjob), createdRayJob)).To(gomega.Succeed())
 					g.Expect(createdRayJob.Status.JobDeploymentStatus).To(gomega.Equal(rayv1.JobDeploymentStatusComplete))
-					finishReasonMessage := "Job finished successfully."
-					checkFinishStatusCondition(g, wlLookupKey, finishReasonMessage)
 				}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+				util.ExpectWorkloadToFinish(ctx, k8sManagerClient, wlLookupKey)
 			})
 
 			ginkgo.By("Checking no objects are left in the worker clusters and the RayJob is completed", func() {
@@ -1604,8 +1591,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 						Namespace: wlLookupKey.Namespace,
 					},
 				}
-				expectObjectToBeDeletedOnWorkerClusters(ctx, wl)
-				expectObjectToBeDeletedOnWorkerClusters(ctx, rayjob)
+				util.ExpectObjectToBeDeletedOnClusters(ctx, wl, k8sWorker1Client, k8sWorker2Client)
+				util.ExpectObjectToBeDeletedOnClusters(ctx, rayjob, k8sWorker1Client, k8sWorker2Client)
 			})
 		})
 
@@ -1627,7 +1614,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 
 			wlLookupKey := types.NamespacedName{Name: workloadraycluster.GetWorkloadNameForRayCluster(raycluster.Name, raycluster.UID), Namespace: managerNs.Name}
 			// the execution should be given to the worker1
-			waitForJobAdmitted(wlLookupKey, multiKueueAc.Name, "worker1")
+			util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker1", k8sManagerClient)
 
 			ginkgo.By("Checking the RayCluster is ready", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -1739,7 +1726,7 @@ app = HelloWorld.bind()`,
 
 			wlLookupKey := types.NamespacedName{Name: workloadrayservice.GetWorkloadNameForRayService(rayService.Name, rayService.UID), Namespace: managerNs.Name}
 			// the execution should be given to the worker1
-			waitForJobAdmitted(wlLookupKey, multiKueueAc.Name, "worker1")
+			util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker1", k8sManagerClient)
 
 			ginkgo.By("Checking the RayService is running", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -1767,7 +1754,7 @@ app = HelloWorld.bind()`,
 
 			wlLookupKey := types.NamespacedName{Name: workloadtrainjob.GetWorkloadNameForTrainJob(trainjob.Name, trainjob.UID), Namespace: managerNs.Name}
 			// the execution should be given to the worker1
-			waitForJobAdmitted(wlLookupKey, multiKueueAc.Name, "worker1")
+			util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker1", k8sManagerClient)
 
 			ginkgo.By("Checking the TrainJob is ready", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -1851,38 +1838,6 @@ app = HelloWorld.bind()`,
 	})
 })
 
-func waitForJobAdmitted(wlLookupKey types.NamespacedName, acName, workerName string) {
-	ginkgo.GinkgoHelper()
-	ginkgo.By(fmt.Sprintf("Waiting to be admitted in %s and manager", workerName))
-	gomega.Eventually(func(g gomega.Gomega) {
-		createdWorkload := &kueue.Workload{}
-		g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
-		g.Expect(apimeta.FindStatusCondition(createdWorkload.Status.Conditions, kueue.WorkloadAdmitted)).To(gomega.BeComparableTo(&metav1.Condition{
-			Type:    kueue.WorkloadAdmitted,
-			Status:  metav1.ConditionTrue,
-			Reason:  "Admitted",
-			Message: "The workload is admitted",
-		}, util.IgnoreConditionTimestampsAndObservedGeneration))
-	}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
-	util.ExpectAdmissionCheckStateWithMessage(
-		ctx, k8sManagerClient, wlLookupKey,
-		acName,
-		kueue.CheckStateReady,
-		fmt.Sprintf(`The workload got reservation on "%s"`, workerName),
-	)
-}
-
-func checkFinishStatusCondition(g gomega.Gomega, wlLookupKey types.NamespacedName, finishReasonMessage string) {
-	createdWorkload := &kueue.Workload{}
-	g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
-	g.Expect(apimeta.FindStatusCondition(createdWorkload.Status.Conditions, kueue.WorkloadFinished)).To(gomega.BeComparableTo(&metav1.Condition{
-		Type:    kueue.WorkloadFinished,
-		Status:  metav1.ConditionTrue,
-		Reason:  kueue.WorkloadFinishedReasonSucceeded,
-		Message: finishReasonMessage,
-	}, util.IgnoreConditionTimestampsAndObservedGeneration))
-}
-
 func ensurePodWorkloadsRunning(deployment *appsv1.Deployment, managerNs corev1.Namespace, multiKueueAc *kueue.AdmissionCheck, kubernetesClients map[string]client.Client) {
 	// Given the unpredictable nature of where the deployment pods run this function gathers the workload of a Pod first
 	// it then gets the Pod's assigned cluster from the admission check message and uses the appropriate client to ensure the Pod is running
@@ -1933,18 +1888,6 @@ func GetMultiKueueClusterNameFromAdmissionCheckMessage(message string) string {
 		return workerName
 	}
 	return ""
-}
-
-type objAsPtr[T any] interface {
-	client.Object
-	*T
-}
-
-func expectObjectToBeDeletedOnWorkerClusters[PtrT objAsPtr[T], T any](ctx context.Context, obj PtrT) {
-	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
-		util.ExpectObjectToBeDeleted(ctx, k8sWorker1Client, obj, false)
-		util.ExpectObjectToBeDeleted(ctx, k8sWorker2Client, obj, false)
-	}, util.Timeout, util.Interval).Should(gomega.Succeed())
 }
 
 func expectJobToBeCreatedAndManagedBy(ctx context.Context, c client.Client, job *batchv1.Job, managedBy string) {

--- a/test/e2e/multikueue/tas_test.go
+++ b/test/e2e/multikueue/tas_test.go
@@ -296,8 +296,8 @@ var _ = ginkgo.Describe("MultiKueue with TopologyAwareScheduling", func() {
 			})
 
 			ginkgo.By("Checking no objects are left in the worker clusters and the job is completed", func() {
-				expectObjectToBeDeletedOnWorkerClusters(ctx, createdWorkload)
-				expectObjectToBeDeletedOnWorkerClusters(ctx, job)
+				util.ExpectObjectToBeDeletedOnClusters(ctx, createdWorkload, k8sWorker1Client, k8sWorker2Client)
+				util.ExpectObjectToBeDeletedOnClusters(ctx, job, k8sWorker1Client, k8sWorker2Client)
 
 				createdJob := &batchv1.Job{}
 				gomega.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(job), createdJob)).To(gomega.Succeed())
@@ -531,7 +531,7 @@ var _ = ginkgo.Describe("MultiKueue TAS with asymmetric quotas", func() {
 			Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
 			Namespace: managerNs.Name,
 		}
-		waitForJobAdmitted(wlLookupKey, multiKueueAc.Name, "worker1")
+		util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker1", k8sManagerClient)
 
 		ginkgo.By("Waiting for TopologyAssignment to be computed on worker1", func() {
 			waitForTopologyAssignment(k8sWorker1Client, wlLookupKey)
@@ -553,8 +553,8 @@ var _ = ginkgo.Describe("MultiKueue TAS with asymmetric quotas", func() {
 		}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 
 		ginkgo.By("Checking no objects are left in worker clusters and job is completed")
-		expectObjectToBeDeletedOnWorkerClusters(ctx, createdWorkload)
-		expectObjectToBeDeletedOnWorkerClusters(ctx, job)
+		util.ExpectObjectToBeDeletedOnClusters(ctx, createdWorkload, k8sWorker1Client, k8sWorker2Client)
+		util.ExpectObjectToBeDeletedOnClusters(ctx, job, k8sWorker1Client, k8sWorker2Client)
 
 		createdJob := &batchv1.Job{}
 		gomega.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(job), createdJob)).To(gomega.Succeed())
@@ -623,7 +623,7 @@ var _ = ginkgo.Describe("MultiKueue TAS with asymmetric quotas", func() {
 		}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 
 		ginkgo.By("Checking cleanup on worker clusters")
-		expectObjectToBeDeletedOnWorkerClusters(ctx, createdWorkload)
-		expectObjectToBeDeletedOnWorkerClusters(ctx, job)
+		util.ExpectObjectToBeDeletedOnClusters(ctx, createdWorkload, k8sWorker1Client, k8sWorker2Client)
+		util.ExpectObjectToBeDeletedOnClusters(ctx, job, k8sWorker1Client, k8sWorker2Client)
 	})
 })

--- a/test/e2e/multikueuedra/dra_test.go
+++ b/test/e2e/multikueuedra/dra_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package multikueuedra
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -39,19 +38,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/test/util"
 )
-
-type objAsPtr[T any] interface {
-	client.Object
-	*T
-}
-
-func expectObjectToBeDeletedOnWorkerClusters[PtrT objAsPtr[T], T any](ctx context.Context, obj PtrT) {
-	ginkgo.GinkgoHelper()
-	gomega.Eventually(func(g gomega.Gomega) {
-		util.ExpectObjectToBeDeleted(ctx, k8sWorker1Client, obj, false)
-		util.ExpectObjectToBeDeleted(ctx, k8sWorker2Client, obj, false)
-	}, util.Timeout, util.Interval).Should(gomega.Succeed())
-}
 
 var _ = ginkgo.Describe("MultiKueue with DRA", ginkgo.Label("feature:dra", "area:multikueue", "feature:multikueue"), ginkgo.Ordered, func() {
 	var (
@@ -270,8 +256,8 @@ var _ = ginkgo.Describe("MultiKueue with DRA", ginkgo.Label("feature:dra", "area
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("Checking no objects are left in worker clusters and job is completed")
-			expectObjectToBeDeletedOnWorkerClusters(ctx, createdWorkload)
-			expectObjectToBeDeletedOnWorkerClusters(ctx, job)
+			util.ExpectObjectToBeDeletedOnClusters(ctx, createdWorkload, k8sWorker1Client, k8sWorker2Client)
+			util.ExpectObjectToBeDeletedOnClusters(ctx, job, k8sWorker1Client, k8sWorker2Client)
 
 			createdJob := &batchv1.Job{}
 			gomega.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(job), createdJob)).To(gomega.Succeed())

--- a/test/e2e/multikueuedra/suite_test.go
+++ b/test/e2e/multikueuedra/suite_test.go
@@ -30,8 +30,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/types"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
@@ -74,19 +72,6 @@ func TestAPIs(t *testing.T) {
 	ginkgo.RunSpecs(t, suiteName)
 }
 
-func waitForDRAExampleDriverAvailability(ctx context.Context, k8sClient client.Client, clusterName string) {
-	dsKey := types.NamespacedName{Namespace: "dra-example-driver", Name: "dra-example-driver-kubeletplugin"}
-	daemonset := &appsv1.DaemonSet{}
-	waitForAvailableStart := time.Now()
-	ginkgo.By(fmt.Sprintf("Waiting for availability of daemonset %q on cluster %s", dsKey, clusterName))
-	gomega.Eventually(func(g gomega.Gomega) {
-		g.Expect(k8sClient.Get(ctx, dsKey, daemonset)).To(gomega.Succeed())
-		g.Expect(daemonset.Status.DesiredNumberScheduled).To(gomega.BeNumerically(">", 0))
-		g.Expect(daemonset.Status.DesiredNumberScheduled).To(gomega.Equal(daemonset.Status.NumberAvailable))
-	}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
-	ginkgo.GinkgoLogr.Info("DaemonSet is available in the cluster", "daemonset", dsKey, "cluster", clusterName, "waitingTime", time.Since(waitForAvailableStart))
-}
-
 var _ = ginkgo.BeforeSuite(func() {
 	util.SetupLogger()
 
@@ -125,9 +110,9 @@ var _ = ginkgo.BeforeSuite(func() {
 	util.WaitForKueueAvailability(ctx, k8sWorker2Client)
 
 	// Wait for DRA example driver availability on all clusters
-	waitForDRAExampleDriverAvailability(ctx, k8sManagerClient, managerClusterName)
-	waitForDRAExampleDriverAvailability(ctx, k8sWorker1Client, worker1ClusterName)
-	waitForDRAExampleDriverAvailability(ctx, k8sWorker2Client, worker2ClusterName)
+	util.WaitForDRAExampleDriverAvailability(ctx, k8sManagerClient, managerClusterName)
+	util.WaitForDRAExampleDriverAvailability(ctx, k8sWorker1Client, worker1ClusterName)
+	util.WaitForDRAExampleDriverAvailability(ctx, k8sWorker2Client, worker2ClusterName)
 
 	ginkgo.GinkgoLogr.Info(
 		"Kueue and DRA example driver are available in all clusters",

--- a/test/e2e/multikueuesequential/e2e_test.go
+++ b/test/e2e/multikueuesequential/e2e_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package multikueuesequential
 
 import (
-	"context"
 	"fmt"
 	"os/exec"
 
@@ -28,7 +27,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -251,7 +249,7 @@ var _ = ginkgo.Describe("MultiKueue Sequential", func() {
 			createdLeaderWorkload := &kueue.Workload{}
 			wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
 			// the execution should be given to the worker
-			waitForJobAdmitted(wlLookupKey, multiKueueAc.Name, "worker2")
+			util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker2", k8sManagerClient)
 
 			ginkgo.By("Waiting for the manager's job unsuspended", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -284,8 +282,8 @@ var _ = ginkgo.Describe("MultiKueue Sequential", func() {
 			})
 
 			ginkgo.By("Checking no objects are left in the worker clusters and the job is completed", func() {
-				expectObjectToBeDeletedOnWorkerClusters(ctx, createdLeaderWorkload)
-				expectObjectToBeDeletedOnWorkerClusters(ctx, job)
+				util.ExpectObjectToBeDeletedOnClusters(ctx, createdLeaderWorkload, k8sWorker1Client, k8sWorker2Client)
+				util.ExpectObjectToBeDeletedOnClusters(ctx, job, k8sWorker1Client, k8sWorker2Client)
 
 				createdJob := &batchv1.Job{}
 				gomega.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(job), createdJob)).To(gomega.Succeed())
@@ -878,36 +876,3 @@ var _ = ginkgo.Describe("MultiKueue Sequential", func() {
 		})
 	})
 })
-
-func waitForJobAdmitted(wlLookupKey types.NamespacedName, acName, workerName string) {
-	ginkgo.GinkgoHelper()
-	ginkgo.By(fmt.Sprintf("Waiting to be admitted in %s and manager", workerName))
-	gomega.Eventually(func(g gomega.Gomega) {
-		createdWorkload := &kueue.Workload{}
-		g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
-		g.Expect(apimeta.FindStatusCondition(createdWorkload.Status.Conditions, kueue.WorkloadAdmitted)).To(gomega.BeComparableTo(&metav1.Condition{
-			Type:    kueue.WorkloadAdmitted,
-			Status:  metav1.ConditionTrue,
-			Reason:  "Admitted",
-			Message: "The workload is admitted",
-		}, util.IgnoreConditionTimestampsAndObservedGeneration))
-	}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
-	util.ExpectAdmissionCheckStateWithMessage(
-		ctx, k8sManagerClient, wlLookupKey,
-		acName,
-		kueue.CheckStateReady,
-		fmt.Sprintf(`The workload got reservation on "%s"`, workerName),
-	)
-}
-
-type objAsPtr[T any] interface {
-	client.Object
-	*T
-}
-
-func expectObjectToBeDeletedOnWorkerClusters[PtrT objAsPtr[T], T any](ctx context.Context, obj PtrT) {
-	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
-		util.ExpectObjectToBeDeleted(ctx, k8sWorker1Client, obj, false)
-		util.ExpectObjectToBeDeleted(ctx, k8sWorker2Client, obj, false)
-	}, util.Timeout, util.Interval).Should(gomega.Succeed())
-}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1499,3 +1499,39 @@ func waitForDummyWorkloadToRunOnNode(ctx context.Context, c client.Client, node 
 		}, MediumTimeout, Interval).Should(gomega.Succeed())
 	})
 }
+
+func ExpectObjectToBeDeletedOnClusters[PtrT objAsPtr[T], T any](ctx context.Context, obj PtrT, clients ...client.Client) {
+	ginkgo.GinkgoHelper()
+	if len(clients) == 0 {
+		ginkgo.Fail("At least one client must be provided to check for object deletion")
+	}
+	for _, c := range clients {
+		ExpectObjectToBeDeleted(ctx, c, obj, false)
+	}
+}
+
+func ExpectWorkloadAdmittedWithCheck(ctx context.Context, wlLookupKey types.NamespacedName, acName, clusterName string, client client.Client) {
+	ginkgo.GinkgoHelper()
+	ginkgo.By(fmt.Sprintf("Waiting to be admitted in %s and manager clusters", clusterName))
+	ExpectWorkloadsToBeAdmittedByKeys(ctx, client, wlLookupKey)
+	ExpectAdmissionCheckStateWithMessage(
+		ctx, client, wlLookupKey,
+		acName,
+		kueue.CheckStateReady,
+		fmt.Sprintf(`The workload got reservation on "%s"`, clusterName),
+	)
+}
+
+func WaitForDRAExampleDriverAvailability(ctx context.Context, k8sClient client.Client, clusterName string) {
+	ginkgo.GinkgoHelper()
+	dsKey := types.NamespacedName{Namespace: "dra-example-driver", Name: "dra-example-driver-kubeletplugin"}
+	daemonset := &appsv1.DaemonSet{}
+	waitForAvailableStart := time.Now()
+	ginkgo.By(fmt.Sprintf("Waiting for availability of daemonset %q on cluster %s", dsKey, clusterName))
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(k8sClient.Get(ctx, dsKey, daemonset)).To(gomega.Succeed())
+		g.Expect(daemonset.Status.DesiredNumberScheduled).To(gomega.BeNumerically(">", 0))
+		g.Expect(daemonset.Status.DesiredNumberScheduled).To(gomega.Equal(daemonset.Status.NumberAvailable))
+	}, VeryLongTimeout, Interval).Should(gomega.Succeed())
+	ginkgo.GinkgoLogr.Info("DaemonSet is available in the cluster", "daemonset", dsKey, "cluster", clusterName, "waitingTime", time.Since(waitForAvailableStart))
+}


### PR DESCRIPTION
Cherry pick of #10424 on release-0.17.

#10424: [Cleanup] Deduplicate e2e util functions

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```