### PR TITLE
Fix promote_pull.sh to update remotes before branching

### DIFF
--- a/hack/releasing/promote_pull.sh
+++ b/hack/releasing/promote_pull.sh
@@ -128,6 +128,9 @@ if [[ ! "$RELEASE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   exit 1
 fi
 
+echo "+++ Updating upstream remote..."
+git remote update "${KUBERNETES_K8S_IO_UPSTREAM_REMOTE}"
+
 IFS='.' read -r _ MINOR _ <<< "${RELEASE_VERSION#v}"
 
 LAST_SUPPORT_MINOR=$((MINOR - 1))


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Refresh the k8s.io upstream remote before creating the promotion branch so the promotion PR is based on the latest main.

#### Which issue(s) this PR fixes:
Fixes #10535

#### Special notes for your reviewer:
#### Does this PR introduce a user-facing change?
```release-note
NONE
```