### PR TITLE
fix: Fix TAS stateWithLeader aggregation for grouped podsets

### DIFF
--- a/pkg/cache/scheduler/tas_balanced_placement.go
+++ b/pkg/cache/scheduler/tas_balanced_placement.go
@@ -264,7 +264,7 @@ func findBestDomainsForBalancedPlacement(s *TASFlavorSnapshot, params *topologyA
 		}
 		threshold := balanceThresholdValue(sliceCount, selectedDomainsCount, lastDomainWithLeader, lastDomain)
 		if threshold >= bestThreshold {
-			s.pruneDomainsBelowThreshold(requestedLevelSiblingDomains, threshold, params.sliceSize, params.sliceLevelIdx, params.requestedLevelIdx)
+			s.pruneDomainsBelowThreshold(requestedLevelSiblingDomains, threshold, params.sliceSize, params.sliceLevelIdx, params.requestedLevelIdx, params.leaderCount > 0)
 			_, requestedLevelDomainCount, _, _ := evaluateGreedyAssignment(s, requestedLevelSiblingDomains, sliceCount, params.leaderCount)
 			if threshold > bestThreshold || (threshold == bestThreshold && requestedLevelDomainCount < bestDomainCountOnRequestedLevel) {
 				bestThreshold = threshold
@@ -318,7 +318,7 @@ func clearState(d *domain) {
 	}
 }
 
-func (s *TASFlavorSnapshot) pruneDomainsBelowThreshold(domains []*domain, threshold int32, sliceSize int32, sliceLevelIdx int, level int) {
+func (s *TASFlavorSnapshot) pruneDomainsBelowThreshold(domains []*domain, threshold int32, sliceSize int32, sliceLevelIdx int, level int, leaderRequired bool) {
 	for _, d := range domains {
 		for _, c := range d.children {
 			if c.sliceStateWithLeader < threshold {
@@ -327,7 +327,7 @@ func (s *TASFlavorSnapshot) pruneDomainsBelowThreshold(domains []*domain, thresh
 		}
 	}
 	for _, d := range domains {
-		s.fillInCountsHelper(d, sliceSize, sliceLevelIdx, level, nil)
+		s.fillInCountsHelper(d, sliceSize, sliceLevelIdx, level, nil, leaderRequired)
 		if d.sliceStateWithLeader < threshold {
 			clearState(d)
 		}

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -4506,6 +4506,240 @@ func TestFindTopologyAssignments(t *testing.T) {
 				},
 			},
 		},
+		"find topology assignment for grouped podsets skips domain where only workers fit without leader": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("small-used").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "small").
+					Label(corev1.LabelHostname, "small-used").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2800m"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("small-free").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "small").
+					Label(corev1.LabelHostname, "small-free").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2800m"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("large-free").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "large").
+					Label(corev1.LabelHostname, "large-free").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("6"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("filler", "test-ns").
+					NodeName("small-used").
+					StatusPhase(corev1.PodRunning).
+					Request(corev1.ResourceCPU, "2500m").
+					Obj(),
+			},
+			levels: defaultThreeLevels,
+			podSets: []PodSetTestCase{
+				{
+					podSetName: "leader",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasRackLabel),
+					},
+					requests: resources.Requests{
+						corev1.ResourceCPU: 2500,
+					},
+					podSetGroupName: new("sameGroup"),
+					count:           1,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: defaultOneLevel,
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"large-free"}},
+						},
+					},
+				},
+				{
+					podSetName: "workers",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasRackLabel),
+					},
+					requests: resources.Requests{
+						corev1.ResourceCPU: 2500,
+					},
+					podSetGroupName: new("sameGroup"),
+					count:           1,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: defaultOneLevel,
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"large-free"}},
+						},
+					},
+				},
+			},
+		},
+		"find topology assignment for grouped podsets skips domain where mixed-size workers only fit without leader": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("small-used").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "small").
+					Label(corev1.LabelHostname, "small-used").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2800m"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("small-free").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "small").
+					Label(corev1.LabelHostname, "small-free").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2800m"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("large-free").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "large").
+					Label(corev1.LabelHostname, "large-free").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("6"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("filler", "test-ns").
+					NodeName("small-used").
+					StatusPhase(corev1.PodRunning).
+					Request(corev1.ResourceCPU, "2500m").
+					Obj(),
+			},
+			levels: defaultThreeLevels,
+			podSets: []PodSetTestCase{
+				{
+					podSetName: "leader",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasRackLabel),
+					},
+					requests: resources.Requests{
+						corev1.ResourceCPU: 2500,
+					},
+					podSetGroupName: new("sameGroup"),
+					count:           1,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: defaultOneLevel,
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"large-free"}},
+						},
+					},
+				},
+				{
+					podSetName: "workers",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasRackLabel),
+					},
+					requests: resources.Requests{
+						corev1.ResourceCPU: 500,
+					},
+					podSetGroupName: new("sameGroup"),
+					count:           2,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: defaultOneLevel,
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 2, Values: []string{"large-free"}},
+						},
+					},
+				},
+			},
+		},
+		"find topology assignment for grouped podsets keeps tight domain when leader and workers fit together": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("small-used").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "small").
+					Label(corev1.LabelHostname, "small-used").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2800m"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("small-free").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "small").
+					Label(corev1.LabelHostname, "small-free").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2800m"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("large-free").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "large").
+					Label(corev1.LabelHostname, "large-free").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("6"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("filler", "test-ns").
+					NodeName("small-used").
+					StatusPhase(corev1.PodRunning).
+					Request(corev1.ResourceCPU, "2500m").
+					Obj(),
+			},
+			levels: defaultThreeLevels,
+			podSets: []PodSetTestCase{
+				{
+					podSetName: "leader",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasRackLabel),
+					},
+					requests: resources.Requests{
+						corev1.ResourceCPU: 1000,
+					},
+					podSetGroupName: new("sameGroup"),
+					count:           1,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: defaultOneLevel,
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"small-free"}},
+						},
+					},
+				},
+				{
+					podSetName: "workers",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasRackLabel),
+					},
+					requests: resources.Requests{
+						corev1.ResourceCPU: 1000,
+					},
+					podSetGroupName: new("sameGroup"),
+					count:           1,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: defaultOneLevel,
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"small-free"}},
+						},
+					},
+				},
+			},
+		},
 		"find topology assignment for two podsets with the same group - no fit": {
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1").

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1699,16 +1699,14 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 		leaderState = max(child.leaderState, leaderState)
 	}
 	domain.state = childrenCapacity
+	sliceStateWithLeader := int32(0)
 	if minStateWithLeaderDifference == math.MaxInt32 {
 		domain.stateWithLeader = 0
 	} else {
 		domain.stateWithLeader = childrenCapacity - minStateWithLeaderDifference
-	}
-	domain.leaderState = leaderState
-	sliceStateWithLeader := int32(0)
-	if minSliceStateWithLeaderDifference != math.MaxInt32 {
 		sliceStateWithLeader = sliceCapacity - minSliceStateWithLeaderDifference
 	}
+	domain.leaderState = leaderState
 
 	if level == sliceLevelIdx {
 		// initialize the sliceState for the requested slice level.

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1668,7 +1668,7 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 	// logic for a parent
 	childrenCapacity := int32(0)
 	sliceCapacity := int32(0)
-	hasWithLeaderCapacityContributor = false
+	hasWithLeaderCapacityContributor := false
 	minStateWithLeaderDifference := int32(math.MaxInt32)
 	minSliceStateWithLeaderDifference := int32(math.MaxInt32)
 	leaderState := int32(0)

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1668,7 +1668,7 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 	// logic for a parent
 	childrenCapacity := int32(0)
 	sliceCapacity := int32(0)
-
+	hasWithLeaderCapacityContributor = false
 	minStateWithLeaderDifference := int32(math.MaxInt32)
 	minSliceStateWithLeaderDifference := int32(math.MaxInt32)
 	leaderState := int32(0)
@@ -1693,6 +1693,7 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 		childrenCapacity += childState
 		sliceCapacity += child.sliceState
 		if !leaderRequired || child.leaderState > 0 {
+			hasWithLeaderCapacityContributor = true
 			minStateWithLeaderDifference = min(childState-childStateWithLeader, minStateWithLeaderDifference)
 			minSliceStateWithLeaderDifference = min(child.sliceState-child.sliceStateWithLeader, minSliceStateWithLeaderDifference)
 		}
@@ -1700,11 +1701,11 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 	}
 	domain.state = childrenCapacity
 	sliceStateWithLeader := int32(0)
-	if minStateWithLeaderDifference == math.MaxInt32 {
-		domain.stateWithLeader = 0
-	} else {
+	if hasWithLeaderCapacityContributor {
 		domain.stateWithLeader = childrenCapacity - minStateWithLeaderDifference
 		sliceStateWithLeader = sliceCapacity - minSliceStateWithLeaderDifference
+	} else {
+		domain.stateWithLeader = 0
 	}
 	domain.leaderState = leaderState
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1642,7 +1642,7 @@ func (s *TASFlavorSnapshot) fillInCounts(requirements *topologyAssignmentPodRequ
 		leaf.stateWithLeader = requirements.requests.CountIn(remainingCapacity)
 	}
 	for _, root := range s.roots {
-		s.fillInCountsHelper(root, state.sliceSize, state.sliceLevelIdx, 0, state.sliceSizeAtLevel)
+		s.fillInCountsHelper(root, state.sliceSize, state.sliceLevelIdx, 0, state.sliceSizeAtLevel, state.leaderCount > 0)
 	}
 }
 
@@ -1655,7 +1655,7 @@ func belongsToRequiredDomain(leaf *leafDomain, requiredReplacementDomain utiltas
 	return strings.HasPrefix(string(utiltas.DomainID(leaf.levelValues)), string(requiredReplacementDomain))
 }
 
-func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, sliceLevelIdx int, level int, sliceSizeAtLevel map[int]int32) {
+func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, sliceLevelIdx int, level int, sliceSizeAtLevel map[int]int32, leaderRequired bool) {
 	// logic for a leaf
 	if len(domain.children) == 0 {
 		if level == sliceLevelIdx {
@@ -1681,7 +1681,7 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 	innerSize, hasInnerConstraint := sliceSizeAtLevel[childLevel]
 
 	for _, child := range domain.children {
-		s.fillInCountsHelper(child, sliceSize, sliceLevelIdx, childLevel, sliceSizeAtLevel)
+		s.fillInCountsHelper(child, sliceSize, sliceLevelIdx, childLevel, sliceSizeAtLevel, leaderRequired)
 
 		childState := child.state
 		childStateWithLeader := child.stateWithLeader
@@ -1692,14 +1692,23 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 
 		childrenCapacity += childState
 		sliceCapacity += child.sliceState
-		minStateWithLeaderDifference = min(childState-childStateWithLeader, minStateWithLeaderDifference)
-		minSliceStateWithLeaderDifference = min(child.sliceState-child.sliceStateWithLeader, minSliceStateWithLeaderDifference)
+		if !leaderRequired || child.leaderState > 0 {
+			minStateWithLeaderDifference = min(childState-childStateWithLeader, minStateWithLeaderDifference)
+			minSliceStateWithLeaderDifference = min(child.sliceState-child.sliceStateWithLeader, minSliceStateWithLeaderDifference)
+		}
 		leaderState = max(child.leaderState, leaderState)
 	}
 	domain.state = childrenCapacity
-	domain.stateWithLeader = childrenCapacity - minStateWithLeaderDifference
+	if minStateWithLeaderDifference == math.MaxInt32 {
+		domain.stateWithLeader = 0
+	} else {
+		domain.stateWithLeader = childrenCapacity - minStateWithLeaderDifference
+	}
 	domain.leaderState = leaderState
-	sliceStateWithLeader := sliceCapacity - minSliceStateWithLeaderDifference
+	sliceStateWithLeader := int32(0)
+	if minSliceStateWithLeaderDifference != math.MaxInt32 {
+		sliceStateWithLeader = sliceCapacity - minSliceStateWithLeaderDifference
+	}
 
 	if level == sliceLevelIdx {
 		// initialize the sliceState for the requested slice level.


### PR DESCRIPTION
  ## What this PR does

  For grouped podSets with a leader, parent topology domains were computing the `stateWithLeader` penalty across all children, including children that cannot host the leader. Empty or fully occupied children have `state=0`,
  `stateWithLeader=0`, and `leaderState=0`, so they contributed a zero penalty. This could make the parent domain report `stateWithLeader == state`, even when the only leader-capable child could not also fit the workers after placing
  the leader.

  In practice, this caused the scheduler to select a smaller topology domain that looked like it could fit the grouped workload during phase 1, then fail during assignment generation and produce an empty/malformed
  `TopologyAssignment`.

  This PR changes the parent aggregation logic so that, when a leader is required, only leader-capable children contribute to the `stateWithLeader` and `sliceStateWithLeader` penalty calculation. If no child can host the leader, the
  parent with-leader capacity is set to zero.

  The balanced placement pruning path was updated to preserve the same leader-aware aggregation behavior when recomputing domain counts.

  ## Tests

  Added regression coverage in `TestFindTopologyAssignments` for:
  - equal-size grouped leader/worker podSets where the small domain must be skipped
  - mixed-size grouped podSets where workers fit without the leader but not after leader placement
  - a positive case where leader and workers do fit together on the tight domain and should still be assigned there

  Fixes #10778.
  
  ```release-note
TAS: Fix handling of PodSet groups which could lead in some scenarios to empty topologyAssignment.
```