### PR TITLE
Add WorkloadPriorityClassDefaulting support

### DIFF
--- a/pkg/controller/constants/constants.go
+++ b/pkg/controller/constants/constants.go
@@ -47,6 +47,11 @@ const (
 	// This label is always mutable because it might be useful for the preemption.
 	WorkloadPriorityClassLabel = "kueue.x-k8s.io/priority-class"
 
+	// DefaultWorkloadPriorityClassName is the name for the default
+	// WorkloadPriorityClass that is applied if WorkloadPriorityClassLabel is not
+	// specified and the WorkloadPriorityClassDefaulting feature gate is enabled.
+	DefaultWorkloadPriorityClassName = "default"
+
 	// ProvReqAnnotationPrefix is the prefix for annotations that should be pass to ProvisioningRequest as Parameters.
 	ProvReqAnnotationPrefix = "provreq.kueue.x-k8s.io/"
 

--- a/pkg/controller/jobframework/base_webhook.go
+++ b/pkg/controller/jobframework/base_webhook.go
@@ -71,6 +71,7 @@ func (w *BaseWebhook[T]) Default(ctx context.Context, obj T) error {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(5).Info("Applying defaults")
 	ApplyDefaultLocalQueue(job.Object(), w.Queues.DefaultLocalQueueExist)
+	ApplyDefaultWorkloadPriorityClass(ctx, w.Client, job.Object())
 	if err := ApplyDefaultForSuspend(ctx, job, w.Client, w.ManageJobsWithoutQueueName, w.ManagedJobsNamespaceSelector); err != nil {
 		return err
 	}

--- a/pkg/controller/jobframework/defaults.go
+++ b/pkg/controller/jobframework/defaults.go
@@ -22,12 +22,15 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/features"
+	utilpriority "sigs.k8s.io/kueue/pkg/util/priority"
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 )
 
@@ -59,6 +62,33 @@ func ApplyDefaultLocalQueue(jobObj client.Object, defaultQueueExist func(string)
 		labels[constants.QueueLabel] = string(constants.DefaultLocalQueueName)
 		jobObj.SetLabels(labels)
 	}
+}
+
+func ApplyDefaultWorkloadPriorityClass(ctx context.Context, c client.Client, jobObj client.Object) {
+	if !features.Enabled(features.WorkloadPriorityClassDefaulting) {
+		return
+	}
+	if WorkloadPriorityClassName(jobObj) != "" {
+		return
+	}
+	if IsOwnerManagedByKueueForObject(jobObj) {
+		return
+	}
+	exists, err := utilpriority.DefaultWorkloadPriorityClassExist(ctx, c)
+	if err != nil {
+		log := ctrl.LoggerFrom(ctx)
+		log.V(2).Error(err, "Failed to check for default WorkloadPriorityClass")
+		return
+	}
+	if !exists {
+		return
+	}
+	labels := jobObj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string, 1)
+	}
+	labels[constants.WorkloadPriorityClassLabel] = constants.DefaultWorkloadPriorityClassName
+	jobObj.SetLabels(labels)
 }
 
 func ApplyDefaultForManagedBy(job GenericJob, queues *qcache.Manager, cache *schdcache.Cache, log logr.Logger) {

--- a/pkg/controller/jobframework/defaults_test.go
+++ b/pkg/controller/jobframework/defaults_test.go
@@ -22,8 +22,14 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 )
@@ -101,6 +107,78 @@ func TestWorkloadShouldBeSuspended(t *testing.T) {
 			}
 			if suspend != tc.wantSuspend {
 				t.Errorf("Unexpected result: got %v wanted %v", suspend, tc.wantSuspend)
+			}
+		})
+	}
+}
+
+func TestApplyDefaultWorkloadPriorityClass(t *testing.T) {
+	t.Cleanup(EnableIntegrationsForTest(t, "batch/job"))
+	parent := utiltestingjob.MakeJob("parent", "default").UID("parent").Queue("default").Obj()
+
+	defaultWPC := &kueue.WorkloadPriorityClass{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.DefaultWorkloadPriorityClassName},
+		Value:      100,
+	}
+
+	scheme := runtime.NewScheme()
+	if err := kueue.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed adding kueue scheme: %v", err)
+	}
+
+	cases := map[string]struct {
+		job                    client.Object
+		wpcObjects             []client.Object
+		featureGates           map[featuregate.Feature]bool
+		wantPriorityClassLabel string
+	}{
+		"feature gate enabled, no label, default WPC exists": {
+			job:                    utiltestingjob.MakeJob("test-job", "default").Obj(),
+			wpcObjects:             []client.Object{defaultWPC},
+			featureGates:           map[featuregate.Feature]bool{features.WorkloadPriorityClassDefaulting: true},
+			wantPriorityClassLabel: constants.DefaultWorkloadPriorityClassName,
+		},
+		"feature gate disabled, no label, default WPC exists": {
+			job:                    utiltestingjob.MakeJob("test-job", "default").Obj(),
+			wpcObjects:             []client.Object{defaultWPC},
+			featureGates:           map[featuregate.Feature]bool{features.WorkloadPriorityClassDefaulting: false},
+			wantPriorityClassLabel: "",
+		},
+		"feature gate enabled, label already set": {
+			job:                    utiltestingjob.MakeJob("test-job", "default").WorkloadPriorityClass("high").Obj(),
+			wpcObjects:             []client.Object{defaultWPC},
+			featureGates:           map[featuregate.Feature]bool{features.WorkloadPriorityClassDefaulting: true},
+			wantPriorityClassLabel: "high",
+		},
+		"feature gate enabled, no label, default WPC does not exist": {
+			job:                    utiltestingjob.MakeJob("test-job", "default").Obj(),
+			wpcObjects:             nil,
+			featureGates:           map[featuregate.Feature]bool{features.WorkloadPriorityClassDefaulting: true},
+			wantPriorityClassLabel: "",
+		},
+		"feature gate enabled, owner managed by kueue": {
+			job: utiltestingjob.MakeJob("test-job", "default").
+				OwnerReference(parent.Name, batchv1.SchemeGroupVersion.WithKind("Job")).
+				Obj(),
+			wpcObjects:             []client.Object{defaultWPC},
+			featureGates:           map[featuregate.Feature]bool{features.WorkloadPriorityClassDefaulting: true},
+			wantPriorityClassLabel: "",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+			ctx, _ := utiltesting.ContextWithLog(t)
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if len(tc.wpcObjects) > 0 {
+				builder = builder.WithObjects(tc.wpcObjects...)
+			}
+			k8sClient := builder.Build()
+			ApplyDefaultWorkloadPriorityClass(ctx, k8sClient, tc.job)
+			got := tc.job.GetLabels()[constants.WorkloadPriorityClassLabel]
+			if got != tc.wantPriorityClassLabel {
+				t.Errorf("unexpected priority class label: got %q, want %q", got, tc.wantPriorityClassLabel)
 			}
 		})
 	}

--- a/pkg/controller/jobs/deployment/deployment_webhook.go
+++ b/pkg/controller/jobs/deployment/deployment_webhook.go
@@ -73,6 +73,7 @@ func (wh *Webhook) Default(ctx context.Context, obj *appsv1.Deployment) error {
 	log.V(5).Info("Propagating queue-name")
 
 	jobframework.ApplyDefaultLocalQueue(deployment.Object(), wh.queues.DefaultLocalQueueExist)
+	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, wh.client, deployment.Object())
 	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, deployment.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
 	if err != nil {
 		return err

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -105,6 +105,7 @@ func (w *JobWebhook) Default(ctx context.Context, obj *batchv1.Job) error {
 	log.V(5).Info("Applying defaults")
 
 	jobframework.ApplyDefaultLocalQueue(job.Object(), w.queues.DefaultLocalQueueExist)
+	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())
 	if err := jobframework.ApplyDefaultForSuspend(ctx, job, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}

--- a/pkg/controller/jobs/jobset/jobset_webhook.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook.go
@@ -78,6 +78,7 @@ func (w *JobSetWebhook) Default(ctx context.Context, obj *jobsetapi.JobSet) erro
 	log.V(5).Info("Applying defaults")
 
 	jobframework.ApplyDefaultLocalQueue(obj, w.queues.DefaultLocalQueueExist)
+	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, obj)
 	if err := jobframework.ApplyDefaultForSuspend(ctx, jobSet, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
@@ -77,6 +77,7 @@ func (wh *Webhook) Default(ctx context.Context, obj *leaderworkersetv1.LeaderWor
 	log.V(5).Info("Applying defaults")
 
 	jobframework.ApplyDefaultLocalQueue(obj, wh.queues.DefaultLocalQueueExist)
+	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, wh.client, obj)
 	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, lws.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
 	if err != nil {
 		return err

--- a/pkg/controller/jobs/mpijob/mpijob_webhook.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook.go
@@ -94,6 +94,7 @@ func (w *MpiJobWebhook) Default(ctx context.Context, obj *v2beta1.MPIJob) error 
 	log.V(5).Info("Applying defaults")
 
 	jobframework.ApplyDefaultLocalQueue(mpiJob.Object(), w.queues.DefaultLocalQueueExist)
+	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, mpiJob.Object())
 	if err := jobframework.ApplyDefaultForSuspend(ctx, mpiJob, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -157,6 +157,8 @@ func (w *PodWebhook) Default(ctx context.Context, obj *corev1.Pod) error {
 			pod.pod.Labels[ctrlconstants.QueueLabel] = string(ctrlconstants.DefaultLocalQueueName)
 		}
 
+		jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, pod.Object())
+
 		suspend = jobframework.QueueNameForObject(pod.Object()) != "" || w.manageJobsWithoutQueueName
 		if suspend {
 			if pod.pod.Labels == nil {

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -552,6 +552,94 @@ func TestDefault(t *testing.T) {
 				Queue("queue").
 				Obj(),
 		},
+		"default WorkloadPriorityClass is applied when feature gate is enabled and pod has no priority class label": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:         false,
+				features.WorkloadPriorityClassDefaulting: true,
+			},
+			initObjects: []client.Object{
+				defaultNamespace,
+				utiltestingapi.MakeWorkloadPriorityClass(constants.DefaultWorkloadPriorityClassName).PriorityValue(100).Obj(),
+			},
+			podSelector:       &metav1.LabelSelector{},
+			namespaceSelector: defaultNamespaceSelector,
+			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("queue").
+				Obj(),
+			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("queue").
+				Label(constants.WorkloadPriorityClassLabel, constants.DefaultWorkloadPriorityClassName).
+				ManagedByKueueLabel().
+				KueueSchedulingGate().
+				RoleHash("a9f06f3a").
+				KueueFinalizer().
+				Obj(),
+		},
+		"default WorkloadPriorityClass is not applied when feature gate is disabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:         false,
+				features.WorkloadPriorityClassDefaulting: false,
+			},
+			initObjects: []client.Object{
+				defaultNamespace,
+				utiltestingapi.MakeWorkloadPriorityClass(constants.DefaultWorkloadPriorityClassName).PriorityValue(100).Obj(),
+			},
+			podSelector:       &metav1.LabelSelector{},
+			namespaceSelector: defaultNamespaceSelector,
+			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("queue").
+				Obj(),
+			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("queue").
+				ManagedByKueueLabel().
+				KueueSchedulingGate().
+				RoleHash("a9f06f3a").
+				KueueFinalizer().
+				Obj(),
+		},
+		"default WorkloadPriorityClass is not applied when pod already has a priority class label": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:         false,
+				features.WorkloadPriorityClassDefaulting: true,
+			},
+			initObjects: []client.Object{
+				defaultNamespace,
+				utiltestingapi.MakeWorkloadPriorityClass(constants.DefaultWorkloadPriorityClassName).PriorityValue(100).Obj(),
+			},
+			podSelector:       &metav1.LabelSelector{},
+			namespaceSelector: defaultNamespaceSelector,
+			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("queue").
+				Label(constants.WorkloadPriorityClassLabel, "high").
+				Obj(),
+			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("queue").
+				Label(constants.WorkloadPriorityClassLabel, "high").
+				ManagedByKueueLabel().
+				KueueSchedulingGate().
+				RoleHash("a9f06f3a").
+				KueueFinalizer().
+				Obj(),
+		},
+		"default WorkloadPriorityClass is not applied when default WorkloadPriorityClass does not exist": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:         false,
+				features.WorkloadPriorityClassDefaulting: true,
+			},
+			initObjects:       []client.Object{defaultNamespace},
+			podSelector:       &metav1.LabelSelector{},
+			namespaceSelector: defaultNamespaceSelector,
+			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("queue").
+				Obj(),
+			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("queue").
+				ManagedByKueueLabel().
+				KueueSchedulingGate().
+				RoleHash("a9f06f3a").
+				KueueFinalizer().
+				Obj(),
+		},
 	}
 
 	for name, tc := range testCases {

--- a/pkg/controller/jobs/raycluster/raycluster_webhook.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook.go
@@ -88,6 +88,7 @@ func (w *RayClusterWebhook) Default(ctx context.Context, obj *rayv1.RayCluster) 
 	log := ctrl.LoggerFrom(ctx).WithName("raycluster-webhook")
 	log.V(10).Info("Applying defaults")
 	jobframework.ApplyDefaultLocalQueue(job.Object(), w.queues.DefaultLocalQueueExist)
+	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())
 	if err := jobframework.ApplyDefaultForSuspend(ctx, job, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}

--- a/pkg/controller/jobs/rayjob/rayjob_webhook.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook.go
@@ -79,6 +79,7 @@ func (w *RayJobWebhook) Default(ctx context.Context, obj *rayv1.RayJob) error {
 	log := ctrl.LoggerFrom(ctx).WithName("rayjob-webhook")
 	log.V(5).Info("Applying defaults")
 	jobframework.ApplyDefaultLocalQueue(job.Object(), w.queues.DefaultLocalQueueExist)
+	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())
 	if err := jobframework.ApplyDefaultForSuspend(ctx, job, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}

--- a/pkg/controller/jobs/rayservice/rayservice_webhook.go
+++ b/pkg/controller/jobs/rayservice/rayservice_webhook.go
@@ -90,6 +90,7 @@ func (w *RayServiceWebhook) Default(ctx context.Context, obj *rayv1.RayService) 
 	log := ctrl.LoggerFrom(ctx).WithName("rayservice-webhook")
 	log.V(10).Info("Applying defaults")
 	jobframework.ApplyDefaultLocalQueue(job.Object(), w.queues.DefaultLocalQueueExist)
+	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())
 	if err := jobframework.ApplyDefaultForSuspend(ctx, job, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}

--- a/pkg/controller/jobs/sparkapplication/sparkapplication_webhook.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_webhook.go
@@ -82,6 +82,7 @@ func (w *SparkApplicationWebhook) Default(ctx context.Context, obj *sparkv1beta2
 	log.V(5).Info("Applying defaults")
 
 	jobframework.ApplyDefaultLocalQueue(job.Object(), w.queues.DefaultLocalQueueExist)
+	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())
 	if err := jobframework.ApplyDefaultForSuspend(ctx, job, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -82,6 +82,7 @@ func (wh *Webhook) Default(ctx context.Context, stsObj *appsv1.StatefulSet) erro
 	log.V(5).Info("Propagating queue-name")
 
 	jobframework.ApplyDefaultLocalQueue(ss.Object(), wh.queues.DefaultLocalQueueExist)
+	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, wh.client, ss.Object())
 	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, ss.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
 	if err != nil {
 		return err

--- a/pkg/controller/jobs/trainjob/trainjob_webhook.go
+++ b/pkg/controller/jobs/trainjob/trainjob_webhook.go
@@ -73,6 +73,7 @@ func (w *TrainJobWebhook) Default(ctx context.Context, obj *kftrainerapi.TrainJo
 	log.V(5).Info("Applying defaults")
 
 	jobframework.ApplyDefaultLocalQueue(trainJob.Object(), w.queues.DefaultLocalQueueExist)
+	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, trainJob.Object())
 	jobframework.ApplyDefaultForManagedBy(trainJob, w.queues, w.cache, log)
 	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, trainJob.Object(), w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector)
 	if err != nil {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -408,6 +408,14 @@ const (
 	// (pod-group-name and prebuilt-workload-name) via annotations. When the gate is
 	// disabled, the label-based identifiers are used instead.
 	WorkloadIdentifierAnnotations featuregate.Feature = "WorkloadIdentifierAnnotations"
+
+	// owner: @atosatto
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/10765-workload-priority-class-defaulting
+	//
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/10765
+	// Enable defaulting of WorkloadPriorityClass to a WorkloadPriorityClass
+	// named "default" when no explicit priority class label is set.
+	WorkloadPriorityClassDefaulting featuregate.Feature = "WorkloadPriorityClassDefaulting"
 )
 
 func init() {
@@ -634,6 +642,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	WorkloadIdentifierAnnotations: {
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
+	},
+	WorkloadPriorityClassDefaulting: {
+		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }
 

--- a/pkg/util/priority/priority.go
+++ b/pkg/util/priority/priority.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	schedulingv1 "k8s.io/api/scheduling/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -142,4 +143,17 @@ func getDefaultPriorityClass(ctx context.Context, client client.Client) (*schedu
 	}
 
 	return defaultPC, nil
+}
+
+// DefaultWorkloadPriorityClassExist returns true if a WorkloadPriorityClass
+// named "default" exists in the cluster.
+func DefaultWorkloadPriorityClassExist(ctx context.Context, c client.Client) (bool, error) {
+	wpc := &kueue.WorkloadPriorityClass{}
+	if err := c.Get(ctx, types.NamespacedName{Name: controllerconstants.DefaultWorkloadPriorityClassName}, wpc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }

--- a/pkg/util/priority/priority_test.go
+++ b/pkg/util/priority/priority_test.go
@@ -217,6 +217,62 @@ func TestGetPriorityFromWorkloadPriorityClass(t *testing.T) {
 	}
 }
 
+func TestDefaultWorkloadPriorityClassExist(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := kueue.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed adding kueue scheme: %v", err)
+	}
+
+	tests := map[string]struct {
+		workloadPriorityClassList *kueue.WorkloadPriorityClassList
+		wantExist                 bool
+	}{
+		"default workloadPriorityClass exists": {
+			workloadPriorityClassList: &kueue.WorkloadPriorityClassList{
+				Items: []kueue.WorkloadPriorityClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "default"},
+						Value:      100,
+					},
+				},
+			},
+			wantExist: true,
+		},
+		"default workloadPriorityClass does not exist": {
+			workloadPriorityClassList: &kueue.WorkloadPriorityClassList{
+				Items: []kueue.WorkloadPriorityClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "other"},
+						Value:      50,
+					},
+				},
+			},
+			wantExist: false,
+		},
+		"no workloadPriorityClasses exist": {
+			workloadPriorityClassList: &kueue.WorkloadPriorityClassList{},
+			wantExist:                 false,
+		},
+	}
+
+	for desc, tt := range tests {
+		t.Run(desc, func(t *testing.T) {
+			t.Parallel()
+
+			builder := fake.NewClientBuilder().WithScheme(scheme).WithLists(tt.workloadPriorityClassList)
+			client := builder.Build()
+			ctx, _ := utiltesting.ContextWithLog(t)
+			exist, err := DefaultWorkloadPriorityClassExist(ctx, client)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if exist != tt.wantExist {
+				t.Errorf("unexpected result: got: %v, expected: %v", exist, tt.wantExist)
+			}
+		})
+	}
+}
+
 func TestPriorityBoost(t *testing.T) {
 	tests := map[string]struct {
 		workload     *kueue.Workload

--- a/site/content/en/docs/concepts/workload_priority_class.md
+++ b/site/content/en/docs/concepts/workload_priority_class.md
@@ -120,4 +120,5 @@ after the `QuotaReserved` condition is `True`.
 
 - Learn how to [run jobs](/docs/tasks/run/jobs)
 - Learn how to [run jobs with workload priority](/docs/tasks/manage/run_job_with_workload_priority)
+- Learn how to [setup a default WorkloadPriorityClass](/docs/tasks/manage/enforce_job_management/setup_default_workload_priority_class)
 - Read the [API reference](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-WorkloadPriorityClass) for `WorkloadPriorityClass`

--- a/site/content/en/docs/tasks/manage/enforce_job_management/setup_default_workload_priority_class.md
+++ b/site/content/en/docs/tasks/manage/enforce_job_management/setup_default_workload_priority_class.md
@@ -1,0 +1,37 @@
+---
+title: "Setup default WorkloadPriorityClass"
+date: 2026-04-27
+weight: 11
+description: >
+  Setup a default WorkloadPriorityClass to assign a queueing priority to jobs that don't specify one.
+---
+
+{{< feature-state state="alpha" for_version="v0.18" >}}
+
+This page describes how to setup a default WorkloadPriorityClass to ensure that all Kueue-managed workloads receive a consistent queueing priority,
+even if the `kueue.x-k8s.io/priority-class` label is not specified explicitly.
+
+## Setup default WorkloadPriorityClass
+
+WorkloadPriorityClassDefaulting is a feature that allows the use of a WorkloadPriorityClass with name `default` as the default WorkloadPriorityClass
+for workloads that do not have the `kueue.x-k8s.io/priority-class` label.
+
+To use this feature:
+
+- enable the `WorkloadPriorityClassDefaulting` feature gate in the Kueue configuration.
+  Check the [Installation](/docs/installation/#change-the-feature-gates-configuration) guide for details on feature gate configuration.
+
+- create a WorkloadPriorityClass with the name `default`:
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  name: default
+value: 1000
+description: "Default workload priority"
+```
+
+That's all! Now, to test the feature, create a Job without the `kueue.x-k8s.io/priority-class` label. Observe that the Job is updated with the `kueue.x-k8s.io/priority-class: default` label.
+
+Note that jobs that already have the `kueue.x-k8s.io/priority-class` label won't be modified.

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -481,6 +481,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.18"
+- name: WorkloadPriorityClassDefaulting
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.18"
 - name: WorkloadRequestUseMergePatch
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -481,6 +481,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.18"
+- name: WorkloadPriorityClassDefaulting
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.18"
 - name: WorkloadRequestUseMergePatch
   versionedSpecs:
   - default: false

--- a/test/e2e/sequential/baseline/workloadpriorityclassdefaulting_test.go
+++ b/test/e2e/sequential/baseline/workloadpriorityclassdefaulting_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package baseline
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	config "sigs.k8s.io/kueue/apis/config/v1beta2"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
+	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("WorkloadPriorityClassDefaulting", ginkgo.Label("feature:workloadpriorityclassdefaulting"), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+	var (
+		ns         *corev1.Namespace
+		rf         *kueue.ResourceFlavor
+		cq         *kueue.ClusterQueue
+		lq         *kueue.LocalQueue
+		defaultWPC *kueue.WorkloadPriorityClass
+	)
+
+	ginkgo.BeforeAll(func() {
+		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
+			cfg.FeatureGates = map[string]bool{string(features.WorkloadPriorityClassDefaulting): true}
+		})
+
+		rf = utiltestingapi.MakeResourceFlavor("default").Obj()
+		util.MustCreate(ctx, k8sClient, rf)
+
+		cq = utiltestingapi.MakeClusterQueue("cluster-queue").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(rf.Name).Resource(corev1.ResourceCPU, "5").Obj()).
+			Obj()
+		util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+	})
+
+	ginkgo.AfterAll(func() {
+		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, cq, true, util.MediumTimeout)
+		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, rf, true, util.MediumTimeout)
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "wpc-defaulting-")
+		lq = utiltestingapi.MakeLocalQueue("main", ns.Name).ClusterQueue("cluster-queue").Obj()
+		util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+
+		defaultWPC = utiltestingapi.MakeWorkloadPriorityClass(controllerconstants.DefaultWorkloadPriorityClassName).PriorityValue(100).Obj()
+		util.MustCreate(ctx, k8sClient, defaultWPC)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, defaultWPC, true, util.MediumTimeout)
+		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
+	})
+
+	ginkgo.It("should default the WorkloadPriorityClass and admit a job with the defaulted priority", func() {
+		var job *batchv1.Job
+
+		ginkgo.By("creating a job without a WorkloadPriorityClass label", func() {
+			job = testingjob.MakeJob("job-no-wpc", ns.Name).
+				Queue("main").
+				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+				RequestAndLimit(corev1.ResourceCPU, "100m").
+				Obj()
+			util.MustCreate(ctx, k8sClient, job)
+		})
+
+		ginkgo.By("verifying the default WorkloadPriorityClass label was set on the job", func() {
+			createdJob := &batchv1.Job{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: ns.Name}, createdJob)).Should(gomega.Succeed())
+				g.Expect(createdJob.Labels).Should(gomega.HaveKeyWithValue(
+					controllerconstants.WorkloadPriorityClassLabel,
+					controllerconstants.DefaultWorkloadPriorityClassName,
+				))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("verifying the workload has the default WorkloadPriorityClass priority", func() {
+			wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: ns.Name}
+			util.ExpectWorkloadsWithWorkloadPriority(ctx, k8sClient, controllerconstants.DefaultWorkloadPriorityClassName, 100, wlLookupKey)
+		})
+
+		ginkgo.By("verifying the workload is admitted and the job completes", func() {
+			wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: ns.Name}
+			createdWorkload := &kueue.Workload{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+				g.Expect(createdWorkload.Status.Admission).ShouldNot(gomega.BeNil())
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.MediumTimeout)
+		})
+	})
+
+	ginkgo.It("should not override an existing WorkloadPriorityClass label", func() {
+		highWPC := utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(1000).Obj()
+		util.MustCreate(ctx, k8sClient, highWPC)
+		ginkgo.DeferCleanup(func() {
+			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, highWPC, true, util.MediumTimeout)
+		})
+
+		var job *batchv1.Job
+
+		ginkgo.By("creating a job with an explicit WorkloadPriorityClass label", func() {
+			job = testingjob.MakeJob("job-with-wpc", ns.Name).
+				Queue("main").
+				WorkloadPriorityClass("high").
+				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+				RequestAndLimit(corev1.ResourceCPU, "100m").
+				Obj()
+			util.MustCreate(ctx, k8sClient, job)
+		})
+
+		ginkgo.By("verifying the existing WorkloadPriorityClass label is preserved", func() {
+			createdJob := &batchv1.Job{}
+			gomega.Consistently(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: ns.Name}, createdJob)).Should(gomega.Succeed())
+				g.Expect(createdJob.Labels).Should(gomega.HaveKeyWithValue(
+					controllerconstants.WorkloadPriorityClassLabel, "high",
+				))
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("verifying the workload has the explicit WorkloadPriorityClass priority", func() {
+			wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: ns.Name}
+			util.ExpectWorkloadsWithWorkloadPriority(ctx, k8sClient, "high", 1000, wlLookupKey)
+		})
+	})
+})

--- a/test/integration/singlecluster/webhook/jobs/job_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/job_webhook_test.go
@@ -25,11 +25,14 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/utils/ptr"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 	"sigs.k8s.io/kueue/test/util"
 )
@@ -215,5 +218,97 @@ var _ = ginkgo.Describe("Job Webhook with manageJobsWithoutQueueName disabled", 
 		updatedJob.Spec.Parallelism = ptr.To[int32](6)
 		delete(updatedJob.Annotations, job.StoppingAnnotation)
 		gomega.Expect(k8sClient.Update(ctx, updatedJob)).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("Should not set the default WorkloadPriorityClass label when the feature gate is disabled", func() {
+		defaultWPC := utiltestingapi.MakeWorkloadPriorityClass(constants.DefaultWorkloadPriorityClassName).PriorityValue(100).Obj()
+		util.MustCreate(ctx, k8sClient, defaultWPC)
+		ginkgo.DeferCleanup(func() {
+			gomega.Expect(k8sClient.Delete(ctx, defaultWPC)).To(gomega.Succeed())
+		})
+
+		j := testingjob.MakeJob("job-without-wpc-gate-off", ns.Name).Queue("test-queue").Obj()
+		util.MustCreate(ctx, k8sClient, j)
+
+		lookupKey := types.NamespacedName{Name: j.Name, Namespace: j.Namespace}
+		createdJob := &batchv1.Job{}
+		gomega.Consistently(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+			g.Expect(createdJob.Labels).ShouldNot(gomega.HaveKey(constants.WorkloadPriorityClassLabel))
+		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+	})
+})
+
+var _ = ginkgo.Describe("Job Webhook with WorkloadPriorityClassDefaulting enabled", ginkgo.Ordered, func() {
+	var ns *corev1.Namespace
+	var defaultWPC *kueue.WorkloadPriorityClass
+
+	ginkgo.BeforeAll(func() {
+		fwk.StartManager(ctx, cfg, managerSetup(job.SetupWebhook))
+	})
+	ginkgo.BeforeEach(func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.WorkloadPriorityClassDefaulting, true)
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "wpc-defaulting-")
+		defaultWPC = utiltestingapi.MakeWorkloadPriorityClass(constants.DefaultWorkloadPriorityClassName).PriorityValue(100).Obj()
+		util.MustCreate(ctx, k8sClient, defaultWPC)
+	})
+	ginkgo.AfterEach(func() {
+		gomega.Expect(k8sClient.Delete(ctx, defaultWPC)).To(gomega.Succeed())
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+	})
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.It("Should set the default WorkloadPriorityClass label when the default WPC exists", func() {
+		j := testingjob.MakeJob("job-without-wpc", ns.Name).Queue("test-queue").Obj()
+		util.MustCreate(ctx, k8sClient, j)
+
+		lookupKey := types.NamespacedName{Name: j.Name, Namespace: j.Namespace}
+		createdJob := &batchv1.Job{}
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+			g.Expect(createdJob.Labels).Should(gomega.HaveKeyWithValue(
+				constants.WorkloadPriorityClassLabel,
+				constants.DefaultWorkloadPriorityClassName,
+			))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("Should not override an existing WorkloadPriorityClass label", func() {
+		highWPC := utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(1000).Obj()
+		util.MustCreate(ctx, k8sClient, highWPC)
+		ginkgo.DeferCleanup(func() {
+			gomega.Expect(k8sClient.Delete(ctx, highWPC)).To(gomega.Succeed())
+		})
+
+		j := testingjob.MakeJob("job-with-wpc", ns.Name).Queue("test-queue").WorkloadPriorityClass("high").Obj()
+		util.MustCreate(ctx, k8sClient, j)
+
+		lookupKey := types.NamespacedName{Name: j.Name, Namespace: j.Namespace}
+		createdJob := &batchv1.Job{}
+		gomega.Consistently(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+			g.Expect(createdJob.Labels).Should(gomega.HaveKeyWithValue(
+				constants.WorkloadPriorityClassLabel, "high",
+			))
+		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("Should not set the label when the default WPC does not exist", func() {
+		gomega.Expect(k8sClient.Delete(ctx, defaultWPC)).To(gomega.Succeed())
+
+		j := testingjob.MakeJob("job-no-default-wpc", ns.Name).Queue("test-queue").Obj()
+		util.MustCreate(ctx, k8sClient, j)
+
+		lookupKey := types.NamespacedName{Name: j.Name, Namespace: j.Namespace}
+		createdJob := &batchv1.Job{}
+		gomega.Consistently(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+			g.Expect(createdJob.Labels).ShouldNot(gomega.HaveKey(constants.WorkloadPriorityClassLabel))
+		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+
+		defaultWPC = utiltestingapi.MakeWorkloadPriorityClass(constants.DefaultWorkloadPriorityClassName).PriorityValue(100).Obj()
+		util.MustCreate(ctx, k8sClient, defaultWPC)
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Implement WorkloadPriorityClass defaulting ([KEP-10765](https://github.com/kubernetes-sigs/kueue/pull/10796))

#### Which issue(s) this PR fixes:

Fixes #10765 

#### Does this PR introduce a user-facing change?

```release-note
Add `WorkloadPriorityClassDefaulting` feature-gate to set a default WorkloadPriorityClass on Jobs if WorkloadPriorityClassLabel is not set and the `default` WorkloadPriorityClass exists
```