### PR TITLE
Automated cherry pick of #10550: Fix promote_pull.sh to update remotes before branching

### DIFF
--- a/hack/releasing/promote_pull.sh
+++ b/hack/releasing/promote_pull.sh
@@ -122,6 +122,9 @@ if [[ ! "$RELEASE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   exit 1
 fi
 
+echo "+++ Updating upstream remote..."
+git remote update "${KUBERNETES_K8S_IO_UPSTREAM_REMOTE}"
+
 IFS='.' read -r MAJOR MINOR _ <<< "${RELEASE_VERSION#v}"
 
 declare -r MAJOR_MINOR="$MAJOR.$MINOR"


### PR DESCRIPTION
Cherry pick of #10550 on release-0.16.
#10550: Fix promote_pull.sh to update remotes before branching

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
#### What type of PR is this?
/kind bug


```release-note
NONE
```