### PR TITLE
Fix nil panic in tas node controller when referencing nil .status.admission.  

### DIFF
--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -356,9 +356,9 @@ func (r *nodeReconciler) getWorkloadStatus(
 
 	ready := utiltas.IsNodeStatusConditionTrue(node.Status.Conditions, corev1.NodeReady)
 	hasTASAssignment := false
-	if wl.Status.Admission != nil {
-		hasTASAssignment = utiltas.HasTASAssignmentOnNode(wl.Status.Admission.PodSetAssignments, nodeName)
-	}
+	//if wl.Status.Admission != nil {
+	hasTASAssignment = utiltas.HasTASAssignmentOnNode(wl.Status.Admission.PodSetAssignments, nodeName)
+	//}
 
 	switch {
 	case !hasTASAssignment:

--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -355,7 +355,10 @@ func (r *nodeReconciler) getWorkloadStatus(
 	}
 
 	ready := utiltas.IsNodeStatusConditionTrue(node.Status.Conditions, corev1.NodeReady)
-	hasTASAssignment := utiltas.HasTASAssignmentOnNode(wl.Status.Admission.PodSetAssignments, nodeName)
+	var hasTASAssignment bool
+	if wl.Status.Admission != nil {
+		hasTASAssignment = utiltas.HasTASAssignmentOnNode(wl.Status.Admission.PodSetAssignments, nodeName)
+	}
 
 	switch {
 	case !hasTASAssignment:

--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -355,7 +355,7 @@ func (r *nodeReconciler) getWorkloadStatus(
 	}
 
 	ready := utiltas.IsNodeStatusConditionTrue(node.Status.Conditions, corev1.NodeReady)
-	var hasTASAssignment bool
+	hasTASAssignment := false
 	if wl.Status.Admission != nil {
 		hasTASAssignment = utiltas.HasTASAssignmentOnNode(wl.Status.Admission.PodSetAssignments, nodeName)
 	}

--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -355,10 +355,7 @@ func (r *nodeReconciler) getWorkloadStatus(
 	}
 
 	ready := utiltas.IsNodeStatusConditionTrue(node.Status.Conditions, corev1.NodeReady)
-	hasTASAssignment := false
-	//if wl.Status.Admission != nil {
-	hasTASAssignment = utiltas.HasTASAssignmentOnNode(wl.Status.Admission.PodSetAssignments, nodeName)
-	//}
+	hasTASAssignment := utiltas.HasTASAssignmentOnNode(wl.Status.Admission, nodeName)
 
 	switch {
 	case !hasTASAssignment:

--- a/pkg/controller/tas/node_controller_test.go
+++ b/pkg/controller/tas/node_controller_test.go
@@ -847,6 +847,27 @@ func TestNodeFailureReconciler(t *testing.T) {
 				features.TASReplaceNodeOnPodTermination: true,
 			},
 		},
+		"Workload without admission (nil Admission status) - handled safely": {
+			initObjs: []client.Object{
+				baseNode.Clone().StatusConditions(corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: now}).Obj(),
+				utiltestingapi.MakeWorkload(wlName, nsName).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
+					Obj(),
+				testingpod.MakePod("stray-pod-on-node", nsName).
+					Annotation(kueue.WorkloadAnnotation, wlName).
+					Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
+					NodeSelector(corev1.LabelHostname, nodeName).
+					StatusPhase(corev1.PodPending).
+					Obj(),
+			},
+			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
+			wantUnhealthyNodes: nil,
+			wantPatchedPods:    []string{"stray-pod-on-node"},
+		},
 		"Node NotReady, workload missing TAS assignment but has late pod -> Workload marked Healthy, pod patched": {
 			initObjs: []client.Object{
 				unassignedNode.Clone().StatusConditions(corev1.NodeCondition{

--- a/pkg/util/tas/tas_assignment.go
+++ b/pkg/util/tas/tas_assignment.go
@@ -313,8 +313,11 @@ func ComputeUsagePerDomain(ta *TopologyAssignment, singlePodRequests resources.R
 	return usage
 }
 
-func HasTASAssignmentOnNode(psa []kueue.PodSetAssignment, nodeName string) bool {
-	for _, psa := range psa {
+func HasTASAssignmentOnNode(admission *kueue.Admission, nodeName string) bool {
+	if admission == nil {
+		return false
+	}
+	for _, psa := range admission.PodSetAssignments {
 		if psa.TopologyAssignment == nil || !IsLowestLevelHostname(psa.TopologyAssignment.Levels) {
 			continue
 		}

--- a/pkg/util/tas/tas_assignment_test.go
+++ b/pkg/util/tas/tas_assignment_test.go
@@ -793,22 +793,30 @@ func TestLowestLevelValues_iteratorStops(t *testing.T) {
 
 func TestHasTASAssignmentOnNode(t *testing.T) {
 	testCases := []struct {
-		name     string
-		psa      []kueue.PodSetAssignment
-		nodeName string
-		want     bool
+		name      string
+		admission *kueue.Admission
+		nodeName  string
+		want      bool
 	}{
 		{
-			name:     "empty assignments",
-			psa:      nil,
-			nodeName: "node1",
-			want:     false,
+			name:      "nil admission",
+			admission: nil,
+			nodeName:  "node1",
+			want:      false,
+		},
+		{
+			name:      "empty pod set assignments",
+			admission: &kueue.Admission{},
+			nodeName:  "node1",
+			want:      false,
 		},
 		{
 			name: "no topology assignment",
-			psa: []kueue.PodSetAssignment{
-				{
-					Name: "ps1",
+			admission: &kueue.Admission{
+				PodSetAssignments: []kueue.PodSetAssignment{
+					{
+						Name: "ps1",
+					},
 				},
 			},
 			nodeName: "node1",
@@ -816,20 +824,22 @@ func TestHasTASAssignmentOnNode(t *testing.T) {
 		},
 		{
 			name: "topology level is not hostname",
-			psa: []kueue.PodSetAssignment{
-				{
-					Name: "ps1",
-					TopologyAssignment: &kueue.TopologyAssignment{
-						Levels: []string{"example.com/rack"},
-						Slices: []kueue.TopologyAssignmentSlice{
-							{
-								DomainCount: 1,
-								PodCounts: kueue.TopologyAssignmentSlicePodCounts{
-									Universal: ptr.To(int32(1)),
-								},
-								ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
-									{
-										Universal: ptr.To("rack1"),
+			admission: &kueue.Admission{
+				PodSetAssignments: []kueue.PodSetAssignment{
+					{
+						Name: "ps1",
+						TopologyAssignment: &kueue.TopologyAssignment{
+							Levels: []string{"example.com/rack"},
+							Slices: []kueue.TopologyAssignmentSlice{
+								{
+									DomainCount: 1,
+									PodCounts: kueue.TopologyAssignmentSlicePodCounts{
+										Universal: ptr.To[int32](1),
+									},
+									ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
+										{
+											Universal: ptr.To("rack1"),
+										},
 									},
 								},
 							},
@@ -842,20 +852,22 @@ func TestHasTASAssignmentOnNode(t *testing.T) {
 		},
 		{
 			name: "pod on target node",
-			psa: []kueue.PodSetAssignment{
-				{
-					Name: "ps1",
-					TopologyAssignment: &kueue.TopologyAssignment{
-						Levels: []string{corev1.LabelHostname},
-						Slices: []kueue.TopologyAssignmentSlice{
-							{
-								DomainCount: 1,
-								PodCounts: kueue.TopologyAssignmentSlicePodCounts{
-									Universal: ptr.To(int32(1)),
-								},
-								ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
-									{
-										Universal: ptr.To("node1"),
+			admission: &kueue.Admission{
+				PodSetAssignments: []kueue.PodSetAssignment{
+					{
+						Name: "ps1",
+						TopologyAssignment: &kueue.TopologyAssignment{
+							Levels: []string{corev1.LabelHostname},
+							Slices: []kueue.TopologyAssignmentSlice{
+								{
+									DomainCount: 1,
+									PodCounts: kueue.TopologyAssignmentSlicePodCounts{
+										Universal: ptr.To[int32](1),
+									},
+									ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
+										{
+											Universal: ptr.To("node1"),
+										},
 									},
 								},
 							},
@@ -868,20 +880,22 @@ func TestHasTASAssignmentOnNode(t *testing.T) {
 		},
 		{
 			name: "pod on different node",
-			psa: []kueue.PodSetAssignment{
-				{
-					Name: "ps1",
-					TopologyAssignment: &kueue.TopologyAssignment{
-						Levels: []string{corev1.LabelHostname},
-						Slices: []kueue.TopologyAssignmentSlice{
-							{
-								DomainCount: 1,
-								PodCounts: kueue.TopologyAssignmentSlicePodCounts{
-									Universal: ptr.To(int32(1)),
-								},
-								ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
-									{
-										Universal: ptr.To("node2"),
+			admission: &kueue.Admission{
+				PodSetAssignments: []kueue.PodSetAssignment{
+					{
+						Name: "ps1",
+						TopologyAssignment: &kueue.TopologyAssignment{
+							Levels: []string{corev1.LabelHostname},
+							Slices: []kueue.TopologyAssignmentSlice{
+								{
+									DomainCount: 1,
+									PodCounts: kueue.TopologyAssignmentSlicePodCounts{
+										Universal: ptr.To[int32](1),
+									},
+									ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
+										{
+											Universal: ptr.To("node2"),
+										},
 									},
 								},
 							},
@@ -894,21 +908,23 @@ func TestHasTASAssignmentOnNode(t *testing.T) {
 		},
 		{
 			name: "multiple domains, target node present in one",
-			psa: []kueue.PodSetAssignment{
-				{
-					Name: "ps1",
-					TopologyAssignment: &kueue.TopologyAssignment{
-						Levels: []string{corev1.LabelHostname},
-						Slices: []kueue.TopologyAssignmentSlice{
-							{
-								DomainCount: 2,
-								PodCounts: kueue.TopologyAssignmentSlicePodCounts{
-									Individual: []int32{2, 3},
-								},
-								ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
-									{
-										Individual: &kueue.TopologyAssignmentSliceLevelIndividualValues{
-											Roots: []string{"node1", "node2"},
+			admission: &kueue.Admission{
+				PodSetAssignments: []kueue.PodSetAssignment{
+					{
+						Name: "ps1",
+						TopologyAssignment: &kueue.TopologyAssignment{
+							Levels: []string{corev1.LabelHostname},
+							Slices: []kueue.TopologyAssignmentSlice{
+								{
+									DomainCount: 2,
+									PodCounts: kueue.TopologyAssignmentSlicePodCounts{
+										Individual: []int32{2, 3},
+									},
+									ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
+										{
+											Individual: &kueue.TopologyAssignmentSliceLevelIndividualValues{
+												Roots: []string{"node1", "node2"},
+											},
 										},
 									},
 								},
@@ -922,39 +938,41 @@ func TestHasTASAssignmentOnNode(t *testing.T) {
 		},
 		{
 			name: "multiple pod sets, target node present in multiple",
-			psa: []kueue.PodSetAssignment{
-				{
-					Name: "ps1",
-					TopologyAssignment: &kueue.TopologyAssignment{
-						Levels: []string{corev1.LabelHostname},
-						Slices: []kueue.TopologyAssignmentSlice{
-							{
-								DomainCount: 1,
-								PodCounts: kueue.TopologyAssignmentSlicePodCounts{
-									Universal: ptr.To(int32(1)),
-								},
-								ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
-									{
-										Universal: ptr.To("node1"),
+			admission: &kueue.Admission{
+				PodSetAssignments: []kueue.PodSetAssignment{
+					{
+						Name: "ps1",
+						TopologyAssignment: &kueue.TopologyAssignment{
+							Levels: []string{corev1.LabelHostname},
+							Slices: []kueue.TopologyAssignmentSlice{
+								{
+									DomainCount: 1,
+									PodCounts: kueue.TopologyAssignmentSlicePodCounts{
+										Universal: ptr.To[int32](1),
+									},
+									ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
+										{
+											Universal: ptr.To("node1"),
+										},
 									},
 								},
 							},
 						},
 					},
-				},
-				{
-					Name: "ps2",
-					TopologyAssignment: &kueue.TopologyAssignment{
-						Levels: []string{corev1.LabelHostname},
-						Slices: []kueue.TopologyAssignmentSlice{
-							{
-								DomainCount: 1,
-								PodCounts: kueue.TopologyAssignmentSlicePodCounts{
-									Universal: ptr.To(int32(5)),
-								},
-								ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
-									{
-										Universal: ptr.To("node1"),
+					{
+						Name: "ps2",
+						TopologyAssignment: &kueue.TopologyAssignment{
+							Levels: []string{corev1.LabelHostname},
+							Slices: []kueue.TopologyAssignmentSlice{
+								{
+									DomainCount: 1,
+									PodCounts: kueue.TopologyAssignmentSlicePodCounts{
+										Universal: ptr.To[int32](5),
+									},
+									ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
+										{
+											Universal: ptr.To("node1"),
+										},
 									},
 								},
 							},
@@ -969,7 +987,7 @@ func TestHasTASAssignmentOnNode(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := HasTASAssignmentOnNode(tc.psa, tc.nodeName)
+			got := HasTASAssignmentOnNode(tc.admission, tc.nodeName)
 			if got != tc.want {
 				t.Errorf("HasTASAssignmentOnNode() = %v, want %v", got, tc.want)
 			}

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -522,6 +522,48 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 		})
 	})
 
+	ginkgo.When("Workload without admission has pods with node selector", func() {
+		var (
+			node *corev1.Node
+			wl   *kueue.Workload
+			pod  *corev1.Pod
+		)
+
+		ginkgo.BeforeEach(func() {
+			node = testingnode.MakeNode("node-test").
+				Label("node-group", "tas").
+				Ready().
+				Obj()
+			util.CreateNodesWithStatus(ctx, k8sClient, []corev1.Node{*node})
+
+			wl = utiltestingapi.MakeWorkload("wl-pending", ns.Name).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+
+			pod = testingpod.MakePod("pod-with-selector", ns.Name).
+				Annotation(kueue.WorkloadAnnotation, wl.Name).
+				Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
+				NodeSelector(corev1.LabelHostname, "node-test").
+				StatusPhase(corev1.PodPending).
+				Obj()
+			util.MustCreate(ctx, k8sClient, pod)
+		})
+
+		ginkgo.AfterEach(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, pod, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, wl, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, node, true)
+		})
+
+		ginkgo.It("should not panic during node reconciliation", func() {
+			gomega.Consistently(func(g gomega.Gomega) {
+				var fetchedNode corev1.Node
+				g.Expect(k8sClient.Get(ctx, apitypes.NamespacedName{Name: "node-test"}, &fetchedNode)).To(gomega.Succeed())
+			}, util.ShortConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+		})
+	})
+
 	ginkgo.When("Single TAS Resource Flavor", func() {
 		var (
 			tasFlavor    *kueue.ResourceFlavor

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -531,7 +531,6 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 		ginkgo.BeforeEach(func() {
 			node = testingnode.MakeNode("node-test").
-				Label("node-group", "tas").
 				Ready().
 				Obj()
 			util.CreateNodesWithStatus(ctx, k8sClient, []corev1.Node{*node})
@@ -556,11 +555,22 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, node, true)
 		})
 
-		ginkgo.It("should not panic during node reconciliation", func() {
-			gomega.Consistently(func(g gomega.Gomega) {
-				var fetchedNode corev1.Node
-				g.Expect(k8sClient.Get(ctx, apitypes.NamespacedName{Name: "node-test"}, &fetchedNode)).To(gomega.Succeed())
-			}, util.ShortConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+		ginkgo.It("should mark stray pods as failed during node reconciliation", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(node), node)).To(gomega.Succeed())
+				node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
+					Key:    "trigger-reconcile",
+					Value:  "true",
+					Effect: corev1.TaintEffectNoSchedule,
+				})
+				g.Expect(k8sClient.Update(ctx, node)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				var fetchedPod corev1.Pod
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), &fetchedPod)).To(gomega.Succeed())
+				g.Expect(fetchedPod.Status.Phase).To(gomega.Equal(corev1.PodFailed))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area tas

#### What this PR does / why we need it:
Add nil check for workload status admission field before accessing it for further TAS assignment checks

#### Which issue(s) this PR fixes:
Fixes #10640

#### Special notes for your reviewer:
It's almost the same as https://github.com/kubernetes-sigs/kueue/pull/10036

#### Does this PR introduce a user-facing change?
```release-note
TAS: Fix nil pointer panic in TAS node reconciler when unadmitted workloads exist in the cluster.
```