### PR TITLE
Automated cherry pick of #10268: [Cleanup] Parallelise MultiKueue e2e tests

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -150,6 +150,7 @@ test-e2e-helm: test-e2e
 test-multikueue-e2e-parallel-builds:
 	$(MAKE) -j2 kind-ray-project-mini-image-build kind-secretreader-plugin-image-build
 
+test-multikueue-e2e-main: E2E_NPROCS := 3
 .PHONY: test-multikueue-e2e-main
 test-multikueue-e2e-main: setup-e2e-env test-multikueue-e2e-parallel-builds run-test-multikueue-e2e-$(E2E_KIND_VERSION:kindest/node:v%=%)
 

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -150,7 +150,7 @@ test-e2e-helm: test-e2e
 test-multikueue-e2e-parallel-builds:
 	$(MAKE) -j2 kind-ray-project-mini-image-build kind-secretreader-plugin-image-build
 
-test-multikueue-e2e-main: E2E_NPROCS := 3
+test-multikueue-e2e-main: E2E_NPROCS := 5
 .PHONY: test-multikueue-e2e-main
 test-multikueue-e2e-main: setup-e2e-env test-multikueue-e2e-parallel-builds run-test-multikueue-e2e-$(E2E_KIND_VERSION:kindest/node:v%=%)
 

--- a/pkg/util/testing/v1beta2/wrappers.go
+++ b/pkg/util/testing/v1beta2/wrappers.go
@@ -930,6 +930,8 @@ func (c *ClusterQueueWrapper) Active(status metav1.ConditionStatus) *ClusterQueu
 // No name should be given in the MakeClusterQueue for the GeneratedName to work.
 func (c *ClusterQueueWrapper) GeneratedName(name string) *ClusterQueueWrapper {
 	c.GenerateName = name
+	c.Name = ""
+
 	return c
 }
 
@@ -1163,6 +1165,12 @@ func (rf *ResourceFlavorWrapper) Obj() *kueue.ResourceFlavor {
 	return &rf.ResourceFlavor
 }
 
+func (rf *ResourceFlavorWrapper) GeneratedName(name string) *ResourceFlavorWrapper {
+	rf.GenerateName = name
+	rf.Name = ""
+	return rf
+}
+
 // TopologyName sets the topology name
 func (rf *ResourceFlavorWrapper) TopologyName(name string) *ResourceFlavorWrapper {
 	rf.Spec.TopologyName = ptr.To(kueue.TopologyReference(name))
@@ -1352,6 +1360,12 @@ func MakeAdmissionCheck(name string) *AdmissionCheckWrapper {
 	}
 }
 
+func (ac *AdmissionCheckWrapper) GeneratedName(name string) *AdmissionCheckWrapper {
+	ac.GenerateName = name
+	ac.Name = ""
+	return ac
+}
+
 type AdmissionCheckStrategyRuleWrapper struct {
 	kueue.AdmissionCheckStrategyRule
 }
@@ -1430,6 +1444,12 @@ func MakeWorkloadPriorityClass(name string) *WorkloadPriorityClassWrapper {
 	}
 }
 
+func (p *WorkloadPriorityClassWrapper) GeneratedName(name string) *WorkloadPriorityClassWrapper {
+	p.GenerateName = name
+	p.Name = ""
+	return p
+}
+
 // PriorityValue updates value of WorkloadPriorityClass.
 func (p *WorkloadPriorityClassWrapper) PriorityValue(v int32) *WorkloadPriorityClassWrapper {
 	p.Value = v
@@ -1455,6 +1475,12 @@ func MakeMultiKueueConfig(name string) *MultiKueueConfigWrapper {
 	}
 }
 
+func MakeMultiKueueConfigWithGeneratedName(namePrefix string) *MultiKueueConfigWrapper {
+	mkc := MakeMultiKueueConfig("")
+	mkc.GenerateName = namePrefix
+	return mkc
+}
+
 func (mkc *MultiKueueConfigWrapper) Obj() *kueue.MultiKueueConfig {
 	return &mkc.MultiKueueConfig
 }
@@ -1476,6 +1502,12 @@ func MakeMultiKueueCluster(name string) *MultiKueueClusterWrapper {
 			},
 		},
 	}
+}
+
+func MakeMultiKueueClusterWithGeneratedName(namePrefix string) *MultiKueueClusterWrapper {
+	mkc := MakeMultiKueueCluster("")
+	mkc.GenerateName = namePrefix
+	return mkc
 }
 
 func (mkc *MultiKueueClusterWrapper) Obj() *kueue.MultiKueueCluster {

--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -78,6 +78,14 @@ func (j *JobWrapper) Clone() *JobWrapper {
 	return &JobWrapper{Job: *j.DeepCopy()}
 }
 
+// GeneratedName sets the prefix for the server to generate unique name.
+func (j *JobWrapper) GeneratedName(name string) *JobWrapper {
+	j.GenerateName = name
+	j.Name = ""
+
+	return j
+}
+
 func (j *JobWrapper) BackoffLimit(limit int32) *JobWrapper {
 	j.Spec.BackoffLimit = ptr.To(limit)
 	return j

--- a/pkg/util/testingjobs/trainjob/wrappers.go
+++ b/pkg/util/testingjobs/trainjob/wrappers.go
@@ -163,6 +163,13 @@ func (t *TrainJobWrapper) JobsStatus(statuses ...kftrainerapi.JobStatus) *TrainJ
 	return t
 }
 
+// RequestAndLimit adds a resource request and limit to the Trainer node for the given resource name.
+func (t *TrainJobWrapper) RequestAndLimit(r corev1.ResourceName, request, limit string) *TrainJobWrapper {
+	t.Spec.Trainer.ResourcesPerNode.Requests[r] = resource.MustParse(request)
+	t.Spec.Trainer.ResourcesPerNode.Limits[r] = resource.MustParse(limit)
+	return t
+}
+
 type RuntimePatchWrapper struct{ kftrainerapi.RuntimePatch }
 
 // MakeRuntimePatch creates a wrapper for a TrainJob RuntimePatch.

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -34,9 +34,9 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
@@ -78,6 +78,18 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
+const (
+	// extra virtual resource that allows to directly to a specific worker cluster, without relying on real resources.
+	extraResourceGPUHighCost = "example.com/gpu-h100"
+	extraResourceGPULowCost  = "example.com/gpu-v100s"
+)
+
+type kubernetesClientsMap map[string]struct {
+	client     client.Client
+	restClient *rest.RESTClient
+	cfg        *rest.Config
+}
+
 var _ = ginkgo.Describe("MultiKueue", func() {
 	var (
 		managerNs *corev1.Namespace
@@ -105,6 +117,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 		worker2Flavor  *kueue.ResourceFlavor
 		worker2Cq      *kueue.ClusterQueue
 		worker2Lq      *kueue.LocalQueue
+
+		kubernetesClients kubernetesClientsMap
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -112,36 +126,42 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 		worker1Ns = util.CreateNamespaceWithLog(ctx, k8sWorker1Client, managerNs.Name)
 		worker2Ns = util.CreateNamespaceWithLog(ctx, k8sWorker2Client, managerNs.Name)
 
-		workerCluster1 = utiltestingapi.MakeMultiKueueCluster("worker1").KubeConfig(kueue.SecretLocationType, "multikueue1").Obj()
+		workerCluster1 = utiltestingapi.MakeMultiKueueClusterWithGeneratedName("worker1-").KubeConfig(kueue.SecretLocationType, "multikueue1").Obj()
 		util.MustCreate(ctx, k8sManagerClient, workerCluster1)
 
-		workerCluster2 = utiltestingapi.MakeMultiKueueCluster("worker2").KubeConfig(kueue.SecretLocationType, "multikueue2").Obj()
+		workerCluster2 = utiltestingapi.MakeMultiKueueClusterWithGeneratedName("worker2-").KubeConfig(kueue.SecretLocationType, "multikueue2").Obj()
 		util.MustCreate(ctx, k8sManagerClient, workerCluster2)
 
-		multiKueueConfig = utiltestingapi.MakeMultiKueueConfig("multikueueconfig").Clusters("worker1", "worker2").Obj()
+		multiKueueConfig = utiltestingapi.MakeMultiKueueConfigWithGeneratedName("multikueueconfig-").Clusters(workerCluster1.Name, workerCluster2.Name).Obj()
 		util.MustCreate(ctx, k8sManagerClient, multiKueueConfig)
 
-		multiKueueAc = utiltestingapi.MakeAdmissionCheck("ac1").
+		multiKueueAc = utiltestingapi.MakeAdmissionCheck("").
+			GeneratedName("ac1-").
 			ControllerName(kueue.MultiKueueControllerName).
 			Parameters(kueue.GroupVersion.Group, "MultiKueueConfig", multiKueueConfig.Name).
 			Obj()
 		util.CreateAdmissionChecksAndWaitForActive(ctx, k8sManagerClient, multiKueueAc)
 
-		managerHighWPC = utiltestingapi.MakeWorkloadPriorityClass("high-workload").PriorityValue(300).Obj()
+		managerHighWPC = utiltestingapi.MakeWorkloadPriorityClass("").
+			GeneratedName("high-workload-").PriorityValue(300).Obj()
 		util.MustCreate(ctx, k8sManagerClient, managerHighWPC)
 
-		managerLowWPC = utiltestingapi.MakeWorkloadPriorityClass("low-workload").PriorityValue(100).Obj()
+		managerLowWPC = utiltestingapi.MakeWorkloadPriorityClass("").
+			GeneratedName("low-workload-").PriorityValue(100).Obj()
 		util.MustCreate(ctx, k8sManagerClient, managerLowWPC)
 
-		managerFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
+		managerFlavor = utiltestingapi.MakeResourceFlavor("").GeneratedName("default-").Obj()
 		util.MustCreate(ctx, k8sManagerClient, managerFlavor)
 
-		managerCq = utiltestingapi.MakeClusterQueue("q1").
+		managerCq = utiltestingapi.MakeClusterQueue("").
+			GeneratedName("q1-").
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas(managerFlavor.Name).
 					Resource(corev1.ResourceCPU, "2").
 					Resource(corev1.ResourceMemory, "4G").
 					Resource(corev1.ResourceEphemeralStorage, "100G").
+					Resource(extraResourceGPUHighCost, "2").
+					Resource(extraResourceGPULowCost, "2").
 					Obj(),
 			).
 			AdmissionChecks(kueue.AdmissionCheckReference(multiKueueAc.Name)).
@@ -154,21 +174,23 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 		managerLq = utiltestingapi.MakeLocalQueue(managerCq.Name, managerNs.Name).ClusterQueue(managerCq.Name).Obj()
 		util.CreateLocalQueuesAndWaitForActive(ctx, k8sManagerClient, managerLq)
 
-		worker1HighWPC = utiltestingapi.MakeWorkloadPriorityClass("high-workload").PriorityValue(300).Obj()
+		worker1HighWPC = utiltestingapi.MakeWorkloadPriorityClass(managerHighWPC.Name).PriorityValue(300).Obj()
 		util.MustCreate(ctx, k8sWorker1Client, worker1HighWPC)
 
-		worker1LowWPC = utiltestingapi.MakeWorkloadPriorityClass("low-workload").PriorityValue(100).Obj()
+		worker1LowWPC = utiltestingapi.MakeWorkloadPriorityClass(managerLowWPC.Name).PriorityValue(100).Obj()
 		util.MustCreate(ctx, k8sWorker1Client, worker1LowWPC)
 
-		worker1Flavor = utiltestingapi.MakeResourceFlavor("default").Obj()
+		worker1Flavor = utiltestingapi.MakeResourceFlavor(managerFlavor.Name).Obj()
 		util.MustCreate(ctx, k8sWorker1Client, worker1Flavor)
 
-		worker1Cq = utiltestingapi.MakeClusterQueue("q1").
+		worker1Cq = utiltestingapi.MakeClusterQueue(managerCq.Name).
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas(worker1Flavor.Name).
 					Resource(corev1.ResourceCPU, "2").
 					Resource(corev1.ResourceMemory, "1G").
 					Resource(corev1.ResourceEphemeralStorage, "15G").
+					Resource(extraResourceGPUHighCost, "2").
+					Resource(extraResourceGPULowCost, "1").
 					Obj(),
 			).
 			Preemption(kueue.ClusterQueuePreemption{
@@ -180,21 +202,23 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 		worker1Lq = utiltestingapi.MakeLocalQueue(worker1Cq.Name, worker1Ns.Name).ClusterQueue(worker1Cq.Name).Obj()
 		util.CreateLocalQueuesAndWaitForActive(ctx, k8sWorker1Client, worker1Lq)
 
-		worker2HighWPC = utiltestingapi.MakeWorkloadPriorityClass("high-workload").PriorityValue(300).Obj()
+		worker2HighWPC = utiltestingapi.MakeWorkloadPriorityClass(managerHighWPC.Name).PriorityValue(300).Obj()
 		util.MustCreate(ctx, k8sWorker2Client, worker2HighWPC)
 
-		worker2LowWPC = utiltestingapi.MakeWorkloadPriorityClass("low-workload").PriorityValue(100).Obj()
+		worker2LowWPC = utiltestingapi.MakeWorkloadPriorityClass(managerLowWPC.Name).PriorityValue(100).Obj()
 		util.MustCreate(ctx, k8sWorker2Client, worker2LowWPC)
 
-		worker2Flavor = utiltestingapi.MakeResourceFlavor("default").Obj()
+		worker2Flavor = utiltestingapi.MakeResourceFlavor(managerFlavor.Name).Obj()
 		util.MustCreate(ctx, k8sWorker2Client, worker2Flavor)
 
-		worker2Cq = utiltestingapi.MakeClusterQueue("q1").
+		worker2Cq = utiltestingapi.MakeClusterQueue(managerCq.Name).
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas(worker2Flavor.Name).
 					Resource(corev1.ResourceCPU, "1200m").
 					Resource(corev1.ResourceMemory, "4G").
 					Resource(corev1.ResourceEphemeralStorage, "5G").
+					Resource(extraResourceGPUHighCost, "1").
+					Resource(extraResourceGPULowCost, "2").
 					Obj(),
 			).
 			Preemption(kueue.ClusterQueuePreemption{
@@ -205,6 +229,19 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 
 		worker2Lq = utiltestingapi.MakeLocalQueue(worker2Cq.Name, worker2Ns.Name).ClusterQueue(worker2Cq.Name).Obj()
 		util.CreateLocalQueuesAndWaitForActive(ctx, k8sWorker2Client, worker2Lq)
+
+		kubernetesClients = kubernetesClientsMap{
+			workerCluster1.Name: {
+				client:     k8sWorker1Client,
+				restClient: worker1RestClient,
+				cfg:        worker1Cfg,
+			},
+			workerCluster2.Name: {
+				client:     k8sWorker2Client,
+				restClient: worker2RestClient,
+				cfg:        worker2Cfg,
+			},
+		}
 	})
 
 	ginkgo.AfterEach(func() {
@@ -247,15 +284,14 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sWorker2Client, worker2Ns)
 	})
 
-	ginkgo.When("Creating a multikueue admission check", func() {
+	ginkgo.When("Creating a multikueue integration workload", func() {
 		ginkgo.It("Should create a pod on worker if admitted", func() {
 			pod := testingpod.MakePod("pod", managerNs.Name).
+				RequestAndLimit(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceMemory, "100M").
 				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
-				RequestAndLimit(corev1.ResourceCPU, "1").
-				RequestAndLimit(corev1.ResourceMemory, "2G").
 				Queue(managerLq.Name).
 				Obj()
-			// Since it requires 2G of memory, this pod can only be admitted in worker 2.
 
 			ginkgo.By("Creating the pod", func() {
 				util.MustCreate(ctx, k8sManagerClient, pod)
@@ -267,13 +303,12 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 
 			wlLookupKey := types.NamespacedName{Name: workloadpod.GetWorkloadNameForPod(pod.Name, pod.UID), Namespace: managerNs.Name}
 
-			// the execution should be given to worker2
-			ginkgo.By("Waiting to be admitted in worker2", func() {
+			ginkgo.By("Waiting to be admitted in worker", func() {
 				util.ExpectAdmissionCheckStateWithMessage(
 					ctx, k8sManagerClient, wlLookupKey,
 					multiKueueAc.Name,
 					kueue.CheckStateReady,
-					`The workload got reservation on "worker2"`,
+					"",
 				)
 
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -321,12 +356,9 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 		})
 
 		ginkgo.It("Should create pods on worker if the deployment is admitted", func() {
-			var kubernetesClients = map[string]client.Client{
-				"worker1": k8sWorker1Client,
-				"worker2": k8sWorker2Client,
-			}
-
 			deployment := testingdeployment.MakeDeployment("deployment", managerNs.Name).
+				RequestAndLimit(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceMemory, "100M").
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				Replicas(3).
 				TerminationGracePeriod(1).
@@ -427,7 +459,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				for _, workerClient := range kubernetesClients {
 					pods := &corev1.PodList{}
 					gomega.Eventually(func(g gomega.Gomega) {
-						g.Expect(workerClient.List(ctx, pods, client.InNamespace(managerNs.Namespace), client.MatchingLabels(deployment.Spec.Selector.MatchLabels))).To(gomega.Succeed())
+						g.Expect(workerClient.client.List(ctx, pods, client.InNamespace(managerNs.Namespace), client.MatchingLabels(deployment.Spec.Selector.MatchLabels))).To(gomega.Succeed())
 						g.Expect(pods.Items).To(gomega.BeEmpty())
 					}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 				}
@@ -436,9 +468,10 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 
 		ginkgo.It("Should sync a StatefulSet to worker if admitted", func() {
 			statefulset := testingstatefulset.MakeStatefulSet("statefulset", managerNs.Name).
+				RequestAndLimit(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceMemory, "100M").
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				Replicas(3).
-				Request(corev1.ResourceCPU, "500m").
 				TerminationGracePeriod(1).
 				Queue(managerLq.Name).
 				Obj()
@@ -452,19 +485,20 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				Namespace: managerNs.Name,
 			}
 
-			util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker1", k8sManagerClient)
+			admittedWorkerName := ExpectWorkloadsToBeAdmittedAndGetWorkerName(ctx, k8sManagerClient, wlLookupKey, multiKueueAc.Name)
+			workerClient := kubernetesClients[admittedWorkerName].client
 
 			ginkgo.By("Waiting for StatefulSet to be synced to worker cluster", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					workerSts := &appsv1.StatefulSet{}
-					g.Expect(k8sWorker1Client.Get(ctx, client.ObjectKeyFromObject(statefulset), workerSts)).To(gomega.Succeed())
+					g.Expect(workerClient.Get(ctx, client.ObjectKeyFromObject(statefulset), workerSts)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Waiting for all replicas to be ready on worker cluster", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					workerSts := &appsv1.StatefulSet{}
-					g.Expect(k8sWorker1Client.Get(ctx, client.ObjectKeyFromObject(statefulset), workerSts)).To(gomega.Succeed())
+					g.Expect(workerClient.Get(ctx, client.ObjectKeyFromObject(statefulset), workerSts)).To(gomega.Succeed())
 					g.Expect(workerSts.Status.ReadyReplicas).To(gomega.Equal(int32(3)))
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -484,7 +518,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 
 			ginkgo.By("Deleting the statefulset", func() {
 				util.ExpectObjectToBeDeleted(ctx, k8sManagerClient, statefulset, true)
-				util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sWorker1Client, statefulset, false, util.MediumTimeout)
+				util.ExpectObjectToBeDeletedWithTimeout(ctx, workerClient, statefulset, false, util.MediumTimeout)
 			})
 		})
 
@@ -493,8 +527,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				Replicas(2).
 				Size(2).
-				RequestAndLimit(corev1.ResourceCPU, "200m").
-				Request(corev1.ResourceMemory, "1G").
+				RequestAndLimit(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceMemory, "100M").
 				Queue(managerLq.Name).
 				TerminationGracePeriod(1).
 				Obj()
@@ -515,13 +549,16 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				Namespace: managerNs.Name,
 			}
 
-			ginkgo.By("Verifying both workloads are admitted on worker2", func() {
+			admittedWorkerName := ExpectWorkloadsToBeAdmittedAndGetWorkerName(ctx, k8sManagerClient, wlLookupKey0, multiKueueAc.Name)
+			workerClient := kubernetesClients[admittedWorkerName].client
+
+			ginkgo.By("Verifying both workloads are admitted on the same worker", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					wl0 := &kueue.Workload{}
-					g.Expect(k8sWorker2Client.Get(ctx, wlLookupKey0, wl0)).To(gomega.Succeed())
+					g.Expect(workerClient.Get(ctx, wlLookupKey0, wl0)).To(gomega.Succeed())
 					g.Expect(workload.IsAdmitted(wl0)).To(gomega.BeTrue())
 					wl1 := &kueue.Workload{}
-					g.Expect(k8sWorker2Client.Get(ctx, wlLookupKey1, wl1)).To(gomega.Succeed())
+					g.Expect(workerClient.Get(ctx, wlLookupKey1, wl1)).To(gomega.Succeed())
 					g.Expect(workload.IsAdmitted(wl1)).To(gomega.BeTrue())
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -529,14 +566,14 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			ginkgo.By("Waiting for LWS to be synced to worker cluster", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					workerLWS := &leaderworkersetv1.LeaderWorkerSet{}
-					g.Expect(k8sWorker2Client.Get(ctx, client.ObjectKeyFromObject(lws), workerLWS)).To(gomega.Succeed())
+					g.Expect(workerClient.Get(ctx, client.ObjectKeyFromObject(lws), workerLWS)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Waiting for all replicas to be ready on worker cluster", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					workerLWS := &leaderworkersetv1.LeaderWorkerSet{}
-					g.Expect(k8sWorker2Client.Get(ctx, client.ObjectKeyFromObject(lws), workerLWS)).To(gomega.Succeed())
+					g.Expect(workerClient.Get(ctx, client.ObjectKeyFromObject(lws), workerLWS)).To(gomega.Succeed())
 					g.Expect(workerLWS.Status.ReadyReplicas).To(gomega.Equal(int32(2)))
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -556,15 +593,15 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 
 			ginkgo.By("Deleting the leaderworkerset", func() {
 				util.ExpectObjectToBeDeleted(ctx, k8sManagerClient, lws, true)
-				util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sWorker2Client, lws, false, util.MediumTimeout)
+				util.ExpectObjectToBeDeletedWithTimeout(ctx, workerClient, lws, false, util.MediumTimeout)
 			})
 
 			ginkgo.By("Checking that all workloads are deleted from manager and worker clusters", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sManagerClient.Get(ctx, wlLookupKey0, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
 					g.Expect(k8sManagerClient.Get(ctx, wlLookupKey1, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
-					g.Expect(k8sWorker2Client.Get(ctx, wlLookupKey0, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
-					g.Expect(k8sWorker2Client.Get(ctx, wlLookupKey1, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
+					g.Expect(workerClient.Get(ctx, wlLookupKey0, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
+					g.Expect(workerClient.Get(ctx, wlLookupKey1, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
@@ -575,8 +612,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				Replicas(lwsReplicas).
 				Size(2).
-				RequestAndLimit(corev1.ResourceCPU, "200m").
-				Request(corev1.ResourceMemory, "600M").
+				RequestAndLimit(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceMemory, "100M").
 				Queue(managerLq.Name).
 				TerminationGracePeriod(1).
 				Obj()
@@ -605,10 +642,13 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
+			admittedWorkerName := ExpectWorkloadsToBeAdmittedAndGetWorkerName(ctx, k8sManagerClient, wlKeys[0], multiKueueAc.Name)
+			workerClient := kubernetesClients[admittedWorkerName].client
+
 			ginkgo.By("Verifying primary workload is admitted on worker2", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					wl := &kueue.Workload{}
-					g.Expect(k8sWorker2Client.Get(ctx, wlKeys[0], wl)).To(gomega.Succeed())
+					g.Expect(workerClient.Get(ctx, wlKeys[0], wl)).To(gomega.Succeed())
 					g.Expect(workload.IsAdmitted(wl)).To(gomega.BeTrue())
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -616,7 +656,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			ginkgo.By("Verifying LWS is synced to worker cluster", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					workerLWS := &leaderworkersetv1.LeaderWorkerSet{}
-					g.Expect(k8sWorker2Client.Get(ctx, client.ObjectKeyFromObject(lws), workerLWS)).To(gomega.Succeed())
+					g.Expect(workerClient.Get(ctx, client.ObjectKeyFromObject(lws), workerLWS)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -636,14 +676,14 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 
 			ginkgo.By("Deleting the leaderworkerset", func() {
 				util.ExpectObjectToBeDeleted(ctx, k8sManagerClient, lws, true)
-				util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sWorker2Client, lws, false, util.MediumTimeout)
+				util.ExpectObjectToBeDeletedWithTimeout(ctx, workerClient, lws, false, util.MediumTimeout)
 			})
 
 			ginkgo.By("Checking that all workloads are deleted from manager and worker clusters", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					for _, key := range wlKeys {
 						g.Expect(k8sManagerClient.Get(ctx, key, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
-						g.Expect(k8sWorker2Client.Get(ctx, key, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
+						g.Expect(workerClient.Get(ctx, key, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
 					}
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -654,9 +694,9 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			groupName := "test-group"
 			group := testingpod.MakePod(groupName, managerNs.Name).
 				Queue(managerLq.Name).
+				RequestAndLimit(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceMemory, "100M").
 				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
-				RequestAndLimit(corev1.ResourceCPU, "200m").
-				RequestAndLimit(corev1.ResourceMemory, "1G").
 				MakeGroup(numPods)
 
 			ginkgo.By("Creating the Pod group", func() {
@@ -668,7 +708,6 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				}
 			})
 
-			// Since it requires 2G of memory, this pod group can only be admitted in worker 2.
 			pods := &corev1.PodList{}
 			ginkgo.By("ensure all pods are created", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -678,14 +717,15 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			})
 
 			wlLookupKey := types.NamespacedName{Name: groupName, Namespace: managerNs.Name}
+			admittedWorkerName := ExpectWorkloadsToBeAdmittedAndGetWorkerName(ctx, k8sManagerClient, wlLookupKey, multiKueueAc.Name)
 
-			// the execution should be given to worker2
-			ginkgo.By("Waiting to be admitted in worker2", func() {
+			// the execution should be given to the admitted worker
+			ginkgo.By("Waiting to be admitted in the worker", func() {
 				util.ExpectAdmissionCheckStateWithMessage(
 					ctx, k8sManagerClient, wlLookupKey,
 					multiKueueAc.Name,
 					kueue.CheckStateReady,
-					`The workload got reservation on "worker2"`,
+					fmt.Sprintf("The workload got reservation on %q", admittedWorkerName),
 				)
 
 				ginkgo.By("ensure all pods are created", func() {
@@ -709,12 +749,11 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 		})
 
 		ginkgo.It("Should run a job on worker if admitted", func() {
-			// Since it requires 2G of memory, this job can only be admitted in worker 2.
 			job := testingjob.MakeJob("job", managerNs.Name).
 				Queue(kueue.LocalQueueName(managerLq.Name)).
-				RequestAndLimit(corev1.ResourceCPU, "1").
-				RequestAndLimit(corev1.ResourceMemory, "2G").
 				TerminationGracePeriod(1).
+				RequestAndLimit(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceMemory, "100M").
 				// Give it the time to be observed Active in the live status update step.
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				Obj()
@@ -730,14 +769,16 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 
 			createdLeaderWorkload := &kueue.Workload{}
 			wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
+			admittedWorkerName := ExpectWorkloadsToBeAdmittedAndGetWorkerName(ctx, k8sManagerClient, wlLookupKey, multiKueueAc.Name)
+			admittedWorker := kubernetesClients[admittedWorkerName]
 
-			// the execution should be given to the worker
-			ginkgo.By("Waiting to be admitted in worker2, and the manager's job unsuspended", func() {
+			// the execution should be given to the admitted worker
+			ginkgo.By("Waiting to be admitted in admitted worker, and the manager's job unsuspended", func() {
 				util.ExpectAdmissionCheckStateWithMessage(
 					ctx, k8sManagerClient, wlLookupKey,
 					multiKueueAc.Name,
 					kueue.CheckStateReady,
-					`The workload got reservation on "worker2"`,
+					fmt.Sprintf("The workload got reservation on %q", admittedWorkerName),
 				)
 
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -759,7 +800,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 
 			ginkgo.By("Finishing the job's pod", func() {
 				listOpts := util.GetListOptsFromLabel(fmt.Sprintf("batch.kubernetes.io/job-name=%s", job.Name))
-				util.WaitForActivePodsAndTerminate(ctx, k8sWorker2Client, worker2RestClient, worker2Cfg, job.Namespace, 1, 0, listOpts)
+				util.WaitForActivePodsAndTerminate(ctx, admittedWorker.client, admittedWorker.restClient, admittedWorker.cfg, job.Namespace, 1, 0, listOpts)
 			})
 
 			ginkgo.By("Waiting for the job to finish", func() {
@@ -784,14 +825,483 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			})
 		})
 
+		ginkgo.It("Should run a jobSet on worker if admitted", func() {
+			jobSet := testingjobset.MakeJobSet("job-set", managerNs.Name).
+				Queue(managerLq.Name).
+				ReplicatedJobs(
+					testingjobset.ReplicatedJobRequirements{
+						Name:        "replicated-job-1",
+						Replicas:    2,
+						Parallelism: 2,
+						Completions: 2,
+						Image:       util.GetAgnHostImage(),
+						// Give it the time to be observed Active in the live status update step.
+						Args: util.BehaviorWaitForDeletion,
+					},
+				).
+				RequestAndLimit("replicated-job-1", corev1.ResourceCPU, "100m").
+				RequestAndLimit("replicated-job-1", corev1.ResourceMemory, "100M").
+				Obj()
+
+			ginkgo.By("Creating the jobSet", func() {
+				util.MustCreate(ctx, k8sManagerClient, jobSet)
+			})
+
+			createdLeaderWorkload := &kueue.Workload{}
+			wlLookupKey := types.NamespacedName{Name: workloadjobset.GetWorkloadNameForJobSet(jobSet.Name, jobSet.UID), Namespace: managerNs.Name}
+
+			admittedWorkerName := ExpectWorkloadsToBeAdmittedAndGetWorkerName(ctx, k8sManagerClient, wlLookupKey, multiKueueAc.Name)
+			admittedWorker := kubernetesClients[admittedWorkerName]
+
+			ginkgo.By("Waiting for the jobSet to get status updates", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					createdJobset := &jobset.JobSet{}
+					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(jobSet), createdJobset)).To(gomega.Succeed())
+
+					g.Expect(createdJobset.Status.ReplicatedJobsStatus).To(gomega.BeComparableTo([]jobset.ReplicatedJobStatus{
+						{
+							Name:   "replicated-job-1",
+							Ready:  2,
+							Active: 2,
+						},
+					}, cmpopts.IgnoreFields(jobset.ReplicatedJobStatus{}, "Succeeded", "Failed")))
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Finishing the jobset pods", func() {
+				listOpts := util.GetListOptsFromLabel(fmt.Sprintf("jobset.sigs.k8s.io/jobset-name=%s", jobSet.Name))
+				util.WaitForActivePodsAndTerminate(ctx, admittedWorker.client, admittedWorker.restClient, admittedWorker.cfg, jobSet.Namespace, 4, 0, listOpts)
+			})
+
+			ginkgo.By("Waiting for the jobSet to finish", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, createdLeaderWorkload)).To(gomega.Succeed())
+
+					g.Expect(apimeta.FindStatusCondition(createdLeaderWorkload.Status.Conditions, kueue.WorkloadFinished)).To(gomega.BeComparableTo(&metav1.Condition{
+						Type:    kueue.WorkloadFinished,
+						Status:  metav1.ConditionTrue,
+						Reason:  kueue.WorkloadFinishedReasonSucceeded,
+						Message: "jobset completed successfully",
+					}, util.IgnoreConditionTimestampsAndObservedGeneration))
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking no objects are left in the worker clusters and the jobSet is completed", func() {
+				util.ExpectObjectToBeDeletedOnClusters(ctx, createdLeaderWorkload, k8sWorker1Client, k8sWorker2Client)
+				util.ExpectObjectToBeDeletedOnClusters(ctx, jobSet, k8sWorker1Client, k8sWorker2Client)
+
+				createdJobSet := &jobset.JobSet{}
+				gomega.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(jobSet), createdJobSet)).To(gomega.Succeed())
+				gomega.Expect(ptr.Deref(createdJobSet.Spec.Suspend, true)).To(gomega.BeFalse())
+				gomega.Expect(createdJobSet.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(
+					metav1.Condition{
+						Type:    string(jobset.JobSetCompleted),
+						Status:  metav1.ConditionTrue,
+						Reason:  "AllJobsCompleted",
+						Message: "jobset completed successfully",
+					},
+					util.IgnoreConditionTimestampsAndObservedGeneration)))
+			})
+		})
+
+		ginkgo.It("Should run an appwrapper containing a job on worker if admitted", func() {
+			jobName := "job-1"
+			aw := testingaw.MakeAppWrapper("aw", managerNs.Name).
+				Queue(managerLq.Name).
+				Component(testingaw.Component{
+					Template: testingjob.MakeJob(jobName, managerNs.Name).
+						SetTypeMeta().
+						Suspend(false).
+						Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion). // Give it the time to be observed Active in the live status update step.
+						Parallelism(2).
+						RequestAndLimit(corev1.ResourceCPU, "100m").
+						RequestAndLimit(corev1.ResourceMemory, "100M").
+						TerminationGracePeriod(1).
+						SetTypeMeta().Obj(),
+				}).
+				Obj()
+
+			ginkgo.By("Creating the appwrapper", func() {
+				util.MustCreate(ctx, k8sManagerClient, aw)
+			})
+
+			wlLookupKey := types.NamespacedName{Name: workloadaw.GetWorkloadNameForAppWrapper(aw.Name, aw.UID), Namespace: managerNs.Name}
+
+			admittedWorkerName := ExpectWorkloadsToBeAdmittedAndGetWorkerName(ctx, k8sManagerClient, wlLookupKey, multiKueueAc.Name)
+			admittedWorker := kubernetesClients[admittedWorkerName]
+
+			ginkgo.By("Waiting for the appwrapper to get status updates", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					createdAppWrapper := &awv1beta2.AppWrapper{}
+					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(aw), createdAppWrapper)).To(gomega.Succeed())
+					g.Expect(createdAppWrapper.Status.Phase).To(gomega.Equal(awv1beta2.AppWrapperRunning))
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Finishing the wrapped job's pods", func() {
+				listOpts := util.GetListOptsFromLabel(fmt.Sprintf("batch.kubernetes.io/job-name=%s", jobName))
+				util.WaitForActivePodsAndTerminate(ctx, admittedWorker.client, admittedWorker.restClient, admittedWorker.cfg, aw.Namespace, 2, 0, listOpts)
+			})
+
+			ginkgo.By("Waiting for the appwrapper to finish", func() {
+				util.ExpectWorkloadToFinish(ctx, k8sManagerClient, wlLookupKey)
+			})
+
+			ginkgo.By("Checking no objects are left in the worker clusters and the appwrapper is completed", func() {
+				createdWorkload := &kueue.Workload{}
+				gomega.Expect(k8sManagerClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				util.ExpectObjectToBeDeletedOnClusters(ctx, createdWorkload, k8sWorker1Client, k8sWorker2Client)
+				util.ExpectObjectToBeDeletedOnClusters(ctx, aw, k8sWorker1Client, k8sWorker2Client)
+
+				createdAppWrapper := &awv1beta2.AppWrapper{}
+				gomega.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(aw), createdAppWrapper)).To(gomega.Succeed())
+				gomega.Expect(createdAppWrapper.Spec.Suspend).To(gomega.BeFalse())
+				gomega.Expect(createdAppWrapper.Status.Phase).To(gomega.Equal(awv1beta2.AppWrapperSucceeded))
+			})
+		})
+
+		ginkgo.It("Should run a kubeflow PyTorchJob on worker if admitted", func() {
+			pyTorchJob := testingpytorchjob.MakePyTorchJob("pytorchjob1", managerNs.Name).
+				ManagedBy(kueue.MultiKueueControllerName).
+				Queue(managerLq.Name).
+				PyTorchReplicaSpecs(
+					testingpytorchjob.PyTorchReplicaSpecRequirement{
+						ReplicaType:   kftraining.PyTorchJobReplicaTypeMaster,
+						ReplicaCount:  1,
+						RestartPolicy: "Never",
+						Image:         util.GetAgnHostImage(),
+						Args:          util.BehaviorExitFast,
+					},
+				).
+				RequestAndLimit(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceCPU, "100m").
+				RequestAndLimit(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceMemory, "100M").
+				RequestAndLimit(kftraining.PyTorchJobReplicaTypeWorker, corev1.ResourceCPU, "100m").
+				RequestAndLimit(kftraining.PyTorchJobReplicaTypeWorker, corev1.ResourceMemory, "100M").
+				Obj()
+
+			ginkgo.By("Creating the PyTorchJob", func() {
+				util.MustCreate(ctx, k8sManagerClient, pyTorchJob)
+			})
+
+			wlLookupKey := types.NamespacedName{Name: workloadpytorchjob.GetWorkloadNameForPyTorchJob(pyTorchJob.Name, pyTorchJob.UID), Namespace: managerNs.Name}
+
+			admittedWorker := ExpectWorkloadsToBeAdmittedAndGetWorkerName(ctx, k8sManagerClient, wlLookupKey, multiKueueAc.Name)
+			ginkgo.GinkgoLogr.Info("PyTorchJob %s is admitted in worker cluster %s", pyTorchJob.Name, admittedWorker)
+
+			ginkgo.By("Waiting for the PyTorchJob to finish", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					createdPyTorchJob := &kftraining.PyTorchJob{}
+					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(pyTorchJob), createdPyTorchJob)).To(gomega.Succeed())
+					g.Expect(createdPyTorchJob.Status.ReplicaStatuses[kftraining.PyTorchJobReplicaTypeMaster]).To(gomega.BeComparableTo(
+						&kftraining.ReplicaStatus{
+							Active:    0,
+							Succeeded: 1,
+							Selector: fmt.Sprintf(
+								"training.kubeflow.org/job-name=%s,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master",
+								createdPyTorchJob.Name,
+							),
+						},
+					))
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+				util.ExpectWorkloadToFinish(ctx, k8sManagerClient, wlLookupKey)
+			})
+
+			ginkgo.By("Checking no objects are left in the worker clusters and the PyTorchJob is completed", func() {
+				wl := &kueue.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      wlLookupKey.Name,
+						Namespace: wlLookupKey.Namespace,
+					},
+				}
+				util.ExpectObjectToBeDeletedOnClusters(ctx, wl, k8sWorker1Client, k8sWorker2Client)
+				util.ExpectObjectToBeDeletedOnClusters(ctx, pyTorchJob, k8sWorker1Client, k8sWorker2Client)
+			})
+		})
+
+		ginkgo.It("Should run a MPIJob on worker if admitted", func() {
+			mpijob := testingmpijob.MakeMPIJob("mpijob1", managerNs.Name).
+				Queue(managerLq.Name).
+				ManagedBy(kueue.MultiKueueControllerName).
+				MPIJobReplicaSpecs(
+					testingmpijob.MPIJobReplicaSpecRequirement{
+						ReplicaType:   kfmpi.MPIReplicaTypeLauncher,
+						ReplicaCount:  1,
+						RestartPolicy: "OnFailure",
+						Image:         util.GetAgnHostImage(),
+						Args:          util.BehaviorExitFast,
+					},
+					testingmpijob.MPIJobReplicaSpecRequirement{
+						ReplicaType:   kfmpi.MPIReplicaTypeWorker,
+						ReplicaCount:  1,
+						RestartPolicy: "OnFailure",
+						Image:         util.GetAgnHostImage(),
+						Args:          util.BehaviorExitFast,
+					},
+				).
+				RequestAndLimit(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "100m").
+				RequestAndLimit(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceMemory, "100M").
+				RequestAndLimit(kfmpi.MPIReplicaTypeWorker, corev1.ResourceCPU, "100m").
+				RequestAndLimit(kfmpi.MPIReplicaTypeWorker, corev1.ResourceMemory, "100M").
+				Obj()
+
+			ginkgo.By("Creating the MPIJob", func() {
+				util.MustCreate(ctx, k8sManagerClient, mpijob)
+			})
+
+			wlLookupKey := types.NamespacedName{Name: workloadmpijob.GetWorkloadNameForMPIJob(mpijob.Name, mpijob.UID), Namespace: managerNs.Name}
+
+			admittedWorker := ExpectWorkloadsToBeAdmittedAndGetWorkerName(ctx, k8sManagerClient, wlLookupKey, multiKueueAc.Name)
+			ginkgo.GinkgoLogr.Info("MPIJob %s is admitted in worker cluster %s", mpijob.Name, admittedWorker)
+
+			ginkgo.By("Waiting for the MPIJob to finish", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					createdMPIJob := &kfmpi.MPIJob{}
+					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(mpijob), createdMPIJob)).To(gomega.Succeed())
+					g.Expect(createdMPIJob.Status.ReplicaStatuses[kfmpi.MPIReplicaTypeLauncher]).To(gomega.BeComparableTo(
+						&kfmpi.ReplicaStatus{
+							Active:    0,
+							Succeeded: 1,
+						},
+					))
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+				util.ExpectWorkloadToFinish(ctx, k8sManagerClient, wlLookupKey)
+			})
+
+			ginkgo.By("Checking no objects are left in the worker clusters and the MPIJob is completed", func() {
+				wl := &kueue.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      wlLookupKey.Name,
+						Namespace: wlLookupKey.Namespace,
+					},
+				}
+				util.ExpectObjectToBeDeletedOnClusters(ctx, wl, k8sWorker1Client, k8sWorker2Client)
+				util.ExpectObjectToBeDeletedOnClusters(ctx, mpijob, k8sWorker1Client, k8sWorker2Client)
+			})
+		})
+
+		ginkgo.It("Should run a TrainJob on worker if admitted", func() {
+			trainjob := testingtrainjob.MakeTrainJob("trainjob-test", managerNs.Name).
+				RuntimeRefName("torch-distributed").
+				Queue(managerLq.Name).
+				RequestAndLimit(corev1.ResourceCPU, "100m", "100m").
+				RequestAndLimit(corev1.ResourceMemory, "100M", "100M").
+				// Even if we override the image coming from the TrainingRuntime, we still need to set the command and args
+				TrainerImage(util.GetAgnHostImage(), []string{"/agnhost"}, util.BehaviorExitFast).
+				Obj()
+
+			ginkgo.By("Creating the trainjob", func() {
+				util.MustCreate(ctx, k8sManagerClient, trainjob)
+			})
+
+			wlLookupKey := types.NamespacedName{Name: workloadtrainjob.GetWorkloadNameForTrainJob(trainjob.Name, trainjob.UID), Namespace: managerNs.Name}
+
+			admittedWorker := ExpectWorkloadsToBeAdmittedAndGetWorkerName(ctx, k8sManagerClient, wlLookupKey, multiKueueAc.Name)
+			ginkgo.GinkgoLogr.Info("TrainJob %s is admitted in worker cluster %s", trainjob.Name, admittedWorker)
+
+			ginkgo.By("Checking the TrainJob is ready", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					createdTrainJob := &kftrainer.TrainJob{}
+					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(trainjob), createdTrainJob)).To(gomega.Succeed())
+					g.Expect(ptr.Deref(createdTrainJob.Spec.Suspend, false)).To(gomega.BeFalse())
+				}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.When("Ray integration tests", ginkgo.Ordered, func() {
+			ginkgo.It("Should run a RayJob on worker if admitted", func() {
+				kuberayTestImage := util.GetKuberayTestImage()
+				rayjob := testingrayjob.MakeJob("rayjob1", managerNs.Name).
+					Suspend(true).
+					Queue(managerLq.Name).
+					WithSubmissionMode(rayv1.K8sJobMode).
+					Entrypoint("python -c \"import ray; ray.init(); print(ray.cluster_resources())\"").
+					RequestAndLimit(rayv1.HeadNode, corev1.ResourceCPU, "1").
+					RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "0.5").
+					Image(rayv1.HeadNode, kuberayTestImage).
+					Image(rayv1.WorkerNode, kuberayTestImage).
+					Obj()
+
+				ginkgo.By("Creating the RayJob", func() {
+					util.MustCreate(ctx, k8sManagerClient, rayjob)
+				})
+
+				wlLookupKey := types.NamespacedName{Name: workloadrayjob.GetWorkloadNameForRayJob(rayjob.Name, rayjob.UID), Namespace: managerNs.Name}
+
+				admittedWorker := ExpectWorkloadsToBeAdmittedAndGetWorkerName(ctx, k8sManagerClient, wlLookupKey, multiKueueAc.Name)
+				ginkgo.GinkgoLogr.Info(fmt.Sprintf("RayJob %s/%s is admitted in worker cluster %s", rayjob.Name, rayjob.Namespace, admittedWorker))
+
+				ginkgo.By("Waiting for the RayJob to finish", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						createdRayJob := &rayv1.RayJob{}
+						g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(rayjob), createdRayJob)).To(gomega.Succeed())
+						g.Expect(createdRayJob.Status.JobDeploymentStatus).To(gomega.Equal(rayv1.JobDeploymentStatusComplete))
+					}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+					util.ExpectWorkloadToFinish(ctx, k8sManagerClient, wlLookupKey)
+				})
+
+				ginkgo.By("Checking no objects are left in the worker clusters and the RayJob is completed", func() {
+					wl := &kueue.Workload{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      wlLookupKey.Name,
+							Namespace: wlLookupKey.Namespace,
+						},
+					}
+					util.ExpectObjectToBeDeletedOnClusters(ctx, wl, k8sWorker1Client, k8sWorker2Client)
+					util.ExpectObjectToBeDeletedOnClusters(ctx, rayjob, k8sWorker1Client, k8sWorker2Client)
+				})
+			})
+
+			ginkgo.It("Should run a RayCluster on worker if admitted", func() {
+				kuberayTestImage := util.GetKuberayTestImage()
+				raycluster := testingraycluster.MakeCluster("raycluster1", managerNs.Name).
+					Suspend(true).
+					Queue(managerLq.Name).
+					RequestAndLimit(rayv1.HeadNode, corev1.ResourceCPU, "1").
+					RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "0.5").
+					Image(rayv1.HeadNode, kuberayTestImage, []string{}).
+					Image(rayv1.WorkerNode, kuberayTestImage, []string{}).
+					Obj()
+
+				ginkgo.By("Creating the RayCluster", func() {
+					util.MustCreate(ctx, k8sManagerClient, raycluster)
+				})
+
+				wlLookupKey := types.NamespacedName{Name: workloadraycluster.GetWorkloadNameForRayCluster(raycluster.Name, raycluster.UID), Namespace: managerNs.Name}
+				// the execution should be given to the worker1
+				admittedWorker := ExpectWorkloadsToBeAdmittedAndGetWorkerName(ctx, k8sManagerClient, wlLookupKey, multiKueueAc.Name)
+				ginkgo.GinkgoLogr.Info(fmt.Sprintf("RayCluster %s/%s is admitted in worker cluster %s", raycluster.Name, raycluster.Namespace, admittedWorker))
+
+				ginkgo.By("Checking the RayCluster is ready", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						createdRayCluster := &rayv1.RayCluster{}
+						g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(raycluster), createdRayCluster)).To(gomega.Succeed())
+						g.Expect(createdRayCluster.Status.DesiredWorkerReplicas).To(gomega.Equal(int32(1)))
+						g.Expect(createdRayCluster.Status.ReadyWorkerReplicas).To(gomega.Equal(int32(1)))
+						g.Expect(createdRayCluster.Status.AvailableWorkerReplicas).To(gomega.Equal(int32(1)))
+					}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+				})
+			})
+
+			ginkgo.It("Should run a RayService on worker if admitted", func() {
+				kuberayTestImage := util.GetKuberayTestImage()
+
+				// Create ConfigMap with a simple Ray Serve application
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rayservice-hello",
+						Namespace: managerNs.Name,
+					},
+					Data: map[string]string{
+						"hello_serve.py": `from ray import serve
+
+@serve.deployment
+class HelloWorld:
+    def __call__(self, request):
+        return "Hello, World!"
+
+app = HelloWorld.bind()`,
+					},
+				}
+
+				serveConfigV2 := `applications:
+  - name: hello_app
+    import_path: hello_serve:app
+    route_prefix: /
+    deployments:
+      - name: HelloWorld
+        num_replicas: 1
+        max_replicas_per_node: 1
+        ray_actor_options:
+          num_cpus: 0.2`
+
+				volumes := []corev1.Volume{
+					{
+						Name: "code-sample",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "rayservice-hello",
+								},
+								Items: []corev1.KeyToPath{
+									{
+										Key:  "hello_serve.py",
+										Path: "hello_serve.py",
+									},
+								},
+							},
+						},
+					},
+				}
+				volumeMounts := []corev1.VolumeMount{
+					{
+						Name:      "code-sample",
+						MountPath: "/home/ray/samples",
+					},
+				}
+				env := []corev1.EnvVar{
+					{
+						Name:  "PYTHONPATH",
+						Value: "/home/ray/samples:$PYTHONPATH",
+					},
+				}
+
+				rayService := testingrayservice.MakeService("rayservice1", managerNs.Name).
+					Suspend(true).
+					Queue(managerLq.Name).
+					RequestAndLimit(rayv1.HeadNode, corev1.ResourceCPU, "1").
+					RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "0.5").
+					Image(rayv1.HeadNode, kuberayTestImage).
+					Image(rayv1.WorkerNode, kuberayTestImage).
+					RayStartParam(rayv1.HeadNode, "object-store-memory", "100000000").
+					WithServeConfigV2(serveConfigV2).
+					Env(rayv1.HeadNode, env).
+					Env(rayv1.WorkerNode, env).
+					Volumes(rayv1.HeadNode, volumes).
+					Volumes(rayv1.WorkerNode, volumes).
+					VolumeMounts(rayv1.HeadNode, volumeMounts).
+					VolumeMounts(rayv1.WorkerNode, volumeMounts).
+					Obj()
+
+				rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName = "small-group"
+				rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].MinReplicas = ptr.To[int32](1)
+				rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].MaxReplicas = ptr.To[int32](2)
+
+				ginkgo.By("Creating the ConfigMap on all clusters", func() {
+					worker1ConfigMap := configMap.DeepCopy()
+					worker2ConfigMap := configMap.DeepCopy()
+					util.MustCreate(ctx, k8sManagerClient, configMap)
+					util.MustCreate(ctx, k8sWorker1Client, worker1ConfigMap)
+					util.MustCreate(ctx, k8sWorker2Client, worker2ConfigMap)
+				})
+
+				ginkgo.By("Creating the RayService", func() {
+					util.MustCreate(ctx, k8sManagerClient, rayService)
+				})
+
+				wlLookupKey := types.NamespacedName{Name: workloadrayservice.GetWorkloadNameForRayService(rayService.Name, rayService.UID), Namespace: managerNs.Name}
+
+				admittedWorker := ExpectWorkloadsToBeAdmittedAndGetWorkerName(ctx, k8sManagerClient, wlLookupKey, multiKueueAc.Name)
+				ginkgo.GinkgoLogr.Info(fmt.Sprintf("RayService %s/%s is admitted in worker cluster %s", rayService.Name, rayService.Namespace, admittedWorker))
+
+				ginkgo.By("Checking the RayService is running", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						createdRayService := &rayv1.RayService{}
+						g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(rayService), createdRayService)).To(gomega.Succeed())
+						g.Expect(createdRayService.Spec.RayClusterSpec.Suspend).To(gomega.Equal(ptr.To(false)))
+						g.Expect(apimeta.IsStatusConditionTrue(createdRayService.Status.Conditions, string(rayv1.RayServiceReady))).To(gomega.BeTrue())
+					}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+				})
+			})
+		})
+	})
+	ginkgo.When("Preemption with a multikueue admission check", func() {
 		ginkgo.It("Should preempt a running low-priority workload when a high-priority workload is admitted (same worker)", func() {
-			lowJob := testingjob.MakeJob("low-job", managerNs.Name).
+			lowJob := testingjob.MakeJob("", managerNs.Name).
+				GeneratedName("low-job-").
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				WorkloadPriorityClass(managerLowWPC.Name).
 				Queue(kueue.LocalQueueName(managerLq.Name)).
-				RequestAndLimit(corev1.ResourceCPU, "2").
-				RequestAndLimit(corev1.ResourceMemory, "1G").
-				TerminationGracePeriod(1).
+				RequestAndLimit(extraResourceGPUHighCost, "2").
 				Obj()
 			util.MustCreate(ctx, k8sManagerClient, lowJob)
 
@@ -816,13 +1326,12 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			highJob := testingjob.MakeJob("high-job", managerNs.Name).
+			highJob := testingjob.MakeJob("", managerNs.Name).
+				GeneratedName("high-job-").
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				WorkloadPriorityClass(managerHighWPC.Name).
 				Queue(kueue.LocalQueueName(managerLq.Name)).
-				RequestAndLimit(corev1.ResourceCPU, "2").
-				RequestAndLimit(corev1.ResourceMemory, "1G").
-				TerminationGracePeriod(1).
+				RequestAndLimit(extraResourceGPUHighCost, "2").
 				Obj()
 			util.MustCreate(ctx, k8sManagerClient, highJob)
 
@@ -863,14 +1372,183 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			})
 		})
 
-		ginkgo.It("Should preempt a running low-priority workload on a worker when a high-priority workload is admitted to it by manager", func() {
-			lowJob := testingjob.MakeJob("low-job", managerNs.Name).
+		ginkgo.It("Should re-do admission process when workload gets evicted in the worker", func() {
+			job := testingjob.MakeJob("job", managerNs.Name).
+				WorkloadPriorityClass(managerLowWPC.Name).
+				Queue(kueue.LocalQueueName(managerLq.Name)).
+				RequestAndLimit(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceMemory, "0.1G").
+				RequestAndLimit(extraResourceGPUHighCost, "2"). // This will make the workload only schedulable in worker1
+				Obj()
+			util.MustCreate(ctx, k8sManagerClient, job)
+
+			wlKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
+			managerWl := &kueue.Workload{}
+			workerWorkload := &kueue.Workload{}
+
+			ginkgo.By("Checking that the workload is created and admitted in the manager cluster", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sManagerClient.Get(ctx, wlKey, managerWl)).To(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(managerWl)).To(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking that the workload is created on worker1", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sWorker1Client.Get(ctx, wlKey, workerWorkload)).To(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(workerWorkload)).To(gomega.BeTrue())
+					g.Expect(workerWorkload.Spec).To(gomega.BeComparableTo(managerWl.Spec))
+
+					g.Expect(k8sWorker2Client.Get(ctx, wlKey, workerWorkload)).To(utiltesting.BeNotFoundError())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Switching worker cluster queues' resources to enforce re-admission on the worker2", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sWorker1Client.Get(ctx, client.ObjectKeyFromObject(worker1Cq), worker1Cq)).To(gomega.Succeed())
+					g.Expect(k8sWorker1Client.Update(ctx, util.SetResourceNominalQuota(worker1Cq, extraResourceGPUHighCost, "1"))).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sWorker2Client.Get(ctx, client.ObjectKeyFromObject(worker2Cq), worker2Cq)).To(gomega.Succeed())
+					g.Expect(k8sWorker2Client.Update(ctx, util.SetResourceNominalQuota(worker2Cq, extraResourceGPUHighCost, "2"))).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+			ginkgo.By("Triggering eviction in worker1", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sWorker1Client.Get(ctx, wlKey, workerWorkload)).To(gomega.Succeed())
+					g.Expect(workload.SetConditionAndUpdate(
+						ctx,
+						k8sWorker1Client,
+						workerWorkload,
+						kueue.WorkloadEvicted,
+						metav1.ConditionTrue,
+						kueue.WorkloadEvictedByPreemption,
+						"By test",
+						"evict",
+						util.RealClock,
+					)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking that the workload is re-admitted in worker2", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sManagerClient.Get(ctx, wlKey, managerWl)).To(gomega.Succeed())
+					g.Expect(managerWl.Status.ClusterName).To(gomega.HaveValue(gomega.Equal(workerCluster2.Name)))
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking that the workload is created in worker2", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sWorker2Client.Get(ctx, wlKey, workerWorkload)).To(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(workerWorkload)).To(gomega.BeTrue())
+					g.Expect(workerWorkload.Spec).To(gomega.BeComparableTo(managerWl.Spec))
+
+					g.Expect(k8sWorker1Client.Get(ctx, wlKey, workerWorkload)).To(utiltesting.BeNotFoundError())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("Should preempt a running low-priority workload when a high-priority workload is admitted (other workers)", func() {
+			lowJob := testingjob.MakeJob("", managerNs.Name).
+				GeneratedName("low-job-").
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				WorkloadPriorityClass(managerLowWPC.Name).
 				Queue(kueue.LocalQueueName(managerLq.Name)).
-				RequestAndLimit(corev1.ResourceCPU, "1").
-				RequestAndLimit(corev1.ResourceMemory, "2G").
-				TerminationGracePeriod(1).
+				RequestAndLimit(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceMemory, "0.1G").
+				RequestAndLimit(extraResourceGPUHighCost, "2").
+				RequestAndLimit(extraResourceGPULowCost, "1").
+				Obj()
+			util.MustCreate(ctx, k8sManagerClient, lowJob)
+
+			lowWlKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(lowJob.Name, lowJob.UID), Namespace: managerNs.Name}
+
+			managerLowWl := &kueue.Workload{}
+			workerLowWorkload := &kueue.Workload{}
+
+			ginkgo.By("Checking that the low-priority workload is created and admitted in the manager cluster", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sManagerClient.Get(ctx, lowWlKey, managerLowWl)).To(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(managerLowWl)).To(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking that the low-priority workload is created in worker1 and not in worker2, and that its spec matches the manager workload", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sWorker1Client.Get(ctx, lowWlKey, workerLowWorkload)).To(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(workerLowWorkload)).To(gomega.BeTrue())
+					g.Expect(workerLowWorkload.Spec).To(gomega.BeComparableTo(managerLowWl.Spec))
+					g.Expect(k8sWorker2Client.Get(ctx, lowWlKey, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			highJob := testingjob.MakeJob("", managerNs.Name).
+				GeneratedName("high-job-").
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				WorkloadPriorityClass(managerHighWPC.Name).
+				Queue(kueue.LocalQueueName(managerLq.Name)).
+				RequestAndLimit(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceMemory, "0.1G").
+				RequestAndLimit(extraResourceGPUHighCost, "1").
+				RequestAndLimit(extraResourceGPULowCost, "2").
+				Obj()
+			util.MustCreate(ctx, k8sManagerClient, highJob)
+
+			highWlKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(highJob.Name, highJob.UID), Namespace: managerNs.Name}
+
+			managerHighWl := &kueue.Workload{}
+			workerHighWorkload := &kueue.Workload{}
+
+			ginkgo.By("Checking that the high-priority workload is created and admitted in the manager cluster", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sManagerClient.Get(ctx, highWlKey, managerHighWl)).To(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(managerHighWl)).To(gomega.BeTrue())
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking that the high-priority workload is created in worker2 and not in worker1, and that its spec matches the manager workload", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sWorker2Client.Get(ctx, highWlKey, workerHighWorkload)).To(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(workerHighWorkload)).To(gomega.BeTrue())
+					g.Expect(workerHighWorkload.Spec).To(gomega.BeComparableTo(managerHighWl.Spec))
+					g.Expect(k8sWorker1Client.Get(ctx, highWlKey, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking that the low-priority workload is preempted in the manager cluster", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sManagerClient.Get(ctx, lowWlKey, managerLowWl)).To(gomega.Succeed())
+					g.Expect(workload.IsEvicted(managerLowWl)).To(gomega.BeTrue())
+					g.Expect(managerLowWl.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.WorkloadPreempted))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking that the low-priority workload is deleted from the worker clusters", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sWorker1Client.Get(ctx, lowWlKey, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
+					g.Expect(k8sWorker2Client.Get(ctx, lowWlKey, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("Should preempt a running low-priority workload on a worker when a high-priority workload is admitted to it by manager", func() {
+			ginkgo.By("Adjusting manager CQ quota to allow both jobs", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(managerCq), managerCq)).To(gomega.Succeed())
+					g.Expect(k8sManagerClient.Update(ctx, util.SetResourceNominalQuota(managerCq, extraResourceGPULowCost, "4"))).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			lowJob := testingjob.MakeJob("", managerNs.Name).
+				GeneratedName("low-job-").
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				WorkloadPriorityClass(managerLowWPC.Name).
+				Queue(kueue.LocalQueueName(managerLq.Name)).
+				RequestAndLimit(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceMemory, "0.1G").
+				RequestAndLimit(extraResourceGPUHighCost, "1").
+				RequestAndLimit(extraResourceGPULowCost, "2").
 				Obj()
 			util.MustCreate(ctx, k8sManagerClient, lowJob)
 
@@ -903,13 +1581,15 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			highJob := testingjob.MakeJob("high-job", managerNs.Name).
+			highJob := testingjob.MakeJob("", managerNs.Name).
+				GeneratedName("high-job-").
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				WorkloadPriorityClass(managerHighWPC.Name).
 				Queue(kueue.LocalQueueName(managerLq.Name)).
-				RequestAndLimit(corev1.ResourceCPU, "1").
-				RequestAndLimit(corev1.ResourceMemory, "2G").
-				TerminationGracePeriod(1).
+				RequestAndLimit(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceMemory, "0.1G").
+				RequestAndLimit(extraResourceGPUHighCost, "1").
+				RequestAndLimit(extraResourceGPULowCost, "2").
 				Obj()
 			util.MustCreate(ctx, k8sManagerClient, highJob)
 
@@ -971,164 +1651,16 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
+	})
 
-		ginkgo.It("Should re-do admission process when workload gets evicted in the worker", func() {
-			job := testingjob.MakeJob("job", managerNs.Name).
-				WorkloadPriorityClass(managerLowWPC.Name).
-				Queue(kueue.LocalQueueName(managerLq.Name)).
-				RequestAndLimit(corev1.ResourceCPU, "1.5").
-				RequestAndLimit(corev1.ResourceMemory, "0.5G").
-				Obj()
-			util.MustCreate(ctx, k8sManagerClient, job)
-
-			wlKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
-			managerWl := &kueue.Workload{}
-			workerWorkload := &kueue.Workload{}
-
-			ginkgo.By("Checking that the workload is created and admitted in the manager cluster", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sManagerClient.Get(ctx, wlKey, managerWl)).To(gomega.Succeed())
-					g.Expect(workload.IsAdmitted(managerWl)).To(gomega.BeTrue())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("Checking that the workload is created on worker1", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sWorker1Client.Get(ctx, wlKey, workerWorkload)).To(gomega.Succeed())
-					g.Expect(workload.IsAdmitted(workerWorkload)).To(gomega.BeTrue())
-					g.Expect(workerWorkload.Spec).To(gomega.BeComparableTo(managerWl.Spec))
-
-					g.Expect(k8sWorker2Client.Get(ctx, wlKey, workerWorkload)).To(utiltesting.BeNotFoundError())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("Switching worker cluster queues' resources to enforce re-admission on the worker2", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sWorker1Client.Get(ctx, client.ObjectKeyFromObject(worker1Cq), worker1Cq)).To(gomega.Succeed())
-					worker1Cq.Spec.ResourceGroups[0].Flavors[0].Resources[0].NominalQuota = resource.MustParse("1")
-					g.Expect(k8sWorker1Client.Update(ctx, worker1Cq)).To(gomega.Succeed())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sWorker2Client.Get(ctx, client.ObjectKeyFromObject(worker2Cq), worker2Cq)).To(gomega.Succeed())
-					worker2Cq.Spec.ResourceGroups[0].Flavors[0].Resources[0].NominalQuota = resource.MustParse("2")
-					g.Expect(k8sWorker2Client.Update(ctx, worker2Cq)).To(gomega.Succeed())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("Triggering eviction in worker1", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sWorker1Client.Get(ctx, wlKey, workerWorkload)).To(gomega.Succeed())
-					g.Expect(workload.SetConditionAndUpdate(ctx, k8sWorker1Client, workerWorkload, kueue.WorkloadEvicted, metav1.ConditionTrue, kueue.WorkloadEvictedByPreemption, "By test", "evict", util.RealClock)).
-						To(gomega.Succeed())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("Checking that the workload is re-admitted in worker2", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sManagerClient.Get(ctx, wlKey, managerWl)).To(gomega.Succeed())
-					g.Expect(managerWl.Status.ClusterName).To(gomega.HaveValue(gomega.Equal("worker2")))
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("Checking that the workload is created in worker2", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sWorker2Client.Get(ctx, wlKey, workerWorkload)).To(gomega.Succeed())
-					g.Expect(workload.IsAdmitted(workerWorkload)).To(gomega.BeTrue())
-					g.Expect(workerWorkload.Spec).To(gomega.BeComparableTo(managerWl.Spec))
-
-					g.Expect(k8sWorker1Client.Get(ctx, wlKey, workerWorkload)).To(utiltesting.BeNotFoundError())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-		})
-
-		ginkgo.It("Should preempt a running low-priority workload when a high-priority workload is admitted (other workers)", func() {
-			lowJob := testingjob.MakeJob("low-job", managerNs.Name).
-				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
-				WorkloadPriorityClass(managerLowWPC.Name).
-				Queue(kueue.LocalQueueName(managerLq.Name)).
-				RequestAndLimit(corev1.ResourceCPU, "2").
-				RequestAndLimit(corev1.ResourceMemory, "1G").
-				TerminationGracePeriod(1).
-				Obj()
-			util.MustCreate(ctx, k8sManagerClient, lowJob)
-
-			lowWlKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(lowJob.Name, lowJob.UID), Namespace: managerNs.Name}
-
-			managerLowWl := &kueue.Workload{}
-			workerLowWorkload := &kueue.Workload{}
-
-			ginkgo.By("Checking that the low-priority workload is created and admitted in the manager cluster", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sManagerClient.Get(ctx, lowWlKey, managerLowWl)).To(gomega.Succeed())
-					g.Expect(workload.IsAdmitted(managerLowWl)).To(gomega.BeTrue())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("Checking that the low-priority workload is created in worker1 and not in worker2, and that its spec matches the manager workload", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sWorker1Client.Get(ctx, lowWlKey, workerLowWorkload)).To(gomega.Succeed())
-					g.Expect(workload.IsAdmitted(workerLowWorkload)).To(gomega.BeTrue())
-					g.Expect(workerLowWorkload.Spec).To(gomega.BeComparableTo(managerLowWl.Spec))
-					g.Expect(k8sWorker2Client.Get(ctx, lowWlKey, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			highJob := testingjob.MakeJob("high-job", managerNs.Name).
-				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
-				WorkloadPriorityClass(managerHighWPC.Name).
-				Queue(kueue.LocalQueueName(managerLq.Name)).
-				RequestAndLimit(corev1.ResourceCPU, "1").
-				RequestAndLimit(corev1.ResourceMemory, "2G").
-				TerminationGracePeriod(1).
-				Obj()
-			util.MustCreate(ctx, k8sManagerClient, highJob)
-
-			highWlKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(highJob.Name, highJob.UID), Namespace: managerNs.Name}
-
-			managerHighWl := &kueue.Workload{}
-			workerHighWorkload := &kueue.Workload{}
-
-			ginkgo.By("Checking that the high-priority workload is created and admitted in the manager cluster", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sManagerClient.Get(ctx, highWlKey, managerHighWl)).To(gomega.Succeed())
-					g.Expect(workload.IsAdmitted(managerHighWl)).To(gomega.BeTrue())
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("Checking that the high-priority workload is created in worker2 and not in worker1, and that its spec matches the manager workload", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sWorker2Client.Get(ctx, highWlKey, workerHighWorkload)).To(gomega.Succeed())
-					g.Expect(workload.IsAdmitted(workerHighWorkload)).To(gomega.BeTrue())
-					g.Expect(workerHighWorkload.Spec).To(gomega.BeComparableTo(managerHighWl.Spec))
-					g.Expect(k8sWorker1Client.Get(ctx, highWlKey, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("Checking that the low-priority workload is preempted in the manager cluster", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sManagerClient.Get(ctx, lowWlKey, managerLowWl)).To(gomega.Succeed())
-					g.Expect(workload.IsEvicted(managerLowWl)).To(gomega.BeTrue())
-					g.Expect(managerLowWl.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.WorkloadPreempted))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("Checking that the low-priority workload is deleted from the worker clusters", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sWorker1Client.Get(ctx, lowWlKey, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
-					g.Expect(k8sWorker2Client.Get(ctx, lowWlKey, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-		})
-
+	ginkgo.When("Priority class mutation", func() {
 		ginkgo.It("Should allow to mutate kueue.x-k8s.io/priority-class (other workers)", func() {
 			job1 := testingjob.MakeJob("job1", managerNs.Name).
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				WorkloadPriorityClass(managerHighWPC.Name).
 				Queue(kueue.LocalQueueName(managerLq.Name)).
-				RequestAndLimit(corev1.ResourceCPU, "2").
-				RequestAndLimit(corev1.ResourceMemory, "1G").
-				TerminationGracePeriod(1).
+				RequestAndLimit(extraResourceGPUHighCost, "2").
+				RequestAndLimit(extraResourceGPULowCost, "1").
 				Obj()
 			ginkgo.By("Creating the first job", func() {
 				util.MustCreate(ctx, k8sManagerClient, job1)
@@ -1160,9 +1692,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				WorkloadPriorityClass(managerHighWPC.Name).
 				Queue(kueue.LocalQueueName(managerLq.Name)).
-				RequestAndLimit(corev1.ResourceCPU, "1").
-				RequestAndLimit(corev1.ResourceMemory, "2G").
-				TerminationGracePeriod(1).
+				RequestAndLimit(extraResourceGPUHighCost, "1").
+				RequestAndLimit(extraResourceGPULowCost, "2").
 				Obj()
 			ginkgo.By("Creating the second job", func() {
 				util.MustCreate(ctx, k8sManagerClient, job2)
@@ -1298,473 +1829,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
-
-		ginkgo.It("Should run a jobSet on worker if admitted", func() {
-			// Since it requires 2 CPU in total, this jobset can only be admitted in worker 1.
-			jobSet := testingjobset.MakeJobSet("job-set", managerNs.Name).
-				Queue(managerLq.Name).
-				ReplicatedJobs(
-					testingjobset.ReplicatedJobRequirements{
-						Name:        "replicated-job-1",
-						Replicas:    2,
-						Parallelism: 2,
-						Completions: 2,
-						Image:       util.GetAgnHostImage(),
-						// Give it the time to be observed Active in the live status update step.
-						Args: util.BehaviorWaitForDeletion,
-					},
-				).
-				RequestAndLimit("replicated-job-1", corev1.ResourceCPU, "500m").
-				RequestAndLimit("replicated-job-1", corev1.ResourceMemory, "200M").
-				Obj()
-
-			ginkgo.By("Creating the jobSet", func() {
-				util.MustCreate(ctx, k8sManagerClient, jobSet)
-			})
-
-			createdLeaderWorkload := &kueue.Workload{}
-			wlLookupKey := types.NamespacedName{Name: workloadjobset.GetWorkloadNameForJobSet(jobSet.Name, jobSet.UID), Namespace: managerNs.Name}
-			// the execution should be given to the worker1
-			util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker1", k8sManagerClient)
-
-			ginkgo.By("Waiting for the jobSet to get status updates", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					createdJobset := &jobset.JobSet{}
-					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(jobSet), createdJobset)).To(gomega.Succeed())
-
-					g.Expect(createdJobset.Status.ReplicatedJobsStatus).To(gomega.BeComparableTo([]jobset.ReplicatedJobStatus{
-						{
-							Name:   "replicated-job-1",
-							Ready:  2,
-							Active: 2,
-						},
-					}, cmpopts.IgnoreFields(jobset.ReplicatedJobStatus{}, "Succeeded", "Failed")))
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("Finishing the jobset pods", func() {
-				listOpts := util.GetListOptsFromLabel(fmt.Sprintf("jobset.sigs.k8s.io/jobset-name=%s", jobSet.Name))
-				util.WaitForActivePodsAndTerminate(ctx, k8sWorker1Client, worker1RestClient, worker1Cfg, jobSet.Namespace, 4, 0, listOpts)
-			})
-
-			ginkgo.By("Waiting for the jobSet to finish", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, createdLeaderWorkload)).To(gomega.Succeed())
-
-					g.Expect(apimeta.FindStatusCondition(createdLeaderWorkload.Status.Conditions, kueue.WorkloadFinished)).To(gomega.BeComparableTo(&metav1.Condition{
-						Type:    kueue.WorkloadFinished,
-						Status:  metav1.ConditionTrue,
-						Reason:  kueue.WorkloadFinishedReasonSucceeded,
-						Message: "jobset completed successfully",
-					}, util.IgnoreConditionTimestampsAndObservedGeneration))
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("Checking no objects are left in the worker clusters and the jobSet is completed", func() {
-				util.ExpectObjectToBeDeletedOnClusters(ctx, createdLeaderWorkload, k8sWorker1Client, k8sWorker2Client)
-				util.ExpectObjectToBeDeletedOnClusters(ctx, jobSet, k8sWorker1Client, k8sWorker2Client)
-
-				createdJobSet := &jobset.JobSet{}
-				gomega.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(jobSet), createdJobSet)).To(gomega.Succeed())
-				gomega.Expect(ptr.Deref(createdJobSet.Spec.Suspend, true)).To(gomega.BeFalse())
-				gomega.Expect(createdJobSet.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(
-					metav1.Condition{
-						Type:    string(jobset.JobSetCompleted),
-						Status:  metav1.ConditionTrue,
-						Reason:  "AllJobsCompleted",
-						Message: "jobset completed successfully",
-					},
-					util.IgnoreConditionTimestampsAndObservedGeneration)))
-			})
-		})
-
-		ginkgo.It("Should run an appwrapper containing a job on worker if admitted", func() {
-			// Since it requires 2 CPU in total, this appwrapper can only be admitted in worker 1.
-			jobName := "job-1"
-			aw := testingaw.MakeAppWrapper("aw", managerNs.Name).
-				Queue(managerLq.Name).
-				Component(testingaw.Component{
-					Template: testingjob.MakeJob(jobName, managerNs.Name).
-						SetTypeMeta().
-						Suspend(false).
-						Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion). // Give it the time to be observed Active in the live status update step.
-						Parallelism(2).
-						RequestAndLimit(corev1.ResourceCPU, "1").
-						TerminationGracePeriod(1).
-						SetTypeMeta().Obj(),
-				}).
-				Obj()
-
-			ginkgo.By("Creating the appwrapper", func() {
-				util.MustCreate(ctx, k8sManagerClient, aw)
-			})
-
-			wlLookupKey := types.NamespacedName{Name: workloadaw.GetWorkloadNameForAppWrapper(aw.Name, aw.UID), Namespace: managerNs.Name}
-
-			// the execution should be given to worker 1
-			util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker1", k8sManagerClient)
-
-			ginkgo.By("Waiting for the appwrapper to get status updates", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					createdAppWrapper := &awv1beta2.AppWrapper{}
-					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(aw), createdAppWrapper)).To(gomega.Succeed())
-					g.Expect(createdAppWrapper.Status.Phase).To(gomega.Equal(awv1beta2.AppWrapperRunning))
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("Finishing the wrapped job's pods", func() {
-				listOpts := util.GetListOptsFromLabel(fmt.Sprintf("batch.kubernetes.io/job-name=%s", jobName))
-				util.WaitForActivePodsAndTerminate(ctx, k8sWorker1Client, worker1RestClient, worker1Cfg, aw.Namespace, 2, 0, listOpts)
-			})
-
-			ginkgo.By("Waiting for the appwrapper to finish", func() {
-				util.ExpectWorkloadToFinish(ctx, k8sManagerClient, wlLookupKey)
-			})
-
-			ginkgo.By("Checking no objects are left in the worker clusters and the appwrapper is completed", func() {
-				createdWorkload := &kueue.Workload{}
-				gomega.Expect(k8sManagerClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
-				util.ExpectObjectToBeDeletedOnClusters(ctx, createdWorkload, k8sWorker1Client, k8sWorker2Client)
-				util.ExpectObjectToBeDeletedOnClusters(ctx, aw, k8sWorker1Client, k8sWorker2Client)
-
-				createdAppWrapper := &awv1beta2.AppWrapper{}
-				gomega.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(aw), createdAppWrapper)).To(gomega.Succeed())
-				gomega.Expect(createdAppWrapper.Spec.Suspend).To(gomega.BeFalse())
-				gomega.Expect(createdAppWrapper.Status.Phase).To(gomega.Equal(awv1beta2.AppWrapperSucceeded))
-			})
-		})
-
-		ginkgo.It("Should run a kubeflow PyTorchJob on worker if admitted", func() {
-			// Since it requires 1600M of memory, this job can only be admitted in worker 2.
-			pyTorchJob := testingpytorchjob.MakePyTorchJob("pytorchjob1", managerNs.Name).
-				ManagedBy(kueue.MultiKueueControllerName).
-				Queue(managerLq.Name).
-				PyTorchReplicaSpecs(
-					testingpytorchjob.PyTorchReplicaSpecRequirement{
-						ReplicaType:   kftraining.PyTorchJobReplicaTypeMaster,
-						ReplicaCount:  1,
-						RestartPolicy: "Never",
-						Image:         util.GetAgnHostImage(),
-						Args:          util.BehaviorExitFast,
-					},
-				).
-				RequestAndLimit(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceCPU, "1").
-				RequestAndLimit(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceMemory, "1600M").
-				Obj()
-
-			ginkgo.By("Creating the PyTorchJob", func() {
-				util.MustCreate(ctx, k8sManagerClient, pyTorchJob)
-			})
-
-			wlLookupKey := types.NamespacedName{Name: workloadpytorchjob.GetWorkloadNameForPyTorchJob(pyTorchJob.Name, pyTorchJob.UID), Namespace: managerNs.Name}
-
-			// the execution should be given to the worker 2
-			util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker2", k8sManagerClient)
-
-			ginkgo.By("Waiting for the PyTorchJob to finish", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					createdPyTorchJob := &kftraining.PyTorchJob{}
-					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(pyTorchJob), createdPyTorchJob)).To(gomega.Succeed())
-					g.Expect(createdPyTorchJob.Status.ReplicaStatuses[kftraining.PyTorchJobReplicaTypeMaster]).To(gomega.BeComparableTo(
-						&kftraining.ReplicaStatus{
-							Active:    0,
-							Succeeded: 1,
-							Selector: fmt.Sprintf(
-								"training.kubeflow.org/job-name=%s,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master",
-								createdPyTorchJob.Name,
-							),
-						},
-					))
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
-				util.ExpectWorkloadToFinish(ctx, k8sManagerClient, wlLookupKey)
-			})
-
-			ginkgo.By("Checking no objects are left in the worker clusters and the PyTorchJob is completed", func() {
-				wl := &kueue.Workload{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      wlLookupKey.Name,
-						Namespace: wlLookupKey.Namespace,
-					},
-				}
-				util.ExpectObjectToBeDeletedOnClusters(ctx, wl, k8sWorker1Client, k8sWorker2Client)
-				util.ExpectObjectToBeDeletedOnClusters(ctx, pyTorchJob, k8sWorker1Client, k8sWorker2Client)
-			})
-		})
-
-		ginkgo.It("Should run a MPIJob on worker if admitted", func() {
-			// Since it requires 1.5 CPU, this job can only be admitted in worker 1.
-			mpijob := testingmpijob.MakeMPIJob("mpijob1", managerNs.Name).
-				Queue(managerLq.Name).
-				ManagedBy(kueue.MultiKueueControllerName).
-				MPIJobReplicaSpecs(
-					testingmpijob.MPIJobReplicaSpecRequirement{
-						ReplicaType:   kfmpi.MPIReplicaTypeLauncher,
-						ReplicaCount:  1,
-						RestartPolicy: "OnFailure",
-						Image:         util.GetAgnHostImage(),
-						Args:          util.BehaviorExitFast,
-					},
-					testingmpijob.MPIJobReplicaSpecRequirement{
-						ReplicaType:   kfmpi.MPIReplicaTypeWorker,
-						ReplicaCount:  1,
-						RestartPolicy: "OnFailure",
-						Image:         util.GetAgnHostImage(),
-						Args:          util.BehaviorExitFast,
-					},
-				).
-				RequestAndLimit(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "1").
-				RequestAndLimit(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceMemory, "200M").
-				RequestAndLimit(kfmpi.MPIReplicaTypeWorker, corev1.ResourceCPU, "0.5").
-				RequestAndLimit(kfmpi.MPIReplicaTypeWorker, corev1.ResourceMemory, "100M").
-				Obj()
-
-			ginkgo.By("Creating the MPIJob", func() {
-				util.MustCreate(ctx, k8sManagerClient, mpijob)
-			})
-
-			wlLookupKey := types.NamespacedName{Name: workloadmpijob.GetWorkloadNameForMPIJob(mpijob.Name, mpijob.UID), Namespace: managerNs.Name}
-
-			// the execution should be given to the worker1
-			util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker1", k8sManagerClient)
-
-			ginkgo.By("Waiting for the MPIJob to finish", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					createdMPIJob := &kfmpi.MPIJob{}
-					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(mpijob), createdMPIJob)).To(gomega.Succeed())
-					g.Expect(createdMPIJob.Status.ReplicaStatuses[kfmpi.MPIReplicaTypeLauncher]).To(gomega.BeComparableTo(
-						&kfmpi.ReplicaStatus{
-							Active:    0,
-							Succeeded: 1,
-						},
-					))
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
-				util.ExpectWorkloadToFinish(ctx, k8sManagerClient, wlLookupKey)
-			})
-
-			ginkgo.By("Checking no objects are left in the worker clusters and the MPIJob is completed", func() {
-				wl := &kueue.Workload{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      wlLookupKey.Name,
-						Namespace: wlLookupKey.Namespace,
-					},
-				}
-				util.ExpectObjectToBeDeletedOnClusters(ctx, wl, k8sWorker1Client, k8sWorker2Client)
-				util.ExpectObjectToBeDeletedOnClusters(ctx, mpijob, k8sWorker1Client, k8sWorker2Client)
-			})
-		})
-
-		ginkgo.It("Should run a RayJob on worker if admitted", func() {
-			kuberayTestImage := util.GetKuberayTestImage()
-			// Since it requires 1.5 CPU, this job can only be admitted in worker 1.
-			rayjob := testingrayjob.MakeJob("rayjob1", managerNs.Name).
-				Suspend(true).
-				Queue(managerLq.Name).
-				WithSubmissionMode(rayv1.K8sJobMode).
-				RequestAndLimit(rayv1.HeadNode, corev1.ResourceCPU, "1").
-				RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "0.5").
-				Entrypoint("python -c \"import ray; ray.init(); print(ray.cluster_resources())\"").
-				Image(rayv1.HeadNode, kuberayTestImage).
-				Image(rayv1.WorkerNode, kuberayTestImage).
-				Obj()
-
-			ginkgo.By("Creating the RayJob", func() {
-				util.MustCreate(ctx, k8sManagerClient, rayjob)
-			})
-
-			wlLookupKey := types.NamespacedName{Name: workloadrayjob.GetWorkloadNameForRayJob(rayjob.Name, rayjob.UID), Namespace: managerNs.Name}
-			// the execution should be given to the worker1
-			util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker1", k8sManagerClient)
-
-			ginkgo.By("Waiting for the RayJob to finish", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					createdRayJob := &rayv1.RayJob{}
-					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(rayjob), createdRayJob)).To(gomega.Succeed())
-					g.Expect(createdRayJob.Status.JobDeploymentStatus).To(gomega.Equal(rayv1.JobDeploymentStatusComplete))
-				}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
-				util.ExpectWorkloadToFinish(ctx, k8sManagerClient, wlLookupKey)
-			})
-
-			ginkgo.By("Checking no objects are left in the worker clusters and the RayJob is completed", func() {
-				wl := &kueue.Workload{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      wlLookupKey.Name,
-						Namespace: wlLookupKey.Namespace,
-					},
-				}
-				util.ExpectObjectToBeDeletedOnClusters(ctx, wl, k8sWorker1Client, k8sWorker2Client)
-				util.ExpectObjectToBeDeletedOnClusters(ctx, rayjob, k8sWorker1Client, k8sWorker2Client)
-			})
-		})
-
-		ginkgo.It("Should run a RayCluster on worker if admitted", func() {
-			kuberayTestImage := util.GetKuberayTestImage()
-			// Since it requires 1.5 CPU, this job can only be admitted in worker 1.
-			raycluster := testingraycluster.MakeCluster("raycluster1", managerNs.Name).
-				Suspend(true).
-				Queue(managerLq.Name).
-				RequestAndLimit(rayv1.HeadNode, corev1.ResourceCPU, "1").
-				RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "0.5").
-				Image(rayv1.HeadNode, kuberayTestImage, []string{}).
-				Image(rayv1.WorkerNode, kuberayTestImage, []string{}).
-				Obj()
-
-			ginkgo.By("Creating the RayCluster", func() {
-				util.MustCreate(ctx, k8sManagerClient, raycluster)
-			})
-
-			wlLookupKey := types.NamespacedName{Name: workloadraycluster.GetWorkloadNameForRayCluster(raycluster.Name, raycluster.UID), Namespace: managerNs.Name}
-			// the execution should be given to the worker1
-			util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker1", k8sManagerClient)
-
-			ginkgo.By("Checking the RayCluster is ready", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					createdRayCluster := &rayv1.RayCluster{}
-					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(raycluster), createdRayCluster)).To(gomega.Succeed())
-					g.Expect(createdRayCluster.Status.DesiredWorkerReplicas).To(gomega.Equal(int32(1)))
-					g.Expect(createdRayCluster.Status.ReadyWorkerReplicas).To(gomega.Equal(int32(1)))
-					g.Expect(createdRayCluster.Status.AvailableWorkerReplicas).To(gomega.Equal(int32(1)))
-				}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
-			})
-		})
-
-		ginkgo.It("Should run a RayService on worker if admitted", func() {
-			kuberayTestImage := util.GetKuberayTestImage()
-
-			// Create ConfigMap with a simple Ray Serve application
-			configMap := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "rayservice-hello",
-					Namespace: managerNs.Name,
-				},
-				Data: map[string]string{
-					"hello_serve.py": `from ray import serve
-
-@serve.deployment
-class HelloWorld:
-    def __call__(self, request):
-        return "Hello, World!"
-
-app = HelloWorld.bind()`,
-				},
-			}
-
-			serveConfigV2 := `applications:
-  - name: hello_app
-    import_path: hello_serve:app
-    route_prefix: /
-    deployments:
-      - name: HelloWorld
-        num_replicas: 1
-        max_replicas_per_node: 1
-        ray_actor_options:
-          num_cpus: 0.2`
-
-			volumes := []corev1.Volume{
-				{
-					Name: "code-sample",
-					VolumeSource: corev1.VolumeSource{
-						ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "rayservice-hello",
-							},
-							Items: []corev1.KeyToPath{
-								{
-									Key:  "hello_serve.py",
-									Path: "hello_serve.py",
-								},
-							},
-						},
-					},
-				},
-			}
-			volumeMounts := []corev1.VolumeMount{
-				{
-					Name:      "code-sample",
-					MountPath: "/home/ray/samples",
-				},
-			}
-			env := []corev1.EnvVar{
-				{
-					Name:  "PYTHONPATH",
-					Value: "/home/ray/samples:$PYTHONPATH",
-				},
-			}
-
-			// Since it requires 1.5 CPU, this service can only be admitted in worker 1.
-			rayService := testingrayservice.MakeService("rayservice1", managerNs.Name).
-				Suspend(true).
-				Queue(managerLq.Name).
-				RequestAndLimit(rayv1.HeadNode, corev1.ResourceCPU, "1").
-				RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "0.5").
-				Image(rayv1.HeadNode, kuberayTestImage).
-				Image(rayv1.WorkerNode, kuberayTestImage).
-				RayStartParam(rayv1.HeadNode, "object-store-memory", "100000000").
-				WithServeConfigV2(serveConfigV2).
-				Env(rayv1.HeadNode, env).
-				Env(rayv1.WorkerNode, env).
-				Volumes(rayv1.HeadNode, volumes).
-				Volumes(rayv1.WorkerNode, volumes).
-				VolumeMounts(rayv1.HeadNode, volumeMounts).
-				VolumeMounts(rayv1.WorkerNode, volumeMounts).
-				Obj()
-
-			rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName = "small-group"
-			rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].MinReplicas = ptr.To[int32](1)
-			rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].MaxReplicas = ptr.To[int32](2)
-
-			ginkgo.By("Creating the ConfigMap on all clusters", func() {
-				worker1ConfigMap := configMap.DeepCopy()
-				worker2ConfigMap := configMap.DeepCopy()
-				util.MustCreate(ctx, k8sManagerClient, configMap)
-				util.MustCreate(ctx, k8sWorker1Client, worker1ConfigMap)
-				util.MustCreate(ctx, k8sWorker2Client, worker2ConfigMap)
-			})
-
-			ginkgo.By("Creating the RayService", func() {
-				util.MustCreate(ctx, k8sManagerClient, rayService)
-			})
-
-			wlLookupKey := types.NamespacedName{Name: workloadrayservice.GetWorkloadNameForRayService(rayService.Name, rayService.UID), Namespace: managerNs.Name}
-			// the execution should be given to the worker1
-			util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker1", k8sManagerClient)
-
-			ginkgo.By("Checking the RayService is running", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					createdRayService := &rayv1.RayService{}
-					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(rayService), createdRayService)).To(gomega.Succeed())
-					g.Expect(createdRayService.Spec.RayClusterSpec.Suspend).To(gomega.Equal(ptr.To(false)))
-					g.Expect(apimeta.IsStatusConditionTrue(createdRayService.Status.Conditions, string(rayv1.RayServiceReady))).To(gomega.BeTrue())
-				}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
-			})
-		})
-
-		ginkgo.It("Should run a TrainJob on worker if admitted", func() {
-			trainjob := testingtrainjob.MakeTrainJob("trainjob-test", managerNs.Name).
-				RuntimeRefName("torch-distributed").
-				Queue(managerLq.Name).
-				// Even if we override the image coming from the TrainingRuntime, we still need to set the command and args
-				TrainerImage(util.GetAgnHostImage(), []string{"/agnhost"}, util.BehaviorExitFast).
-				TrainerRequest(corev1.ResourceCPU, "2").
-				TrainerRequest(corev1.ResourceMemory, "1G").
-				Obj()
-
-			ginkgo.By("Creating the trainjob", func() {
-				util.MustCreate(ctx, k8sManagerClient, trainjob)
-			})
-
-			wlLookupKey := types.NamespacedName{Name: workloadtrainjob.GetWorkloadNameForTrainJob(trainjob.Name, trainjob.UID), Namespace: managerNs.Name}
-			// the execution should be given to the worker1
-			util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker1", k8sManagerClient)
-
-			ginkgo.By("Checking the TrainJob is ready", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					createdTrainJob := &kftrainer.TrainJob{}
-					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(trainjob), createdTrainJob)).To(gomega.Succeed())
-					g.Expect(ptr.Deref(createdTrainJob.Spec.Suspend, false)).To(gomega.BeFalse())
-				}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
-			})
-		})
 	})
+
 	ginkgo.When("Cluster Role Sharing", func() {
 		var (
 			// Regular Kueue Cluster Queues and Local Queues
@@ -1793,16 +1859,16 @@ app = HelloWorld.bind()`,
 		ginkgo.It("should allow to run a MultiKueue and a regular Job on the same cluster", func() {
 			jobMk := testingjob.MakeJob("job-mk", managerNs.Name).
 				Queue(kueue.LocalQueueName(managerLq.Name)).
+				TerminationGracePeriod(1).
 				RequestAndLimit(corev1.ResourceCPU, "1").
 				RequestAndLimit(corev1.ResourceMemory, "2G").
-				TerminationGracePeriod(1).
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				Obj()
 			jobRegular := testingjob.MakeJob("job-regular", managerNs.Name).
 				Queue(kueue.LocalQueueName(managerRegularLq.Name)).
+				TerminationGracePeriod(1).
 				RequestAndLimit(corev1.ResourceCPU, "1").
 				RequestAndLimit(corev1.ResourceMemory, "2G").
-				TerminationGracePeriod(1).
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				Obj()
 
@@ -1838,7 +1904,25 @@ app = HelloWorld.bind()`,
 	})
 })
 
-func ensurePodWorkloadsRunning(deployment *appsv1.Deployment, managerNs corev1.Namespace, multiKueueAc *kueue.AdmissionCheck, kubernetesClients map[string]client.Client) {
+func ExpectWorkloadsToBeAdmittedAndGetWorkerName(ctx context.Context, client client.Client, wlLookupKey types.NamespacedName, acName string) string {
+	ginkgo.GinkgoHelper()
+	createdWorkload := &kueue.Workload{}
+	var workerName string
+	util.ExpectWorkloadsToBeAdmittedByKeys(ctx, client, wlLookupKey)
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(client.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+		admissionCheckMessage := admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(acName)).Message
+		workerName = GetMultiKueueClusterNameFromAdmissionCheckMessage(admissionCheckMessage)
+		g.Expect(workerName).NotTo(gomega.BeEmpty())
+	}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+	return workerName
+}
+
+func ensurePodWorkloadsRunning(deployment *appsv1.Deployment, managerNs corev1.Namespace, multiKueueAc *kueue.AdmissionCheck, kubernetesClients map[string]struct {
+	client     client.Client
+	restClient *rest.RESTClient
+	cfg        *rest.Config
+}) {
 	// Given the unpredictable nature of where the deployment pods run this function gathers the workload of a Pod first
 	// it then gets the Pod's assigned cluster from the admission check message and uses the appropriate client to ensure the Pod is running
 	pods := &corev1.PodList{}
@@ -1871,7 +1955,7 @@ func ensurePodWorkloadsRunning(deployment *appsv1.Deployment, managerNs corev1.N
 			ginkgo.By(fmt.Sprintf("Verifying pod is running on worker cluster %s", workerClusterName), func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdPod := &corev1.Pod{}
-					g.Expect(workerCluster.Get(ctx, client.ObjectKey{Namespace: pod.Namespace, Name: pod.Name}, createdPod)).To(gomega.Succeed())
+					g.Expect(workerCluster.client.Get(ctx, client.ObjectKey{Namespace: pod.Namespace, Name: pod.Name}, createdPod)).To(gomega.Succeed())
 					g.Expect(createdPod.Status.Phase).Should(gomega.Equal(corev1.PodRunning))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})

--- a/test/e2e/multikueue/suite_test.go
+++ b/test/e2e/multikueue/suite_test.go
@@ -70,9 +70,67 @@ func TestAPIs(t *testing.T) {
 	)
 }
 
-var _ = ginkgo.BeforeSuite(func() {
-	util.SetupLogger()
+var _ = ginkgo.SynchronizedBeforeSuite(
+	func() {
+		util.SetupLogger()
 
+		initClusterClients()
+		createSharedMultiKueueSecrets(context.Background())
+	},
+	func() {
+		util.SetupLogger()
+
+		initClusterClients()
+		ctx = ginkgo.GinkgoT().Context()
+
+		waitForAvailableStart := time.Now()
+		util.WaitForKueueAvailability(ctx, k8sManagerClient)
+		util.WaitForKueueAvailability(ctx, k8sWorker1Client)
+		util.WaitForKueueAvailability(ctx, k8sWorker2Client)
+
+		util.WaitForJobSetAvailability(ctx, k8sManagerClient)
+		util.WaitForJobSetAvailability(ctx, k8sWorker1Client)
+		util.WaitForJobSetAvailability(ctx, k8sWorker2Client)
+
+		util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sManagerClient)
+		util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sWorker1Client)
+		util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sWorker2Client)
+
+		util.WaitForKubeFlowMPIOperatorAvailability(ctx, k8sWorker1Client)
+		util.WaitForKubeFlowMPIOperatorAvailability(ctx, k8sWorker2Client)
+
+		util.WaitForAppWrapperAvailability(ctx, k8sManagerClient)
+		util.WaitForAppWrapperAvailability(ctx, k8sWorker1Client)
+		util.WaitForAppWrapperAvailability(ctx, k8sWorker2Client)
+
+		util.WaitForKubeRayOperatorAvailability(ctx, k8sManagerClient)
+		util.WaitForKubeRayOperatorAvailability(ctx, k8sWorker1Client)
+		util.WaitForKubeRayOperatorAvailability(ctx, k8sWorker2Client)
+
+		util.WaitForLeaderWorkerSetAvailability(ctx, k8sManagerClient)
+		util.WaitForLeaderWorkerSetAvailability(ctx, k8sWorker1Client)
+		util.WaitForLeaderWorkerSetAvailability(ctx, k8sWorker2Client)
+
+		ginkgo.GinkgoLogr.Info(
+			"Kueue and all required operators are available in all the clusters",
+			"waitingTime", time.Since(waitForAvailableStart),
+		)
+
+		discoveryClient, err := discovery.NewDiscoveryClientForConfig(managerCfg)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		managerK8SVersion, err = kubeversion.FetchServerVersion(discoveryClient)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	},
+)
+
+var _ = ginkgo.SynchronizedAfterSuite(
+	func() {},
+	func() {
+		cleanupSharedMultiKueueSecrets(context.Background())
+	},
+)
+
+func initClusterClients() {
 	managerClusterName = cmp.Or(os.Getenv("MANAGER_KIND_CLUSTER_NAME"), "kind-manager")
 	worker1ClusterName = cmp.Or(os.Getenv("WORKER1_KIND_CLUSTER_NAME"), "kind-worker1")
 	worker2ClusterName = cmp.Or(os.Getenv("WORKER2_KIND_CLUSTER_NAME"), "kind-worker2")
@@ -88,62 +146,26 @@ var _ = ginkgo.BeforeSuite(func() {
 	managerRestClient = util.CreateRestClient(managerCfg)
 	worker1RestClient = util.CreateRestClient(worker1Cfg)
 	worker2RestClient = util.CreateRestClient(worker2Cfg)
+}
 
-	ctx = ginkgo.GinkgoT().Context()
-
+func createSharedMultiKueueSecrets(ctx context.Context) {
+	var err error
 	worker1KConfig, err = util.KubeconfigForMultiKueueSA(ctx, k8sWorker1Client, worker1Cfg, kueueNS, "mksa", worker1ClusterName, util.MultiKueueRulesForManager(ctx, k8sManagerClient))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	gomega.Expect(util.MakeMultiKueueSecret(ctx, k8sManagerClient, kueueNS, "multikueue1", worker1KConfig)).To(gomega.Succeed())
-	ginkgo.DeferCleanup(func() {
-		gomega.Expect(util.CleanMultiKueueSecret(ctx, k8sManagerClient, kueueNS, "multikueue1")).To(gomega.Succeed())
-		gomega.Expect(util.CleanKubeconfigForMultiKueueSA(ctx, k8sWorker1Client, kueueNS, "mksa")).To(gomega.Succeed())
-	})
+
+	gomega.Expect(util.MakeMultiKueueSecret(ctx, k8sManagerClient, kueueNS, "multikueue1", worker1KConfig)).NotTo(gomega.HaveOccurred())
 
 	worker2KConfig, err = util.KubeconfigForMultiKueueSA(ctx, k8sWorker2Client, worker2Cfg, kueueNS, "mksa", worker2ClusterName, util.MultiKueueRulesForManager(ctx, k8sManagerClient))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	gomega.Expect(util.MakeMultiKueueSecret(ctx, k8sManagerClient, kueueNS, "multikueue2", worker2KConfig)).To(gomega.Succeed())
-	ginkgo.DeferCleanup(func() {
-		gomega.Expect(util.CleanMultiKueueSecret(ctx, k8sManagerClient, kueueNS, "multikueue2")).To(gomega.Succeed())
-		gomega.Expect(util.CleanKubeconfigForMultiKueueSA(ctx, k8sWorker2Client, kueueNS, "mksa")).To(gomega.Succeed())
-	})
+	gomega.Expect(util.MakeMultiKueueSecret(ctx, k8sManagerClient, kueueNS, "multikueue2", worker2KConfig)).NotTo(gomega.HaveOccurred())
+}
 
-	waitForAvailableStart := time.Now()
-	util.WaitForKueueAvailability(ctx, k8sManagerClient)
-	util.WaitForKueueAvailability(ctx, k8sWorker1Client)
-	util.WaitForKueueAvailability(ctx, k8sWorker2Client)
-
-	util.WaitForJobSetAvailability(ctx, k8sManagerClient)
-	util.WaitForJobSetAvailability(ctx, k8sWorker1Client)
-	util.WaitForJobSetAvailability(ctx, k8sWorker2Client)
-
-	util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sManagerClient)
-	util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sWorker1Client)
-	util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sWorker2Client)
-
-	util.WaitForKubeFlowMPIOperatorAvailability(ctx, k8sWorker1Client)
-	util.WaitForKubeFlowMPIOperatorAvailability(ctx, k8sWorker2Client)
-
-	util.WaitForAppWrapperAvailability(ctx, k8sManagerClient)
-	util.WaitForAppWrapperAvailability(ctx, k8sWorker1Client)
-	util.WaitForAppWrapperAvailability(ctx, k8sWorker2Client)
-
-	util.WaitForKubeRayOperatorAvailability(ctx, k8sManagerClient)
-	util.WaitForKubeRayOperatorAvailability(ctx, k8sWorker1Client)
-	util.WaitForKubeRayOperatorAvailability(ctx, k8sWorker2Client)
-
-	util.WaitForLeaderWorkerSetAvailability(ctx, k8sManagerClient)
-	util.WaitForLeaderWorkerSetAvailability(ctx, k8sWorker1Client)
-	util.WaitForLeaderWorkerSetAvailability(ctx, k8sWorker2Client)
-
-	ginkgo.GinkgoLogr.Info(
-		"Kueue and all required operators are available in all the clusters",
-		"waitingTime", time.Since(waitForAvailableStart),
-	)
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(managerCfg)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	managerK8SVersion, err = kubeversion.FetchServerVersion(discoveryClient)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-})
+func cleanupSharedMultiKueueSecrets(ctx context.Context) {
+	gomega.Expect(util.CleanMultiKueueSecret(ctx, k8sManagerClient, kueueNS, "multikueue1")).NotTo(gomega.HaveOccurred())
+	gomega.Expect(util.CleanMultiKueueSecret(ctx, k8sManagerClient, kueueNS, "multikueue2")).NotTo(gomega.HaveOccurred())
+	gomega.Expect(util.CleanKubeconfigForMultiKueueSA(ctx, k8sWorker1Client, kueueNS, "mksa")).NotTo(gomega.HaveOccurred())
+	gomega.Expect(util.CleanKubeconfigForMultiKueueSA(ctx, k8sWorker2Client, kueueNS, "mksa")).NotTo(gomega.HaveOccurred())
+}
 
 var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
 	err := util.ConfigureSuiteReporting(report)

--- a/test/e2e/multikueue/tas_test.go
+++ b/test/e2e/multikueue/tas_test.go
@@ -101,31 +101,34 @@ var _ = ginkgo.Describe("MultiKueue with TopologyAwareScheduling", func() {
 		worker1Ns = util.CreateNamespaceWithLog(ctx, k8sWorker1Client, managerNs.Name)
 		worker2Ns = util.CreateNamespaceWithLog(ctx, k8sWorker2Client, managerNs.Name)
 
-		workerCluster1 = utiltestingapi.MakeMultiKueueCluster("worker1").KubeConfig(kueue.SecretLocationType, "multikueue1").Obj()
+		workerCluster1 = utiltestingapi.MakeMultiKueueClusterWithGeneratedName("worker1-").KubeConfig(kueue.SecretLocationType, "multikueue1").Obj()
 		util.MustCreate(ctx, k8sManagerClient, workerCluster1)
 
-		workerCluster2 = utiltestingapi.MakeMultiKueueCluster("worker2").KubeConfig(kueue.SecretLocationType, "multikueue2").Obj()
+		workerCluster2 = utiltestingapi.MakeMultiKueueClusterWithGeneratedName("worker2-").KubeConfig(kueue.SecretLocationType, "multikueue2").Obj()
 		util.MustCreate(ctx, k8sManagerClient, workerCluster2)
 
-		multiKueueConfig = utiltestingapi.MakeMultiKueueConfig("multikueueconfig").Clusters("worker1", "worker2").Obj()
+		multiKueueConfig = utiltestingapi.MakeMultiKueueConfigWithGeneratedName("multikueueconfig-").Clusters(workerCluster1.Name, workerCluster2.Name).Obj()
 		util.MustCreate(ctx, k8sManagerClient, multiKueueConfig)
 
-		multiKueueAc = utiltestingapi.MakeAdmissionCheck("ac1").
+		multiKueueAc = utiltestingapi.MakeAdmissionCheck("").
+			GeneratedName("ac1-").
 			ControllerName(kueue.MultiKueueControllerName).
 			Parameters(kueue.GroupVersion.Group, "MultiKueueConfig", multiKueueConfig.Name).
 			Obj()
 		util.CreateAdmissionChecksAndWaitForActive(ctx, k8sManagerClient, multiKueueAc)
 
-		managerTopology = utiltestingapi.MakeDefaultOneLevelTopology("default")
+		managerTopology = utiltestingapi.MakeDefaultOneLevelTopology("default-" + managerNs.Name)
 		util.MustCreate(ctx, k8sManagerClient, managerTopology)
 
-		managerFlavor = utiltestingapi.MakeResourceFlavor("tas-flavor").
+		managerFlavor = utiltestingapi.MakeResourceFlavor("").
+			GeneratedName("tas-flavor-").
 			NodeLabel(tasNodeGroupLabel, instanceType).
 			TopologyName(managerTopology.Name).
 			Obj()
 		util.MustCreate(ctx, k8sManagerClient, managerFlavor)
 
-		managerCq = utiltestingapi.MakeClusterQueue("q1").
+		managerCq = utiltestingapi.MakeClusterQueue("").
+			GeneratedName("q1-").
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas(managerFlavor.Name).
 					Resource(corev1.ResourceCPU, "8").
@@ -139,16 +142,16 @@ var _ = ginkgo.Describe("MultiKueue with TopologyAwareScheduling", func() {
 		managerLq = utiltestingapi.MakeLocalQueue(managerCq.Name, managerNs.Name).ClusterQueue(managerCq.Name).Obj()
 		util.CreateLocalQueuesAndWaitForActive(ctx, k8sManagerClient, managerLq)
 
-		worker1Topology = utiltestingapi.MakeDefaultOneLevelTopology("default")
+		worker1Topology = utiltestingapi.MakeDefaultOneLevelTopology("default-" + worker1Ns.Name)
 		util.MustCreate(ctx, k8sWorker1Client, worker1Topology)
 
-		worker1Flavor = utiltestingapi.MakeResourceFlavor("tas-flavor").
+		worker1Flavor = utiltestingapi.MakeResourceFlavor(managerFlavor.Name).
 			NodeLabel(tasNodeGroupLabel, instanceType).
 			TopologyName(worker1Topology.Name).
 			Obj()
 		util.MustCreate(ctx, k8sWorker1Client, worker1Flavor)
 
-		worker1Cq = utiltestingapi.MakeClusterQueue("q1").
+		worker1Cq = utiltestingapi.MakeClusterQueue(managerCq.Name).
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas(worker1Flavor.Name).
 					Resource(corev1.ResourceCPU, "8").
@@ -161,16 +164,16 @@ var _ = ginkgo.Describe("MultiKueue with TopologyAwareScheduling", func() {
 		worker1Lq = utiltestingapi.MakeLocalQueue(worker1Cq.Name, worker1Ns.Name).ClusterQueue(worker1Cq.Name).Obj()
 		util.CreateLocalQueuesAndWaitForActive(ctx, k8sWorker1Client, worker1Lq)
 
-		worker2Topology = utiltestingapi.MakeDefaultOneLevelTopology("default")
+		worker2Topology = utiltestingapi.MakeDefaultOneLevelTopology("default-" + worker2Ns.Name)
 		util.MustCreate(ctx, k8sWorker2Client, worker2Topology)
 
-		worker2Flavor = utiltestingapi.MakeResourceFlavor("tas-flavor").
+		worker2Flavor = utiltestingapi.MakeResourceFlavor(managerFlavor.Name).
 			NodeLabel(tasNodeGroupLabel, instanceType).
 			TopologyName(worker2Topology.Name).
 			Obj()
 		util.MustCreate(ctx, k8sWorker2Client, worker2Flavor)
 
-		worker2Cq = utiltestingapi.MakeClusterQueue("q1").
+		worker2Cq = utiltestingapi.MakeClusterQueue(managerCq.Name).
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas(worker2Flavor.Name).
 					Resource(corev1.ResourceCPU, "4").
@@ -399,6 +402,8 @@ var _ = ginkgo.Describe("MultiKueue TAS with asymmetric quotas", func() {
 		managerLq *kueue.LocalQueue
 		worker1Lq *kueue.LocalQueue
 		worker2Lq *kueue.LocalQueue
+
+		kubernetesClients kubernetesClientsMap
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -406,49 +411,52 @@ var _ = ginkgo.Describe("MultiKueue TAS with asymmetric quotas", func() {
 		worker1Ns = util.CreateNamespaceWithLog(ctx, k8sWorker1Client, managerNs.Name)
 		worker2Ns = util.CreateNamespaceWithLog(ctx, k8sWorker2Client, managerNs.Name)
 
-		managerTopology = utiltestingapi.MakeDefaultOneLevelTopology("default")
+		managerTopology = utiltestingapi.MakeDefaultOneLevelTopology("default-" + managerNs.Name)
 		util.MustCreate(ctx, k8sManagerClient, managerTopology)
 
-		worker1Topology = utiltestingapi.MakeDefaultOneLevelTopology("default")
+		worker1Topology = utiltestingapi.MakeDefaultOneLevelTopology("default-" + worker1Ns.Name)
 		util.MustCreate(ctx, k8sWorker1Client, worker1Topology)
 
-		worker2Topology = utiltestingapi.MakeDefaultOneLevelTopology("default")
+		worker2Topology = utiltestingapi.MakeDefaultOneLevelTopology("default-" + worker2Ns.Name)
 		util.MustCreate(ctx, k8sWorker2Client, worker2Topology)
 
 		managerTasFlavor = utiltestingapi.MakeResourceFlavor("tas-flavor").
+			GeneratedName("tas-flavor-").
 			NodeLabel(tasNodeGroupLabel, instanceType).
 			TopologyName(managerTopology.Name).
 			Obj()
 		util.MustCreate(ctx, k8sManagerClient, managerTasFlavor)
 
-		worker1TasFlavor = utiltestingapi.MakeResourceFlavor("tas-flavor").
+		worker1TasFlavor = utiltestingapi.MakeResourceFlavor(managerTasFlavor.Name).
 			NodeLabel(tasNodeGroupLabel, instanceType).
 			TopologyName(worker1Topology.Name).
 			Obj()
 		util.MustCreate(ctx, k8sWorker1Client, worker1TasFlavor)
 
-		worker2TasFlavor = utiltestingapi.MakeResourceFlavor("tas-flavor").
+		worker2TasFlavor = utiltestingapi.MakeResourceFlavor(managerTasFlavor.Name).
 			NodeLabel(tasNodeGroupLabel, instanceType).
 			TopologyName(worker2Topology.Name).
 			Obj()
 		util.MustCreate(ctx, k8sWorker2Client, worker2TasFlavor)
 
-		workerCluster1 = utiltestingapi.MakeMultiKueueCluster("worker1").KubeConfig(kueue.SecretLocationType, "multikueue1").Obj()
+		workerCluster1 = utiltestingapi.MakeMultiKueueClusterWithGeneratedName("worker1-").KubeConfig(kueue.SecretLocationType, "multikueue1").Obj()
 		util.MustCreate(ctx, k8sManagerClient, workerCluster1)
 
-		workerCluster2 = utiltestingapi.MakeMultiKueueCluster("worker2").KubeConfig(kueue.SecretLocationType, "multikueue2").Obj()
+		workerCluster2 = utiltestingapi.MakeMultiKueueClusterWithGeneratedName("worker2-").KubeConfig(kueue.SecretLocationType, "multikueue2").Obj()
 		util.MustCreate(ctx, k8sManagerClient, workerCluster2)
 
-		multiKueueConfig = utiltestingapi.MakeMultiKueueConfig("multikueueconfig").Clusters("worker1", "worker2").Obj()
+		multiKueueConfig = utiltestingapi.MakeMultiKueueConfigWithGeneratedName("multikueueconfig-").Clusters(workerCluster1.Name, workerCluster2.Name).Obj()
 		util.MustCreate(ctx, k8sManagerClient, multiKueueConfig)
 
-		multiKueueAc = utiltestingapi.MakeAdmissionCheck("ac1").
+		multiKueueAc = utiltestingapi.MakeAdmissionCheck("").
+			GeneratedName("ac1-").
 			ControllerName(kueue.MultiKueueControllerName).
 			Parameters(kueue.GroupVersion.Group, "MultiKueueConfig", multiKueueConfig.Name).
 			Obj()
 		util.CreateAdmissionChecksAndWaitForActive(ctx, k8sManagerClient, multiKueueAc)
 
-		managerCq = utiltestingapi.MakeClusterQueue("tas-cq").
+		managerCq = utiltestingapi.MakeClusterQueue("").
+			GeneratedName("tas-cq-").
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas(managerTasFlavor.Name).
 					Resource(corev1.ResourceCPU, "4").
@@ -463,7 +471,7 @@ var _ = ginkgo.Describe("MultiKueue TAS with asymmetric quotas", func() {
 		util.CreateLocalQueuesAndWaitForActive(ctx, k8sManagerClient, managerLq)
 
 		// Worker1: 2 CPU quota (can fit 1.5 CPU jobs)
-		worker1Cq = utiltestingapi.MakeClusterQueue("tas-cq").
+		worker1Cq = utiltestingapi.MakeClusterQueue(managerCq.Name).
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas(worker1TasFlavor.Name).
 					Resource(corev1.ResourceCPU, "2").
@@ -477,7 +485,7 @@ var _ = ginkgo.Describe("MultiKueue TAS with asymmetric quotas", func() {
 		util.CreateLocalQueuesAndWaitForActive(ctx, k8sWorker1Client, worker1Lq)
 
 		// Worker2: 1 CPU quota (cannot fit 1.5 CPU jobs)
-		worker2Cq = utiltestingapi.MakeClusterQueue("tas-cq").
+		worker2Cq = utiltestingapi.MakeClusterQueue(managerCq.Name).
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas(worker2TasFlavor.Name).
 					Resource(corev1.ResourceCPU, "1").
@@ -489,6 +497,19 @@ var _ = ginkgo.Describe("MultiKueue TAS with asymmetric quotas", func() {
 
 		worker2Lq = utiltestingapi.MakeLocalQueue(worker2Cq.Name, worker2Ns.Name).ClusterQueue(worker2Cq.Name).Obj()
 		util.CreateLocalQueuesAndWaitForActive(ctx, k8sWorker2Client, worker2Lq)
+
+		kubernetesClients = kubernetesClientsMap{
+			workerCluster1.Name: {
+				client:     k8sWorker1Client,
+				restClient: worker1RestClient,
+				cfg:        worker1Cfg,
+			},
+			workerCluster2.Name: {
+				client:     k8sWorker2Client,
+				restClient: worker2RestClient,
+				cfg:        worker2Cfg,
+			},
+		}
 	})
 
 	ginkgo.AfterEach(func() {
@@ -531,19 +552,20 @@ var _ = ginkgo.Describe("MultiKueue TAS with asymmetric quotas", func() {
 			Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
 			Namespace: managerNs.Name,
 		}
-		util.ExpectWorkloadAdmittedWithCheck(ctx, wlLookupKey, multiKueueAc.Name, "worker1", k8sManagerClient)
+		admittedWorkerName := ExpectWorkloadsToBeAdmittedAndGetWorkerName(ctx, k8sManagerClient, wlLookupKey, multiKueueAc.Name)
+		workerClient := kubernetesClients[admittedWorkerName].client
 
-		ginkgo.By("Waiting for TopologyAssignment to be computed on worker1", func() {
-			waitForTopologyAssignment(k8sWorker1Client, wlLookupKey)
+		ginkgo.By(fmt.Sprintf("Waiting for TopologyAssignment to be computed on %s", admittedWorkerName), func() {
+			waitForTopologyAssignment(workerClient, wlLookupKey)
 		})
 
 		ginkgo.By("Waiting for DelayedTopologyRequest to be marked Ready on manager", func() {
 			waitForDelayedTopologyRequestReady(wlLookupKey)
 		})
 
-		ginkgo.By("Finishing the job's pods on worker1")
+		ginkgo.By(fmt.Sprintf("Finishing the job's pods on %s", admittedWorkerName))
 		listOpts := util.GetListOptsFromLabel(fmt.Sprintf("%s=%s", batchv1.JobNameLabel, job.Name))
-		util.WaitForActivePodsAndTerminate(ctx, k8sWorker1Client, worker1RestClient, worker1Cfg, job.Namespace, 1, 0, listOpts)
+		util.WaitForActivePodsAndTerminate(ctx, workerClient, kubernetesClients[admittedWorkerName].restClient, kubernetesClients[admittedWorkerName].cfg, job.Namespace, 1, 0, listOpts)
 
 		ginkgo.By("Waiting for workload to finish")
 		createdWorkload := &kueue.Workload{}
@@ -607,7 +629,7 @@ var _ = ginkgo.Describe("MultiKueue TAS with asymmetric quotas", func() {
 			waitForDelayedTopologyRequestReady(wlLookupKey)
 		})
 
-		ginkgo.By("Finishing the job's pods")
+		ginkgo.By(fmt.Sprintf("Finishing the job's pods on %s", assignedClusterName))
 		listOpts := util.GetListOptsFromLabel(fmt.Sprintf("%s=%s", batchv1.JobNameLabel, job.Name))
 		if assignedClusterName == workerCluster1.Name {
 			util.WaitForActivePodsAndTerminate(ctx, k8sWorker1Client, worker1RestClient, worker1Cfg, job.Namespace, 1, 0, listOpts)

--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -46,6 +46,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -761,4 +762,18 @@ func KPortForward(cfg *rest.Config, restClient *rest.RESTClient, ns, podName str
 	case err := <-errChan:
 		return 0, nil, fmt.Errorf("port forward failed: %w", err)
 	}
+}
+
+func SetResourceNominalQuota(cq *kueue.ClusterQueue, resourceName corev1.ResourceName, value string) *kueue.ClusterQueue {
+	for rgi := range cq.Spec.ResourceGroups {
+		for fi := range cq.Spec.ResourceGroups[rgi].Flavors {
+			for ri := range cq.Spec.ResourceGroups[rgi].Flavors[fi].Resources {
+				if cq.Spec.ResourceGroups[rgi].Flavors[fi].Resources[ri].Name == resourceName {
+					cq.Spec.ResourceGroups[rgi].Flavors[fi].Resources[ri].NominalQuota = resource.MustParse(value)
+					return cq
+				}
+			}
+		}
+	}
+	return cq
 }


### PR DESCRIPTION
Cherry pick of #10268 on release-0.17.

#10268: [Cleanup] Parallelise MultiKueue e2e tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

```release-note
NONE
```