### PR TITLE
Add E2E regression tests for HA follower cache stale ghost workload bug

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -132,7 +132,7 @@ test-multikueue-integration: compile-crd-manifests envtest ginkgo dep-crds ginkg
 	$(BIN_DIR)/ginkgo-top -i $(ARTIFACTS)/multikueue-integration.json > $(ARTIFACTS)/multikueue-integration-top.yaml
 
 ## Label Taxonomy:
-##   Features: appwrapper,certs,deployment,job,fairsharing,jaxjob,jobset,kuberay,kueuectl,leaderworkerset,metrics,pod,pytorchjob,statefulset,tas,trainjob,visibility,e2e_v1beta1
+##   Features: appwrapper,certs,deployment,job,fairsharing,jaxjob,jobset,kuberay,kueuectl,leaderworkerset,metrics,pod,pytorchjob,statefulset,tas,trainjob,visibility,e2e_v1beta1,ha
 ##
 ## Examples:
 ##   Run only AppWrapper tests: GINKGO_ARGS="--label-filter=feature:appwrapper" make test-e2e

--- a/site/content/en/docs/contribution_guidelines/testing.md
+++ b/site/content/en/docs/contribution_guidelines/testing.md
@@ -241,7 +241,7 @@ INTEGRATION_FILTERS="--label-filter=feature:fairsharing" make test-integration
 SingleCluster tests are labeled by feature and area. You can use `GINKGO_ARGS` with `--label-filter` to run specific tests:
 
 **Label Taxonomy:**
-- Features: `appwrapper,certs,deployment,job,fairsharing,jaxjob,jobset,kuberay,kueuectl,leaderworkerset,metrics,pod,pytorchjob,statefulset,tas,trainjob,visibility,e2e_v1beta1`
+- Features: `appwrapper,certs,deployment,job,fairsharing,jaxjob,jobset,kuberay,kueuectl,leaderworkerset,metrics,pod,pytorchjob,statefulset,tas,trainjob,visibility,e2e_v1beta1,ha`
 
 **Examples:**
 ```shell

--- a/test/e2e/sequential/baseline/ha_failover_test.go
+++ b/test/e2e/sequential/baseline/ha_failover_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package baseline
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("HA Failover", ginkgo.Label("feature:ha"), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+	var (
+		ns *corev1.Namespace
+		rf *kueue.ResourceFlavor
+		cq *kueue.ClusterQueue
+		lq *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeAll(func() {
+		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "ha-failover-")
+
+		rf = utiltestingapi.MakeResourceFlavor("rf").Obj()
+		util.MustCreate(ctx, k8sClient, rf)
+
+		cq = utiltestingapi.MakeClusterQueue("cq").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas(rf.Name).
+					Resource(corev1.ResourceCPU, "1").
+					Obj(),
+			).
+			Preemption(kueue.ClusterQueuePreemption{
+				WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
+			}).
+			Obj()
+		util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+		lq = utiltestingapi.MakeLocalQueue("lq", ns.Name).ClusterQueue(cq.Name).Obj()
+		util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, lq, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, rf, true)
+		util.WaitForKueueAvailabilityNoRestartCountCheck(ctx, k8sClient)
+	})
+
+	ginkgo.It("should admit a workload after leader failover when a previously admitted workload was deleted", func() {
+		ginkgo.By("admitting workload-a so it enters both leader and follower caches")
+		wl1 := utiltestingapi.MakeWorkload("workload-1", ns.Name).
+			Queue(kueue.LocalQueueName(lq.Name)).
+			Request(corev1.ResourceCPU, "1").
+			Obj()
+		util.MustCreate(ctx, k8sClient, wl1)
+		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+
+		ginkgo.By("deleting workload-1")
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, wl1, true)
+
+		ginkgo.By("forcing a leader failover so the former follower becomes the new leader")
+		util.ForceLeaderFailover(ctx, k8sClient)
+
+		ginkgo.By("creating workload-2 and expecting the new leader to admit it")
+		wl2 := utiltestingapi.MakeWorkload("workload-2", ns.Name).
+			Queue(kueue.LocalQueueName(lq.Name)).
+			Request(corev1.ResourceCPU, "1").
+			Obj()
+		util.MustCreate(ctx, k8sClient, wl2)
+		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+	})
+
+	ginkgo.It("should admit a high-priority workload after lower-priority workload-1 removal and leader failover with preemption of existing lower-priority workload-2", func() {
+		ginkgo.By("admitting low priority wl1 and wl2 so they enter both leader and follower caches")
+		wl1 := utiltestingapi.MakeWorkload("workload-1", ns.Name).
+			Queue(kueue.LocalQueueName(lq.Name)).
+			Request(corev1.ResourceCPU, "500m").
+			Priority(100).
+			Obj()
+		util.MustCreate(ctx, k8sClient, wl1)
+		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+
+		wl2 := utiltestingapi.MakeWorkload("workload-2", ns.Name).
+			Queue(kueue.LocalQueueName(lq.Name)).
+			Request(corev1.ResourceCPU, "500m").
+			Priority(100).
+			Obj()
+		util.MustCreate(ctx, k8sClient, wl2)
+		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+
+		ginkgo.By("deleting workload-1")
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, wl1, true)
+
+		ginkgo.By("forcing a leader failover so the former follower becomes the new leader")
+		util.ForceLeaderFailover(ctx, k8sClient)
+
+		ginkgo.By("creating workload-3")
+		wl3 := utiltestingapi.MakeWorkload("workload-3", ns.Name).
+			Queue(kueue.LocalQueueName(lq.Name)).
+			Request(corev1.ResourceCPU, "1").
+			Priority(200).
+			Obj()
+		util.MustCreate(ctx, k8sClient, wl3)
+
+		ginkgo.By("expecting wl2 to be preempted")
+		util.ExpectWorkloadsToBePreempted(ctx, k8sClient, wl2)
+		util.FinishEvictionForWorkloads(ctx, k8sClient, wl2)
+
+		ginkgo.By("expecting wl3 to be admitted")
+		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl3)
+	})
+})

--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -529,6 +529,33 @@ func waitForKueueAvailability(ctx context.Context, k8sClient client.Client, chec
 	waitForLeaderElection(ctx, k8sClient)
 }
 
+// ForceLeaderFailover deletes the current leader pod
+// and waits for a new replica to acquire the leader lease
+func ForceLeaderFailover(ctx context.Context, k8sClient client.Client) {
+	ginkgo.GinkgoHelper()
+	kueueNS := GetKueueNamespace()
+	leaseKey := types.NamespacedName{Namespace: kueueNS, Name: configapi.DefaultLeaderElectionID}
+
+	lease := &coordinationv1.Lease{}
+	gomega.Expect(k8sClient.Get(ctx, leaseKey, lease)).To(gomega.Succeed())
+
+	holderIdentity := ptr.Deref(lease.Spec.HolderIdentity, "")
+	gomega.Expect(holderIdentity).NotTo(gomega.BeEmpty(), "expected a current leader to be elected")
+	leaderPodName := strings.SplitN(holderIdentity, "_", 2)[0]
+
+	ginkgo.By(fmt.Sprintf("Deleting leader pod %q to force failover", leaderPodName))
+	leaderPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: kueueNS, Name: leaderPodName}}
+	gomega.Expect(k8sClient.Delete(ctx, leaderPod)).To(gomega.Succeed())
+
+	ginkgo.By("Waiting for a new leader to be elected")
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(k8sClient.Get(ctx, leaseKey, lease)).To(gomega.Succeed())
+		newHolder := ptr.Deref(lease.Spec.HolderIdentity, "")
+		g.Expect(newHolder).NotTo(gomega.BeEmpty())
+		g.Expect(newHolder).NotTo(gomega.Equal(holderIdentity))
+	}, LongTimeout, Interval).Should(gomega.Succeed())
+}
+
 // waitForLeaderElection waits for the kueue controller to acquire the leader lease
 func waitForLeaderElection(ctx context.Context, k8sClient client.Client) {
 	ginkgo.GinkgoHelper()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10529

#### Special notes for your reviewer:

I reverted https://github.com/kubernetes-sigs/kueue/pull/10518 to break the newly added test, to see if the test catches regression that it suppose to catch 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
