### PR TITLE
Automated cherry pick of #10797: Update SubtreeQuota post cohort deletion

### DIFF
--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -506,9 +506,17 @@ func (c *Cache) AddOrUpdateCohort(apiCohort *kueue.Cohort) error {
 	return cohort.updateCohort(apiCohort, oldParent)
 }
 
+// DeleteCohort removes the cohort from the cache and updates the SubtreeQuota
+// of ancestor cohorts to reflect the removal.
 func (c *Cache) DeleteCohort(cohortName kueue.CohortReference) {
 	c.Lock()
 	defer c.Unlock()
+
+	var parent *cohort
+	if cohort := c.hm.Cohort(cohortName); cohort != nil {
+		parent = cohort.Parent()
+	}
+
 	c.hm.DeleteCohort(cohortName)
 
 	// If the cohort still exists after deletion, it means
@@ -516,6 +524,10 @@ func (c *Cache) DeleteCohort(cohortName kueue.CohortReference) {
 	// We need to run update algorithm.
 	if cohort := c.hm.Cohort(cohortName); cohort != nil {
 		updateCohortResourceNode(cohort)
+	}
+
+	if parent != nil {
+		updateCohortTreeResourcesIfNoCycle(parent)
 	}
 }
 

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -3639,6 +3639,128 @@ func TestCohortCycles(t *testing.T) {
 	})
 }
 
+func TestDeleteCohortUpdatesAncestorSubtreeQuota(t *testing.T) {
+	mustAddCohort := func(t *testing.T, cache *Cache, cohort *kueue.Cohort) {
+		t.Helper()
+		if err := cache.AddOrUpdateCohort(cohort); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	testCases := map[string]struct {
+		setup      func(*testing.T, *Cache)
+		deleteName kueue.CohortReference
+		wantBefore map[kueue.CohortReference]resources.FlavorResourceQuantities
+		wantAfter  map[kueue.CohortReference]resources.FlavorResourceQuantities
+	}{
+		"deleting child cohort updates parent SubtreeQuota": {
+			setup: func(t *testing.T, cache *Cache) {
+				mustAddCohort(t, cache, utiltestingapi.MakeCohort("root").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj()).
+					Obj())
+				mustAddCohort(t, cache, utiltestingapi.MakeCohort("child").
+					Parent("root").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj()).
+					Obj())
+			},
+			deleteName: "child",
+			wantBefore: map[kueue.CohortReference]resources.FlavorResourceQuantities{
+				"root": {
+					{Flavor: "default", Resource: corev1.ResourceCPU}: 15_000,
+				},
+			},
+			wantAfter: map[kueue.CohortReference]resources.FlavorResourceQuantities{
+				"root": {
+					{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+				},
+			},
+		},
+		"deleting grandchild cohort updates all ancestors SubtreeQuota": {
+			setup: func(t *testing.T, cache *Cache) {
+				mustAddCohort(t, cache, utiltestingapi.MakeCohort("root").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj()).
+					Obj())
+				mustAddCohort(t, cache, utiltestingapi.MakeCohort("mid").
+					Parent("root").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj()).
+					Obj())
+				mustAddCohort(t, cache, utiltestingapi.MakeCohort("leaf").
+					Parent("mid").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "3").Obj()).
+					Obj())
+			},
+			deleteName: "leaf",
+			wantBefore: map[kueue.CohortReference]resources.FlavorResourceQuantities{
+				"mid": {
+					{Flavor: "default", Resource: corev1.ResourceCPU}: 8_000,
+				},
+				"root": {
+					{Flavor: "default", Resource: corev1.ResourceCPU}: 18_000,
+				},
+			},
+			wantAfter: map[kueue.CohortReference]resources.FlavorResourceQuantities{
+				"mid": {
+					{Flavor: "default", Resource: corev1.ResourceCPU}: 5_000,
+				},
+				"root": {
+					{Flavor: "default", Resource: corev1.ResourceCPU}: 15_000,
+				},
+			},
+		},
+		"deleting cohort with children updates parent SubtreeQuota": {
+			setup: func(t *testing.T, cache *Cache) {
+				ctx, _ := utiltesting.ContextWithLog(t)
+				mustAddCohort(t, cache, utiltestingapi.MakeCohort("root").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj()).
+					Obj())
+				mustAddCohort(t, cache, utiltestingapi.MakeCohort("mid").
+					Parent("root").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj()).
+					Obj())
+
+				if err := cache.AddClusterQueue(ctx, utiltestingapi.MakeClusterQueue("cq").
+					Cohort("mid").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "7").Obj()).
+					Obj()); err != nil {
+					t.Fatal(err)
+				}
+			},
+			deleteName: "mid",
+			wantBefore: map[kueue.CohortReference]resources.FlavorResourceQuantities{
+				"root": {
+					{Flavor: "default", Resource: corev1.ResourceCPU}: 22_000,
+				},
+			},
+			wantAfter: map[kueue.CohortReference]resources.FlavorResourceQuantities{
+				"root": {
+					{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			cache := New(utiltesting.NewFakeClient())
+			tc.setup(t, cache)
+
+			for cohortName, wantSubtreeQuota := range tc.wantBefore {
+				if diff := cmp.Diff(wantSubtreeQuota, cache.hm.Cohort(cohortName).getResourceNode().SubtreeQuota); diff != "" {
+					t.Errorf("before deletion, %s unexpected SubtreeQuota (-want,+got):\n%s", cohortName, diff)
+				}
+			}
+
+			cache.DeleteCohort(tc.deleteName)
+
+			for cohortName, wantSubtreeQuota := range tc.wantAfter {
+				if diff := cmp.Diff(wantSubtreeQuota, cache.hm.Cohort(cohortName).getResourceNode().SubtreeQuota); diff != "" {
+					t.Errorf("after deletion, %s unexpected SubtreeQuota (-want,+got):\n%s", cohortName, diff)
+				}
+			}
+		})
+	}
+}
+
 func TestClusterQueueAncestors(t *testing.T) {
 	testCases := map[string]struct {
 		cohorts       []*kueue.Cohort

--- a/pkg/util/testing/v1beta2/wrappers.go
+++ b/pkg/util/testing/v1beta2/wrappers.go
@@ -830,6 +830,12 @@ func (c *CohortWrapper) FairWeight(w resource.Quantity) *CohortWrapper {
 	return c
 }
 
+func (c *CohortWrapper) GeneratedName(name string) *CohortWrapper {
+	c.GenerateName = name
+	c.Name = ""
+	return c
+}
+
 // ClusterQueueWrapper wraps a ClusterQueue.
 type ClusterQueueWrapper struct{ kueue.ClusterQueue }
 

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"sync/atomic"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -2880,6 +2881,108 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectPendingWorkloadsMetric(cq2, 0, 1)
 			util.ExpectReservingActiveWorkloadsMetric(cq2, 0)
 			util.ExpectAdmittedWorkloadsTotalMetric(cq2, "", 0)
+		})
+	})
+	ginkgo.When("Deleting child Cohort should update borrowable resources for parent Cohort", func() {
+		var (
+			root    *kueue.Cohort
+			chLeft  *kueue.Cohort
+			chRight *kueue.Cohort
+		)
+
+		ginkgo.AfterEach(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, root, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, chLeft, true)
+		})
+
+		ginkgo.It("Should not admit from stale subtree quota after deleting sibling cohort", func() {
+			// 		    Root Cohort (quota 0)
+			//             SubtreeQuota = 22
+			//             /               \
+			//    Left Cohort (quota 0)   Right Cohort (quota 5)
+			//    Subtree = 10             Subtree = 12
+			//      |                      |
+			//     cq-a                   cq-b
+			//     nominal 10             nominal 7
+			ginkgo.By("Creating the Cohorts")
+			root = utiltestingapi.MakeCohort("").GeneratedName("root-").Obj()
+			util.MustCreate(ctx, k8sClient, root)
+
+			chLeft = utiltestingapi.MakeCohort("").
+				GeneratedName("left-").
+				Parent(kueue.CohortReference(root.GetName())).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(onDemandFlavor.Name).
+						Resource(corev1.ResourceCPU, "0").
+						Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, chLeft)
+
+			chRight = utiltestingapi.MakeCohort("").
+				GeneratedName("right-").
+				Parent(kueue.CohortReference(root.GetName())).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(onDemandFlavor.Name).
+						Resource(corev1.ResourceCPU, "5").
+						Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, chRight)
+
+			ginkgo.By("creating ClusterQueues")
+			cqA := createQueue(utiltestingapi.MakeClusterQueue("cq-a").
+				Cohort(kueue.CohortReference(chLeft.GetName())).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(onDemandFlavor.Name).
+						Resource(corev1.ResourceCPU, "10").
+						Obj(),
+				).
+				Obj())
+
+			createQueue(utiltestingapi.MakeClusterQueue("cq-b").
+				Cohort(kueue.CohortReference(chRight.GetName())).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(onDemandFlavor.Name).
+						Resource(corev1.ResourceCPU, "7").
+						Obj(),
+				).
+				Obj())
+
+			ginkgo.By("admitting baseline workload on cq-a")
+			wlBase := utiltestingapi.MakeWorkload("wl-base", ns.Name).
+				Queue(kueue.LocalQueueName(cqA.Name)).
+				Request(corev1.ResourceCPU, "10").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wlBase)
+			util.ExpectWorkloadToBeAdmittedAs(
+				ctx,
+				k8sClient,
+				wlBase,
+				utiltestingapi.MakeAdmission(cqA.Name).
+					PodSets(
+						utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(onDemandFlavor.GetName()), "10").
+							Obj(),
+					).
+					Obj(),
+			)
+
+			ginkgo.By("deleting explicit cohort right while cq-b still references it")
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, chRight, true)
+			// Wait for the cache to process the cohort deletion
+			time.Sleep(util.ConsistentDuration)
+
+			ginkgo.By("trying to admit extra workload on cq-a after deletion of cohort right")
+			// root cohort subtree quota should be properly recomputed after deletion of right cohort
+			// and should reflect the fact that cq-b is no longer borrowable
+			// admitting of the workload "wl-after-delete" should fail be pending
+			wlAfterDelete := utiltestingapi.MakeWorkload("wl-after-delete", ns.Name).
+				Queue(kueue.LocalQueueName(cqA.Name)).
+				Request(corev1.ResourceCPU, "8").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wlAfterDelete)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wlAfterDelete)
 		})
 	})
 	ginkgo.When("Workload slicing with multiple podSets", func() {


### PR DESCRIPTION
Cherry pick of #10797 on release-0.16.

#10797: Update SubtreeQuota post cohort deletion

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note
Scheduling: Fixed a bug in Kueue's cache that could leave stale SubtreeQuota values in ancestor cohorts after a child Cohort
was deleted, leading to potential over-admission of workloads and incorrect metrics reporting.
```