### PR TITLE
chore: Simplify Golangci-lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -77,16 +77,10 @@ linters:
       context-background: true
       context-todo: true
   exclusions:
-    generated: lax
+    warn-unused: true
     presets:
-      - comments
-      - common-false-positives
-      - legacy
       - std-error-handling
     rules:
-      - linters:
-          - staticcheck
-        text: 'SA1019: .*\.NewSimpleClientset is deprecated: NewClientset replaces this with support for field management, which significantly improves server side apply testing.'
       - linters:
           - staticcheck
         text: 'SA1019: j.Status.State is deprecated: the State field is replaced by the Conditions field.'
@@ -102,16 +96,6 @@ linters:
       - linters:
           - fatcontext
         path: ^test/*
-      - linters:
-          - revive
-        path: 'util/*'
-        text: 'var-naming: avoid meaningless package names'
-    paths:
-      - bin
-      - vendor
-      - third_party$
-      - builtin$
-      - examples$
 issues:
   # Show all issues from a linter
   max-issues-per-linter: 0
@@ -133,10 +117,4 @@ formatters:
       max-len: 200
       reformat-tags: false
   exclusions:
-    generated: lax
-    paths:
-      - bin
-      - vendor
-      - third_party$
-      - builtin$
-      - examples$
+    warn-unused: true


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Enable `exclusions.warn-unused` and remove unused Golangci-lint config options.

#### Special notes for your reviewer:

```console
❯ golangci-lint run
WARN [runner/exclusion_paths] The pattern "bin" match no issues 
WARN [runner/exclusion_paths] The pattern "vendor" match no issues 
WARN [runner/exclusion_paths] The pattern "third_party$" match no issues 
WARN [runner/exclusion_paths] The pattern "builtin$" match no issues 
WARN [runner/exclusion_paths] The pattern "examples$" match no issues 
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "examples$", Linters: "gci, golines"] 
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Text: "SA1019: .*\\.NewSimpleClientset is deprecated: NewClientset replaces this with support for field management, which significantly improves server side apply testing.", Linters: "staticcheck"] 
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "bin", Linters: "gci, golines"] 
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "vendor", Linters: "gci, golines"] 
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "builtin$", Linters: "gci, golines"] 
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Text: "var-naming: avoid meaningless package names", Path: "util/*", Linters: "revive"] 
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "third_party$", Linters: "gci, golines"] 
0 issues.
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```