### PR TITLE
fix(queue): avoid blocking send on DRA reconcile channel

### DIFF
--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -450,13 +450,13 @@ func (m *Manager) DefaultLocalQueueExist(namespace string) bool {
 // addLocalQueueLocked registers the local queue under the manager lock and
 // returns the DRA reconcile channel and any workloads that need DRA reconciling.
 // Callers must send events to the channel after this returns (outside any lock).
-func (m *Manager) addLocalQueueLocked(ctx context.Context, q *kueue.LocalQueue) (chan<- event.TypedGenericEvent[*kueue.Workload], []*kueue.Workload, error) {
+func (m *Manager) addLocalQueueLocked(ctx context.Context, q *kueue.LocalQueue) ([]*kueue.Workload, error) {
 	m.Lock()
 	defer m.Unlock()
 
 	key := queue.Key(q)
 	if _, ok := m.localQueues[key]; ok {
-		return nil, nil, fmt.Errorf("queue %q already exists", q.Name)
+		return nil, fmt.Errorf("queue %q already exists", q.Name)
 	}
 	qImpl := newLocalQueue(q)
 	m.localQueues[key] = qImpl
@@ -470,7 +470,7 @@ func (m *Manager) addLocalQueueLocked(ctx context.Context, q *kueue.LocalQueue) 
 	// queue might have been added earlier.
 	var workloads kueue.WorkloadList
 	if err := m.client.List(ctx, &workloads, client.MatchingFields{utilindexer.WorkloadQueueKey: q.Name}, client.InNamespace(q.Namespace)); err != nil {
-		return nil, nil, fmt.Errorf("listing workloads that match the queue: %w", err)
+		return nil, fmt.Errorf("listing workloads that match the queue: %w", err)
 	}
 	var draWorkloads []*kueue.Workload
 	for _, w := range workloads.Items {
@@ -486,11 +486,9 @@ func (m *Manager) addLocalQueueLocked(ctx context.Context, q *kueue.LocalQueue) 
 
 		log := ctrl.LoggerFrom(ctx).WithValues("workload", klog.KObj(&w))
 		if dra.NeedsDRAReconcile(&w) {
-			if m.draReconcileChannel != nil {
-				// Collect DRA workloads to send outside the lock; DeepCopy keeps a
-				// stable pointer since the range variable is reused each iteration.
-				draWorkloads = append(draWorkloads, w.DeepCopy())
-			}
+			// Collect DRA workloads to send outside the lock; DeepCopy keeps a
+			// stable pointer since the range variable is reused each iteration.
+			draWorkloads = append(draWorkloads, w.DeepCopy())
 			continue
 		}
 
@@ -504,18 +502,22 @@ func (m *Manager) addLocalQueueLocked(ctx context.Context, q *kueue.LocalQueue) 
 		m.Broadcast()
 	}
 
-	return m.draReconcileChannel, draWorkloads, nil
+	return draWorkloads, nil
 }
 
 func (m *Manager) AddLocalQueue(ctx context.Context, q *kueue.LocalQueue) error {
-	ch, draWorkloads, err := m.addLocalQueueLocked(ctx, q)
+	draWorkloads, err := m.addLocalQueueLocked(ctx, q)
 	if err != nil {
 		return err
 	}
 
+	if !features.Enabled(features.DynamicResourceAllocation) {
+		return nil
+	}
+
 	for _, wl := range draWorkloads {
 		log := ctrl.LoggerFrom(ctx).WithValues("workload", klog.KObj(wl))
-		ch <- event.TypedGenericEvent[*kueue.Workload]{Object: wl}
+		m.draReconcileChannel <- event.TypedGenericEvent[*kueue.Workload]{Object: wl}
 		log.V(4).Info("Sent DRA workload to reconcile channel due to LocalQueue creation")
 	}
 

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -449,10 +449,10 @@ func (m *Manager) DefaultLocalQueueExist(namespace string) bool {
 
 func (m *Manager) AddLocalQueue(ctx context.Context, q *kueue.LocalQueue) error {
 	m.Lock()
-	defer m.Unlock()
 
 	key := queue.Key(q)
 	if _, ok := m.localQueues[key]; ok {
+		m.Unlock()
 		return fmt.Errorf("queue %q already exists", q.Name)
 	}
 	qImpl := newLocalQueue(q)
@@ -467,8 +467,10 @@ func (m *Manager) AddLocalQueue(ctx context.Context, q *kueue.LocalQueue) error 
 	// queue might have been added earlier.
 	var workloads kueue.WorkloadList
 	if err := m.client.List(ctx, &workloads, client.MatchingFields{utilindexer.WorkloadQueueKey: q.Name}, client.InNamespace(q.Namespace)); err != nil {
+		m.Unlock()
 		return fmt.Errorf("listing workloads that match the queue: %w", err)
 	}
+	var draWorkloadsToReconcile []*kueue.Workload
 	for _, w := range workloads.Items {
 		m.assignWorkload(workload.Key(&w), qImpl.Key)
 
@@ -483,8 +485,10 @@ func (m *Manager) AddLocalQueue(ctx context.Context, q *kueue.LocalQueue) error 
 		log := ctrl.LoggerFrom(ctx).WithValues("workload", klog.KObj(&w))
 		if dra.NeedsDRAReconcile(&w) {
 			if m.draReconcileChannel != nil {
-				m.draReconcileChannel <- event.TypedGenericEvent[*kueue.Workload]{Object: &w}
-				log.V(4).Info("Sent DRA workload to reconcile channel due to LocalQueue creation")
+				// Defer sending until after releasing the manager lock:
+				// - avoid blocking sends while holding the lock
+				// - keep a stable object pointer (range variable address is unsafe)
+				draWorkloadsToReconcile = append(draWorkloadsToReconcile, w.DeepCopy())
 			}
 			continue
 		}
@@ -498,6 +502,19 @@ func (m *Manager) AddLocalQueue(ctx context.Context, q *kueue.LocalQueue) error 
 	if cq != nil && cq.AddFromLocalQueue(qImpl, m.roleTracker, m.customLabels) {
 		m.Broadcast()
 	}
+
+	// Unlock before sending DRA reconcile events.
+	ch := m.draReconcileChannel
+	m.Unlock()
+
+	if ch != nil {
+		for _, wl := range draWorkloadsToReconcile {
+			log := ctrl.LoggerFrom(ctx).WithValues("workload", klog.KObj(wl))
+			ch <- event.TypedGenericEvent[*kueue.Workload]{Object: wl}
+			log.V(4).Info("Sent DRA workload to reconcile channel due to LocalQueue creation")
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -447,13 +447,16 @@ func (m *Manager) DefaultLocalQueueExist(namespace string) bool {
 	return ok
 }
 
-func (m *Manager) AddLocalQueue(ctx context.Context, q *kueue.LocalQueue) error {
+// addLocalQueueLocked registers the local queue under the manager lock and
+// returns the DRA reconcile channel and any workloads that need DRA reconciling.
+// Callers must send events to the channel after this returns (outside any lock).
+func (m *Manager) addLocalQueueLocked(ctx context.Context, q *kueue.LocalQueue) (chan<- event.TypedGenericEvent[*kueue.Workload], []*kueue.Workload, error) {
 	m.Lock()
+	defer m.Unlock()
 
 	key := queue.Key(q)
 	if _, ok := m.localQueues[key]; ok {
-		m.Unlock()
-		return fmt.Errorf("queue %q already exists", q.Name)
+		return nil, nil, fmt.Errorf("queue %q already exists", q.Name)
 	}
 	qImpl := newLocalQueue(q)
 	m.localQueues[key] = qImpl
@@ -467,10 +470,9 @@ func (m *Manager) AddLocalQueue(ctx context.Context, q *kueue.LocalQueue) error 
 	// queue might have been added earlier.
 	var workloads kueue.WorkloadList
 	if err := m.client.List(ctx, &workloads, client.MatchingFields{utilindexer.WorkloadQueueKey: q.Name}, client.InNamespace(q.Namespace)); err != nil {
-		m.Unlock()
-		return fmt.Errorf("listing workloads that match the queue: %w", err)
+		return nil, nil, fmt.Errorf("listing workloads that match the queue: %w", err)
 	}
-	var draWorkloadsToReconcile []*kueue.Workload
+	var draWorkloads []*kueue.Workload
 	for _, w := range workloads.Items {
 		m.assignWorkload(workload.Key(&w), qImpl.Key)
 
@@ -485,10 +487,9 @@ func (m *Manager) AddLocalQueue(ctx context.Context, q *kueue.LocalQueue) error 
 		log := ctrl.LoggerFrom(ctx).WithValues("workload", klog.KObj(&w))
 		if dra.NeedsDRAReconcile(&w) {
 			if m.draReconcileChannel != nil {
-				// Defer sending until after releasing the manager lock:
-				// - avoid blocking sends while holding the lock
-				// - keep a stable object pointer (range variable address is unsafe)
-				draWorkloadsToReconcile = append(draWorkloadsToReconcile, w.DeepCopy())
+				// Collect DRA workloads to send outside the lock; DeepCopy keeps a
+				// stable pointer since the range variable is reused each iteration.
+				draWorkloads = append(draWorkloads, w.DeepCopy())
 			}
 			continue
 		}
@@ -503,16 +504,19 @@ func (m *Manager) AddLocalQueue(ctx context.Context, q *kueue.LocalQueue) error 
 		m.Broadcast()
 	}
 
-	// Unlock before sending DRA reconcile events.
-	ch := m.draReconcileChannel
-	m.Unlock()
+	return m.draReconcileChannel, draWorkloads, nil
+}
 
-	if ch != nil {
-		for _, wl := range draWorkloadsToReconcile {
-			log := ctrl.LoggerFrom(ctx).WithValues("workload", klog.KObj(wl))
-			ch <- event.TypedGenericEvent[*kueue.Workload]{Object: wl}
-			log.V(4).Info("Sent DRA workload to reconcile channel due to LocalQueue creation")
-		}
+func (m *Manager) AddLocalQueue(ctx context.Context, q *kueue.LocalQueue) error {
+	ch, draWorkloads, err := m.addLocalQueueLocked(ctx, q)
+	if err != nil {
+		return err
+	}
+
+	for _, wl := range draWorkloads {
+		log := ctrl.LoggerFrom(ctx).WithValues("workload", klog.KObj(wl))
+		ch <- event.TypedGenericEvent[*kueue.Workload]{Object: wl}
+		log.V(4).Info("Sent DRA workload to reconcile channel due to LocalQueue creation")
 	}
 
 	return nil

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -97,20 +97,15 @@ func TestAddLocalQueue_DRAReconcileChannelGuaranteedDelivery(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.DynamicResourceAllocation, true)
 
 	// Create an admissible workload that triggers dra.NeedsDRAReconcile via HasDRA().
-	wl := utiltestingapi.MakeWorkload("wl", "earth").Queue("foo").Obj()
 	tmplName := "claim-tmpl"
-	wl.Spec.PodSets = []kueue.PodSet{{
-		Name:  "ps",
-		Count: 1,
-		Template: corev1.PodTemplateSpec{
-			Spec: corev1.PodSpec{
-				ResourceClaims: []corev1.PodResourceClaim{{
-					Name:                      "rc",
-					ResourceClaimTemplateName: &tmplName,
-				}},
-			},
-		},
-	}}
+	wl := utiltestingapi.MakeWorkload("wl", "earth").Queue("foo").PodSets(
+		*utiltestingapi.MakePodSet("ps", 1).PodSpec(corev1.PodSpec{
+			ResourceClaims: []corev1.PodResourceClaim{{
+				Name:                      "rc",
+				ResourceClaimTemplateName: &tmplName,
+			}},
+		}).Obj(),
+	).Obj()
 
 	kClient := utiltesting.NewFakeClient(wl)
 	manager := NewManagerForUnitTests(kClient, nil)
@@ -130,7 +125,7 @@ func TestAddLocalQueue_DRAReconcileChannelGuaranteedDelivery(t *testing.T) {
 	// The send must happen outside the manager lock, so draining here cannot deadlock.
 	select {
 	case <-ch:
-	case <-time.After(5 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("timed out waiting to drain draReconcileChannel")
 	}
 
@@ -140,7 +135,7 @@ func TestAddLocalQueue_DRAReconcileChannelGuaranteedDelivery(t *testing.T) {
 		if err != nil {
 			t.Fatalf("AddLocalQueue returned error: %v", err)
 		}
-	case <-time.After(5 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("AddLocalQueue did not complete after draReconcileChannel was drained")
 	}
 

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -35,8 +35,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	testingclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
 	"sigs.k8s.io/kueue/pkg/util/queue"
@@ -88,6 +90,63 @@ func TestAddLocalQueueOrphans(t *testing.T) {
 	}
 	if diff := cmp.Diff(expectedWorkloads, assignedWorkloads); diff != "" {
 		t.Errorf("Unexpected assigned workloads (-want,+got):\n%s", diff)
+	}
+}
+
+func TestAddLocalQueue_DRAReconcileChannelGuaranteedDelivery(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.DynamicResourceAllocation, true)
+
+	// Create an admissible workload that triggers dra.NeedsDRAReconcile via HasDRA().
+	wl := utiltestingapi.MakeWorkload("wl", "earth").Queue("foo").Obj()
+	tmplName := "claim-tmpl"
+	wl.Spec.PodSets = []kueue.PodSet{{
+		Name:  "ps",
+		Count: 1,
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				ResourceClaims: []corev1.PodResourceClaim{{
+					Name:                      "rc",
+					ResourceClaimTemplateName: &tmplName,
+				}},
+			},
+		},
+	}}
+
+	kClient := utiltesting.NewFakeClient(wl)
+	manager := NewManagerForUnitTests(kClient, nil)
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	// Pre-fill the channel so the first send blocks until we drain it.
+	ch := make(chan event.TypedGenericEvent[*kueue.Workload], 1)
+	ch <- event.TypedGenericEvent[*kueue.Workload]{Object: wl}
+	manager.SetDRAReconcileChannel(ch)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- manager.AddLocalQueue(ctx, utiltestingapi.MakeLocalQueue("foo", "earth").ClusterQueue("cq").Obj())
+	}()
+
+	// Drain the pre-filled event to unblock AddLocalQueue's blocking send.
+	// The send must happen outside the manager lock, so draining here cannot deadlock.
+	select {
+	case <-ch:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting to drain draReconcileChannel")
+	}
+
+	// AddLocalQueue must complete after the channel is drained.
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("AddLocalQueue returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("AddLocalQueue did not complete after draReconcileChannel was drained")
+	}
+
+	// The workload event must have been delivered (guaranteed, not dropped).
+	if got := len(ch); got != 1 {
+		t.Fatalf("unexpected draReconcileChannel length: got %d, want 1", got)
 	}
 }
 

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -3251,6 +3251,9 @@ func TestReconcile(t *testing.T) {
 				queueOptions := []qcache.Option{qcache.WithPreemptionExpectations(preemptexpectations.New())}
 				qManager := qcache.NewManagerForUnitTests(cl, cqCache, queueOptions...)
 				reconciler := NewWorkloadReconciler(cl, qManager, cqCache, recorder, tc.reconcilerOpts...)
+				if features.Enabled(features.DynamicResourceAllocation) {
+					qManager.SetDRAReconcileChannel(reconciler.GetDRAReconcileChannel())
+				}
 				// use a fake clock with jitter = 0 to be able to assert on the requeueAt.
 				reconciler.clock = fakeClock
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

The original blocking send was inside the manager lock. If the channel buffer (size=10) filled up, AddLocalQueue would hold the manager lock for an extended period, blocking all other manager operations (scheduling, workload admission, etc.) until the channel drained.

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
