### PR TITLE
KEP-9992: TAS priority-aware non-TAS pod capacity

### DIFF
--- a/keps/9992-tas-priority-aware-capacity/README.md
+++ b/keps/9992-tas-priority-aware-capacity/README.md
@@ -1,0 +1,201 @@
+# KEP-9992: TAS Priority-Aware Non-TAS Pod Capacity
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+  - [Notes/Constraints/Caveats](#notesconstraintscaveats)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Configuration API](#configuration-api)
+  - [Behavior](#behavior)
+  - [Test Plan](#test-plan)
+  - [Graduation Criteria](#graduation-criteria)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+  - [Feature Gate with Hardcoded Negative Priority](#feature-gate-with-hardcoded-negative-priority)
+  - [Per-ClusterQueue Priority Threshold](#per-clusterqueue-priority-threshold)
+  - [Full kube-scheduler preemptionPolicy Awareness](#full-kube-scheduler-preemptionpolicy-awareness)
+<!-- /toc -->
+
+## Summary
+
+When TAS computes available capacity on a node, it subtracts the resource
+usage of all non-TAS pods regardless of their Kubernetes pod priority. This
+means low-priority pods that kube-scheduler would preempt for a higher-priority workload are still
+counted as unavailable. TAS then rejects admission even though the
+workload would successfully schedule with preemption.
+
+This KEP introduces a configurable priority threshold in the Kueue
+`Configuration` API. When set, non-TAS pods with priority strictly below
+the threshold are excluded from TAS capacity calculations, allowing
+admission decisions to account for capacity available via kube-scheduler preemption.
+
+## Motivation
+
+It is difficult to run TAS workloads alongside non-trivial amounts of preemptable work.
+
+Known cases:
+
+- **CoreWeave HPC verification pods** (priority -1) on GPU nodes
+  ([#9992](https://github.com/kubernetes-sigs/kueue/issues/9992))
+
+### Goals
+
+- Allow TAS to exclude low-priority non-TAS pods from capacity
+  calculations via a configurable priority threshold.
+
+- Preserve existing behavior when the threshold is not configured. 
+
+### Non-Goals
+
+- Per-ClusterQueue or per-ResourceFlavor priority thresholds.
+- Awareness of the incoming workload's `preemptionPolicy`.
+- Kueue-driven preemption of non-TAS pods. Actual preemption remains the responsibility of kube-scheduler.
+
+## Proposal
+
+Add a `topologyAwareScheduling` section to the Kueue `Configuration`
+API with a `nonTASPodsPriorityThreshold` field. When the
+`TASPriorityAwareNonTASUsage` feature gate is enabled and the threshold is set, non-TAS pods whose `pod.Spec.Priority` is strictly less than
+the configured value are excluded from TAS capacity calculations.
+
+### User Stories
+
+**CoreWeave HPC verification.** CoreWeave runs HPC verification pods
+at priority -1. With `nonTASPodsPriorityThreshold: 0`, TAS excludes
+these pods. Any workload at priority >= 0 sees full node capacity.
+
+**DaemonSet health checks on GPU nodes.** GPU health check DaemonSets
+running at very low priority with the expectation of being preempted.
+Without this feature, TAS sees insufficient memory on every node and
+blocks admission for workloads that would fit after preemption.
+
+### Notes/Constraints/Caveats
+
+- The threshold uses strict less-than: pods with `priority < threshold`
+  are excluded, pods with `priority >= threshold` are always counted.
+- If the threshold is nil (default), all non-TAS pods are counted,
+  preserving current behavior.
+- This feature does not guarantee kube-scheduler will actually preempt
+  the excluded pods. If the incoming workload has
+  `preemptionPolicy: Never` or lower priority than the excluded pods,
+  the workload may be admitted but fail to schedule. This is a known
+  limitation addressed in [Alternatives](#alternatives).
+
+### Risks and Mitigations
+
+**Risk: Misalignment between TAS threshold and TAS workload**
+The workload could either have `preemptionPolicy: Never` or have a Priority value less than the threshold AND the workloads we are ignoring.
+This would lead to the workload being admitted and then failing to schedule
+
+*Mitigation:* Kueue's `waitForPodsReady` detects workloads whose pods
+do not reach Ready within the configured timeout, evicts them, and
+requeues with exponential backoff.
+
+## Design Details
+
+### Configuration API
+
+Add to the Kueue `Configuration` type:
+
+```go
+type Configuration struct {
+    // ...existing fields...
+
+    // TopologyAwareScheduling holds configuration for TAS behavior.
+    // +optional
+    TopologyAwareScheduling *TopologyAwareScheduling `json:"topologyAwareScheduling,omitempty"`
+}
+
+type TopologyAwareScheduling struct {
+    // NonTASPodsPriorityThreshold, when set, excludes non-TAS pods with
+    // pod.Spec.Priority strictly less than this value from TAS capacity
+    // calculations. This allows TAS to account for capacity that would be
+    // reclaimed by kube-scheduler preemption.
+    //
+    // For example, setting this to 0 excludes only negative-priority pods.
+    // Setting this to 1000 excludes pods with priority < 1000.
+    //
+    // When nil (default), all non-TAS pods are counted toward capacity,
+    // preserving existing behavior.
+    // +optional
+    NonTASPodsPriorityThreshold *int32 `json:"nonTASPodsPriorityThreshold,omitempty"`
+}
+```
+
+Example configuration:
+
+```yaml
+apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+topologyAwareScheduling:
+  nonTASPodsPriorityThreshold: 1000
+```
+
+### Behavior
+
+When the feature is enabled and the Priority threshold is configured, pods under the threshold are not counted in the non-TAS usage data, allowing TAS pods to be admitted.
+
+### Test Plan
+
+[x] I/we understand the owners of the involved components may require
+updates to existing tests to make this code solid enough prior to
+committing the changes necessary to implement this enhancement.
+
+- Pods below threshold are excluded from capacity calculations.
+- Pods at or above threshold are included.
+- Enabled flag + Nil threshold preserves existing behavior (all pods counted).
+- Disabled flag preserves existing behavior (all pods counted).
+- TAS admits a workload when low-priority non-TAS pods (below
+  threshold) occupy capacity on all candidate nodes.
+- TAS rejects a workload when non-TAS pods at or above the threshold
+  occupy capacity.
+
+### Graduation Criteria
+
+**Alpha (v0.18):**
+- Feature gate `TASPriorityAwareNonTASUsage` disabled by default.
+- Configuration API field added.
+- Unit and integration tests passing.
+- Documentation updated.
+
+**Beta:**
+- Feature gate enabled by default (nil threshold preserves existing behavior).
+- No significant bugs reported during alpha.
+
+**GA:**
+- Feature gate locked to enabled.
+- At least two releases at beta with no issues.
+
+## Implementation History
+
+- 2026-04-28: KEP created based on discussion in
+  [#9992](https://github.com/kubernetes-sigs/kueue/issues/9992).
+- Prior work: [Changes by @Huang-Wei](https://github.com/Huang-Wei/kueue/commit/bb27afed0383f3db21c406ff07fd0fe631e6eba6)
+  based on v0.16.2 demonstrating this approach.
+
+## Drawbacks
+
+- A global threshold is very blunt. All TAS-enabled
+  ClusterQueues see the same filtered capacity, even queues whose
+  workloads cannot actually preempt the excluded pods.
+- Kueue users must reason about the interaction between the
+  threshold and their PriorityClass hierarchy. Misconfiguration can
+  lead to workloads being admitted but failing to schedule.
+
+## Alternatives
+
+### Full kube-scheduler preemptionPolicy Awareness
+
+Rather than a configured threshold, TAS would check the incoming
+workload's `preemptionPolicy` and `priority` from its PodTemplate and
+dynamically exclude non-TAS pods that would be preempted. This is the
+cleaner than the current approach as it mirrors what kube-scheduler would actually
+do, but is much more complicated. 
+
+This would also allow for much more nuanced deployments than our one-size-fits-all threshold. 

--- a/keps/9992-tas-priority-aware-capacity/kep.yaml
+++ b/keps/9992-tas-priority-aware-capacity/kep.yaml
@@ -1,0 +1,25 @@
+title: TAS Priority-Aware Non-TAS Pod Capacity
+kep-number: 9992
+authors:
+  - "@islewis"
+  - "@Huang-Wei"
+status: provisional
+creation-date: 2026-04-28
+reviewers:
+  - "@mimowo"
+approvers:
+  - TBD
+
+see-also:
+  - "https://github.com/kubernetes-sigs/kueue/issues/9992"
+
+stage: alpha
+
+latest-milestone: "v0.18"
+
+milestone:
+  alpha: "v0.18"
+
+feature-gates:
+  - name: TASPriorityAwareNonTASUsage
+disable-supported: true


### PR DESCRIPTION
Adds a KEP proposing a configurable priority threshold for TAS capacity calculations. Non-TAS pods below the threshold are excluded from capacity accounting, allowing TAS to admit workloads that would schedule after kube-scheduler preemption.

  Ref: https://github.com/kubernetes-sigs/kueue/issues/9992

  <!--  Thanks for sending a pull request!  Here are some tips for you:

  1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
  2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
  3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
  4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
  5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
  -->

  #### What type of PR is this?

  <!--
  Add one of the following kinds:
  /kind bug
  /kind cleanup
  /kind documentation
  /kind feature
  /kind kep

  Optionally add one or more of the following kinds if applicable:
  /kind api-change
  /kind deprecation
  /kind failing-test
  /kind flake
  /kind regression

  Please also consider setting the area:
  /area tas
  /area integrations
  /area multikueue
  /area dashboard
  /area localization
  /area testing
  /area website
  -->

  /kind kep
  /area tas

  #### What this PR does / why we need it:

  TAS currently subtracts all non-TAS pod usage from node allocatable when computing capacity, regardless of pod priority. This blocks admission of high-priority workloads when low-priority pods (health checks, placeholders, verification jobs) occupy resources that kube-scheduler would preempt.

  This KEP proposes adding a `nonTASPodsPriorityThreshold` field to the Kueue Configuration API, gated behind a `TASPriorityAwareNonTASUsage` feature gate. Non-TAS pods with priority below the threshold are excluded from capacity calculations.

  #### Which issue(s) this PR fixes:
  <!--
  *Automatically closes linked issue when PR is merged.
  Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
  _If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
  -->
  Ref #9992

  #### Special notes for your reviewer:

  This KEP follows from the design discussion in #9992. The global threshold is proposed as a first step, with full `preemptionPolicy` awareness discussed as a future direction. 

  #### Does this PR introduce a user-facing change?
  <!--
  If no, just write "NONE" in the release-note block below.
  If yes, a release note is required:
  Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
  -->
  ```release-note
  NONE
