### PR TITLE
[zh-CN] Sync jobs.md and add dra.md translation

### DIFF
--- a/site/content/zh-CN/docs/tasks/run/dra.md
+++ b/site/content/zh-CN/docs/tasks/run/dra.md
@@ -1,0 +1,131 @@
+---
+title: "使用 DRA 设备运行工作负载"
+linkTitle: "DRA"
+date: 2026-03-22
+weight: 7
+description: >
+  运行请求由 Kubernetes 动态资源分配 (DRA) 管理硬件设备的工作负载，并使用 Kueue 配额管理。
+---
+
+本页面展示如何运行请求硬件设备（如 GPU）的工作负载，这些设备由
+[动态资源分配 (DRA)](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/)
+在已启用 Kueue 的 Kubernetes 集群中管理。示例使用批量 Job，但相同的做法适用于
+Kueue 支持的任何[工作负载类型](/docs/concepts/workload)。
+
+本页面的目标受众是[批量用户](/docs/tasks#batch-user)。
+
+有关 Kueue 如何处理 DRA 资源的概念性详细信息，请参阅
+[动态资源分配概念](/docs/concepts/dynamic_resource_allocation)。
+
+## 准备工作
+
+确保满足以下条件：
+
+- 正在运行 Kubernetes 集群。
+- kubectl 命令行工具可以与集群通信。
+- [已安装 Kueue](/docs/installation)。
+- 集群已[配置配额](/docs/tasks/manage/administer_cluster_quotas)，
+  且 `ClusterQueue` 中包含 DRA 资源。
+- 您的管理员已在 Kueue 中[配置 DRA 支持](/docs/tasks/manage/setup_dra)。
+
+## 0. 识别您命名空间中可用的队列
+
+运行以下命令列出您命名空间中可用的 `LocalQueue`。
+
+```shell
+kubectl -n default get localqueues
+```
+
+输出类似于：
+
+```
+NAME         CLUSTERQUEUE    PENDING WORKLOADS
+user-queue   cluster-queue   0
+```
+
+[ClusterQueue](/docs/concepts/cluster_queue) 定义队列的配额。
+
+## 1. 定义工作负载
+
+使用 DRA 设备运行工作负载与[运行常规 Job](/docs/tasks/run/jobs) 类似。
+您必须设置 `kueue.x-k8s.io/queue-name` 标签来选择要提交工作负载的 `LocalQueue`。
+
+根据管理员配置集群的方式，有两种请求 DRA 设备的方式。请选择与您的设置匹配的方式。
+
+### 使用 ResourceClaimTemplate
+
+当您需要显式描述所需的设备时，请使用此方法。创建 `ResourceClaimTemplate` 并从工作负载中引用它：
+
+{{< include "examples/dra/sample-dra-rct-job.yaml" "yaml" >}}
+
+### 使用扩展资源
+
+当集群中存在带有 `spec.extendedResourceName` 的 `DeviceClass` 时，请使用此方法。
+您可以使用标准的 `resources.requests` 语法请求设备，就像请求 CPU 或内存一样。
+无需 `ResourceClaimTemplate`：
+
+{{< include "examples/dra/sample-dra-extended-resource-job.yaml" "yaml" >}}
+
+如果您不确定使用哪种方法，请咨询您的管理员。
+
+## 2. 运行工作负载
+
+您可以使用以下命令运行工作负载。
+
+对于基于 ResourceClaimTemplate 的工作负载：
+
+```shell
+kubectl create -f https://kueue.sigs.k8s.io/examples/dra/sample-dra-rct-job.yaml
+```
+
+对于基于扩展资源的工作负载：
+
+```shell
+kubectl create -f https://kueue.sigs.k8s.io/examples/dra/sample-dra-extended-resource-job.yaml
+```
+
+在内部，Kueue 将为此 Job 创建相应的[工作负载](/docs/concepts/workload)。
+
+## 3.（可选）监控工作负载状态
+
+您可以使用以下命令查看工作负载状态：
+
+```shell
+kubectl -n default get workloads.kueue.x-k8s.io
+```
+
+要检查工作负载是否已 admission 并查看 DRA 资源核算：
+
+```shell
+kubectl -n default describe workload <workload-name>
+```
+
+查看 `Conditions` 部分了解 admission 状态，查看 `Events` 部分了解详细信息。
+如果工作负载已获 admission，您可以验证 `status.admission.podSetAssignments[].resourceUsage` 字段中配额的资源使用情况：
+
+```shell
+kubectl -n default get workloads.kueue.x-k8s.io <workload-name> -o yaml
+```
+
+## 故障排除
+
+### 工作负载未获 admission
+
+如果工作负载保持 `Pending` 状态：
+
+- 验证 `ClusterQueue` 有 DRA 资源的配额，且未被其他工作负载完全占用。
+- 运行 `kubectl -n default describe workload <workload-name>` 并查看 Events 部分了解 admission 拒绝原因。
+
+### 重复计数（扩展资源路径）
+
+如果配额使用显示的值是预期的两倍（例如，单个 GPU 显示为 `2` 而不是 `1`），
+则可能未启用 `DRAExtendedResources` 功能门控。
+请管理员验证 [DRA 配置](/docs/tasks/manage/setup_dra)。
+
+### 缺少 DeviceClass
+
+对于扩展资源路径，`DeviceClass` 必须在提交工作负载之前存在。
+如果它是在您的工作负载被拒绝之后创建的，则在另一个集群事件触发重新排队之前，
+工作负载可能不会重新评估。删除并重新创建工作负载以强制重新评估。
+
+有关一般故障排除，请参阅[故障排除指南](/docs/tasks/troubleshooting)。

--- a/site/content/zh-CN/docs/tasks/run/jobs.md
+++ b/site/content/zh-CN/docs/tasks/run/jobs.md
@@ -1,6 +1,6 @@
 ---
-title: "运行 Kubernetes Job"
-linkTitle: "Kubernetes Job"
+title: "运行一个 Kubernetes Job"
+linkTitle: "Kubernetes Jobs"
 date: 2022-02-14
 weight: 4
 description: >
@@ -11,26 +11,26 @@ description: >
 
 本页面的目标受众是[批量用户](/docs/tasks#batch-user)。
 
-## 开始之前 {#before-you-begin}
+## 开始之前
 
 确保满足以下条件：
 
 - Kubernetes 集群正在运行。
 - kubectl 命令行工具能够与您的集群通信。
-- [已安装 Kueue](/zh-CN/docs/installation)。
-- 集群已[配置配额](/zh-CN/docs/tasks/manage/administer_cluster_quotas)。
+- [已安装 Kueue](/docs/installation)。
+- 集群已[配置配额](/docs/tasks/manage/administer_cluster_quotas)。
 
-下图显示了您在本教程中将要学习的所有概念：
+下图显示了您在本教程中将要交互的所有概念：
 
 ![Kueue Components](/images/queueing-components.svg)
 
-## 0. 识别命名空间中可用的队列 {#0-identify-the-queues-available-in-your-namespace}
+## 0. 识别您命名空间中可用的队列
 
 运行以下命令列出您命名空间中可用的 `LocalQueues`。
 
 ```shell
 kubectl -n default get localqueues
-# 或使用 'queues' 别名。
+# 或使用 'queues' 别名
 kubectl -n default get queues
 ```
 
@@ -41,24 +41,24 @@ NAME         CLUSTERQUEUE    PENDING WORKLOADS
 user-queue   cluster-queue   3
 ```
 
-[ClusterQueue](/zh-CN/docs/concepts/cluster_queue) 定义了队列的配额。
+[ClusterQueue](/docs/concepts/cluster_queue) 定义队列的配额。
 
-## 1. 定义 Job {#1-define-the-job}
+## 1. 定义 Job
 
-在 Kueue 中运行 Job 类似于[在 Kubernetes 集群中运行 Job](https://kubernetes.io/docs/tasks/job/)，
-只是没有使用 Kueue。但是，您必须考虑以下差异：
+在 Kueue 中运行 Job 与[在 Kubernetes 集群中运行 Job](https://kubernetes.io/docs/tasks/job/) 类似，只是没有使用 Kueue。但是，您必须设置 `kueue.x-k8s.io/queue-name` 标签来选择您要提交 Job 的 LocalQueue。
+如果使用 [LocalQueue 默认值](/docs/tasks/manage/enforce_job_management/setup_default_local_queue)，您也可以跳过设置 "queue name" 标签。
 
-- 您应该在[挂起状态](https://kubernetes.io/docs/concepts/workloads/controllers/job/#suspending-a-job)下创建 Job，
-  因为 Kueue 将决定何时是启动 Job 的最佳时间。
-- 您必须设置要提交 Job 的队列。使用
- `kueue.x-k8s.io/queue-name` 标签。
-- 您应该为每个 Job Pod 包含资源请求。
+您应该为每个 Job Pod 指定[资源请求或限制](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)。
+如果您只指定限制，Kueue 会将限制值视为请求。请参阅 [Kueue 如何使用资源请求](/docs/concepts/workload#resource-requests) 了解详细信息。
 
-这是一个包含三个 Pod 的示例 Job，它们只是休眠几秒钟。
+请注意，您不需要在[挂起状态](https://kubernetes.io/docs/concepts/workloads/controllers/job/#suspending-a-job)下创建 Job。
+Kueue 通过 webhook 自动管理 Job 的挂起，并决定启动 Job 的最佳时机。
+
+这是一个包含三个 Pod 的示例 Job，这些 Pod 只是休眠几秒钟。
 
 {{< include "examples/jobs/sample-job.yaml" "yaml" >}}
 
-## 2. 运行 Job {#2-run-the-job}
+## 2. 运行 Job
 
 您可以使用以下命令运行 Job：
 
@@ -66,20 +66,20 @@ user-queue   cluster-queue   3
 kubectl create -f sample-job.yaml
 ```
 
-在内部，Kueue 将为此 Job 创建一个与名称匹配的相应[Workload](/zh-CN/docs/concepts/workload)。
+在内部，Kueue 将为此 Job 创建一个名称匹配的相应 [Workload](/docs/concepts/workload)。
 
 ```shell
 kubectl -n default get workloads.kueue.x-k8s.io
 ```
 
-输出将类似于以下内容：
+输出类似于以下内容：
 
 ```shell
 NAME               QUEUE         RESERVED IN   ADMITTED   AGE
 sample-job-sl4bm   user-queue                             1s
 ```
 
-## 3. （可选）监控 Workload 的状态 {#3-optional-monitor-the-status-of-the-workload}
+## 3.（可选）监控工作负载的状态
 
 您可以使用以下命令查看 Workload 状态：
 
@@ -87,8 +87,7 @@ sample-job-sl4bm   user-queue                             1s
 kubectl -n default describe workload sample-job-sl4bm
 ```
 
-如果 ClusterQueue 没有足够的配额来运行 Workload，
-输出将类似于以下内容：
+如果 ClusterQueue 没有足够的配额来运行 Workload，输出类似于以下内容：
 
 ```shell
 Name:         sample-job-sl4bm
@@ -112,8 +111,7 @@ Status:
 Events:               <none>
 ```
 
-当 ClusterQueue 有足够的配额来运行 Workload 时，它将让此 Workload 准入。
-要查看 Workload 是否被准入，运行以下命令：
+当 ClusterQueue 有足够的配额运行 Workload 时，它将 admission 该 Workload。要查看 Workload 是否已被 admission，请运行以下命令：
 
 ```shell
 kubectl -n default get workloads.kueue.x-k8s.io
@@ -126,7 +124,7 @@ NAME               QUEUE         RESERVED IN   ADMITTED   AGE
 sample-job-sl4bm   user-queue    cluster-queue True       1s
 ```
 
-要查看 Workload 准入的事件，运行以下命令：
+要查看 Workload admission 的事件，请运行以下命令：
 
 ```shell
 kubectl -n default describe workload sample-job-sl4bm
@@ -148,23 +146,23 @@ Events:
 kubectl -n default describe workload sample-job-sl4bm
 ```
 
-一旦 Workload 完成运行，输出类似于以下内容：
+当 Workload 运行完成后，输出类似于以下内容：
 
 ```shell
 ...
 Status:
   Conditions:
     ...
-    Last Probe Time:       2022-03-28T19:43:37Z                                                                                                                      
-    Last Transition Time:  2022-03-28T19:43:37Z                                                                                                                      
-    Message:               Job finished successfully                                                                                                                 
-    Reason:                JobFinished                                                                                                                               
-    Status:                True                                                                                                                                      
+    Last Probe Time:       2022-03-28T19:43:37Z
+    Last Transition Time:  2022-03-28T19:43:37Z
+    Message:               Job finished successfully
+    Reason:                JobFinished
+    Status:                True
     Type:                  Finished
 ...
 ```
 
-要查看 Job 状态的更多详细信息，运行以下命令：
+要查看有关 Job 状态的更多详细信息，请运行以下命令：
 
 ```shell
 kubectl -n default describe job sample-job-sl4bm
@@ -195,26 +193,114 @@ Events:
   Normal  Completed         18m   job-controller        Job completed
 ```
 
-由于事件的时间戳精度为秒，事件可能与实际发生的顺序略有不同。
+由于事件的时间戳精确到秒，事件的列出顺序可能与实际发生顺序略有不同。
 
-## 部分准入 {#partial-admission}
+## 部分 Admission
 
 {{< feature-state state="beta" for_version="v0.5" >}}
 
-Kueue 提供了批量用户创建 Job 的能力，这些 Job 理想情况下将以并行度 `P0` 运行，
-但如果 Job 不适合可用配额，可以接受较小的并行度 `Pn`。
+Kueue 为批量用户提供了创建 Job 的能力，这些 Job 理想情况下将使用并行度 `P0` 运行，但如果 Job 不适合可用配额，则可以接受较小的并行度 `Pn`。
 
-Kueue 只有在准入过程中同时考虑了_借用_和_抢占_，
-并且两者都不可行的情况下，才会尝试减少并行度。
+Kueue 只会在 admission 过程中考虑了 _borrowing_ 和 _preemption_ 之后且两者都不可行时，才尝试降低并行度。
 
-要允许部分准入，您可以在 Job 的 `kueue.x-k8s.io/job-min-parallelism`
-注解中提供最小可接受并行度 `Pmin`，`Pn` 应该大于 0 且小于 `P0`。
-当 Job 被部分准入时，其并行度将设置为 `Pn`，`Pn` 将设置为 `Pmin` 和 `P0`
-之间的最大可接受值。Job 的完成计数不会改变。
+要允许部分 admission，您可以在 Job 的 `kueue.x-k8s.io/job-min-parallelism` 注解中提供最小可接受的并行度 `Pmin`，`Pn` 应该大于 0 且小于 `P0`。当 Job 被部分 admission 时，其并行度将设置为 `Pn`，`Pn` 将设置为 `Pmin` 和 `P0` 之间的最大可接受值。Job 的完成计数不会更改。
 
 例如，由以下清单定义的 Job：
 
 {{< include "examples/jobs/sample-job-partial-admission.yaml" "yaml" >}}
 
-当在只有 9 个 CPU 可用的 ClusterQueue 中排队时，它将以 `parallelism=9`
-被准入。请注意，完成次数不会改变。
+当在只有 9 个 CPU 可用的 ClusterQueue 中排队时，它将以 `parallelism=9` 被 admission。请注意，完成的数量不会更改。
+
+## ElasticJob
+
+{{< feature-state state="alpha" for_version="v0.13" >}}
+
+Kueue 支持批量用户**无需重新创建、重新启动或挂起** Job 即可扩展 Job 的并行度的能力。
+
+要启用此功能，请确保以下条件：
+
+* `ElasticJobsViaWorkloadSlices` 功能门控设置为 `true`
+* Job 带有 `kueue.x-k8s.io/elastic-job: "true"` 注解
+
+例如，由以下清单定义的 Job：
+
+{{< include "examples/jobs/sample-scalable-job.yaml" "yaml" >}}
+
+创建 Job 后，您可以通过更新 `parallelism` 字段并应用更改来扩展它。
+
+当**扩展**时，您应该观察到：
+
+* 为更新后的并行度创建并 admission 了新的 **Workload**
+* 之前的 **Workload** 被标记为 `Finished`
+
+### 示例演练
+
+#### 创建
+
+1. 使用提供的示例创建 Job。
+2. 观察 Job、Pod 和 Workload 对象。
+
+```text
+kubectl get job,deploy,rs,pod,workload
+
+NAME                           STATUS    COMPLETIONS   DURATION   AGE
+job.batch/sample-elastic-job   Running   0/10          4s         4s
+
+NAME                           READY   STATUS    RESTARTS   AGE
+pod/sample-elastic-job-468nl   1/1     Running   0          4s
+pod/sample-elastic-job-gd9qn   1/1     Running   0          4s
+pod/sample-elastic-job-snk6j   1/1     Running   0          4s
+
+NAME                                                   QUEUE       RESERVED IN   ADMITTED   FINISHED   ACTIVE   POD-COUNT   AGE
+workload.kueue.x-k8s.io/job-sample-elastic-job-615b3   user-queue  user-queue    True                  true     3           4s
+```
+
+#### 缩容
+
+1. 更新示例，将 `parallelism` 值从 `3` 减少到 `1`。
+2. 观察 Job、Pod 和 Workload 对象的更改。
+
+```text
+kubectl get job,deploy,rs,pod,workload
+
+NAME                           STATUS    COMPLETIONS   DURATION   AGE
+job.batch/sample-elastic-job   Running   0/10          27s        27s
+
+NAME                           READY   STATUS        RESTARTS   AGE
+pod/sample-elastic-job-468nl   1/1     Terminating   0          27s <-- 
+pod/sample-elastic-job-gd9qn   1/1     Running       0          27s
+pod/sample-elastic-job-snk6j   1/1     Terminating   0          27s <--
+
+NAME                                                   QUEUE       RESERVED IN   ADMITTED   FINISHED   ACTIVE   POD-COUNT   AGE
+workload.kueue.x-k8s.io/job-sample-elastic-job-615b3   user-queue  user-queue    True                  true     1           4s
+```
+
+* 两个 Pod 正在终止，而剩余的 Pod 继续运行。
+* 没有创建新的 Workload 对象。
+
+#### 扩容
+
+1. 更新示例，将 `parallelism` 值从 `1` 增加到 `4`。
+2. 观察 Job、Pod 和 Workload 对象的更改。
+
+```text
+kubectl get job,deploy,rs,pod,workload
+
+NAME                           STATUS    COMPLETIONS   DURATION   AGE
+job.batch/sample-elastic-job   Running   1/10          82s        82s
+
+NAME                           READY   STATUS      RESTARTS   AGE
+pod/sample-elastic-job-4xtsq   1/1     Running     0          10s 
+pod/sample-elastic-job-fl6j4   1/1     Running     0          10s
+pod/sample-elastic-job-gd9qn   1/1     Running     0          52s <-- 旧 Pod
+pod/sample-elastic-job-q482v   1/1     Running     0          10s
+
+
+NAME                                                   QUEUE       RESERVED IN   ADMITTED   FINISHED   ACTIVE   POD-COUNT   AGE
+workload.kueue.x-k8s.io/job-sample-elastic-job-615b3   user-queue  user-queue    True       True       true     1           52s <-- 旧 Workload
+workload.kueue.x-k8s.io/job-sample-elastic-job-992ea   user-queue  user-queue    True                  true     4           10s <-- 新 Workload
+```
+
+* 创建并运行新的 Pod。
+* 创建了具有更新后 Pod 计数的**新 Workload**。
+* **旧的 Workload** 被标记为 `Finished`。


### PR DESCRIPTION
Chinese translation updates for kueue documentation:

1. **Sync jobs.md** - Update Chinese translation to match English version:
   - Title: 添加 "一个" (Run A Kubernetes Job)
   - linkTitle: 添加 "s" (Kubernetes Jobs)
   - Links: 从 /zh-CN/... 更新为 /docs/...
   - 新增 Partial admission (部分 Admission) 和 ElasticJob 章节

2. **Add dra.md** - New translation for Dynamic Resource Allocation