### PR TITLE
Filter workload infos by namespace in pendingWorkloadsInLqREST.

### DIFF
--- a/pkg/visibility/storage/pending_workloads_lq.go
+++ b/pkg/visibility/storage/pending_workloads_lq.go
@@ -83,7 +83,7 @@ func (m *pendingWorkloadsInLqREST) Get(ctx context.Context, name string, opts ru
 		if len(wls) >= int(limit) {
 			break
 		}
-		if wlInfo.Obj.Spec.QueueName == lqName {
+		if wlInfo.Obj.Namespace == namespace && wlInfo.Obj.Spec.QueueName == lqName {
 			if skippedWls < int(offset) {
 				skippedWls++
 			} else {

--- a/test/e2e/singlecluster/visibility_test.go
+++ b/test/e2e/singlecluster/visibility_test.go
@@ -439,6 +439,75 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
+
+		ginkgo.It("Should fetch information about the position of pending workloads with the same localQueue name in different namespaces", func() {
+			const localQueueName = "local-queue"
+
+			ginkgo.By("Create a LocalQueue", func() {
+				lqA := utiltestingapi.MakeLocalQueue(localQueueName, nsA.Name).ClusterQueue(clusterQueue.Name).Obj()
+				util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lqA)
+			})
+
+			ginkgo.By("Create a LocalQueue with the same name in a different Namespace", func() {
+				lqB := utiltestingapi.MakeLocalQueue(localQueueName, nsB.Name).ClusterQueue(clusterQueue.Name).Obj()
+				util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lqB)
+			})
+
+			ginkgo.By("Schedule different jobs in different Namespaces", func() {
+				jobCases := []struct {
+					name     string
+					ns       string
+					priority string
+				}{
+					{name: "job-a", ns: nsA.Name, priority: midPriorityClass.Name},
+					{name: "job-b", ns: nsB.Name, priority: lowPriorityClass.Name},
+				}
+				for _, jobCase := range jobCases {
+					job := testingjob.MakeJob(jobCase.name, jobCase.ns).
+						Queue(localQueueName).
+						Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+						RequestAndLimit(corev1.ResourceCPU, "2").
+						PriorityClass(jobCase.priority).
+						Obj()
+					util.MustCreate(ctx, k8sClient, job)
+				}
+			})
+
+			ginkgo.By("Verify their positions and priorities in Namespace 'a'", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					info, err := kueueClientset.VisibilityV1beta2().LocalQueues(nsA.Name).GetPendingWorkloadsSummary(ctx, localQueueName, metav1.GetOptions{})
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+					g.Expect(info.Items).Should(gomega.BeComparableTo([]visibility.PendingWorkload{{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace:       nsA.Name,
+							OwnerReferences: defaultOwnerReferenceForJob("job-a"),
+						},
+						Priority:               midPriorityClass.Value,
+						PositionInLocalQueue:   0,
+						PositionInClusterQueue: 0,
+						LocalQueueName:         localQueueName,
+					}}, pendingWorkloadsCmpOpts...))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Verify their positions and priorities in Namespace 'b'", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					info, err := kueueClientset.VisibilityV1beta2().LocalQueues(nsB.Name).GetPendingWorkloadsSummary(ctx, localQueueName, metav1.GetOptions{})
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+					g.Expect(info.Items).Should(gomega.BeComparableTo([]visibility.PendingWorkload{{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace:       nsB.Name,
+							OwnerReferences: defaultOwnerReferenceForJob("job-b"),
+						},
+						Priority:               lowPriorityClass.Value,
+						PositionInLocalQueue:   0,
+						PositionInClusterQueue: 1,
+						LocalQueueName:         localQueueName,
+					}}, pendingWorkloadsCmpOpts...))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
 		ginkgo.It("Should allow fetching information about position of pending workloads from different LocalQueues from different Namespaces", func() {
 			ginkgo.By("Create a LocalQueue in a different Namespace", func() {
 				localQueueB = utiltestingapi.MakeLocalQueue("b", nsB.Name).ClusterQueue(clusterQueue.Name).Obj()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10575

#### Special notes for your reviewer:

https://github.com/kubernetes-sigs/kueue/pull/10668#discussion_r3121744369.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
VisibilityOnDemand: Fixed a bug in the visibility endpoint, that listing workloads from a local queue includes
workloads from other LocalQueues in different namespaces, if the other LocalQueues have the same name.
```