### PR TITLE
[TrainJob] Don't patch the TrainingRuntime with the queue label in th…

### DIFF
--- a/pkg/controller/jobs/trainjob/trainjob_webhook.go
+++ b/pkg/controller/jobs/trainjob/trainjob_webhook.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	kftrainerapi "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -29,7 +28,6 @@ import (
 
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
-	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/webhook"
@@ -90,13 +88,6 @@ func (w *TrainJobWebhook) Default(ctx context.Context, obj *kftrainerapi.TrainJo
 	}
 	if suspend {
 		trainJob.Suspend()
-		if trainJobQueueName := jobframework.QueueNameForObject(trainJob.Object()); trainJobQueueName != "" {
-			runtimePatch.TrainingRuntimeSpec.Template.Metadata = &metav1.ObjectMeta{
-				Labels: map[string]string{
-					controllerconstants.QueueLabel: string(trainJobQueueName),
-				},
-			}
-		}
 	}
 	trainJob.Spec.RuntimePatches = append(trainJob.Spec.RuntimePatches, runtimePatch)
 	return nil

--- a/pkg/controller/jobs/trainjob/trainjob_webhook_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_webhook_test.go
@@ -208,7 +208,6 @@ func TestDefault(t *testing.T) {
 			trainJob: testTrainJob.Clone().Queue(testLocalQueue.Name).Obj(),
 			wantTrainJob: testExpectedTrainJob.Clone().Queue(testLocalQueue.Name).
 				Suspend(true).
-				JobSetLabel(controllerconstants.QueueLabel, testLocalQueue.Name).
 				Obj(),
 		},
 		"should not suspend a TrainJob without a queue label if manageJobsWithoutQueueName is not enabled": {
@@ -227,7 +226,6 @@ func TestDefault(t *testing.T) {
 			wantTrainJob: testExpectedTrainJob.Clone().
 				Suspend(true).
 				Queue(string(controllerconstants.DefaultLocalQueueName)).
-				JobSetLabel(controllerconstants.QueueLabel, string(controllerconstants.DefaultLocalQueueName)).
 				Obj(),
 			withDefaultLocalQueue: true,
 		},
@@ -238,9 +236,8 @@ func TestDefault(t *testing.T) {
 		},
 		"should set managedBy to multiKueue if the user didn't specify any": {
 			trainJob: testTrainJob.Clone().Queue(testLocalQueue.Name).Obj(),
-			wantTrainJob: testTrainJob.Clone().Queue(testLocalQueue.Name).
+			wantTrainJob: testExpectedTrainJob.Clone().Queue(testLocalQueue.Name).
 				Suspend(true).
-				JobSetLabel(controllerconstants.QueueLabel, testLocalQueue.Name).
 				ManagedBy(kueue.MultiKueueControllerName).
 				Obj(),
 			featureGates:                 map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
@@ -250,7 +247,6 @@ func TestDefault(t *testing.T) {
 			trainJob: testTrainJob.Clone().Queue(testLocalQueue.Name).ManagedBy("user").Obj(),
 			wantTrainJob: testExpectedTrainJob.Clone().Queue(testLocalQueue.Name).
 				Suspend(true).
-				JobSetLabel(controllerconstants.QueueLabel, testLocalQueue.Name).
 				ManagedBy("user").
 				Obj(),
 			featureGates:                 map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
@@ -260,7 +256,6 @@ func TestDefault(t *testing.T) {
 			trainJob: testTrainJob.Clone().Queue(testLocalQueue.Name).Obj(),
 			wantTrainJob: testExpectedTrainJob.Clone().Queue(testLocalQueue.Name).
 				Suspend(true).
-				JobSetLabel(controllerconstants.QueueLabel, testLocalQueue.Name).
 				Obj(),
 			featureGates:                 map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 			withMultiKueueAdmissionCheck: false,

--- a/test/integration/singlecluster/webhook/jobs/trainjob_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/trainjob_webhook_test.go
@@ -26,7 +26,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"sigs.k8s.io/kueue/pkg/constants"
-	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	workloadtrainjob "sigs.k8s.io/kueue/pkg/controller/jobs/trainjob"
 	testingjobset "sigs.k8s.io/kueue/pkg/util/testingjobs/jobset"
@@ -84,14 +83,13 @@ var _ = ginkgo.Describe("Trainjob Webhook", func() {
 				util.MustCreate(ctx, k8sClient, trainJob)
 			})
 
-			ginkgo.By("suspending it and setting the child jobset labels", func() {
+			ginkgo.By("suspending it", func() {
 				createdTrainJob := kftrainerapi.TrainJob{}
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: trainJob.Name, Namespace: ns.Name}, &createdTrainJob)).Should(gomega.Succeed())
 					g.Expect(ptr.Deref(createdTrainJob.Spec.Suspend, false)).Should(gomega.BeTrue())
 					kueueRuntimePatch := testingtrainjob.KueueRuntimePatch(&createdTrainJob)
 					g.Expect(kueueRuntimePatch).ShouldNot(gomega.BeNil())
-					g.Expect(kueueRuntimePatch.TrainingRuntimeSpec.Template.Metadata.Labels).To(gomega.HaveKeyWithValue(controllerconstants.QueueLabel, "queue"))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area integrations

#### What this PR does / why we need it:

The trainjob mutating webhook was unnecessarily patching the TrainingRuntime with the queue label. That's not necessary anymore now that the integration is not accessing the underlying Jobset aymore

#### Which issue(s) this PR fixes:

Fixes #10099

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
