### PR TITLE
TAS: NodeHotSwap should not add "late pods" to UnhealthyNodes

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -117,7 +117,6 @@ test-integration-baseline: test-integration ## Run baseline integration tests fo
 
 .PHONY: test-integration-extended
 test-integration-extended: INTEGRATION_FILTERS= --label-filter="slow || redundant"
-test-integration-extended: GINKGO_ARGS="--focus=should not add unhealthy node when Ready condition is missing but late pods exist"
 test-integration-extended: test-integration ## Run extended integration tests for singlecluster suites.
 
 .PHONY: test-multikueue-integration

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -117,6 +117,7 @@ test-integration-baseline: test-integration ## Run baseline integration tests fo
 
 .PHONY: test-integration-extended
 test-integration-extended: INTEGRATION_FILTERS= --label-filter="slow || redundant"
+test-integration-extended: GINKGO_ARGS="--focus=should not add unhealthy node when Ready condition is missing but late pods exist"
 test-integration-extended: test-integration ## Run extended integration tests for singlecluster suites.
 
 .PHONY: test-multikueue-integration

--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -306,7 +306,11 @@ func groupPodsByWorkload(pods []corev1.Pod) map[types.NamespacedName][]*corev1.P
 	return result
 }
 
-func (r *nodeReconciler) getWorkloadsFromLatePods(ctx context.Context, nodeName string, existingWorkloads sets.Set[types.NamespacedName]) (sets.Set[types.NamespacedName], map[types.NamespacedName][]*corev1.Pod, error) {
+func (r *nodeReconciler) getWorkloadsFromLatePods(
+	ctx context.Context,
+	nodeName string,
+	existingWorkloads sets.Set[types.NamespacedName],
+) (sets.Set[types.NamespacedName], map[types.NamespacedName][]*corev1.Pod, error) {
 	nodeSelectorPodsByWorkload, err := r.listPodsAssignedByNodeSelector(ctx, nodeName)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -154,7 +154,7 @@ func (r *nodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		}
 	}
 
-	affectedWorkloads, err := r.getWorkloadsOnNode(ctx, req.Name)
+	affectedWorkloads, err := r.getWorkloadsOnNodeFromTASAssignment(ctx, req.Name)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -181,7 +181,12 @@ func (r *nodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		affectedWorkloads = affectedWorkloads.Difference(evictedWorkloads)
 	}
 
-	latePodWorkloads, nodeSelectorPodsByWorkload, err := r.getWorkloadsFromLatePods(ctx, req.Name, affectedWorkloads)
+	nodeSelectorPodsByWorkload, err := r.listPodsAssignedByNodeSelector(ctx, req.Name)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	latePodWorkloads, err := r.getWorkloadsFromPodsOnNode(ctx, req.Name, affectedWorkloads, nodeSelectorPodsByWorkload)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -306,15 +311,14 @@ func groupPodsByWorkload(pods []corev1.Pod) map[types.NamespacedName][]*corev1.P
 	return result
 }
 
-func (r *nodeReconciler) getWorkloadsFromLatePods(
+// getWorkloadsFromPodsOnNode returns the set of workloads that pods on the node belong to.
+// It ignores the workloads that are already in the existingWorkloads set.
+func (r *nodeReconciler) getWorkloadsFromPodsOnNode(
 	ctx context.Context,
 	nodeName string,
 	existingWorkloads sets.Set[types.NamespacedName],
-) (sets.Set[types.NamespacedName], map[types.NamespacedName][]*corev1.Pod, error) {
-	nodeSelectorPodsByWorkload, err := r.listPodsAssignedByNodeSelector(ctx, nodeName)
-	if err != nil {
-		return nil, nil, err
-	}
+	nodeSelectorPodsByWorkload map[types.NamespacedName][]*corev1.Pod,
+) (sets.Set[types.NamespacedName], error) {
 	latePodWorkloads := sets.New[types.NamespacedName]()
 	logger := r.logger().V(4).WithValues("node", nodeName)
 	for wlKey := range nodeSelectorPodsByWorkload {
@@ -330,11 +334,11 @@ func (r *nodeReconciler) getWorkloadsFromLatePods(
 			latePodWorkloads.Insert(wlKey)
 		}
 	}
-	return latePodWorkloads, nodeSelectorPodsByWorkload, nil
+	return latePodWorkloads, nil
 }
 
-// getWorkloadsOnNode gets all workloads that have the given node assigned in TAS topology assignment
-func (r *nodeReconciler) getWorkloadsOnNode(ctx context.Context, nodeName string) (sets.Set[types.NamespacedName], error) {
+// getWorkloadsOnNodeFromTASAssignment gets all workloads that have the given node assigned in TAS topology assignment
+func (r *nodeReconciler) getWorkloadsOnNodeFromTASAssignment(ctx context.Context, nodeName string) (sets.Set[types.NamespacedName], error) {
 	var workloadsOnNode kueue.WorkloadList
 	if err := r.client.List(ctx, &workloadsOnNode, client.MatchingFields{indexer.AdmittedWorkloadNodesKey: nodeName}); err != nil {
 		return nil, fmt.Errorf("failed to list workloads: %w", err)

--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -154,11 +154,7 @@ func (r *nodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		}
 	}
 
-	nodeSelectorPodsByWorkload, err := r.listPodsAssignedByNodeSelector(ctx, req.Name)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	affectedWorkloads, err := r.getWorkloadsOnNode(ctx, req.Name, nodeSelectorPodsByWorkload)
+	affectedWorkloads, err := r.getWorkloadsOnNode(ctx, req.Name)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -184,6 +180,12 @@ func (r *nodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		// Only reconcile workloads that were not evicted.
 		affectedWorkloads = affectedWorkloads.Difference(evictedWorkloads)
 	}
+
+	latePodWorkloads, nodeSelectorPodsByWorkload, err := r.getWorkloadsFromLatePods(ctx, req.Name, affectedWorkloads)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	affectedWorkloads = affectedWorkloads.Union(latePodWorkloads)
 
 	return r.reconcileWorkloadsOnNode(ctx, req.Name, &node, affectedWorkloads, nodeSelectorPodsByWorkload)
 }
@@ -304,25 +306,15 @@ func groupPodsByWorkload(pods []corev1.Pod) map[types.NamespacedName][]*corev1.P
 	return result
 }
 
-// getWorkloadsOnNode gets all workloads that have the given node assigned in TAS topology assignment
-// or have "late" pods assigned to this node via nodeSelector.
-func (r *nodeReconciler) getWorkloadsOnNode(ctx context.Context, nodeName string, nodeSelectorPodsByWorkload map[types.NamespacedName][]*corev1.Pod) (sets.Set[types.NamespacedName], error) {
-	var workloadsOnNode kueue.WorkloadList
-	if err := r.client.List(ctx, &workloadsOnNode, client.MatchingFields{indexer.AdmittedWorkloadNodesKey: nodeName}); err != nil {
-		return nil, fmt.Errorf("failed to list workloads: %w", err)
+func (r *nodeReconciler) getWorkloadsFromLatePods(ctx context.Context, nodeName string, existingWorkloads sets.Set[types.NamespacedName]) (sets.Set[types.NamespacedName], map[types.NamespacedName][]*corev1.Pod, error) {
+	nodeSelectorPodsByWorkload, err := r.listPodsAssignedByNodeSelector(ctx, nodeName)
+	if err != nil {
+		return nil, nil, err
 	}
-	tasWorkloadsOnNode := sets.New[types.NamespacedName]()
-	for i := range workloadsOnNode.Items {
-		wl := &workloadsOnNode.Items[i]
-		tasWorkloadsOnNode.Insert(types.NamespacedName{Name: wl.Name, Namespace: wl.Namespace})
-	}
-
+	latePodWorkloads := sets.New[types.NamespacedName]()
 	logger := r.logger().V(4).WithValues("node", nodeName)
-	// Also find workloads from any pods that are assigned to this node by TopologyAssignment
-	// but not yet bound. These might be stale "late" pods for a workload that has already
-	// been reassigned to another node.
 	for wlKey := range nodeSelectorPodsByWorkload {
-		if tasWorkloadsOnNode.Has(wlKey) {
+		if existingWorkloads.Has(wlKey) {
 			continue
 		}
 		var wl kueue.Workload
@@ -331,8 +323,22 @@ func (r *nodeReconciler) getWorkloadsOnNode(ctx context.Context, nodeName string
 			continue
 		}
 		if !workload.IsFinished(&wl) && !workload.IsEvicted(&wl) {
-			tasWorkloadsOnNode.Insert(wlKey)
+			latePodWorkloads.Insert(wlKey)
 		}
+	}
+	return latePodWorkloads, nodeSelectorPodsByWorkload, nil
+}
+
+// getWorkloadsOnNode gets all workloads that have the given node assigned in TAS topology assignment
+func (r *nodeReconciler) getWorkloadsOnNode(ctx context.Context, nodeName string) (sets.Set[types.NamespacedName], error) {
+	var workloadsOnNode kueue.WorkloadList
+	if err := r.client.List(ctx, &workloadsOnNode, client.MatchingFields{indexer.AdmittedWorkloadNodesKey: nodeName}); err != nil {
+		return nil, fmt.Errorf("failed to list workloads: %w", err)
+	}
+	tasWorkloadsOnNode := sets.New[types.NamespacedName]()
+	for i := range workloadsOnNode.Items {
+		wl := &workloadsOnNode.Items[i]
+		tasWorkloadsOnNode.Insert(types.NamespacedName{Name: wl.Name, Namespace: wl.Namespace})
 	}
 
 	return tasWorkloadsOnNode, nil

--- a/pkg/controller/tas/node_controller_test.go
+++ b/pkg/controller/tas/node_controller_test.go
@@ -374,7 +374,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 					Type:               corev1.NodeReady,
 					Status:             corev1.ConditionFalse,
 					LastTransitionTime: earlierTime}).Obj(),
-				workloadReassignedWithUnhealthyNode,
+				workloadReassigned,
 				testingpod.MakePod("late-pod", nsName).
 					Annotation(kueue.WorkloadAnnotation, wlName).
 					Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").

--- a/pkg/controller/tas/node_controller_test.go
+++ b/pkg/controller/tas/node_controller_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package tas
 
 import (
+	"context"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -73,6 +75,24 @@ func TestNodeFailureReconciler(t *testing.T) {
 		).
 		AdmittedAt(true, testStartTime).
 		Obj()
+
+	workloadReassigned := utiltestingapi.MakeWorkload(wlName, nsName).
+		Finalizers(kueue.ResourceInUseFinalizerName).
+		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
+		ReserveQuotaAt(
+			utiltestingapi.MakeAdmission("cq").
+				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
+					TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+						Domains(utiltestingapi.MakeTopologyDomainAssignment([]string{nodeName2}, 1).Obj()).
+						Obj()).
+					Obj()).
+				Obj(), testStartTime,
+		).
+		AdmittedAt(true, testStartTime).
+		Obj()
+	workloadReassignedWithUnhealthyNode := workloadReassigned.DeepCopy()
+	workloadReassignedWithUnhealthyNode.Status.UnhealthyNodes = []kueue.UnhealthyNode{{Name: nodeName}}
 
 	workloadWithUnhealthyNode := baseWorkload.DeepCopy()
 	workloadWithUnhealthyNode.Status.UnhealthyNodes = []kueue.UnhealthyNode{{Name: nodeName}}
@@ -178,6 +198,8 @@ func TestNodeFailureReconciler(t *testing.T) {
 		// Patching the status in tests (via fake client and strategic merge interceptor)
 		// doesn't correctly handle clearing the list.
 		ignoreUnhealthyNodes bool
+		wantError            bool
+		injectPatchError     bool
 	}{
 		"Node Found and Healthy - not marked as unavailable": {
 			initObjs: []client.Object{
@@ -316,6 +338,55 @@ func TestNodeFailureReconciler(t *testing.T) {
 			},
 			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
 			wantUnhealthyNodes: []kueue.UnhealthyNode{{Name: nodeName}},
+		},
+		"Node Deleted, late pod exists for reassigned workload -> UnhealthyNodes not polluted": {
+			initObjs: []client.Object{
+				workloadReassigned,
+				testingpod.MakePod("late-pod", nsName).
+					Annotation(kueue.WorkloadAnnotation, wlName).
+					Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
+					NodeSelector(corev1.LabelHostname, nodeName).
+					StatusPhase(corev1.PodPending).
+					Obj(),
+			},
+			reconcileRequests:    []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
+			wantUnhealthyNodes:   nil,
+			ignoreUnhealthyNodes: false,
+		},
+		"NodeReady missing, late pod exists for reassigned workload -> UnhealthyNodes not polluted": {
+			initObjs: []client.Object{
+				testingnode.MakeNode(nodeName).Obj(),
+				workloadReassigned,
+				testingpod.MakePod("late-pod", nsName).
+					Annotation(kueue.WorkloadAnnotation, wlName).
+					Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
+					NodeSelector(corev1.LabelHostname, nodeName).
+					StatusPhase(corev1.PodPending).
+					Obj(),
+			},
+			reconcileRequests:    []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
+			wantUnhealthyNodes:   nil,
+			ignoreUnhealthyNodes: false,
+		},
+		"Node NotReady, timer expired, patch fails during removal -> UnhealthyNodes not polluted": {
+			initObjs: []client.Object{
+				baseNode.Clone().StatusConditions(corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionFalse,
+					LastTransitionTime: earlierTime}).Obj(),
+				workloadReassignedWithUnhealthyNode,
+				testingpod.MakePod("late-pod", nsName).
+					Annotation(kueue.WorkloadAnnotation, wlName).
+					Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
+					NodeSelector(corev1.LabelHostname, nodeName).
+					StatusPhase(corev1.PodPending).
+					Obj(),
+			},
+			reconcileRequests:    []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
+			wantUnhealthyNodes:   nil,
+			ignoreUnhealthyNodes: false,
+			injectPatchError:     true,
+			wantError:            false,
 		},
 		"Two Nodes Unhealthy (NotReady), delay passed - workload evicted": {
 			featureGates: map[featuregate.Feature]bool{features.TASReplaceNodeOnPodTermination: false},
@@ -920,7 +991,19 @@ func TestNodeFailureReconciler(t *testing.T) {
 			clientBuilder := utiltesting.NewClientBuilder().
 				WithObjects(tc.initObjs...).
 				WithStatusSubresource(tc.initObjs...).
-				WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
+				WithInterceptorFuncs(interceptor.Funcs{
+					SubResourcePatch: func(ctx context.Context, client client.Client, subResource string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+						if tc.injectPatchError && subResource == "status" {
+							if wl, ok := obj.(*kueue.Workload); ok && wl.Name == wlName {
+								// Fail only if it's trying to remove the node (it's not in the list anymore).
+								if !slices.Contains(wl.Status.UnhealthyNodes, kueue.UnhealthyNode{Name: nodeName}) {
+									return fmt.Errorf("injected patch error on removal")
+								}
+							}
+						}
+						return utiltesting.TreatSSAAsStrategicMerge(ctx, client, subResource, obj, patch, opts...)
+					},
+				})
 			ctx, _ := utiltesting.ContextWithLog(t)
 			err := indexer.SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder))
 			if err != nil {
@@ -938,8 +1021,8 @@ func TestNodeFailureReconciler(t *testing.T) {
 			var result reconcile.Result
 			for _, req := range tc.reconcileRequests {
 				result, err = r.Reconcile(ctx, req)
-				if err != nil {
-					t.Errorf("Reconcile() error = %v for request %v", err, req)
+				if (err != nil) != tc.wantError {
+					t.Errorf("Reconcile() error = %v, wantError %v for request %v", err, tc.wantError, req)
 				}
 			}
 			wl := &kueue.Workload{}

--- a/pkg/controller/tas/node_controller_test.go
+++ b/pkg/controller/tas/node_controller_test.go
@@ -18,6 +18,7 @@ package tas
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"testing"
@@ -997,7 +998,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 							if wl, ok := obj.(*kueue.Workload); ok && wl.Name == wlName {
 								// Fail only if it's trying to remove the node (it's not in the list anymore).
 								if !slices.Contains(wl.Status.UnhealthyNodes, kueue.UnhealthyNode{Name: nodeName}) {
-									return fmt.Errorf("injected patch error on removal")
+									return errors.New("injected patch error on removal")
 								}
 							}
 						}

--- a/pkg/controller/tas/node_controller_test.go
+++ b/pkg/controller/tas/node_controller_test.go
@@ -92,8 +92,6 @@ func TestNodeFailureReconciler(t *testing.T) {
 		).
 		AdmittedAt(true, testStartTime).
 		Obj()
-	workloadReassignedWithUnhealthyNode := workloadReassigned.DeepCopy()
-	workloadReassignedWithUnhealthyNode.Status.UnhealthyNodes = []kueue.UnhealthyNode{{Name: nodeName}}
 
 	workloadWithUnhealthyNode := baseWorkload.DeepCopy()
 	workloadWithUnhealthyNode.Status.UnhealthyNodes = []kueue.UnhealthyNode{{Name: nodeName}}

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -1535,6 +1535,110 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
 				})
 			})
+
+			ginkgo.It("should not add unhealthy node when node is deleted but late pods exist", func() {
+				var wl *kueue.Workload
+				nodeName := nodes[0].Name
+				var terminatingPodName string
+
+				ginkgo.By("creating a workload that gets admitted", func() {
+					wl = utiltestingapi.MakeWorkload("wl", ns.Name).
+						PodSets(*utiltestingapi.MakePodSet("worker", 2).
+							PreferredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+							Obj()).
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
+					util.MustCreate(ctx, k8sClient, wl)
+				})
+
+				ginkgo.By("verify the workload is admitted to x3 and x1", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+					gomega.Expect(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+						utiltas.V1Beta2From(&utiltas.TopologyAssignment{
+							Levels: []string{corev1.LabelHostname},
+							Domains: []utiltas.TopologyDomainAssignment{
+								{Count: 1, Values: []string{"x3"}},
+								{Count: 1, Values: []string{"x1"}},
+							},
+						}),
+					))
+				})
+
+				createPodsForWorkload(wl, ns.Name, true, false)
+
+				ginkgo.By("make one pod terminating on x3", func() {
+					pod0 := &corev1.Pod{}
+					gomega.Expect(k8sClient.Get(ctx, apitypes.NamespacedName{Name: fmt.Sprintf("%s-0", wl.Name), Namespace: ns.Name}, pod0)).Should(gomega.Succeed())
+					pod1 := &corev1.Pod{}
+					gomega.Expect(k8sClient.Get(ctx, apitypes.NamespacedName{Name: fmt.Sprintf("%s-1", wl.Name), Namespace: ns.Name}, pod1)).Should(gomega.Succeed())
+
+					for _, podCopy := range []*corev1.Pod{pod0, pod1} {
+						if podCopy.Spec.NodeSelector[corev1.LabelHostname] == nodeName {
+							terminatingPodName = podCopy.Name
+							podCopy.Finalizers = append(podCopy.Finalizers, "kueue.x-k8s.io/dummy-finalizer")
+							gomega.Expect(k8sClient.Update(ctx, podCopy)).Should(gomega.Succeed())
+							gomega.Expect(k8sClient.Delete(ctx, podCopy)).Should(gomega.Succeed())
+						} else {
+							gomega.Expect(k8sClient.Delete(ctx, podCopy)).Should(gomega.Succeed())
+						}
+					}
+				})
+
+				ginkgo.By("make node NotReady to trigger node replacement", func() {
+					nodeToUpdate := &corev1.Node{}
+					gomega.Expect(k8sClient.Get(ctx, apitypes.NamespacedName{Name: nodeName}, nodeToUpdate)).Should(gomega.Succeed())
+					util.SetNodeCondition(ctx, k8sClient, nodeToUpdate, &corev1.NodeCondition{
+						Type:               corev1.NodeReady,
+						Status:             corev1.ConditionFalse,
+						LastTransitionTime: metav1.NewTime(time.Now().Add(-tas.NodeFailureDelay)),
+					})
+				})
+
+				ginkgo.By("verify Hot Swap completes", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+						g.Expect(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+							utiltas.V1Beta2From(&utiltas.TopologyAssignment{
+								Levels: []string{corev1.LabelHostname},
+								Domains: []utiltas.TopologyDomainAssignment{
+									{Count: 1, Values: []string{"x1"}},
+									{Count: 1, Values: []string{"x4"}},
+								},
+							}),
+						))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("verify UnhealthyNodes becomes empty after Hot Swap", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+						g.Expect(wl.Status.UnhealthyNodes).Should(gomega.BeEmpty())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("delete node object entirely", func() {
+					nodeToDelete := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+					gomega.Expect(k8sClient.Delete(ctx, nodeToDelete)).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("verify unhealthy nodes is not polluted", func() {
+					gomega.Consistently(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+						g.Expect(wl.Status.UnhealthyNodes).Should(gomega.BeEmpty())
+					}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("cleanup pod finalizer", func() {
+					podToCleanup := &corev1.Pod{}
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, apitypes.NamespacedName{Name: terminatingPodName, Namespace: ns.Name}, podToCleanup)).To(gomega.Succeed())
+						podToCleanup.Finalizers = nil
+						g.Expect(k8sClient.Update(ctx, podToCleanup)).Should(gomega.Succeed())
+						g.Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, podToCleanup))).To(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+			})
+
 			ginkgo.It("should remove node from unhealthyNodes when the node recovers", func() {
 				var wl1 *kueue.Workload
 				nodeName := nodes[0].Name

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -1536,7 +1536,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				})
 			})
 
-			ginkgo.It("should not add unhealthy node when node is deleted but late pods exist", func() {
+			ginkgo.It("should not add unhealthy node when node is deleted but late pods exist", framework.SlowSpec, func() {
 				var wl *kueue.Workload
 				nodeName := nodes[0].Name
 				var terminatingPodName string

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -1584,7 +1584,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					}
 				})
 
-				ginkgo.By("make node NotReady to trigger node replacement", func() {
+				ginkgo.By("make node x3 NotReady to trigger node replacement", func() {
 					nodeToUpdate := &corev1.Node{}
 					gomega.Expect(k8sClient.Get(ctx, apitypes.NamespacedName{Name: nodeName}, nodeToUpdate)).Should(gomega.Succeed())
 					util.SetNodeCondition(ctx, k8sClient, nodeToUpdate, &corev1.NodeCondition{
@@ -1712,7 +1712,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 
-				ginkgo.By("make node Ready first to trigger reconcile on subsequent update", func() {
+				ginkgo.By("make node x3 Ready first to trigger reconcile on subsequent update", func() {
 					nodeToUpdate := &corev1.Node{}
 					gomega.Expect(k8sClient.Get(ctx, apitypes.NamespacedName{Name: nodeName}, nodeToUpdate)).Should(gomega.Succeed())
 					util.SetNodeCondition(ctx, k8sClient, nodeToUpdate, &corev1.NodeCondition{

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -1712,6 +1712,16 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 
+				ginkgo.By("make node Ready first to trigger reconcile on subsequent update", func() {
+					nodeToUpdate := &corev1.Node{}
+					gomega.Expect(k8sClient.Get(ctx, apitypes.NamespacedName{Name: nodeName}, nodeToUpdate)).Should(gomega.Succeed())
+					util.SetNodeCondition(ctx, k8sClient, nodeToUpdate, &corev1.NodeCondition{
+						Type:               corev1.NodeReady,
+						Status:             corev1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(time.Now()),
+					})
+				})
+
 				ginkgo.By("remove NodeReady condition completely", func() {
 					nodeToUpdate := &corev1.Node{}
 					gomega.Expect(k8sClient.Get(ctx, apitypes.NamespacedName{Name: nodeName}, nodeToUpdate)).Should(gomega.Succeed())

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -1639,6 +1639,104 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				})
 			})
 
+			ginkgo.It("should not add unhealthy node when Ready condition is missing but late pods exist", framework.SlowSpec, func() {
+				var wl *kueue.Workload
+				nodeName := nodes[0].Name
+				var terminatingPodName string
+
+				ginkgo.By("creating a workload that gets admitted", func() {
+					wl = utiltestingapi.MakeWorkload("wl", ns.Name).
+						PodSets(*utiltestingapi.MakePodSet("worker", 2).
+							PreferredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+							Obj()).
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
+					util.MustCreate(ctx, k8sClient, wl)
+				})
+
+				ginkgo.By("verify the workload is admitted to x3 and x1", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+					gomega.Expect(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+						utiltas.V1Beta2From(&utiltas.TopologyAssignment{
+							Levels: []string{corev1.LabelHostname},
+							Domains: []utiltas.TopologyDomainAssignment{
+								{Count: 1, Values: []string{"x3"}},
+								{Count: 1, Values: []string{"x1"}},
+							},
+						}),
+					))
+				})
+
+				createPodsForWorkload(wl, ns.Name, true, false)
+
+				ginkgo.By("make one pod terminating on x3", func() {
+					pod0 := &corev1.Pod{}
+					gomega.Expect(k8sClient.Get(ctx, apitypes.NamespacedName{Name: fmt.Sprintf("%s-0", wl.Name), Namespace: ns.Name}, pod0)).Should(gomega.Succeed())
+					pod1 := &corev1.Pod{}
+					gomega.Expect(k8sClient.Get(ctx, apitypes.NamespacedName{Name: fmt.Sprintf("%s-1", wl.Name), Namespace: ns.Name}, pod1)).Should(gomega.Succeed())
+
+					for _, podCopy := range []*corev1.Pod{pod0, pod1} {
+						if podCopy.Spec.NodeSelector[corev1.LabelHostname] == nodeName {
+							terminatingPodName = podCopy.Name
+							podCopy.Finalizers = append(podCopy.Finalizers, "kueue.x-k8s.io/dummy-finalizer")
+							gomega.Expect(k8sClient.Update(ctx, podCopy)).Should(gomega.Succeed())
+							gomega.Expect(k8sClient.Delete(ctx, podCopy)).Should(gomega.Succeed())
+						} else {
+							gomega.Expect(k8sClient.Delete(ctx, podCopy)).Should(gomega.Succeed())
+						}
+					}
+				})
+
+				ginkgo.By("make node NotReady to trigger node replacement", func() {
+					nodeToUpdate := &corev1.Node{}
+					gomega.Expect(k8sClient.Get(ctx, apitypes.NamespacedName{Name: nodeName}, nodeToUpdate)).Should(gomega.Succeed())
+					util.SetNodeCondition(ctx, k8sClient, nodeToUpdate, &corev1.NodeCondition{
+						Type:               corev1.NodeReady,
+						Status:             corev1.ConditionFalse,
+						LastTransitionTime: metav1.NewTime(time.Now().Add(-tas.NodeFailureDelay)),
+					})
+				})
+
+				ginkgo.By("verify Hot Swap completes", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+						g.Expect(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+							utiltas.V1Beta2From(&utiltas.TopologyAssignment{
+								Levels: []string{corev1.LabelHostname},
+								Domains: []utiltas.TopologyDomainAssignment{
+									{Count: 1, Values: []string{"x1"}},
+									{Count: 1, Values: []string{"x4"}},
+								},
+							}),
+						))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("remove NodeReady condition completely", func() {
+					nodeToUpdate := &corev1.Node{}
+					gomega.Expect(k8sClient.Get(ctx, apitypes.NamespacedName{Name: nodeName}, nodeToUpdate)).Should(gomega.Succeed())
+					nodeToUpdate.Status.Conditions = nil
+					gomega.Expect(k8sClient.Status().Update(ctx, nodeToUpdate)).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("verify unhealthy nodes is not polluted", func() {
+					gomega.Consistently(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+						g.Expect(wl.Status.UnhealthyNodes).Should(gomega.BeEmpty())
+					}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("cleanup pod finalizer", func() {
+					podToCleanup := &corev1.Pod{}
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, apitypes.NamespacedName{Name: terminatingPodName, Namespace: ns.Name}, podToCleanup)).To(gomega.Succeed())
+						podToCleanup.Finalizers = nil
+						g.Expect(k8sClient.Update(ctx, podToCleanup)).Should(gomega.Succeed())
+						g.Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, podToCleanup))).To(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+			})
+
 			ginkgo.It("should remove node from unhealthyNodes when the node recovers", func() {
 				var wl1 *kueue.Workload
 				nodeName := nodes[0].Name


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area tas

#### What this PR does / why we need it:
A workload's UnhealthyNodes list may be polluted by nodes that no longer belong to the workload if 'late pods' are still present on them.

#### Which issue(s) this PR fixes:
Fixes #10750

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
TAS: Refine the NodeHotSwap logic to ensure that UnhealthyNodes are only updated for workloads currently assigned to a Node via a topology topology assignment. This prevents "late pods" from stale topologies from triggering inaccurate health reporting.
```

> AI Assistance Disclosure: This pull request was created with the assistance of AI