### PR TITLE
Add util AssertMsg logging to e2e kuberay_test

### DIFF
--- a/test/e2e/singlecluster/kuberay_test.go
+++ b/test/e2e/singlecluster/kuberay_test.go
@@ -164,33 +164,33 @@ var _ = ginkgo.Describe("Kuberay", ginkgo.Label("area:singlecluster", "feature:k
 		})
 
 		ginkgo.By("Waiting for the RayJob cluster become ready", func() {
+			createdRayJob := &rayv1.RayJob{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				createdRayJob := &rayv1.RayJob{}
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayJob), createdRayJob)).To(gomega.Succeed())
 				g.Expect(createdRayJob.Spec.Suspend).To(gomega.BeFalse())
 				g.Expect(createdRayJob.Status.JobDeploymentStatus).To(gomega.Equal(rayv1.JobDeploymentStatusRunning))
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("RayJob cluster did not become ready", createdRayJob))
 		})
 
 		ginkgo.By("Verify ray job worker pods have queue labels assigned", func() {
+			pods := &corev1.PodList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				var pods corev1.PodList
-				g.Expect(k8sClient.List(ctx, &pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
+				g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				g.Expect(pods.Items).ToNot(gomega.BeEmpty())
 				for _, pod := range pods.Items {
 					g.Expect(pod.Labels[constants.ClusterQueueLabel]).To(gomega.Equal(clusterQueueName))
 					g.Expect(pod.Labels[constants.LocalQueueLabel]).To(gomega.Equal(localQueueName))
 				}
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Worker pods missing expected queue labels", pods))
 		})
 
 		ginkgo.By("Waiting for the RayJob to finish", func() {
+			createdRayJob := &rayv1.RayJob{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				createdRayJob := &rayv1.RayJob{}
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayJob), createdRayJob)).To(gomega.Succeed())
 				g.Expect(createdRayJob.Status.JobDeploymentStatus).To(gomega.Equal(rayv1.JobDeploymentStatusComplete))
 				g.Expect(createdRayJob.Status.JobStatus).To(gomega.Equal(rayv1.JobStatusSucceeded))
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("RayJob did not finish successfully", createdRayJob))
 		})
 	})
 
@@ -285,8 +285,8 @@ print(ray.get([my_task.remote(i, 60) for i in range(3)]))`,
 		})
 
 		ginkgo.By("Checking one workload is created", func() {
+			workloadList := &kueue.WorkloadList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				workloadList := &kueue.WorkloadList{}
 				g.Expect(k8sClient.List(ctx, workloadList, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				g.Expect(workloadList.Items).NotTo(gomega.BeEmpty(), "Expected at least one workload in namespace")
 				hasAdmittedWorkload := false
@@ -297,47 +297,47 @@ print(ray.get([my_task.remote(i, 60) for i in range(3)]))`,
 					}
 				}
 				g.Expect(hasAdmittedWorkload).To(gomega.BeTrue(), "Expected admitted workload")
-			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("No admitted workload found in namespace", workloadList))
 		})
 
 		ginkgo.By("Waiting for the RayJob cluster become ready", func() {
+			createdRayJob := &rayv1.RayJob{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				createdRayJob := &rayv1.RayJob{}
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayJob), createdRayJob)).To(gomega.Succeed())
 				g.Expect(createdRayJob.Spec.Suspend).To(gomega.BeFalse())
 				g.Expect(createdRayJob.Status.JobDeploymentStatus).To(gomega.Equal(rayv1.JobDeploymentStatusRunning))
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("RayJob cluster did not become ready", createdRayJob))
 		})
 
 		ginkgo.By("Waiting for 3 pods in rayjob namespace", func() {
 			// 3 rayjob pods: head, worker, submitter job
+			podList := &corev1.PodList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				podList := &corev1.PodList{}
 				g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				g.Expect(podList.Items).To(gomega.HaveLen(3), "Expected exactly 3 pods in rayjob namespace")
 				// Get worker pod names and check count
 				workerPodNames := getRunningWorkerPodNames(podList)
 				g.Expect(workerPodNames).To(gomega.HaveLen(1), "Expected exactly 1 pod with 'workers' in the name")
-			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Unexpected pod set in rayjob namespace", podList))
 		})
 
 		// RayJob is top level job, the submitter job created by RayJob will not create its own workload, there will be only 1 workload
 		ginkgo.By("Waiting for 1 workloads", func() {
 			// 1 workload for the ray cluster
+			workloadList := &kueue.WorkloadList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				workloadList := &kueue.WorkloadList{}
 				g.Expect(k8sClient.List(ctx, workloadList, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				g.Expect(workloadList.Items).To(gomega.HaveLen(1), "Expected exactly 1 workload")
-			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Expected exactly 1 workload", workloadList))
 		})
 
 		ginkgo.By("Waiting for all 2 worker pods to be running", func() {
+			podList := &corev1.PodList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				podList := &corev1.PodList{}
 				g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				runningWorkers := getRunningWorkerPodNames(podList)
 				g.Expect(runningWorkers).To(gomega.HaveLen(2), "Expected 2 running worker pods")
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Did not observe 2 running worker pods", podList))
 		})
 
 		var deletedPodName string
@@ -357,23 +357,23 @@ print(ray.get([my_task.remote(i, 60) for i in range(3)]))`,
 		})
 
 		ginkgo.By("Waiting for a new worker pod to replace the deleted one", func() {
+			podList := &corev1.PodList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				podList := &corev1.PodList{}
 				g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				runningWorkers := getRunningWorkerPodNames(podList)
 				g.Expect(runningWorkers).To(gomega.HaveLen(2), "Expected 2 running worker pods after replacement")
 				g.Expect(runningWorkers).NotTo(gomega.ContainElement(deletedPodName),
 					"Deleted pod should not be present among running workers")
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList(fmt.Sprintf("Replacement worker pod did not appear after deleting %q", deletedPodName), podList))
 		})
 
 		ginkgo.By("Waiting for the RayJob to finish", func() {
+			createdRayJob := &rayv1.RayJob{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				createdRayJob := &rayv1.RayJob{}
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayJob), createdRayJob)).To(gomega.Succeed())
 				g.Expect(createdRayJob.Status.JobDeploymentStatus).To(gomega.Equal(rayv1.JobDeploymentStatusComplete))
 				g.Expect(createdRayJob.Status.JobStatus).To(gomega.Equal(rayv1.JobStatusSucceeded))
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("RayJob did not finish successfully", createdRayJob))
 		})
 	})
 
@@ -480,8 +480,8 @@ print([ray.get(my_task.remote(i, 1)) for i in range(32)])`,
 		})
 
 		ginkgo.By("Checking one workload is created", func() {
+			workloadList := &kueue.WorkloadList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				workloadList := &kueue.WorkloadList{}
 				g.Expect(k8sClient.List(ctx, workloadList, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				g.Expect(workloadList.Items).NotTo(gomega.BeEmpty(), "Expected at least one workload in namespace")
 				hasAdmittedWorkload := false
@@ -492,53 +492,53 @@ print([ray.get(my_task.remote(i, 1)) for i in range(32)])`,
 					}
 				}
 				g.Expect(hasAdmittedWorkload).To(gomega.BeTrue(), "Expected admitted workload")
-			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("No admitted workload found in namespace", workloadList))
 		})
 
 		ginkgo.By("Waiting for the RayJob cluster become ready", func() {
+			createdRayJob := &rayv1.RayJob{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				createdRayJob := &rayv1.RayJob{}
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayJob), createdRayJob)).To(gomega.Succeed())
 				g.Expect(createdRayJob.Spec.Suspend).To(gomega.BeFalse())
 				g.Expect(createdRayJob.Status.JobDeploymentStatus).To(gomega.Equal(rayv1.JobDeploymentStatusRunning))
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("RayJob cluster did not become ready", createdRayJob))
 		})
 
 		ginkgo.By("Waiting for 3 pods in rayjob namespace", func() {
 			// 3 rayjob pods: head, worker, submitter job
+			podList := &corev1.PodList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				podList := &corev1.PodList{}
 				g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				g.Expect(podList.Items).To(gomega.HaveLen(3), "Expected exactly 3 pods in rayjob namespace")
 				// Get worker pod names and check count
 				workerPodNames := getRunningWorkerPodNames(podList)
 				g.Expect(workerPodNames).To(gomega.HaveLen(1), "Expected exactly 1 pod with 'workers' in the name")
-			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Unexpected pod set in rayjob namespace", podList))
 		})
 
 		// RayJob is top level job, the submitter job created by RayJob will not create its own workload, there will be only 1 workload
 		ginkgo.By("Waiting for 1 workloads", func() {
 			// 1 workload for the ray cluster
+			workloadList := &kueue.WorkloadList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				workloadList := &kueue.WorkloadList{}
 				g.Expect(k8sClient.List(ctx, workloadList, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				g.Expect(workloadList.Items).To(gomega.HaveLen(1), "Expected exactly 1 workload")
-			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Expected exactly 1 workload", workloadList))
 		})
 
 		ginkgo.By("Waiting for second scale-up to 5 workers due to high parallelism tasks", func() {
+			podList := &corev1.PodList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				podList := &corev1.PodList{}
 				g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				// Get worker pod names and check count
 				currentPodNames := getRunningWorkerPodNames(podList)
 				g.Expect(currentPodNames).To(gomega.HaveLen(5), "Expected exactly 5 pods with 'workers' in the name after second scale-up")
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Did not scale up to 5 worker pods", podList))
 		})
 
 		ginkgo.By("Checking podset-replica-sizes annotation is set on the RayJob after second scale-up", func() {
+			createdRayJob := &rayv1.RayJob{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				createdRayJob := &rayv1.RayJob{}
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayJob), createdRayJob)).To(gomega.Succeed())
 				g.Expect(createdRayJob.Annotations).To(gomega.HaveKey(workloadraycluster.RayClusterPodsetReplicaSizesAnnotation),
 					"Expected podset-replica-sizes annotation on RayJob after second scale-up")
@@ -546,31 +546,31 @@ print([ray.get(my_task.remote(i, 1)) for i in range(32)])`,
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(count).To(gomega.Equal(int32(5)),
 					"Expected workers-group-0 count = 5 after second scale-up")
-			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("podset-replica-sizes annotation not updated after second scale-up", createdRayJob))
 		})
 
 		ginkgo.By("Waiting for at least 3 total workloads due to multiple scale-ups", func() {
 			// Use >= 3 since multiple scale-up events should create additional workload slices.
+			workloadList := &kueue.WorkloadList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				workloadList := &kueue.WorkloadList{}
 				g.Expect(k8sClient.List(ctx, workloadList, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				g.Expect(len(workloadList.Items)).To(gomega.BeNumerically(">=", 3), "Expected at least 3 workloads due to multiple scale-ups")
-			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Did not observe >=3 workloads from multiple scale-ups", workloadList))
 		})
 
 		ginkgo.By("Waiting for workers reduced to 1 due to scaling down", func() {
+			podList := &corev1.PodList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				podList := &corev1.PodList{}
 				g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				// Get worker pod names and check count
 				currentPodNames := getRunningWorkerPodNames(podList)
 				g.Expect(currentPodNames).To(gomega.HaveLen(1), "Expected exactly 1 pods with 'workers' in the name")
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Workers did not scale down to 1", podList))
 		})
 
 		ginkgo.By("Checking podset-replica-sizes annotation updated after scaling down", func() {
+			createdRayJob := &rayv1.RayJob{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				createdRayJob := &rayv1.RayJob{}
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayJob), createdRayJob)).To(gomega.Succeed())
 				g.Expect(createdRayJob.Annotations).To(gomega.HaveKey(workloadraycluster.RayClusterPodsetReplicaSizesAnnotation),
 					"Expected podset-replica-sizes annotation on RayJob after scaling down")
@@ -578,16 +578,16 @@ print([ray.get(my_task.remote(i, 1)) for i in range(32)])`,
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(count).To(gomega.Equal(int32(1)),
 					"Expected workers-group-0 count = 1 after scaling down")
-			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("podset-replica-sizes annotation not updated after scaling down", createdRayJob))
 		})
 
 		ginkgo.By("Waiting for the RayJob to finish", func() {
+			createdRayJob := &rayv1.RayJob{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				createdRayJob := &rayv1.RayJob{}
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayJob), createdRayJob)).To(gomega.Succeed())
 				g.Expect(createdRayJob.Status.JobDeploymentStatus).To(gomega.Equal(rayv1.JobDeploymentStatusComplete))
 				g.Expect(createdRayJob.Status.JobStatus).To(gomega.Equal(rayv1.JobStatusSucceeded))
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("RayJob did not finish successfully", createdRayJob))
 		})
 	})
 
@@ -620,13 +620,13 @@ print([ray.get(my_task.remote(i, 1)) for i in range(32)])`,
 		})
 
 		ginkgo.By("Checking the RayCluster is ready", func() {
+			createdRayCluster := &rayv1.RayCluster{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				createdRayCluster := &rayv1.RayCluster{}
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(raycluster), createdRayCluster)).To(gomega.Succeed())
 				g.Expect(createdRayCluster.Status.DesiredWorkerReplicas).To(gomega.Equal(int32(1)))
 				g.Expect(createdRayCluster.Status.ReadyWorkerReplicas).To(gomega.Equal(int32(1)))
 				g.Expect(createdRayCluster.Status.AvailableWorkerReplicas).To(gomega.Equal(int32(1)))
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("RayCluster did not become ready", createdRayCluster))
 		})
 	})
 
@@ -737,12 +737,12 @@ app = HelloWorld.bind()`,
 		})
 
 		ginkgo.By("Checking the RayService is running", func() {
+			createdRayService := &rayv1.RayService{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				createdRayService := &rayv1.RayService{}
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayService), createdRayService)).To(gomega.Succeed())
 				g.Expect(createdRayService.Spec.RayClusterSpec.Suspend).To(gomega.Equal(ptr.To(false)))
 				g.Expect(apimeta.IsStatusConditionTrue(createdRayService.Status.Conditions, string(rayv1.RayServiceReady))).To(gomega.BeTrue())
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("RayService did not become ready", createdRayService))
 		})
 
 		ginkgo.By("Verifying the RayService responds to HTTP requests via port-forward", func() {

--- a/test/e2e/singlecluster/kuberay_test.go
+++ b/test/e2e/singlecluster/kuberay_test.go
@@ -315,10 +315,16 @@ print(ray.get([my_task.remote(i, 60) for i in range(3)]))`,
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				g.Expect(podList.Items).To(gomega.HaveLen(3), "Expected exactly 3 pods in rayjob namespace")
-				// Get worker pod names and check count
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Waiting for exactly 1 worker pod", func() {
+			podList := &corev1.PodList{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				workerPodNames := getRunningWorkerPodNames(podList)
 				g.Expect(workerPodNames).To(gomega.HaveLen(1), "Expected exactly 1 pod with 'workers' in the name")
-			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Unexpected pod set in rayjob namespace", podList))
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Expected exactly 1 worker pod", podList))
 		})
 
 		// RayJob is top level job, the submitter job created by RayJob will not create its own workload, there will be only 1 workload
@@ -328,7 +334,7 @@ print(ray.get([my_task.remote(i, 60) for i in range(3)]))`,
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.List(ctx, workloadList, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				g.Expect(workloadList.Items).To(gomega.HaveLen(1), "Expected exactly 1 workload")
-			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Expected exactly 1 workload", workloadList))
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 		})
 
 		ginkgo.By("Waiting for all 2 worker pods to be running", func() {
@@ -510,10 +516,16 @@ print([ray.get(my_task.remote(i, 1)) for i in range(32)])`,
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				g.Expect(podList.Items).To(gomega.HaveLen(3), "Expected exactly 3 pods in rayjob namespace")
-				// Get worker pod names and check count
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Waiting for exactly 1 worker pod", func() {
+			podList := &corev1.PodList{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				workerPodNames := getRunningWorkerPodNames(podList)
 				g.Expect(workerPodNames).To(gomega.HaveLen(1), "Expected exactly 1 pod with 'workers' in the name")
-			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Unexpected pod set in rayjob namespace", podList))
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Expected exactly 1 worker pod", podList))
 		})
 
 		// RayJob is top level job, the submitter job created by RayJob will not create its own workload, there will be only 1 workload
@@ -523,7 +535,7 @@ print([ray.get(my_task.remote(i, 1)) for i in range(32)])`,
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.List(ctx, workloadList, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				g.Expect(workloadList.Items).To(gomega.HaveLen(1), "Expected exactly 1 workload")
-			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Expected exactly 1 workload", workloadList))
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 		})
 
 		ginkgo.By("Waiting for second scale-up to 5 workers due to high parallelism tasks", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:
Add util AssertMsg logging to e2e kuberay_test

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
https://github.com/kubernetes-sigs/kueue/issues/10642#issuecomment-4288028366

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```