### PR TITLE
Fix e2e helper waiting for NodeReady after disruption

### DIFF
--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1504,6 +1504,7 @@ func waitForDummyWorkloadToRunOnNode(ctx context.Context, c client.Client, node 
 			Queue(kueue.LocalQueueName(lq.Name)).
 			NodeSelector(corev1.LabelHostname, node.Name).
 			Image(GetAgnHostImage(), BehaviorExitFast).
+			RequestAndLimit(corev1.ResourceCPU, "200m").
 			Obj()
 
 		MustCreate(ctx, c, dummyJob)
@@ -1515,7 +1516,7 @@ func waitForDummyWorkloadToRunOnNode(ctx context.Context, c client.Client, node 
 				Type:   batchv1.JobComplete,
 				Status: corev1.ConditionTrue,
 			}, cmpopts.IgnoreFields(batchv1.JobCondition{}, "LastTransitionTime", "LastProbeTime", "Reason", "Message"))))
-		}, MediumTimeout, Interval).Should(gomega.Succeed())
+		}, LongTimeout, Interval).Should(gomega.Succeed())
 	})
 }
 


### PR DESCRIPTION

#### What type of PR is this?

/kind flake
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10420

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```