### PR TITLE
[WIP] tas domain usage

### DIFF
--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -592,8 +592,10 @@ func (c *clusterQueue) updateWorkloadTASUsage(log logr.Logger, wi *workload.Info
 			log.V(2).Info("TAS flavor used by workload not found in cache", "tasFlavor", tasFlavor)
 		case op == add:
 			tasFlvCache.addUsage(key, tasUsage)
+			tasFlvCache.reportDomainMetrics(tasFlavor)
 		case op == subtract:
 			tasFlvCache.removeUsage(key)
+			tasFlvCache.reportDomainMetrics(tasFlavor)
 		}
 	}
 }

--- a/pkg/cache/scheduler/tas_cache.go
+++ b/pkg/cache/scheduler/tas_cache.go
@@ -124,10 +124,20 @@ func (t *tasCache) DeleteTopology(name kueue.TopologyReference) {
 // delete a terminated pod.
 func (t *tasCache) Update(pod *corev1.Pod, log logr.Logger) {
 	t.nonTasUsageCache.update(pod, log)
+	t.reportAllFlavorMetrics()
 }
 
 func (t *tasCache) DeletePodByKey(key client.ObjectKey) {
 	t.nonTasUsageCache.delete(key)
+	t.reportAllFlavorMetrics()
+}
+
+func (t *tasCache) reportAllFlavorMetrics() {
+	t.RLock()
+	defer t.RUnlock()
+	for flavorName, flavorCache := range t.flavorCache {
+		flavorCache.reportDomainMetrics(flavorName)
+	}
 }
 
 func (t *tasCache) SyncNode(node *corev1.Node) {

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -18,6 +18,7 @@ package scheduler
 
 import (
 	"slices"
+	"strings"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -26,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/resources"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -89,6 +91,11 @@ type TASFlavorCache struct {
 	// nonTasUsageCache maintains the usage coming from non-TAS pods,
 	// e.g. static Pods or DaemonSet pods.
 	nonTasUsageCache *nonTasUsageCache
+
+	// nodesCache is used to resolve hostname-only domain IDs to full-path domain
+	// IDs when reporting multi-level metrics for topologies where the lowest level
+	// is kubernetes.io/hostname.
+	nodesCache *nodesCache
 }
 
 func (t *tasCache) NewTASFlavorCache(topologyInfo topologyInformation,
@@ -100,6 +107,7 @@ func (t *tasCache) NewTASFlavorCache(topologyInfo topologyInformation,
 		usage:            make(map[utiltas.TopologyDomainID]resources.Requests),
 		wlUsage:          make(map[workload.Reference][]workload.TopologyDomainRequests),
 		nonTasUsageCache: t.nonTasUsageCache,
+		nodesCache:       t.nodesCache,
 	}
 }
 
@@ -168,6 +176,114 @@ func (c *TASFlavorCache) updateUsage(topologyRequests []workload.TopologyDomainR
 			c.usage[domainID].Add(resources.Requests{corev1.ResourcePods: int64(tr.Count)})
 		}
 	}
+}
+
+// reportDomainMetrics clears and re-reports kueue_tas_domain_usage for every
+// topology level.  For each level the leaf-domain usage values are aggregated
+// into that level's domains so operators can observe both host-level and
+// rack/block-level totals.
+func (c *TASFlavorCache) reportDomainMetrics(flavorName kueue.ResourceFlavorReference) {
+	if len(c.topology.Levels) == 0 {
+		return
+	}
+	c.RLock()
+	defer c.RUnlock()
+	metrics.ClearTASDomainUsageForFlavor(string(flavorName))
+	// When the lowest topology level is kubernetes.io/hostname, buildAssignment
+	// stores only the hostname value in the workload's TopologyAssignment, so
+	// the usage map keys are hostname-only (e.g. "host-1" instead of
+	// "rack-1,host-1").  Resolve them to full-path IDs before aggregating.
+	fullPathUsage := c.resolveFullPathUsage()
+	for levelIdx, levelKey := range c.topology.Levels {
+		levelUsage := make(map[utiltas.TopologyDomainID]resources.Requests)
+		for fullPathID, requests := range fullPathUsage {
+			levelDomainID := domainIDPrefix(fullPathID, levelIdx+1)
+			if _, ok := levelUsage[levelDomainID]; !ok {
+				levelUsage[levelDomainID] = requests.Clone()
+			} else {
+				levelUsage[levelDomainID].Add(requests)
+			}
+		}
+		for domainID, reqs := range levelUsage {
+			for resourceName, quantity := range reqs {
+				if resourceName == corev1.ResourcePods {
+					continue
+				}
+				metrics.ReportTASDomainUsage(string(flavorName), levelKey, string(domainID), string(resourceName), resourceFloat(resourceName, quantity))
+			}
+		}
+	}
+}
+
+// resolveFullPathUsage returns a merged usage map keyed by full-path domain IDs,
+// combining TAS workload usage with non-TAS pod usage (DaemonSets, static pods).
+// For topologies where buildAssignment stores only the hostname, the keys in
+// c.usage are hostname-only; buildNodeToFullPath resolves them to the full path.
+// Non-TAS usage is keyed by node name and is only included for nodes that match
+// this flavor's node labels (mirroring how snapshot.go filters non-TAS usage).
+func (c *TASFlavorCache) resolveFullPathUsage() map[utiltas.TopologyDomainID]resources.Requests {
+	nodeToFullPath := c.buildNodeToFullPath()
+	result := make(map[utiltas.TopologyDomainID]resources.Requests, len(c.usage))
+
+	for domainID, requests := range c.usage {
+		fullPathID := domainID
+		if len(strings.Split(string(domainID), ",")) < len(c.topology.Levels) {
+			if full, ok := nodeToFullPath[string(domainID)]; ok {
+				fullPathID = full
+			}
+		}
+		if existing, ok := result[fullPathID]; ok {
+			existing.Add(requests)
+		} else {
+			result[fullPathID] = requests.Clone()
+		}
+	}
+
+	for nodeName, requests := range c.nonTasUsageCache.usagePerNode() {
+		if fullPathID, ok := nodeToFullPath[nodeName]; ok {
+			if existing, ok := result[fullPathID]; ok {
+				existing.Add(requests)
+			} else {
+				result[fullPathID] = requests.Clone()
+			}
+		}
+	}
+
+	return result
+}
+
+// buildNodeToFullPath queries the nodesCache for nodes matching this flavor and
+// returns a map from node identifier to the full comma-joined topology path.
+// Both the node name (used by nonTasUsageCache) and the kubernetes.io/hostname
+// label value (used as the domain ID key in c.usage) are stored as keys.
+func (c *TASFlavorCache) buildNodeToFullPath() map[string]utiltas.TopologyDomainID {
+	if c.nodesCache == nil {
+		return nil
+	}
+	nodes := c.nodesCache.find(c.flavor.NodeLabels, c.topology.Levels)
+	mapping := make(map[string]utiltas.TopologyDomainID, len(nodes)*2)
+	for _, node := range nodes {
+		levelValues := make([]string, len(c.topology.Levels))
+		for i, level := range c.topology.Levels {
+			levelValues[i] = node.Labels[level]
+		}
+		fullPathID := utiltas.DomainID(levelValues)
+		mapping[node.Name] = fullPathID
+		if hostname := node.Labels[corev1.LabelHostname]; hostname != "" {
+			mapping[hostname] = fullPathID
+		}
+	}
+	return mapping
+}
+
+// domainIDPrefix returns the first n comma-separated components of a domain ID.
+// For example, domainIDPrefix("rack-1,host-2", 1) returns "rack-1".
+func domainIDPrefix(domainID utiltas.TopologyDomainID, n int) utiltas.TopologyDomainID {
+	parts := strings.SplitN(string(domainID), ",", n+1)
+	if len(parts) <= n {
+		return domainID
+	}
+	return utiltas.TopologyDomainID(strings.Join(parts[:n], ","))
 }
 
 type nodeInfo struct {

--- a/pkg/cache/scheduler/tas_flavor_metrics_test.go
+++ b/pkg/cache/scheduler/tas_flavor_metrics_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/metrics"
+	"sigs.k8s.io/kueue/pkg/resources"
+	"sigs.k8s.io/kueue/pkg/workload"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	testingmetrics "sigs.k8s.io/kueue/pkg/util/testing/metrics"
+)
+
+const (
+	testFlavorName  kueue.ResourceFlavorReference = "gpu-flavor"
+	testTopologyRef kueue.TopologyReference        = "default"
+	testGPUResource corev1.ResourceName            = "nvidia.com/gpu"
+	testRackLabel                                   = "cloud.com/topology-rack"
+)
+
+func newTestTASFlavorCache(levels []string) *TASFlavorCache {
+	tc := NewTASCache(utiltesting.NewFakeClient())
+	return tc.NewTASFlavorCache(
+		topologyInformation{Levels: levels},
+		flavorInformation{TopologyName: testTopologyRef},
+	)
+}
+
+func collectTASDomainMetrics(flavor string) []testingmetrics.MetricDataPoint {
+	return testingmetrics.CollectFilteredGaugeVec(
+		metrics.TASDomainUsage,
+		map[string]string{"flavor": flavor},
+	)
+}
+
+var sortMetrics = cmpopts.SortSlices(func(a, b testingmetrics.MetricDataPoint) bool {
+	return a.Less(&b)
+})
+
+func wantDP(flavor, domain, domainID, resource string, value float64) testingmetrics.MetricDataPoint {
+	return testingmetrics.MetricDataPoint{
+		Labels: map[string]string{
+			"flavor":    flavor,
+			"domain":    domain,
+			"domain_id": domainID,
+			"resource":  resource,
+		},
+		Value: value,
+	}
+}
+
+// TestReportDomainMetricsSingleHost verifies that a single-level (hostname only)
+// topology reports usage at the host level.
+func TestReportDomainMetricsSingleHost(t *testing.T) {
+	cache := newTestTASFlavorCache([]string{corev1.LabelHostname})
+	defer metrics.ClearTASDomainUsageForFlavor(string(testFlavorName))
+
+	// Two pods on host-1, each requesting 4 GPUs → 8 GPUs total.
+	cache.addUsage("wl1", []workload.TopologyDomainRequests{
+		{
+			Values:            []string{"host-1"},
+			SinglePodRequests: resources.Requests{testGPUResource: 4},
+			Count:             2,
+		},
+	})
+	cache.reportDomainMetrics(testFlavorName)
+
+	want := []testingmetrics.MetricDataPoint{
+		wantDP(string(testFlavorName), corev1.LabelHostname, "host-1", string(testGPUResource), 8),
+	}
+	if diff := cmp.Diff(want, collectTASDomainMetrics(string(testFlavorName)), sortMetrics); diff != "" {
+		t.Errorf("unexpected metric data (-want +got):\n%s", diff)
+	}
+}
+
+// TestReportDomainMetricsMultipleHosts verifies that multiple leaf domains are
+// reported independently.
+func TestReportDomainMetricsMultipleHosts(t *testing.T) {
+	cache := newTestTASFlavorCache([]string{corev1.LabelHostname})
+	defer metrics.ClearTASDomainUsageForFlavor(string(testFlavorName))
+
+	cache.addUsage("wl1", []workload.TopologyDomainRequests{
+		{Values: []string{"host-1"}, SinglePodRequests: resources.Requests{testGPUResource: 8}, Count: 1},
+		{Values: []string{"host-2"}, SinglePodRequests: resources.Requests{testGPUResource: 4}, Count: 1},
+	})
+	cache.reportDomainMetrics(testFlavorName)
+
+	want := []testingmetrics.MetricDataPoint{
+		wantDP(string(testFlavorName), corev1.LabelHostname, "host-1", string(testGPUResource), 8),
+		wantDP(string(testFlavorName), corev1.LabelHostname, "host-2", string(testGPUResource), 4),
+	}
+	if diff := cmp.Diff(want, collectTASDomainMetrics(string(testFlavorName)), sortMetrics); diff != "" {
+		t.Errorf("unexpected metric data (-want +got):\n%s", diff)
+	}
+}
+
+// TestReportDomainMetricsWorkloadRemoval verifies that removing a workload
+// causes its domain metrics to disappear (usage reaches zero → series cleared).
+func TestReportDomainMetricsWorkloadRemoval(t *testing.T) {
+	cache := newTestTASFlavorCache([]string{corev1.LabelHostname})
+	defer metrics.ClearTASDomainUsageForFlavor(string(testFlavorName))
+
+	cache.addUsage("wl1", []workload.TopologyDomainRequests{
+		{Values: []string{"host-1"}, SinglePodRequests: resources.Requests{testGPUResource: 8}, Count: 1},
+	})
+	cache.reportDomainMetrics(testFlavorName)
+
+	if got := collectTASDomainMetrics(string(testFlavorName)); len(got) != 1 {
+		t.Fatalf("expected 1 metric after add, got %d", len(got))
+	}
+
+	cache.removeUsage("wl1")
+	cache.reportDomainMetrics(testFlavorName)
+
+	// After removal the domain still appears with value 0 (idle but known).
+	want := []testingmetrics.MetricDataPoint{
+		wantDP(string(testFlavorName), corev1.LabelHostname, "host-1", string(testGPUResource), 0),
+	}
+	if diff := cmp.Diff(want, collectTASDomainMetrics(string(testFlavorName)), sortMetrics); diff != "" {
+		t.Errorf("unexpected metric data after removal (-want +got):\n%s", diff)
+	}
+}
+
+// TestReportDomainMetricsMultiLevelTopology verifies that a two-level topology
+// (rack → host) produces metrics at both the rack level and the host level.
+// Rack-1 holds host-1 and host-2; rack-2 holds host-3.
+func TestReportDomainMetricsMultiLevelTopology(t *testing.T) {
+	cache := newTestTASFlavorCache([]string{testRackLabel, corev1.LabelHostname})
+	defer metrics.ClearTASDomainUsageForFlavor(string(testFlavorName))
+
+	cache.addUsage("wl1", []workload.TopologyDomainRequests{
+		{Values: []string{"rack-1", "host-1"}, SinglePodRequests: resources.Requests{testGPUResource: 8}, Count: 1},
+		{Values: []string{"rack-1", "host-2"}, SinglePodRequests: resources.Requests{testGPUResource: 8}, Count: 1},
+		{Values: []string{"rack-2", "host-3"}, SinglePodRequests: resources.Requests{testGPUResource: 4}, Count: 1},
+	})
+	cache.reportDomainMetrics(testFlavorName)
+
+	want := []testingmetrics.MetricDataPoint{
+		// Rack-level aggregates (domain = rack label key, domain_id = just the rack value).
+		wantDP(string(testFlavorName), testRackLabel, "rack-1", string(testGPUResource), 16),
+		wantDP(string(testFlavorName), testRackLabel, "rack-2", string(testGPUResource), 4),
+		// Host-level leaf domains (domain = hostname label key, domain_id = full path).
+		wantDP(string(testFlavorName), corev1.LabelHostname, "rack-1,host-1", string(testGPUResource), 8),
+		wantDP(string(testFlavorName), corev1.LabelHostname, "rack-1,host-2", string(testGPUResource), 8),
+		wantDP(string(testFlavorName), corev1.LabelHostname, "rack-2,host-3", string(testGPUResource), 4),
+	}
+	if diff := cmp.Diff(want, collectTASDomainMetrics(string(testFlavorName)), sortMetrics); diff != "" {
+		t.Errorf("unexpected metric data (-want +got):\n%s", diff)
+	}
+}
+
+// TestReportDomainMetricsEmptyLevels verifies that a cache with no topology
+// levels neither panics nor emits any metrics.
+func TestReportDomainMetricsEmptyLevels(t *testing.T) {
+	cache := newTestTASFlavorCache([]string{})
+	cache.reportDomainMetrics(testFlavorName)
+	// Verified by absence of panic; no metrics should appear.
+	if got := collectTASDomainMetrics(string(testFlavorName)); len(got) != 0 {
+		t.Errorf("expected 0 metrics for empty topology, got %d", len(got))
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -267,6 +267,10 @@ var (
 	// +metricsdoc:group=cohort
 	// +metricsdoc:labels=cohort="the name of the Cohort",replica_role="one of `leader`, `follower`, or `standalone`"
 	CohortSubtreeAdmittedActiveWorkloads *prometheus.GaugeVec
+
+	// +metricsdoc:group=tas
+	// +metricsdoc:labels=flavor="the resource flavor name",domain="the topology level key (e.g. kubernetes.io/hostname)",domain_id="the topology domain identifier",resource="the resource name"
+	TASDomainUsage *prometheus.GaugeVec
 )
 
 type gaugeCleanupScope uint8
@@ -807,6 +811,15 @@ If the Cohort has a weight of zero and is borrowing, this will return NaN.`,
 		}, append([]string{"cohort", "replica_role"}, extraLabels...),
 	)
 	trackGaugeVec(CohortSubtreeAdmittedActiveWorkloads)
+
+	TASDomainUsage = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: constants.KueueName,
+			Name:      "tas_domain_usage",
+			Help:      "The usage of resources in a topology domain as seen by Kueue (includes QuotaReserved workloads).",
+		},
+		[]string{"flavor", "domain", "domain_id", "resource"},
+	)
 }
 
 func init() {
@@ -1222,6 +1235,14 @@ func ClearClusterQueueResourceReservations(cqName, flavor, resource string) {
 	ClusterQueueResourceReservations.DeletePartialMatch(lbls)
 }
 
+func ReportTASDomainUsage(flavor, domain, domainID, resource string, value float64) {
+	TASDomainUsage.WithLabelValues(flavor, domain, domainID, resource).Set(value)
+}
+
+func ClearTASDomainUsageForFlavor(flavor string) {
+	TASDomainUsage.DeletePartialMatch(prometheus.Labels{"flavor": flavor})
+}
+
 func Register() {
 	metrics.Registry.MustRegister(
 		buildInfo,
@@ -1257,6 +1278,9 @@ func Register() {
 		CohortSubtreeResourceReservations,
 		CohortSubtreeAdmittedActiveWorkloads,
 	)
+	if features.Enabled(features.TopologyAwareScheduling) {
+		metrics.Registry.MustRegister(TASDomainUsage)
+	}
 	if features.Enabled(features.LocalQueueMetrics) {
 		RegisterLQMetrics()
 	}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -414,6 +414,71 @@ func TestCohortMetrics(t *testing.T) {
 	expectFilteredMetricsCount(t, CohortSubtreeResourceReservations, 0, "cohort", "cohort_two")
 }
 
+func TestReportAndCleanupTASDomainUsage(t *testing.T) {
+	const (
+		flavor1   = "gpu-flavor"
+		flavor2   = "cpu-flavor"
+		domain    = "kubernetes.io/hostname"
+		domainID1 = "host-1"
+		domainID2 = "host-2"
+		resource  = "nvidia.com/gpu"
+	)
+
+	// Report usage for two domains under flavor1 and one domain under flavor2.
+	ReportTASDomainUsage(flavor1, domain, domainID1, resource, 8)
+	ReportTASDomainUsage(flavor1, domain, domainID2, resource, 4)
+	ReportTASDomainUsage(flavor2, domain, domainID1, resource, 2)
+
+	expectFilteredMetricsCount(t, TASDomainUsage, 2, "flavor", flavor1)
+	expectFilteredMetricsCount(t, TASDomainUsage, 1, "flavor", flavor2)
+	expectFilteredMetricsCount(t, TASDomainUsage, 1, "flavor", flavor1, "domain_id", domainID1)
+	expectFilteredMetricsCount(t, TASDomainUsage, 1, "flavor", flavor1, "domain_id", domainID2)
+
+	// Clearing flavor1 should leave flavor2 intact.
+	ClearTASDomainUsageForFlavor(flavor1)
+
+	expectFilteredMetricsCount(t, TASDomainUsage, 0, "flavor", flavor1)
+	expectFilteredMetricsCount(t, TASDomainUsage, 1, "flavor", flavor2)
+
+	ClearTASDomainUsageForFlavor(flavor2)
+	expectFilteredMetricsCount(t, TASDomainUsage, 0, "flavor", flavor2)
+}
+
+// TestReportAndCleanupTASDomainUsageMultiLevel verifies that multi-level topology
+// domain IDs (rack,host) are reported correctly.  Each rack contains two hosts, and
+// the leaf-level label key ("kubernetes.io/hostname") is used as the domain label.
+func TestReportAndCleanupTASDomainUsageMultiLevel(t *testing.T) {
+	const (
+		flavor      = "gpu-flavor-ml"
+		leafDomain  = "kubernetes.io/hostname"
+		gpuResource = "nvidia.com/gpu"
+	)
+	// domain_id encodes the full path: "<rack>,<host>"
+	domains := map[string]float64{
+		"rack-1,host-1": 8,
+		"rack-1,host-2": 8,
+		"rack-2,host-3": 4,
+		"rack-2,host-4": 4,
+	}
+	for domainID, usage := range domains {
+		ReportTASDomainUsage(flavor, leafDomain, domainID, gpuResource, usage)
+	}
+
+	// All four leaf domains should be present.
+	expectFilteredMetricsCount(t, TASDomainUsage, 4, "flavor", flavor)
+
+	// Rack-1 hosts are individually addressable.
+	expectFilteredMetricsCount(t, TASDomainUsage, 1, "flavor", flavor, "domain_id", "rack-1,host-1")
+	expectFilteredMetricsCount(t, TASDomainUsage, 1, "flavor", flavor, "domain_id", "rack-1,host-2")
+
+	// Rack-2 hosts are individually addressable.
+	expectFilteredMetricsCount(t, TASDomainUsage, 1, "flavor", flavor, "domain_id", "rack-2,host-3")
+	expectFilteredMetricsCount(t, TASDomainUsage, 1, "flavor", flavor, "domain_id", "rack-2,host-4")
+
+	ClearTASDomainUsageForFlavor(flavor)
+	expectFilteredMetricsCount(t, TASDomainUsage, 0, "flavor", flavor)
+}
+
 func TestClearCohortMetricsOnlyClearsScopedGauges(t *testing.T) {
 	const cohortName = "cohort-scope"
 

--- a/test/e2e/tas/metrics_test.go
+++ b/test/e2e/tas/metrics_test.go
@@ -1,0 +1,250 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tas
+
+import (
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingjobspod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("TAS Domain Usage Metrics", ginkgo.Label("area:tas", "feature:metrics"), func() {
+	var (
+		ns *corev1.Namespace
+
+		metricsReaderClusterRoleBinding *rbacv1.ClusterRoleBinding
+		curlContainerName               string
+		curlPod                         *corev1.Pod
+	)
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-tas-metrics-")
+
+		kueueNS := util.GetKueueNamespace()
+
+		metricsReaderClusterRoleBinding = &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "tas-metrics-reader-" + ns.Name},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      "kueue-controller-manager",
+					Namespace: kueueNS,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     "kueue-metrics-reader",
+			},
+		}
+		util.MustCreate(ctx, k8sClient, metricsReaderClusterRoleBinding)
+
+		curlPod = testingjobspod.MakePod("curl-metrics-"+ns.Name, kueueNS).
+			ServiceAccountName("kueue-controller-manager").
+			Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+			TerminationGracePeriod(1).
+			Obj()
+		util.MustCreate(ctx, k8sClient, curlPod)
+
+		ginkgo.By("Waiting for the curl pod to be running", func() {
+			util.WaitForPodRunning(ctx, k8sClient, curlPod)
+		})
+		curlContainerName = curlPod.Spec.Containers[0].Name
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, metricsReaderClusterRoleBinding, true)
+		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, curlPod, true, util.MediumTimeout)
+	})
+
+	ginkgo.When("TAS workloads are admitted across multiple domains", func() {
+		var (
+			topology     *kueue.Topology
+			tasFlavor    *kueue.ResourceFlavor
+			clusterQueue *kueue.ClusterQueue
+			localQueue   *kueue.LocalQueue
+			wl1          *kueue.Workload
+			wl2          *kueue.Workload
+		)
+
+		ginkgo.BeforeEach(func() {
+			topology = utiltestingapi.MakeDefaultOneLevelTopology("tas-metrics-topology-" + ns.Name)
+			util.MustCreate(ctx, k8sClient, topology)
+
+			tasFlavor = utiltestingapi.MakeResourceFlavor("tas-metrics-flavor-"+ns.Name).
+				NodeLabel(tasNodeGroupLabel, instanceType).
+				TopologyName(topology.Name).
+				Obj()
+			util.MustCreate(ctx, k8sClient, tasFlavor)
+
+			clusterQueue = utiltestingapi.MakeClusterQueue("").
+				GeneratedName("tas-metrics-cq-").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(tasFlavor.Name).
+						Resource(corev1.ResourceCPU, "4").
+						Resource(extraResource, "8").
+						Obj(),
+				).
+				Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+
+			localQueue = utiltestingapi.MakeLocalQueue("", ns.Name).
+				GeneratedName("tas-metrics-lq-").
+				ClusterQueue(clusterQueue.Name).
+				Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+
+			wl1 = utiltestingapi.MakeWorkload("tas-metrics-wl1", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					Request(corev1.ResourceName(extraResource), "1").
+					RequiredTopologyRequest(corev1.LabelHostname).
+					Obj()).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl1)
+
+			wl2 = utiltestingapi.MakeWorkload("tas-metrics-wl2", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					Request(corev1.ResourceName(extraResource), "1").
+					RequiredTopologyRequest(corev1.LabelHostname).
+					Obj()).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl2)
+		})
+
+		ginkgo.AfterEach(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, wl1, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, wl2, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, localQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+		})
+
+		ginkgo.It("should report kueue_tas_domain_usage per assigned domain and clear on deletion", func() {
+			var admittedWL1, admittedWL2 kueue.Workload
+
+			ginkgo.By("waiting for both workloads to be admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl2)
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), &admittedWL1)).To(gomega.Succeed())
+					g.Expect(admittedWL1.Status.Admission).ShouldNot(gomega.BeNil())
+					g.Expect(admittedWL1.Status.Admission.PodSetAssignments[0].TopologyAssignment).ShouldNot(gomega.BeNil())
+
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), &admittedWL2)).To(gomega.Succeed())
+					g.Expect(admittedWL2.Status.Admission).ShouldNot(gomega.BeNil())
+					g.Expect(admittedWL2.Status.Admission.PodSetAssignments[0].TopologyAssignment).ShouldNot(gomega.BeNil())
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			// Read the assigned node hostnames from each workload's TopologyAssignment
+			// so the metric assertions use the actual domain_id values.
+			domainIDsFromWL := func(wl *kueue.Workload) []string {
+				ta := utiltas.InternalFrom(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment)
+				seen := map[string]bool{}
+				var ids []string
+				for _, d := range ta.Domains {
+					id := strings.Join(d.Values, ",")
+					if !seen[id] {
+						seen[id] = true
+						ids = append(ids, id)
+					}
+				}
+				return ids
+			}
+
+			wl1DomainIDs := domainIDsFromWL(&admittedWL1)
+			wl2DomainIDs := domainIDsFromWL(&admittedWL2)
+
+			allDomainIDs := map[string]bool{}
+			for _, id := range append(wl1DomainIDs, wl2DomainIDs...) {
+				allDomainIDs[id] = true
+			}
+
+			ginkgo.By("verifying kueue_tas_domain_usage appears for every assigned domain", func() {
+				var expectedMetrics [][]string
+				for domainID := range allDomainIDs {
+					expectedMetrics = append(expectedMetrics, []string{
+						"kueue_tas_domain_usage",
+						tasFlavor.Name,
+						`"` + corev1.LabelHostname + `"`,
+						`"` + domainID + `"`,
+						`"` + extraResource + `"`,
+					})
+				}
+				util.ExpectMetricsToBeAvailable(ctx, cfg, restClient, curlPod.Name, curlContainerName, expectedMetrics)
+			})
+
+			ginkgo.By("deleting wl1 and verifying its exclusive domains drop to zero", func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, wl1, true)
+
+				wl2IDs := map[string]bool{}
+				for _, id := range wl2DomainIDs {
+					wl2IDs[id] = true
+				}
+
+				var zeroMetrics [][]string
+				for _, id := range wl1DomainIDs {
+					if !wl2IDs[id] {
+						zeroMetrics = append(zeroMetrics, []string{
+							"kueue_tas_domain_usage",
+							tasFlavor.Name,
+							`"` + corev1.LabelHostname + `"`,
+							`"` + id + `"`,
+							`"` + extraResource + `"`,
+							" 0",
+						})
+					}
+				}
+				if len(zeroMetrics) > 0 {
+					util.ExpectMetricsToBeAvailable(ctx, cfg, restClient, curlPod.Name, curlContainerName, zeroMetrics)
+				}
+			})
+
+			ginkgo.By("deleting wl2 and verifying all domains drop to zero", func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, wl2, true)
+
+				var zeroMetrics [][]string
+				for domainID := range allDomainIDs {
+					zeroMetrics = append(zeroMetrics, []string{
+						"kueue_tas_domain_usage",
+						tasFlavor.Name,
+						`"` + corev1.LabelHostname + `"`,
+						`"` + domainID + `"`,
+						`"` + extraResource + `"`,
+						" 0",
+					})
+				}
+				util.ExpectMetricsToBeAvailable(ctx, cfg, restClient, curlPod.Name, curlContainerName, zeroMetrics)
+			})
+		})
+	})
+})

--- a/test/e2e/tas/suite_test.go
+++ b/test/e2e/tas/suite_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -37,6 +38,8 @@ import (
 var (
 	k8sClient       client.WithWatch
 	ctx             context.Context
+	cfg             *rest.Config
+	restClient      *rest.RESTClient
 	defaultKueueCfg *configapi.Configuration
 	kindClusterName = os.Getenv("KIND_CLUSTER_NAME")
 )
@@ -56,8 +59,9 @@ var _ = ginkgo.BeforeSuite(func() {
 	util.SetupLogger()
 
 	var err error
-	k8sClient, _, err = util.CreateClientUsingCluster("")
+	k8sClient, cfg, err = util.CreateClientUsingCluster("")
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	restClient = util.CreateRestClient(cfg)
 	ctx = ginkgo.GinkgoT().Context()
 
 	defaultKueueCfg = util.GetKueueConfiguration(ctx, k8sClient)

--- a/test/integration/singlecluster/tas/tas_metrics_test.go
+++ b/test/integration/singlecluster/tas/tas_metrics_test.go
@@ -1,0 +1,330 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tas
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/component-base/metrics/testutil"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/metrics"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
+	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+const (
+	tasMetricsGPUResource = "nvidia.com/gpu"
+)
+
+// tasDomainUsageValue returns the current value of the kueue_tas_domain_usage
+// gauge for the given label combination.  Returns 0 if no series exists yet.
+func tasDomainUsageValue(flavor, domain, domainID, resourceName string) float64 {
+	v, err := testutil.GetGaugeMetricValue(
+		metrics.TASDomainUsage.WithLabelValues(flavor, domain, domainID, resourceName),
+	)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+var _ = ginkgo.Describe("TAS Domain Usage Metrics", ginkgo.Ordered, func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeAll(func() {
+		fwk.StartManager(ctx, cfg, managerSetup())
+	})
+
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "tas-metrics-")
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+	})
+
+	// ── single-level (hostname only) topology ──────────────────────────────────
+
+	ginkgo.When("a single-level hostname topology is used", func() {
+		var (
+			nodes        []corev1.Node
+			topology     *kueue.Topology
+			tasFlavor    *kueue.ResourceFlavor
+			clusterQueue *kueue.ClusterQueue
+			localQueue   *kueue.LocalQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			nodes = []corev1.Node{
+				*testingnode.MakeNode("sl-host-1").
+					Label("node-group", "tas").
+					Label(corev1.LabelHostname, "sl-host-1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:                        resource.MustParse("1"),
+						corev1.ResourceName(tasMetricsGPUResource): resource.MustParse("8"),
+						corev1.ResourcePods:                       resource.MustParse("16"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("sl-host-2").
+					Label("node-group", "tas").
+					Label(corev1.LabelHostname, "sl-host-2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:                        resource.MustParse("1"),
+						corev1.ResourceName(tasMetricsGPUResource): resource.MustParse("8"),
+						corev1.ResourcePods:                       resource.MustParse("16"),
+					}).
+					Ready().
+					Obj(),
+			}
+			util.CreateNodesWithStatus(ctx, k8sClient, nodes)
+
+			topology = utiltestingapi.MakeDefaultOneLevelTopology("sl-topology")
+			util.MustCreate(ctx, k8sClient, topology)
+
+			tasFlavor = utiltestingapi.MakeResourceFlavor("sl-tas-flavor").
+				NodeLabel("node-group", "tas").
+				TopologyName("sl-topology").
+				Obj()
+			util.MustCreate(ctx, k8sClient, tasFlavor)
+
+			clusterQueue = utiltestingapi.MakeClusterQueue("sl-cluster-queue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(tasFlavor.Name).
+						Resource(corev1.ResourceName(tasMetricsGPUResource), "16").
+						Obj(),
+				).
+				Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+
+			localQueue = utiltestingapi.MakeLocalQueue("sl-local-queue", ns.Name).
+				ClusterQueue(clusterQueue.Name).
+				Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+			for i := range nodes {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, &nodes[i], true)
+			}
+		})
+
+		ginkgo.It("should report domain usage after workload admission", func() {
+			wl := utiltestingapi.MakeWorkload("sl-wl1", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
+					Request(corev1.ResourceName(tasMetricsGPUResource), "4").
+					RequiredTopologyRequest(corev1.LabelHostname).
+					Obj()).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+
+			ginkgo.By("verifying workload is fully admitted (topology assigned)", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+			})
+
+			// 2 pods × 4 GPUs = 8 GPUs reserved on whichever host was selected.
+			ginkgo.By("verifying 8 GPUs of domain usage are visible in the metric", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					h1 := tasDomainUsageValue(tasFlavor.Name, corev1.LabelHostname, "sl-host-1", tasMetricsGPUResource)
+					h2 := tasDomainUsageValue(tasFlavor.Name, corev1.LabelHostname, "sl-host-2", tasMetricsGPUResource)
+					g.Expect(h1 + h2).To(gomega.Equal(8.0))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("should drop domain usage to zero after workload finishes", func() {
+			wl := utiltestingapi.MakeWorkload("sl-wl2", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					Request(corev1.ResourceName(tasMetricsGPUResource), "4").
+					RequiredTopologyRequest(corev1.LabelHostname).
+					Obj()).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+
+			ginkgo.By("verifying workload is fully admitted (topology assigned)", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+			})
+
+			ginkgo.By("verifying 4 GPUs of domain usage are visible in the metric", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					h1 := tasDomainUsageValue(tasFlavor.Name, corev1.LabelHostname, "sl-host-1", tasMetricsGPUResource)
+					h2 := tasDomainUsageValue(tasFlavor.Name, corev1.LabelHostname, "sl-host-2", tasMetricsGPUResource)
+					g.Expect(h1 + h2).To(gomega.Equal(4.0))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("finishing the workload", func() {
+				util.FinishWorkloads(ctx, k8sClient, wl)
+			})
+
+			ginkgo.By("verifying domain usage drops to zero after the workload is finished", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					h1 := tasDomainUsageValue(tasFlavor.Name, corev1.LabelHostname, "sl-host-1", tasMetricsGPUResource)
+					h2 := tasDomainUsageValue(tasFlavor.Name, corev1.LabelHostname, "sl-host-2", tasMetricsGPUResource)
+					g.Expect(h1 + h2).To(gomega.Equal(0.0))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("should include non-TAS pod usage in the domain metric", func() {
+			// Simulate a DaemonSet pod running on sl-host-1, consuming 2 GPUs.
+			// The NonTasUsageReconciler picks this up and adds it to the TAS cache.
+			nonTasPod := testingpod.MakePod("nt-pod", ns.Name).
+				RequestAndLimit(corev1.ResourceName(tasMetricsGPUResource), "2").
+				NodeName("sl-host-1").
+				Obj()
+			util.MustCreate(ctx, k8sClient, nonTasPod)
+
+			wl := utiltestingapi.MakeWorkload("sl-wl-nt", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					Request(corev1.ResourceName(tasMetricsGPUResource), "4").
+					RequiredTopologyRequest(corev1.LabelHostname).
+					Obj()).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+
+			ginkgo.By("verifying workload is admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+			})
+
+			// Total across both hosts: 4 (TAS workload) + 2 (non-TAS pod) = 6 GPUs.
+			// The non-TAS pod is on sl-host-1; the workload may land on either host.
+			ginkgo.By("verifying the metric reflects both TAS and non-TAS GPU usage", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					h1 := tasDomainUsageValue(tasFlavor.Name, corev1.LabelHostname, "sl-host-1", tasMetricsGPUResource)
+					h2 := tasDomainUsageValue(tasFlavor.Name, corev1.LabelHostname, "sl-host-2", tasMetricsGPUResource)
+					g.Expect(h1 + h2).To(gomega.Equal(6.0))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	})
+
+	// ── three-level (block → rack → hostname) topology ────────────────────────
+
+	ginkgo.When("a three-level block/rack/hostname topology is used", func() {
+		var (
+			nodes        []corev1.Node
+			topology     *kueue.Topology
+			tasFlavor    *kueue.ResourceFlavor
+			clusterQueue *kueue.ClusterQueue
+			localQueue   *kueue.LocalQueue
+		)
+
+		// Single node topology layout (deterministic placement):
+		//   block-1
+		//     rack-1  →  ml-host-1 (8 GPUs)
+		ginkgo.BeforeEach(func() {
+			nodes = []corev1.Node{
+				*testingnode.MakeNode("ml-host-1").
+					Label("node-group", "tas").
+					Label(utiltesting.DefaultBlockTopologyLevel, "block-1").
+					Label(utiltesting.DefaultRackTopologyLevel, "rack-1").
+					Label(corev1.LabelHostname, "ml-host-1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:                        resource.MustParse("1"),
+						corev1.ResourceName(tasMetricsGPUResource): resource.MustParse("8"),
+						corev1.ResourcePods:                       resource.MustParse("16"),
+					}).
+					Ready().
+					Obj(),
+			}
+			util.CreateNodesWithStatus(ctx, k8sClient, nodes)
+
+			topology = utiltestingapi.MakeDefaultThreeLevelTopology("ml-topology")
+			util.MustCreate(ctx, k8sClient, topology)
+
+			tasFlavor = utiltestingapi.MakeResourceFlavor("ml-tas-flavor").
+				NodeLabel("node-group", "tas").
+				TopologyName("ml-topology").
+				Obj()
+			util.MustCreate(ctx, k8sClient, tasFlavor)
+
+			clusterQueue = utiltestingapi.MakeClusterQueue("ml-cluster-queue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(tasFlavor.Name).
+						Resource(corev1.ResourceName(tasMetricsGPUResource), "8").
+						Obj(),
+				).
+				Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+
+			localQueue = utiltestingapi.MakeLocalQueue("ml-local-queue", ns.Name).
+				ClusterQueue(clusterQueue.Name).
+				Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+			for i := range nodes {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, &nodes[i], true)
+			}
+		})
+
+		ginkgo.It("should report usage at host, rack, and block levels", func() {
+			// RequiredTopologyRequest at the outermost (block) level ensures the
+			// full-path domain ID ("block-1,rack-1,ml-host-1") is stored in the
+			// TAS cache, enabling correct rack and block rollup assertions.
+			wl := utiltestingapi.MakeWorkload("ml-wl1", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					Request(corev1.ResourceName(tasMetricsGPUResource), "4").
+					RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+					Obj()).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+
+			ginkgo.By("verifying workload is fully admitted (topology assigned)", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+			})
+
+			ginkgo.By("verifying host-level domain usage", func() {
+				util.ExpectTASDomainUsageMetric(tasFlavor.Name, corev1.LabelHostname, "block-1,rack-1,ml-host-1", tasMetricsGPUResource, 4)
+			})
+
+			ginkgo.By("verifying rack-level domain usage (aggregate of hosts in rack-1)", func() {
+				util.ExpectTASDomainUsageMetric(tasFlavor.Name, utiltesting.DefaultRackTopologyLevel, "block-1,rack-1", tasMetricsGPUResource, 4)
+			})
+
+			ginkgo.By("verifying block-level domain usage (aggregate of all racks in block-1)", func() {
+				util.ExpectTASDomainUsageMetric(tasFlavor.Name, utiltesting.DefaultBlockTopologyLevel, "block-1", tasMetricsGPUResource, 4)
+			})
+		})
+	})
+})

--- a/test/util/metrics.go
+++ b/test/util/metrics.go
@@ -336,3 +336,9 @@ func ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric(cohortName kueue.Coho
 	lvs := []string{string(cohortName), roletracker.RoleStandalone}
 	expectGaugeMetric(metrics.CohortSubtreeAdmittedActiveWorkloads, lvs, gomega.Equal(count))
 }
+
+func ExpectTASDomainUsageMetric(flavor, domain, domainID, resource string, value float64) {
+	ginkgo.GinkgoHelper()
+	lvs := []string{flavor, domain, domainID, resource}
+	expectGaugeMetric(metrics.TASDomainUsage, lvs, gomega.Equal(value))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
--> /kind feature

#### What this PR does / why we need it:
Adds domain level usage. Emits a workload metric that tells me node usage. See: #10505

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10505

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Metric emitting TAS domain level usage
```