### PR TITLE
Automated cherry pick of #10120: Wait for the node to be ready in FailureRecoveryPolicy e2e test

### DIFF
--- a/test/e2e/customconfigs/failure_recovery_policy_test.go
+++ b/test/e2e/customconfigs/failure_recovery_policy_test.go
@@ -32,6 +32,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/util/tas"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 	"sigs.k8s.io/kueue/test/util"
@@ -164,6 +165,14 @@ var _ = ginkgo.Describe("Failure Recovery Policy", ginkgo.Ordered, ginkgo.Contin
 			ginkgo.By("starting the kubelet on the node running the pod", func() {
 				cmd := exec.Command("docker", "exec", nodeName, "systemctl", "start", "kubelet")
 				gomega.Expect(cmd.Run()).To(gomega.Succeed())
+			})
+
+			ginkgo.By("waiting for the node to be ready again", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					node := &corev1.Node{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: nodeName, Namespace: ns.Name}, node)).To(gomega.Succeed())
+					g.Expect(tas.IsNodeStatusConditionTrue(node.Status.Conditions, corev1.NodeReady)).To(gomega.BeTrue())
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("deleting the cluster queue", func() {

--- a/test/e2e/customconfigs/failure_recovery_policy_test.go
+++ b/test/e2e/customconfigs/failure_recovery_policy_test.go
@@ -32,7 +32,6 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/features"
-	"sigs.k8s.io/kueue/pkg/util/tas"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 	"sigs.k8s.io/kueue/test/util"
@@ -161,20 +160,18 @@ var _ = ginkgo.Describe("Failure Recovery Policy", ginkgo.Ordered, ginkgo.Contin
 			})
 		})
 
-		ginkgo.AfterEach(func() {
+		ginkgo.JustAfterEach(func() {
 			ginkgo.By("starting the kubelet on the node running the pod", func() {
 				cmd := exec.Command("docker", "exec", nodeName, "systemctl", "start", "kubelet")
 				gomega.Expect(cmd.Run()).To(gomega.Succeed())
 			})
 
 			ginkgo.By("waiting for the node to be ready again", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					node := &corev1.Node{}
-					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: nodeName, Namespace: ns.Name}, node)).To(gomega.Succeed())
-					g.Expect(tas.IsNodeStatusConditionTrue(node.Status.Conditions, corev1.NodeReady)).To(gomega.BeTrue())
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+				util.ExpectNodeToBecomeReady(ctx, k8sClient, nodeName, lq)
 			})
+		})
 
+		ginkgo.AfterEach(func() {
 			ginkgo.By("deleting the cluster queue", func() {
 				util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
 			})

--- a/test/e2e/tas/hotswap_test.go
+++ b/test/e2e/tas/hotswap_test.go
@@ -22,7 +22,6 @@ import (
 	"os/exec"
 	"slices"
 
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
@@ -109,13 +108,8 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 					Status: corev1.ConditionTrue,
 				})
 
-				gomega.Eventually(func(g gomega.Gomega) {
-					var node corev1.Node
-					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: nodeToRestore.Name}, &node)).To(gomega.Succeed())
-					g.Expect(tas.IsNodeStatusConditionTrue(node.Status.Conditions, corev1.NodeReady)).To(gomega.BeTrue())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				util.ExpectNodeToBecomeReady(ctx, k8sClient, nodeToRestore.Name, localQueue)
 
-				waitForDummyWorkloadToRunOnNode(nodeToRestore, localQueue)
 				nodeToRestore = nil
 			}
 			gomega.Expect(util.DeleteAllJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
@@ -709,25 +703,6 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 		})
 	})
 })
-
-func waitForDummyWorkloadToRunOnNode(node *corev1.Node, lq *kueue.LocalQueue) {
-	ginkgo.By(fmt.Sprintf("Waiting for a dummy workload to run on the recovered node %s", node.Name), func() {
-		dummyJob := testingjob.MakeJob(fmt.Sprintf("dummy-job-%s", node.Name), lq.Namespace).
-			Queue(kueue.LocalQueueName(lq.Name)).
-			NodeSelector(corev1.LabelHostname, node.Name).
-			Image(util.GetAgnHostImage(), util.BehaviorExitFast).
-			Obj()
-		gomega.Expect(k8sClient.Create(ctx, dummyJob)).To(gomega.Succeed())
-		gomega.Eventually(func(g gomega.Gomega) {
-			var createdDummyJob batchv1.Job
-			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(dummyJob), &createdDummyJob)).To(gomega.Succeed())
-			g.Expect(createdDummyJob.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(batchv1.JobCondition{
-				Type:   batchv1.JobComplete,
-				Status: corev1.ConditionTrue,
-			}, cmpopts.IgnoreFields(batchv1.JobCondition{}, "LastTransitionTime", "LastProbeTime", "Reason", "Message"))))
-		}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
-	})
-}
 
 func expectWorkloadTopologyAssignment(ctx context.Context, k8sClient client.Client, wlKey client.ObjectKey, numPods int, expectedNodes []string) {
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -73,6 +73,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
@@ -1448,4 +1449,38 @@ func WaitForDRAExampleDriverAvailability(ctx context.Context, k8sClient client.C
 		g.Expect(daemonset.Status.DesiredNumberScheduled).To(gomega.Equal(daemonset.Status.NumberAvailable))
 	}, VeryLongTimeout, Interval).Should(gomega.Succeed())
 	ginkgo.GinkgoLogr.Info("DaemonSet is available in the cluster", "daemonset", dsKey, "cluster", clusterName, "waitingTime", time.Since(waitForAvailableStart))
+}
+func ExpectNodeToBecomeReady(ctx context.Context, c client.Client, nodeName string, localQueue *kueue.LocalQueue) {
+	ginkgo.GinkgoHelper()
+
+	node := &corev1.Node{}
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(c.Get(ctx, client.ObjectKey{Name: nodeName}, node)).To(gomega.Succeed())
+		g.Expect(utiltas.IsNodeStatusConditionTrue(node.Status.Conditions, corev1.NodeReady)).To(gomega.BeTrue())
+	}, Timeout, Interval).Should(gomega.Succeed())
+
+	waitForDummyWorkloadToRunOnNode(ctx, c, node, localQueue)
+}
+
+func waitForDummyWorkloadToRunOnNode(ctx context.Context, c client.Client, node *corev1.Node, lq *kueue.LocalQueue) {
+	ginkgo.GinkgoHelper()
+
+	ginkgo.By(fmt.Sprintf("Waiting for a dummy workload to run on the recovered node %s", node.Name), func() {
+		dummyJob := testingjob.MakeJob(fmt.Sprintf("dummy-job-%s", node.Name), lq.Namespace).
+			Queue(kueue.LocalQueueName(lq.Name)).
+			NodeSelector(corev1.LabelHostname, node.Name).
+			Image(GetAgnHostImage(), BehaviorExitFast).
+			Obj()
+
+		MustCreate(ctx, c, dummyJob)
+
+		gomega.Eventually(func(g gomega.Gomega) {
+			var createdDummyJob batchv1.Job
+			g.Expect(c.Get(ctx, client.ObjectKeyFromObject(dummyJob), &createdDummyJob)).To(gomega.Succeed())
+			g.Expect(createdDummyJob.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(batchv1.JobCondition{
+				Type:   batchv1.JobComplete,
+				Status: corev1.ConditionTrue,
+			}, cmpopts.IgnoreFields(batchv1.JobCondition{}, "LastTransitionTime", "LastProbeTime", "Reason", "Message"))))
+		}, MediumTimeout, Interval).Should(gomega.Succeed())
+	})
 }


### PR DESCRIPTION
Cherry pick of #10120 on release-0.16.

#10120: Wait for the node to be ready in FailureRecoveryPolicy e2e test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup
/kind flake


```release-note
NONE
```