### PR TITLE
Detect and log missing scheduling gates

### DIFF
--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -193,6 +193,14 @@ type TopLevelJob interface {
 	IsTopLevel() bool
 }
 
+// JobWithSchedulingGateDetection should be implemented by Jobs that need
+// to detect missing scheduling gates after ensureOneWorkload().
+type JobWithSchedulingGateDetection interface {
+	// DetectMissingSchedulingGates detects missing scheduling gates.
+	// Returns true if gates are missing and an error if detection fails.
+	DetectMissingSchedulingGates(ctx context.Context, c client.Client) (bool, error)
+}
+
 func QueueName(job GenericJob) kueue.LocalQueueName {
 	return QueueNameForObject(job.Object())
 }

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -70,8 +70,9 @@ import (
 )
 
 const (
-	FailedToStartFinishedReason = "FailedToStart"
-	managedOwnersChainLimit     = 10
+	FailedToStartFinishedReason         = "FailedToStart"
+	managedOwnersChainLimit             = 10
+	schedulingGateDetectionRequeueDelay = 2 * time.Second
 )
 
 var (
@@ -430,6 +431,17 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 	wl, err := r.ensureOneWorkload(ctx, job, object)
 	if err != nil {
 		return ctrl.Result{}, err
+	}
+
+	// 1.1 Catchall detection for missing scheduling gates (for elastic jobs like Ray Clusters)
+	if jobWithGateDetection, implements := job.(JobWithSchedulingGateDetection); implements {
+		gatesMissing, err := jobWithGateDetection.DetectMissingSchedulingGates(ctx, r.client)
+		// Log the error but continue with the rest of the reconcile loop
+		if err != nil {
+			log.Error(err, "Failed to detect if scheduling gates are missing")
+		} else if gatesMissing {
+			log.Error(nil, "Missing scheduling gates detected, but not injecting them")
+		}
 	}
 
 	// Update workload conditions if implemented JobWithCustomWorkloadConditions interface.

--- a/pkg/controller/jobs/raycluster/raycluster_controller.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller.go
@@ -19,14 +19,17 @@ package raycluster
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	rayutils "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -77,6 +80,7 @@ type RayCluster rayv1.RayCluster
 
 var _ jobframework.GenericJob = (*RayCluster)(nil)
 var _ jobframework.JobWithManagedBy = (*RayCluster)(nil)
+var _ jobframework.JobWithSchedulingGateDetection = (*RayCluster)(nil)
 
 func (j *RayCluster) Object() client.Object {
 	return (*rayv1.RayCluster)(j)
@@ -206,4 +210,60 @@ func (j *RayCluster) ManagedBy() *string {
 
 func (j *RayCluster) SetManagedBy(managedBy *string) {
 	j.Spec.ManagedBy = managedBy
+}
+
+// DetectMissingSchedulingGates detects missing ElasticJobSchedulingGate
+// This is called in the generic reconcile loop after ensureOneWorkload()
+func (j *RayCluster) DetectMissingSchedulingGates(ctx context.Context, c client.Client) (bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	// Check if this is an elastic job and has a finalizer (indicating it's managed by Kueue)
+	if !j.isElasticJobWithFinalizer() {
+		// Not an elastic job or not managed by Kueue, skip
+		return false, nil
+	}
+
+	// Check if scheduling gates are missing
+	missingGatesInHead := j.isMissingElasticJobSchedulingGate(&j.Spec.HeadGroupSpec.Template)
+	missingGatesInWorkers := []int{}
+
+	for i, wgs := range j.Spec.WorkerGroupSpecs {
+		if j.isMissingElasticJobSchedulingGate(&wgs.Template) {
+			missingGatesInWorkers = append(missingGatesInWorkers, i)
+		}
+	}
+
+	// If no gates are missing, nothing to do
+	if !missingGatesInHead && len(missingGatesInWorkers) == 0 {
+		return false, nil
+	}
+
+	// Log the detection of missing gates
+	log.Error(nil, "Detected missing ElasticJobSchedulingGate in Ray Cluster",
+		"rayCluster", client.ObjectKeyFromObject(j.Object()),
+		"missingInHead", missingGatesInHead,
+		"missingInWorkers", missingGatesInWorkers)
+
+	// Return true to indicate gates are missing
+	return true, nil
+}
+
+// isElasticJobWithFinalizer checks if the RayCluster is an elastic job and has a finalizer
+func (j *RayCluster) isElasticJobWithFinalizer() bool {
+	// Check if it's an elastic job (using the same logic as webhook)
+	if !isAnElasticJob((*rayv1.RayCluster)(j)) {
+		return false
+	}
+
+	// Check if it has finalizers (indicating it's managed by Kueue)
+	return len(j.Object().GetFinalizers()) > 0
+}
+
+// isMissingElasticJobSchedulingGate checks if a pod template is missing the ElasticJobSchedulingGate
+func (j *RayCluster) isMissingElasticJobSchedulingGate(template *corev1.PodTemplateSpec) bool {
+	elasticGate := corev1.PodSchedulingGate{
+		Name: kueue.ElasticJobSchedulingGate,
+	}
+
+	return !slices.Contains(template.Spec.SchedulingGates, elasticGate)
 }

--- a/pkg/controller/jobs/raycluster/raycluster_webhook.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook.go
@@ -90,6 +90,7 @@ func (w *RayClusterWebhook) Default(ctx context.Context, obj *rayv1.RayCluster) 
 	log.V(10).Info("Applying defaults")
 	jobframework.ApplyDefaultLocalQueue(job.Object(), w.queues.DefaultLocalQueueExist)
 	if err := jobframework.ApplyDefaultForSuspend(ctx, job, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
+		log.Error(err, "Failed to apply default for suspend")
 		return err
 	}
 	jobframework.ApplyDefaultForManagedBy(job, w.queues, w.cache, log)


### PR DESCRIPTION

#### What type of PR is this?
/kind feature 
/area integrations

#### What this PR does / why we need it:
As noted in [Issue 10167](https://github.com/kubernetes-sigs/kueue/issues/10167), sometimes we see Ray Clusters without scheduling gates for elastic jobs. This is a big problem when it happens with a Ray Service with GCS FT enabled, because the Ray Cluster has a finalizer in that situation, and KubeRay cannot remove that finalizer -- because Kueue rejects the finalizer removal if the gates are missing. As a result, Ray Clusters remain in zombie state but that means Kueue workloads also remain. Another consequence is that, if a Ray Cluster needs to be preempted by another job A, and the deletion fails due to missing gates, the preemption awaits. 

This PR logs an error in the generic job reconcile loop when we detect Ray Clusters which are elastic jobs but are missing scheduling gates. It also logs an error in the RC webhook if ApplyDefaultForSuspend() fails, which would cause the gates to not be applied.  

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10167

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```