### PR TITLE
Update SubtreeQuota post cohort deletion

### DIFF
--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -540,6 +540,8 @@ func (c *Cache) AddOrUpdateCohort(apiCohort *kueue.Cohort) error {
 	return nil
 }
 
+// DeleteCohort removes the cohort from the cache and updates the SubtreeQuota
+// of ancestor cohorts to reflect the removal.
 func (c *Cache) DeleteCohort(cohortName kueue.CohortReference) {
 	c.Lock()
 	defer c.Unlock()
@@ -552,7 +554,6 @@ func (c *Cache) DeleteCohort(cohortName kueue.CohortReference) {
 	}
 
 	c.hm.DeleteCohort(cohortName)
-	c.handleParentUpdate(parent)
 
 	// If the cohort still exists after deletion, it means
 	// that it has one or more children referencing it.
@@ -560,6 +561,12 @@ func (c *Cache) DeleteCohort(cohortName kueue.CohortReference) {
 	if cohort := c.hm.Cohort(cohortName); cohort != nil {
 		updateCohortResourceNode(cohort)
 	}
+
+	if parent != nil {
+		updateCohortTreeResourcesIfNoCycle(parent)
+	}
+
+	c.handleParentUpdate(parent)
 }
 
 func (c *Cache) handleParentUpdate(cachedParent *cohort) {

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -3570,148 +3570,125 @@ func TestCohortCycles(t *testing.T) {
 }
 
 func TestDeleteCohortUpdatesAncestorSubtreeQuota(t *testing.T) {
-	t.Run("deleting child cohort updates parent SubtreeQuota", func(t *testing.T) {
-		cache := New(utiltesting.NewFakeClient())
-
-		root := utiltestingapi.MakeCohort("root").
-			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj()).
-			Obj()
-		if err := cache.AddOrUpdateCohort(root); err != nil {
+	mustAddCohort := func(t *testing.T, cache *Cache, cohort *kueue.Cohort) {
+		t.Helper()
+		if err := cache.AddOrUpdateCohort(cohort); err != nil {
 			t.Fatal(err)
 		}
+	}
 
-		child := utiltestingapi.MakeCohort("child").
-			Parent("root").
-			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj()).
-			Obj()
-		if err := cache.AddOrUpdateCohort(child); err != nil {
-			t.Fatal(err)
-		}
+	testCases := map[string]struct {
+		setup      func(*testing.T, *Cache)
+		deleteName kueue.CohortReference
+		wantBefore map[kueue.CohortReference]resources.FlavorResourceQuantities
+		wantAfter  map[kueue.CohortReference]resources.FlavorResourceQuantities
+	}{
+		"deleting child cohort updates parent SubtreeQuota": {
+			setup: func(t *testing.T, cache *Cache) {
+				mustAddCohort(t, cache, utiltestingapi.MakeCohort("root").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj()).
+					Obj())
+				mustAddCohort(t, cache, utiltestingapi.MakeCohort("child").
+					Parent("root").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj()).
+					Obj())
+			},
+			deleteName: "child",
+			wantBefore: map[kueue.CohortReference]resources.FlavorResourceQuantities{
+				"root": {
+					{Flavor: "default", Resource: corev1.ResourceCPU}: 15_000,
+				},
+			},
+			wantAfter: map[kueue.CohortReference]resources.FlavorResourceQuantities{
+				"root": {
+					{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+				},
+			},
+		},
+		"deleting grandchild cohort updates all ancestors SubtreeQuota": {
+			setup: func(t *testing.T, cache *Cache) {
+				mustAddCohort(t, cache, utiltestingapi.MakeCohort("root").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj()).
+					Obj())
+				mustAddCohort(t, cache, utiltestingapi.MakeCohort("mid").
+					Parent("root").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj()).
+					Obj())
+				mustAddCohort(t, cache, utiltestingapi.MakeCohort("leaf").
+					Parent("mid").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "3").Obj()).
+					Obj())
+			},
+			deleteName: "leaf",
+			wantBefore: map[kueue.CohortReference]resources.FlavorResourceQuantities{
+				"mid": {
+					{Flavor: "default", Resource: corev1.ResourceCPU}: 8_000,
+				},
+				"root": {
+					{Flavor: "default", Resource: corev1.ResourceCPU}: 18_000,
+				},
+			},
+			wantAfter: map[kueue.CohortReference]resources.FlavorResourceQuantities{
+				"mid": {
+					{Flavor: "default", Resource: corev1.ResourceCPU}: 5_000,
+				},
+				"root": {
+					{Flavor: "default", Resource: corev1.ResourceCPU}: 15_000,
+				},
+			},
+		},
+		"deleting cohort with children updates parent SubtreeQuota": {
+			setup: func(t *testing.T, cache *Cache) {
+				ctx, _ := utiltesting.ContextWithLog(t)
+				mustAddCohort(t, cache, utiltestingapi.MakeCohort("root").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj()).
+					Obj())
+				mustAddCohort(t, cache, utiltestingapi.MakeCohort("mid").
+					Parent("root").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj()).
+					Obj())
 
-		// before deletion: root SubtreeQuota = 10 (own) + 5 (child) = 15
-		wantBefore := resources.FlavorResourceQuantities{
-			{Flavor: "default", Resource: corev1.ResourceCPU}: 15_000,
-		}
-		if diff := cmp.Diff(wantBefore, cache.hm.Cohort("root").getResourceNode().SubtreeQuota); diff != "" {
-			t.Errorf("before deletion, unexpected SubtreeQuota (-want,+got):\n%s", diff)
-		}
+				if err := cache.AddClusterQueue(ctx, utiltestingapi.MakeClusterQueue("cq").
+					Cohort("mid").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "7").Obj()).
+					Obj()); err != nil {
+					t.Fatal(err)
+				}
+			},
+			deleteName: "mid",
+			wantBefore: map[kueue.CohortReference]resources.FlavorResourceQuantities{
+				"root": {
+					{Flavor: "default", Resource: corev1.ResourceCPU}: 22_000,
+				},
+			},
+			wantAfter: map[kueue.CohortReference]resources.FlavorResourceQuantities{
+				"root": {
+					{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+				},
+			},
+		},
+	}
 
-		cache.DeleteCohort("child")
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			cache := New(utiltesting.NewFakeClient())
+			tc.setup(t, cache)
 
-		// after deletion: root SubtreeQuota = 10 (own only)
-		wantAfter := resources.FlavorResourceQuantities{
-			{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
-		}
-		if diff := cmp.Diff(wantAfter, cache.hm.Cohort("root").getResourceNode().SubtreeQuota); diff != "" {
-			t.Errorf("after deletion, unexpected SubtreeQuota (-want,+got):\n%s", diff)
-		}
-	})
+			for cohortName, wantSubtreeQuota := range tc.wantBefore {
+				if diff := cmp.Diff(wantSubtreeQuota, cache.hm.Cohort(cohortName).getResourceNode().SubtreeQuota); diff != "" {
+					t.Errorf("before deletion, %s unexpected SubtreeQuota (-want,+got):\n%s", cohortName, diff)
+				}
+			}
 
-	t.Run("deleting grandchild cohort updates all ancestors SubtreeQuota", func(t *testing.T) {
-		cache := New(utiltesting.NewFakeClient())
+			cache.DeleteCohort(tc.deleteName)
 
-		root := utiltestingapi.MakeCohort("root").
-			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj()).
-			Obj()
-		if err := cache.AddOrUpdateCohort(root); err != nil {
-			t.Fatal(err)
-		}
-
-		mid := utiltestingapi.MakeCohort("mid").
-			Parent("root").
-			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj()).
-			Obj()
-		if err := cache.AddOrUpdateCohort(mid); err != nil {
-			t.Fatal(err)
-		}
-
-		leaf := utiltestingapi.MakeCohort("leaf").
-			Parent("mid").
-			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "3").Obj()).
-			Obj()
-		if err := cache.AddOrUpdateCohort(leaf); err != nil {
-			t.Fatal(err)
-		}
-
-		// before: mid = 5+3 = 8, root = 10+8 = 18
-		wantMidBefore := resources.FlavorResourceQuantities{
-			{Flavor: "default", Resource: corev1.ResourceCPU}: 8_000,
-		}
-		wantRootBefore := resources.FlavorResourceQuantities{
-			{Flavor: "default", Resource: corev1.ResourceCPU}: 18_000,
-		}
-		if diff := cmp.Diff(wantMidBefore, cache.hm.Cohort("mid").getResourceNode().SubtreeQuota); diff != "" {
-			t.Errorf("before deletion, mid unexpected SubtreeQuota (-want,+got):\n%s", diff)
-		}
-		if diff := cmp.Diff(wantRootBefore, cache.hm.Cohort("root").getResourceNode().SubtreeQuota); diff != "" {
-			t.Errorf("before deletion, root unexpected SubtreeQuota (-want,+got):\n%s", diff)
-		}
-
-		cache.DeleteCohort("leaf")
-
-		// after: mid = 5, root = 10+5 = 15
-		wantMidAfter := resources.FlavorResourceQuantities{
-			{Flavor: "default", Resource: corev1.ResourceCPU}: 5_000,
-		}
-		wantRootAfter := resources.FlavorResourceQuantities{
-			{Flavor: "default", Resource: corev1.ResourceCPU}: 15_000,
-		}
-		if diff := cmp.Diff(wantMidAfter, cache.hm.Cohort("mid").getResourceNode().SubtreeQuota); diff != "" {
-			t.Errorf("after deletion, mid unexpected SubtreeQuota (-want,+got):\n%s", diff)
-		}
-		if diff := cmp.Diff(wantRootAfter, cache.hm.Cohort("root").getResourceNode().SubtreeQuota); diff != "" {
-			t.Errorf("after deletion, root unexpected SubtreeQuota (-want,+got):\n%s", diff)
-		}
-	})
-
-	t.Run("deleting cohort with children updates parent SubtreeQuota", func(t *testing.T) {
-		cache := New(utiltesting.NewFakeClient())
-		ctx, _ := utiltesting.ContextWithLog(t)
-
-		root := utiltestingapi.MakeCohort("root").
-			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj()).
-			Obj()
-		if err := cache.AddOrUpdateCohort(root); err != nil {
-			t.Fatal(err)
-		}
-
-		mid := utiltestingapi.MakeCohort("mid").
-			Parent("root").
-			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj()).
-			Obj()
-		if err := cache.AddOrUpdateCohort(mid); err != nil {
-			t.Fatal(err)
-		}
-
-		// cq is a child of mid; after mid is deleted, mid becomes implicit (no parent)
-		// and is detached from root. So root loses mid's entire subtree contribution.
-		if err := cache.AddClusterQueue(ctx, utiltestingapi.MakeClusterQueue("cq").
-			Cohort("mid").
-			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "7").Obj()).
-			Obj()); err != nil {
-			t.Fatal(err)
-		}
-
-		// before: mid = 5+7 = 12, root = 10+12 = 22
-		wantRootBefore := resources.FlavorResourceQuantities{
-			{Flavor: "default", Resource: corev1.ResourceCPU}: 22_000,
-		}
-		if diff := cmp.Diff(wantRootBefore, cache.hm.Cohort("root").getResourceNode().SubtreeQuota); diff != "" {
-			t.Errorf("before deletion, root unexpected SubtreeQuota (-want,+got):\n%s", diff)
-		}
-
-		// Delete mid (explicit cohort). It becomes implicit because cq still references it.
-		cache.DeleteCohort("mid")
-
-		// after: mid is detached from root entirely (implicit mid has no parent),
-		// so root = 10 (own quota only)
-		wantRootAfter := resources.FlavorResourceQuantities{
-			{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
-		}
-		if diff := cmp.Diff(wantRootAfter, cache.hm.Cohort("root").getResourceNode().SubtreeQuota); diff != "" {
-			t.Errorf("after deletion, root unexpected SubtreeQuota (-want,+got):\n%s", diff)
-		}
-	})
+			for cohortName, wantSubtreeQuota := range tc.wantAfter {
+				if diff := cmp.Diff(wantSubtreeQuota, cache.hm.Cohort(cohortName).getResourceNode().SubtreeQuota); diff != "" {
+					t.Errorf("after deletion, %s unexpected SubtreeQuota (-want,+got):\n%s", cohortName, diff)
+				}
+			}
+		})
+	}
 }
 func TestClusterQueueAncestors(t *testing.T) {
 	testCases := map[string]struct {

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -3569,6 +3569,150 @@ func TestCohortCycles(t *testing.T) {
 	})
 }
 
+func TestDeleteCohortUpdatesAncestorSubtreeQuota(t *testing.T) {
+	t.Run("deleting child cohort updates parent SubtreeQuota", func(t *testing.T) {
+		cache := New(utiltesting.NewFakeClient())
+
+		root := utiltestingapi.MakeCohort("root").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj()).
+			Obj()
+		if err := cache.AddOrUpdateCohort(root); err != nil {
+			t.Fatal(err)
+		}
+
+		child := utiltestingapi.MakeCohort("child").
+			Parent("root").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj()).
+			Obj()
+		if err := cache.AddOrUpdateCohort(child); err != nil {
+			t.Fatal(err)
+		}
+
+		// before deletion: root SubtreeQuota = 10 (own) + 5 (child) = 15
+		wantBefore := resources.FlavorResourceQuantities{
+			{Flavor: "default", Resource: corev1.ResourceCPU}: 15_000,
+		}
+		if diff := cmp.Diff(wantBefore, cache.hm.Cohort("root").getResourceNode().SubtreeQuota); diff != "" {
+			t.Errorf("before deletion, unexpected SubtreeQuota (-want,+got):\n%s", diff)
+		}
+
+		cache.DeleteCohort("child")
+
+		// after deletion: root SubtreeQuota = 10 (own only)
+		wantAfter := resources.FlavorResourceQuantities{
+			{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+		}
+		if diff := cmp.Diff(wantAfter, cache.hm.Cohort("root").getResourceNode().SubtreeQuota); diff != "" {
+			t.Errorf("after deletion, unexpected SubtreeQuota (-want,+got):\n%s", diff)
+		}
+	})
+
+	t.Run("deleting grandchild cohort updates all ancestors SubtreeQuota", func(t *testing.T) {
+		cache := New(utiltesting.NewFakeClient())
+
+		root := utiltestingapi.MakeCohort("root").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj()).
+			Obj()
+		if err := cache.AddOrUpdateCohort(root); err != nil {
+			t.Fatal(err)
+		}
+
+		mid := utiltestingapi.MakeCohort("mid").
+			Parent("root").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj()).
+			Obj()
+		if err := cache.AddOrUpdateCohort(mid); err != nil {
+			t.Fatal(err)
+		}
+
+		leaf := utiltestingapi.MakeCohort("leaf").
+			Parent("mid").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "3").Obj()).
+			Obj()
+		if err := cache.AddOrUpdateCohort(leaf); err != nil {
+			t.Fatal(err)
+		}
+
+		// before: mid = 5+3 = 8, root = 10+8 = 18
+		wantMidBefore := resources.FlavorResourceQuantities{
+			{Flavor: "default", Resource: corev1.ResourceCPU}: 8_000,
+		}
+		wantRootBefore := resources.FlavorResourceQuantities{
+			{Flavor: "default", Resource: corev1.ResourceCPU}: 18_000,
+		}
+		if diff := cmp.Diff(wantMidBefore, cache.hm.Cohort("mid").getResourceNode().SubtreeQuota); diff != "" {
+			t.Errorf("before deletion, mid unexpected SubtreeQuota (-want,+got):\n%s", diff)
+		}
+		if diff := cmp.Diff(wantRootBefore, cache.hm.Cohort("root").getResourceNode().SubtreeQuota); diff != "" {
+			t.Errorf("before deletion, root unexpected SubtreeQuota (-want,+got):\n%s", diff)
+		}
+
+		cache.DeleteCohort("leaf")
+
+		// after: mid = 5, root = 10+5 = 15
+		wantMidAfter := resources.FlavorResourceQuantities{
+			{Flavor: "default", Resource: corev1.ResourceCPU}: 5_000,
+		}
+		wantRootAfter := resources.FlavorResourceQuantities{
+			{Flavor: "default", Resource: corev1.ResourceCPU}: 15_000,
+		}
+		if diff := cmp.Diff(wantMidAfter, cache.hm.Cohort("mid").getResourceNode().SubtreeQuota); diff != "" {
+			t.Errorf("after deletion, mid unexpected SubtreeQuota (-want,+got):\n%s", diff)
+		}
+		if diff := cmp.Diff(wantRootAfter, cache.hm.Cohort("root").getResourceNode().SubtreeQuota); diff != "" {
+			t.Errorf("after deletion, root unexpected SubtreeQuota (-want,+got):\n%s", diff)
+		}
+	})
+
+	t.Run("deleting cohort with children updates parent SubtreeQuota", func(t *testing.T) {
+		cache := New(utiltesting.NewFakeClient())
+		ctx, _ := utiltesting.ContextWithLog(t)
+
+		root := utiltestingapi.MakeCohort("root").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj()).
+			Obj()
+		if err := cache.AddOrUpdateCohort(root); err != nil {
+			t.Fatal(err)
+		}
+
+		mid := utiltestingapi.MakeCohort("mid").
+			Parent("root").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj()).
+			Obj()
+		if err := cache.AddOrUpdateCohort(mid); err != nil {
+			t.Fatal(err)
+		}
+
+		// cq is a child of mid; after mid is deleted, mid becomes implicit (no parent)
+		// and is detached from root. So root loses mid's entire subtree contribution.
+		if err := cache.AddClusterQueue(ctx, utiltestingapi.MakeClusterQueue("cq").
+			Cohort("mid").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "7").Obj()).
+			Obj()); err != nil {
+			t.Fatal(err)
+		}
+
+		// before: mid = 5+7 = 12, root = 10+12 = 22
+		wantRootBefore := resources.FlavorResourceQuantities{
+			{Flavor: "default", Resource: corev1.ResourceCPU}: 22_000,
+		}
+		if diff := cmp.Diff(wantRootBefore, cache.hm.Cohort("root").getResourceNode().SubtreeQuota); diff != "" {
+			t.Errorf("before deletion, root unexpected SubtreeQuota (-want,+got):\n%s", diff)
+		}
+
+		// Delete mid (explicit cohort). It becomes implicit because cq still references it.
+		cache.DeleteCohort("mid")
+
+		// after: mid is detached from root entirely (implicit mid has no parent),
+		// so root = 10 (own quota only)
+		wantRootAfter := resources.FlavorResourceQuantities{
+			{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+		}
+		if diff := cmp.Diff(wantRootAfter, cache.hm.Cohort("root").getResourceNode().SubtreeQuota); diff != "" {
+			t.Errorf("after deletion, root unexpected SubtreeQuota (-want,+got):\n%s", diff)
+		}
+	})
+}
 func TestClusterQueueAncestors(t *testing.T) {
 	testCases := map[string]struct {
 		cohorts       []*kueue.Cohort

--- a/pkg/cache/scheduler/cohort_metrics_test.go
+++ b/pkg/cache/scheduler/cohort_metrics_test.go
@@ -162,84 +162,197 @@ func TestRecordCohortMetrics_Guards(t *testing.T) {
 	}
 }
 
-func TestRecordCohortMetrics_QuotaHierarchyLikeIntegration(t *testing.T) {
-	fixture := newCohortMetricsFixture(t)
-	cache := fixture.cache
-	ctx, log := fixture.ctx, fixture.log
-
+func TestCohortMetrics_QuotaHierarchyScenarios(t *testing.T) {
 	frDefaultCPU := resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceCPU}
 	frFlavor1CPU := resources.FlavorResource{Flavor: "flavor1", Resource: corev1.ResourceCPU}
 	frFlavor1GPU := resources.FlavorResource{Flavor: "flavor1", Resource: corev1.ResourceName("nvidia.com/gpu")}
 
-	setupRecordMetricsHierarchy(ctx, t, log, cache,
-		[]*kueue.ResourceFlavor{
-			utiltestingapi.MakeResourceFlavor("default").Obj(),
-			utiltestingapi.MakeResourceFlavor("flavor1").Obj(),
-		},
-		[]*kueue.Cohort{
-			utiltestingapi.MakeCohort("root").
-				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("flavor1").
-					Resource(corev1.ResourceCPU, "20").
-					Resource("nvidia.com/gpu", "5").
-					Obj()).
-				Obj(),
-			utiltestingapi.MakeCohort("ch1").
-				Parent("root").
-				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
-					Resource(corev1.ResourceCPU, "15").
-					Obj()).
-				Obj(),
-			utiltestingapi.MakeCohort("ch2").
-				Parent("root").
-				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
-					Resource(corev1.ResourceCPU, "10").
-					Obj()).
-				Obj(),
-			utiltestingapi.MakeCohort("ch3").
-				Parent("root").
-				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("flavor1").
-					Resource(corev1.ResourceCPU, "5").
-					Resource("nvidia.com/gpu", "1").
-					Obj()).
-				Obj(),
-		},
-		[]*kueue.ClusterQueue{
-			utiltestingapi.MakeClusterQueue("cqa").
-				Cohort("ch1").
-				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj()).
-				Obj(),
-			utiltestingapi.MakeClusterQueue("cqb").
-				Cohort("ch1").
-				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj()).
-				Obj(),
-			utiltestingapi.MakeClusterQueue("cqd").
-				Cohort("ch2").
-				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj()).
-				Obj(),
-			utiltestingapi.MakeClusterQueue("cqe").
-				Cohort("ch2").
-				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj()).
-				Obj(),
-		},
-	)
-	t.Run("QuotaHierarchyLikeIntegration", func(t *testing.T) {
-		clearCohortMetricsForTest(t, "root", "ch1", "ch2", "ch3")
+	testCases := []struct {
+		name string
+		run  func(t *testing.T, cache *Cache, log logr.Logger)
+	}{
+		{
+			name: "RecordCohortMetrics_QuotaHierarchyLikeIntegration",
+			run: func(t *testing.T, cache *Cache, log logr.Logger) {
+				cache.RecordCohortMetrics(log, "ch1")
+				cache.RecordCohortMetrics(log, "ch2")
+				cache.RecordCohortMetrics(log, "ch3")
 
-		cache.RecordCohortMetrics(log, "ch1")
-		cache.RecordCohortMetrics(log, "ch2")
-		cache.RecordCohortMetrics(log, "ch3")
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch1", frDefaultCPU), 30)
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch2", frDefaultCPU), 20)
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch3", frFlavor1CPU), 5)
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch3", frFlavor1GPU), 1)
 
-		expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch1", frDefaultCPU), 30)
-		expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch2", frDefaultCPU), 20)
-		expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch3", frFlavor1CPU), 5)
-		expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch3", frFlavor1GPU), 1)
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 50)
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frFlavor1CPU), 25)
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frFlavor1GPU), 6)
+			},
+		},
+		{
+			name: "DeleteCohort_DoesNotRepublishStaleAncestorQuotaMetrics",
+			run: func(t *testing.T, cache *Cache, log logr.Logger) {
+				cqd := utiltestingapi.MakeClusterQueue("cqd").
+					Cohort("ch3").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default").
+							Resource(corev1.ResourceCPU, "5").
+							Obj(),
+					).
+					Obj()
+				if err := cache.UpdateClusterQueue(log, cqd); err != nil {
+					t.Fatalf("moving cqd to ch3: %v", err)
+				}
 
-		expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 50)
-		expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frFlavor1CPU), 25)
-		expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frFlavor1GPU), 6)
-	})
+				cqe := utiltestingapi.MakeClusterQueue("cqe").
+					Cohort("ch3").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default").
+							Resource(corev1.ResourceCPU, "5").
+							Obj(),
+					).
+					Obj()
+				if err := cache.UpdateClusterQueue(log, cqe); err != nil {
+					t.Fatalf("moving cqe to ch3: %v", err)
+				}
+
+				cache.RecordCohortMetrics(log, "ch1")
+				cache.RecordCohortMetrics(log, "ch2")
+				cache.RecordCohortMetrics(log, "ch3")
+
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 50)
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frFlavor1CPU), 25)
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frFlavor1GPU), 6)
+
+				cache.ClearCohortMetrics(log, "ch2")
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 40)
+
+				cache.DeleteCohort("ch2")
+
+				// Mimics the  republish (e.g. AFS driven) from another cohort update.
+				// Before the fix, stale root.SubtreeQuota caused this call to write 50 again.
+				cache.RecordCohortMetrics(log, "ch3")
+
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch3", frDefaultCPU), 10)
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 40)
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frFlavor1CPU), 25)
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frFlavor1GPU), 6)
+			},
+		},
+		{
+			name: "ClearCohortMetrics_ClearsTargetAndAncestors",
+			run: func(t *testing.T, cache *Cache, log logr.Logger) {
+				addTestUsage(cache, []usageChange{
+					{cqName: "cqa", fr: frDefaultCPU, val: 6_000},
+					{cqName: "cqd", fr: frDefaultCPU, val: 7_000},
+				})
+
+				cache.RecordCohortMetrics(log, "ch1")
+				cache.RecordCohortMetrics(log, "ch2")
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch1", frDefaultCPU), 30)
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch2", frDefaultCPU), 20)
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 50)
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("root", frDefaultCPU), 13)
+
+				cache.ClearCohortMetrics(log, "ch1")
+				expectGaugeCount(t, kueuemetrics.CohortSubtreeQuota, 0, cohortMetricLabels("ch1", frDefaultCPU))
+				expectGaugeCount(t, kueuemetrics.CohortSubtreeResourceReservations, 0, cohortMetricLabels("ch1", frDefaultCPU))
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch2", frDefaultCPU), 20)
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("ch2", frDefaultCPU), 7)
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 20)
+				expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("root", frDefaultCPU), 7)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newCohortMetricsFixture(t)
+			cache := fixture.cache
+			ctx, log := fixture.ctx, fixture.log
+
+			setupRecordMetricsHierarchy(
+				ctx, t, log, cache,
+				[]*kueue.ResourceFlavor{
+					utiltestingapi.MakeResourceFlavor("default").Obj(),
+					utiltestingapi.MakeResourceFlavor("flavor1").Obj(),
+				},
+				[]*kueue.Cohort{
+					utiltestingapi.MakeCohort("root").
+						ResourceGroup(
+							*utiltestingapi.MakeFlavorQuotas("flavor1").
+								Resource(corev1.ResourceCPU, "20").
+								Resource("nvidia.com/gpu", "5").
+								Obj(),
+						).
+						Obj(),
+					utiltestingapi.MakeCohort("ch1").
+						Parent("root").
+						ResourceGroup(
+							*utiltestingapi.MakeFlavorQuotas("default").
+								Resource(corev1.ResourceCPU, "15").
+								Obj(),
+						).
+						Obj(),
+					utiltestingapi.MakeCohort("ch2").
+						Parent("root").
+						ResourceGroup(
+							*utiltestingapi.MakeFlavorQuotas("default").
+								Resource(corev1.ResourceCPU, "10").
+								Obj(),
+						).
+						Obj(),
+					utiltestingapi.MakeCohort("ch3").
+						Parent("root").
+						ResourceGroup(
+							*utiltestingapi.MakeFlavorQuotas("flavor1").
+								Resource(corev1.ResourceCPU, "5").
+								Resource("nvidia.com/gpu", "1").
+								Obj(),
+						).
+						Obj(),
+				},
+				[]*kueue.ClusterQueue{
+					utiltestingapi.MakeClusterQueue("cqa").
+						Cohort("ch1").
+						ResourceGroup(
+							*utiltestingapi.MakeFlavorQuotas("default").
+								Resource(corev1.ResourceCPU, "10").
+								Obj(),
+						).
+						Obj(),
+					utiltestingapi.MakeClusterQueue("cqb").
+						Cohort("ch1").
+						ResourceGroup(
+							*utiltestingapi.MakeFlavorQuotas("default").
+								Resource(corev1.ResourceCPU, "5").
+								Obj(),
+						).
+						Obj(),
+					utiltestingapi.MakeClusterQueue("cqd").
+						Cohort("ch2").
+						ResourceGroup(
+							*utiltestingapi.MakeFlavorQuotas("default").
+								Resource(corev1.ResourceCPU, "5").
+								Obj(),
+						).
+						Obj(),
+					utiltestingapi.MakeClusterQueue("cqe").
+						Cohort("ch2").
+						ResourceGroup(
+							*utiltestingapi.MakeFlavorQuotas("default").
+								Resource(corev1.ResourceCPU, "5").
+								Obj(),
+						).
+						Obj(),
+				},
+			)
+
+			clearCohortMetricsForTest(t, "root", "ch1", "ch2", "ch3")
+
+			tc.run(t, cache, log)
+		})
+	}
 }
-
 func TestRecordCohortMetrics_ReservationsChildParentLikeIntegration(t *testing.T) {
 	fixture := newCohortMetricsFixture(t)
 	cache := fixture.cache
@@ -306,64 +419,6 @@ func TestRecordCohortMetrics_ReservationsChildParentLikeIntegration(t *testing.T
 	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("ch1", frDefaultCPU), 6)
 	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("ch2", frDefaultCPU), 7)
 	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("root", frDefaultCPU), 13)
-}
-
-func TestClearCohortMetrics_ClearsTargetAndAncestors(t *testing.T) {
-	fixture := newCohortMetricsFixture(t)
-	cache := fixture.cache
-	ctx, log := fixture.ctx, fixture.log
-	frDefaultCPU := resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceCPU}
-
-	setupRecordMetricsHierarchy(
-		ctx, t, log, cache,
-		[]*kueue.ResourceFlavor{
-			utiltestingapi.MakeResourceFlavor("default").Obj(),
-		},
-		[]*kueue.Cohort{
-			utiltestingapi.MakeCohort("root").
-				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "30").Obj()).
-				Obj(),
-			utiltestingapi.MakeCohort("ch1").
-				Parent("root").
-				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "8").Obj()).
-				Obj(),
-			utiltestingapi.MakeCohort("ch2").
-				Parent("root").
-				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "6").Obj()).
-				Obj(),
-		},
-		[]*kueue.ClusterQueue{
-			utiltestingapi.MakeClusterQueue("cqa").
-				Cohort("ch1").
-				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj()).
-				Obj(),
-			utiltestingapi.MakeClusterQueue("cqb").
-				Cohort("ch2").
-				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "8").Obj()).
-				Obj(),
-		},
-	)
-
-	clearCohortMetricsForTest(t, "root", "ch1", "ch2")
-	addTestUsage(cache, []usageChange{
-		{cqName: "cqa", fr: frDefaultCPU, val: 6_000},
-		{cqName: "cqb", fr: frDefaultCPU, val: 7_000},
-	})
-
-	cache.RecordCohortMetrics(log, "ch1")
-	cache.RecordCohortMetrics(log, "ch2")
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch1", frDefaultCPU), 18)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch2", frDefaultCPU), 14)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 62)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("root", frDefaultCPU), 13)
-
-	cache.ClearCohortMetrics(log, "ch1")
-	expectGaugeCount(t, kueuemetrics.CohortSubtreeQuota, 0, cohortMetricLabels("ch1", frDefaultCPU))
-	expectGaugeCount(t, kueuemetrics.CohortSubtreeResourceReservations, 0, cohortMetricLabels("ch1", frDefaultCPU))
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch2", frDefaultCPU), 14)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("ch2", frDefaultCPU), 7)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 44)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("root", frDefaultCPU), 7)
 }
 
 type cohortMetricsFixture struct {
@@ -461,139 +516,4 @@ func expectGaugeValue(t *testing.T, collector prometheus.Collector, labels map[s
 	if dps[0].Value != want {
 		t.Fatalf("unexpected metric value for labels %v: got=%v want=%v", labels, dps[0].Value, want)
 	}
-}
-
-func TestDeleteCohort_DoesNotRepublishStaleAncestorQuotaMetrics(t *testing.T) {
-	fixture := newCohortMetricsFixture(t)
-	cache := fixture.cache
-	ctx, log := fixture.ctx, fixture.log
-
-	frDefaultCPU := resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceCPU}
-	frFlavor1CPU := resources.FlavorResource{Flavor: "flavor1", Resource: corev1.ResourceCPU}
-	frFlavor1GPU := resources.FlavorResource{Flavor: "flavor1", Resource: corev1.ResourceName("nvidia.com/gpu")}
-
-	setupRecordMetricsHierarchy(
-		ctx, t, log, cache,
-		[]*kueue.ResourceFlavor{
-			utiltestingapi.MakeResourceFlavor("default").Obj(),
-			utiltestingapi.MakeResourceFlavor("flavor1").Obj(),
-		},
-		[]*kueue.Cohort{
-			utiltestingapi.MakeCohort("root").
-				ResourceGroup(
-					*utiltestingapi.MakeFlavorQuotas("flavor1").
-						Resource(corev1.ResourceCPU, "20").
-						Resource("nvidia.com/gpu", "5").
-						Obj(),
-				).
-				Obj(),
-			utiltestingapi.MakeCohort("ch1").
-				Parent("root").
-				ResourceGroup(
-					*utiltestingapi.MakeFlavorQuotas("default").
-						Resource(corev1.ResourceCPU, "15").
-						Obj(),
-				).
-				Obj(),
-			utiltestingapi.MakeCohort("ch2").
-				Parent("root").
-				ResourceGroup(
-					*utiltestingapi.MakeFlavorQuotas("default").
-						Resource(corev1.ResourceCPU, "10").
-						Obj(),
-				).
-				Obj(),
-			utiltestingapi.MakeCohort("ch3").
-				Parent("root").
-				ResourceGroup(
-					*utiltestingapi.MakeFlavorQuotas("flavor1").
-						Resource(corev1.ResourceCPU, "5").
-						Resource("nvidia.com/gpu", "1").
-						Obj(),
-				).
-				Obj(),
-		},
-		[]*kueue.ClusterQueue{
-			utiltestingapi.MakeClusterQueue("cqa").
-				Cohort("ch1").
-				ResourceGroup(
-					*utiltestingapi.MakeFlavorQuotas("default").
-						Resource(corev1.ResourceCPU, "10").
-						Obj(),
-				).
-				Obj(),
-			utiltestingapi.MakeClusterQueue("cqb").
-				Cohort("ch1").
-				ResourceGroup(
-					*utiltestingapi.MakeFlavorQuotas("default").
-						Resource(corev1.ResourceCPU, "5").
-						Obj(),
-				).
-				Obj(),
-			utiltestingapi.MakeClusterQueue("cqd").
-				Cohort("ch2").
-				ResourceGroup(
-					*utiltestingapi.MakeFlavorQuotas("default").
-						Resource(corev1.ResourceCPU, "5").
-						Obj(),
-				).
-				Obj(),
-			utiltestingapi.MakeClusterQueue("cqe").
-				Cohort("ch2").
-				ResourceGroup(
-					*utiltestingapi.MakeFlavorQuotas("default").
-						Resource(corev1.ResourceCPU, "5").
-						Obj(),
-				).
-				Obj(),
-		},
-	)
-
-	clearCohortMetricsForTest(t, "root", "ch1", "ch2", "ch3")
-
-	cqd := utiltestingapi.MakeClusterQueue("cqd").
-		Cohort("ch3").
-		ResourceGroup(
-			*utiltestingapi.MakeFlavorQuotas("default").
-				Resource(corev1.ResourceCPU, "5").
-				Obj(),
-		).
-		Obj()
-	if err := cache.UpdateClusterQueue(log, cqd); err != nil {
-		t.Fatalf("moving cqd to ch3: %v", err)
-	}
-
-	cqe := utiltestingapi.MakeClusterQueue("cqe").
-		Cohort("ch3").
-		ResourceGroup(
-			*utiltestingapi.MakeFlavorQuotas("default").
-				Resource(corev1.ResourceCPU, "5").
-				Obj(),
-		).
-		Obj()
-	if err := cache.UpdateClusterQueue(log, cqe); err != nil {
-		t.Fatalf("moving cqe to ch3: %v", err)
-	}
-
-	cache.RecordCohortMetrics(log, "ch1")
-	cache.RecordCohortMetrics(log, "ch2")
-	cache.RecordCohortMetrics(log, "ch3")
-
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 50_000)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frFlavor1CPU), 25_000)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frFlavor1GPU), 6)
-
-	cache.ClearCohortMetrics(log, "ch2")
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 40_000)
-
-	cache.DeleteCohort("ch2")
-
-	// Mimics the  republish (e.g. AFS driven) from another cohort update.
-	// Before the fix, stale root.SubtreeQuota caused this call to write 50_000 again.
-	cache.RecordCohortMetrics(log, "ch3")
-
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch3", frDefaultCPU), 10_000)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 40_000)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frFlavor1CPU), 25_000)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frFlavor1GPU), 6)
 }

--- a/pkg/cache/scheduler/cohort_metrics_test.go
+++ b/pkg/cache/scheduler/cohort_metrics_test.go
@@ -462,3 +462,138 @@ func expectGaugeValue(t *testing.T, collector prometheus.Collector, labels map[s
 		t.Fatalf("unexpected metric value for labels %v: got=%v want=%v", labels, dps[0].Value, want)
 	}
 }
+
+func TestDeleteCohort_DoesNotRepublishStaleAncestorQuotaMetrics(t *testing.T) {
+	fixture := newCohortMetricsFixture(t)
+	cache := fixture.cache
+	ctx, log := fixture.ctx, fixture.log
+
+	frDefaultCPU := resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceCPU}
+	frFlavor1CPU := resources.FlavorResource{Flavor: "flavor1", Resource: corev1.ResourceCPU}
+	frFlavor1GPU := resources.FlavorResource{Flavor: "flavor1", Resource: corev1.ResourceName("nvidia.com/gpu")}
+
+	setupRecordMetricsHierarchy(
+		ctx, t, log, cache,
+		[]*kueue.ResourceFlavor{
+			utiltestingapi.MakeResourceFlavor("default").Obj(),
+			utiltestingapi.MakeResourceFlavor("flavor1").Obj(),
+		},
+		[]*kueue.Cohort{
+			utiltestingapi.MakeCohort("root").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("flavor1").
+						Resource(corev1.ResourceCPU, "20").
+						Resource("nvidia.com/gpu", "5").
+						Obj(),
+				).
+				Obj(),
+			utiltestingapi.MakeCohort("ch1").
+				Parent("root").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "15").
+						Obj(),
+				).
+				Obj(),
+			utiltestingapi.MakeCohort("ch2").
+				Parent("root").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "10").
+						Obj(),
+				).
+				Obj(),
+			utiltestingapi.MakeCohort("ch3").
+				Parent("root").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("flavor1").
+						Resource(corev1.ResourceCPU, "5").
+						Resource("nvidia.com/gpu", "1").
+						Obj(),
+				).
+				Obj(),
+		},
+		[]*kueue.ClusterQueue{
+			utiltestingapi.MakeClusterQueue("cqa").
+				Cohort("ch1").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "10").
+						Obj(),
+				).
+				Obj(),
+			utiltestingapi.MakeClusterQueue("cqb").
+				Cohort("ch1").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "5").
+						Obj(),
+				).
+				Obj(),
+			utiltestingapi.MakeClusterQueue("cqd").
+				Cohort("ch2").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "5").
+						Obj(),
+				).
+				Obj(),
+			utiltestingapi.MakeClusterQueue("cqe").
+				Cohort("ch2").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "5").
+						Obj(),
+				).
+				Obj(),
+		},
+	)
+
+	clearCohortMetricsForTest(t, "root", "ch1", "ch2", "ch3")
+
+	cqd := utiltestingapi.MakeClusterQueue("cqd").
+		Cohort("ch3").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("default").
+				Resource(corev1.ResourceCPU, "5").
+				Obj(),
+		).
+		Obj()
+	if err := cache.UpdateClusterQueue(log, cqd); err != nil {
+		t.Fatalf("moving cqd to ch3: %v", err)
+	}
+
+	cqe := utiltestingapi.MakeClusterQueue("cqe").
+		Cohort("ch3").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("default").
+				Resource(corev1.ResourceCPU, "5").
+				Obj(),
+		).
+		Obj()
+	if err := cache.UpdateClusterQueue(log, cqe); err != nil {
+		t.Fatalf("moving cqe to ch3: %v", err)
+	}
+
+	cache.RecordCohortMetrics(log, "ch1")
+	cache.RecordCohortMetrics(log, "ch2")
+	cache.RecordCohortMetrics(log, "ch3")
+
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 50_000)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frFlavor1CPU), 25_000)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frFlavor1GPU), 6)
+
+	cache.ClearCohortMetrics(log, "ch2")
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 40_000)
+
+	cache.DeleteCohort("ch2")
+
+	// Mimics the  republish (e.g. AFS driven) from another cohort update.
+	// Before the fix, stale root.SubtreeQuota caused this call to write 50_000 again.
+	cache.RecordCohortMetrics(log, "ch3")
+
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch3", frDefaultCPU), 10_000)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 40_000)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frFlavor1CPU), 25_000)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frFlavor1GPU), 6)
+}

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -2936,6 +2936,104 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectAdmittedWorkloadsTotalMetric(cq2, "", 0)
 		})
 	})
+	ginkgo.When("Deleting child Cohort should update borrowable resources for parent Cohort", func() {
+		var (
+			root    *kueue.Cohort
+			chLeft  *kueue.Cohort
+			chRight *kueue.Cohort
+		)
+
+		ginkgo.AfterEach(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, root, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, chLeft, true)
+		})
+
+		ginkgo.It("Should not admit from stale subtree quota after deleting sibling cohort", func() {
+			// 		    Root Cohort (quota 0)
+			//             SubtreeQuota = 22
+			//             /               \
+			//    Left Cohort (quota 0)   Right Cohort (quota 5)
+			//    Subtree = 10             Subtree = 12
+			//      |                      |
+			//     cq-a                   cq-b
+			//     nominal 10             nominal 7
+			ginkgo.By("Creating the Cohorts")
+			root = utiltestingapi.MakeCohort("root").Obj()
+			util.MustCreate(ctx, k8sClient, root)
+
+			chLeft = utiltestingapi.MakeCohort("ch-left").
+				Parent("root").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(onDemandFlavor.Name).
+						Resource(corev1.ResourceCPU, "0").
+						Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, chLeft)
+
+			chRight = utiltestingapi.MakeCohort("ch-right").
+				Parent("root").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(onDemandFlavor.Name).
+						Resource(corev1.ResourceCPU, "5").
+						Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, chRight)
+
+			ginkgo.By("creating ClusterQueues")
+			cqA := createQueue(utiltestingapi.MakeClusterQueue("cq-a").
+				Cohort(kueue.CohortReference(chLeft.GetName())).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(onDemandFlavor.Name).
+						Resource(corev1.ResourceCPU, "10").
+						Obj(),
+				).
+				Obj())
+
+			createQueue(utiltestingapi.MakeClusterQueue("cq-b").
+				Cohort(kueue.CohortReference(chRight.GetName())).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(onDemandFlavor.Name).
+						Resource(corev1.ResourceCPU, "7").
+						Obj(),
+				).
+				Obj())
+
+			ginkgo.By("admitting baseline workload on cq-a")
+			wlBase := utiltestingapi.MakeWorkload("wl-base", ns.Name).
+				Queue(kueue.LocalQueueName(cqA.Name)).
+				Request(corev1.ResourceCPU, "10").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wlBase)
+			util.ExpectWorkloadToBeAdmittedAs(
+				ctx,
+				k8sClient,
+				wlBase,
+				utiltestingapi.MakeAdmission(cqA.Name).
+					PodSets(
+						utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(onDemandFlavor.GetName()), "10").
+							Obj(),
+					).
+					Obj(),
+			)
+
+			ginkgo.By("deleting explicit cohort right while cq-b still references it")
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, chRight, true)
+
+			ginkgo.By("trying to admit extra workload on cq-a after deletion of cohort right")
+			// root cohort subtree quota should be properly recomputed after deletion of right cohort
+			// and should reflect the fact that cq-b is no longer borrowable
+			// admitting of the workload "wl-after-delete" should fail be pending
+			wlAfterDelete := utiltestingapi.MakeWorkload("wl-after-delete", ns.Name).
+				Queue(kueue.LocalQueueName(cqA.Name)).
+				Request(corev1.ResourceCPU, "8").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wlAfterDelete)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wlAfterDelete)
+		})
+	})
 	ginkgo.When("Workload slicing with multiple podSets", func() {
 		var (
 			resourceFlavor *kueue.ResourceFlavor


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Update the SubtreeQuota of all ancestors to reflect the removal of the deleted cohort. 
Without this, stale SubtreeQuota values would cause any subsequent RecordCohortMetrics call for ancestor cohorts to re-publish the pre-deletion metric values.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10417 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```