### PR TITLE
Automated cherry pick of #10710: rename customconfigs to sequential tests and split taxonomy

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -167,13 +167,6 @@ test-tas-e2e: setup-e2e-env kind-ray-project-mini-image-build run-test-tas-e2e-$
 test-tas-e2e-helm: E2E_USE_HELM=true
 test-tas-e2e-helm: test-tas-e2e
 
-
-.PHONY: test-e2e-customconfigs
-test-e2e-customconfigs: test-e2e-sequential-baseline test-e2e-sequential-extended
-
-.PHONY: test-e2e-customconfigs-helm
-test-e2e-customconfigs-helm: test-e2e-sequential-baseline-helm test-e2e-sequential-extended-helm
-
 .PHONY: test-e2e-certmanager
 test-e2e-certmanager: setup-e2e-env run-test-e2e-certmanager-$(E2E_KIND_VERSION:kindest/node:v%=%)
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Read the [overview](https://kueue.sigs.k8s.io/docs/overview/) and watch the Kueu
     [1.35](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-main-1-35),
     on Kind.
   - ✔️ E2E TAS Test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-tas-main)
-  - ✔️ E2E Custom Configs Test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-customconfigs-main)
+  - ✔️ E2E Sequential Baseline Test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-sequential-baseline-main)
+  - ✔️ E2E Sequential Extended Test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-sequential-extended-main)
   - ✔️ E2E Cert Manager Test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-certmanager-main)
   - ✔️ Performance Test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-scheduling-perf-main)
 - ✔️ Scalability verification via [performance tests](https://github.com/kubernetes-sigs/kueue/tree/main/test/performance).

--- a/site/content/en/docs/contribution_guidelines/testing.md
+++ b/site/content/en/docs/contribution_guidelines/testing.md
@@ -216,8 +216,8 @@ GINKGO_ARGS="--label-filter=feature:deployment" make test-e2e-helm
 GINKGO_ARGS="--label-filter=feature:jobset,feature:trainjob" make test-e2e
 ```
 
-### Use label filters for e2e customconfigs tests
-CustomConfigs tests are labeled by feature. You can use `GINKGO_ARGS` with `--label-filter` to run specific tests:
+### Use label filters for e2e sequential tests
+Sequential tests (Baseline and Extended) are labeled by feature. You can use `GINKGO_ARGS` with `--label-filter` to run specific tests:
 
 **Label Taxonomy:**
 - Features: `admissionfairsharing, certs, failurerecoverypolicy, managejobswithoutqueuename, objectretentionpolicies, reconcile, visibility, waitforpodsready`

--- a/site/content/en/docs/contribution_guidelines/testing.md
+++ b/site/content/en/docs/contribution_guidelines/testing.md
@@ -219,8 +219,11 @@ GINKGO_ARGS="--label-filter=feature:jobset,feature:trainjob" make test-e2e
 ### Use label filters for e2e sequential tests
 Sequential tests (Baseline and Extended) are labeled by feature. You can use `GINKGO_ARGS` with `--label-filter` to run specific tests:
 
-**Label Taxonomy:**
-- Features: `admissionfairsharing, certs, failurerecoverypolicy, managejobswithoutqueuename, objectretentionpolicies, reconcile, visibility, waitforpodsready`
+**Label Taxonomy (Baseline):**
+- Features: `admissionfairsharing, certs, failurerecoverypolicy, localqueuemetrics, objectretentionpolicies, podintegrationautoenablement, reconcile, visibility, waitforpodsready`
+
+**Label Taxonomy (Extended):**
+- Features: `managejobswithoutqueuename, spark`
 
 **Examples:**
 ```shell

--- a/site/content/en/docs/contribution_guidelines/testing.md
+++ b/site/content/en/docs/contribution_guidelines/testing.md
@@ -220,10 +220,10 @@ GINKGO_ARGS="--label-filter=feature:jobset,feature:trainjob" make test-e2e
 Sequential tests (Baseline and Extended) are labeled by feature. You can use `GINKGO_ARGS` with `--label-filter` to run specific tests:
 
 **Label Taxonomy (Baseline):**
-- Features: `admissionfairsharing, certs, failurerecoverypolicy, localqueuemetrics, objectretentionpolicies, podintegrationautoenablement, reconcile, visibility, waitforpodsready`
+- Features: `admissionfairsharing, certs, failurerecoverypolicy, objectretentionpolicies, podintegrationautoenablement, reconcile, visibility, waitforpodsready`
 
 **Label Taxonomy (Extended):**
-- Features: `managejobswithoutqueuename, spark`
+- Features: `managejobswithoutqueuename`
 
 **Examples:**
 ```shell
@@ -231,7 +231,7 @@ Sequential tests (Baseline and Extended) are labeled by feature. You can use `GI
 GINKGO_ARGS="--label-filter=feature:admissionfairsharing" make test-e2e-sequential-baseline
 
 # Run only suite tests (Extended)
-GINKGO_ARGS="--label-filter=feature:suite" make test-e2e-sequential-extended
+GINKGO_ARGS="--label-filter=feature:managejobswithoutqueuename" make test-e2e-sequential-extended
 ```
 
 ### Use Ginkgo --focus arg

--- a/site/content/en/docs/contribution_guidelines/testing.md
+++ b/site/content/en/docs/contribution_guidelines/testing.md
@@ -231,7 +231,7 @@ Sequential tests (Baseline and Extended) are labeled by feature. You can use `GI
 GINKGO_ARGS="--label-filter=feature:admissionfairsharing" make test-e2e-sequential-baseline
 
 # Run only suite tests (Extended)
-GINKGO_ARGS="--label-filter=feature:managejobswithoutqueuename" make test-e2e-sequential-extended
+GINKGO_ARGS="--label-filter=feature:suite" make test-e2e-sequential-extended
 ```
 
 ### Use Ginkgo --focus arg


### PR DESCRIPTION
Cherry pick of #10710 on release-0.16.

#10710: rename customconfigs to sequential tests and split taxonomy

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```