### PR TITLE
Fix flaky preemption test by ensuring proper cleanup of preempted wor…

### DIFF
--- a/test/integration/singlecluster/scheduler/preemption_test.go
+++ b/test/integration/singlecluster/scheduler/preemption_test.go
@@ -326,6 +326,9 @@ var _ = ginkgo.Describe("Preemption", func() {
 				evictedWorkloads := util.FilterEvictedWorkloads(ctx, k8sClient, lowPriorityWorkloads...)
 				g.Expect(evictedWorkloads).To(gomega.HaveLen(lowPrioWorkloadCount))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Finishing eviction for preempted workloads")
+			util.FinishEvictionForWorkloads(ctx, k8sClient, lowPriorityWorkloads...)
 		})
 
 		ginkgo.It("Should include job UID in preemption condition when the label is set", func() {


### PR DESCRIPTION
…kloads during teardown

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Fix flaky preemption test by ensuring proper cleanup of preempted workloads during teardown
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10321 

#### Special notes for your reviewer:
I analyzed logs from bad run and good run. 

bad run: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-kueue-test-integration-main/2047038359364177920
good run: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-kueue-test-integration-main/2047219555025031168

After the analysis, I think it is race condition problem. After 8 low priority workloads are removed, scheduler tries to assume (admit) second-high-prio workload in cache. Scheduler gets from workload its cluster queue name and adds to cache cluster queue "second-high-prio" workload. CQ reconciler is called at the exact moment when cache has "second-high-prio" object in it, because CQ at this moment of time is not empty, CQ is not removed. Afterwards we see that workload is removed from cache, but it is too late, CQ reconciler will not be called after the race condition. 

**Fix:**
If we unset quota reservation on all 8 evicted workloads, I think it will go through all "second-high-prio" stages before `AfterEach` runs. This will resolve the issue with the race condition. 

**Proof:**

Bad run
1. Tries to assume "second-high-prio" in cache
2. CQ reconciler called
3. "second-high-prio" removed from cache
```
  2026-04-22T20:05:19.594270283Z	LEVEL(-2)	scheduler	scheduler/scheduler.go:760	Workload assumed in the cache	{"replica-role": "standalone", "schedulingCycle": 352, "workload": {"name":"second-high-prio","namespace":"preemption-kmpcb"}, "clusterQueue": {"name":"cq"}}
  <...>
  2026-04-22T20:05:19.595874765Z	LEVEL(-2)	clusterqueue-reconciler	core/clusterqueue_controller.go:171	Reconcile ClusterQueue	{"replica-role": "standalone", "name": "cq", "reconcileID": "64dce9e5-0bef-4cf5-b0f1-495b396d7b2d"}
  <...>
  2026-04-22T20:05:19.59852424Z	LEVEL(-2)	scheduler	scheduler/scheduler.go:733	Workload not admitted because it was deleted	{"replica-role": "standalone", "schedulingCycle": 352, "workload": {"name":"second-high-prio","namespace":"preemption-kmpcb"}, "clusterQueue": {"name":"cq"}}
```

Good run 
1. Tries to assume "second-high-prio" in cache
2. "second-high-prio" removed from cache
3. CQ reconciler called
```
  2026-04-23T08:05:52.939459925Z	LEVEL(-2)	scheduler	scheduler/scheduler.go:760	Workload assumed in the cache	{"replica-role": "standalone", "schedulingCycle": 110, "workload": {"name":"second-high-prio","namespace":"preemption-7clwn"}, "clusterQueue": {"name":"cq"}}
  <...>
  2026-04-23T08:05:52.943119405Z	LEVEL(-2)	scheduler	scheduler/scheduler.go:733	Workload not admitted because it was deleted	{"replica-role": "standalone", "schedulingCycle": 110, "workload": {"name":"second-high-prio","namespace":"preemption-7clwn"}, "clusterQueue": {"name":"cq"}}
  <...>
  2026-04-23T08:05:53.014035868Z	LEVEL(-2)	clusterqueue-reconciler	core/clusterqueue_controller.go:170	Reconcile ClusterQueue	{"replica-role": "standalone", "name": "cq", "reconcileID": "d115d158-0905-471b-8e62-9737e5276eaa"}
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
