### PR TITLE
Automated cherry pick of #10023: Release automation: Use full version name for promotion PRs

### DIFF
--- a/hack/releasing/promote_pull.sh
+++ b/hack/releasing/promote_pull.sh
@@ -125,9 +125,7 @@ fi
 echo "+++ Updating upstream remote..."
 git remote update "${KUBERNETES_K8S_IO_UPSTREAM_REMOTE}"
 
-IFS='.' read -r MAJOR MINOR _ <<< "${RELEASE_VERSION#v}"
-
-declare -r MAJOR_MINOR="$MAJOR.$MINOR"
+IFS='.' read -r _ MINOR _ <<< "${RELEASE_VERSION#v}"
 
 LAST_SUPPORT_MINOR=$((MINOR - 1))
 if [ "$LAST_SUPPORT_MINOR" -lt 0 ]; then
@@ -379,11 +377,11 @@ function push_and_create_pr() {
   fi
 }
 
-K8S_IO_BRANCH="kueue-promote-${MAJOR_MINOR}"
+K8S_IO_BRANCH="kueue-promote-${RELEASE_VERSION}"
 declare -r K8S_IO_BRANCH
 K8S_IO_BRANCH_UNIQUE="${K8S_IO_BRANCH}-$(date +%s)"
 declare -r K8S_IO_BRANCH_UNIQUE
-K8S_IO_PR_NAME="Kueue: Promote ${MAJOR_MINOR}"
+K8S_IO_PR_NAME="Kueue: Promote ${RELEASE_VERSION}"
 declare -r K8S_IO_PR_NAME
 
 prepare_local_branch main "${K8S_IO_BRANCH_UNIQUE}" "${K8S_IO_PR_NAME}"


### PR DESCRIPTION
Cherry pick of #10023 on release-0.16.

#10023: Release automation: Use full version name for promotion PRs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```