### PR TITLE
TAS: split topology assignment state

### DIFF
--- a/pkg/cache/scheduler/tas_balanced_placement.go
+++ b/pkg/cache/scheduler/tas_balanced_placement.go
@@ -236,17 +236,18 @@ func sortDomainsByCapacityAndEntropy(domains []*domain) {
 }
 
 // findBestDomainsForBalancedPlacement evaluates domains for balanced placement.
-// It returns the best set of domains, the balance threshold, and whether a balanced placement is possible.
-func findBestDomainsForBalancedPlacement(s *TASFlavorSnapshot, state *findTopologyAssignmentState) ([]*domain, int32) {
+// It returns the best set of domains and the balance threshold.
+// A threshold greater than zero means balanced placement is possible.
+func findBestDomainsForBalancedPlacement(s *TASFlavorSnapshot, params *topologyAssignmentParameters) ([]*domain, int32) {
 	// check if balanced placement is possible: look one level above the preferred level
 	// see if any (single) domain on that level fits the request and compute for each of
 	// them the balance threshold value
-	sliceCount := state.count / state.sliceSize
+	sliceCount := params.count / params.sliceSize
 	var requestedLevelDomainsToConsider [][]*domain
-	if state.levelIdx == 0 {
+	if params.requestedLevelIdx == 0 {
 		requestedLevelDomainsToConsider = [][]*domain{slices.Collect(maps.Values(s.domainsPerLevel[0]))}
 	} else {
-		for _, higherLevelDomain := range slices.Collect(maps.Values(s.domainsPerLevel[state.levelIdx-1])) {
+		for _, higherLevelDomain := range slices.Collect(maps.Values(s.domainsPerLevel[params.requestedLevelIdx-1])) {
 			requestedLevelDomainsToConsider = append(requestedLevelDomainsToConsider, higherLevelDomain.children)
 		}
 	}
@@ -256,15 +257,15 @@ func findBestDomainsForBalancedPlacement(s *TASFlavorSnapshot, state *findTopolo
 	var currFitDomain []*domain
 
 	for _, requestedLevelSiblingDomains := range requestedLevelDomainsToConsider {
-		lowerLevelDomains := getLowerLevelDomains(s, requestedLevelSiblingDomains, state.levelIdx, state.sliceLevelIdx)
-		fits, selectedDomainsCount, lastDomainWithLeader, lastDomain := evaluateGreedyAssignment(s, lowerLevelDomains, sliceCount, state.leaderCount)
+		lowerLevelDomains := getLowerLevelDomains(s, requestedLevelSiblingDomains, params.requestedLevelIdx, params.sliceLevelIdx)
+		fits, selectedDomainsCount, lastDomainWithLeader, lastDomain := evaluateGreedyAssignment(s, lowerLevelDomains, sliceCount, params.leaderCount)
 		if !fits {
 			continue
 		}
 		threshold := balanceThresholdValue(sliceCount, selectedDomainsCount, lastDomainWithLeader, lastDomain)
 		if threshold >= bestThreshold {
-			s.pruneDomainsBelowThreshold(requestedLevelSiblingDomains, threshold, state.sliceSize, state.sliceLevelIdx, state.levelIdx)
-			_, requestedLevelDomainCount, _, _ := evaluateGreedyAssignment(s, requestedLevelSiblingDomains, sliceCount, state.leaderCount)
+			s.pruneDomainsBelowThreshold(requestedLevelSiblingDomains, threshold, params.sliceSize, params.sliceLevelIdx, params.requestedLevelIdx)
+			_, requestedLevelDomainCount, _, _ := evaluateGreedyAssignment(s, requestedLevelSiblingDomains, sliceCount, params.leaderCount)
 			if threshold > bestThreshold || (threshold == bestThreshold && requestedLevelDomainCount < bestDomainCountOnRequestedLevel) {
 				bestThreshold = threshold
 				bestDomainCountOnRequestedLevel = requestedLevelDomainCount
@@ -276,22 +277,23 @@ func findBestDomainsForBalancedPlacement(s *TASFlavorSnapshot, state *findTopolo
 }
 
 // applyBalancedPlacementAlgorithm applies the balanced placement algorithm to determine domain assignments
-// on the requested level(s)
-func applyBalancedPlacementAlgorithm(s *TASFlavorSnapshot, state *findTopologyAssignmentState, bestThreshold int32, currFitDomain []*domain) ([]*domain, int, string) {
-	sliceCount := state.count / state.sliceSize
+// on the requested level(s) and returns the selected domains, the starting level index, and
+// failure reason.
+func applyBalancedPlacementAlgorithm(s *TASFlavorSnapshot, params *topologyAssignmentParameters, bestThreshold int32, currFitDomain []*domain) ([]*domain, int, string) {
+	sliceCount := params.count / params.sliceSize
 	var fitLevelIdx int
-	if state.levelIdx < state.sliceLevelIdx {
-		resultDomains := selectOptimalDomainSetToFit(s, currFitDomain, sliceCount, state.leaderCount, state.sliceSize, true)
+	if params.requestedLevelIdx < params.sliceLevelIdx {
+		resultDomains := selectOptimalDomainSetToFit(s, currFitDomain, sliceCount, params.leaderCount, params.sliceSize, true)
 		if resultDomains == nil {
 			return nil, 0, "TAS Balanced Placement: Cannot find optimal domain set to fit the request"
 		}
 		currFitDomain = s.lowerLevelDomains(resultDomains)
-		fitLevelIdx = state.levelIdx + 1
+		fitLevelIdx = params.requestedLevelIdx + 1
 	} else {
-		fitLevelIdx = state.levelIdx
+		fitLevelIdx = params.requestedLevelIdx
 	}
 	var reason string
-	currFitDomain, reason = placeSlicesOnDomainsBalanced(s, currFitDomain, sliceCount, state.leaderCount, state.sliceSize, bestThreshold)
+	currFitDomain, reason = placeSlicesOnDomainsBalanced(s, currFitDomain, sliceCount, params.leaderCount, params.sliceSize, bestThreshold)
 	if len(reason) > 0 {
 		return nil, 0, reason
 	}

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -429,9 +429,9 @@ type ExclusionStats struct {
 	TotalNodes     int
 }
 
-// findTopologyAssignmentState stores derived inputs for a single run of the
-// TAS assignment algorithm.
-type findTopologyAssignmentState struct {
+// topologyAssignmentPodRequirements stores pod-driven scheduling filters and
+// resource inputs that are only needed while filling per-domain counts.
+type topologyAssignmentPodRequirements struct {
 	requests                  resources.Requests
 	leaderRequests            *resources.Requests
 	assumedUsage              map[utiltas.TopologyDomainID]resources.Requests
@@ -439,17 +439,28 @@ type findTopologyAssignmentState struct {
 	selector                  labels.Selector
 	affinitySelector          *nodeaffinity.NodeSelector
 	requiredReplacementDomain utiltas.TopologyDomainID
-	stats                     *ExclusionStats
-	sliceSizeAtLevel          map[int]int32
-	sliceSize                 int32
-	count                     int32
-	leaderCount               int32
-	levelIdx                  int
-	sliceLevelIdx             int
-	required                  bool
-	unconstrained             bool
 	simulateEmpty             bool
-	multiLayerConstraints     []kueue.PodsetSliceRequiredTopologyConstraint
+}
+
+// topologyAssignmentParameters stores placement-specific inputs that remain
+// relevant after domain capacities are computed.
+type topologyAssignmentParameters struct {
+	sliceSizeAtLevel      map[int]int32
+	sliceSize             int32
+	count                 int32
+	leaderCount           int32
+	requestedLevelIdx     int
+	sliceLevelIdx         int
+	required              bool
+	unconstrained         bool
+	multiLayerConstraints []kueue.PodsetSliceRequiredTopologyConstraint
+}
+
+// findTopologyAssignmentState stores the derived state for a single run of the
+// TAS placement algorithm.
+type findTopologyAssignmentState struct {
+	topologyAssignmentParameters
+	stats *ExclusionStats
 }
 
 func newExclusionStats() *ExclusionStats {
@@ -795,19 +806,23 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	leaderTasPodSetRequests *TASPodSetRequests,
 	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
 	simulateEmpty bool, requiredReplacementDomain utiltas.TopologyDomainID) (map[kueue.PodSetReference]*utiltas.TopologyAssignment, string) {
-	state := &findTopologyAssignmentState{
+	requirements := &topologyAssignmentPodRequirements{
 		assumedUsage:              assumedUsage,
 		requiredReplacementDomain: requiredReplacementDomain,
-		stats:                     newExclusionStats(),
-		count:                     workersTasPodSetRequests.Count,
 		simulateEmpty:             simulateEmpty,
 	}
-	state.requests = workersTasPodSetRequests.SinglePodRequests.Clone()
-	state.requests.Add(resources.Requests{corev1.ResourcePods: 1})
+	state := &findTopologyAssignmentState{
+		topologyAssignmentParameters: topologyAssignmentParameters{
+			count: workersTasPodSetRequests.Count,
+		},
+		stats: newExclusionStats(),
+	}
+	requirements.requests = workersTasPodSetRequests.SinglePodRequests.Clone()
+	requirements.requests.Add(resources.Requests{corev1.ResourcePods: 1})
 
 	if leaderTasPodSetRequests != nil {
-		state.leaderRequests = ptr.To(leaderTasPodSetRequests.SinglePodRequests.Clone())
-		state.leaderRequests.Add(resources.Requests{corev1.ResourcePods: 1})
+		requirements.leaderRequests = ptr.To(leaderTasPodSetRequests.SinglePodRequests.Clone())
+		requirements.leaderRequests.Add(resources.Requests{corev1.ResourcePods: 1})
 		state.leaderCount = 1
 	}
 
@@ -832,11 +847,11 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	if topologyKey == nil {
 		return nil, "topology level not specified"
 	}
-	levelIdx, found := s.resolveLevelIdx(*topologyKey)
+	requestedLevelIdx, found := s.resolveLevelIdx(*topologyKey)
 	if !found {
 		return nil, fmt.Sprintf("no requested topology level: %s", *topologyKey)
 	}
-	state.levelIdx = levelIdx
+	state.requestedLevelIdx = requestedLevelIdx
 
 	sliceTopologyKey := s.sliceLevelKeyWithDefault(workersTasPodSetRequests.PodSet.TopologyRequest, s.lowestLevel())
 	sliceLevelIdx, found := s.resolveLevelIdx(sliceTopologyKey)
@@ -845,7 +860,7 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	}
 	state.sliceLevelIdx = sliceLevelIdx
 
-	if state.levelIdx > state.sliceLevelIdx {
+	if state.requestedLevelIdx > state.sliceLevelIdx {
 		return nil, fmt.Sprintf("podset slice topology %s is above the podset topology %s", sliceTopologyKey, *topologyKey)
 	}
 
@@ -859,16 +874,16 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 		state.multiLayerConstraints = workersTasPodSetRequests.PodSet.TopologyRequest.PodsetSliceRequiredTopologyConstraints
 	}
 
-	state.tolerations = append(info.Tolerations, s.tolerations...)
+	requirements.tolerations = append(info.Tolerations, s.tolerations...)
 
 	if s.isLowestLevelNode {
 		sel, err := labels.ValidatedSelectorFromSet(info.NodeSelector)
 		if err != nil {
 			return nil, fmt.Sprintf("invalid node selectors: %s, reason: %s", info.NodeSelector, err)
 		}
-		state.selector = sel
+		requirements.selector = sel
 	} else {
-		state.selector = labels.Everything()
+		requirements.selector = labels.Everything()
 	}
 
 	if info.Affinity != nil && info.Affinity.NodeAffinity != nil {
@@ -877,12 +892,12 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 			if err != nil {
 				return nil, fmt.Sprintf("invalid affinity node selectors: %s, reason: %s", requiredAffinity, err)
 			}
-			state.affinitySelector = affinitySelector
+			requirements.affinitySelector = affinitySelector
 		}
 	}
 
 	// phase 1 - determine the number of pods and slices which can fit in each topology domain
-	s.fillInCounts(state)
+	s.fillInCounts(requirements, state)
 
 	// phase 2a: determine the level at which the assignment is done along with
 	// the domains which can accommodate all pods/slices
@@ -891,10 +906,10 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	var useBalancedPlacement bool
 	if features.Enabled(features.TASBalancedPlacement) && !state.required && !state.unconstrained {
 		var bestThreshold int32
-		currFitDomain, bestThreshold = findBestDomainsForBalancedPlacement(s, state)
+		currFitDomain, bestThreshold = findBestDomainsForBalancedPlacement(s, &state.topologyAssignmentParameters)
 		useBalancedPlacement = bestThreshold > 0
 		if useBalancedPlacement {
-			currFitDomain, fitLevelIdx, reason = applyBalancedPlacementAlgorithm(s, state, bestThreshold, currFitDomain)
+			currFitDomain, fitLevelIdx, reason = applyBalancedPlacementAlgorithm(s, &state.topologyAssignmentParameters, bestThreshold, currFitDomain)
 			if len(reason) > 0 {
 				return nil, reason
 			}
@@ -902,7 +917,7 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	}
 
 	if !useBalancedPlacement {
-		fitLevelIdx, currFitDomain, reason = s.findLevelWithFitDomains(state.levelIdx, state)
+		fitLevelIdx, currFitDomain, reason = s.findLevelWithFitDomains(state.requestedLevelIdx, state)
 		if len(reason) > 0 {
 			return nil, reason
 		}
@@ -911,26 +926,26 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	// topology domains at each level
 	// if unconstrained is set, we'll only do it once
 	currFitDomain = s.updateCountsToMinimumGeneric(currFitDomain, state.count, state.leaderCount, state.sliceSize, state.unconstrained, true)
-	levelIdx = fitLevelIdx
-	for ; levelIdx < min(len(s.domainsPerLevel)-1, state.sliceLevelIdx) && !useBalancedPlacement; levelIdx++ {
+	currentLevelIdx := fitLevelIdx
+	for ; currentLevelIdx < min(len(s.domainsPerLevel)-1, state.sliceLevelIdx) && !useBalancedPlacement; currentLevelIdx++ {
 		// If we are "above" the requested slice topology level and we don't run the balanced placement algorithm,
 		// we're greedily assigning pods/slices to all domains without checking what we've assigned to parent domains.
 		sortedLowerDomains := s.sortedDomains(s.lowerLevelDomains(currFitDomain), state.unconstrained)
 		currFitDomain = s.updateCountsToMinimumGeneric(sortedLowerDomains, state.count, state.leaderCount, state.sliceSize, state.unconstrained, true)
 	}
 
-	for ; levelIdx < len(s.domainsPerLevel)-1; levelIdx++ {
+	for ; currentLevelIdx < len(s.domainsPerLevel)-1; currentLevelIdx++ {
 		// If we are "at" or "below" the requested slice topology level or we run the balanced placement algorithm
 		// we have to carefully assign pods to domains based on what we've assigned to parent domains,
 		// that's why we're iterating through each parent domain and assigning `domain.state` amount of pods
 		// to its child domains.
 		sliceSizeOnLevel := state.sliceSize
-		if levelIdx >= state.sliceLevelIdx {
+		if currentLevelIdx >= state.sliceLevelIdx {
 			// Default to 1 (individual pod assignment) below the outermost
 			// slice level, unless an additional slice layer specifies a
 			// different size at this level.
 			sliceSizeOnLevel = 1
-			if sz, ok := state.sliceSizeAtLevel[levelIdx+1]; ok {
+			if sz, ok := state.sliceSizeAtLevel[currentLevelIdx+1]; ok {
 				sliceSizeOnLevel = sz
 			}
 		}
@@ -1215,13 +1230,16 @@ func findBestFitDomainBy(domains []*domain, needed int32, state domainState) *do
 	return bestDomain
 }
 
+// findLevelWithFitDomains finds the highest-priority set of domains at or
+// above the searched level that can accommodate the requested slices and
+// leaders.
 func (s *TASFlavorSnapshot) findLevelWithFitDomains(
-	levelIdx int,
+	searchLevelIdx int,
 	state *findTopologyAssignmentState,
 ) (int, []*domain, string) {
-	domains := s.domainsPerLevel[levelIdx]
+	domains := s.domainsPerLevel[searchLevelIdx]
 	if len(domains) == 0 {
-		return 0, nil, fmt.Sprintf("no topology domains at level: %s", s.levelKeys[levelIdx])
+		return 0, nil, fmt.Sprintf("no topology domains at level: %s", s.levelKeys[searchLevelIdx])
 	}
 	levelDomains := slices.Collect(maps.Values(domains))
 	sortedDomain := s.sortedDomainsWithLeader(levelDomains, state.unconstrained)
@@ -1234,7 +1252,7 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 	}
 	notFitReason := func(slicesFitCount, totalRequestsSlicesCount int32) string {
 		if len(state.multiLayerConstraints) > 0 {
-			return s.multiLayerNotFitMessage(levelIdx, state.count, state.multiLayerConstraints, state.stats)
+			return s.multiLayerNotFitMessage(searchLevelIdx, state.count, state.multiLayerConstraints, state.stats)
 		}
 		return s.notFitMessage(slicesFitCount, totalRequestsSlicesCount, state.sliceSize, state.stats)
 	}
@@ -1242,7 +1260,7 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 	if useLeastFreeCapacityAlgorithm(state.unconstrained) {
 		for _, candidateDomain := range sortedDomain {
 			if candidateDomain.sliceState >= sliceCount {
-				return levelIdx, []*domain{candidateDomain}, ""
+				return searchLevelIdx, []*domain{candidateDomain}, ""
 			}
 		}
 		if state.required {
@@ -1254,8 +1272,8 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 		if state.required {
 			return 0, nil, notFitReason(topDomain.sliceState, sliceCount)
 		}
-		if levelIdx > 0 && !state.unconstrained {
-			return s.findLevelWithFitDomains(levelIdx-1, state)
+		if searchLevelIdx > 0 && !state.unconstrained {
+			return s.findLevelWithFitDomains(searchLevelIdx-1, state)
 		}
 		results := []*domain{}
 		remainingSliceCount := sliceCount
@@ -1297,9 +1315,9 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 		if remainingSliceCount > 0 {
 			return 0, nil, notFitReason(sliceCount-remainingSliceCount, sliceCount)
 		}
-		return levelIdx, results, ""
+		return searchLevelIdx, results, ""
 	}
-	return levelIdx, []*domain{topDomain}, ""
+	return searchLevelIdx, []*domain{topDomain}, ""
 }
 
 func useBestFitAlgorithm(unconstrained bool) bool {
@@ -1545,7 +1563,9 @@ func (s *TASFlavorSnapshot) sortedDomains(domains []*domain, unconstrained bool)
 	return result
 }
 
-func (s *TASFlavorSnapshot) fillInCounts(state *findTopologyAssignmentState) {
+// fillInCounts computes per-domain pod, slice, and leader capacities from the
+// pod requirements, then rolls those capacities up the topology tree.
+func (s *TASFlavorSnapshot) fillInCounts(requirements *topologyAssignmentPodRequirements, state *findTopologyAssignmentState) {
 	for _, domain := range s.domains {
 		// cleanup the state in case some remaining values are present from computing
 		// assignments for previous PodSets.
@@ -1561,7 +1581,7 @@ func (s *TASFlavorSnapshot) fillInCounts(state *findTopologyAssignmentState) {
 		if s.isLowestLevelNode {
 			// 1. Check Tolerations against Node Taints
 			nodeTaints := leaf.node.Taints
-			taint, untolerated := corev1helpers.FindMatchingUntoleratedTaint(s.log, nodeTaints, state.tolerations, func(t *corev1.Taint) bool {
+			taint, untolerated := corev1helpers.FindMatchingUntoleratedTaint(s.log, nodeTaints, requirements.tolerations, func(t *corev1.Taint) bool {
 				return t.Effect == corev1.TaintEffectNoSchedule || t.Effect == corev1.TaintEffectNoExecute
 			}, true)
 			if untolerated {
@@ -1576,14 +1596,14 @@ func (s *TASFlavorSnapshot) fillInCounts(state *findTopologyAssignmentState) {
 				nodeLabelSet = nodeLabels
 			}
 
-			if !state.selector.Matches(nodeLabelSet) {
+			if !requirements.selector.Matches(nodeLabelSet) {
 				s.log.V(5).Info("excluding node that doesn't match nodeSelectors", "domainID", leaf.id, "nodeLabels", nodeLabelSet)
 				state.stats.NodeSelector++
 				continue
 			}
 
 			// 3. Check Node against Affinity Node Selector
-			if state.affinitySelector != nil && !state.affinitySelector.Match(leaf.node.toNode()) {
+			if requirements.affinitySelector != nil && !requirements.affinitySelector.Match(leaf.node.toNode()) {
 				s.log.V(5).Info("excluding node that doesn't match requiredDuringSchedulingIgnoredDuringExecution affinity", "domainID", leaf.id)
 				state.stats.Affinity++
 				continue
@@ -1592,20 +1612,20 @@ func (s *TASFlavorSnapshot) fillInCounts(state *findTopologyAssignmentState) {
 
 		// 4. While correcting the topologyAssignment with a failed node
 		// check if the leaf belongs to the required domain
-		if !belongsToRequiredDomain(leaf, state.requiredReplacementDomain) {
+		if !belongsToRequiredDomain(leaf, requirements.requiredReplacementDomain) {
 			state.stats.TopologyDomain++
 			continue
 		}
 
 		remainingCapacity := leaf.freeCapacity.Clone()
-		if !state.simulateEmpty {
+		if !requirements.simulateEmpty {
 			remainingCapacity.Sub(leaf.tasUsage)
 		}
-		if leafAssumedUsage, found := state.assumedUsage[leaf.id]; found {
+		if leafAssumedUsage, found := requirements.assumedUsage[leaf.id]; found {
 			remainingCapacity.Sub(leafAssumedUsage)
 		}
 		var limitingRes corev1.ResourceName
-		leaf.state, limitingRes = state.requests.CountInWithLimitingResource(remainingCapacity)
+		leaf.state, limitingRes = requirements.requests.CountInWithLimitingResource(remainingCapacity)
 
 		// Track resource exclusions: if this node can't fit even one pod,
 		// identify which resource is the bottleneck.
@@ -1614,12 +1634,12 @@ func (s *TASFlavorSnapshot) fillInCounts(state *findTopologyAssignmentState) {
 		}
 
 		leaf.leaderState = 0
-		if state.leaderRequests != nil && state.leaderRequests.CountIn(remainingCapacity) > 0 {
+		if requirements.leaderRequests != nil && requirements.leaderRequests.CountIn(remainingCapacity) > 0 {
 			leaf.leaderState = 1
-			remainingCapacity.Sub(*state.leaderRequests)
+			remainingCapacity.Sub(*requirements.leaderRequests)
 		}
 
-		leaf.stateWithLeader = state.requests.CountIn(remainingCapacity)
+		leaf.stateWithLeader = requirements.requests.CountIn(remainingCapacity)
 	}
 	for _, root := range s.roots {
 		s.fillInCountsHelper(root, state.sliceSize, state.sliceLevelIdx, 0, state.sliceSizeAtLevel)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area tas

#### What this PR does / why we need it:
Split `findTopologyAssignmentState` into `topologyAssignmentPodRequirements` and `topologyAssignmentTASParameters`, so pod requirement inputs are only used up to `fillInCounts` and the placement algos only receive the TAS placement state.

#### Which issue(s) this PR fixes:
Followup #10537

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```