### PR TITLE
website: Add patch upgrade policy to installation docs

### DIFF
--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -14,6 +14,7 @@ description: >
   - [Install by Helm](#install-by-helm)
   - [Add metrics scraping for prometheus-operator](#add-metrics-scraping-for-prometheus-operator)
   - [Add API Priority and Fairness configuration for the visibility API](#add-api-priority-and-fairness-configuration-for-the-visibility-api)
+  - [Upgrade policy](#upgrade-policy)
   - [Uninstall](#uninstall)
 - [Install a custom-configured released version](#install-a-custom-configured-released-version)
 - [Install the latest development version](#install-the-latest-development-version)
@@ -103,6 +104,17 @@ For more detailed setup instructions and optional metrics configuration, see the
 ### Add API Priority and Fairness configuration for the visibility API
 
 See [Configure API Priority and Fairness](/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand/#configure-api-priority-and-fairness) for more details.
+
+### Upgrade policy
+
+When upgrading Kueue, review the following release notes:
+
+- **Minor releases:** The `.0` release notes for each new minor version you cross.
+- **Patch releases:** The patch release notes up to and including your target version, but only within your target minor release line.
+
+**Note:** You do not need to review patch notes from previous minor versions, as those changes are covered in the next `.0` release notes.
+
+{{< upgrade-policy-example >}}
 
 ### Uninstall
 

--- a/site/content/zh-CN/docs/installation/_index.md
+++ b/site/content/zh-CN/docs/installation/_index.md
@@ -14,6 +14,7 @@ description: >
   - [通过 Helm 安装](#install-by-helm)
   - [为 Prometheus-Operator 添加指标采集](#add-metrics-scraping-for-prometheus-operator)
   - [为可见性 API 添加 API 优先级和公平性配置](#add-api-priority-and-fairness-configuration-for-the-visibility-api)
+  - [升级策略](#upgrade-policy)
   - [卸载](#uninstall)
 - [安装自定义配置的正式版本](#install-a-custom-configured-released-version)
 - [安装最新开发版本](#install-the-latest-development-version)
@@ -100,6 +101,17 @@ kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases
 ### 为可见性 API 添加 API 优先级和公平性配置 {#add-api-priority-and-fairness-configuration-for-the-visibility-api}
 
 有关更多详细信息，请参阅[配置 API 优先级和公平性](/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand/#configure-api-priority-and-fairness)。
+
+### 升级策略 {#upgrade-policy}
+
+升级 Kueue 时，请查看以下发布说明：
+
+- **次版本发布：** 升级过程中跨越的每个新次版本的 `.0` 发布说明。
+- **补丁发布：** 目标次版本线中直到并包括目标版本的补丁发布说明。
+
+**注意：** 你不需要查看先前次版本的补丁发布说明，因为这些变更已包含在下一个 `.0` 发布说明中。
+
+{{< upgrade-policy-example >}}
 
 ### 卸载 {#uninstall}
 

--- a/site/layouts/shortcodes/upgrade-policy-example.html
+++ b/site/layouts/shortcodes/upgrade-policy-example.html
@@ -1,0 +1,66 @@
+{{- $currentVersion := site.Params.version -}}
+{{- $versionParts := split (replaceRE "^v" "" $currentVersion) "." -}}
+{{- $majorVersion := index $versionParts 0 -}}
+{{- $currentMinorVersion := int (index $versionParts 1) -}}
+{{- $currentPatchVersion := int (index $versionParts 2) -}}
+{{- $previousMinorVersion := sub $currentMinorVersion 1 -}}
+{{- $exampleSourceVersion := printf "v%s.%d.1" $majorVersion (sub $currentMinorVersion 2) -}}
+{{- $releaseURLPrefix := "https://github.com/kubernetes-sigs/kueue/releases/tag/" -}}
+
+{{/* Find the latest stable patch in the previous minor line. */}}
+{{- $previousMinorTagsURL := printf "https://api.github.com/repos/kubernetes-sigs/kueue/git/matching-refs/tags/v%s.%d." $majorVersion $previousMinorVersion -}}
+{{- $previousMinorTagsResource := resources.GetRemote $previousMinorTagsURL -}}
+{{- $previousMinorTags := $previousMinorTagsResource | transform.Unmarshal -}}
+{{- $stablePreviousMinorPattern := printf "^v%s\\.%d\\.[0-9]+$" $majorVersion $previousMinorVersion -}}
+{{- $previousMinorLatestPatch := 0 -}}
+{{- range $previousMinorTags -}}
+  {{- $tagName := replace .ref "refs/tags/" "" -}}
+  {{- if findRE $stablePreviousMinorPattern $tagName -}}
+    {{- $tagParts := split (replaceRE "^v" "" $tagName) "." -}}
+    {{- $patchVersion := int (index $tagParts 2) -}}
+    {{- if gt $patchVersion $previousMinorLatestPatch -}}
+      {{- $previousMinorLatestPatch = $patchVersion -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $previousMinorTargetVersion := printf "v%s.%d.%d" $majorVersion $previousMinorVersion $previousMinorLatestPatch -}}
+
+{{/* Example 1: upgrade to the latest release, crossing each new minor line. */}}
+{{- $latestReleaseNotes := slice -}}
+{{- range seq (add (sub $currentMinorVersion 2) 1) $currentMinorVersion -}}
+  {{- $latestReleaseNotes = $latestReleaseNotes | append (printf "v%s.%d.0" $majorVersion .) -}}
+{{- end -}}
+{{- if gt $currentPatchVersion 0 -}}
+  {{- range seq 1 $currentPatchVersion -}}
+    {{- $latestReleaseNotes = $latestReleaseNotes | append (printf "v%s.%d.%d" $majorVersion $currentMinorVersion .) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/* Example 2: upgrade to the latest patch in the previous minor line. */}}
+{{- $previousMinorReleaseNotes := slice -}}
+{{- range seq 0 $previousMinorLatestPatch -}}
+  {{- $previousMinorReleaseNotes = $previousMinorReleaseNotes | append (printf "v%s.%d.%d" $majorVersion $previousMinorVersion .) -}}
+{{- end -}}
+
+{{- $latestReleaseNoteLinks := slice -}}
+{{- range $latestReleaseNotes -}}
+  {{- $latestReleaseNoteLinks = $latestReleaseNoteLinks | append (printf "<a href=\"%s%s\"><code>%s</code></a>" $releaseURLPrefix . .) -}}
+{{- end -}}
+{{- $previousMinorReleaseNoteLinks := slice -}}
+{{- range $previousMinorReleaseNotes -}}
+  {{- $previousMinorReleaseNoteLinks = $previousMinorReleaseNoteLinks | append (printf "<a href=\"%s%s\"><code>%s</code></a>" $releaseURLPrefix . .) -}}
+{{- end -}}
+
+{{- if eq .Page.Lang "zh-cn" -}}
+{{- $latestReleaseNoteList := delimit $latestReleaseNoteLinks "、" " 和 " | safeHTML -}}
+{{- $previousMinorReleaseNoteList := delimit $previousMinorReleaseNoteLinks "、" " 和 " | safeHTML -}}
+<p>例如：</p>
+<p>从 <a href="{{ $releaseURLPrefix }}{{ $exampleSourceVersion }}"><code>{{ $exampleSourceVersion }}</code></a> 升级到 <a href="{{ $releaseURLPrefix }}{{ $currentVersion }}"><code>{{ $currentVersion }}</code></a> 时，请查看 {{ $latestReleaseNoteList }} 的升级说明。</p>
+<p>从 <a href="{{ $releaseURLPrefix }}{{ $exampleSourceVersion }}"><code>{{ $exampleSourceVersion }}</code></a> 升级到 <a href="{{ $releaseURLPrefix }}{{ $previousMinorTargetVersion }}"><code>{{ $previousMinorTargetVersion }}</code></a> 时，请查看 {{ $previousMinorReleaseNoteList }} 的升级说明。</p>
+{{- else -}}
+{{- $latestReleaseNoteList := delimit $latestReleaseNoteLinks ", " ", and " | safeHTML -}}
+{{- $previousMinorReleaseNoteList := delimit $previousMinorReleaseNoteLinks ", " ", and " | safeHTML -}}
+<p>For example:</p>
+<p>When upgrading from <a href="{{ $releaseURLPrefix }}{{ $exampleSourceVersion }}"><code>{{ $exampleSourceVersion }}</code></a> to <a href="{{ $releaseURLPrefix }}{{ $currentVersion }}"><code>{{ $currentVersion }}</code></a>, review the upgrade notes for {{ $latestReleaseNoteList }}.</p>
+<p>When upgrading from <a href="{{ $releaseURLPrefix }}{{ $exampleSourceVersion }}"><code>{{ $exampleSourceVersion }}</code></a> to <a href="{{ $releaseURLPrefix }}{{ $previousMinorTargetVersion }}"><code>{{ $previousMinorTargetVersion }}</code></a>, review the upgrade notes for {{ $previousMinorReleaseNoteList }}.</p>
+{{- end -}}


### PR DESCRIPTION

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
Add section in the Installation page about patch upgrade policy.
The example is rendered separately with auto-generated links.

<img width="1869" height="502" alt="image" src="https://github.com/user-attachments/assets/f25de520-189a-487f-9429-a0b8d7b94106" />

#### Which issue(s) this PR fixes:
Part of #10489

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```