### PR TITLE
docs: update Workload priority fields to v1beta2 schema

### DIFF
--- a/site/content/en/docs/concepts/workload_priority_class.md
+++ b/site/content/en/docs/concepts/workload_priority_class.md
@@ -41,10 +41,11 @@ spec:
 ```
 
 Kueue generates the following `Workload` for the Job above.
-The `PriorityClassName` field can accept either `PriorityClass` or
-`WorkloadPriorityClass` name as a value. To distinguish, when using `WorkloadPriorityClass`,
-a `priorityClassSource` field has the `kueue.x-k8s.io/workloadpriorityclass` value.
-When using `PriorityClass`, a `priorityClassSource` field has the `scheduling.k8s.io/priorityclass` value.
+The `priorityClassRef` field references either a `PriorityClass` or a `WorkloadPriorityClass`.
+To distinguish, when using `WorkloadPriorityClass`, `priorityClassRef.group` is
+`kueue.x-k8s.io` and `priorityClassRef.kind` is `WorkloadPriorityClass`.
+When using `PriorityClass`, `priorityClassRef.group` is `scheduling.k8s.io` and
+`priorityClassRef.kind` is `PriorityClass`.
 
 ```yaml
 apiVersion: kueue.x-k8s.io/v1beta2
@@ -52,8 +53,10 @@ kind: Workload
 metadata:
   name: job-sample-job-7f173
 spec:
-  priorityClassSource: kueue.x-k8s.io/workloadpriorityclass
-  priorityClassName: sample-priority
+  priorityClassRef:
+    group: kueue.x-k8s.io
+    kind: WorkloadPriorityClass
+    name: sample-priority
   priority: 10000
   queueName: user-queue
 ...

--- a/site/content/en/docs/tasks/manage/run_job_with_workload_priority.md
+++ b/site/content/en/docs/tasks/manage/run_job_with_workload_priority.md
@@ -77,8 +77,10 @@ kind: Workload
 metadata:
   name: job-sample-job-7f173
 spec:
-  priorityClassSource: kueue.x-k8s.io/workloadpriorityclass
-  priorityClassName: sample-priority
+  priorityClassRef:
+    group: kueue.x-k8s.io
+    kind: WorkloadPriorityClass
+    name: sample-priority
   priority: 10000
   queueName: user-queue
   podSets:


### PR DESCRIPTION
Fixes #10702

The Workload YAML examples in the WorkloadPriorityClass concept and task
pages were still using the v1beta1 fields `priorityClassSource` and
`priorityClassName`. This PR updates them to the v1beta2 `priorityClassRef`
schema.

**Changes:**
- `site/content/en/docs/concepts/workload_priority_class.md`: Updated prose and YAML example
- `site/content/en/docs/tasks/manage/run_job_with_workload_priority.md`: Updated YAML example

```release-note
NONE
```