### PR TITLE
metrics: unify stale gauge cleanup and resync

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -366,7 +366,7 @@ func main() {
 	if roleTracker != nil {
 		roleTracker.OnElected(func() {
 			metrics.ClearGaugeMetricsForRole(roletracker.RoleFollower)
-			cCache.ResyncGaugeMetrics()
+			cCache.ResyncGaugeMetrics(setupLog)
 			queues.ResyncGaugeMetrics()
 		})
 	}

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -381,7 +381,7 @@ func (m *Manager) IsConcurrentAdmissionParentWithoutLock(wl *kueue.Workload) boo
 	return m.ConcurrentAdmissionEnabledWithoutLock(cqName) && !concurrentadmission.IsVariant(wl)
 }
 
-func (m *Manager) UpdateClusterQueue(ctx context.Context, cq *kueue.ClusterQueue, specUpdated, labelsUpdated bool) error {
+func (m *Manager) UpdateClusterQueue(ctx context.Context, cq *kueue.ClusterQueue, specUpdated bool) error {
 	m.Lock()
 	defer m.Unlock()
 	cqName := kueue.ClusterQueueReference(cq.Name)
@@ -407,7 +407,7 @@ func (m *Manager) UpdateClusterQueue(ctx context.Context, cq *kueue.ClusterQueue
 		notifyRetryInadmissibleWithoutLock(m, sets.New(cqName))
 	}
 	becameActive := !oldActive && cqImpl.Active()
-	if becameActive || labelsUpdated {
+	if becameActive {
 		reportPendingWorkloads(m, cqName)
 	}
 	if becameActive {
@@ -900,18 +900,44 @@ func (m *Manager) queueSecondPass(ctx context.Context, w *kueue.Workload, iterat
 	}
 }
 
+func (m *Manager) resyncClusterQueueGaugeMetricsLocked(cq *ClusterQueue) {
+	if cq == nil {
+		return
+	}
+	reportCQPendingWorkloads(m, cq)
+	reportCQFinishedWorkloads(cq, m.roleTracker, m.customLabels)
+}
+
+func (m *Manager) ResyncClusterQueueGaugeMetrics(cqName kueue.ClusterQueueReference) {
+	m.RLock()
+	defer m.RUnlock()
+	m.resyncClusterQueueGaugeMetricsLocked(m.hm.ClusterQueue(cqName))
+}
+
+func (m *Manager) resyncLocalQueueGaugeMetricsLocked(lq *LocalQueue) {
+	if lq == nil {
+		return
+	}
+	reportLQPendingWorkloads(m, lq)
+	reportLQFinishedWorkloads(m, lq)
+}
+
+func (m *Manager) ResyncLocalQueueGaugeMetrics(lqRef queue.LocalQueueReference) {
+	m.RLock()
+	defer m.RUnlock()
+	m.resyncLocalQueueGaugeMetricsLocked(m.localQueues[lqRef])
+}
+
 // ResyncGaugeMetrics re-reports pending and finished workload gauge metrics.
 func (m *Manager) ResyncGaugeMetrics() {
 	m.RLock()
 	defer m.RUnlock()
 	for _, cq := range m.hm.ClusterQueues() {
-		reportCQPendingWorkloads(m, cq)
-		reportCQFinishedWorkloads(cq, m.roleTracker, m.customLabels)
+		m.resyncClusterQueueGaugeMetricsLocked(cq)
 	}
 	if m.lqMetrics.IsEnabled() {
 		for _, lq := range m.localQueues {
-			reportLQPendingWorkloads(m, lq)
-			reportLQFinishedWorkloads(m, lq)
+			m.resyncLocalQueueGaugeMetricsLocked(lq)
 		}
 	}
 }

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -32,11 +32,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	testingclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
 	"sigs.k8s.io/kueue/pkg/util/queue"
@@ -202,7 +205,7 @@ func TestUpdateClusterQueue(t *testing.T) {
 
 	// Put cq2 in the same cohort as cq1.
 	clusterQueues[1].Spec.CohortName = clusterQueues[0].Spec.CohortName
-	if err := manager.UpdateClusterQueue(ctx, clusterQueues[1], true, false); err != nil {
+	if err := manager.UpdateClusterQueue(ctx, clusterQueues[1], true); err != nil {
 		t.Fatalf("Failed to update ClusterQueue: %v", err)
 	}
 
@@ -237,72 +240,141 @@ func TestUpdateClusterQueue(t *testing.T) {
 	}
 }
 
-// TestUpdateClusterQueueLabelsUpdated tests that labelsUpdated triggers pending
-// workload metrics reporting without requeuing inadmissible workloads.
-func TestUpdateClusterQueueLabelsUpdated(t *testing.T) {
-	cases := map[string]struct {
-		labelsUpdated    bool
-		wantMetricsCount int
-	}{
-		"labelsUpdated=true reports metrics": {
-			labelsUpdated:    true,
-			wantMetricsCount: 2, // active + inadmissible gauges
-		},
-		"labelsUpdated=false does not report metrics": {
-			labelsUpdated:    false,
-			wantMetricsCount: 0,
-		},
+func TestResyncClusterQueueGaugeMetrics(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	defer metrics.InitMetricVectors(nil)
+
+	customLabels := metrics.NewCustomLabels([]configapi.ControllerMetricsCustomLabel{{Name: "team"}})
+	fakeClient := utiltesting.NewFakeClient(
+		utiltesting.MakeNamespace(defaultNamespace),
+		utiltestingapi.MakeWorkload("done", defaultNamespace).Queue("foo").Finished().Obj(),
+	)
+	manager, _ := NewManagerForUnitTestsWithRequeuer(fakeClient, nil, WithCustomLabels(customLabels))
+
+	cq := utiltestingapi.MakeClusterQueue("cq1").Label("team", "alpha").Obj()
+	lq := utiltestingapi.MakeLocalQueue("foo", defaultNamespace).ClusterQueue("cq1").Obj()
+	wl := utiltestingapi.MakeWorkload("a", defaultNamespace).Queue("foo").Creation(time.Now()).Obj()
+	customLabels.CQStore("cq1", cq.GetLabels(), cq.GetAnnotations())
+
+	if err := manager.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Failed adding clusterQueue: %v", err)
 	}
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			ctx, _ := utiltesting.ContextWithLog(t)
-			cq := utiltestingapi.MakeClusterQueue("cq1").Obj()
-			lq := utiltestingapi.MakeLocalQueue("foo", defaultNamespace).ClusterQueue("cq1").Obj()
-			wl := utiltestingapi.MakeWorkload("a", defaultNamespace).Queue("foo").Creation(time.Now()).Obj()
-
-			cl := utiltesting.NewFakeClient(utiltesting.MakeNamespace(defaultNamespace))
-			manager, watcher := NewManagerForUnitTestsWithRequeuer(cl, nil)
-
-			if err := manager.AddClusterQueue(ctx, cq); err != nil {
-				t.Fatalf("Failed adding clusterQueue: %v", err)
-			}
-			if err := manager.AddLocalQueue(ctx, lq); err != nil {
-				t.Fatalf("Failed adding queue: %v", err)
-			}
-
-			watcher.ProcessRequeues(ctx)
-
-			manager.getClusterQueue("cq1").popCycle++
-			if err := cl.Create(ctx, wl); err != nil {
-				t.Fatalf("Failed adding workload to client: %v", err)
-			}
-			manager.RequeueWorkload(ctx, workload.NewInfo(wl), RequeueReasonGeneric)
-
-			wantInadmissibleWorkloads := map[kueue.ClusterQueueReference][]workload.Reference{
-				"cq1": {"default/a"},
-			}
-			if diff := cmp.Diff(wantInadmissibleWorkloads, manager.DumpInadmissible()); diff != "" {
-				t.Fatalf("Unexpected set of inadmissible workloads (-want +got):\n%s", diff)
-			}
-
-			metrics.PendingWorkloads.Reset()
-
-			if err := manager.UpdateClusterQueue(ctx, cq, false, tc.labelsUpdated); err != nil {
-				t.Fatalf("Failed to update ClusterQueue: %v", err)
-			}
-
-			expectGaugeCount(t, metrics.PendingWorkloads, tc.wantMetricsCount, map[string]string{"cluster_queue": "cq1"})
-
-			watcher.ProcessRequeues(ctx)
-
-			if diff := cmp.Diff(wantInadmissibleWorkloads, manager.DumpInadmissible()); diff != "" {
-				t.Errorf("Unexpected set of inadmissible workloads (-want +got):\n%s", diff)
-			}
-			if diff := cmp.Diff(map[kueue.ClusterQueueReference][]workload.Reference(nil), manager.Dump()); diff != "" {
-				t.Errorf("Unexpected active workloads (-want +got):\n%s", diff)
-			}
-		})
+	if err := manager.AddLocalQueue(ctx, lq); err != nil {
+		t.Fatalf("Failed adding queue: %v", err)
 	}
+	if err := fakeClient.Create(ctx, wl); err != nil {
+		t.Fatalf("Failed adding workload to client: %v", err)
+	}
+	manager.RequeueWorkload(ctx, workload.NewInfo(wl), RequeueReasonGeneric)
+	manager.ResyncClusterQueueGaugeMetrics("cq1")
+
+	expectPending := func(team string, count int) {
+		t.Helper()
+		got := len(testingmetrics.CollectFilteredGaugeVec(metrics.PendingWorkloads, map[string]string{
+			"cluster_queue": "cq1",
+			"custom_team":   team,
+		}))
+		if got != count {
+			t.Fatalf("Unexpected pending workload metric count for team %q: got %d, want %d", team, got, count)
+		}
+	}
+	expectFinished := func(team string, count int) {
+		t.Helper()
+		got := len(testingmetrics.CollectFilteredGaugeVec(metrics.FinishedWorkloads, map[string]string{
+			"cluster_queue": "cq1",
+			"custom_team":   team,
+		}))
+		if got != count {
+			t.Fatalf("Unexpected finished workload metric count for team %q: got %d, want %d", team, got, count)
+		}
+	}
+
+	expectPending("alpha", 2)
+	expectFinished("alpha", 1)
+
+	customLabels.CQStore("cq1", map[string]string{"team": "beta"}, nil)
+	metrics.ClearClusterQueueMetrics("cq1")
+	metrics.ClearClusterQueueMetricsOnLabelChange("cq1")
+	manager.ResyncClusterQueueGaugeMetrics("cq1")
+
+	expectPending("alpha", 0)
+	expectFinished("alpha", 0)
+	expectPending("beta", 2)
+	expectFinished("beta", 1)
+}
+
+func TestResyncLocalQueueGaugeMetrics(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	defer metrics.InitMetricVectors(nil)
+
+	features.SetFeatureGateDuringTest(t, features.LocalQueueMetrics, true)
+
+	customLabels := metrics.NewCustomLabels([]configapi.ControllerMetricsCustomLabel{{Name: "team"}})
+	fakeClient := utiltesting.NewFakeClient(
+		utiltesting.MakeNamespace(defaultNamespace),
+		utiltestingapi.MakeWorkload("done", defaultNamespace).Queue("foo").Finished().Obj(),
+	)
+	manager, _ := NewManagerForUnitTestsWithRequeuer(fakeClient, nil,
+		WithCustomLabels(customLabels),
+		WithLocalQueueMetrics(&metrics.LocalQueueMetricsConfig{Enabled: true, QueueSelector: labels.Everything()}),
+	)
+
+	cq := utiltestingapi.MakeClusterQueue("cq1").Obj()
+	lq := utiltestingapi.MakeLocalQueue("foo", defaultNamespace).Label("team", "alpha").ClusterQueue("cq1").Obj()
+	wl := utiltestingapi.MakeWorkload("a", defaultNamespace).Queue("foo").Creation(time.Now()).Obj()
+	customLabels.LQStore(queue.Key(lq), lq.GetLabels(), lq.GetAnnotations())
+
+	if err := manager.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Failed adding clusterQueue: %v", err)
+	}
+	if err := manager.AddLocalQueue(ctx, lq); err != nil {
+		t.Fatalf("Failed adding queue: %v", err)
+	}
+	if err := fakeClient.Create(ctx, wl); err != nil {
+		t.Fatalf("Failed adding workload to client: %v", err)
+	}
+	manager.RequeueWorkload(ctx, workload.NewInfo(wl), RequeueReasonGeneric)
+	manager.ResyncLocalQueueGaugeMetrics(queue.Key(lq))
+
+	expectPending := func(team string, count int) {
+		t.Helper()
+		got := len(testingmetrics.CollectFilteredGaugeVec(metrics.LocalQueuePendingWorkloads, map[string]string{
+			"name":        "foo",
+			"namespace":   defaultNamespace,
+			"custom_team": team,
+		}))
+		if got != count {
+			t.Fatalf("Unexpected local queue pending metric count for team %q: got %d, want %d", team, got, count)
+		}
+	}
+	expectFinished := func(team string, count int) {
+		t.Helper()
+		got := len(testingmetrics.CollectFilteredGaugeVec(metrics.LocalQueueFinishedWorkloads, map[string]string{
+			"name":        "foo",
+			"namespace":   defaultNamespace,
+			"custom_team": team,
+		}))
+		if got != count {
+			t.Fatalf("Unexpected local queue finished metric count for team %q: got %d, want %d", team, got, count)
+		}
+	}
+
+	expectPending("alpha", 2)
+	expectFinished("alpha", 1)
+
+	updatedLq := lq.DeepCopy()
+	updatedLq.Labels["team"] = "beta"
+	customLabels.LQStore(queue.Key(updatedLq), updatedLq.GetLabels(), updatedLq.GetAnnotations())
+	if err := manager.UpdateLocalQueue(logr.Discard(), updatedLq); err != nil {
+		t.Fatalf("Failed to update local queue: %v", err)
+	}
+	clearLQMetrics(queue.Key(updatedLq))
+	manager.ResyncLocalQueueGaugeMetrics(queue.Key(updatedLq))
+
+	expectPending("alpha", 0)
+	expectFinished("alpha", 0)
+	expectPending("beta", 2)
+	expectFinished("beta", 1)
 }
 
 func TestPendingResourceMetrics(t *testing.T) {
@@ -653,7 +725,7 @@ func TestClusterQueueToActive(t *testing.T) {
 		t.Fatalf("Failed adding clusterQueue %v", err)
 	}
 
-	if err := manager.UpdateClusterQueue(ctx, runningCq, false, false); err != nil {
+	if err := manager.UpdateClusterQueue(ctx, runningCq, false); err != nil {
 		t.Fatalf("Failed to update ClusterQueue: %v", err)
 	}
 

--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -495,6 +495,66 @@ func (c *Cache) UpdateClusterQueue(log logr.Logger, cq *kueue.ClusterQueue) erro
 	return nil
 }
 
+func (c *Cache) resyncClusterQueueGaugeMetricsLocked(cq *clusterQueue) {
+	if cq == nil {
+		return
+	}
+	metrics.ReportClusterQueueStatus(cq.Name, cq.Status, cq.customMetricLabelValues, c.roleTracker)
+	cq.reportActiveWorkloads()
+	if c.resourceMetricsEnabled {
+		cq.reportResourceMetrics(c.fairSharingEnabled)
+	}
+	for _, lq := range cq.localQueues {
+		c.resyncLocalQueueGaugeMetricsLocked(cq, lq)
+	}
+}
+
+func (c *Cache) ResyncClusterQueueGaugeMetrics(cqName kueue.ClusterQueueReference) {
+	c.RLock()
+	defer c.RUnlock()
+	c.resyncClusterQueueGaugeMetricsLocked(c.hm.ClusterQueue(cqName))
+}
+
+func (c *Cache) resyncLocalQueueGaugeMetricsLocked(cq *clusterQueue, lq *LocalQueue) {
+	if cq == nil || lq == nil || !lq.shouldExposeMetrics(c.lqMetrics) {
+		return
+	}
+	lq.reportActiveWorkloads(c.roleTracker)
+	lq.reportResourceMetrics(cq.resourceNode.Quotas, c.roleTracker)
+}
+
+func (c *Cache) ResyncLocalQueueGaugeMetrics(cqName kueue.ClusterQueueReference, lqRef queue.LocalQueueReference) {
+	c.RLock()
+	defer c.RUnlock()
+	cq := c.hm.ClusterQueue(cqName)
+	if cq == nil {
+		return
+	}
+	lq, ok := cq.localQueues[lqRef]
+	if !ok {
+		return
+	}
+	c.resyncLocalQueueGaugeMetricsLocked(cq, lq)
+}
+
+func (c *Cache) ResyncCohortGaugeMetrics(log logr.Logger, cohortName kueue.CohortReference) {
+	c.RecordCohortMetrics(log, cohortName)
+	c.RLock()
+	defer c.RUnlock()
+	cohort := c.hm.Cohort(cohortName)
+	if cohort == nil || hierarchy.HasCycle(cohort) {
+		return
+	}
+	if c.fairSharingEnabled {
+		drs := dominantResourceShare(cohort, nil)
+		var customLabelValues []string
+		if features.Enabled(features.CustomMetricLabels) {
+			customLabelValues = c.customLabels.CohortGet(cohort.Name)
+		}
+		metrics.ReportCohortWeightedShare(cohort.Name, drs.PreciseWeightedShare(), customLabelValues, c.roleTracker)
+	}
+}
+
 func (c *Cache) DeleteClusterQueue(cq *kueue.ClusterQueue) {
 	c.Lock()
 	defer c.Unlock()
@@ -1031,31 +1091,25 @@ func (c *Cache) MatchingClusterQueues(nsLabels map[string]string) sets.Set[kueue
 }
 
 // ResyncGaugeMetrics re-reports CQ/LQ status, active workload, resource, and weighted share gauge metrics.
-func (c *Cache) ResyncGaugeMetrics() {
+func (c *Cache) ResyncGaugeMetrics(log logr.Logger) {
 	c.RLock()
-	defer c.RUnlock()
-	for _, cq := range c.hm.ClusterQueues() {
-		metrics.ReportClusterQueueStatus(cq.Name, cq.Status, cq.customMetricLabelValues, c.roleTracker)
-		cq.reportActiveWorkloads()
-		if c.resourceMetricsEnabled {
-			cq.reportResourceMetrics(c.fairSharingEnabled)
-		}
-		for _, lq := range cq.localQueues {
-			if lq.shouldExposeMetrics(c.lqMetrics) {
-				lq.reportActiveWorkloads(c.roleTracker)
-				lq.reportResourceMetrics(cq.resourceNode.Quotas, c.roleTracker)
-			}
-		}
+	cqs := c.hm.ClusterQueues()
+	cqNames := make([]kueue.ClusterQueueReference, 0, len(cqs))
+	for _, cq := range cqs {
+		cqNames = append(cqNames, cq.Name)
 	}
-	if c.fairSharingEnabled {
-		for _, cohort := range c.hm.Cohorts() {
-			drs := dominantResourceShare(cohort, nil)
-			var customLabelValues []string
-			if features.Enabled(features.CustomMetricLabels) {
-				customLabelValues = c.customLabels.CohortGet(cohort.Name)
-			}
-			metrics.ReportCohortWeightedShare(cohort.Name, drs.PreciseWeightedShare(), customLabelValues, c.roleTracker)
-		}
+	cohorts := c.hm.Cohorts()
+	cohortNames := make([]kueue.CohortReference, 0, len(cohorts))
+	for _, cohort := range cohorts {
+		cohortNames = append(cohortNames, cohort.Name)
+	}
+	c.RUnlock()
+
+	for _, cqName := range cqNames {
+		c.ResyncClusterQueueGaugeMetrics(cqName)
+	}
+	for _, cohortName := range cohortNames {
+		c.ResyncCohortGaugeMetrics(log, cohortName)
 	}
 }
 

--- a/pkg/cache/scheduler/cache_resync_metrics_test.go
+++ b/pkg/cache/scheduler/cache_resync_metrics_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/metrics"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	testingmetrics "sigs.k8s.io/kueue/pkg/util/testing/metrics"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+)
+
+func TestResyncClusterQueueGaugeMetricsUsesUpdatedCustomLabels(t *testing.T) {
+	ctx, log := utiltesting.ContextWithLog(t)
+	defer metrics.InitMetricVectors(nil)
+	features.SetFeatureGateDuringTest(t, features.CustomMetricLabels, true)
+
+	customLabels := metrics.NewCustomLabels([]configapi.ControllerMetricsCustomLabel{{Name: "team"}})
+	cache := New(utiltesting.NewFakeClient(), WithCustomLabels(customLabels), WithResourceMetrics(true))
+
+	cache.AddOrUpdateResourceFlavor(log, utiltestingapi.MakeResourceFlavor("default").Obj())
+
+	cq := utiltestingapi.MakeClusterQueue("cq1").
+		Label("team", "alpha").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("default").
+				Resource(corev1.ResourceCPU, "5").
+				Obj(),
+		).Obj()
+
+	customLabels.CQStore("cq1", cq.GetLabels(), cq.GetAnnotations())
+	if err := cache.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Failed to add cluster queue: %v", err)
+	}
+	cache.ResyncClusterQueueGaugeMetrics("cq1")
+
+	expectStatus := func(team string, count int) {
+		t.Helper()
+		got := len(testingmetrics.CollectFilteredGaugeVec(metrics.ClusterQueueByStatus, map[string]string{
+			"cluster_queue": "cq1",
+			"custom_team":   team,
+		}))
+		if got != count {
+			t.Fatalf("Unexpected cluster queue status metric count for team %q: got %d, want %d", team, got, count)
+		}
+	}
+	expectQuota := func(team string, count int) {
+		t.Helper()
+		got := len(testingmetrics.CollectFilteredGaugeVec(metrics.ClusterQueueResourceNominalQuota, map[string]string{
+			"cluster_queue": "cq1",
+			"custom_team":   team,
+		}))
+		if got != count {
+			t.Fatalf("Unexpected cluster queue quota metric count for team %q: got %d, want %d", team, got, count)
+		}
+	}
+
+	expectStatus("alpha", len(metrics.CQStatuses))
+	expectQuota("alpha", 1)
+
+	customLabels.CQStore("cq1", map[string]string{"team": "beta"}, nil)
+	updatedCQ := cq.DeepCopy()
+	updatedCQ.Labels["team"] = "beta"
+	if err := cache.UpdateClusterQueue(log, updatedCQ); err != nil {
+		t.Fatalf("Failed to update cluster queue: %v", err)
+	}
+
+	metrics.ClearClusterQueueMetrics("cq1")
+	metrics.ClearClusterQueueMetricsOnLabelChange("cq1")
+	metrics.ClearCacheMetrics("cq1")
+	metrics.ClearClusterQueueResourceMetrics("cq1")
+	cache.ResyncClusterQueueGaugeMetrics("cq1")
+
+	expectStatus("alpha", 0)
+	expectQuota("alpha", 0)
+	expectStatus("beta", len(metrics.CQStatuses))
+	expectQuota("beta", 1)
+}
+
+func TestResyncCohortGaugeMetricsUsesUpdatedCustomLabels(t *testing.T) {
+	ctx, log := utiltesting.ContextWithLog(t)
+	defer metrics.InitMetricVectors(nil)
+	features.SetFeatureGateDuringTest(t, features.CustomMetricLabels, true)
+
+	customLabels := metrics.NewCustomLabels([]configapi.ControllerMetricsCustomLabel{{Name: "team"}})
+	cache := New(utiltesting.NewFakeClient(), WithCustomLabels(customLabels), WithFairSharing(true))
+
+	cache.AddOrUpdateResourceFlavor(log, utiltestingapi.MakeResourceFlavor("default").Obj())
+
+	cohort := utiltestingapi.MakeCohort("cohort1").Label("team", "alpha").Obj()
+	customLabels.CohortStore(kueue.CohortReference("cohort1"), cohort.GetLabels(), cohort.GetAnnotations())
+	if err := cache.AddOrUpdateCohort(cohort); err != nil {
+		t.Fatalf("Failed to add cohort: %v", err)
+	}
+	cq := utiltestingapi.MakeClusterQueue("cq1").
+		Cohort("cohort1").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("default").
+				Resource(corev1.ResourceCPU, "5").
+				Obj(),
+		).Obj()
+	if err := cache.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Failed to add cluster queue: %v", err)
+	}
+
+	cache.ResyncCohortGaugeMetrics(log, "cohort1")
+
+	expectQuota := func(team string, count int) {
+		t.Helper()
+		got := len(testingmetrics.CollectFilteredGaugeVec(metrics.CohortSubtreeQuota, map[string]string{
+			"cohort":      "cohort1",
+			"custom_team": team,
+		}))
+		if got != count {
+			t.Fatalf("Unexpected cohort subtree quota metric count for team %q: got %d, want %d", team, got, count)
+		}
+	}
+	expectWeightedShare := func(team string, count int) {
+		t.Helper()
+		got := len(testingmetrics.CollectFilteredGaugeVec(metrics.CohortWeightedShare, map[string]string{
+			"cohort":      "cohort1",
+			"custom_team": team,
+		}))
+		if got != count {
+			t.Fatalf("Unexpected cohort weighted share metric count for team %q: got %d, want %d", team, got, count)
+		}
+	}
+
+	expectQuota("alpha", 1)
+	expectWeightedShare("alpha", 1)
+
+	customLabels.CohortStore(kueue.CohortReference("cohort1"), map[string]string{"team": "beta"}, nil)
+	updatedCohort := cohort.DeepCopy()
+	updatedCohort.Labels["team"] = "beta"
+	if err := cache.AddOrUpdateCohort(updatedCohort); err != nil {
+		t.Fatalf("Failed to update cohort: %v", err)
+	}
+
+	metrics.ClearCohortMetrics("cohort1")
+	cache.ResyncCohortGaugeMetrics(log, "cohort1")
+
+	expectQuota("alpha", 0)
+	expectWeightedShare("alpha", 0)
+	expectQuota("beta", 1)
+	expectWeightedShare("beta", 1)
+}

--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -168,15 +168,10 @@ func (r *ClusterQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	log.V(2).Info("Reconcile ClusterQueue")
 
 	if features.Enabled(features.CustomMetricLabels) {
-		r.customLabels.CQStoreAndClear(kueue.ClusterQueueReference(cqObj.Name),
+		r.customLabels.CQStore(
+			kueue.ClusterQueueReference(cqObj.Name),
 			cqObj.GetLabels(), cqObj.GetAnnotations(),
-			func() {
-				cqRef := kueue.ClusterQueueReference(cqObj.Name)
-				metrics.ClearClusterQueueMetrics(cqRef)
-				metrics.ClearClusterQueueMetricsOnLabelChange(cqRef)
-				metrics.ClearCacheMetrics(cqObj.Name)
-				metrics.ClearClusterQueueResourceMetrics(cqObj.Name)
-			})
+		)
 	}
 
 	if cqObj.DeletionTimestamp.IsZero() {
@@ -382,22 +377,16 @@ func (r *ClusterQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.ClusterQ
 
 	var labelsUpdated bool
 	if features.Enabled(features.CustomMetricLabels) {
-		labelsUpdated = r.customLabels.CQStoreAndClear(
+		labelsUpdated = r.customLabels.CQStore(
 			kueue.ClusterQueueReference(e.ObjectNew.GetName()),
 			e.ObjectNew.GetLabels(), e.ObjectNew.GetAnnotations(),
-			func() {
-				cqRef := kueue.ClusterQueueReference(e.ObjectNew.Name)
-				metrics.ClearClusterQueueMetrics(cqRef)
-				metrics.ClearClusterQueueMetricsOnLabelChange(cqRef)
-				metrics.ClearCacheMetrics(e.ObjectNew.Name)
-				metrics.ClearClusterQueueResourceMetrics(e.ObjectNew.Name)
-			})
+		)
 	}
 
 	if err := r.cache.UpdateClusterQueue(log, e.ObjectNew); err != nil {
 		log.Error(err, "Failed to update clusterQueue in cache")
 	}
-	if err := r.qManager.UpdateClusterQueue(context.Background(), e.ObjectNew, specUpdated, labelsUpdated); err != nil {
+	if err := r.qManager.UpdateClusterQueue(context.Background(), e.ObjectNew, specUpdated); err != nil {
 		log.Error(err, "Failed to update clusterQueue in queue manager")
 	}
 
@@ -407,8 +396,11 @@ func (r *ClusterQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.ClusterQ
 		r.cache.RecordCohortMetrics(log, e.ObjectOld.Spec.CohortName)
 	}
 
-	if r.reportResourceMetrics {
+	if r.reportResourceMetrics && !labelsUpdated {
 		r.updateResourceMetrics(log, e.ObjectOld, e.ObjectNew)
+	}
+	if labelsUpdated {
+		r.resyncClusterQueueGaugeMetrics(e.ObjectNew)
 	}
 	return true
 }
@@ -427,6 +419,16 @@ func (r *ClusterQueueReconciler) updateResourceMetrics(log logr.Logger, oldCq, n
 		r.cache.ClearClusterQueueOldResourceMetrics(log, oldCq)
 	}
 	r.cache.RecordClusterQueueResourceMetrics(log, kueue.ClusterQueueReference(newCq.Name))
+}
+
+func (r *ClusterQueueReconciler) resyncClusterQueueGaugeMetrics(cq *kueue.ClusterQueue) {
+	cqRef := kueue.ClusterQueueReference(cq.Name)
+	metrics.ClearClusterQueueMetrics(cqRef)
+	metrics.ClearClusterQueueMetricsOnLabelChange(cqRef)
+	metrics.ClearCacheMetrics(cq.Name)
+	metrics.ClearClusterQueueResourceMetrics(cq.Name)
+	r.qManager.ResyncClusterQueueGaugeMetrics(cqRef)
+	r.cache.ResyncClusterQueueGaugeMetrics(cqRef)
 }
 
 // cqNamespaceHandler handles namespace update events.

--- a/pkg/controller/core/cohort_controller.go
+++ b/pkg/controller/core/cohort_controller.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"context"
+	"slices"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -142,12 +143,11 @@ func (r *CohortReconciler) Update(e event.TypedUpdateEvent[*kueue.Cohort]) bool 
 
 	var customLabelsChanged bool
 	if features.Enabled(features.CustomMetricLabels) {
-		customLabelsChanged = r.customLabels.CohortStoreAndClear(
-			kueue.CohortReference(e.ObjectNew.GetName()),
-			e.ObjectNew.GetLabels(), e.ObjectNew.GetAnnotations(),
-			func() {
-				metrics.ClearCohortMetrics(kueue.CohortReference(e.ObjectNew.GetName()))
-			})
+		// Store in Reconcile so labelsUpdated remains true for clear-and-resync.
+		customLabelsChanged = !slices.Equal(
+			r.customLabels.CohortGet(kueue.CohortReference(e.ObjectNew.GetName())),
+			r.customLabels.ExtractValues(e.ObjectNew.GetLabels(), e.ObjectNew.GetAnnotations()),
+		)
 	}
 
 	if equality.Semantic.DeepEqual(e.ObjectOld.Spec, e.ObjectNew.Spec) && !customLabelsChanged {
@@ -191,18 +191,25 @@ func (r *CohortReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	var labelsUpdated bool
 	if features.Enabled(features.CustomMetricLabels) {
-		r.customLabels.CohortStoreAndClear(kueue.CohortReference(cohort.Name),
+		labelsUpdated = r.customLabels.CohortStore(
+			kueue.CohortReference(cohort.Name),
 			cohort.GetLabels(), cohort.GetAnnotations(),
-			func() { metrics.ClearCohortMetrics(kueue.CohortReference(cohort.Name)) })
+		)
 	}
 
 	log.V(2).Info("Cohort is being created or updated", "resources", cohort.Spec.ResourceGroups)
 	if err := r.cache.AddOrUpdateCohort(&cohort); err != nil {
 		log.V(2).Error(err, "Error adding or updating cohort in the cache")
 	}
-	r.cache.RecordCohortMetrics(log, kueue.CohortReference(req.Name))
 	r.qManager.AddOrUpdateCohort(ctx, &cohort)
+	if labelsUpdated {
+		metrics.ClearCohortMetrics(kueue.CohortReference(req.Name))
+		r.cache.ResyncCohortGaugeMetrics(log, kueue.CohortReference(req.Name))
+	} else {
+		r.cache.RecordCohortMetrics(log, kueue.CohortReference(req.Name))
+	}
 
 	err := r.updateCohortStatusIfChanged(ctx, &cohort)
 	return ctrl.Result{}, client.IgnoreNotFound(err)

--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -184,14 +184,10 @@ func (r *LocalQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	log.V(2).Info("Reconcile LocalQueue")
 
 	if features.Enabled(features.CustomMetricLabels) {
-		r.customLabels.LQStoreAndClear(utilqueue.Key(&queueObj),
+		r.customLabels.LQStore(
+			utilqueue.Key(&queueObj),
 			queueObj.GetLabels(), queueObj.GetAnnotations(),
-			func() {
-				lqRef := localQueueReferenceFromLocalQueue(&queueObj)
-				metrics.ClearLocalQueueMetrics(lqRef)
-				metrics.ClearLocalQueueCacheMetrics(lqRef)
-				metrics.ClearLocalQueueResourceMetrics(lqRef)
-			})
+		)
 	}
 
 	if ptr.Deref(queueObj.Spec.StopPolicy, kueue.None) != kueue.None {
@@ -289,15 +285,15 @@ func (r *LocalQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.LocalQueue
 	log := r.logger().WithValues("localQueue", klog.KObj(e.ObjectNew))
 	log.V(2).Info("Queue update event")
 
+	var customLabelsChanged bool
 	if features.Enabled(features.CustomMetricLabels) {
-		r.customLabels.LQStoreAndClear(utilqueue.Key(e.ObjectNew),
+		customLabelsChanged = r.customLabels.LQStore(
+			utilqueue.Key(e.ObjectNew),
 			e.ObjectNew.GetLabels(), e.ObjectNew.GetAnnotations(),
-			func() {
-				clearLocalQueueMetrics(e.ObjectNew)
-			})
+		)
 	}
 
-	if r.lqMetrics.ShouldExposeLocalQueueMetrics(e.ObjectNew.GetLabels()) {
+	if r.lqMetrics.ShouldExposeLocalQueueMetrics(e.ObjectNew.GetLabels()) && !customLabelsChanged {
 		r.updateLocalQueueResourceMetrics(log, e.ObjectNew)
 	} else if r.lqMetrics.ShouldExposeLocalQueueMetrics(e.ObjectOld.GetLabels()) {
 		clearLocalQueueMetrics(e.ObjectOld)
@@ -305,8 +301,11 @@ func (r *LocalQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.LocalQueue
 
 	oldStopPolicy := ptr.Deref(e.ObjectOld.Spec.StopPolicy, kueue.None)
 	newStopPolicy := ptr.Deref(e.ObjectNew.Spec.StopPolicy, kueue.None)
+	clusterQueueChanged := e.ObjectOld.Spec.ClusterQueue != e.ObjectNew.Spec.ClusterQueue
+	stoppingQueue := oldStopPolicy != newStopPolicy && newStopPolicy != kueue.None
 
-	if newStopPolicy == oldStopPolicy {
+	switch {
+	case oldStopPolicy == newStopPolicy:
 		if newStopPolicy == kueue.None {
 			if err := r.queues.UpdateLocalQueue(log, e.ObjectNew); err != nil {
 				log.Error(err, "Failed to update queue in the queueing system")
@@ -315,18 +314,23 @@ func (r *LocalQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.LocalQueue
 		if err := r.cache.UpdateLocalQueue(e.ObjectOld, e.ObjectNew); err != nil {
 			log.Error(err, "Failed to update localQueue in the cache")
 		}
-		return true
-	}
-
-	if newStopPolicy == kueue.None {
+	case newStopPolicy == kueue.None:
+		if customLabelsChanged || clusterQueueChanged {
+			if err := r.cache.UpdateLocalQueue(e.ObjectOld, e.ObjectNew); err != nil {
+				log.Error(err, "Failed to update localQueue in the cache")
+			}
+		}
 		ctx := logr.NewContext(context.Background(), log)
 		if err := r.queues.AddLocalQueue(ctx, e.ObjectNew); err != nil {
 			log.Error(err, "Failed to add localQueue to the queueing system")
 		}
-		return true
+	default:
+		r.queues.DeleteLocalQueue(log, e.ObjectOld)
 	}
 
-	r.queues.DeleteLocalQueue(log, e.ObjectOld)
+	if customLabelsChanged && !stoppingQueue {
+		r.resyncLocalQueueGaugeMetrics(e.ObjectNew)
+	}
 
 	return true
 }
@@ -428,6 +432,27 @@ func clearLocalQueueMetrics(lq *kueue.LocalQueue) {
 	metrics.ClearLocalQueueMetrics(lqRef)
 	metrics.ClearLocalQueueCacheMetrics(lqRef)
 	metrics.ClearLocalQueueResourceMetrics(lqRef)
+}
+
+func (r *LocalQueueReconciler) resyncLocalQueueGaugeMetrics(lq *kueue.LocalQueue) {
+	lqKey := utilqueue.Key(lq)
+	clearLocalQueueMetrics(lq)
+	r.queues.ResyncLocalQueueGaugeMetrics(lqKey)
+	r.cache.ResyncLocalQueueGaugeMetrics(lq.Spec.ClusterQueue, lqKey)
+
+	if !r.lqMetrics.ShouldExposeLocalQueueMetrics(lq.GetLabels()) {
+		return
+	}
+	condition := meta.FindStatusCondition(lq.Status.Conditions, kueue.LocalQueueActive)
+	if condition == nil {
+		return
+	}
+	metrics.ReportLocalQueueStatus(
+		localQueueReferenceFromLocalQueue(lq),
+		condition.Status,
+		r.customLabels.LQGet(lqKey),
+		r.roleTracker,
+	)
 }
 
 func (r *LocalQueueReconciler) Generic(e event.TypedGenericEvent[*kueue.LocalQueue]) bool {

--- a/pkg/metrics/custom_labels.go
+++ b/pkg/metrics/custom_labels.go
@@ -40,15 +40,6 @@ func (s CustomLabelStore[K]) Store(key K, newVals []string) bool {
 	return existed && !slices.Equal(old, newVals)
 }
 
-// StoreAndClear is like Store but also calls clearFn on change.
-func (s CustomLabelStore[K]) StoreAndClear(key K, newVals []string, clearFn func()) bool {
-	changed := s.Store(key, newVals)
-	if changed && clearFn != nil {
-		clearFn()
-	}
-	return changed
-}
-
 func (s CustomLabelStore[K]) Get(key K) []string {
 	vals, _ := s.m.Get(string(key))
 	return vals
@@ -115,10 +106,6 @@ func storeFor[K ~string](cl *CustomLabels, s CustomLabelStore[K], key K, labels,
 	return s.Store(key, cl.ExtractValues(labels, annotations))
 }
 
-func storeAndClearFor[K ~string](cl *CustomLabels, s CustomLabelStore[K], key K, labels, annotations map[string]string, clearFn func()) bool {
-	return s.StoreAndClear(key, cl.ExtractValues(labels, annotations), clearFn)
-}
-
 func getFor[K ~string](cl *CustomLabels, s CustomLabelStore[K], key K) []string {
 	vals := s.Get(key)
 	if vals == nil && len(cl.names) > 0 {
@@ -136,13 +123,6 @@ func (cl *CustomLabels) CQStore(key kueue.ClusterQueueReference, labels, annotat
 		return false
 	}
 	return storeFor(cl, cl.cq, key, labels, annotations)
-}
-
-func (cl *CustomLabels) CQStoreAndClear(key kueue.ClusterQueueReference, labels, annotations map[string]string, clearFn func()) bool {
-	if cl == nil {
-		return false
-	}
-	return storeAndClearFor(cl, cl.cq, key, labels, annotations, clearFn)
 }
 
 func (cl *CustomLabels) CQGet(key kueue.ClusterQueueReference) []string {
@@ -166,13 +146,6 @@ func (cl *CustomLabels) LQStore(key utilqueue.LocalQueueReference, labels, annot
 	return storeFor(cl, cl.lq, key, labels, annotations)
 }
 
-func (cl *CustomLabels) LQStoreAndClear(key utilqueue.LocalQueueReference, labels, annotations map[string]string, clearFn func()) bool {
-	if cl == nil {
-		return false
-	}
-	return storeAndClearFor(cl, cl.lq, key, labels, annotations, clearFn)
-}
-
 func (cl *CustomLabels) LQGet(key utilqueue.LocalQueueReference) []string {
 	if cl == nil {
 		return nil
@@ -192,13 +165,6 @@ func (cl *CustomLabels) CohortStore(key kueue.CohortReference, labels, annotatio
 		return false
 	}
 	return storeFor(cl, cl.cohort, key, labels, annotations)
-}
-
-func (cl *CustomLabels) CohortStoreAndClear(key kueue.CohortReference, labels, annotations map[string]string, clearFn func()) bool {
-	if cl == nil {
-		return false
-	}
-	return storeAndClearFor(cl, cl.cohort, key, labels, annotations, clearFn)
 }
 
 func (cl *CustomLabels) CohortGet(key kueue.CohortReference) []string {

--- a/test/integration/singlecluster/controller/core/custom_labels_test.go
+++ b/test/integration/singlecluster/controller/core/custom_labels_test.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
+	testingmetrics "sigs.k8s.io/kueue/pkg/util/testing/metrics"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/test/util"
 )
@@ -134,6 +135,13 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 
 			ginkgo.By("verifying metric with custom_team=alpha")
 			util.ExpectPendingWorkloadsMetric(cq, 1, 0, "alpha")
+			util.ExpectClusterQueueStatusMetric(cq, metrics.CQStatusActive, "alpha")
+			gomega.Eventually(func() int {
+				return len(testingmetrics.CollectFilteredGaugeVec(metrics.ClusterQueueResourceNominalQuota, map[string]string{
+					"cluster_queue": cq.Name,
+					"custom_team":   "alpha",
+				}))
+			}, util.Timeout, util.Interval).Should(gomega.Equal(1))
 
 			ginkgo.By("updating CQ label to team=beta")
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -145,18 +153,31 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 
 			ginkgo.By("verifying metric with custom_team=beta appears")
 			gomega.Eventually(func(g gomega.Gomega) {
-				metricBeta := metrics.PendingWorkloads.WithLabelValues("cq-change", metrics.PendingStatusActive, roletracker.RoleStandalone, "beta")
-				v, err := testutil.GetGaugeMetricValue(metricBeta)
-				g.Expect(err).ToNot(gomega.HaveOccurred())
-				g.Expect(v).To(gomega.Equal(float64(1)))
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.PendingWorkloads, map[string]string{
+					"cluster_queue": cq.Name,
+					"custom_team":   "beta",
+				})).To(gomega.HaveLen(2))
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.ClusterQueueResourceNominalQuota, map[string]string{
+					"cluster_queue": cq.Name,
+					"custom_team":   "beta",
+				})).To(gomega.HaveLen(1))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.ExpectClusterQueueStatusMetric(cq, metrics.CQStatusActive, "beta")
 
 			ginkgo.By("verifying old alpha series is cleaned")
 			gomega.Eventually(func(g gomega.Gomega) {
-				metricAlpha := metrics.PendingWorkloads.WithLabelValues("cq-change", metrics.PendingStatusActive, roletracker.RoleStandalone, "alpha")
-				v, err := testutil.GetGaugeMetricValue(metricAlpha)
-				g.Expect(err).ToNot(gomega.HaveOccurred())
-				g.Expect(v).To(gomega.Equal(float64(0)))
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.PendingWorkloads, map[string]string{
+					"cluster_queue": cq.Name,
+					"custom_team":   "alpha",
+				})).To(gomega.BeEmpty())
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.ClusterQueueByStatus, map[string]string{
+					"cluster_queue": cq.Name,
+					"custom_team":   "alpha",
+				})).To(gomega.BeEmpty())
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.ClusterQueueResourceNominalQuota, map[string]string{
+					"cluster_queue": cq.Name,
+					"custom_team":   "alpha",
+				})).To(gomega.BeEmpty())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
@@ -505,6 +526,88 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			ginkgo.By("verifying LQ EvictedWorkloadsTotal includes custom labels")
 			util.ExpectLQEvictedWorkloadsTotalMetric(lq, "Preempted", "", "", 1, "platform")
 		})
+
+		ginkgo.It("should resync LQ gauge metrics on label value change", func() {
+			cq = utiltestingapi.MakeClusterQueue("cq-lq-change").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(defaultFlavor.Name).
+						Resource(corev1.ResourceCPU, "5").
+						Obj(),
+				).Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+			lq := utiltestingapi.MakeLocalQueue("lq-change", ns.Name).
+				Label("team", "alpha").
+				ClusterQueue(cq.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+
+			wl := utiltestingapi.MakeWorkload("wl-lq-change", ns.Name).
+				Queue(kueue.LocalQueueName(lq.Name)).
+				Request(corev1.ResourceCPU, "1").Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, wl)
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.LocalQueuePendingWorkloads, map[string]string{
+					"name":        lq.Name,
+					"namespace":   lq.Namespace,
+					"custom_team": "alpha",
+				})).To(gomega.HaveLen(2))
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.LocalQueueByStatus, map[string]string{
+					"name":        lq.Name,
+					"namespace":   lq.Namespace,
+					"custom_team": "alpha",
+				})).To(gomega.HaveLen(len(metrics.ConditionStatusValues)))
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.LocalQueueResourceReservations, map[string]string{
+					"name":        lq.Name,
+					"namespace":   lq.Namespace,
+					"custom_team": "alpha",
+				})).To(gomega.HaveLen(1))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedLq kueue.LocalQueue
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lq), &updatedLq)).To(gomega.Succeed())
+				updatedLq.Labels["team"] = "beta"
+				g.Expect(k8sClient.Update(ctx, &updatedLq)).To(gomega.Succeed())
+			}, util.Timeout, util.ShortInterval).Should(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.LocalQueuePendingWorkloads, map[string]string{
+					"name":        lq.Name,
+					"namespace":   lq.Namespace,
+					"custom_team": "beta",
+				})).To(gomega.HaveLen(2))
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.LocalQueueByStatus, map[string]string{
+					"name":        lq.Name,
+					"namespace":   lq.Namespace,
+					"custom_team": "beta",
+				})).To(gomega.HaveLen(len(metrics.ConditionStatusValues)))
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.LocalQueueResourceReservations, map[string]string{
+					"name":        lq.Name,
+					"namespace":   lq.Namespace,
+					"custom_team": "beta",
+				})).To(gomega.HaveLen(1))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.LocalQueuePendingWorkloads, map[string]string{
+					"name":        lq.Name,
+					"namespace":   lq.Namespace,
+					"custom_team": "alpha",
+				})).To(gomega.BeEmpty())
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.LocalQueueByStatus, map[string]string{
+					"name":        lq.Name,
+					"namespace":   lq.Namespace,
+					"custom_team": "alpha",
+				})).To(gomega.BeEmpty())
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.LocalQueueResourceReservations, map[string]string{
+					"name":        lq.Name,
+					"namespace":   lq.Namespace,
+					"custom_team": "alpha",
+				})).To(gomega.BeEmpty())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
 	})
 
 	ginkgo.When("CustomMetricLabels enabled with scheduler for preemption", func() {
@@ -676,6 +779,89 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 				metric := metrics.CohortWeightedShare.WithLabelValues(lvs...)
 				_, err := testutil.GetGaugeMetricValue(metric)
 				g.Expect(err).ToNot(gomega.HaveOccurred())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("should resync cohort gauge metrics on label value change", func() {
+			cohort = utiltestingapi.MakeCohort("cohort-labeled").
+				Label("team", "data-eng").
+				Obj()
+			util.MustCreate(ctx, k8sClient, cohort)
+
+			cq = utiltestingapi.MakeClusterQueue("cq-cohort-change").
+				Cohort("cohort-labeled").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(defaultFlavor.Name).
+						Resource(corev1.ResourceCPU, "5").
+						Obj(),
+				).Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+			lq := utiltestingapi.MakeLocalQueue("lq-cohort-change", ns.Name).
+				ClusterQueue(cq.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+
+			wl := utiltestingapi.MakeWorkload("wl-cohort-change", ns.Name).
+				Queue(kueue.LocalQueueName(lq.Name)).
+				Request(corev1.ResourceCPU, "1").Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(updatedWl.Status.Admission).ToNot(gomega.BeNil())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.CohortSubtreeQuota, map[string]string{
+					"cohort":      cohort.Name,
+					"custom_team": "data-eng",
+				})).To(gomega.HaveLen(1))
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.CohortSubtreeResourceReservations, map[string]string{
+					"cohort":      cohort.Name,
+					"custom_team": "data-eng",
+				})).To(gomega.HaveLen(1))
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.CohortWeightedShare, map[string]string{
+					"cohort":      cohort.Name,
+					"custom_team": "data-eng",
+				})).To(gomega.HaveLen(1))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedCohort kueue.Cohort
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cohort), &updatedCohort)).To(gomega.Succeed())
+				updatedCohort.Labels["team"] = "data-test"
+				g.Expect(k8sClient.Update(ctx, &updatedCohort)).To(gomega.Succeed())
+			}, util.Timeout, util.ShortInterval).Should(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.CohortSubtreeQuota, map[string]string{
+					"cohort":      cohort.Name,
+					"custom_team": "data-test",
+				})).To(gomega.HaveLen(1))
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.CohortSubtreeResourceReservations, map[string]string{
+					"cohort":      cohort.Name,
+					"custom_team": "data-test",
+				})).To(gomega.HaveLen(1))
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.CohortWeightedShare, map[string]string{
+					"cohort":      cohort.Name,
+					"custom_team": "data-test",
+				})).To(gomega.HaveLen(1))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.CohortSubtreeQuota, map[string]string{
+					"cohort":      cohort.Name,
+					"custom_team": "data-eng",
+				})).To(gomega.BeEmpty())
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.CohortSubtreeResourceReservations, map[string]string{
+					"cohort":      cohort.Name,
+					"custom_team": "data-eng",
+				})).To(gomega.BeEmpty())
+				g.Expect(testingmetrics.CollectFilteredGaugeVec(metrics.CohortWeightedShare, map[string]string{
+					"cohort":      cohort.Name,
+					"custom_team": "data-eng",
+				})).To(gomega.BeEmpty())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 

--- a/test/integration/singlecluster/controller/core/suite_test.go
+++ b/test/integration/singlecluster/controller/core/suite_test.go
@@ -143,7 +143,7 @@ func managerAndControllerSetup(controllersCfg *config.Configuration, options ...
 		if opts.roleTracker != nil {
 			opts.roleTracker.OnElected(func() {
 				metrics.ClearGaugeMetricsForRole(roletracker.RoleFollower)
-				cCache.ResyncGaugeMetrics()
+				cCache.ResyncGaugeMetrics(ginkgo.GinkgoLogr)
 				queues.ResyncGaugeMetrics()
 			})
 		}

--- a/test/util/metrics.go
+++ b/test/util/metrics.go
@@ -237,14 +237,14 @@ func ExpectLQAdmissionWaitTimeMetric(lq *kueue.LocalQueue, priorityClass string,
 	expectHistogramMetric(metrics.LocalQueueAdmissionWaitTime, gomega.Equal(count), lq.Name, lq.Namespace, priorityClass, roletracker.RoleStandalone)
 }
 
-func ExpectClusterQueueStatusMetric(cq *kueue.ClusterQueue, status metrics.ClusterQueueStatus) {
+func ExpectClusterQueueStatusMetric(cq *kueue.ClusterQueue, status metrics.ClusterQueueStatus, customLabelValues ...string) {
 	ginkgo.GinkgoHelper()
 	for i, s := range metrics.CQStatuses {
 		var wantV float64
 		if metrics.CQStatuses[i] == status {
 			wantV = 1
 		}
-		lvs := []string{cq.Name, string(s), roletracker.RoleStandalone}
+		lvs := append([]string{cq.Name, string(s), roletracker.RoleStandalone}, customLabelValues...)
 		expectGaugeMetric(metrics.ClusterQueueByStatus, lvs, gomega.Equal(wantV), "cluster_queue_status with status=%s", s)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Makes custom metric label changes follow the same cleanup and resync flow as `ResyncGaugeMetrics`.

When metric labels change on a CQ, LQ or Cohort, Kueue now removes the old gauge metrics and reports them again with the new label values.

Also fixes the last cohort subtree case, old `cohort_subtree_admitted_active_workloads` metrics are removed when a CQ changes both its cohort and its custom label at the same time.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9854

#### Special notes for your reviewer:
PR builds on #10276, which was merged as the 1st step

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```