### PR TITLE
site: Add Sandbox operator integration documentation

### DIFF
--- a/site/content/en/docs/tasks/run/external_workloads/_index.md
+++ b/site/content/en/docs/tasks/run/external_workloads/_index.md
@@ -18,4 +18,5 @@ You can use AppWrapper, job-based workloads and pod-based workloads.
 - [Run a Flux Miniclusters using job integration](/docs/tasks/run/external_workloads/flux_miniclusters).
 - [Run an Argo Workflow using pod integration](/docs/tasks/run/external_workloads/argo_workflow).
 - [Run a tekton cd pipeline using pod integration](/docs/tasks/run/external_workloads/tektoncd)
+- [Run a Sandbox using pod integration](/docs/tasks/run/external_workloads/sandbox)
 

--- a/site/content/en/docs/tasks/run/external_workloads/sandbox.md
+++ b/site/content/en/docs/tasks/run/external_workloads/sandbox.md
@@ -1,0 +1,67 @@
+---
+title: "Run A Sandbox"
+linkTitle: "Sandbox"
+date: 2026-04-19
+weight: 8
+description: >
+  Integrate Kueue with the Sandbox operator.
+---
+
+This page shows how to leverage Kueue's scheduling and resource management capabilities when running [Sandboxes](https://github.com/kubernetes-sigs/agent-sandbox).
+
+This guide is for [batch users](/docs/tasks#batch-user) that have a basic understanding of Kueue. For more information, see [Kueue's overview](/docs/overview).
+
+The Sandbox operator provides isolated environments for running AI agent workloads.
+Kueue manages the Pods created by the Sandbox controller through the [Plain Pod](/docs/tasks/run/plain_pods) integration,
+where each Sandbox Pod is represented as a single independent Plain Pod.
+
+## Before you begin
+
+1. Learn how to [install Kueue with a custom manager configuration](/docs/installation/#install-a-custom-configured-released-version).
+
+1. Follow the steps in [Run Plain Pods](/docs/tasks/run/plain_pods/#before-you-begin) to learn how to enable and configure the `pod` integration.
+
+1. Check [Administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) for details on the initial Kueue setup.
+
+1. Install the [Sandbox operator](https://github.com/kubernetes-sigs/agent-sandbox).
+
+## Sandbox definition
+
+### a. Queue selection
+
+The target [local queue](/docs/concepts/local_queue) should be specified in the
+`spec.podTemplate.metadata.labels` section of the Sandbox configuration.
+
+```yaml
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        kueue.x-k8s.io/queue-name: user-queue
+```
+
+### b. Configure the resource needs
+
+The resource needs of the workload can be configured in the `spec.podTemplate.spec.containers`.
+
+```yaml
+spec:
+  podTemplate:
+    spec:
+      containers:
+      - resources:
+          requests:
+            cpu: "100m"
+            memory: "200Mi"
+```
+
+## Sample Sandbox
+
+Here is a sample Sandbox:
+
+{{< include "examples/pod-based-workloads/sample-sandbox.yaml" "yaml" >}}
+
+## Limitations
+
+- Kueue will only manage pods created by the Sandbox operator.
+- Each Sandbox Pod will create a new Workload resource and must wait for admission by Kueue.

--- a/site/static/examples/pod-based-workloads/sample-sandbox.yaml
+++ b/site/static/examples/pod-based-workloads/sample-sandbox.yaml
@@ -1,0 +1,20 @@
+apiVersion: agents.x-k8s.io/v1alpha1
+kind: Sandbox
+metadata:
+  name: hello-world-kueue
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        kueue.x-k8s.io/queue-name: user-queue
+    spec:
+      containers:
+      - name: hello
+        image: busybox
+        command: ["sleep"]
+        args: ["6000"]
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "200Mi"
+      restartPolicy: Never


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/area integrations

#### What this PR does / why we need it:

Adds documentation for integrating Kueue with the Kubernetes
[Sandbox operator](https://github.com/kubernetes-sigs/agent-sandbox)
(agent-sandbox) using the pod integration. The Sandbox operator provides
isolated environments for running AI agent workloads, and users can
leverage Kueue's scheduling and resource management by setting the
queue-name label on the Sandbox's podTemplate.

This adds:
- A new documentation page under external workloads
- A sample Sandbox manifest in pod-based-workloads examples
- An entry in the external frameworks index

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

The integration works through the existing plain Pod integration,
similar to Argo Workflows and Tekton.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

---
> **AI Assistance Disclosure**: This pull request was created with the assistance of AI (Claude Code by Anthropic).