### PR TITLE
[WIP] Fix TAS capacity gap for terminating pods

### DIFF
--- a/pkg/controller/tas/non_tas_usage_controller.go
+++ b/pkg/controller/tas/non_tas_usage_controller.go
@@ -84,7 +84,24 @@ func belongsToNonTASCache(pod *corev1.Pod) bool {
 	if pod == nil {
 		return false
 	}
-	if utiltas.IsTAS(pod) {
+	// Terminating TAS pods (DeletionTimestamp set, not yet terminal) must be
+	// included here to prevent overcommit: once a Workload's tasUsage is
+	// removed the pod still consumes node resources until it reaches a
+	// terminal phase. Without this, terminating TAS pods are invisible to
+	// both accounting systems (tasUsage already released, nonTasUsageCache
+	// previously excluded them).
+	//
+	// This may temporarily double-count resources when the Workload has not
+	// yet been marked Finished (tasUsage still present). This is the safe
+	// direction: under-admission is preferable to over-admission for
+	// expensive resources like GPUs. The overlap window is bounded by the
+	// time between DeletionTimestamp being set and the Workload entering
+	// Finished state.
+	//
+	// TODO(KEP-6143): when quotaReleaseStrategy is OnTerminal, TAS pods
+	// should remain tracked exclusively via tasUsage for their full
+	// lifecycle, eliminating both the gap and the overlap.
+	if utiltas.IsTAS(pod) && pod.DeletionTimestamp.IsZero() {
 		return false
 	}
 	if len(pod.Spec.NodeName) == 0 {

--- a/pkg/controller/tas/non_tas_usage_controller_test.go
+++ b/pkg/controller/tas/non_tas_usage_controller_test.go
@@ -56,6 +56,36 @@ func TestBelongsToNonTASCache(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "terminating TAS pod",
+			pod: testingpod.MakePod("pod", "ns").
+				NodeName("node-a").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, "rack").
+				StatusPhase(corev1.PodRunning).
+				Delete().
+				Obj(),
+			want: true,
+		},
+		{
+			name: "terminating TAS pod with unconstrained topology",
+			pod: testingpod.MakePod("pod", "ns").
+				NodeName("node-a").
+				Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "").
+				StatusPhase(corev1.PodRunning).
+				Delete().
+				Obj(),
+			want: true,
+		},
+		{
+			name: "terminated TAS pod",
+			pod: testingpod.MakePod("pod", "ns").
+				NodeName("node-a").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, "rack").
+				StatusPhase(corev1.PodSucceeded).
+				Delete().
+				Obj(),
+			want: false,
+		},
+		{
 			name: "scheduled succeeded non-TAS pod",
 			pod:  testingpod.MakePod("pod", "ns").NodeName("node-a").StatusPhase(corev1.PodSucceeded).Obj(),
 			want: false,
@@ -101,6 +131,16 @@ func TestNonTasUsageReconcilerCreateDelete(t *testing.T) {
 				Annotation(kueue.PodSetRequiredTopologyAnnotation, "rack").
 				Obj(),
 			want: false,
+		},
+		{
+			name: "terminating TAS pod",
+			pod: testingpod.MakePod("pod", "ns").
+				NodeName("node-a").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, "rack").
+				StatusPhase(corev1.PodRunning).
+				Delete().
+				Obj(),
+			want: true,
 		},
 		{
 			name: "terminated scheduled non-TAS pod",
@@ -191,6 +231,37 @@ func TestShouldReconcilePodUpdate(t *testing.T) {
 				StatusPhase(corev1.PodRunning).
 				Obj(),
 			want: false,
+		},
+		{
+			name: "reconciles when TAS pod starts terminating",
+			oldPod: testingpod.MakePod("pod", "ns").
+				NodeName("node-a").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, "rack").
+				StatusPhase(corev1.PodRunning).
+				Obj(),
+			newPod: testingpod.MakePod("pod", "ns").
+				NodeName("node-a").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, "rack").
+				StatusPhase(corev1.PodRunning).
+				Delete().
+				Obj(),
+			want: true,
+		},
+		{
+			name: "reconciles when terminating TAS pod reaches terminal phase",
+			oldPod: testingpod.MakePod("pod", "ns").
+				NodeName("node-a").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, "rack").
+				StatusPhase(corev1.PodRunning).
+				Delete().
+				Obj(),
+			newPod: testingpod.MakePod("pod", "ns").
+				NodeName("node-a").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, "rack").
+				StatusPhase(corev1.PodSucceeded).
+				Delete().
+				Obj(),
+			want: true,
 		},
 		{
 			name:   "ignores unscheduled non-TAS update",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

TAS can release workload `tasUsage` when a Workload becomes `Finished`, while the underlying TAS pod may still be terminating and consuming node resources.

Before this change, terminating TAS pods were excluded from `nonTasUsageCache`, creating a resource-accounting gap:
1) no longer counted in `tasUsage` (workload finished path), and
2) not counted in `nonTasUsageCache` (TAS annotation filter).

This could make nodes look free and allow over-admission even though terminating pods still hold capacity.

This PR updates non-TAS cache membership so terminating TAS pods (`deletionTimestamp` set and non-terminal phase) are included in accounting, and adds unit test coverage for:
1) `belongsToNonTASCache` terminating/terminated TAS cases,
2) `Create`/`Delete` predicate behavior for terminating TAS pods,
3) update transitions when TAS pods start terminating and then reach terminal phase.

#### Which issue(s) this PR fixes:

Fixes #10076

#### Special notes for your reviewer:

This is a tactical fix to close the immediate accounting gap.  
Longer-term behavior alignment is tracked by KEP-6143 (quota release strategy).  
A TODO is included to handle `OnTerminal` strategy semantics explicitly.

#### Does this PR introduce a user-facing change?

```release-note
NONE