### PR TITLE
rename customconfigs to sequential tests and split taxonomy

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -168,13 +168,6 @@ test-tas-e2e: setup-e2e-env kind-ray-project-mini-image-build run-test-tas-e2e-$
 test-tas-e2e-helm: E2E_USE_HELM=true
 test-tas-e2e-helm: test-tas-e2e
 
-
-.PHONY: test-e2e-customconfigs
-test-e2e-customconfigs: test-e2e-sequential-baseline test-e2e-sequential-extended
-
-.PHONY: test-e2e-customconfigs-helm
-test-e2e-customconfigs-helm: test-e2e-sequential-baseline-helm test-e2e-sequential-extended-helm
-
 .PHONY: test-e2e-certmanager
 test-e2e-certmanager: setup-e2e-env run-test-e2e-certmanager-$(E2E_KIND_VERSION:kindest/node:v%=%)
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Read the [overview](https://kueue.sigs.k8s.io/docs/overview/) and watch the Kueu
     [1.35](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-main-1-35),
     on Kind.
   - ✔️ E2E TAS Test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-tas-main)
-  - ✔️ E2E Custom Configs Test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-customconfigs-main)
+  - ✔️ E2E Sequential Baseline Test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-sequential-baseline-main)
+  - ✔️ E2E Sequential Extended Test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-sequential-extended-main)
   - ✔️ E2E Cert Manager Test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-certmanager-main)
   - ✔️ Performance Test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-scheduling-perf-main)
 - ✔️ Scalability verification via [performance tests](https://github.com/kubernetes-sigs/kueue/tree/main/test/performance).

--- a/site/content/en/docs/contribution_guidelines/testing.md
+++ b/site/content/en/docs/contribution_guidelines/testing.md
@@ -271,6 +271,7 @@ GINKGO_ARGS="--label-filter=feature:admissionfairsharing" make test-e2e-sequenti
 
 # Run only spark tests (Extended)
 GINKGO_ARGS="--label-filter=feature:spark" make test-e2e-sequential-extended
+```
 
 ### Use Ginkgo --focus arg
 ```shell

--- a/site/content/en/docs/contribution_guidelines/testing.md
+++ b/site/content/en/docs/contribution_guidelines/testing.md
@@ -255,11 +255,14 @@ GINKGO_ARGS="--label-filter=feature:deployment" make test-e2e-helm
 GINKGO_ARGS="--label-filter=feature:jobset,feature:trainjob" make test-e2e
 ```
 
-### Use label filters for e2e customconfigs tests
-CustomConfigs tests are labeled by feature. You can use `GINKGO_ARGS` with `--label-filter` to run specific tests:
+### Use label filters for e2e sequential tests
+Sequential tests (Baseline and Extended) are labeled by feature. You can use `GINKGO_ARGS` with `--label-filter` to run specific tests:
 
-**Label Taxonomy:**
-- Features: `admissionfairsharing, certs, failurerecoverypolicy, managejobswithoutqueuename, localqueuemetrics, objectretentionpolicies, podintegrationautoenablement, reconcile, spark, visibility, waitforpodsready`
+**Label Taxonomy (Baseline):**
+- Features: `admissionfairsharing, certs, failurerecoverypolicy, localqueuemetrics, objectretentionpolicies, podintegrationautoenablement, reconcile, visibility, waitforpodsready`
+
+**Label Taxonomy (Extended):**
+- Features: `managejobswithoutqueuename, spark`
 
 **Examples:**
 ```shell
@@ -268,7 +271,6 @@ GINKGO_ARGS="--label-filter=feature:admissionfairsharing" make test-e2e-sequenti
 
 # Run only spark tests (Extended)
 GINKGO_ARGS="--label-filter=feature:spark" make test-e2e-sequential-extended
-```
 
 ### Use Ginkgo --focus arg
 ```shell


### PR DESCRIPTION
Title: Cleanup: Remove legacy customconfigs targets and sync docs

Description:
Following the test-infra updates in PR #36839, the legacy customconfigs e2e test jobs are no longer used.

This PR performs a quick cleanup:

Makefile: Removes the obsolete test-e2e-customconfigs targets.

Docs & README: Replaces "customconfigs" references with the new sequential-baseline and sequential-extended targets, and updates the Testgrid badges accordingly.

Related
 https://github.com/kubernetes-sigs/kueue/pull/10595
#10689