### PR TITLE
fix(metrics): convert milliCPU to CPU units

### DIFF
--- a/pkg/cache/scheduler/cohort_metrics.go
+++ b/pkg/cache/scheduler/cohort_metrics.go
@@ -130,13 +130,13 @@ func (c *Cache) applyCohortMetricPoint(p cohortMetricPoint) {
 	if p.quotaQty <= 0 {
 		metrics.ClearCohortSubtreeQuota(p.cohortName, flavor, resource)
 	} else {
-		metrics.ReportCohortSubtreeQuota(p.cohortName, flavor, resource, p.quotaQty, c.customLabels.CohortGet(p.cohortName), c.roleTracker)
+		metrics.ReportCohortSubtreeQuota(p.cohortName, flavor, resource, resourceFloat(resource, p.quotaQty), c.customLabels.CohortGet(p.cohortName), c.roleTracker)
 	}
 
 	if p.reservationsQty <= 0 {
 		metrics.ClearCohortSubtreeResourceReservations(p.cohortName, flavor, resource)
 	} else {
-		metrics.ReportCohortSubtreeResourceReservations(p.cohortName, flavor, resource, p.reservationsQty, c.customLabels.CohortGet(p.cohortName), c.roleTracker)
+		metrics.ReportCohortSubtreeResourceReservations(p.cohortName, flavor, resource, resourceFloat(resource, p.reservationsQty), c.customLabels.CohortGet(p.cohortName), c.roleTracker)
 	}
 }
 

--- a/pkg/cache/scheduler/cohort_metrics_test.go
+++ b/pkg/cache/scheduler/cohort_metrics_test.go
@@ -113,12 +113,12 @@ func TestRecordCohortMetrics_Guards(t *testing.T) {
 					{
 						cohort: cohortLeft,
 						fr:     fr,
-						quota:  float64(cache.hm.Cohort(cohortLeft).resourceNode.SubtreeQuota[fr]),
+						quota:  resourceFloat(fr.Resource, cache.hm.Cohort(cohortLeft).resourceNode.SubtreeQuota[fr]),
 					},
 					{
 						cohort: cohortRoot,
 						fr:     fr,
-						quota:  float64(cache.hm.Cohort(cohortRoot).resourceNode.SubtreeQuota[fr]),
+						quota:  resourceFloat(fr.Resource, cache.hm.Cohort(cohortRoot).resourceNode.SubtreeQuota[fr]),
 					},
 				}
 			},
@@ -229,13 +229,13 @@ func TestRecordCohortMetrics_QuotaHierarchyLikeIntegration(t *testing.T) {
 		cache.RecordCohortMetrics(log, "ch2")
 		cache.RecordCohortMetrics(log, "ch3")
 
-		expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch1", frDefaultCPU), 30_000)
-		expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch2", frDefaultCPU), 20_000)
-		expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch3", frFlavor1CPU), 5_000)
+		expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch1", frDefaultCPU), 30)
+		expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch2", frDefaultCPU), 20)
+		expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch3", frFlavor1CPU), 5)
 		expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch3", frFlavor1GPU), 1)
 
-		expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 50_000)
-		expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frFlavor1CPU), 25_000)
+		expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 50)
+		expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frFlavor1CPU), 25)
 		expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frFlavor1GPU), 6)
 	})
 }
@@ -282,30 +282,30 @@ func TestRecordCohortMetrics_ReservationsChildParentLikeIntegration(t *testing.T
 		{cqName: "cqa", fr: frDefaultCPU, val: 6_000},
 	})
 	cache.RecordCohortMetrics(log, "ch1")
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("ch1", frDefaultCPU), 6_000)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("root", frDefaultCPU), 6_000)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("ch1", frDefaultCPU), 6)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("root", frDefaultCPU), 6)
 
 	addTestUsage(cache, []usageChange{
 		{cqName: "cqa", fr: frDefaultCPU, val: 16_000},
 	})
 	cache.RecordCohortMetrics(log, "ch1")
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("ch1", frDefaultCPU), 16_000)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("root", frDefaultCPU), 16_000)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("ch1", frDefaultCPU), 16)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("root", frDefaultCPU), 16)
 
 	addTestUsage(cache, []usageChange{
 		{cqName: "cqb", fr: frDefaultCPU, val: 7_000},
 	})
 	cache.RecordCohortMetrics(log, "ch2")
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("ch2", frDefaultCPU), 7_000)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("root", frDefaultCPU), 23_000)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("ch2", frDefaultCPU), 7)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("root", frDefaultCPU), 23)
 
 	addTestUsage(cache, []usageChange{
 		{cqName: "cqa", fr: frDefaultCPU, val: 6_000},
 	})
 	cache.RecordCohortMetrics(log, "ch1")
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("ch1", frDefaultCPU), 6_000)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("ch2", frDefaultCPU), 7_000)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("root", frDefaultCPU), 13_000)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("ch1", frDefaultCPU), 6)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("ch2", frDefaultCPU), 7)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("root", frDefaultCPU), 13)
 }
 
 func TestClearCohortMetrics_ClearsTargetAndAncestors(t *testing.T) {
@@ -352,18 +352,18 @@ func TestClearCohortMetrics_ClearsTargetAndAncestors(t *testing.T) {
 
 	cache.RecordCohortMetrics(log, "ch1")
 	cache.RecordCohortMetrics(log, "ch2")
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch1", frDefaultCPU), 18_000)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch2", frDefaultCPU), 14_000)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 62_000)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("root", frDefaultCPU), 13_000)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch1", frDefaultCPU), 18)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch2", frDefaultCPU), 14)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 62)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("root", frDefaultCPU), 13)
 
 	cache.ClearCohortMetrics(log, "ch1")
 	expectGaugeCount(t, kueuemetrics.CohortSubtreeQuota, 0, cohortMetricLabels("ch1", frDefaultCPU))
 	expectGaugeCount(t, kueuemetrics.CohortSubtreeResourceReservations, 0, cohortMetricLabels("ch1", frDefaultCPU))
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch2", frDefaultCPU), 14_000)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("ch2", frDefaultCPU), 7_000)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 44_000)
-	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("root", frDefaultCPU), 7_000)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("ch2", frDefaultCPU), 14)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("ch2", frDefaultCPU), 7)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, cohortMetricLabels("root", frDefaultCPU), 44)
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, cohortMetricLabels("root", frDefaultCPU), 7)
 }
 
 type cohortMetricsFixture struct {

--- a/pkg/controller/core/cohort_controller_test.go
+++ b/pkg/controller/core/cohort_controller_test.go
@@ -230,7 +230,7 @@ func TestCohortReconcileLifecycle(t *testing.T) {
 			t.Fatal("expected metric value")
 		}
 		wantCNQ := []testingmetrics.MetricDataPoint{
-			{Labels: labels, Value: 10_000},
+			{Labels: labels, Value: 10},
 		}
 		checkMetricDataPoints(t, cnq, wantCNQ)
 	}
@@ -274,7 +274,7 @@ func TestCohortReconcileLifecycle(t *testing.T) {
 			t.Fatal("expected metric value")
 		}
 		wantCNQ := []testingmetrics.MetricDataPoint{
-			{Labels: labels, Value: 5_000},
+			{Labels: labels, Value: 5},
 		}
 		checkMetricDataPoints(t, cnq, wantCNQ)
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1046,12 +1046,12 @@ func ReportCohortSubtreeQuota(
 	cohort kueue.CohortReference,
 	flavor kueue.ResourceFlavorReference,
 	resource corev1.ResourceName,
-	quota int64,
+	quota float64,
 	customLabelValues []string,
 	tracker *roletracker.RoleTracker,
 ) {
 	labels := append([]string{string(cohort), string(flavor), string(resource), roletracker.GetRole(tracker)}, customLabelValues...)
-	CohortSubtreeQuota.WithLabelValues(labels...).Set(float64(quota))
+	CohortSubtreeQuota.WithLabelValues(labels...).Set(quota)
 }
 
 func ReportCohortSubtreeAdmittedWorkload(cohort kueue.CohortReference, priorityClass string, customLabelValues []string, tracker *roletracker.RoleTracker) {
@@ -1079,12 +1079,12 @@ func ReportCohortSubtreeResourceReservations(
 	cohort kueue.CohortReference,
 	flavor kueue.ResourceFlavorReference,
 	resource corev1.ResourceName,
-	usage int64,
+	usage float64,
 	customLabelValues []string,
 	tracker *roletracker.RoleTracker,
 ) {
 	labels := append([]string{string(cohort), string(flavor), string(resource), roletracker.GetRole(tracker)}, customLabelValues...)
-	CohortSubtreeResourceReservations.WithLabelValues(labels...).Set(float64(usage))
+	CohortSubtreeResourceReservations.WithLabelValues(labels...).Set(usage)
 }
 
 func ClearCohortSubtreeResourceReservations(cohort kueue.CohortReference, flavor kueue.ResourceFlavorReference, resource corev1.ResourceName) {

--- a/test/integration/singlecluster/controller/core/custom_labels_test.go
+++ b/test/integration/singlecluster/controller/core/custom_labels_test.go
@@ -665,10 +665,10 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("verifying CohortSubtreeQuota includes custom_team=data-eng")
-			util.ExpectCohortSubtreeQuotaGaugeMetric(cohort.Name, defaultFlavor.Name, corev1.ResourceCPU.String(), 5_000, "data-eng")
+			util.ExpectCohortSubtreeQuotaGaugeMetric(cohort.Name, defaultFlavor.Name, corev1.ResourceCPU.String(), 5, "data-eng")
 
 			ginkgo.By("verifying CohortSubtreeResourceReservations includes custom_team=data-eng")
-			util.ExpectCohortSubtreeResourceReservationsGaugeMetric(cohort.Name, defaultFlavor.Name, corev1.ResourceCPU.String(), 1_000, "data-eng")
+			util.ExpectCohortSubtreeResourceReservationsGaugeMetric(cohort.Name, defaultFlavor.Name, corev1.ResourceCPU.String(), 1, "data-eng")
 
 			ginkgo.By("verifying CohortWeightedShare includes custom_team=data-eng")
 			gomega.Eventually(func(g gomega.Gomega) {

--- a/test/integration/singlecluster/scheduler/fairsharing/metrics_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/metrics_test.go
@@ -158,7 +158,7 @@ var _ = ginkgo.Describe("Cohorts", func() {
 					g.Expect(k8sClient.Update(ctx, &cq)).To(gomega.Succeed())
 				}, util.Timeout, util.ShortInterval).Should(gomega.Succeed())
 
-				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceCPU.String(), 10_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceCPU.String(), 10)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceMemory.String(), util.ResourceQtyToFloat64("10Gi"))
 			})
 
@@ -181,7 +181,7 @@ var _ = ginkgo.Describe("Cohorts", func() {
 					).Obj())
 
 				// combined values of resources of cqa(10 cpu, 10Gi) and cqb(5 cpu, 5Gi) and ch1 cohort(15 cpu, 15Gi)
-				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceCPU.String(), 30_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceCPU.String(), 30)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceMemory.String(), util.ResourceQtyToFloat64("30Gi"))
 			})
 
@@ -213,7 +213,7 @@ var _ = ginkgo.Describe("Cohorts", func() {
 					).Obj())
 
 				// combined values of resources of cqd(5 cpu, 5Gi) and cqe(5 cpu, 5Gi) and ch2 cohort(10 cpu, 10Gi)
-				util.ExpectCohortSubtreeQuotaGaugeMetric("ch2", defaultFlavor.Name, corev1.ResourceCPU.String(), 20_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("ch2", defaultFlavor.Name, corev1.ResourceCPU.String(), 20)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("ch2", defaultFlavor.Name, corev1.ResourceMemory.String(), util.ResourceQtyToFloat64("20Gi"))
 			})
 
@@ -238,9 +238,9 @@ var _ = ginkgo.Describe("Cohorts", func() {
 				}, util.Timeout, util.ShortInterval).Should(gomega.Succeed())
 
 				// combined values of resources of ch1(30 cpu, 30Gi) and ch2(20 cpu, 20Gi) and root cohort flavor1 (20 cpu, 5 gpu)
-				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 50_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 50)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceMemory.String(), util.ResourceQtyToFloat64("50Gi"))
-				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, corev1.ResourceCPU.String(), 20_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, corev1.ResourceCPU.String(), 20)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, "nvidia.com/gpu", 5)
 
 				util.ExpectCohortSubtreeQuotaGaugeMetricCleaned("root", flavor2.Name, corev1.ResourceCPU.String())
@@ -257,12 +257,12 @@ var _ = ginkgo.Describe("Cohorts", func() {
 							Obj(),
 					).Obj())
 
-				util.ExpectCohortSubtreeQuotaGaugeMetric("ch3", flavor1.Name, corev1.ResourceCPU.String(), 5_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("ch3", flavor1.Name, corev1.ResourceCPU.String(), 5)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("ch3", flavor1.Name, "nvidia.com/gpu", 1)
 
-				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 50_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 50)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceMemory.String(), util.ResourceQtyToFloat64("50Gi"))
-				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, corev1.ResourceCPU.String(), 25_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, corev1.ResourceCPU.String(), 25)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, "nvidia.com/gpu", 6)
 			})
 
@@ -277,17 +277,17 @@ var _ = ginkgo.Describe("Cohorts", func() {
 					).Obj())
 
 				// combined values of resources of cqg(1 cpu, 1Gi) and ch3 cohort(5 cpu, 1 gpu)
-				util.ExpectCohortSubtreeQuotaGaugeMetric("ch3", flavor1.Name, corev1.ResourceCPU.String(), 5_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("ch3", flavor1.Name, corev1.ResourceCPU.String(), 5)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("ch3", flavor1.Name, "nvidia.com/gpu", 1)
-				util.ExpectCohortSubtreeQuotaGaugeMetric("ch3", flavor2.Name, corev1.ResourceCPU.String(), 1_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("ch3", flavor2.Name, corev1.ResourceCPU.String(), 1)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("ch3", flavor2.Name, corev1.ResourceMemory.String(), 1.073741824e+09)
 
 				// updated combined values of resources of ch1(30 cpu, 30Gi) and ch2(20 cpu, 20Gi) and ch3 flavor2 (6 cpu, 1 gpu) and root cohort flavor1 (20 cpu, 5 gpu)
-				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 50_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 50)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceMemory.String(), util.ResourceQtyToFloat64("50Gi"))
-				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, corev1.ResourceCPU.String(), 25_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, corev1.ResourceCPU.String(), 25)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, "nvidia.com/gpu", 6)
-				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor2.Name, corev1.ResourceCPU.String(), 1_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor2.Name, corev1.ResourceCPU.String(), 1)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor2.Name, corev1.ResourceMemory.String(), util.ResourceQtyToFloat64("1Gi"))
 			})
 
@@ -295,14 +295,14 @@ var _ = ginkgo.Describe("Cohorts", func() {
 				util.ExpectObjectToBeDeleted(ctx, k8sClient, cqs["cqg"], true)
 
 				// updated values for ch3 with cqg removed, and root with ch3 updated
-				util.ExpectCohortSubtreeQuotaGaugeMetric("ch3", flavor1.Name, corev1.ResourceCPU.String(), 5_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("ch3", flavor1.Name, corev1.ResourceCPU.String(), 5)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("ch3", flavor1.Name, "nvidia.com/gpu", 1)
 				util.ExpectCohortSubtreeQuotaGaugeMetricCleaned("ch3", flavor2.Name, corev1.ResourceCPU.String())
 				util.ExpectCohortSubtreeQuotaGaugeMetricCleaned("ch3", flavor2.Name, corev1.ResourceMemory.String())
 
-				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 50_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 50)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceMemory.String(), util.ResourceQtyToFloat64("50Gi"))
-				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, corev1.ResourceCPU.String(), 25_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, corev1.ResourceCPU.String(), 25)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, "nvidia.com/gpu", 6)
 
 				// root metrics for flavor2 with cqg removed
@@ -322,12 +322,12 @@ var _ = ginkgo.Describe("Cohorts", func() {
 				}, util.Timeout, util.ShortInterval).Should(gomega.Succeed())
 
 				// updated values for ch3 with cqd and cqe added, and root with ch3 updated
-				util.ExpectCohortSubtreeQuotaGaugeMetric("ch3", defaultFlavor.Name, corev1.ResourceCPU.String(), 10_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("ch3", defaultFlavor.Name, corev1.ResourceCPU.String(), 10)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("ch3", defaultFlavor.Name, corev1.ResourceMemory.String(), util.ResourceQtyToFloat64("10Gi"))
 
-				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 50_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 50)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceMemory.String(), util.ResourceQtyToFloat64("50Gi"))
-				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, corev1.ResourceCPU.String(), 25_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, corev1.ResourceCPU.String(), 25)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, "nvidia.com/gpu", 6)
 			})
 
@@ -335,13 +335,13 @@ var _ = ginkgo.Describe("Cohorts", func() {
 				util.ExpectObjectToBeDeleted(ctx, k8sClient, cohorts["ch2"], true)
 
 				// updated values for ch3 with cqd and cqe added, and root with ch3 updated
-				util.ExpectCohortSubtreeQuotaGaugeMetric("ch3", defaultFlavor.Name, corev1.ResourceCPU.String(), 10_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("ch3", defaultFlavor.Name, corev1.ResourceCPU.String(), 10)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("ch3", defaultFlavor.Name, corev1.ResourceMemory.String(), util.ResourceQtyToFloat64("10Gi"))
 
 				// root metrics with ch2 removed, so only ch1 and ch3 values
-				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 40_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 40)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceMemory.String(), util.ResourceQtyToFloat64("40Gi"))
-				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, corev1.ResourceCPU.String(), 25_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, corev1.ResourceCPU.String(), 25)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, "nvidia.com/gpu", 6)
 
 				// ch2 metrics removed
@@ -372,13 +372,13 @@ var _ = ginkgo.Describe("Cohorts", func() {
 					g.Expect(k8sClient.Update(ctx, &ch1)).To(gomega.Succeed())
 				}, util.Timeout, util.ShortInterval).Should(gomega.Succeed())
 
-				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceCPU.String(), 35_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceCPU.String(), 35)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceMemory.String(), util.ResourceQtyToFloat64("30Gi"))
 
 				// root metrics updated with new quotas of ch1
-				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 45_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 45)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceMemory.String(), util.ResourceQtyToFloat64("40Gi"))
-				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, corev1.ResourceCPU.String(), 25_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, corev1.ResourceCPU.String(), 25)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("root", flavor1.Name, "nvidia.com/gpu", 6)
 			})
 		})
@@ -400,10 +400,10 @@ var _ = ginkgo.Describe("Cohorts", func() {
 							Obj(),
 					).Obj())
 
-				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", flavor1.Name, corev1.ResourceCPU.String(), 5_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", flavor1.Name, corev1.ResourceCPU.String(), 5)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", flavor1.Name, "nvidia.com/gpu", 1)
 
-				util.ExpectCohortSubtreeQuotaGaugeMetric("ch2", flavor1.Name, corev1.ResourceCPU.String(), 3_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("ch2", flavor1.Name, corev1.ResourceCPU.String(), 3)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("ch2", flavor1.Name, "nvidia.com/gpu", 1)
 			})
 
@@ -417,7 +417,7 @@ var _ = ginkgo.Describe("Cohorts", func() {
 							Obj(),
 					).Obj())
 
-				util.ExpectCohortSubtreeQuotaGaugeMetric("ch0", flavor1.Name, corev1.ResourceCPU.String(), 1_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("ch0", flavor1.Name, corev1.ResourceCPU.String(), 1)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("ch0", flavor1.Name, "nvidia.com/gpu", 1)
 			})
 
@@ -430,7 +430,7 @@ var _ = ginkgo.Describe("Cohorts", func() {
 				}, util.Timeout, util.ShortInterval).Should(gomega.Succeed())
 
 				// updated values for ch1 with cq1 added
-				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", flavor1.Name, corev1.ResourceCPU.String(), 6_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", flavor1.Name, corev1.ResourceCPU.String(), 6)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", flavor1.Name, "nvidia.com/gpu", 2)
 
 				// cleared up values for ch0 with cq1 removed
@@ -447,11 +447,11 @@ var _ = ginkgo.Describe("Cohorts", func() {
 				}, util.Timeout, util.ShortInterval).Should(gomega.Succeed())
 
 				// updated values for ch2 with cq1 added
-				util.ExpectCohortSubtreeQuotaGaugeMetric("ch2", flavor1.Name, corev1.ResourceCPU.String(), 4_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("ch2", flavor1.Name, corev1.ResourceCPU.String(), 4)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("ch2", flavor1.Name, "nvidia.com/gpu", 2)
 
 				// updated values for ch1 with cq1 removed
-				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", flavor1.Name, corev1.ResourceCPU.String(), 5_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", flavor1.Name, corev1.ResourceCPU.String(), 5)
 				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", flavor1.Name, "nvidia.com/gpu", 1)
 			})
 		})
@@ -1038,9 +1038,9 @@ var _ = ginkgo.Describe("Cohorts", func() {
 				util.ExpectCohortSubtreeResourceReservationsGaugeMetricCleaned("ch2", defaultFlavor.Name, corev1.ResourceCPU.String())
 				util.ExpectCohortSubtreeResourceReservationsGaugeMetricCleaned("root", defaultFlavor.Name, corev1.ResourceCPU.String())
 
-				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceCPU.String(), 16_000)
-				util.ExpectCohortSubtreeQuotaGaugeMetric("ch2", defaultFlavor.Name, corev1.ResourceCPU.String(), 12_000)
-				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 35_000)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceCPU.String(), 16)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("ch2", defaultFlavor.Name, corev1.ResourceCPU.String(), 12)
+				util.ExpectCohortSubtreeQuotaGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 35)
 			})
 
 			ginkgo.By("Admit workload in ch1: reservations rises in ch1 , which is reflected in root", func() {
@@ -1050,8 +1050,8 @@ var _ = ginkgo.Describe("Cohorts", func() {
 					Obj())
 				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlCh1a)
 
-				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceCPU.String(), 6_000)
-				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 6_000)
+				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceCPU.String(), 6)
+				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 6)
 			})
 
 			ginkgo.By("Add more load in ch1", func() {
@@ -1067,8 +1067,8 @@ var _ = ginkgo.Describe("Cohorts", func() {
 					Obj())
 				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlCh1c)
 
-				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceCPU.String(), 16_000)
-				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 16_000)
+				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceCPU.String(), 16)
+				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 16)
 			})
 
 			ginkgo.By("Admit workload in ch2 and verify reservations in root", func() {
@@ -1078,23 +1078,23 @@ var _ = ginkgo.Describe("Cohorts", func() {
 					Obj())
 				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlCh2)
 
-				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("ch2", defaultFlavor.Name, corev1.ResourceCPU.String(), 7_000)
-				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 23_000)
+				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("ch2", defaultFlavor.Name, corev1.ResourceCPU.String(), 7)
+				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 23)
 			})
 
 			ginkgo.By("Finish one workload and verify reservations", func() {
 				util.FinishWorkloads(ctx, k8sClient, wlCh1c)
 
-				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceCPU.String(), 14_000)
-				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 21_000)
+				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceCPU.String(), 14)
+				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 21)
 			})
 
 			ginkgo.By("Release high-overflow workload in ch1 and verify reservations", func() {
 				util.FinishWorkloads(ctx, k8sClient, wlCh1b)
 
-				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceCPU.String(), 6_000)
-				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("ch2", defaultFlavor.Name, corev1.ResourceCPU.String(), 7_000)
-				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 13_000)
+				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceCPU.String(), 6)
+				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("ch2", defaultFlavor.Name, corev1.ResourceCPU.String(), 7)
+				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 13)
 			})
 
 			ginkgo.By("Move cqb from ch2 to ch1 and verify recomputed hierarchical attribution", func() {
@@ -1106,8 +1106,8 @@ var _ = ginkgo.Describe("Cohorts", func() {
 				}, util.Timeout, util.ShortInterval).Should(gomega.Succeed())
 
 				// ch1 gains recomputed reservations after the move, ch2 goes to zero
-				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceCPU.String(), 13_000)
-				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 13_000)
+				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("ch1", defaultFlavor.Name, corev1.ResourceCPU.String(), 13)
+				util.ExpectCohortSubtreeResourceReservationsGaugeMetric("root", defaultFlavor.Name, corev1.ResourceCPU.String(), 13)
 				util.ExpectCohortSubtreeResourceReservationsGaugeMetricCleaned("ch2", defaultFlavor.Name, corev1.ResourceCPU.String())
 			})
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
in cohort subtree metrics `kueue_cohort_subtree_quota` and `kueue_cohort_subtree_resource_reservations` were reporting raw milliCPU values (e.g. 30000) instead of CPU units (e.g. 30.0), unlike the equivalent ClusterQueue metrics which correctly use resourceFloat(). Apply the same conversion in applyCohortMetricPoint and update the metric function signatures to accept float64.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/10746

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Observability: Fix kueue_cohort_subtree_quota and kueue_cohort_subtree_resource_reservations metrics incorrectly reporting raw milliCPU values instead of CPU units for CPU resources.
```
