### PR TITLE
KEP-10270: Automatic ClusterQueue quota limits based on node selectors

### DIFF
--- a/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
+++ b/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
@@ -1,109 +1,84 @@
 # KEP-10270: Automatic quota limits based on node selectors
 
 <!-- toc -->
-- [Summary](#summary)
-- [Motivation](#motivation)
-  - [Goals](#goals)
-  - [Non-Goals](#non-goals)
-- [Proposal](#proposal)
-  - [User Stories](#user-stories)
-    - [Story 1](#story-1)
-    - [Story 2](#story-2)
-    - [Story 3](#story-3)
-    - [Story 4](#story-4)
-  - [Notes/Constraints/Caveats](#notesconstraintscaveats)
-  - [Risks and Mitigations](#risks-and-mitigations)
-- [Design Details](#design-details)
-  - [Alpha: Coarse-Grained Auto-Detection](#alpha-coarse-grained-auto-detection)
-    - [API Changes (Alpha)](#api-changes-alpha)
-    - [Validation Rules (Alpha)](#validation-rules-alpha)
-    - [Status Extension](#status-extension)
-  - [Beta: Fine-Grained Node Label Intersection](#beta-fine-grained-node-label-intersection)
-    - [API Changes (Beta)](#api-changes-beta)
-    - [Intersection Semantics](#intersection-semantics)
-    - [Validation Rules (Beta)](#validation-rules-beta)
-  - [Controller Design](#controller-design)
-    - [Node Watcher](#node-watcher)
-    - [Reconciliation Loop](#reconciliation-loop)
-  - [Interaction with Existing Features](#interaction-with-existing-features)
-  - [RBAC Requirements](#rbac-requirements)
-  - [Test Plan](#test-plan)
-    - [Prerequisite testing updates](#prerequisite-testing-updates)
-    - [Unit Tests](#unit-tests)
-    - [Integration Tests](#integration-tests)
-    - [e2e Tests](#e2e-tests)
-  - [Graduation Criteria](#graduation-criteria)
-    - [Alpha](#alpha)
-    - [Beta](#beta)
-    - [GA](#ga)
-- [Implementation History](#implementation-history)
+  - [Summary](#summary)
+  - [Motivation](#motivation)
+    - [Goals](#goals)
+    - [Non-Goals](#non-goals)
+  - [Proposal](#proposal)
+    - [User Stories](#user-stories)
+      - [Story 1](#story-1)
+      - [Story 2](#story-2)
+      - [Story 3](#story-3)
+      - [Story 4](#story-4)
+    - [Notes/Constraints/Caveats](#notesconstraintscaveats)
+    - [Risks and Mitigations](#risks-and-mitigations)
+  - [Design Details](#design-details)
+    - [Alpha: NodeQuotaPolicy CRD](#alpha-nodequotapolicy-crd)
+      - [API: NodeQuotaPolicy](#api-nodequotapolicy)
+      - [ClusterQueue and Cohort API Changes](#clusterqueue-and-cohort-api-changes)
+      - [Validation Rules (Alpha)](#validation-rules-alpha)
+      - [Status Reporting](#status-reporting)
+    - [Beta: Fine-Grained Node Label Intersection](#beta-fine-grained-node-label-intersection)
+      - [API Changes (Beta)](#api-changes-beta)
+      - [Intersection Semantics](#intersection-semantics)
+      - [Validation Rules (Beta)](#validation-rules-beta)
+    - [Controller Design](#controller-design)
+      - [Node Watcher](#node-watcher)
+      - [Reconciliation Loop](#reconciliation-loop)
+    - [Interaction with Existing Features](#interaction-with-existing-features)
+    - [RBAC Requirements](#rbac-requirements)
+    - [Test Plan](#test-plan)
+      - [Prerequisite testing updates](#prerequisite-testing-updates)
+      - [Unit Tests](#unit-tests)
+      - [Integration Tests](#integration-tests)
+      - [e2e Tests](#e2e-tests)
+    - [Graduation Criteria](#graduation-criteria)
+      - [Alpha](#alpha)
+      - [Beta](#beta)
+      - [GA](#ga)
+  - [Implementation History](#implementation-history)
+  - [Open Questions](#open-questions)
+    - [OQ-1: Initial value of <code>nominalQuota</code> when managed by NodeQuotaPolicy](#oq-1-initial-value-of-nominalquota-when-managed-by-nodequotapolicy)
+- [NodeQuotaPolicy authored separately](#nodequotapolicy-authored-separately)
 <!-- /toc -->
 
 ## Summary
 
-This KEP proposes extending the ClusterQueue and Cohort APIs to support automatic
-quota detection based on node labels. Instead of requiring administrators to
-manually set and maintain `nominalQuota` values, Kueue can dynamically compute
-quotas by watching Kubernetes Nodes and aggregating their Allocatable resources.
+This KEP proposes a new cluster-scoped CRD, `NodeQuotaPolicy`, that enables automatic quota computation for ClusterQueues and Cohorts based on physical node capacity. For this design, a dedicated controller reads `NodeQuotaPolicy` objects, watches the Nodes they select, aggregates `node.Status.Allocatable`, and writes the computed `nominalQuota` back into the target ClusterQueue or Cohort.
+
+This design follows the Kubernetes principle of **separation of concerns**: ClusterQueue and Cohort remain responsible only for declaring what the quota is (a single numeric value), while `NodeQuotaPolicy` and its controller are responsible for how that quota is derived. The analogy is kubelet computing `node.Status.Allocatable` independently from the Node object's schema — the Node does not embed the calculation logic.
 
 The feature is delivered in two phases:
 
-- **Alpha (coarse-grained)**: A simple `autoDetect: true` flag at the flavor
-  level. Kueue uses the associated ResourceFlavor's `nodeLabels` to select nodes
-  and computes quota for all resources in that flavor automatically.
-- **Beta (fine-grained)**: Administrators can additionally specify `nodeLabels`
-  at the Cohort and ClusterQueue levels. The effective node set is the
-  **intersection** of all configured label selectors (Cohort, ClusterQueue,
-  ResourceFlavor), enabling per-scope narrowing of which nodes contribute to
-  quota.
+- **Alpha**: A `NodeQuotaPolicy` CRD with `targetRef` (ClusterQueue or Cohort) and per-flavor rules. The controller uses the referenced ResourceFlavor's `nodeLabels` to select nodes and writes the summed `Allocatable` as `nominalQuota`.
+- **Beta**: An optional `nodeLabels` field in `FlavorNodeQuotaPolicy` allows administrators to narrow the effective node set via intersection with the ResourceFlavor's `nodeLabels`, enabling per-CQ regional or zonal quota subsetting without creating additional ResourceFlavors.
 
 ## Motivation
 
-Currently, `nominalQuota` in a ClusterQueue or Cohort is a static value that
-administrators must manually configure and update. When the underlying node pool
-changes (e.g., monthly node onboarding, manual provisioning), administrators
-must manually adjust quotas to reflect the new cluster capacity. This creates
-several problems:
+Currently, `nominalQuota` in a ClusterQueue or Cohort is a static value that administrators must manually configure and update. When the underlying node pool changes (e.g., monthly node onboarding, manual provisioning), administrators must manually adjust quotas to reflect the new cluster capacity. This creates several problems:
 
-1. **Operational overhead**: Manually updating quotas for each provisioning event
-   is error-prone and labor intensive.
-2. **Quota drift**: If quotas are not updated promptly, Kueue may over-admit
-   workloads (quota > actual capacity) or under-utilize the cluster (quota <
-   actual capacity).
-3. **Redundant configuration**: Capacity management is already handled at the
-   node pool level. Requiring administrators to duplicate this information in
-   ClusterQueue or Cohort configuration is redundant.
-4. **ResourceFlavor already knows the nodes**: A ResourceFlavor specifies
-   `nodeLabels` that associate it with a set of Nodes. However, Kueue does not
-   use this information to compute how many resources those nodes actually provide.
-   The administrator must separately and manually state the total quota.
+1. **Operational overhead**: Manually updating quotas for each provisioning event is error-prone and labor intensive.
+2. **Quota drift**: If quotas are not updated promptly, Kueue may over-admit workloads (quota > actual capacity) or under-utilize the cluster (quota < actual capacity).
+3. **Redundant configuration**: Capacity management is already handled at the node pool level. Requiring administrators to duplicate this information in ClusterQueue or Cohort configuration is redundant.
+4. **ResourceFlavor already knows the nodes**: A ResourceFlavor specifies `nodeLabels` that associate it with a set of Nodes. However, Kueue does not use this information to compute how many resources those nodes actually provide. The administrator must separately and manually state the total quota.
 
 ### Goals
 
-- Allow ClusterQueue and Cohort quotas to be automatically computed from the
-  Allocatable resources of Nodes matching a ResourceFlavor's `nodeLabels`.
-- (Beta) Support additional `nodeLabels` at CQ and Cohort levels to narrow the
-  effective node set via intersection.
-- Support configurable headroom to reserve resources for DaemonSets and
-  non-Kueue workloads running alongside Kueue workloads on the same nodes.
-- Ensure automatic quotas update dynamically as Nodes are added, removed, or
-  change status.
-- Be backward compatible — existing static `nominalQuota` configurations
-  continue to work unchanged.
-- Allow individual resources within a flavor to override with a manual
-  `nominalQuota` (e.g., for custom resources not reported by nodes).
+- Introduce a `NodeQuotaPolicy` CRD that declares how to derive `nominalQuota` for a target ClusterQueue or Cohort from the `Allocatable` resources of matching Nodes.
+- Keep ClusterQueue and Cohort APIs unchanged with respect to quota declaration: `nominalQuota` remains the single authoritative value consumed by the scheduler.
+- Support configurable headroom to reserve resources for DaemonSets and non-Kueue workloads running alongside Kueue workloads on the same nodes.
+- Ensure computed quotas update dynamically as Nodes are added, removed, or change status.
+- Be backward compatible — existing static `nominalQuota` configurations continue to work unchanged.
+- (Beta) Allow `nodeLabels` in `NodeQuotaPolicy` to narrow the node set beyond what the ResourceFlavor alone selects, enabling per-region or per-zone quota subsetting.
 
 ### Non-Goals
 
-- Replace or deprecate static `nominalQuota`. Both modes will coexist.
+- Replace or deprecate static `nominalQuota`. Both modes coexist.
 - Automatically create or manage ResourceFlavors.
-- Account for resources consumed by non-Kueue workloads beyond a configurable
-  headroom percentage or fixed amount.
-- Drive reactive autoscaling. This feature reflects current node capacity only.
-  Reactive capacity provisioning via cluster-autoscaler is covered by
-  ProvisioningRequest (KEP-1136).
-- Introduce auto-detection for DRA Device resources. DRA quota is managed
-  through DeviceClassMappings (KEP-2941).
+- Account for resources consumed by non-Kueue workloads beyond a configurable headroom percentage or fixed amount.
+- Drive reactive autoscaling. This feature reflects current node capacity only. Reactive capacity provisioning via cluster-autoscaler is covered by ProvisioningRequest (KEP-1136).
+- Introduce auto-detection for DRA Device resources. DRA quota is managed through DeviceClassMappings (KEP-2941).
 
 ## Proposal
 
@@ -111,13 +86,10 @@ several problems:
 
 #### Story 1
 
-As a cluster administrator, I manage a GPU node pool. Each node has 8 GPUs and
-is labeled `gpu-type=a100`. I already have a ResourceFlavor that uses this label.
-I want Kueue to automatically compute GPU quota from those nodes without me
-updating the ClusterQueue every time a node is added or removed.
+As a cluster administrator, I manage a GPU node pool. Each node has 8 GPUs and is labeled `gpu-type=a100`. I already have a ResourceFlavor that uses this label. I want Kueue to automatically compute GPU quota from those nodes without me updating the ClusterQueue every time a node is added or removed.
 
 ```yaml
-# Existing ResourceFlavor (unchanged)
+# Existing ResourceFlavor — unchanged
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
@@ -127,6 +99,7 @@ spec:
     gpu-type: a100
 
 ---
+# ClusterQueue — unchanged, nominalQuota will be written by the controller
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
@@ -136,46 +109,83 @@ spec:
   - coveredResources: ["nvidia.com/gpu"]
     flavors:
     - name: gpu-nodes
-      autoDetect: true   # uses gpu-nodes ResourceFlavor nodeLabels automatically
       resources:
       - name: nvidia.com/gpu
+        nominalQuota: "0"   # placeholder; NodeQuotaPolicy controller overwrites this
+
+---
+# NodeQuotaPolicy — declares how to compute nominalQuota for gpu-team-cq
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: NodeQuotaPolicy
+metadata:
+  name: gpu-team-auto-quota
+spec:
+  targetRef:
+    kind: ClusterQueue
+    name: gpu-team-cq
+  flavorPolicies:
+  - flavorName: gpu-nodes   # uses gpu-nodes ResourceFlavor nodeLabels: {gpu-type: a100}
 ```
 
 #### Story 2
 
-As a platform engineer, I run a multi-tenant cluster where different teams use
-different node pools. I want each team's ClusterQueue to automatically reflect
-the capacity of their dedicated node pool, with 5% headroom reserved for system
-DaemonSets running on those nodes.
+As a platform engineer, I run a multi-tenant cluster where different teams use different node pools. I want each team's ClusterQueue to automatically reflect the capacity of their dedicated node pool, with 5% headroom reserved for system DaemonSets running on those nodes. One resource (`example.com/token`) is not reported by nodes and must be set manually.
 
 ```yaml
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: NodeQuotaPolicy
+metadata:
+  name: team-alpha-auto-quota
+spec:
+  targetRef:
+    kind: ClusterQueue
+    name: team-alpha-cq
+  flavorPolicies:
+  - flavorName: team-alpha-nodes   # ResourceFlavor nodeLabels: {team: alpha}
+    headroom:
+      percentage: 5                # reserve 5% for DaemonSets
+    resourceOverrides:
+    - name: example.com/token      # not reported by nodes — fixed manual value
+      nominalQuota: "100"
+
+---
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: team-alpha-cq
 spec:
   resourceGroups:
-  - coveredResources: ["cpu", "memory"]
+  - coveredResources: ["cpu", "memory", "example.com/token"]
     flavors:
-    - name: team-alpha-nodes   # ResourceFlavor with nodeLabels: {team: alpha}
-      autoDetect: true
-      headroom:
-        percentage: 5
+    - name: team-alpha-nodes
       resources:
-      - name: cpu              # both cpu and memory auto-computed
+      - name: cpu
+        nominalQuota: "0"          # overwritten by controller
       - name: memory
+        nominalQuota: "0"          # overwritten by controller
       - name: example.com/token
-        nominalQuota: 100      # not reported by nodes — manual override
+        nominalQuota: "0"          # overwritten by resourceOverride in NodeQuotaPolicy
 ```
 
 #### Story 3
 
-As a capacity administrator at a large organization, I onboard new node pools
-monthly. I want total capacity to automatically land at the Cohort level as a
-shared pool, so my team can then statically carve up `nominalQuota` across
-ClusterQueues.
+As a capacity administrator at a large organization, I onboard new node pools monthly. I want total capacity to automatically land at the Cohort level as a shared pool, so my team can then statically carve up `nominalQuota` across ClusterQueues.
 
 ```yaml
-# Cohort: shared pool — auto-detected from shared-nodes ResourceFlavor
+# NodeQuotaPolicy targets the Cohort directly
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: NodeQuotaPolicy
+metadata:
+  name: org-cohort-auto-quota
+spec:
+  targetRef:
+    kind: Cohort
+    name: org-cohort
+  flavorPolicies:
+  - flavorName: shared-nodes   # ResourceFlavor nodeLabels: {node-pool: shared}
+
+---
+# Cohort: nominalQuota written by controller
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: Cohort
 metadata:
@@ -184,14 +194,15 @@ spec:
   resourceGroups:
   - coveredResources: ["cpu", "memory"]
     flavors:
-    - name: shared-nodes     # ResourceFlavor with nodeLabels: {node-pool: shared}
-      autoDetect: true
+    - name: shared-nodes
       resources:
       - name: cpu
+        nominalQuota: "0"
       - name: memory
+        nominalQuota: "0"
 
 ---
-# CQs borrow from the cohort shared pool
+# CQs borrow from the cohort's auto-computed shared pool
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
@@ -204,29 +215,20 @@ spec:
     - name: shared-nodes
       resources:
       - name: cpu
-        nominalQuota: 0     # borrows from cohort's auto-detected pool
+        nominalQuota: "0"     # borrows from cohort's auto-detected pool
       - name: memory
-        nominalQuota: 0
+        nominalQuota: "0"
 ```
 
-Note: the Cohort's `nominalQuota` represents additional shared resources on top
-of CQ quotas. A CQ and its parent Cohort may both use `autoDetect` as long as
-their ResourceFlavors' `nodeLabels` select **different** physical nodes, to
-avoid double-counting.
+Note: the Cohort's `nominalQuota` represents additional shared resources on top of CQ quotas. A CQ and its parent Cohort may both be targeted by separate `NodeQuotaPolicy` objects as long as their ResourceFlavors' `nodeLabels` select **different** physical nodes to avoid double-counting.
 
 #### Story 4
 
-**(Beta)** As a cluster administrator managing a multi-region cluster, I have a
-ResourceFlavor `gpu-nodes` that covers all A100 GPU nodes across all regions.
-I want one ClusterQueue to automatically compute quota from only the `us-east`
-region's GPU nodes, and another from `us-west`, without creating separate
-ResourceFlavors per region.
-
-Since a ClusterQueue can reference multiple flavors, the additional `nodeLabels`
-for fine-grained filtering are placed at the **flavor level**, not the CQ level.
+**(Beta)** As a cluster administrator managing a multi-region cluster, I have a ResourceFlavor `gpu-nodes` that covers all A100 GPU nodes across all regions. I want one ClusterQueue to automatically compute quota from only the `us-east` region's GPU nodes, and another from `us-west`, without creating separate ResourceFlavors per region.
 
 ```yaml
 # ResourceFlavor covers all A100 nodes across regions
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: gpu-nodes
@@ -235,7 +237,37 @@ spec:
     gpu-type: a100
 
 ---
-# CQ narrows to us-east by adding nodeLabels on the flavor entry (Beta)
+# NodeQuotaPolicy for us-east: narrows to region=us-east via nodeLabels (Beta)
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: NodeQuotaPolicy
+metadata:
+  name: us-east-gpu-quota
+spec:
+  targetRef:
+    kind: ClusterQueue
+    name: us-east-gpu-cq
+  flavorPolicies:
+  - flavorName: gpu-nodes
+    nodeLabels:
+      region: us-east        # effective nodes: gpu-type=a100 AND region=us-east
+
+---
+# NodeQuotaPolicy for us-west: narrows to region=us-west via nodeLabels (Beta)
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: NodeQuotaPolicy
+metadata:
+  name: us-west-gpu-quota
+spec:
+  targetRef:
+    kind: ClusterQueue
+    name: us-west-gpu-cq
+  flavorPolicies:
+  - flavorName: gpu-nodes
+    nodeLabels:
+      region: us-west        # effective nodes: gpu-type=a100 AND region=us-west
+
+---
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: us-east-gpu-cq
@@ -244,14 +276,12 @@ spec:
   - coveredResources: ["nvidia.com/gpu"]
     flavors:
     - name: gpu-nodes
-      autoDetect: true
-      nodeLabels:            # Beta: flavor-level label narrows this flavor's node set
-        region: us-east
       resources:
       - name: nvidia.com/gpu
-      # effective nodes: gpu-type=a100 AND region=us-east
+        nominalQuota: "0"
 
 ---
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: us-west-gpu-cq
@@ -260,264 +290,343 @@ spec:
   - coveredResources: ["nvidia.com/gpu"]
     flavors:
     - name: gpu-nodes
-      autoDetect: true
-      nodeLabels:
-        region: us-west
       resources:
       - name: nvidia.com/gpu
-      # effective nodes: gpu-type=a100 AND region=us-west
+        nominalQuota: "0"
 ```
 
 ### Notes/Constraints/Caveats
 
-- **`autoDetect` and `nominalQuota` interaction**: When `autoDetect: true` is
-  set at the flavor level, individual resource entries must not set `nominalQuota`
-  unless they explicitly want to override auto-detection for that resource.
-- **Headroom and Allocatable**: `node.Status.Allocatable` already equals total
-  node capacity minus kubelet's `kube-reserved` and `system-reserved`, so those
-  system reservations are implicitly handled. The `headroom` field is for
-  DaemonSets and other non-Kueue pods that consume node resources beyond what
-  kubelet reserves.
-- **Cohort + CQ autoDetect overlap**: A Cohort and a CQ within it may both set
-  `autoDetect: true` on the same flavor only if their ResourceFlavors' nodeLabels
-  select **different** physical nodes. Overlapping node sets cause double-counting.
-  This is the administrator's responsibility; Beta will add validation warnings
-  for overlapping selectors.
-- **Node readiness filtering**: By default only Nodes with condition `Ready=True`
-  are counted. An optional `includeNotReady` field can override this.
-- **Rate limiting**: The controller aggregates node events and re-computes quotas
-  at a bounded frequency (e.g., every 15 seconds) to avoid excessive API writes.
-- **Feature gate**: This feature is gated behind `AutomaticQuotaFromNodes`
-  (disabled by default in Alpha).
-- **Recommended use case**: This feature targets predictable, known capacity
-  (fixed node pools, periodic onboarding). For reactive autoscaling via
-  ProvisioningRequest, static `nominalQuota` remains recommended.
+- **Separation of concerns**: `NodeQuotaPolicy` owns the computation logic; ClusterQueue and Cohort own only the quota value. This mirrors the kubelet pattern where `node.Status.Allocatable` is computed externally and written into the Node object — the Node schema does not embed the computation.
+- **Headroom and Allocatable**: `node.Status.Allocatable` already equals total node capacity minus kubelet's `kube-reserved` and `system-reserved`, so those system reservations are implicitly handled. The `headroom` field is for DaemonSets and other non-Kueue pods that consume node resources beyond what kubelet reserves.
+- **Cohort + CQ NodeQuotaPolicy overlap**: A Cohort and a CQ within it may each be targeted by a `NodeQuotaPolicy` only if their respective ResourceFlavors' effective node sets (after label intersection) are **disjoint**. Overlapping node sets cause double-counting. Beta will add validation warnings for overlapping selectors.
+- **Node readiness filtering**: By default only Nodes with condition `Ready=True` are counted. The `includeNotReady` field in `FlavorNodeQuotaPolicy` can override this.
+- **Rate limiting**: The controller aggregates node events and re-computes quotas at a bounded frequency (e.g., every 15 seconds) to avoid excessive API writes to ClusterQueue or Cohort.
+- **Feature gate**: This feature is gated behind `AutomaticQuotaFromNodes` (disabled by default in Alpha).
+- **Recommended use case**: This feature targets predictable, known capacity (fixed node pools, periodic onboarding). For reactive autoscaling via ProvisioningRequest, static `nominalQuota` remains recommended.
 
 ### Risks and Mitigations
 
-- **Stale quota if Node watch is delayed**: Kueue already relies on informer
-  caches for correctness. Risk is no different from existing Workload/Pod watches.
-- **Resource churn causing frequent quota updates**: Mitigation: batch node
-  events with a bounded reconciliation interval (e.g., 15 seconds). Only update
-  status when the computed quota actually changes.
-- **Conflicting selectors across ClusterQueues or between Cohort and CQ**:
-  Overlapping node sets lead to over-committed quotas, same as manually
-  overlapping quotas today. Beta will add validation warnings.
-- **Security**: The controller needs `get`, `list`, `watch` on Nodes. Kueue
-  already has these permissions for TAS. No additional RBAC needed.
+- **Stale quota if Node watch is delayed**: Kueue already relies on informer caches for correctness. Risk is no different from existing Workload/Pod watches.
+- **Resource churn causing frequent quota updates**: Mitigation: batch node events with a bounded reconciliation interval (e.g., 15 seconds). Only write to the target object when the computed quota actually changes.
+- **Conflicting selectors across ClusterQueues or between Cohort and CQ**: Overlapping node sets lead to over-committed quotas, same as manually overlapping quotas today. Beta will add validation warnings.
+- **Concurrent writes**: If an administrator manually edits `nominalQuota` on a CQ that is managed by a `NodeQuotaPolicy`, the controller will overwrite it on the next reconcile. This is the same behavior as HPA overwriting `spec.replicas`. Administrators should be aware that managed fields are authoritative in `NodeQuotaPolicy`, not in the CQ.
+- **Security**: The controller needs `get`, `list`, `watch` on Nodes and `patch` on ClusterQueues and Cohorts. Node watching is already granted to Kueue for TAS. Patch on ClusterQueue/Cohort is already granted for existing controllers. No additional RBAC changes are needed.
 
 ## Design Details
 
-### Alpha: Coarse-Grained Auto-Detection
+### Alpha: NodeQuotaPolicy CRD
 
-#### API Changes (Alpha)
+The core design principle is that **ClusterQueue and Cohort APIs are not modified**. All auto-detection configuration lives in the new `NodeQuotaPolicy` CRD. The controller writes computed values into `nominalQuota` fields of the target object, just as the HPA controller writes `spec.replicas` into a Deployment.
 
-Add `autoDetect`, `headroom`, and `includeNotReady` at the **flavor level**
-(`FlavorQuotas` struct) in `apis/kueue/v1beta2/clusterqueue_types.go`. This
-struct is shared by both ClusterQueue and Cohort `resourceGroups`.
+#### API: NodeQuotaPolicy
+
+New file: `apis/kueue/v1beta2/nodequotapolicy_types.go`
 
 ```go
-type FlavorQuotas struct {
-    // name of this flavor.
-    Name ResourceFlavorReference `json:"name"`
+// NodeQuotaPolicy drives automatic quota computation for a ClusterQueue or
+// Cohort. A dedicated controller watches this object together with the Nodes
+// selected by the referenced ResourceFlavors, aggregates their Allocatable
+// resources, and writes the result back into the target object's nominalQuota
+// fields.
+//
+// +genclient
+// +genclient:nonNamespaced
+// +kubebuilder:object:root=true
+// +kubebuilder:storageversion
+// +kubebuilder:resource:scope=Cluster,shortName={nqp}
+// +kubebuilder:subresource:status
+type NodeQuotaPolicy struct {
+    metav1.TypeMeta   `json:",inline"`
+    metav1.ObjectMeta `json:"metadata,omitempty"`
 
-    // autoDetect enables automatic quota computation for all resources in
-    // this flavor. When true, Kueue watches Nodes matching the associated
-    // ResourceFlavor's nodeLabels and computes nominalQuota as the sum of
-    // their Allocatable values for each resource. Individual resources may
-    // still override with nominalQuota for resources not reported by nodes.
-    // Mutually exclusive with setting nominalQuota on all resources in this
-    // flavor simultaneously.
+    Spec   NodeQuotaPolicySpec   `json:"spec,omitempty"`
+    Status NodeQuotaPolicyStatus `json:"status,omitempty"`
+}
+
+// NodeQuotaPolicySpec defines the desired state of NodeQuotaPolicy.
+type NodeQuotaPolicySpec struct {
+    // targetRef identifies the ClusterQueue or Cohort whose nominalQuota
+    // this policy manages. Exactly one NodeQuotaPolicy may target a given
+    // (kind, name) pair; the controller rejects duplicates.
+    // +required
+    TargetRef NodeQuotaPolicyTargetRef `json:"targetRef"`
+
+    // flavorPolicies defines per-flavor quota computation rules. Each entry
+    // corresponds to one flavor in the target object's resourceGroups.
+    // The controller only writes nominalQuota for (flavor, resource) pairs
+    // that appear both in flavorPolicies and in the target object's spec.
+    // +listType=map
+    // +listMapKey=flavorName
+    // +kubebuilder:validation:MinItems=1
+    // +kubebuilder:validation:MaxItems=64
+    // +required
+    FlavorPolicies []FlavorNodeQuotaPolicy `json:"flavorPolicies"`
+}
+
+// NodeQuotaPolicyTargetRef identifies the object whose nominalQuota is managed.
+type NodeQuotaPolicyTargetRef struct {
+    // kind is the type of the target object.
+    // +kubebuilder:validation:Enum=ClusterQueue;Cohort
+    // +required
+    Kind string `json:"kind"`
+
+    // name is the name of the target ClusterQueue or Cohort.
+    // +required
+    // +kubebuilder:validation:MaxLength=253
+    // +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+    Name string `json:"name"`
+}
+
+// FlavorNodeQuotaPolicy defines how to compute nominalQuota for one flavor.
+type FlavorNodeQuotaPolicy struct {
+    // flavorName references the ResourceFlavor whose nodeLabels are used as
+    // the base node selector. The referenced ResourceFlavor must define at
+    // least one nodeLabel; otherwise the controller marks the policy as invalid.
+    // +required
+    FlavorName ResourceFlavorReference `json:"flavorName"`
+
+    // nodeLabels optionally narrows the effective node set by intersecting with
+    // the ResourceFlavor's nodeLabels. Useful when multiple ClusterQueues share
+    // one ResourceFlavor but each targets a different node subset (e.g., per
+    // region or zone). Beta field; ignored in Alpha.
     // +optional
-    AutoDetect bool `json:"autoDetect,omitempty"`
+    // +mapType=atomic
+    // +kubebuilder:validation:MaxProperties=8
+    NodeLabels map[string]string `json:"nodeLabels,omitempty"`
 
-    // headroom defines how much capacity to reserve from the auto-detected
-    // total. Applies only when autoDetect is true.
-    // Note: node.Status.Allocatable already accounts for kubelet kube-reserved
-    // and system-reserved; headroom is for DaemonSets and other non-Kueue pods.
+    // headroom reserves capacity from the computed total for DaemonSets and
+    // other non-Kueue pods. node.Status.Allocatable already accounts for
+    // kubelet kube-reserved and system-reserved; headroom is additional.
+    // At most one of percentage or fixed may be set.
     // +optional
     Headroom *QuotaHeadroom `json:"headroom,omitempty"`
 
-    // includeNotReady specifies whether Nodes without Ready=True should be
-    // included in quota computation. Defaults to false.
-    // Applies only when autoDetect is true.
+    // includeNotReady controls whether Nodes without the Ready=True condition
+    // contribute to quota computation. Defaults to false (only Ready nodes).
     // +optional
     IncludeNotReady *bool `json:"includeNotReady,omitempty"`
 
-    Resources []ResourceQuota `json:"resources,omitempty"`
+    // resourceOverrides pins specific resources to a fixed nominalQuota,
+    // bypassing node-based computation for those resources. Use this for
+    // custom resources that are not reported in node.Status.Allocatable
+    // (e.g., example.com/token). Takes precedence over node-derived values.
+    // +optional
+    // +listType=map
+    // +listMapKey=name
+    // +kubebuilder:validation:MaxItems=64
+    ResourceOverrides []ResourceQuotaOverride `json:"resourceOverrides,omitempty"`
 }
 
-// QuotaHeadroom configures how much capacity to reserve from the
-// auto-detected total.
+// ResourceQuotaOverride pins a specific resource to a fixed nominalQuota,
+// bypassing node-based computation for that resource.
+type ResourceQuotaOverride struct {
+    // name is the Kubernetes resource name (e.g., example.com/token).
+    // +required
+    Name corev1.ResourceName `json:"name"`
+
+    // nominalQuota is the fixed quota value for this resource.
+    // +required
+    NominalQuota resource.Quantity `json:"nominalQuota"`
+}
+
+// QuotaHeadroom configures how much capacity to reserve from the computed total.
+// +kubebuilder:validation:XValidation:rule="!(has(self.percentage) && has(self.fixed))",message="at most one of percentage or fixed may be set"
 type QuotaHeadroom struct {
-    // percentage specifies the percentage of total Allocatable to subtract.
-    // Must be between 0 and 100.
+    // percentage of total Allocatable to subtract (0–100).
     // +optional
     // +kubebuilder:validation:Minimum=0
     // +kubebuilder:validation:Maximum=100
     Percentage *int32 `json:"percentage,omitempty"`
 
-    // fixed specifies a fixed quantity to subtract as headroom.
+    // fixed is a fixed quantity to subtract from the computed total.
     // +optional
     Fixed *resource.Quantity `json:"fixed,omitempty"`
 }
+
+// NodeQuotaPolicyStatus records the results of the most recent reconciliation.
+type NodeQuotaPolicyStatus struct {
+    // conditions describe the current state of this policy. A Ready condition
+    // is set to True after the first successful write to the target object.
+    // +optional
+    // +listType=map
+    // +listMapKey=type
+    // +kubebuilder:validation:MaxItems=8
+    Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+    // computedQuotas reports the nominalQuota values most recently written to
+    // the target object, one entry per (flavor, resource) pair.
+    // +optional
+    ComputedQuotas []ComputedFlavorQuota `json:"computedQuotas,omitempty"`
+}
+
+// ComputedFlavorQuota captures the output of one reconciliation cycle for a
+// single (flavor, resource) pair.
+type ComputedFlavorQuota struct {
+    // flavorName is the ResourceFlavor this entry belongs to.
+    FlavorName ResourceFlavorReference `json:"flavorName"`
+
+    // resourceName is the Kubernetes resource (e.g., nvidia.com/gpu).
+    ResourceName corev1.ResourceName `json:"resourceName"`
+
+    // quantity is the nominalQuota value written to the target object,
+    // after headroom subtraction.
+    Quantity resource.Quantity `json:"quantity"`
+
+    // nodeCount is the number of matching Nodes that contributed to the sum.
+    NodeCount int32 `json:"nodeCount"`
+
+    // lastUpdated is the timestamp of the most recent successful write.
+    LastUpdated metav1.Time `json:"lastUpdated"`
+}
+
+// +kubebuilder:object:root=true
+
+// NodeQuotaPolicyList contains a list of NodeQuotaPolicy.
+type NodeQuotaPolicyList struct {
+    metav1.TypeMeta `json:",inline"`
+    metav1.ListMeta `json:"metadata,omitempty"`
+    Items           []NodeQuotaPolicy `json:"items"`
+}
+
+func init() {
+    SchemeBuilder.Register(&NodeQuotaPolicy{}, &NodeQuotaPolicyList{})
+}
 ```
 
-`ResourceQuota` is unchanged in Alpha. Individual resources may set `nominalQuota`
-to override auto-detection for that specific resource (e.g., custom resources
-not reported by node Allocatable).
+#### ClusterQueue and Cohort API Changes
+
+**No changes** to `ClusterQueueSpec`, `CohortSpec`, `FlavorQuotas`, or `ResourceQuota` in Alpha. The `nominalQuota` field is written by the `NodeQuotaPolicyReconciler` via a server-side apply patch, exactly as an HPA controller patches `spec.replicas` on a Deployment.
+
+The Kueue scheduler continues to read `nominalQuota` from the CQ or Cohort spec as today. No scheduler changes are required.
 
 #### Validation Rules (Alpha)
 
-- `autoDetect: true` requires the `AutomaticQuotaFromNodes` feature gate.
-- `headroom` and `includeNotReady` are only valid when `autoDetect: true`.
-- Within `headroom`, at most one of `percentage` or `fixed` may be set.
-- The associated ResourceFlavor must define `nodeLabels`; if `nodeLabels` is
-  empty, `autoDetect: true` is a validation error.
-- A resource entry must not set `nominalQuota` when `autoDetect: true` is set
-  at the flavor level, unless it is explicitly overriding auto-detection for
-  that resource (permitted but must be acknowledged via a dedicated field in Beta).
+Enforced by the `NodeQuotaPolicy` admission webhook:
 
-#### Status Extension
+- `targetRef.kind` must be `ClusterQueue` or `Cohort`.
+- `flavorPolicies` must not contain duplicate `flavorName` entries.
+- The referenced ResourceFlavor (via `flavorName`) must define at least one `nodeLabel`; otherwise the webhook returns a validation error since there is no node selector to work with.
+- Within `headroom`, at most one of `percentage` or `fixed` may be set (enforced by CEL rule on the struct).
+- `nodeLabels` (Beta field) must be empty in Alpha; the webhook rejects it if the `AutomaticQuotaFromNodes` feature gate is not at Beta or later.
+- Only one `NodeQuotaPolicy` may target a given `(kind, name)` pair. The webhook rejects creation of a second policy that conflicts with an existing one.
 
-Add `detectedQuotas` to both `ClusterQueueStatus` and `CohortStatus` to expose
-the computed quota values:
+#### Status Reporting
 
-```go
-type ClusterQueueStatus struct {
-    // ... existing fields ...
+After each successful reconciliation the controller updates `NodeQuotaPolicy.status`:
 
-    // detectedQuotas reports the most recently computed quota values
-    // for resources using autoDetect. Allows administrators to observe
-    // what Kueue has computed.
-    // +optional
-    DetectedQuotas []DetectedQuota `json:"detectedQuotas,omitempty"`
-}
+```yaml
+# kubectl get nqp gpu-team-auto-quota -o yaml
+status:
+  conditions:
+  - type: Ready
+    status: "True"
+    reason: QuotaApplied
+    message: "Successfully wrote nominalQuota to ClusterQueue gpu-team-cq"
+    lastTransitionTime: "2026-04-30T10:00:00Z"
+  computedQuotas:
+  - flavorName: gpu-nodes
+    resourceName: nvidia.com/gpu
+    quantity: "64"        # 8 nodes × 8 GPUs
+    nodeCount: 8
+    lastUpdated: "2026-04-30T10:00:00Z"
+```
 
-type DetectedQuota struct {
-    // flavorName is the name of the ResourceFlavor.
-    FlavorName ResourceFlavorReference `json:"flavorName"`
+Administrators can inspect computed values without reading the CQ:
 
-    // resourceName is the name of the resource.
-    ResourceName corev1.ResourceName `json:"resourceName"`
-
-    // quantity is the computed quota value after headroom subtraction.
-    Quantity resource.Quantity `json:"quantity"`
-
-    // nodeCount is the number of matching Nodes that contributed.
-    NodeCount int32 `json:"nodeCount"`
-
-    // lastUpdated is when the quota was last recomputed.
-    LastUpdated metav1.Time `json:"lastUpdated"`
-}
+```bash
+kubectl get nqp gpu-team-auto-quota -o jsonpath='{.status.computedQuotas}'
 ```
 
 ### Beta: Fine-Grained Node Label Intersection
 
 #### API Changes (Beta)
 
-Add an optional `nodeLabels` field at the **flavor level** (`FlavorQuotas`
-struct) in both ClusterQueue and Cohort `resourceGroups`. Since a CQ or Cohort
-can reference multiple flavors, placing `nodeLabels` at the flavor level allows
-each flavor to independently narrow its node set.
+The `nodeLabels` field in `FlavorNodeQuotaPolicy` (already present in the Alpha struct definition above) becomes active in Beta. No additional Go struct changes are needed; the field is gated by the feature gate at validation time.
 
-```go
-type FlavorQuotas struct {
-    // name of this flavor.
-    Name ResourceFlavorReference `json:"name"`
+The intersection logic is:
 
-    // autoDetect enables automatic quota computation for all resources in
-    // this flavor using the ResourceFlavor's nodeLabels. (Alpha field)
-    // +optional
-    AutoDetect bool `json:"autoDetect,omitempty"`
-
-    // nodeLabels defines additional labels used to narrow the node set for
-    // quota computation when autoDetect is true. The effective node set is
-    // the intersection of the ResourceFlavor's nodeLabels and these labels.
-    // This allows multiple CQs or Cohorts to reference the same ResourceFlavor
-    // but compute quota from different node subsets (e.g., per-region).
-    // Beta field; requires AutomaticQuotaFromNodes feature gate.
-    // +optional
-    NodeLabels map[string]string `json:"nodeLabels,omitempty"`
-
-    // headroom reserves capacity from the auto-detected total. (Alpha field)
-    // +optional
-    Headroom *QuotaHeadroom `json:"headroom,omitempty"`
-
-    // includeNotReady includes non-Ready nodes in computation. (Alpha field)
-    // +optional
-    IncludeNotReady *bool `json:"includeNotReady,omitempty"`
-
-    Resources []ResourceQuota `json:"resources,omitempty"`
-}
 ```
+effectiveNodes = {nodes matching RF.nodeLabels} ∩ {nodes matching NQP flavorPolicy.nodeLabels}
+```
+
+Each `FlavorNodeQuotaPolicy` computes its node set independently, so two `NodeQuotaPolicy` objects targeting different CQs but referencing the same ResourceFlavor can each narrow to a different regional subset.
 
 #### Intersection Semantics
 
-`nodeLabels` is placed at the **flavor level**, so each flavor entry in a CQ or
-Cohort can independently narrow its node set. The CQ and Cohort each compute
-their quota independently — there is no cross-scope filtering.
-
 ```
-# Node-set perspective (∩ = intersection of matching node sets):
-CQ flavor effectiveNodes     = {nodes matching RF.nodeLabels} ∩ {nodes matching flavor.nodeLabels in CQ}
-Cohort flavor effectiveNodes = {nodes matching RF.nodeLabels} ∩ {nodes matching flavor.nodeLabels in Cohort}
+# Example: RF covers all A100 nodes; NQP narrows per region
+RF.nodeLabels      = {gpu-type: a100}
+NQP.nodeLabels     = {region: us-east}
+effectiveNodes     = nodes where gpu-type=a100 AND region=us-east
 ```
 
-This allows administrators to:
-- Use a single ResourceFlavor that covers a broad node class (e.g., all A100 nodes)
-- Narrow quota computation per-CQ-flavor (e.g., `region=us-east`) or
-  per-Cohort-flavor (e.g., `zone=prod`) without creating additional ResourceFlavors
-- Have multiple CQs share one ResourceFlavor but each compute quota from a
-  different regional or zonal subset of nodes
+If a key appears in both `RF.nodeLabels` and `NQP flavorPolicy.nodeLabels` with **different** values, no nodes can satisfy both selectors simultaneously, resulting in `quantity: "0"` and a `Condition` warning on the `NodeQuotaPolicy`.
 
 #### Validation Rules (Beta)
 
-- `nodeLabels` at CQ or Cohort level is only meaningful when at least one flavor
-  in the object has `autoDetect: true`. A warning is emitted otherwise.
-- If a key appears in both CQ `nodeLabels` and ResourceFlavor `nodeLabels` with
-  different values, the node must satisfy both — in practice this means no nodes
-  match. This is flagged as a validation warning.
-- Beta adds validation warnings when Cohort and CQ selectors (after intersection)
-  still select overlapping node sets.
+- `nodeLabels` in `FlavorNodeQuotaPolicy` requires the `AutomaticQuotaFromNodes` feature gate at Beta or later.
+- A warning condition is emitted on `NodeQuotaPolicy` when the intersection of `RF.nodeLabels` and `flavorPolicy.nodeLabels` produces an empty node set.
+- Beta adds conflict detection: if two `NodeQuotaPolicy` objects targeting different CQs or Cohorts within the same Cohort tree have overlapping effective node sets for the same flavor, a warning condition is emitted on both policies (double-counting risk).
 
 ### Controller Design
 
 #### Node Watcher
 
-A new controller `AutoQuotaReconciler` watches Node objects using a shared
-informer (reusing the same informer as TAS to avoid duplicate Node watches). It
-maintains an in-memory index:
+A new controller `NodeQuotaPolicyReconciler` watches:
+
+- `NodeQuotaPolicy` objects (primary reconcile trigger)
+- `Node` objects via a shared informer (reusing the same informer as TAS to avoid duplicate Node watches)
+- `ResourceFlavor` objects (to pick up `nodeLabels` changes)
+- `ClusterQueue` and `Cohort` objects (to detect when the target is created or deleted)
+
+The controller maintains an in-memory reverse index:
 
 ```
-effectiveLabels -> set of matching nodes -> aggregated Allocatable per resource
+effectiveLabelSet → set of NodeQuotaPolicy names that use this label set
 ```
 
-When a Node is created, updated, or deleted, the controller determines which
-ClusterQueues and Cohorts have affected `autoDetect` flavors and enqueues those
-objects for reconciliation.
+When a Node event arrives, the controller determines which label sets match the node, looks up the affected `NodeQuotaPolicy` names, and enqueues them for reconciliation.
 
 #### Reconciliation Loop
 
-1. Node event arrives (create/update/delete)
-2. Determine affected ClusterQueues and Cohorts by matching their effective label sets
-3. Debounce: coalesce events within a ~15-second window
-4. Recompute effective quota for affected flavors
-5. Update internal cache (scheduler snapshot)
-6. Update ClusterQueue/Cohort Status with `DetectedQuotas`
-7. If quotas decreased, trigger scheduling cycle to evaluate preemptions
+```
+Trigger: NodeQuotaPolicy / Node / ResourceFlavor / ClusterQueue / Cohort event
+         ↓
+1.  Load NodeQuotaPolicy spec (targetRef + flavorPolicies).
+2.  For each FlavorNodeQuotaPolicy:
+    a. Fetch referenced ResourceFlavor → read nodeLabels (base selector).
+    b. (Beta) Intersect base selector with flavorPolicy.nodeLabels.
+    c. List all Nodes matching the effective label set.
+    d. Filter: exclude non-Ready nodes unless includeNotReady=true.
+    e. Sum node.Status.Allocatable for each resource.
+    f. Apply headroom (percentage or fixed subtraction, floor at zero).
+    g. Apply resourceOverrides: replace computed value for overridden resources.
+3.  Compare computed quota map against NodeQuotaPolicy.status.computedQuotas.
+    If unchanged, stop (no write to target object).
+4.  Debounce: coalesce rapid node events within a ~15-second window before
+    writing to avoid excessive API calls.
+5.  Patch target ClusterQueue or Cohort spec via server-side apply:
+    - Write nominalQuota for each (flavor, resource) pair in flavorPolicies.
+    - Only touch fields owned by this NodeQuotaPolicy (field manager:
+      "kueue.x-k8s.io/node-quota-policy").
+6.  Update NodeQuotaPolicy.status.computedQuotas and conditions.
+7.  If any nominalQuota decreased, the Kueue scheduler cache is invalidated
+    and a scheduling cycle runs to evaluate potential preemptions.
+```
 
 ### Interaction with Existing Features
 
 | Feature | Interaction |
 |---|---|
-| Borrowing/Lending | Works unchanged. The auto-detected value replaces `nominalQuota` in all calculations. `borrowingLimit` and `lendingLimit` remain relative to the effective quota. |
-| Hierarchical Cohorts | SubtreeQuota accumulation uses the effective quota from auto-detection at both Cohort and CQ levels. No changes needed in `resource_node.go`. |
-| Preemption | If detected quota decreases (nodes removed), this may trigger preemption of workloads exceeding the new quota. Consistent with existing behavior when an admin manually reduces `nominalQuota`. |
-| Fair Sharing | Share calculations use the effective quota. No changes needed. |
-| ProvisioningRequest | These features target different scenarios. `autoDetect` reflects **current** physical capacity for predictable node pools. ProvisioningRequest is for **reactive** autoscaling — requesting capacity on demand. Using both simultaneously for the same resource is not recommended. Once nodes provisioned by ProvisioningRequest come online, auto-detection naturally picks them up. |
-| TAS (Topology Aware Scheduling) | TAS already watches Nodes via `rfReconciler`. The `AutoQuotaReconciler` reuses the same shared Node informer to avoid duplicate watches. |
-| Cohort quota | Cohort `nominalQuota` represents additional shared resources on top of CQ quotas. `autoDetect: true` at the Cohort flavor level populates that shared pool automatically. Cohort and member CQ flavors must not select overlapping node sets to avoid double-counting. |
+| Borrowing/Lending | Works unchanged. The controller-written `nominalQuota` is the value used by all borrowing/lending calculations. `borrowingLimit` and `lendingLimit` remain relative to the effective quota. |
+| Hierarchical Cohorts | SubtreeQuota accumulation uses the `nominalQuota` written by the controller at both Cohort and CQ levels. No changes needed in `resource_node.go`. |
+| Preemption | If `nominalQuota` decreases (nodes removed), this may trigger preemption of workloads exceeding the new quota. Consistent with existing behavior when an admin manually reduces `nominalQuota`. |
+| Fair Sharing | Share calculations use the `nominalQuota` as written. No changes needed. |
+| ProvisioningRequest | These features target different scenarios. `NodeQuotaPolicy` reflects **current** physical capacity for predictable node pools. ProvisioningRequest is for **reactive** autoscaling. Using both simultaneously for the same resource is not recommended. Once nodes provisioned by ProvisioningRequest come online, the `NodeQuotaPolicy` controller naturally picks them up on the next reconcile. |
+| TAS (Topology Aware Scheduling) | TAS already watches Nodes via `rfReconciler`. The `NodeQuotaPolicyReconciler` reuses the same shared Node informer to avoid duplicate watches. |
+| Cohort quota | A `NodeQuotaPolicy` may target a Cohort directly. Cohort `nominalQuota` represents a shared pool on top of CQ quotas. A CQ and its parent Cohort may each be managed by separate `NodeQuotaPolicy` objects as long as their effective node sets do not overlap. |
+| Manual edits to managed nominalQuota | If an administrator manually patches `nominalQuota` on a CQ managed by a `NodeQuotaPolicy`, the controller will overwrite it at the next reconcile cycle. This is intentional and mirrors HPA behavior. |
 
 ### RBAC Requirements
 
@@ -527,98 +636,194 @@ Kueue already has the necessary RBAC for Node watching:
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 ```
 
-This is currently used by the TAS controller. The `AutoQuotaReconciler` reuses
-the same permissions. No additional RBAC changes are needed.
+The `NodeQuotaPolicyReconciler` additionally needs patch access on ClusterQueue and Cohort, which existing Kueue controllers already have:
+
+```go
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=clusterqueues,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=cohorts,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=nodequotapolicies,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=nodequotapolicies/status,verbs=get;update;patch
+```
+
+No additional RBAC changes are needed beyond the new CRD's own verbs.
 
 ### Test Plan
 
 #### Prerequisite testing updates
 
-Existing unit tests for `resourceNode.available()` and `potentialAvailable()`
-should be extended to verify correct behavior when `nominalQuota` is dynamically
-updated (simulating auto-detection).
+Existing unit tests for `resourceNode.available()` and `potentialAvailable()` should be extended to verify correct behavior when `nominalQuota` is dynamically patched (simulating the controller write path).
 
 #### Unit Tests
 
-- `pkg/cache/scheduler/`: Verify that auto-detected quotas flow correctly into
-  Snapshot, SubtreeQuota, and available calculations at both CQ and Cohort levels.
-- `pkg/controller/core/`: Test the `AutoQuotaReconciler`:
-  - Quota computation from ResourceFlavor `nodeLabels` (Alpha).
-  - Headroom percentage and fixed calculations.
-  - Node readiness filtering.
-  - Per-resource `nominalQuota` override when `autoDetect: true`.
-  - Debouncing behavior.
-  - Status update with `DetectedQuotas`.
-  - (Beta) Label intersection across Cohort, CQ, and ResourceFlavor.
-- API validation: `autoDetect: true` requires non-empty ResourceFlavor `nodeLabels`.
+- `pkg/controller/core/nodequotapolicy_controller.go`:
+  - Quota computation from `ResourceFlavor.nodeLabels` (Alpha).
+  - Headroom: percentage and fixed subtraction, floor-at-zero.
+  - Node readiness filtering (`includeNotReady=false` default).
+  - `resourceOverrides` take precedence over node-derived values.
+  - Debouncing: rapid node events coalesced before write.
+  - No-op when computed quota equals current `nominalQuota`.
+  - Status update: `computedQuotas` and `Ready` condition set correctly.
+  - Conflict detection: two `NodeQuotaPolicy` objects for the same target rejected by webhook.
+  - (Beta) Label intersection across `ResourceFlavor` and `flavorPolicy.nodeLabels`.
+  - (Beta) Empty intersection emits warning condition, writes `quantity: "0"`.
+- API validation webhook:
+  - `flavorName` references a `ResourceFlavor` with at least one `nodeLabel`.
+  - `headroom` CEL rule: `percentage` and `fixed` mutually exclusive.
+  - Duplicate `flavorName` entries rejected.
+  - Second `NodeQuotaPolicy` targeting same CQ rejected.
 
 #### Integration Tests
 
 **Alpha:**
-- ClusterQueue flavor with `autoDetect: true` correctly reflects node capacity.
-- Cohort flavor with `autoDetect: true` correctly reflects shared node capacity;
-  CQs with `nominalQuota: 0` borrow from it.
-- Adding/removing Nodes updates the effective quota.
-- Workload admission respects the auto-detected quota.
-- Quota decrease triggers preemption of over-quota workloads.
-- Mixed flavor: `autoDetect: true` with per-resource `nominalQuota` override.
-- Interaction with borrowing/lending limits.
+
+- `NodeQuotaPolicy` targeting a `ClusterQueue` correctly reflects node capacity.
+- `NodeQuotaPolicy` targeting a `Cohort` correctly reflects shared node capacity; CQs with `nominalQuota: 0` borrow from it.
+- Adding/removing Nodes updates the `nominalQuota` in the target CQ/Cohort.
+- Workload admission respects the controller-written `nominalQuota`.
+- `nominalQuota` decrease triggers preemption of over-quota workloads.
+- `resourceOverrides` correctly bypass node-derived values for named resources.
+- Interaction with `borrowingLimit` and `lendingLimit`.
+- Controller does not write when computed quota is unchanged (no spurious updates).
 
 **Beta:**
-- CQ-level `nodeLabels` narrows the node set (intersection with ResourceFlavor labels).
-- Cohort-level `nodeLabels` narrows the node set for all member CQs.
-- Three-way intersection: Cohort + CQ + ResourceFlavor `nodeLabels` all applied.
-- Conflicting labels (same key, different value) result in empty node set and
-  zero quota with a validation warning.
+
+- `flavorPolicy.nodeLabels` narrows the node set (intersection with `ResourceFlavor.nodeLabels`).
+- Two `NodeQuotaPolicy` objects referencing the same `ResourceFlavor` but with different `flavorPolicy.nodeLabels` produce independent quota values for each target CQ.
+- Conflicting labels (same key, different value) produce `quantity: "0"` and a warning condition.
+- Overlapping effective node sets across two `NodeQuotaPolicy` objects in the same Cohort tree produce warning conditions on both.
 
 #### e2e Tests
 
-- End-to-end test with a multi-node cluster verifying that ClusterQueue and
-  Cohort quotas dynamically adjust as Nodes join and leave.
-- (Beta) Multi-region cluster verifying that CQ-level `nodeLabels` correctly
-  restricts quota computation to the appropriate regional node subset.
+- End-to-end with a multi-node cluster: `NodeQuotaPolicy` targeting a CQ dynamically adjusts `nominalQuota` as Nodes join and leave.
+- `NodeQuotaPolicy` targeting a Cohort: shared pool updates and CQs borrow correctly.
+- (Beta) Multi-region cluster: two `NodeQuotaPolicy` objects with different `flavorPolicy.nodeLabels` independently track regional node capacity.
 
 ### Graduation Criteria
 
 #### Alpha
 
 - Feature gate `AutomaticQuotaFromNodes` (default disabled).
-- `autoDetect`, `headroom`, and `includeNotReady` fields added to `FlavorQuotas`
-  struct (shared by ClusterQueue and Cohort `resourceGroups`).
-- `AutoQuotaReconciler` implemented using ResourceFlavor `nodeLabels` for node
-  selection, integrated with scheduler cache and shared Node informer.
-- Per-resource `nominalQuota` override supported when `autoDetect: true`.
-- Status reporting via `DetectedQuotas` on ClusterQueue and Cohort.
+- `NodeQuotaPolicy` CRD implemented with full Go types, CRD manifest, and admission webhook.
+- `NodeQuotaPolicyReconciler` implemented, sharing the Node informer with TAS.
+- Server-side apply patch writes `nominalQuota` to target ClusterQueue or Cohort.
+- `resourceOverrides` supported for resources not reported by nodes.
+- `NodeQuotaPolicy.status` reports `computedQuotas` and `Ready` condition.
 - Unit and integration tests covering core Alpha functionality.
-- Documentation of the new API fields and behavior.
+- Documentation of the new CRD and controller behavior.
 
 #### Beta
 
 - Feature gate default enabled.
-- `nodeLabels` field added to `ClusterQueueSpec` and `CohortSpec` for
-  fine-grained intersection-based node selection.
-- Intersection semantics implemented and documented.
-- Validation warnings for:
-  - Overlapping node sets between Cohort and CQ `autoDetect` flavors.
-  - Conflicting label values across scopes.
+- `flavorPolicy.nodeLabels` field active for fine-grained intersection-based node selection.
+- Intersection semantics implemented, tested, and documented.
+- Conflict detection warnings for overlapping node sets across policies in the same Cohort tree.
 - Metrics:
-  - `kueue_detected_quota` (gauge): current effective quota per object/flavor/resource.
-  - `kueue_quota_detect_reconcile_duration_seconds` (histogram): reconcile latency.
-- Performance testing in large clusters (1000+ Nodes).
+  - `kueue_node_quota_policy_computed_quota` (gauge): current `nominalQuota` per policy/flavor/resource.
+  - `kueue_node_quota_policy_reconcile_duration_seconds` (histogram): reconcile latency per policy.
+- Performance testing in large clusters (1000+ Nodes, 100+ NodeQuotaPolicy objects).
 
 #### GA
 
 - Feature gate removed (always enabled).
-- Stable API with no breaking changes.
+- Stable API with no breaking changes since Beta.
 - Production usage feedback incorporated.
+- Resolve the open question on `nominalQuota` initial value (see [Open Questions](#open-questions)).
 
 ## Implementation History
 
 - 2026-04-23: KEP created based on issue [#10270](https://github.com/kubernetes-sigs/kueue/issues/10270).
 - 2026-04-24: Revised based on review feedback:
-  - Moved `autoDetect` from resource level to flavor level; uses ResourceFlavor
-    `nodeLabels` directly (no duplicated `nodeSelector` field).
+  - Moved `autoDetect` from resource level to flavor level; uses ResourceFlavor `nodeLabels` directly (no duplicated `nodeSelector` field).
   - Extended support to Cohort level.
-  - Split into Alpha (coarse-grained, flavor-level flag) and Beta (fine-grained,
-    label intersection across Cohort/CQ/ResourceFlavor scopes).
+  - Split into Alpha (coarse-grained, flavor-level flag) and Beta (fine-grained, label intersection across Cohort/CQ/ResourceFlavor scopes).
   - Clarified headroom vs. Allocatable semantics and ProvisioningRequest interaction.
+- 2026-04-30: Revised based on architectural feedback (@mwielgus):
+  - Replaced `autoDetect` flag embedded in `FlavorQuotas` with a standalone `NodeQuotaPolicy` CRD and dedicated controller.
+  - ClusterQueue and Cohort APIs are no longer modified; `nominalQuota` remains the single authoritative value, written by the controller.
+  - Controller uses server-side apply with a dedicated field manager, mirroring the HPA pattern for writing `spec.replicas`.
+  - Moved `nodeLabels` (Beta fine-grained intersection) from `FlavorQuotas` into `FlavorNodeQuotaPolicy` within the new CRD.
+
+## Open Questions
+
+### OQ-1: Initial value of `nominalQuota` when managed by NodeQuotaPolicy
+
+When a `NodeQuotaPolicy` targets a ClusterQueue or Cohort, the administrator must still provide an initial value for `nominalQuota` in the CQ/Cohort spec, because the field is currently `+required` and typed as `resource.Quantity` (a non-pointer value type — `"0"` and "unset" are indistinguishable at the Go level). Two options are under consideration:
+
+---
+
+**Option A: Keep `nominalQuota` required; administrator writes `"0"` as a placeholder (Alpha approach)**
+
+The administrator declares `nominalQuota: "0"` as a placeholder for every `(flavor, resource)` pair that will be managed by a `NodeQuotaPolicy`. The controller overwrites this with the real computed value on the first successful reconcile.
+
+```yaml
+# ClusterQueue authored by the administrator
+spec:
+  resourceGroups:
+  - coveredResources: ["nvidia.com/gpu"]
+    flavors:
+    - name: gpu-nodes
+      resources:
+      - name: nvidia.com/gpu
+        nominalQuota: "0"    # placeholder; controller will overwrite
+
+---
+# NodeQuotaPolicy authored separately
+spec:
+  targetRef:
+    kind: ClusterQueue
+    name: gpu-team-cq
+  flavorPolicies:
+  - flavorName: gpu-nodes
+```
+
+Pros:
+- No API change required; fully backward compatible.
+- Identical to the pattern used by HPA writing `spec.replicas: 1` as a placeholder.
+- Simple to implement in Alpha.
+
+Cons:
+- The CQ has `nominalQuota: "0"` between creation and the first controller reconcile, during which all workloads are rejected. This window is typically short (seconds) but non-zero.
+- Reading the CQ in isolation, `nominalQuota: "0"` gives no indication that the field is controller-managed, which can confuse operators.
+
+---
+
+**Option B: Change `nominalQuota` to a pointer type (`*resource.Quantity`), allowing `nil` to mean "externally managed" (Beta/GA approach)**
+
+Change `ResourceQuota.NominalQuota` from `resource.Quantity` to `*resource.Quantity`. A `nil` value signals that the field is managed by an external controller (e.g., `NodeQuotaPolicy`); the scheduler treats `nil` as "wait for controller to populate". A non-nil zero value (`"0"`) retains its current meaning of "no quota".
+
+```go
+// Before (current)
+// +required
+NominalQuota resource.Quantity `json:"nominalQuota,omitempty"`
+
+// After (proposed for Beta)
+// +optional
+NominalQuota *resource.Quantity `json:"nominalQuota,omitempty"`
+```
+
+```yaml
+# ClusterQueue — no nominalQuota written at all; controller populates it
+spec:
+  resourceGroups:
+  - coveredResources: ["nvidia.com/gpu"]
+    flavors:
+    - name: gpu-nodes
+      resources:
+      - name: nvidia.com/gpu
+        # nominalQuota omitted; NodeQuotaPolicy controller will write it
+```
+
+Pros:
+- Cleanest semantics: `nil` unambiguously means "controller-managed".
+- Consistent with `spec.replicas *int32` in Deployment (used by HPA).
+- Eliminates the admission gap where `nominalQuota: "0"` briefly blocks workloads.
+- Allows future tooling to distinguish managed vs. manual fields without requiring an annotation.
+
+Cons:
+- Breaking API change (`resource.Quantity` → `*resource.Quantity`). Requires a CRD version bump or a conversion webhook and careful migration path for existing users who set `nominalQuota` explicitly.
+- More complex webhook validation: `nil` is only valid when a `NodeQuotaPolicy` targeting this CQ/Cohort/flavor/resource exists; otherwise it is a configuration error.
+- Scheduler must be updated to handle `nil` gracefully (treat as 0 with a "pending population" condition on the CQ).
+
+---
+
+**Recommendation**: Use Option A for Alpha (no API change, fast to implement) and plan to adopt Option B in Beta or GA once the API version transition story is clear. The `NodeQuotaPolicy` status `computedQuotas` field provides observability in both options. A `Ready=False` condition with reason `TargetNotPopulated` on the `NodeQuotaPolicy` will surface the "quota not yet written" state in Option A.

--- a/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
+++ b/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
@@ -1,0 +1,624 @@
+# KEP-10270: Automatic quota limits based on node selectors
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+    - [Story 1](#story-1)
+    - [Story 2](#story-2)
+    - [Story 3](#story-3)
+    - [Story 4](#story-4)
+  - [Notes/Constraints/Caveats](#notesconstraintscaveats)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Alpha: Coarse-Grained Auto-Detection](#alpha-coarse-grained-auto-detection)
+    - [API Changes (Alpha)](#api-changes-alpha)
+    - [Validation Rules (Alpha)](#validation-rules-alpha)
+    - [Status Extension](#status-extension)
+  - [Beta: Fine-Grained Node Label Intersection](#beta-fine-grained-node-label-intersection)
+    - [API Changes (Beta)](#api-changes-beta)
+    - [Intersection Semantics](#intersection-semantics)
+    - [Validation Rules (Beta)](#validation-rules-beta)
+  - [Controller Design](#controller-design)
+    - [Node Watcher](#node-watcher)
+    - [Reconciliation Loop](#reconciliation-loop)
+  - [Interaction with Existing Features](#interaction-with-existing-features)
+  - [RBAC Requirements](#rbac-requirements)
+  - [Test Plan](#test-plan)
+    - [Prerequisite testing updates](#prerequisite-testing-updates)
+    - [Unit Tests](#unit-tests)
+    - [Integration Tests](#integration-tests)
+    - [e2e Tests](#e2e-tests)
+  - [Graduation Criteria](#graduation-criteria)
+    - [Alpha](#alpha)
+    - [Beta](#beta)
+    - [GA](#ga)
+- [Implementation History](#implementation-history)
+<!-- /toc -->
+
+## Summary
+
+This KEP proposes extending the ClusterQueue and Cohort APIs to support automatic
+quota detection based on node labels. Instead of requiring administrators to
+manually set and maintain `nominalQuota` values, Kueue can dynamically compute
+quotas by watching Kubernetes Nodes and aggregating their Allocatable resources.
+
+The feature is delivered in two phases:
+
+- **Alpha (coarse-grained)**: A simple `autoDetect: true` flag at the flavor
+  level. Kueue uses the associated ResourceFlavor's `nodeLabels` to select nodes
+  and computes quota for all resources in that flavor automatically.
+- **Beta (fine-grained)**: Administrators can additionally specify `nodeLabels`
+  at the Cohort and ClusterQueue levels. The effective node set is the
+  **intersection** of all configured label selectors (Cohort, ClusterQueue,
+  ResourceFlavor), enabling per-scope narrowing of which nodes contribute to
+  quota.
+
+## Motivation
+
+Currently, `nominalQuota` in a ClusterQueue or Cohort is a static value that
+administrators must manually configure and update. When the underlying node pool
+changes (e.g., monthly node onboarding, manual provisioning), administrators
+must manually adjust quotas to reflect the new cluster capacity. This creates
+several problems:
+
+1. **Operational overhead**: Manually updating quotas for each provisioning event
+   is error-prone and labor intensive.
+2. **Quota drift**: If quotas are not updated promptly, Kueue may over-admit
+   workloads (quota > actual capacity) or under-utilize the cluster (quota <
+   actual capacity).
+3. **Redundant configuration**: Capacity management is already handled at the
+   node pool level. Requiring administrators to duplicate this information in
+   ClusterQueue or Cohort configuration is redundant.
+4. **ResourceFlavor already knows the nodes**: A ResourceFlavor specifies
+   `nodeLabels` that associate it with a set of Nodes. However, Kueue does not
+   use this information to compute how many resources those nodes actually provide.
+   The administrator must separately and manually state the total quota.
+
+### Goals
+
+- Allow ClusterQueue and Cohort quotas to be automatically computed from the
+  Allocatable resources of Nodes matching a ResourceFlavor's `nodeLabels`.
+- (Beta) Support additional `nodeLabels` at CQ and Cohort levels to narrow the
+  effective node set via intersection.
+- Support configurable headroom to reserve resources for DaemonSets and
+  non-Kueue workloads running alongside Kueue workloads on the same nodes.
+- Ensure automatic quotas update dynamically as Nodes are added, removed, or
+  change status.
+- Be backward compatible — existing static `nominalQuota` configurations
+  continue to work unchanged.
+- Allow individual resources within a flavor to override with a manual
+  `nominalQuota` (e.g., for custom resources not reported by nodes).
+
+### Non-Goals
+
+- Replace or deprecate static `nominalQuota`. Both modes will coexist.
+- Automatically create or manage ResourceFlavors.
+- Account for resources consumed by non-Kueue workloads beyond a configurable
+  headroom percentage or fixed amount.
+- Drive reactive autoscaling. This feature reflects current node capacity only.
+  Reactive capacity provisioning via cluster-autoscaler is covered by
+  ProvisioningRequest (KEP-1136).
+- Introduce auto-detection for DRA Device resources. DRA quota is managed
+  through DeviceClassMappings (KEP-2941).
+
+## Proposal
+
+### User Stories
+
+#### Story 1
+
+As a cluster administrator, I manage a GPU node pool. Each node has 8 GPUs and
+is labeled `gpu-type=a100`. I already have a ResourceFlavor that uses this label.
+I want Kueue to automatically compute GPU quota from those nodes without me
+updating the ClusterQueue every time a node is added or removed.
+
+```yaml
+# Existing ResourceFlavor (unchanged)
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: gpu-nodes
+spec:
+  nodeLabels:
+    gpu-type: a100
+
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: gpu-team-cq
+spec:
+  resourceGroups:
+  - coveredResources: ["nvidia.com/gpu"]
+    flavors:
+    - name: gpu-nodes
+      autoDetect: true   # uses gpu-nodes ResourceFlavor nodeLabels automatically
+      resources:
+      - name: nvidia.com/gpu
+```
+
+#### Story 2
+
+As a platform engineer, I run a multi-tenant cluster where different teams use
+different node pools. I want each team's ClusterQueue to automatically reflect
+the capacity of their dedicated node pool, with 5% headroom reserved for system
+DaemonSets running on those nodes.
+
+```yaml
+kind: ClusterQueue
+metadata:
+  name: team-alpha-cq
+spec:
+  resourceGroups:
+  - coveredResources: ["cpu", "memory"]
+    flavors:
+    - name: team-alpha-nodes   # ResourceFlavor with nodeLabels: {team: alpha}
+      autoDetect: true
+      headroom:
+        percentage: 5
+      resources:
+      - name: cpu              # both cpu and memory auto-computed
+      - name: memory
+      - name: example.com/token
+        nominalQuota: 100      # not reported by nodes — manual override
+```
+
+#### Story 3
+
+As a capacity administrator at a large organization, I onboard new node pools
+monthly. I want total capacity to automatically land at the Cohort level as a
+shared pool, so my team can then statically carve up `nominalQuota` across
+ClusterQueues.
+
+```yaml
+# Cohort: shared pool — auto-detected from shared-nodes ResourceFlavor
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: Cohort
+metadata:
+  name: org-cohort
+spec:
+  resourceGroups:
+  - coveredResources: ["cpu", "memory"]
+    flavors:
+    - name: shared-nodes     # ResourceFlavor with nodeLabels: {node-pool: shared}
+      autoDetect: true
+      resources:
+      - name: cpu
+      - name: memory
+
+---
+# CQs borrow from the cohort shared pool
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: team-alpha-cq
+spec:
+  cohortName: org-cohort
+  resourceGroups:
+  - coveredResources: ["cpu", "memory"]
+    flavors:
+    - name: shared-nodes
+      resources:
+      - name: cpu
+        nominalQuota: 0     # borrows from cohort's auto-detected pool
+      - name: memory
+        nominalQuota: 0
+```
+
+Note: the Cohort's `nominalQuota` represents additional shared resources on top
+of CQ quotas. A CQ and its parent Cohort may both use `autoDetect` as long as
+their ResourceFlavors' `nodeLabels` select **different** physical nodes, to
+avoid double-counting.
+
+#### Story 4
+
+**(Beta)** As a cluster administrator managing a multi-region cluster, I have a
+ResourceFlavor `gpu-nodes` that covers all A100 GPU nodes across all regions.
+I want one ClusterQueue to automatically compute quota from only the `us-east`
+region's GPU nodes, and another from `us-west`, without creating separate
+ResourceFlavors per region.
+
+Since a ClusterQueue can reference multiple flavors, the additional `nodeLabels`
+for fine-grained filtering are placed at the **flavor level**, not the CQ level.
+
+```yaml
+# ResourceFlavor covers all A100 nodes across regions
+kind: ResourceFlavor
+metadata:
+  name: gpu-nodes
+spec:
+  nodeLabels:
+    gpu-type: a100
+
+---
+# CQ narrows to us-east by adding nodeLabels on the flavor entry (Beta)
+kind: ClusterQueue
+metadata:
+  name: us-east-gpu-cq
+spec:
+  resourceGroups:
+  - coveredResources: ["nvidia.com/gpu"]
+    flavors:
+    - name: gpu-nodes
+      autoDetect: true
+      nodeLabels:            # Beta: flavor-level label narrows this flavor's node set
+        region: us-east
+      resources:
+      - name: nvidia.com/gpu
+      # effective nodes: gpu-type=a100 AND region=us-east
+
+---
+kind: ClusterQueue
+metadata:
+  name: us-west-gpu-cq
+spec:
+  resourceGroups:
+  - coveredResources: ["nvidia.com/gpu"]
+    flavors:
+    - name: gpu-nodes
+      autoDetect: true
+      nodeLabels:
+        region: us-west
+      resources:
+      - name: nvidia.com/gpu
+      # effective nodes: gpu-type=a100 AND region=us-west
+```
+
+### Notes/Constraints/Caveats
+
+- **`autoDetect` and `nominalQuota` interaction**: When `autoDetect: true` is
+  set at the flavor level, individual resource entries must not set `nominalQuota`
+  unless they explicitly want to override auto-detection for that resource.
+- **Headroom and Allocatable**: `node.Status.Allocatable` already equals total
+  node capacity minus kubelet's `kube-reserved` and `system-reserved`, so those
+  system reservations are implicitly handled. The `headroom` field is for
+  DaemonSets and other non-Kueue pods that consume node resources beyond what
+  kubelet reserves.
+- **Cohort + CQ autoDetect overlap**: A Cohort and a CQ within it may both set
+  `autoDetect: true` on the same flavor only if their ResourceFlavors' nodeLabels
+  select **different** physical nodes. Overlapping node sets cause double-counting.
+  This is the administrator's responsibility; Beta will add validation warnings
+  for overlapping selectors.
+- **Node readiness filtering**: By default only Nodes with condition `Ready=True`
+  are counted. An optional `includeNotReady` field can override this.
+- **Rate limiting**: The controller aggregates node events and re-computes quotas
+  at a bounded frequency (e.g., every 15 seconds) to avoid excessive API writes.
+- **Feature gate**: This feature is gated behind `AutomaticQuotaFromNodes`
+  (disabled by default in Alpha).
+- **Recommended use case**: This feature targets predictable, known capacity
+  (fixed node pools, periodic onboarding). For reactive autoscaling via
+  ProvisioningRequest, static `nominalQuota` remains recommended.
+
+### Risks and Mitigations
+
+- **Stale quota if Node watch is delayed**: Kueue already relies on informer
+  caches for correctness. Risk is no different from existing Workload/Pod watches.
+- **Resource churn causing frequent quota updates**: Mitigation: batch node
+  events with a bounded reconciliation interval (e.g., 15 seconds). Only update
+  status when the computed quota actually changes.
+- **Conflicting selectors across ClusterQueues or between Cohort and CQ**:
+  Overlapping node sets lead to over-committed quotas, same as manually
+  overlapping quotas today. Beta will add validation warnings.
+- **Security**: The controller needs `get`, `list`, `watch` on Nodes. Kueue
+  already has these permissions for TAS. No additional RBAC needed.
+
+## Design Details
+
+### Alpha: Coarse-Grained Auto-Detection
+
+#### API Changes (Alpha)
+
+Add `autoDetect`, `headroom`, and `includeNotReady` at the **flavor level**
+(`FlavorQuotas` struct) in `apis/kueue/v1beta2/clusterqueue_types.go`. This
+struct is shared by both ClusterQueue and Cohort `resourceGroups`.
+
+```go
+type FlavorQuotas struct {
+    // name of this flavor.
+    Name ResourceFlavorReference `json:"name"`
+
+    // autoDetect enables automatic quota computation for all resources in
+    // this flavor. When true, Kueue watches Nodes matching the associated
+    // ResourceFlavor's nodeLabels and computes nominalQuota as the sum of
+    // their Allocatable values for each resource. Individual resources may
+    // still override with nominalQuota for resources not reported by nodes.
+    // Mutually exclusive with setting nominalQuota on all resources in this
+    // flavor simultaneously.
+    // +optional
+    AutoDetect bool `json:"autoDetect,omitempty"`
+
+    // headroom defines how much capacity to reserve from the auto-detected
+    // total. Applies only when autoDetect is true.
+    // Note: node.Status.Allocatable already accounts for kubelet kube-reserved
+    // and system-reserved; headroom is for DaemonSets and other non-Kueue pods.
+    // +optional
+    Headroom *QuotaHeadroom `json:"headroom,omitempty"`
+
+    // includeNotReady specifies whether Nodes without Ready=True should be
+    // included in quota computation. Defaults to false.
+    // Applies only when autoDetect is true.
+    // +optional
+    IncludeNotReady *bool `json:"includeNotReady,omitempty"`
+
+    Resources []ResourceQuota `json:"resources,omitempty"`
+}
+
+// QuotaHeadroom configures how much capacity to reserve from the
+// auto-detected total.
+type QuotaHeadroom struct {
+    // percentage specifies the percentage of total Allocatable to subtract.
+    // Must be between 0 and 100.
+    // +optional
+    // +kubebuilder:validation:Minimum=0
+    // +kubebuilder:validation:Maximum=100
+    Percentage *int32 `json:"percentage,omitempty"`
+
+    // fixed specifies a fixed quantity to subtract as headroom.
+    // +optional
+    Fixed *resource.Quantity `json:"fixed,omitempty"`
+}
+```
+
+`ResourceQuota` is unchanged in Alpha. Individual resources may set `nominalQuota`
+to override auto-detection for that specific resource (e.g., custom resources
+not reported by node Allocatable).
+
+#### Validation Rules (Alpha)
+
+- `autoDetect: true` requires the `AutomaticQuotaFromNodes` feature gate.
+- `headroom` and `includeNotReady` are only valid when `autoDetect: true`.
+- Within `headroom`, at most one of `percentage` or `fixed` may be set.
+- The associated ResourceFlavor must define `nodeLabels`; if `nodeLabels` is
+  empty, `autoDetect: true` is a validation error.
+- A resource entry must not set `nominalQuota` when `autoDetect: true` is set
+  at the flavor level, unless it is explicitly overriding auto-detection for
+  that resource (permitted but must be acknowledged via a dedicated field in Beta).
+
+#### Status Extension
+
+Add `detectedQuotas` to both `ClusterQueueStatus` and `CohortStatus` to expose
+the computed quota values:
+
+```go
+type ClusterQueueStatus struct {
+    // ... existing fields ...
+
+    // detectedQuotas reports the most recently computed quota values
+    // for resources using autoDetect. Allows administrators to observe
+    // what Kueue has computed.
+    // +optional
+    DetectedQuotas []DetectedQuota `json:"detectedQuotas,omitempty"`
+}
+
+type DetectedQuota struct {
+    // flavorName is the name of the ResourceFlavor.
+    FlavorName ResourceFlavorReference `json:"flavorName"`
+
+    // resourceName is the name of the resource.
+    ResourceName corev1.ResourceName `json:"resourceName"`
+
+    // quantity is the computed quota value after headroom subtraction.
+    Quantity resource.Quantity `json:"quantity"`
+
+    // nodeCount is the number of matching Nodes that contributed.
+    NodeCount int32 `json:"nodeCount"`
+
+    // lastUpdated is when the quota was last recomputed.
+    LastUpdated metav1.Time `json:"lastUpdated"`
+}
+```
+
+### Beta: Fine-Grained Node Label Intersection
+
+#### API Changes (Beta)
+
+Add an optional `nodeLabels` field at the **flavor level** (`FlavorQuotas`
+struct) in both ClusterQueue and Cohort `resourceGroups`. Since a CQ or Cohort
+can reference multiple flavors, placing `nodeLabels` at the flavor level allows
+each flavor to independently narrow its node set.
+
+```go
+type FlavorQuotas struct {
+    // name of this flavor.
+    Name ResourceFlavorReference `json:"name"`
+
+    // autoDetect enables automatic quota computation for all resources in
+    // this flavor using the ResourceFlavor's nodeLabels. (Alpha field)
+    // +optional
+    AutoDetect bool `json:"autoDetect,omitempty"`
+
+    // nodeLabels defines additional labels used to narrow the node set for
+    // quota computation when autoDetect is true. The effective node set is
+    // the intersection of the ResourceFlavor's nodeLabels and these labels.
+    // This allows multiple CQs or Cohorts to reference the same ResourceFlavor
+    // but compute quota from different node subsets (e.g., per-region).
+    // Beta field; requires AutomaticQuotaFromNodes feature gate.
+    // +optional
+    NodeLabels map[string]string `json:"nodeLabels,omitempty"`
+
+    // headroom reserves capacity from the auto-detected total. (Alpha field)
+    // +optional
+    Headroom *QuotaHeadroom `json:"headroom,omitempty"`
+
+    // includeNotReady includes non-Ready nodes in computation. (Alpha field)
+    // +optional
+    IncludeNotReady *bool `json:"includeNotReady,omitempty"`
+
+    Resources []ResourceQuota `json:"resources,omitempty"`
+}
+```
+
+#### Intersection Semantics
+
+`nodeLabels` is placed at the **flavor level**, so each flavor entry in a CQ or
+Cohort can independently narrow its node set. The CQ and Cohort each compute
+their quota independently — there is no cross-scope filtering.
+
+```
+# Node-set perspective (∩ = intersection of matching node sets):
+CQ flavor effectiveNodes     = {nodes matching RF.nodeLabels} ∩ {nodes matching flavor.nodeLabels in CQ}
+Cohort flavor effectiveNodes = {nodes matching RF.nodeLabels} ∩ {nodes matching flavor.nodeLabels in Cohort}
+```
+
+This allows administrators to:
+- Use a single ResourceFlavor that covers a broad node class (e.g., all A100 nodes)
+- Narrow quota computation per-CQ-flavor (e.g., `region=us-east`) or
+  per-Cohort-flavor (e.g., `zone=prod`) without creating additional ResourceFlavors
+- Have multiple CQs share one ResourceFlavor but each compute quota from a
+  different regional or zonal subset of nodes
+
+#### Validation Rules (Beta)
+
+- `nodeLabels` at CQ or Cohort level is only meaningful when at least one flavor
+  in the object has `autoDetect: true`. A warning is emitted otherwise.
+- If a key appears in both CQ `nodeLabels` and ResourceFlavor `nodeLabels` with
+  different values, the node must satisfy both — in practice this means no nodes
+  match. This is flagged as a validation warning.
+- Beta adds validation warnings when Cohort and CQ selectors (after intersection)
+  still select overlapping node sets.
+
+### Controller Design
+
+#### Node Watcher
+
+A new controller `AutoQuotaReconciler` watches Node objects using a shared
+informer (reusing the same informer as TAS to avoid duplicate Node watches). It
+maintains an in-memory index:
+
+```
+effectiveLabels -> set of matching nodes -> aggregated Allocatable per resource
+```
+
+When a Node is created, updated, or deleted, the controller determines which
+ClusterQueues and Cohorts have affected `autoDetect` flavors and enqueues those
+objects for reconciliation.
+
+#### Reconciliation Loop
+
+1. Node event arrives (create/update/delete)
+2. Determine affected ClusterQueues and Cohorts by matching their effective label sets
+3. Debounce: coalesce events within a ~15-second window
+4. Recompute effective quota for affected flavors
+5. Update internal cache (scheduler snapshot)
+6. Update ClusterQueue/Cohort Status with `DetectedQuotas`
+7. If quotas decreased, trigger scheduling cycle to evaluate preemptions
+
+### Interaction with Existing Features
+
+| Feature | Interaction |
+|---|---|
+| Borrowing/Lending | Works unchanged. The auto-detected value replaces `nominalQuota` in all calculations. `borrowingLimit` and `lendingLimit` remain relative to the effective quota. |
+| Hierarchical Cohorts | SubtreeQuota accumulation uses the effective quota from auto-detection at both Cohort and CQ levels. No changes needed in `resource_node.go`. |
+| Preemption | If detected quota decreases (nodes removed), this may trigger preemption of workloads exceeding the new quota. Consistent with existing behavior when an admin manually reduces `nominalQuota`. |
+| Fair Sharing | Share calculations use the effective quota. No changes needed. |
+| ProvisioningRequest | These features target different scenarios. `autoDetect` reflects **current** physical capacity for predictable node pools. ProvisioningRequest is for **reactive** autoscaling — requesting capacity on demand. Using both simultaneously for the same resource is not recommended. Once nodes provisioned by ProvisioningRequest come online, auto-detection naturally picks them up. |
+| TAS (Topology Aware Scheduling) | TAS already watches Nodes via `rfReconciler`. The `AutoQuotaReconciler` reuses the same shared Node informer to avoid duplicate watches. |
+| Cohort quota | Cohort `nominalQuota` represents additional shared resources on top of CQ quotas. `autoDetect: true` at the Cohort flavor level populates that shared pool automatically. Cohort and member CQ flavors must not select overlapping node sets to avoid double-counting. |
+
+### RBAC Requirements
+
+Kueue already has the necessary RBAC for Node watching:
+
+```go
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
+```
+
+This is currently used by the TAS controller. The `AutoQuotaReconciler` reuses
+the same permissions. No additional RBAC changes are needed.
+
+### Test Plan
+
+#### Prerequisite testing updates
+
+Existing unit tests for `resourceNode.available()` and `potentialAvailable()`
+should be extended to verify correct behavior when `nominalQuota` is dynamically
+updated (simulating auto-detection).
+
+#### Unit Tests
+
+- `pkg/cache/scheduler/`: Verify that auto-detected quotas flow correctly into
+  Snapshot, SubtreeQuota, and available calculations at both CQ and Cohort levels.
+- `pkg/controller/core/`: Test the `AutoQuotaReconciler`:
+  - Quota computation from ResourceFlavor `nodeLabels` (Alpha).
+  - Headroom percentage and fixed calculations.
+  - Node readiness filtering.
+  - Per-resource `nominalQuota` override when `autoDetect: true`.
+  - Debouncing behavior.
+  - Status update with `DetectedQuotas`.
+  - (Beta) Label intersection across Cohort, CQ, and ResourceFlavor.
+- API validation: `autoDetect: true` requires non-empty ResourceFlavor `nodeLabels`.
+
+#### Integration Tests
+
+**Alpha:**
+- ClusterQueue flavor with `autoDetect: true` correctly reflects node capacity.
+- Cohort flavor with `autoDetect: true` correctly reflects shared node capacity;
+  CQs with `nominalQuota: 0` borrow from it.
+- Adding/removing Nodes updates the effective quota.
+- Workload admission respects the auto-detected quota.
+- Quota decrease triggers preemption of over-quota workloads.
+- Mixed flavor: `autoDetect: true` with per-resource `nominalQuota` override.
+- Interaction with borrowing/lending limits.
+
+**Beta:**
+- CQ-level `nodeLabels` narrows the node set (intersection with ResourceFlavor labels).
+- Cohort-level `nodeLabels` narrows the node set for all member CQs.
+- Three-way intersection: Cohort + CQ + ResourceFlavor `nodeLabels` all applied.
+- Conflicting labels (same key, different value) result in empty node set and
+  zero quota with a validation warning.
+
+#### e2e Tests
+
+- End-to-end test with a multi-node cluster verifying that ClusterQueue and
+  Cohort quotas dynamically adjust as Nodes join and leave.
+- (Beta) Multi-region cluster verifying that CQ-level `nodeLabels` correctly
+  restricts quota computation to the appropriate regional node subset.
+
+### Graduation Criteria
+
+#### Alpha
+
+- Feature gate `AutomaticQuotaFromNodes` (default disabled).
+- `autoDetect`, `headroom`, and `includeNotReady` fields added to `FlavorQuotas`
+  struct (shared by ClusterQueue and Cohort `resourceGroups`).
+- `AutoQuotaReconciler` implemented using ResourceFlavor `nodeLabels` for node
+  selection, integrated with scheduler cache and shared Node informer.
+- Per-resource `nominalQuota` override supported when `autoDetect: true`.
+- Status reporting via `DetectedQuotas` on ClusterQueue and Cohort.
+- Unit and integration tests covering core Alpha functionality.
+- Documentation of the new API fields and behavior.
+
+#### Beta
+
+- Feature gate default enabled.
+- `nodeLabels` field added to `ClusterQueueSpec` and `CohortSpec` for
+  fine-grained intersection-based node selection.
+- Intersection semantics implemented and documented.
+- Validation warnings for:
+  - Overlapping node sets between Cohort and CQ `autoDetect` flavors.
+  - Conflicting label values across scopes.
+- Metrics:
+  - `kueue_detected_quota` (gauge): current effective quota per object/flavor/resource.
+  - `kueue_quota_detect_reconcile_duration_seconds` (histogram): reconcile latency.
+- Performance testing in large clusters (1000+ Nodes).
+
+#### GA
+
+- Feature gate removed (always enabled).
+- Stable API with no breaking changes.
+- Production usage feedback incorporated.
+
+## Implementation History
+
+- 2026-04-23: KEP created based on issue [#10270](https://github.com/kubernetes-sigs/kueue/issues/10270).
+- 2026-04-24: Revised based on review feedback:
+  - Moved `autoDetect` from resource level to flavor level; uses ResourceFlavor
+    `nodeLabels` directly (no duplicated `nodeSelector` field).
+  - Extended support to Cohort level.
+  - Split into Alpha (coarse-grained, flavor-level flag) and Beta (fine-grained,
+    label intersection across Cohort/CQ/ResourceFlavor scopes).
+  - Clarified headroom vs. Allocatable semantics and ProvisioningRequest interaction.

--- a/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
+++ b/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
@@ -493,7 +493,9 @@ type ComputedFlavorQuota struct {
     // nodeCount is the number of matching Nodes that contributed to the sum.
     NodeCount int32 `json:"nodeCount"`
 
-    // lastUpdated is the timestamp of the most recent successful write.
+    // lastUpdated is the time at which quantity last changed, not the last
+    // reconcile time. It is only bumped when the computed value actually
+    // changes, so it does not advance on no-op reconciles.
     LastUpdated metav1.Time `json:"lastUpdated"`
 }
 

--- a/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
+++ b/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
@@ -537,7 +537,23 @@ func init() {
 
 #### ClusterQueue and Cohort API Changes
 
-**No changes** to `ClusterQueueSpec`, `CohortSpec`, `FlavorQuotas`, or `ResourceQuota` in Alpha. The `nominalQuota` field is written by the `NodeQuotaPolicyReconciler` via a server-side apply patch, exactly as an HPA controller patches `spec.replicas` on a Deployment.
+**No spec changes** to `ClusterQueueSpec`, `CohortSpec`, `FlavorQuotas`, or `ResourceQuota` in Alpha. The `nominalQuota` field is written by the `NodeQuotaPolicyReconciler` via a server-side apply patch, exactly as an HPA controller patches `spec.replicas` on a Deployment.
+
+The only API addition is to `CohortStatus`, which gains a `conditions` list so the controller can surface a target-side `NodeQuotaManaged` condition (see [Status Reporting](#status-reporting)). `ClusterQueueStatus` already has `conditions`, so no ClusterQueue change is needed:
+
+```go
+// CohortStatus gains a conditions list (ClusterQueueStatus already has one).
+type CohortStatus struct {
+    // ... existing fields ...
+
+    // conditions hold the latest available observations of the Cohort's state.
+    // +optional
+    // +listType=map
+    // +listMapKey=type
+    // +kubebuilder:validation:MaxItems=8
+    Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+```
 
 The Kueue scheduler continues to read `nominalQuota` from the CQ or Cohort spec as today. No scheduler changes are required.
 

--- a/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
+++ b/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
@@ -352,6 +352,17 @@ type NodeQuotaPolicySpec struct {
     // +required
     TargetRef NodeQuotaPolicyTargetRef `json:"targetRef"`
 
+    // mode controls whether the controller actuates the computed quota.
+    // In "Apply" (the default) the controller writes the computed nominalQuota
+    // to the target object. In "Recommend" the controller only records the
+    // computed values in status.computedQuotas and does not modify the target,
+    // so an external system of record (e.g. GitOps/Terraform) can consume the
+    // proposal and apply it through its own pipeline.
+    // +optional
+    // +kubebuilder:validation:Enum=Apply;Recommend
+    // +kubebuilder:default=Apply
+    Mode NodeQuotaPolicyMode `json:"mode,omitempty"`
+
     // flavorPolicies defines per-flavor quota computation rules. Each entry
     // corresponds to one flavor in the target object's resourceGroups.
     // The controller only writes nominalQuota for (flavor, resource) pairs
@@ -363,6 +374,17 @@ type NodeQuotaPolicySpec struct {
     // +required
     FlavorPolicies []FlavorNodeQuotaPolicy `json:"flavorPolicies"`
 }
+
+// NodeQuotaPolicyMode controls whether the controller actuates the computed quota.
+type NodeQuotaPolicyMode string
+
+const (
+    // NodeQuotaPolicyModeApply writes the computed nominalQuota to the target.
+    NodeQuotaPolicyModeApply NodeQuotaPolicyMode = "Apply"
+    // NodeQuotaPolicyModeRecommend records the computed values in status only,
+    // leaving the target object untouched for an external system to actuate.
+    NodeQuotaPolicyModeRecommend NodeQuotaPolicyMode = "Recommend"
+)
 
 // NodeQuotaPolicyTargetRef identifies the object whose nominalQuota is managed.
 type NodeQuotaPolicyTargetRef struct {

--- a/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
+++ b/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
@@ -754,25 +754,6 @@ writes directly. This mirrors VPA's recommendation-only (`updateMode: Off`) vs.
 auto modes. Exposing the proposed values and letting consumers diff against the
 live object is preferred over persisting a diff artifact that can go stale.
 
-### RBAC Requirements
-
-Kueue already has the necessary RBAC for Node watching:
-
-```go
-// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
-```
-
-The `NodeQuotaPolicyReconciler` additionally needs patch access on ClusterQueue and Cohort, which existing Kueue controllers already have:
-
-```go
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=clusterqueues,verbs=get;list;watch;patch
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=cohorts,verbs=get;list;watch;patch
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=nodequotapolicies,verbs=get;list;watch;patch
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=nodequotapolicies/status,verbs=get;update;patch
-```
-
-No additional RBAC changes are needed beyond the new CRD's own verbs.
-
 ### Test Plan
 
 #### Prerequisite testing updates

--- a/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
+++ b/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
@@ -465,8 +465,15 @@ type NodeQuotaPolicyStatus struct {
     Conditions []metav1.Condition `json:"conditions,omitempty"`
 
     // computedQuotas reports the nominalQuota values most recently written to
-    // the target object, one entry per (flavor, resource) pair.
+    // the target object, one entry per (flavor, resource) pair. Entries are
+    // keyed by (flavorName, resourceName), giving a deterministic order and
+    // stable server-side-apply merge semantics so the status does not churn on
+    // every reconcile.
     // +optional
+    // +listType=map
+    // +listMapKey=flavorName
+    // +listMapKey=resourceName
+    // +kubebuilder:validation:MaxItems=256
     ComputedQuotas []ComputedFlavorQuota `json:"computedQuotas,omitempty"`
 }
 

--- a/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
+++ b/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
@@ -142,9 +142,8 @@ spec:
     name: team-alpha-cq
   flavorPolicies:
   - flavorName: team-alpha-nodes   # ResourceFlavor nodeLabels: {team: alpha}
-    headroom:
-      percentage: 5                # reserve 5% for DaemonSets
-    resourceOverrides:
+    headroomPercentage: 5          # reserve 5% for DaemonSets
+    resources:
     - name: example.com/token      # not reported by nodes — fixed manual value
       nominalQuota: "100"
 
@@ -298,7 +297,7 @@ spec:
 ### Notes/Constraints/Caveats
 
 - **Separation of concerns**: `NodeQuotaPolicy` owns the computation logic; ClusterQueue and Cohort own only the quota value. This mirrors the kubelet pattern where `node.Status.Allocatable` is computed externally and written into the Node object — the Node schema does not embed the computation.
-- **Headroom and Allocatable**: `node.Status.Allocatable` already equals total node capacity minus kubelet's `kube-reserved` and `system-reserved`, so those system reservations are implicitly handled. The `headroom` field is for DaemonSets and other non-Kueue pods that consume node resources beyond what kubelet reserves.
+- **Headroom and Allocatable**: `node.Status.Allocatable` already equals total node capacity minus kubelet's `kube-reserved` and `system-reserved`, so those system reservations are implicitly handled. Headroom (`headroomPercentage`, or per-resource `fixedHeadroom`/`percentageHeadroom`) is for DaemonSets and other non-Kueue pods that consume node resources beyond what kubelet reserves.
 - **Cohort + CQ NodeQuotaPolicy overlap**: A Cohort and a CQ within it may each be targeted by a `NodeQuotaPolicy` only if their respective ResourceFlavors' effective node sets (after label intersection) are **disjoint**; overlapping node sets double-count physical capacity. In Alpha this cannot arise between two policies that target different ResourceFlavors, because flavors are already expected to select disjoint nodes — so there is effectively no new overlap surface. The surface appears in Beta, where `flavorPolicy.nodeLabels` can sub-select within a shared flavor. Detection is reactive, not a webhook check: on overlap the controller sets `Ready=False` with reason `OverlappingNodeSet` on the affected policies and withholds the quota write (keeping the last-known-good value) rather than silently over-provisioning.
 - **Node readiness filtering**: By default only Nodes with condition `Ready=True` are counted. The `includeNotReady` field in `FlavorNodeQuotaPolicy` can override this.
 - **Rate limiting**: The controller aggregates node events and re-computes quotas at a bounded frequency (e.g., every 15 seconds) to avoid excessive API writes to ClusterQueue or Cohort.
@@ -307,10 +306,10 @@ spec:
 
 ### Risks and Mitigations
 
-- **Stale quota if Node watch is delayed**: Kueue already relies on informer caches for correctness. Risk is no different from existing Workload/Pod watches.
+- **Stale quota**: two latency sources contribute. Informer cache lag is involuntary and sub-second — the same as existing Workload/Pod watches. The intentional enqueue debounce (the batch window) is new to this controller and adds to it, so worst-case staleness is roughly informer lag + debounce window + write/scheduler-refresh. The risk is asymmetric: on scale-up the quota lags *below* real capacity, so Kueue under-admits (safe/conservative); on scale-down it lags *above*, so it can transiently over-admit until the controller writes the lower value, which then converges. For the target use case (predictable, slow-changing node pools) a bounded few-second lag is acceptable, and the window is tunable; the controller may also debounce increases while reacting faster to decreases if the scale-down window proves too loose.
 - **Resource churn causing frequent quota updates**: Mitigation: batch node events with a bounded reconciliation interval (e.g., 15 seconds). Only write to the target object when the computed quota actually changes.
 - **Conflicting selectors across ClusterQueues or between Cohort and CQ**: Overlapping effective node sets lead to over-committed quotas, same as manually overlapping quotas today. The controller detects this at reconcile and sets `Ready=False`/`OverlappingNodeSet` on the affected policies while withholding the write, instead of silently over-provisioning (Beta; the Alpha node set is the whole flavor, which is already expected to be disjoint).
-- **Concurrent writes**: If an administrator manually edits `nominalQuota` on a CQ that is managed by a `NodeQuotaPolicy`, the controller will overwrite it on the next reconcile. This is the same behavior as HPA overwriting `spec.replicas`. Administrators should be aware that managed fields are authoritative in `NodeQuotaPolicy`, not in the CQ.
+- **Concurrent writes**: The controller writes via server-side apply with `ForceOwnership` under field manager `kueue.x-k8s.io/node-quota-policy`. This scopes the write to just the `nominalQuota` fields it manages (it does not disturb `borrowingLimit`, other flavors, or labels) while remaining authoritative: if an administrator manually edits a managed `nominalQuota`, the force-apply reclaims it and overwrites on the next reconcile (same behavior as HPA overwriting `spec.replicas`). This is in `Apply` mode; in `Recommend` mode the controller does not write the target at all (see Quota vending / external source of truth).
 - **Security**: The controller needs `get`, `list`, `watch` on Nodes and `patch` on ClusterQueues and Cohorts. Node watching is already granted to Kueue for TAS. Patch on ClusterQueue/Cohort is already granted for existing controllers. No additional RBAC changes are needed.
 
 ## Design Details
@@ -688,12 +687,13 @@ The controller maintains an in-memory reverse index:
 effectiveLabelSet → set of NodeQuotaPolicy names that use this label set
 ```
 
-When a Node event arrives, the controller determines which label sets match the node, looks up the affected `NodeQuotaPolicy` names, and enqueues them for reconciliation.
+When a Node event arrives, the controller determines which label sets match the node, looks up the affected `NodeQuotaPolicy` names, and enqueues them for reconciliation. Node events are predicate-filtered so that only changes to `Allocatable`, labels, or readiness trigger work (not routine heartbeats), and enqueueing is coalesced via `AddAfter(req, batchPeriod)` with the workqueue deduplicating by key — so a burst of Node changes collapses into a single reconcile per policy. This is the same pattern TAS uses (`constants.UpdatesBatchPeriod`) and avoids waiting inside `Reconcile`, which would block a worker.
 
 #### Reconciliation Loop
 
 ```
 Trigger: NodeQuotaPolicy / Node / ResourceFlavor / ClusterQueue / Cohort event
+         (Node events are coalesced at enqueue time — see Node Watcher)
          ↓
 1.  Load NodeQuotaPolicy spec (targetRef + flavorPolicies).
 2.  For each FlavorNodeQuotaPolicy:
@@ -702,33 +702,57 @@ Trigger: NodeQuotaPolicy / Node / ResourceFlavor / ClusterQueue / Cohort event
     c. List all Nodes matching the effective label set.
     d. Filter: exclude non-Ready nodes unless includeNotReady=true.
     e. Sum node.Status.Allocatable for each resource.
-    f. Apply headroom (percentage or fixed subtraction, floor at zero).
-    g. Apply resourceOverrides: replace computed value for overridden resources.
+    f. Apply per-resource rules: pin nominalQuota where set, else subtract
+       fixedHeadroom / percentageHeadroom (falling back to the flavor-wide
+       headroomPercentage), flooring at zero.
 3.  Compare computed quota map against NodeQuotaPolicy.status.computedQuotas.
     If unchanged, stop (no write to target object).
-4.  Debounce: coalesce rapid node events within a ~15-second window before
-    writing to avoid excessive API calls.
-5.  Patch target ClusterQueue or Cohort spec via server-side apply:
-    - Write nominalQuota for each (flavor, resource) pair in flavorPolicies.
-    - Only touch fields owned by this NodeQuotaPolicy (field manager:
-      "kueue.x-k8s.io/node-quota-policy").
-6.  Update NodeQuotaPolicy.status.computedQuotas and conditions.
-7.  If any nominalQuota decreased, the Kueue scheduler cache is invalidated
-    and a scheduling cycle runs to evaluate potential preemptions.
+4.  Pre-check target invariants: the computed nominalQuota for each
+    (flavor, resource) must be >= any existing lendingLimit on the target
+    (webhook-enforced). On violation, withhold the write and set Ready=False
+    (reason LendingLimitExceedsComputedQuota) instead of emitting a patch the
+    target's webhook would reject.
+5.  If mode is Recommend, stop here (values are recorded in status only). If mode
+    is Apply, patch the target ClusterQueue or Cohort spec via server-side apply:
+    - Write nominalQuota for each (flavor, resource) pair.
+    - Apply with field manager "kueue.x-k8s.io/node-quota-policy" and
+      ForceOwnership. The field manager scopes the write to just these
+      nominalQuota fields (leaving borrowingLimit, other flavors, labels
+      untouched); ForceOwnership makes it authoritative, so a manual edit to a
+      managed field is reclaimed on the next reconcile.
+6.  Update NodeQuotaPolicy.status (computedQuotas, conditions) and the
+    NodeQuotaManaged condition on the target.
+7.  If any nominalQuota decreased, the Kueue scheduler cache is updated. The
+    lower quota constrains future admission only; already-admitted workloads are
+    not proactively evicted (an over-quota ClusterQueue simply admits nothing new
+    until usage drops below the new quota).
 ```
 
 ### Interaction with Existing Features
 
 | Feature | Interaction |
 |---|---|
-| Borrowing/Lending | Works unchanged. The controller-written `nominalQuota` is the value used by all borrowing/lending calculations. `borrowingLimit` and `lendingLimit` remain relative to the effective quota. |
+| Borrowing/Lending | The controller writes only `nominalQuota`; `borrowingLimit` and `lendingLimit` are absolute, admin-set values it does not modify. Borrowing/lending math then uses the new `nominalQuota` together with those unchanged limits. Caveat: `lendingLimit ≤ nominalQuota` is webhook-enforced, so a computed decrease below an existing `lendingLimit` would be rejected — the controller pre-checks this and instead sets `Ready=False`/`LendingLimitExceedsComputedQuota`, withholding the write (see Reconciliation Loop). `borrowingLimit` has no such bound. |
 | Hierarchical Cohorts | SubtreeQuota accumulation uses the `nominalQuota` written by the controller at both Cohort and CQ levels. No changes needed in `resource_node.go`. |
-| Preemption | If `nominalQuota` decreases (nodes removed), this may trigger preemption of workloads exceeding the new quota. Consistent with existing behavior when an admin manually reduces `nominalQuota`. |
+| Quota decrease | If `nominalQuota` decreases (nodes removed), the scheduler cache is updated and the lower quota constrains **future** admission only; already-admitted workloads are **not** proactively evicted (an over-quota ClusterQueue simply admits nothing new until usage drops). This matches existing behavior when an admin manually reduces `nominalQuota`. Kueue preemption is admission-driven — triggered by an incoming workload, not by a quota change. |
 | Fair Sharing | Share calculations use the `nominalQuota` as written. No changes needed. |
-| ProvisioningRequest | These features target different scenarios. `NodeQuotaPolicy` reflects **current** physical capacity for predictable node pools. ProvisioningRequest is for **reactive** autoscaling. Using both simultaneously for the same resource is not recommended. Once nodes provisioned by ProvisioningRequest come online, the `NodeQuotaPolicy` controller naturally picks them up on the next reconcile. |
+| ProvisioningRequest | Do not use both for the same resource. ProvisioningRequest is an AdmissionCheck that runs only *after* a workload reserves quota, so it needs `nominalQuota` set to the provisionable max; `NodeQuotaPolicy` instead pins `nominalQuota` to current physical capacity, so a workload exceeding current capacity never reserves quota, never reaches the provisioning check, and the nodes are never created — a deadlock. Use static `nominalQuota` with ProvisioningRequest (reactive autoscaling) and `NodeQuotaPolicy` for fixed/predictable pools. This interaction must be documented for users (see Graduation Criteria). |
 | TAS (Topology Aware Scheduling) | TAS already watches Nodes via `rfReconciler`. The `NodeQuotaPolicyReconciler` reuses the same shared Node informer to avoid duplicate watches. |
 | Cohort quota | A `NodeQuotaPolicy` may target a Cohort directly. Cohort `nominalQuota` represents a shared pool on top of CQ quotas. A CQ and its parent Cohort may each be managed by separate `NodeQuotaPolicy` objects as long as their effective node sets do not overlap. |
-| Manual edits to managed nominalQuota | If an administrator manually patches `nominalQuota` on a CQ managed by a `NodeQuotaPolicy`, the controller will overwrite it at the next reconcile cycle. This is intentional and mirrors HPA behavior. |
+| Manual edits to managed nominalQuota | In `Apply` mode, if an administrator manually patches a managed `nominalQuota`, the controller reclaims and overwrites it on the next reconcile (force server-side apply, scoped to the `nominalQuota` fields it manages). Intentional, mirrors HPA. In `Recommend` mode the controller does not write the target, so manual edits stand. |
+
+**Quota vending / external source of truth.** Large organizations often own the
+desired quota state in an external system (a database, or GitOps/Terraform) and
+vend capacity to teams from there. For them, a controller that authoritatively
+writes `nominalQuota` would fight that system — drift on every plan, a re-write
+after every apply. The `mode` field addresses this: in `Recommend` mode the
+controller computes and records the proposed values in `status.computedQuotas`
+(and sets the `NodeQuotaManaged` condition) but does **not** modify the target, so
+the external system can diff the proposal against the live `nominalQuota` and
+actuate through its own pipeline; in `Apply` mode (the default) the controller
+writes directly. This mirrors VPA's recommendation-only (`updateMode: Off`) vs.
+auto modes. Exposing the proposed values and letting consumers diff against the
+live object is preferred over persisting a diff artifact that can go stale.
 
 ### RBAC Requirements
 
@@ -759,20 +783,26 @@ Existing unit tests for `resourceNode.available()` and `potentialAvailable()` sh
 
 - `pkg/controller/core/nodequotapolicy_controller.go`:
   - Quota computation from `ResourceFlavor.nodeLabels` (Alpha).
-  - Headroom: percentage and fixed subtraction, floor-at-zero.
+  - Headroom: flavor-wide `headroomPercentage` and per-resource `fixedHeadroom`/`percentageHeadroom`, floor-at-zero.
   - Node readiness filtering (`includeNotReady=false` default).
-  - `resourceOverrides` take precedence over node-derived values.
-  - Debouncing: rapid node events coalesced before write.
+  - Per-resource `nominalQuota` rules pin the value, bypassing node-derived computation.
+  - Enqueue coalescing: rapid node events collapse into one reconcile per policy.
   - No-op when computed quota equals current `nominalQuota`.
   - Status update: `computedQuotas` and `Ready` condition set correctly.
-  - Conflict detection: two `NodeQuotaPolicy` objects for the same target rejected by webhook.
+  - Conflict detection: a second `NodeQuotaPolicy` for the same target sets the reactive `DuplicateTarget` condition (not a webhook rejection).
+  - `LendingLimitExceedsComputedQuota`: a computed decrease below an existing `lendingLimit` withholds the write and sets `Ready=False`.
+  - `Recommend` mode records `computedQuotas` without patching the target.
   - (Beta) Label intersection across `ResourceFlavor` and `flavorPolicy.nodeLabels`.
   - (Beta) Empty intersection emits warning condition, writes `quantity: "0"`.
-- API validation webhook:
-  - `flavorName` references a `ResourceFlavor` with at least one `nodeLabel`.
-  - `headroom` CEL rule: `percentage` and `fixed` mutually exclusive.
-  - Duplicate `flavorName` entries rejected.
-  - Second `NodeQuotaPolicy` targeting same CQ rejected.
+- API validation webhook (static checks only):
+  - `targetRef.kind` enum accepted/rejected.
+  - Per-resource rule CEL: at most one of `nominalQuota`/`fixedHeadroom`/`percentageHeadroom` set.
+  - Duplicate `flavorName` entries rejected (list-map key).
+  - `nodeLabels` (Beta field) rejected in Alpha.
+- Reactive controller conditions (not webhook):
+  - `FlavorNotFound` / `FlavorNotInTarget` / `ResourceNotCovered` set with the documented fatal/non-fatal behavior.
+  - `DuplicateTarget` when a second policy targets the same `(kind, name)`.
+  - (Beta) `OverlappingNodeSet` for overlapping effective node sets.
 
 #### Integration Tests
 
@@ -782,8 +812,8 @@ Existing unit tests for `resourceNode.available()` and `potentialAvailable()` sh
 - `NodeQuotaPolicy` targeting a `Cohort` correctly reflects shared node capacity; CQs with `nominalQuota: 0` borrow from it.
 - Adding/removing Nodes updates the `nominalQuota` in the target CQ/Cohort.
 - Workload admission respects the controller-written `nominalQuota`.
-- `nominalQuota` decrease triggers preemption of over-quota workloads.
-- `resourceOverrides` correctly bypass node-derived values for named resources.
+- `nominalQuota` decrease constrains future admission and does not evict already-admitted workloads.
+- Per-resource `nominalQuota` rules correctly bypass node-derived values for named resources.
 - Interaction with `borrowingLimit` and `lendingLimit`.
 - Controller does not write when computed quota is unchanged (no spurious updates).
 
@@ -808,10 +838,10 @@ Existing unit tests for `resourceNode.available()` and `potentialAvailable()` sh
 - `NodeQuotaPolicy` CRD implemented with full Go types, CRD manifest, and admission webhook.
 - `NodeQuotaPolicyReconciler` implemented, sharing the Node informer with TAS.
 - Server-side apply patch writes `nominalQuota` to target ClusterQueue or Cohort.
-- `resourceOverrides` supported for resources not reported by nodes.
-- `NodeQuotaPolicy.status` reports `computedQuotas` and `Ready` condition.
+- Per-resource `resources` rules supported (fixed `nominalQuota` for resources not reported by nodes, plus fixed/percentage headroom).
+- `NodeQuotaPolicy.status` reports `computedQuotas` and `Ready` condition; the target carries a `NodeQuotaManaged` condition.
 - Unit and integration tests covering core Alpha functionality.
-- Documentation of the new CRD and controller behavior.
+- Documentation of the new CRD and controller behavior, including the `mode` (Apply/Recommend) semantics and the interactions with ProvisioningRequest (do not combine on one resource) and borrowing/lending.
 
 #### Beta
 
@@ -884,7 +914,7 @@ Pros:
 - Simple to implement in Alpha.
 
 Cons:
-- The CQ has `nominalQuota: "0"` between creation and the first controller reconcile, during which all workloads are rejected. This window is typically short (seconds) but non-zero.
+- The CQ has `nominalQuota: "0"` between creation and the first controller reconcile. During this window workloads targeting it are not admitted — they wait as inadmissible and are requeued, then admitted once the first quota is written. The window is typically short (seconds) but non-zero.
 - Reading the CQ in isolation, `nominalQuota: "0"` gives no indication that the field is controller-managed, which can confuse operators.
 
 ---
@@ -918,7 +948,6 @@ spec:
 Pros:
 - Cleanest semantics: `nil` unambiguously means "controller-managed".
 - Consistent with `spec.replicas *int32` in Deployment (used by HPA).
-- Eliminates the admission gap where `nominalQuota: "0"` briefly blocks workloads.
 - Allows future tooling to distinguish managed vs. manual fields without requiring an annotation.
 
 Cons:

--- a/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
+++ b/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
@@ -608,6 +608,30 @@ Administrators can inspect computed values without reading the CQ:
 kubectl get nqp gpu-team-auto-quota -o jsonpath='{.status.computedQuotas}'
 ```
 
+**Target-side visibility (ClusterQueue / Cohort).** So operators can see — on the
+managed object itself — that its quota is controller-managed and by which policy,
+the controller also writes a lightweight `NodeQuotaManaged` condition onto the
+target ClusterQueue or Cohort:
+
+```yaml
+# kubectl get clusterqueue gpu-team-cq -o yaml
+status:
+  conditions:
+  - type: NodeQuotaManaged
+    status: "True"
+    reason: NodeQuotaPolicyApplied
+    message: "nominalQuota managed by NodeQuotaPolicy gpu-team-auto-quota; last changed 2026-04-30T10:00:00Z"
+    lastTransitionTime: "2026-04-30T10:00:00Z"
+```
+
+This is deliberately a pointer, not a mirror: the condition names the managing
+policy and last-change time, while the detailed per-(flavor, resource) values stay
+on `NodeQuotaPolicy.status.computedQuotas` (no duplication, and no extra status
+churn on the target). Two complementary signals come for free: the SSA
+`managedFields` on the target already record that `nominalQuota` is owned by the
+`kueue.x-k8s.io/node-quota-policy` field manager, and a printer column on
+`NodeQuotaPolicy` surfaces the policy→target mapping.
+
 ### Beta: Fine-Grained Node Label Intersection
 
 #### API Changes (Beta)

--- a/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
+++ b/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
@@ -589,6 +589,19 @@ status:
     lastUpdated: "2026-04-30T10:00:00Z"
 ```
 
+The two timestamps in this status have distinct semantics:
+
+- **`conditions[Ready].lastTransitionTime`** changes only when the `Ready`
+  condition's `status` transitions (e.g. `True`↔`False`). The controller sets it
+  via the standard `apimeta.SetStatusCondition` helper, so a quota recompute that
+  leaves `Ready=True`, or a `reason`/`message`-only update, does **not** move it.
+- **`computedQuotas[].lastUpdated`** records when that entry's `quantity` last
+  changed, and is bumped only on an actual value change (never on a no-op reconcile).
+
+Status carries current observed state only — the computed values plus `nodeCount`
+(how many Nodes contributed). The per-reconcile narrative (e.g. "evaluated 47
+Nodes, 3 filtered as NotReady") belongs in controller logs/events, not in status.
+
 Administrators can inspect computed values without reading the CQ:
 
 ```bash

--- a/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
+++ b/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
@@ -299,7 +299,7 @@ spec:
 
 - **Separation of concerns**: `NodeQuotaPolicy` owns the computation logic; ClusterQueue and Cohort own only the quota value. This mirrors the kubelet pattern where `node.Status.Allocatable` is computed externally and written into the Node object — the Node schema does not embed the computation.
 - **Headroom and Allocatable**: `node.Status.Allocatable` already equals total node capacity minus kubelet's `kube-reserved` and `system-reserved`, so those system reservations are implicitly handled. The `headroom` field is for DaemonSets and other non-Kueue pods that consume node resources beyond what kubelet reserves.
-- **Cohort + CQ NodeQuotaPolicy overlap**: A Cohort and a CQ within it may each be targeted by a `NodeQuotaPolicy` only if their respective ResourceFlavors' effective node sets (after label intersection) are **disjoint**. Overlapping node sets cause double-counting. Beta will add validation warnings for overlapping selectors.
+- **Cohort + CQ NodeQuotaPolicy overlap**: A Cohort and a CQ within it may each be targeted by a `NodeQuotaPolicy` only if their respective ResourceFlavors' effective node sets (after label intersection) are **disjoint**; overlapping node sets double-count physical capacity. In Alpha this cannot arise between two policies that target different ResourceFlavors, because flavors are already expected to select disjoint nodes — so there is effectively no new overlap surface. The surface appears in Beta, where `flavorPolicy.nodeLabels` can sub-select within a shared flavor. Detection is reactive, not a webhook check: on overlap the controller sets `Ready=False` with reason `OverlappingNodeSet` on the affected policies and withholds the quota write (keeping the last-known-good value) rather than silently over-provisioning.
 - **Node readiness filtering**: By default only Nodes with condition `Ready=True` are counted. The `includeNotReady` field in `FlavorNodeQuotaPolicy` can override this.
 - **Rate limiting**: The controller aggregates node events and re-computes quotas at a bounded frequency (e.g., every 15 seconds) to avoid excessive API writes to ClusterQueue or Cohort.
 - **Feature gate**: This feature is gated behind `AutomaticQuotaFromNodes` (disabled by default in Alpha).
@@ -309,7 +309,7 @@ spec:
 
 - **Stale quota if Node watch is delayed**: Kueue already relies on informer caches for correctness. Risk is no different from existing Workload/Pod watches.
 - **Resource churn causing frequent quota updates**: Mitigation: batch node events with a bounded reconciliation interval (e.g., 15 seconds). Only write to the target object when the computed quota actually changes.
-- **Conflicting selectors across ClusterQueues or between Cohort and CQ**: Overlapping node sets lead to over-committed quotas, same as manually overlapping quotas today. Beta will add validation warnings.
+- **Conflicting selectors across ClusterQueues or between Cohort and CQ**: Overlapping effective node sets lead to over-committed quotas, same as manually overlapping quotas today. The controller detects this at reconcile and sets `Ready=False`/`OverlappingNodeSet` on the affected policies while withholding the write, instead of silently over-provisioning (Beta; the Alpha node set is the whole flavor, which is already expected to be disjoint).
 - **Concurrent writes**: If an administrator manually edits `nominalQuota` on a CQ that is managed by a `NodeQuotaPolicy`, the controller will overwrite it on the next reconcile. This is the same behavior as HPA overwriting `spec.replicas`. Administrators should be aware that managed fields are authoritative in `NodeQuotaPolicy`, not in the CQ.
 - **Security**: The controller needs `get`, `list`, `watch` on Nodes and `patch` on ClusterQueues and Cohorts. Node watching is already granted to Kueue for TAS. Patch on ClusterQueue/Cohort is already granted for existing controllers. No additional RBAC changes are needed.
 
@@ -559,14 +559,22 @@ The Kueue scheduler continues to read `nominalQuota` from the CQ or Cohort spec 
 
 #### Validation Rules (Alpha)
 
-Enforced by the `NodeQuotaPolicy` admission webhook:
+Static, single-object checks are enforced by the `NodeQuotaPolicy` admission webhook:
 
-- `targetRef.kind` must be `ClusterQueue` or `Cohort`.
-- `flavorPolicies` must not contain duplicate `flavorName` entries.
-- The referenced ResourceFlavor (via `flavorName`) must define at least one `nodeLabel`; otherwise the webhook returns a validation error since there is no node selector to work with.
-- Within `headroom`, at most one of `percentage` or `fixed` may be set (enforced by CEL rule on the struct).
-- `nodeLabels` (Beta field) must be empty in Alpha; the webhook rejects it if the `AutomaticQuotaFromNodes` feature gate is not at Beta or later.
-- Only one `NodeQuotaPolicy` may target a given `(kind, name)` pair. The webhook rejects creation of a second policy that conflicts with an existing one.
+- `targetRef.kind` must be `ClusterQueue` or `Cohort` (enum).
+- `flavorPolicies` must not contain duplicate `flavorName` entries (already enforced by the `+listMapKey=flavorName` list-map semantics).
+- Within each `resources[]` rule, at most one of `nominalQuota`, `fixedHeadroom`, or `percentageHeadroom` may be set (CEL rule on the struct).
+- `nodeLabels` (Beta field) must be empty in Alpha; the webhook rejects it unless the `AutomaticQuotaFromNodes` feature gate is at Beta or later.
+
+Cross-object and cluster-state-dependent checks are **not** done in the webhook — they depend on other objects (ResourceFlavors, the target's spec, other policies) or live Node state, which a webhook cannot gate soundly, since the referenced object may be created or change moments later. (This mirrors how a ClusterQueue referencing a missing flavor is handled by the controller as `Active=False`/`FlavorNotFound`, not rejected at admission.) Instead the controller detects them at reconcile and reports them on `NodeQuotaPolicy.status.conditions`:
+
+- **`FlavorNotFound`** — a referenced `flavorName` has no matching ResourceFlavor. *Fatal*: withhold writes, set `Ready=False`, and re-reconcile when the flavor appears.
+- **`FlavorNotInTarget`** — the flavor exists but is not used by the target's `resourceGroups`. *Non-fatal*: per the intersection rule these pairs are a no-op; write the valid flavors and report the dangling one.
+- **`ResourceNotCovered`** — a `resources[]` rule names a resource the target does not cover. *Non-fatal*: skip that resource, write the covered ones, and report.
+- **`DuplicateTarget`** — another `NodeQuotaPolicy` already targets the same `(kind, name)`. The later policy sets `Ready=False` and withholds writes. (Handled here rather than in the webhook, which would otherwise have to list all policies.)
+- **`OverlappingNodeSet`** — (Beta) another policy's effective node set overlaps this one's for the same flavor; see [Notes/Constraints/Caveats](#notesconstraintscaveats).
+
+In short: *fatal* reasons (the policy cannot compute a value) withhold all of the policy's writes; *non-fatal* reasons (a dangling or no-op entry) still apply the valid `(flavor, resource)` pairs and surface the offending entry in the condition message.
 
 #### Status Reporting
 
@@ -661,7 +669,7 @@ If a key appears in both `RF.nodeLabels` and `NQP flavorPolicy.nodeLabels` with 
 
 - `nodeLabels` in `FlavorNodeQuotaPolicy` requires the `AutomaticQuotaFromNodes` feature gate at Beta or later.
 - A warning condition is emitted on `NodeQuotaPolicy` when the intersection of `RF.nodeLabels` and `flavorPolicy.nodeLabels` produces an empty node set.
-- Beta adds conflict detection: if two `NodeQuotaPolicy` objects targeting different CQs or Cohorts within the same Cohort tree have overlapping effective node sets for the same flavor, a warning condition is emitted on both policies (double-counting risk).
+- Beta adds conflict detection: if two `NodeQuotaPolicy` objects targeting different CQs or Cohorts within the same Cohort tree have overlapping effective node sets for the same flavor, the controller sets `Ready=False` with reason `OverlappingNodeSet` on both policies and withholds their writes (double-counting risk).
 
 ### Controller Design
 
@@ -810,7 +818,7 @@ Existing unit tests for `resourceNode.available()` and `potentialAvailable()` sh
 - Feature gate default enabled.
 - `flavorPolicy.nodeLabels` field active for fine-grained intersection-based node selection.
 - Intersection semantics implemented, tested, and documented.
-- Conflict detection warnings for overlapping node sets across policies in the same Cohort tree.
+- Conflict detection for overlapping node sets across policies in the same Cohort tree (`OverlappingNodeSet` condition with the write withheld).
 - Metrics:
   - `kueue_node_quota_policy_computed_quota` (gauge): current `nominalQuota` per policy/flavor/resource.
   - `kueue_node_quota_policy_reconcile_duration_seconds` (histogram): reconcile latency per policy.

--- a/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
+++ b/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
@@ -381,8 +381,12 @@ type NodeQuotaPolicyTargetRef struct {
 // FlavorNodeQuotaPolicy defines how to compute nominalQuota for one flavor.
 type FlavorNodeQuotaPolicy struct {
     // flavorName references the ResourceFlavor whose nodeLabels are used as
-    // the base node selector. The referenced ResourceFlavor must define at
-    // least one nodeLabel; otherwise the controller marks the policy as invalid.
+    // the base node selector. A ResourceFlavor with no nodeLabels is allowed and
+    // matches all nodes (the "default flavor" case); its computed quota is then
+    // the sum of Allocatable across every matching node. Note that a match-all
+    // flavor also counts control-plane/unschedulable nodes unless they are
+    // filtered out (see node filtering); use headroom or per-resource rules to
+    // adjust if needed.
     // +required
     FlavorName ResourceFlavorReference `json:"flavorName"`
 

--- a/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
+++ b/keps/10270-automatic-clusterqueue-quota-node-selectors/README.md
@@ -395,53 +395,59 @@ type FlavorNodeQuotaPolicy struct {
     // +kubebuilder:validation:MaxProperties=8
     NodeLabels map[string]string `json:"nodeLabels,omitempty"`
 
-    // headroom reserves capacity from the computed total for DaemonSets and
-    // other non-Kueue pods. node.Status.Allocatable already accounts for
-    // kubelet kube-reserved and system-reserved; headroom is additional.
-    // At most one of percentage or fixed may be set.
+    // headroomPercentage optionally reserves a percentage of the computed total
+    // across all resources of this flavor, for DaemonSets and other non-Kueue
+    // pods. Being dimensionless, it applies uniformly to every resource.
+    // node.Status.Allocatable already accounts for kubelet kube-reserved and
+    // system-reserved; this is additional. A per-resource rule in `resources`
+    // overrides this default for that resource.
     // +optional
-    Headroom *QuotaHeadroom `json:"headroom,omitempty"`
+    // +kubebuilder:validation:Minimum=0
+    // +kubebuilder:validation:Maximum=100
+    HeadroomPercentage *int32 `json:"headroomPercentage,omitempty"`
 
     // includeNotReady controls whether Nodes without the Ready=True condition
     // contribute to quota computation. Defaults to false (only Ready nodes).
     // +optional
     IncludeNotReady *bool `json:"includeNotReady,omitempty"`
 
-    // resourceOverrides pins specific resources to a fixed nominalQuota,
-    // bypassing node-based computation for those resources. Use this for
-    // custom resources that are not reported in node.Status.Allocatable
-    // (e.g., example.com/token). Takes precedence over node-derived values.
+    // resources defines per-resource quota rules: pin a fixed nominalQuota, or
+    // apply a fixed/percentage headroom that overrides headroomPercentage for
+    // that resource. Resources not listed here are computed from node
+    // Allocatable (minus headroomPercentage, if set).
     // +optional
     // +listType=map
     // +listMapKey=name
     // +kubebuilder:validation:MaxItems=64
-    ResourceOverrides []ResourceQuotaOverride `json:"resourceOverrides,omitempty"`
+    Resources []ResourceQuotaRule `json:"resources,omitempty"`
 }
 
-// ResourceQuotaOverride pins a specific resource to a fixed nominalQuota,
-// bypassing node-based computation for that resource.
-type ResourceQuotaOverride struct {
-    // name is the Kubernetes resource name (e.g., example.com/token).
+// ResourceQuotaRule sets the quota policy for one resource within a flavor.
+// Exactly one of nominalQuota, fixedHeadroom, or percentageHeadroom may be set.
+// +kubebuilder:validation:XValidation:rule="[has(self.nominalQuota), has(self.fixedHeadroom), has(self.percentageHeadroom)].filter(x, x).size() <= 1",message="at most one of nominalQuota, fixedHeadroom, or percentageHeadroom may be set"
+type ResourceQuotaRule struct {
+    // name is the Kubernetes resource name (e.g., nvidia.com/gpu, cpu, memory,
+    // or a custom resource such as example.com/token).
     // +required
     Name corev1.ResourceName `json:"name"`
 
-    // nominalQuota is the fixed quota value for this resource.
-    // +required
-    NominalQuota resource.Quantity `json:"nominalQuota"`
-}
+    // nominalQuota pins this resource to a fixed value, bypassing node-based
+    // computation. Use for resources not reported in node.Status.Allocatable
+    // (e.g., example.com/token). Mutually exclusive with the headroom fields.
+    // +optional
+    NominalQuota *resource.Quantity `json:"nominalQuota,omitempty"`
 
-// QuotaHeadroom configures how much capacity to reserve from the computed total.
-// +kubebuilder:validation:XValidation:rule="!(has(self.percentage) && has(self.fixed))",message="at most one of percentage or fixed may be set"
-type QuotaHeadroom struct {
-    // percentage of total Allocatable to subtract (0–100).
+    // fixedHeadroom subtracts a fixed, correctly-dimensioned quantity from this
+    // resource's node-derived total (floored at zero).
+    // +optional
+    FixedHeadroom *resource.Quantity `json:"fixedHeadroom,omitempty"`
+
+    // percentageHeadroom subtracts a percentage from this resource's node-derived
+    // total, overriding the flavor-wide headroomPercentage for this resource.
     // +optional
     // +kubebuilder:validation:Minimum=0
     // +kubebuilder:validation:Maximum=100
-    Percentage *int32 `json:"percentage,omitempty"`
-
-    // fixed is a fixed quantity to subtract from the computed total.
-    // +optional
-    Fixed *resource.Quantity `json:"fixed,omitempty"`
+    PercentageHeadroom *int32 `json:"percentageHeadroom,omitempty"`
 }
 
 // NodeQuotaPolicyStatus records the results of the most recent reconciliation.

--- a/keps/10270-automatic-clusterqueue-quota-node-selectors/kep.yaml
+++ b/keps/10270-automatic-clusterqueue-quota-node-selectors/kep.yaml
@@ -1,0 +1,36 @@
+title: Concurrent Admission
+kep-number: 10270
+authors:
+  - "@gyliu513"
+status: implementable
+creation-date: 2026-04-23
+reviewers:
+  - "@andrewsykim"
+  - "@amy"
+  - "@kannon92"
+  - "@mwielgus"
+  - "@tenzen-y"
+  - TBD
+approvers:
+  - TBD
+  
+
+# The target maturity stage in the current dev cycle for this KEP.
+stage: alpha
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v0.18"
+
+# The milestone at which this feature was, or is targeted to be, at each stage.
+milestone:
+  alpha: "v0.18"
+#   beta: "v0.3"
+#   stable: "v0.5"
+
+# The following PRR answers are required at alpha release
+# List the feature gate name and the components for which it must be enabled
+feature-gates:
+  - name: AutomaticQuotaFromNodes
+disable-supported: true

--- a/keps/10270-automatic-clusterqueue-quota-node-selectors/kep.yaml
+++ b/keps/10270-automatic-clusterqueue-quota-node-selectors/kep.yaml
@@ -2,6 +2,7 @@ title: Concurrent Admission
 kep-number: 10270
 authors:
   - "@gyliu513"
+  - "@andrewseif"
 status: implementable
 creation-date: 2026-04-23
 reviewers:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind kep
/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related #10270 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a KEP README detailing automatic quota limits based on node selectors, including alpha/beta behavior, conflict detection, status/conditions, and apply vs. recommend modes.
  * Added KEP release-planning metadata for the feature, including stage and milestone information tied to the relevant feature gate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->