### PR TITLE
Verify alpha-enabled manifests render

### DIFF
--- a/Makefile-verify.mk
+++ b/Makefile-verify.mk
@@ -89,7 +89,7 @@ verify-tree-prereqs: verify-go-prereqs verify-docs-prereqs verify-helm-prereqs
 ## Read-only verification targets that should not mutate the repo.
 ## Add new check-only targets here.
 verify-checks: ## Phase 2 (parallel): checks that should run after generation completes.
-verify-checks: verify-ci-lint verify-lint-api verify-fmt-verify verify-shell-lint verify-helm-verify verify-helm-unit-test verify-npm-depcheck
+verify-checks: verify-ci-lint verify-lint-api verify-fmt-verify verify-shell-lint verify-helm-verify verify-helm-unit-test verify-npm-depcheck verify-kustomize-build
 
 # ---- Shared check recipes -------------------------------------------------
 # Each recipe is stored in a variable so that both the lightweight standalone
@@ -150,6 +150,10 @@ $(PROJECT_DIR)/hack/testing/depcheck/verify.sh $(PROJECT_DIR)/cmd/kueueviz/front
 $(PROJECT_DIR)/hack/testing/depcheck/verify.sh $(PROJECT_DIR)/test/e2e/kueueviz
 endef
 
+define _kustomize_build_verify_recipe
+$(KUSTOMIZE) build config/alpha-enabled > /dev/null
+endef
+
 
 # ---- verify-* wrappers (generation prereqs + shared recipe) ---------------
 
@@ -180,6 +184,10 @@ verify-helm-unit-test: verify-tree-prereqs helm helm-unittest-plugin ## Helm uni
 .PHONY: verify-npm-depcheck
 verify-npm-depcheck: verify-tree-prereqs prepare-release-branch ## Depcheck after generation
 	$(_npm_depcheck_recipe)
+
+.PHONY: verify-kustomize-build
+verify-kustomize-build: verify-tree-prereqs kustomize ## Verify alpha-enabled manifests render after generation
+	$(_kustomize_build_verify_recipe)
 
 # ---- Standalone targets (lightweight, for local use) ----------------------
 
@@ -226,6 +234,10 @@ helm-unit-test: helm helm-unittest-plugin ## Run Helm unit tests for the kueue c
 .PHONY: npm-depcheck
 npm-depcheck: ## Verify frontend and e2e npm dependencies.
 	$(_npm_depcheck_recipe)
+
+.PHONY: kustomize-build-verify
+kustomize-build-verify: kustomize ## Validate alpha-enabled manifests render.
+	$(_kustomize_build_verify_recipe)
 
 .PHONY: verify-website-links
 verify-website-links: ## Check for broken internal links on the public website.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area testing


#### What this PR does / why we need it:
`make verify` now renders `config/alpha-enabled`, so CI catches broken alpha-enabled manifests before release artifact generation fails.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4886

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```