### PR TITLE
Set TerminationGracePeriod=1s on JAXJob e2e test to improve stability

### DIFF
--- a/pkg/util/testingjobs/jaxjob/wrappers.go
+++ b/pkg/util/testingjobs/jaxjob/wrappers.go
@@ -218,6 +218,11 @@ func (j *JAXJobWrapper) SetTypeMeta() *JAXJobWrapper {
 	return j
 }
 
+func (j *JAXJobWrapper) TerminationGracePeriod(replicaType kftraining.ReplicaType, seconds int64) *JAXJobWrapper {
+	j.Spec.JAXReplicaSpecs[replicaType].Template.Spec.TerminationGracePeriodSeconds = ptr.To(seconds)
+	return j
+}
+
 // ManagedBy adds a ManagedBy.
 func (j *JAXJobWrapper) ManagedBy(c string) *JAXJobWrapper {
 	j.Spec.RunPolicy.ManagedBy = &c

--- a/test/e2e/singlecluster/jaxjob_test.go
+++ b/test/e2e/singlecluster/jaxjob_test.go
@@ -83,6 +83,7 @@ var _ = ginkgo.Describe("JAX integration", ginkgo.Label("area:singlecluster", "f
 				Suspend(false).
 				SetTypeMeta().
 				JAXReplicaSpecsDefault().
+				TerminationGracePeriod(kftraining.JAXJobReplicaTypeWorker, 1).
 				Parallelism(kftraining.JAXJobReplicaTypeWorker, 2).
 				Image(kftraining.JAXJobReplicaTypeWorker, util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				Request(kftraining.JAXJobReplicaTypeWorker, corev1.ResourceCPU, "1").


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Set TerminationGracePeriod=1s on JAXJob e2e test to improve stability
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Additional improvement for https://github.com/kubernetes-sigs/kueue/pull/10493 PR
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```