### PR TITLE
Automated cherry pick of #10644: Use RunSuite()

### DIFF
--- a/test/e2e/certmanager/suite_test.go
+++ b/test/e2e/certmanager/suite_test.go
@@ -18,8 +18,6 @@ package certmanager
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -44,14 +42,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	suiteName := "End To End Cert Manager Integration Suite"
-	if ver, found := os.LookupEnv("E2E_KIND_VERSION"); found {
-		suiteName = fmt.Sprintf("%s: %s", suiteName, ver)
-	}
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t,
-		suiteName,
-	)
+	util.RunE2ESuite(t, "End To End Cert Manager Integration Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -75,9 +66,4 @@ var _ = ginkgo.BeforeSuite(func() {
 		"Kueue and all required operators are available in the cluster",
 		"waitingTime", time.Since(waitForAvailableStart),
 	)
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })

--- a/test/e2e/dra/suite_test.go
+++ b/test/e2e/dra/suite_test.go
@@ -19,7 +19,6 @@ package dra
 import (
 	"cmp"
 	"context"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -37,14 +36,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	suiteName := "End To End DRA Integration Suite"
-	if ver, found := os.LookupEnv("E2E_KIND_VERSION"); found {
-		suiteName = fmt.Sprintf("%s: %s", suiteName, ver)
-	}
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t,
-		suiteName,
-	)
+	util.RunE2ESuite(t, "End To End DRA Integration Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -64,9 +56,4 @@ var _ = ginkgo.BeforeSuite(func() {
 		"clusterName", clusterName,
 		"waitingTime", time.Since(waitForAvailableStart),
 	)
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })

--- a/test/e2e/multikueue/suite_test.go
+++ b/test/e2e/multikueue/suite_test.go
@@ -19,7 +19,6 @@ package multikueue
 import (
 	"cmp"
 	"context"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -60,14 +59,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	suiteName := "End To End MultiKueue Suite"
-	if ver, found := os.LookupEnv("E2E_KIND_VERSION"); found {
-		suiteName = fmt.Sprintf("%s: %s", suiteName, ver)
-	}
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t,
-		suiteName,
-	)
+	util.RunE2ESuite(t, "End To End MultiKueue Suite")
 }
 
 var _ = ginkgo.SynchronizedBeforeSuite(
@@ -166,8 +158,3 @@ func cleanupSharedMultiKueueSecrets(ctx context.Context) {
 	gomega.Expect(util.CleanKubeconfigForMultiKueueSA(ctx, k8sWorker1Client, kueueNS, "mksa")).NotTo(gomega.HaveOccurred())
 	gomega.Expect(util.CleanKubeconfigForMultiKueueSA(ctx, k8sWorker2Client, kueueNS, "mksa")).NotTo(gomega.HaveOccurred())
 }
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-})

--- a/test/e2e/multikueuedra/suite_test.go
+++ b/test/e2e/multikueuedra/suite_test.go
@@ -23,7 +23,6 @@ package multikueuedra
 import (
 	"cmp"
 	"context"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -64,12 +63,7 @@ var (
 var kueueNS = util.GetKueueNamespace()
 
 func TestAPIs(t *testing.T) {
-	suiteName := "End To End MultiKueue DRA Suite"
-	if ver, found := os.LookupEnv("E2E_KIND_VERSION"); found {
-		suiteName = fmt.Sprintf("%s: %s", suiteName, ver)
-	}
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, suiteName)
+	util.RunE2ESuite(t, "End To End MultiKueue DRA Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -122,10 +116,5 @@ var _ = ginkgo.BeforeSuite(func() {
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(managerCfg)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	managerK8SVersion, err = kubeversion.FetchServerVersion(discoveryClient)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })

--- a/test/e2e/multikueuesequential/suite_test.go
+++ b/test/e2e/multikueuesequential/suite_test.go
@@ -19,7 +19,6 @@ package multikueuesequential
 import (
 	"cmp"
 	"context"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -60,14 +59,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	suiteName := "End To End MultiKueue Suite"
-	if ver, found := os.LookupEnv("E2E_KIND_VERSION"); found {
-		suiteName = fmt.Sprintf("%s: %s", suiteName, ver)
-	}
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t,
-		suiteName,
-	)
+	util.RunE2ESuite(t, "End To End MultiKueue Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -119,10 +111,5 @@ var _ = ginkgo.BeforeSuite(func() {
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(managerCfg)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	managerK8SVersion, err = kubeversion.FetchServerVersion(discoveryClient)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })

--- a/test/e2e/sequential/baseline/suite_test.go
+++ b/test/e2e/sequential/baseline/suite_test.go
@@ -18,7 +18,6 @@ package baseline
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -43,14 +42,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	suiteName := "End To End Sequential Baseline Suite"
-	if ver, found := os.LookupEnv("E2E_KIND_VERSION"); found {
-		suiteName = fmt.Sprintf("%s: %s", suiteName, ver)
-	}
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t,
-		suiteName,
-	)
+	util.RunE2ESuite(t, "End To End Sequential Baseline Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -73,9 +65,4 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })

--- a/test/e2e/sequential/extended/suite_test.go
+++ b/test/e2e/sequential/extended/suite_test.go
@@ -18,7 +18,6 @@ package extended
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -39,14 +38,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	suiteName := "End To End Sequential Extended Suite"
-	if ver, found := os.LookupEnv("E2E_KIND_VERSION"); found {
-		suiteName = fmt.Sprintf("%s: %s", suiteName, ver)
-	}
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t,
-		suiteName,
-	)
+	util.RunE2ESuite(t, "End To End Sequential Extended Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -76,9 +68,4 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })

--- a/test/e2e/singlecluster/suite_test.go
+++ b/test/e2e/singlecluster/suite_test.go
@@ -19,7 +19,6 @@ package singlecluster
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -48,14 +47,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	suiteName := "End To End Suite"
-	if ver, found := os.LookupEnv("E2E_KIND_VERSION"); found {
-		suiteName = fmt.Sprintf("%s: %s", suiteName, ver)
-	}
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t,
-		suiteName,
-	)
+	util.RunE2ESuite(t, "End To End Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -100,9 +92,4 @@ var _ = ginkgo.BeforeSuite(func() {
 		"Kueue and all required operators are available in the cluster",
 		"waitingTime", time.Since(waitForAvailableStart),
 	)
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })

--- a/test/e2e/tas/suite_test.go
+++ b/test/e2e/tas/suite_test.go
@@ -18,7 +18,6 @@ package tas
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -42,14 +41,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	suiteName := "End To End TAS Suite"
-	if ver, found := os.LookupEnv("E2E_KIND_VERSION"); found {
-		suiteName = fmt.Sprintf("%s: %s", suiteName, ver)
-	}
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t,
-		suiteName,
-	)
+	util.RunE2ESuite(t, "End To End TAS Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -97,9 +89,4 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })

--- a/test/e2e/upgrade/suite_test.go
+++ b/test/e2e/upgrade/suite_test.go
@@ -44,11 +44,7 @@ func TestUpgrade(t *testing.T) {
 	if upgradeFrom != "" {
 		suiteName = fmt.Sprintf("%s: %s -> current", suiteName, upgradeFrom)
 	}
-	if ver, found := os.LookupEnv("E2E_KIND_VERSION"); found {
-		suiteName = fmt.Sprintf("%s (K8s %s)", suiteName, ver)
-	}
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, suiteName)
+	util.RunE2ESuite(t, suiteName)
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -76,9 +72,4 @@ var _ = ginkgo.BeforeSuite(func() {
 		"version", upgradeFrom,
 		"waitingTime", time.Since(waitForAvailableStart),
 	)
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })

--- a/test/integration/multikueue/scheduler/suite_test.go
+++ b/test/integration/multikueue/scheduler/suite_test.go
@@ -80,10 +80,7 @@ var (
 )
 
 func TestMultiKueue(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t,
-		"MultiKueue with Scheduler Suite",
-	)
+	util.RunSuite(t, "MultiKueue with Scheduler Suite")
 }
 
 func createCluster(setupFnc framework.ManagerSetup, apiFeatureGates ...string) cluster {
@@ -215,9 +212,4 @@ var _ = ginkgo.AfterSuite(func() {
 	managerTestCluster.fwk.Teardown()
 	worker1TestCluster.fwk.Teardown()
 	worker2TestCluster.fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })

--- a/test/integration/multikueue/suite_test.go
+++ b/test/integration/multikueue/suite_test.go
@@ -92,11 +92,7 @@ var (
 )
 
 func TestMultiKueue(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"MultiKueue Suite",
-	)
+	util.RunSuite(t, "MultiKueue Suite")
 }
 
 func createCluster(setupFnc framework.ManagerSetup, apiFeatureGates ...string) cluster {
@@ -416,9 +412,4 @@ var _ = ginkgo.AfterSuite(func() {
 	managerTestCluster.fwk.Teardown()
 	worker1TestCluster.fwk.Teardown()
 	worker2TestCluster.fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })

--- a/test/integration/multikueue/tas/suite_test.go
+++ b/test/integration/multikueue/tas/suite_test.go
@@ -82,10 +82,7 @@ var (
 )
 
 func TestMultiKueue(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t,
-		"MultiKueue TAS Suite",
-	)
+	util.RunSuite(t, "MultiKueue TAS Suite")
 }
 
 func createCluster(setupFnc framework.ManagerSetup, apiFeatureGates ...string) cluster {
@@ -221,9 +218,4 @@ var _ = ginkgo.AfterSuite(func() {
 	managerTestCluster.fwk.Teardown()
 	worker1TestCluster.fwk.Teardown()
 	worker2TestCluster.fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })

--- a/test/integration/singlecluster/controller/admissionchecks/provisioning/suite_test.go
+++ b/test/integration/singlecluster/controller/admissionchecks/provisioning/suite_test.go
@@ -50,11 +50,7 @@ var (
 )
 
 func TestProvisioning(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"Provisioning admission check suite",
-	)
+	util.RunSuite(t, "Provisioning admission check suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -70,11 +66,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 type managerSetupOpts struct {

--- a/test/integration/singlecluster/controller/core/suite_test.go
+++ b/test/integration/singlecluster/controller/core/suite_test.go
@@ -50,11 +50,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"Core Controllers Suite",
-	)
+	util.RunSuite(t, "Core Controllers Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -68,11 +64,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 type managerSetupOpts struct {

--- a/test/integration/singlecluster/controller/dra/suite_test.go
+++ b/test/integration/singlecluster/controller/dra/suite_test.go
@@ -50,11 +50,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"DRA Controller Suite",
-	)
+	util.RunSuite(t, "DRA Controller Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -79,11 +75,6 @@ var _ = ginkgo.BeforeSuite(func() {
 var _ = ginkgo.AfterSuite(func() {
 	ginkgo.By("tearing down the test environment")
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 // Manager setup used by tests to start controllers with DRA ConfigMap configuration

--- a/test/integration/singlecluster/controller/failurerecovery/suite_test.go
+++ b/test/integration/singlecluster/controller/failurerecovery/suite_test.go
@@ -44,11 +44,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"Failure Recovery Suite",
-	)
+	util.RunSuite(t, "Failure Recovery Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -60,11 +56,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerSetup(ctx context.Context, mgr manager.Manager) {

--- a/test/integration/singlecluster/controller/jobframework/setup/suite_test.go
+++ b/test/integration/singlecluster/controller/jobframework/setup/suite_test.go
@@ -40,17 +40,8 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"Setup Controllers Suite",
-	)
+	util.RunSuite(t, "Setup Controllers Suite")
 }
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-})
 
 func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {
 	return func(ctx context.Context, mgr manager.Manager) {

--- a/test/integration/singlecluster/controller/jobs/appwrapper/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/appwrapper/suite_test.go
@@ -51,11 +51,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"AppWrapper Controller Suite",
-	)
+	util.RunSuite(t, "AppWrapper Controller Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -68,11 +64,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {

--- a/test/integration/singlecluster/controller/jobs/jaxjob/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/jaxjob/suite_test.go
@@ -51,11 +51,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"JAXJob Controller Suite",
-	)
+	util.RunSuite(t, "JAXJob Controller Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -68,11 +64,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {

--- a/test/integration/singlecluster/controller/jobs/job/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/suite_test.go
@@ -54,11 +54,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"Job Controller Suite",
-	)
+	util.RunSuite(t, "Job Controller Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -69,11 +65,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {

--- a/test/integration/singlecluster/controller/jobs/jobset/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/jobset/suite_test.go
@@ -51,11 +51,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"JobSet Controller Suite",
-	)
+	util.RunSuite(t, "JobSet Controller Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -68,11 +64,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {

--- a/test/integration/singlecluster/controller/jobs/mpijob/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/mpijob/suite_test.go
@@ -53,11 +53,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"MPIJob Controller Suite",
-	)
+	util.RunSuite(t, "MPIJob Controller Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -72,11 +68,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerSetup(setupJobManager bool, opts ...jobframework.Option) framework.ManagerSetup {

--- a/test/integration/singlecluster/controller/jobs/paddlejob/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/paddlejob/suite_test.go
@@ -51,11 +51,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"PaddleJob Controller Suite",
-	)
+	util.RunSuite(t, "PaddleJob Controller Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -68,11 +64,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {

--- a/test/integration/singlecluster/controller/jobs/pod/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/suite_test.go
@@ -54,11 +54,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"Pod Controller Suite",
-	)
+	util.RunSuite(t, "Pod Controller Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -71,11 +67,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerSetup(

--- a/test/integration/singlecluster/controller/jobs/pytorchjob/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/pytorchjob/suite_test.go
@@ -51,11 +51,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"PyTorchJob Controller Suite",
-	)
+	util.RunSuite(t, "PyTorchJob Controller Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -68,11 +64,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {

--- a/test/integration/singlecluster/controller/jobs/raycluster/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/raycluster/suite_test.go
@@ -52,11 +52,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"RayCluster Controller Suite",
-	)
+	util.RunSuite(t, "RayCluster Controller Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -70,11 +66,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {

--- a/test/integration/singlecluster/controller/jobs/rayjob/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/suite_test.go
@@ -49,11 +49,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"RayJob Controller Suite",
-	)
+	util.RunSuite(t, "RayJob Controller Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -67,11 +63,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {

--- a/test/integration/singlecluster/controller/jobs/sparkapplication/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/sparkapplication/suite_test.go
@@ -52,11 +52,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"SparkApplication Controller Suite",
-	)
+	util.RunSuite(t, "SparkApplication Controller Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -71,11 +67,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {

--- a/test/integration/singlecluster/controller/jobs/statefulset/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/statefulset/suite_test.go
@@ -52,11 +52,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"StatefulSet Controller Suite",
-	)
+	util.RunSuite(t, "StatefulSet Controller Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -69,11 +65,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {

--- a/test/integration/singlecluster/controller/jobs/tfjob/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/tfjob/suite_test.go
@@ -51,11 +51,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"TFJob Controller Suite",
-	)
+	util.RunSuite(t, "TFJob Controller Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -68,11 +64,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {

--- a/test/integration/singlecluster/controller/jobs/trainjob/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/trainjob/suite_test.go
@@ -52,11 +52,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"TrainJob Controller Suite",
-	)
+	util.RunSuite(t, "TrainJob Controller Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -70,11 +66,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {

--- a/test/integration/singlecluster/controller/jobs/xgboostjob/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/xgboostjob/suite_test.go
@@ -51,11 +51,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"XGBoostJob Controller Suite",
-	)
+	util.RunSuite(t, "XGBoostJob Controller Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -68,11 +64,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {

--- a/test/integration/singlecluster/conversion/suite_test.go
+++ b/test/integration/singlecluster/conversion/suite_test.go
@@ -49,11 +49,7 @@ var (
 )
 
 func TestConversion(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"Conversion Suite",
-	)
+	util.RunSuite(t, "Conversion Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -67,11 +63,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerAndSchedulerSetup(ctx context.Context, mgr manager.Manager) {

--- a/test/integration/singlecluster/importer/suite_test.go
+++ b/test/integration/singlecluster/importer/suite_test.go
@@ -49,11 +49,7 @@ var (
 )
 
 func TestScheduler(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"Importer Suite",
-	)
+	util.RunSuite(t, "Importer Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -64,11 +60,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerAndSchedulerSetup(ctx context.Context, mgr manager.Manager) {

--- a/test/integration/singlecluster/kueuectl/suite_test.go
+++ b/test/integration/singlecluster/kueuectl/suite_test.go
@@ -52,8 +52,7 @@ var (
 )
 
 func TestKueuectl(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Kueuectl Suite")
+	util.RunSuite(t, "Kueuectl Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -74,11 +73,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerSetup(ctx context.Context, mgr manager.Manager) {

--- a/test/integration/singlecluster/scheduler/delayedadmission/suite_test.go
+++ b/test/integration/singlecluster/scheduler/delayedadmission/suite_test.go
@@ -48,11 +48,7 @@ var (
 )
 
 func TestSchedulerWithWaitForPodsReady(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"Scheduler with delayed admission checks Suite",
-	)
+	util.RunSuite(t, "Scheduler with delayed admission checks Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -65,11 +61,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerAndSchedulerSetup(configuration *configapi.Configuration) framework.ManagerSetup {

--- a/test/integration/singlecluster/scheduler/excluderesources/suite_test.go
+++ b/test/integration/singlecluster/scheduler/excluderesources/suite_test.go
@@ -52,11 +52,7 @@ var (
 )
 
 func TestSchedulerWithExcludeResourcePrefixes(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"Scheduler with Exclude Resource Prefixes Suite",
-	)
+	util.RunSuite(t, "Scheduler with Exclude Resource Prefixes Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -69,11 +65,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerAndSchedulerSetup(configuration *config.Configuration) framework.ManagerSetup {

--- a/test/integration/singlecluster/scheduler/fairsharing/suite_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/suite_test.go
@@ -50,11 +50,7 @@ var (
 )
 
 func TestScheduler(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"Scheduler Fair Sharing Suite",
-	)
+	util.RunSuite(t, "Scheduler Fair Sharing Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -67,11 +63,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerAndSchedulerSetup(admissionFairSharing *config.AdmissionFairSharing) framework.ManagerSetup {

--- a/test/integration/singlecluster/scheduler/inadmissible/suite_test.go
+++ b/test/integration/singlecluster/scheduler/inadmissible/suite_test.go
@@ -49,11 +49,7 @@ var (
 )
 
 func TestInadmissibleRequeueing(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"Scheduler Inadmissible Requeueing Suite",
-	)
+	util.RunSuite(t, "Scheduler Inadmissible Requeueing Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -66,11 +62,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerAndSchedulerSetup(ctx context.Context, mgr manager.Manager) {

--- a/test/integration/singlecluster/scheduler/podsready/suite_test.go
+++ b/test/integration/singlecluster/scheduler/podsready/suite_test.go
@@ -48,11 +48,7 @@ var (
 )
 
 func TestSchedulerWithWaitForPodsReady(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"Scheduler with WaitForPodsReady Suite",
-	)
+	util.RunSuite(t, "Scheduler with WaitForPodsReady Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -65,11 +61,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerAndSchedulerSetup(configuration *config.Configuration) framework.ManagerSetup {

--- a/test/integration/singlecluster/scheduler/resourcetransformations/suite_test.go
+++ b/test/integration/singlecluster/scheduler/resourcetransformations/suite_test.go
@@ -48,11 +48,7 @@ var (
 )
 
 func TestResourceTransformations(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"Resource Transformations Suite",
-	)
+	util.RunSuite(t, "Resource Transformations Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -65,11 +61,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerAndSchedulerSetup(transformations []config.ResourceTransformation) framework.ManagerSetup {

--- a/test/integration/singlecluster/scheduler/suite_test.go
+++ b/test/integration/singlecluster/scheduler/suite_test.go
@@ -63,11 +63,7 @@ var (
 )
 
 func TestScheduler(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"Scheduler Suite",
-	)
+	util.RunSuite(t, "Scheduler Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -81,11 +77,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 var _ = ginkgo.BeforeEach(func() {

--- a/test/integration/singlecluster/tas/suite_test.go
+++ b/test/integration/singlecluster/tas/suite_test.go
@@ -56,11 +56,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"TopologyAwareScheduling Suite",
-	)
+	util.RunSuite(t, "TopologyAwareScheduling Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -76,11 +72,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerSetup(resourceTransformations ...config.ResourceTransformation) func(ctx context.Context, mgr manager.Manager) {

--- a/test/integration/singlecluster/webhook/core/suite_test.go
+++ b/test/integration/singlecluster/webhook/core/suite_test.go
@@ -45,10 +45,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t,
-		"Core Webhook Suite",
-	)
+	util.RunSuite(t, "Core Webhook Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -61,11 +58,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerSetup(ctx context.Context, mgr manager.Manager) {

--- a/test/integration/singlecluster/webhook/jobs/suite_test.go
+++ b/test/integration/singlecluster/webhook/jobs/suite_test.go
@@ -46,11 +46,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	ginkgo.RunSpecs(t,
-		"Jobs Webhook Suite",
-	)
+	util.RunSuite(t, "Jobs Webhook Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -71,11 +67,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
-})
-
-var _ = ginkgo.ReportAfterSuite("Generate JUnit Report", func(report ginkgo.Report) {
-	err := util.ConfigureSuiteReporting(report)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
 func managerSetup(setup func(ctrl.Manager, ...jobframework.Option) error, opts ...jobframework.Option) framework.ManagerSetup {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -29,6 +29,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -90,6 +91,19 @@ func init() {
 	format.RegisterCustomFormatter(formatK8sObject)
 }
 
+func RunSuite(t *testing.T, suiteName string) {
+	ginkgo.ReportAfterSuite("Generate JUnit Report", ConfigureSuiteReporting)
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, suiteName)
+}
+
+func RunE2ESuite(t *testing.T, suiteName string) {
+	if ver, found := os.LookupEnv("E2E_KIND_VERSION"); found {
+		suiteName = fmt.Sprintf("%s: %s", suiteName, ver)
+	}
+	RunSuite(t, suiteName)
+}
+
 func formatK8sObject(value any) (string, bool) {
 	if value == nil {
 		return "", false
@@ -130,21 +144,21 @@ var SetupLoggerGetObservedLogs = sync.OnceValue(func() *observer.ObservedLogs {
 	return observedLogs
 })
 
-func ConfigureSuiteReporting(report ginkgo.Report) error {
+func ConfigureSuiteReporting(report ginkgo.Report) {
 	junitConfig := reporters.JunitReportConfig{
 		OmitFailureMessageAttr: true,
 	}
 	suiteName := uniqueSuiteName(report.SuitePath)
 	reportDir := cmp.Or(os.Getenv("ARTIFACTS"), ArtifactsDir)
 	if err := os.MkdirAll(reportDir, 0o755); err != nil {
-		return fmt.Errorf("cannot create suite report directory %q: %w", reportDir, err)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "cannot create suite report directory %q", reportDir)
 	}
 	reportPath := filepath.Join(reportDir, "junit-"+suiteName+".xml")
 	ginkgo.GinkgoLogr.Info(
 		"Generating JUnit report",
 		"path", reportPath,
 	)
-	return reporters.GenerateJUnitReportWithConfig(report, reportPath, junitConfig)
+	gomega.Expect(reporters.GenerateJUnitReportWithConfig(report, reportPath, junitConfig)).To(gomega.Succeed())
 }
 
 func uniqueSuiteName(suitePath string) string {


### PR DESCRIPTION
Cherry pick of #10644 on release-0.17.

#10644: Use RunSuite()

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```