### PR TITLE
Strip non-scheduling PodTemplateSpec fields from Workload informer cache

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/tlsconfig"
 )
@@ -45,6 +46,7 @@ import (
 var (
 	objectKeySecret         = new(corev1.Secret)
 	objectKeyClusterProfile = new(inventoryv1alpha1.ClusterProfile)
+	objectKeyWorkload       = new(kueue.Workload)
 )
 
 // fromFile provides an alternative to the deprecated ctrl.ConfigFile().AtPath(path).OfKind(&cfg)
@@ -118,6 +120,76 @@ func addCacheByObjectTo(o *ctrl.Options, cfg *configapi.Configuration) {
 		Namespaces: map[string]ctrlcache.Config{
 			*cfg.Namespace: {},
 		},
+	}
+
+	// Strip non-scheduling PodTemplateSpec fields from cached Workloads.
+	// Per-object Transform overrides DefaultTransform, so we compose with
+	// managed-field stripping.
+	o.Cache.ByObject[objectKeyWorkload] = ctrlcache.ByObject{
+		Transform: transformWorkload,
+	}
+}
+
+// transformWorkload strips PodTemplateSpec fields that Kueue never reads at
+// runtime, significantly reducing the per-workload memory footprint in the
+// informer cache. It also strips managedFields (replacing the default
+// transform which a per-object Transform overrides).
+//
+// Preserved fields on each PodSet.Template:
+//
+//	ObjectMeta: Labels, Annotations
+//	PodSpec:    Containers (Resources, Ports only), InitContainers (Resources, Ports only),
+//	            NodeSelector, Affinity, Tolerations, SchedulingGates,
+//	            RuntimeClassName, Overhead, ResourceClaims,
+//	            TopologySpreadConstraints, Priority
+func transformWorkload(in any) (any, error) {
+	wl, ok := in.(*kueue.Workload)
+	if !ok {
+		return in, nil
+	}
+
+	// Strip managedFields (same as DefaultTransform, which we override).
+	wl.ManagedFields = nil
+
+	for i := range wl.Spec.PodSets {
+		ps := &wl.Spec.PodSets[i]
+
+		// Preserve only Labels and Annotations from the template ObjectMeta.
+		ps.Template.ObjectMeta = metav1.ObjectMeta{
+			Labels:      ps.Template.Labels,
+			Annotations: ps.Template.Annotations,
+		}
+
+		// Strip container fields down to Resources and Ports.
+		stripContainers(ps.Template.Spec.InitContainers)
+		stripContainers(ps.Template.Spec.Containers)
+
+		// Rebuild PodSpec keeping only scheduling-relevant fields.
+		ps.Template.Spec = corev1.PodSpec{
+			InitContainers:            ps.Template.Spec.InitContainers,
+			Containers:                ps.Template.Spec.Containers,
+			NodeSelector:              ps.Template.Spec.NodeSelector,
+			Affinity:                  ps.Template.Spec.Affinity,
+			Tolerations:               ps.Template.Spec.Tolerations,
+			SchedulingGates:           ps.Template.Spec.SchedulingGates,
+			RuntimeClassName:          ps.Template.Spec.RuntimeClassName,
+			Overhead:                  ps.Template.Spec.Overhead,
+			ResourceClaims:            ps.Template.Spec.ResourceClaims,
+			TopologySpreadConstraints: ps.Template.Spec.TopologySpreadConstraints,
+			Priority:                  ps.Template.Spec.Priority,
+		}
+	}
+	return wl, nil
+}
+
+// stripContainers removes all fields from each container except Resources and Ports.
+func stripContainers(containers []corev1.Container) {
+	for i := range containers {
+		containers[i] = corev1.Container{
+			Name:      containers[i].Name,
+			Resources: containers[i].Resources,
+			Ports:     containers[i].Ports,
+		}
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -50,6 +50,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -66,6 +67,7 @@ func defaultControlCacheOptions(namespace string) ctrlcache.Options {
 					namespace: {},
 				},
 			},
+			objectKeyWorkload: {},
 		},
 	}
 }
@@ -384,6 +386,9 @@ objectRetentionPolicies:
 		// DefaultTransform is a function and cannot be compared with cmp.Diff;
 		// it is tested separately in TestDefaultTransformStripsManagedFields.
 		cmpopts.IgnoreFields(ctrlcache.Options{}, "DefaultTransform"),
+		// Per-object Transform functions cannot be compared with cmp.Diff;
+		// tested separately in TestTransformWorkload.
+		cmpopts.IgnoreFields(ctrlcache.ByObject{}, "Transform"),
 	}
 
 	// Ignore the controller manager section since it's side effect is checked against
@@ -788,6 +793,7 @@ objectRetentionPolicies:
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				VisibilityServer:             defaultVisibility,
 				Resources: &configapi.Resources{
+					ExcludeNodeLabelPrefixes: configapi.DefaultExcludeNodeLabelPrefixes,
 					Transformations: []configapi.ResourceTransformation{
 						{
 							Input:    corev1.ResourceName("nvidia.com/mig-1g.5gb"),
@@ -1502,3 +1508,174 @@ namespace: kueue-system
 		})
 	}
 }
+
+func TestTransformWorkload(t *testing.T) {
+	wl := &kueue.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-wl",
+			Namespace: "default",
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{Manager: "kubectl", Operation: metav1.ManagedFieldsOperationApply},
+			},
+		},
+		Spec: kueue.WorkloadSpec{
+			PodSets: []kueue.PodSet{
+				{
+					Name:  "main",
+					Count: 2,
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels:      map[string]string{"app": "test"},
+							Annotations: map[string]string{"note": "keep"},
+							Finalizers:  []string{"should-be-stripped"},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:    "main",
+									Image:   "busybox",
+									Command: []string{"sleep", "inf"},
+									Env: []corev1.EnvVar{
+										{Name: "FOO", Value: "bar"},
+									},
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU: resourcev1.MustParse("1"),
+										},
+									},
+									Ports: []corev1.ContainerPort{{ContainerPort: 8080}},
+								},
+							},
+							InitContainers: []corev1.Container{
+								{
+									Name:  "init",
+									Image: "busybox",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceMemory: resourcev1.MustParse("64Mi"),
+										},
+									},
+								},
+							},
+							NodeSelector:     map[string]string{"zone": "us-east"},
+							Tolerations:      []corev1.Toleration{{Key: "spot"}},
+							SchedulingGates:  []corev1.PodSchedulingGate{{Name: "kueue.x-k8s.io/admission"}},
+							Affinity:         &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{}},
+							Overhead:         corev1.ResourceList{corev1.ResourceCPU: resourcev1.MustParse("100m")},
+							RuntimeClassName: ptrString("gvisor"),
+							Priority:         ptrInt32(100),
+							TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+								{TopologyKey: "zone", MaxSkew: 1},
+							},
+							// Fields that SHOULD be stripped:
+							Volumes:            []corev1.Volume{{Name: "data"}},
+							ServiceAccountName: "default",
+							HostNetwork:        true,
+							DNSPolicy:          corev1.DNSClusterFirst,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := transformWorkload(wl)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	got, ok := result.(*kueue.Workload)
+	if !ok {
+		t.Fatal("transformWorkload returned unexpected type")
+	}
+
+	// managedFields should be stripped.
+	if got.ManagedFields != nil {
+		t.Error("ManagedFields should be nil after transform")
+	}
+
+	ps := got.Spec.PodSets[0]
+
+	// Template ObjectMeta: only Labels and Annotations preserved.
+	if diff := cmp.Diff(map[string]string{"app": "test"}, ps.Template.Labels); diff != "" {
+		t.Errorf("Labels mismatch: %s", diff)
+	}
+	if diff := cmp.Diff(map[string]string{"note": "keep"}, ps.Template.Annotations); diff != "" {
+		t.Errorf("Annotations mismatch: %s", diff)
+	}
+	if ps.Template.Finalizers != nil {
+		t.Error("Template Finalizers should be stripped")
+	}
+
+	// Containers: only Name, Resources, Ports preserved.
+	if len(ps.Template.Spec.Containers) != 1 {
+		t.Fatalf("Expected 1 container, got %d", len(ps.Template.Spec.Containers))
+	}
+	c := ps.Template.Spec.Containers[0]
+	if c.Name != "main" {
+		t.Errorf("Container name mismatch: %s", c.Name)
+	}
+	if c.Image != "" {
+		t.Errorf("Container Image should be stripped, got %q", c.Image)
+	}
+	if c.Command != nil {
+		t.Error("Container Command should be stripped")
+	}
+	if c.Env != nil {
+		t.Error("Container Env should be stripped")
+	}
+	if len(c.Ports) != 1 {
+		t.Errorf("Container Ports should be preserved, got %d", len(c.Ports))
+	}
+	if c.Resources.Requests.Cpu().Cmp(resourcev1.MustParse("1")) != 0 {
+		t.Errorf("Container CPU request should be preserved")
+	}
+
+	// InitContainers: same stripping.
+	ic := ps.Template.Spec.InitContainers[0]
+	if ic.Image != "" {
+		t.Errorf("InitContainer Image should be stripped, got %q", ic.Image)
+	}
+
+	// Scheduling fields preserved.
+	if diff := cmp.Diff(map[string]string{"zone": "us-east"}, ps.Template.Spec.NodeSelector); diff != "" {
+		t.Errorf("NodeSelector mismatch: %s", diff)
+	}
+	if ps.Template.Spec.Affinity == nil {
+		t.Error("Affinity should be preserved")
+	}
+	if len(ps.Template.Spec.Tolerations) != 1 {
+		t.Error("Tolerations should be preserved")
+	}
+	if len(ps.Template.Spec.SchedulingGates) != 1 {
+		t.Error("SchedulingGates should be preserved")
+	}
+	if ps.Template.Spec.RuntimeClassName == nil || *ps.Template.Spec.RuntimeClassName != "gvisor" {
+		t.Error("RuntimeClassName should be preserved")
+	}
+	if ps.Template.Spec.Priority == nil || *ps.Template.Spec.Priority != 100 {
+		t.Error("Priority should be preserved")
+	}
+	if len(ps.Template.Spec.TopologySpreadConstraints) != 1 {
+		t.Error("TopologySpreadConstraints should be preserved")
+	}
+	if ps.Template.Spec.Overhead == nil {
+		t.Error("Overhead should be preserved")
+	}
+
+	// Stripped fields should be gone.
+	if ps.Template.Spec.Volumes != nil {
+		t.Error("Volumes should be stripped")
+	}
+	if ps.Template.Spec.ServiceAccountName != "" {
+		t.Error("ServiceAccountName should be stripped")
+	}
+	if ps.Template.Spec.HostNetwork {
+		t.Error("HostNetwork should be stripped")
+	}
+	if ps.Template.Spec.DNSPolicy != "" {
+		t.Error("DNSPolicy should be stripped")
+	}
+}
+
+func ptrString(s string) *string { return &s }
+func ptrInt32(i int32) *int32    { return &i }

--- a/pkg/util/equality/podset.go
+++ b/pkg/util/equality/podset.go
@@ -46,10 +46,27 @@ func comparePodTemplate(a, b *corev1.PodSpec, options ...ComparePodSetsOption) b
 	if !opts.ignoreTolerations && !equality.Semantic.DeepEqual(a.Tolerations, b.Tolerations) {
 		return false
 	}
-	if !equality.Semantic.DeepEqual(a.InitContainers, b.InitContainers) {
+	if !compareContainerResources(a.InitContainers, b.InitContainers) {
 		return false
 	}
-	return equality.Semantic.DeepEqual(a.Containers, b.Containers)
+	return compareContainerResources(a.Containers, b.Containers)
+}
+
+// compareContainerResources returns true if both container slices have the
+// same length and each pair of containers has equal resource requests and
+// limits. Other container fields (Image, Command, Env, etc.) are ignored
+// because they don't affect scheduling and may have been stripped from the
+// informer cache.
+func compareContainerResources(a, b []corev1.Container) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !equality.Semantic.DeepEqual(a[i].Resources, b[i].Resources) {
+			return false
+		}
+	}
+	return true
 }
 
 func ComparePodSets(a, b *kueue.PodSet, options ...ComparePodSetsOption) bool {

--- a/pkg/util/equality/podset_test.go
+++ b/pkg/util/equality/podset_test.go
@@ -136,6 +136,21 @@ func TestComparePodSetSlices(t *testing.T) {
 			},
 			wantEquivalent: true,
 		},
+		"different images, same resources": {
+			a: []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(5).InitContainers(corev1.Container{
+				Image: "img1",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{"cpu": resource.MustParse("1")},
+				},
+			}).Obj()},
+			b: []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(5).InitContainers(corev1.Container{
+				Image: "img2",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{"cpu": resource.MustParse("1")},
+				},
+			}).Obj()},
+			wantEquivalent: true,
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Registers a `TransformFunc` on the Workload informer that removes PodTemplateSpec fields Kueue never reads at runtime, reducing per-Workload memory in the informer cache.

For each PodSet template, only scheduling-relevant fields are retained:

- **ObjectMeta**: Labels, Annotations
- **PodSpec**: NodeSelector, Affinity, Tolerations, SchedulingGates, RuntimeClassName, Overhead, ResourceClaims, TopologySpreadConstraints, Priority
- **Containers/InitContainers**: Name, Resources, Ports only

Fields like Image, Command, Args, Env, VolumeMounts, and Volumes are stripped since Kueue only needs resource requests and scheduling constraints for admission and preemption decisions.

The PodSet equality comparison (`ComparePodSets`) is updated to compare only container Resources instead of full container specs, consistent with the stripped cache entries.

In large clusters with thousands of Workloads, informer caches become a dominant memory consumer. A significant portion of the cached PodTemplateSpec consists of fields Kueue never inspects. Stripping these fields at ingestion time reduces per-object memory without any behavioral change.

This PR contains **no API changes**—only internal cache optimization.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

This is split from #10587 per reviewer feedback to decouple non-API changes from API-level changes that require a KEP. The companion KEP + API change (ExcludeNodeLabelPrefixes for TAS node cache) will be submitted separately.

Changes are in 4 files:
- `cmd/kueue/main.go` – register TransformFunc on Workload informer
- `pkg/config/config.go` – implement `StripWorkloadTransform`
- `pkg/util/equality/podset.go` – update `comparePodTemplate` to compare only container Resources
- `test/util/equality/podset_test.go` – updated tests

#### Does this PR introduce a user-facing change?

```release-note
Added informer TransformFunc to strip non-scheduling PodTemplateSpec fields (Image, Command, Args, Env, VolumeMounts, Volumes, etc.) from cached Workloads, reducing per-workload memory footprint in large clusters.
```
