### PR TITLE
Fix Dockerfile cross-compilation for multi-arch builds

### DIFF
--- a/cmd/experimental/kueue-populator/Dockerfile
+++ b/cmd/experimental/kueue-populator/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /workspace/cmd/experimental/kueue-populator
 RUN go mod download
 RUN make build GO_BUILD_ENV='CGO_ENABLED=${CGO_ENABLED} GOOS=linux GOARCH=${TARGETARCH}'
 
-FROM --platform=${BUILDPLATFORM} ${BASE_IMAGE}
+FROM ${BASE_IMAGE}
 WORKDIR /
 COPY --from=builder /workspace/cmd/experimental/kueue-populator/bin/manager .
 USER 65532:65532

--- a/cmd/importer/Dockerfile
+++ b/cmd/importer/Dockerfile
@@ -14,7 +14,7 @@ COPY . .
 # Build
 RUN make importer-build GO_BUILD_ENV='CGO_ENABLED=${CGO_ENABLED} GOOS=linux GOARCH=${TARGETARCH}'
 
-FROM --platform=${BUILDPLATFORM} ${BASE_IMAGE}
+FROM ${BASE_IMAGE}
 WORKDIR /
 COPY --from=builder /workspace/bin/importer .
 USER 65532:65532

--- a/cmd/kueueviz/backend/Dockerfile
+++ b/cmd/kueueviz/backend/Dockerfile
@@ -11,10 +11,11 @@ RUN go mod download
 COPY . .
 
 # Build the application
-RUN CGO_ENABLED=0 go build -o /kueueviz
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /kueueviz
 
 # Runtime stage
-FROM --platform=${BUILDPLATFORM} ${BASE_IMAGE}
+FROM ${BASE_IMAGE}
 USER 65532:65532
 
 # Copy the built application from the builder stage


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area dashboard

#### What this PR does / why we need it:

The runtime `FROM` stage in three Dockerfiles (`cmd/importer/Dockerfile`, `cmd/experimental/kueue-populator/Dockerfile`, and `cmd/kueueviz/backend/Dockerfile`) uses `--platform=${BUILDPLATFORM}`, which pins the base image to the build host's architecture instead of the target's. Additionally, `cmd/kueueviz/backend/Dockerfile` was missing `ARG TARGETARCH` and `GOARCH=${TARGETARCH}`, so `go build` would produce a binary for the build host architecture rather than the target.

Together, these issues cause cross-platform builds (e.g. building `linux/arm64` images on an `amd64` host) to produce containers that fail at runtime with `exec format error`.

This PR:
- Removes `--platform=${BUILDPLATFORM}` from the runtime `FROM` stage in all three Dockerfiles, so Docker defaults to `${TARGETPLATFORM}` (matching the convention in the root `Dockerfile`).
- Adds `ARG TARGETARCH` and passes `GOOS=linux GOARCH=${TARGETARCH}` to `go build` in `cmd/kueueviz/backend/Dockerfile`.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The root `Dockerfile` already follows the correct pattern and documents it explicitly:

```
# final image, implicitly --platform=${TARGETPLATFORM}
FROM ${BASE_IMAGE}
```

The importer and kueue-populator Dockerfiles already had the `GOARCH=${TARGETARCH}` cross-compilation in their build steps, but the runtime stage was pulling the wrong platform's base image. The kueueviz backend was missing both fixes.

#### Does this PR introduce a user-facing change?

```release-note
Fixed multi-arch image builds for importer, kueue-populator, and kueueviz backend images so runtime images
and binaries are built for the target platform, preventing wrong-architecture containers and exec format error
for non-amd64 target platforms, such as arm64, ppc64le, and s390x.
```