### PR TITLE
doc: update workload-priority-class documentation to clarify that WorkloadPriorityClassese is mutable

### DIFF
--- a/site/content/en/docs/concepts/workload_priority_class.md
+++ b/site/content/en/docs/concepts/workload_priority_class.md
@@ -101,12 +101,17 @@ The priority of workloads is used for:
 - Sorting the workloads in the ClusterQueues.
 - Determining whether a workload can preempt others.
 
-## Workload's priority values are always mutable
+## Mutability of priority fields
 
-The `Workload`'s `Priority` field is always mutable.
-If a `Workload` has been pending for a while, you can consider updating its priority to execute it earlier,
-based on your own policies.
-Workload's `PriorityClassSource` and `PriorityClassName` fields are immutable.
+The `kueue.x-k8s.io/priority-class` label on the Job can be changed while the Job is suspended.
+When updated, Kueue reconciles the Workload's priority fields accordingly.
+
+On the Workload, `Priority` is always mutable.
+`priorityClassRef` (and its `group`/`kind`) is mutable while the Workload is pending,
+and becomes immutable once the `QuotaReserved` condition is `True`.
+`priorityClassRef.name` follows the same rule, except when `priorityClassRef.kind` is
+`WorkloadPriorityClass`. In that case, `.priorityClassRef.name` can still be updated
+after the `QuotaReserved` condition is `True`.
 
 ## What's next?
 

--- a/site/content/en/docs/tasks/manage/run_job_with_workload_priority.md
+++ b/site/content/en/docs/tasks/manage/run_job_with_workload_priority.md
@@ -62,8 +62,14 @@ spec:
 Kueue generates the following `Workload` for the Job above.
 The priority of workloads is utilized in queuing, preemption, and other scheduling processes in Kueue.
 This priority doesn't affect pod's priority.  
-Workload's `Priority` field is always mutable because it might be useful for the preemption.
-Workload's `PriorityClassSource` and `PriorityClassName` fields are immutable.
+The `kueue.x-k8s.io/priority-class` label on the Job can be changed while the Job is suspended.
+When updated, Kueue reconciles the Workload's priority fields accordingly.
+On the Workload, `Priority` is always mutable.
+`priorityClassRef` (and its `group`/`kind`) is mutable while the Workload is pending,
+and becomes immutable once the `QuotaReserved` condition is `True`.
+`priorityClassRef.name` follows the same rule, except when `priorityClassRef.kind` is
+`WorkloadPriorityClass`. In that case, `.priorityClassRef.name` can still be updated
+after the `QuotaReserved` condition is `True`.
 
 ```yaml
 apiVersion: kueue.x-k8s.io/v1beta1


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Update WorkloadPriorityClass concept page and task guide to clarify that `priorityClassSource` and `priorityClassName` are mutable while the Workload is pending, and only become immutable once the `QuotaReserved` condition is `True`.

The previous wording stated these fields are unconditionally immutable, which does not match the current implementation as of https://github.com/kubernetes-sigs/kueue/pull/7289 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```