### PR TITLE
fix: downgrade TAS flavor mismatch log from Error to V(3)

### DIFF
--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -941,7 +941,7 @@ func (a *FlavorAssigner) checkFlavorForPodSets(
 		if features.Enabled(features.TopologyAwareScheduling) {
 			ps := &a.wl.Obj.Spec.PodSets[psID]
 			if message := checkPodSetAndFlavorMatchForTAS(a.cq, ps, flavor, rg); message != nil {
-				log.Error(nil, *message)
+				log.V(3).Info(*message)
 				status.appendf("%s", *message)
 				return status
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue where `flavorassigner` was prematurely logging an `ERROR` whenever a flavor did not match a PodSet for TopologyAwareScheduling (TAS). 

Since a non-matching flavor is a normal occurrence during scheduling (meaning the PodSet simply needs to be matched against a different flavor), this should not trigger an error alert. The log level has been downgraded to `V(3).Info` so it is still available for debugging without polluting the main logs.

**Which issue(s) this PR fixes**:
Fixes #10611

**Special notes for your reviewer**:
Tested locally via `go test -v ./pkg/scheduler/flavorassigner` and confirmed the `ERROR` log no longer appears for non-TAS flavors. Full `make test` suite passes successfully.

```release-note
Observability: downgrade the non-compatible flavor error logs to Info level (v3).
```