### PR TITLE
Forcefully delete Failed/Succeeded pods that are stuck on unreachable nodes

### DIFF
--- a/pkg/controller/failurerecovery/pod_termination_controller.go
+++ b/pkg/controller/failurerecovery/pod_termination_controller.go
@@ -41,7 +41,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	utilclient "sigs.k8s.io/kueue/pkg/util/client"
-	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	utiltaints "sigs.k8s.io/kueue/pkg/util/taints"
 )
@@ -204,21 +203,7 @@ func podEligibleForTermination(p *corev1.Pod) bool {
 		return false
 	}
 
-	if p.DeletionTimestamp.IsZero() {
-		return false
-	}
-
-	// Do not filter out partially terminated (condition set, but not deleted) pods to handle
-	// partial executions of the controller caused by errors (for example network errors).
-	return isPodPartiallyForcefullyTerminated(p) || !utilpod.IsTerminated(p)
-}
-
-func isPodPartiallyForcefullyTerminated(p *corev1.Pod) bool {
-	return utilpod.HasCondition(p, &corev1.PodCondition{
-		Type:   KueueFailureRecoveryConditionType,
-		Reason: KueueForcefulTerminationReason,
-		Status: corev1.ConditionTrue,
-	})
+	return !p.DeletionTimestamp.IsZero()
 }
 
 func (r *TerminatingPodReconciler) mapNodeToPods(ctx context.Context, node *corev1.Node) []ctrl.Request {

--- a/pkg/controller/failurerecovery/pod_termination_controller.go
+++ b/pkg/controller/failurerecovery/pod_termination_controller.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	utilclient "sigs.k8s.io/kueue/pkg/util/client"
+	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	utiltaints "sigs.k8s.io/kueue/pkg/util/taints"
 )
@@ -173,7 +174,9 @@ func (r *TerminatingPodReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	)
 
 	err := utilclient.PatchStatus(ctx, r.client, pod, func() (bool, error) {
-		pod.Status.Phase = corev1.PodFailed
+		if !utilpod.IsTerminated(pod) {
+			pod.Status.Phase = corev1.PodFailed
+		}
 		pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
 			Type:    KueueFailureRecoveryConditionType,
 			Status:  corev1.ConditionTrue,

--- a/pkg/controller/failurerecovery/pod_termination_controller_test.go
+++ b/pkg/controller/failurerecovery/pod_termination_controller_test.go
@@ -336,7 +336,7 @@ func TestReconciler(t *testing.T) {
 			wantErr:    nil,
 			wantPod: podToForcefullyDelete.
 				Clone().
-				StatusPhase(corev1.PodFailed).
+				StatusPhase(corev1.PodSucceeded).
 				StatusConditions(corev1.PodCondition{
 					Type:    KueueFailureRecoveryConditionType,
 					Status:  "True",

--- a/pkg/controller/failurerecovery/pod_termination_controller_test.go
+++ b/pkg/controller/failurerecovery/pod_termination_controller_test.go
@@ -311,8 +311,21 @@ func TestReconciler(t *testing.T) {
 			wantPod: podToForcefullyDelete.
 				Clone().
 				StatusPhase(corev1.PodFailed).
+				StatusConditions(corev1.PodCondition{
+					Type:    KueueFailureRecoveryConditionType,
+					Status:  "True",
+					Reason:  KueueForcefulTerminationReason,
+					Message: "Pod forcefully terminated after 1m0s grace period due to unreachable node `unreachable-node` (triggered by `kueue.x-k8s.io/safe-to-forcefully-delete` annotation)",
+				}).
 				Obj(),
-			wantEvents: nil,
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Namespace: "ns", Name: "pod"},
+					EventType: "Warning",
+					Reason:    KueueForcefulTerminationReason,
+					Message:   "Pod forcefully terminated after 1m0s grace period due to unreachable node `unreachable-node` (triggered by `kueue.x-k8s.io/safe-to-forcefully-delete` annotation)",
+				},
+			},
 		},
 		"pod is in succeeded phase": {
 			testPod: podToForcefullyDelete.
@@ -323,9 +336,22 @@ func TestReconciler(t *testing.T) {
 			wantErr:    nil,
 			wantPod: podToForcefullyDelete.
 				Clone().
-				StatusPhase(corev1.PodSucceeded).
+				StatusPhase(corev1.PodFailed).
+				StatusConditions(corev1.PodCondition{
+					Type:    KueueFailureRecoveryConditionType,
+					Status:  "True",
+					Reason:  KueueForcefulTerminationReason,
+					Message: "Pod forcefully terminated after 1m0s grace period due to unreachable node `unreachable-node` (triggered by `kueue.x-k8s.io/safe-to-forcefully-delete` annotation)",
+				}).
 				Obj(),
-			wantEvents: nil,
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Namespace: "ns", Name: "pod"},
+					EventType: "Warning",
+					Reason:    KueueForcefulTerminationReason,
+					Message:   "Pod forcefully terminated after 1m0s grace period due to unreachable node `unreachable-node` (triggered by `kueue.x-k8s.io/safe-to-forcefully-delete` annotation)",
+				},
+			},
 		},
 		"pod is not scheduled on an unreachable node": {
 			testPod: podToForcefullyDelete.

--- a/test/integration/singlecluster/controller/failurerecovery/pod_termination_controller_test.go
+++ b/test/integration/singlecluster/controller/failurerecovery/pod_termination_controller_test.go
@@ -221,4 +221,50 @@ var _ = ginkgo.Describe("Pod termination controller", func() {
 			g.Expect(podOnHealthyNode.Status.Phase).Should(gomega.Equal(corev1.PodPending))
 		}, forcefulTerminationCheckTimeout, util.ShortInterval).Should(gomega.Succeed())
 	})
+
+	ginkgo.It("should forcefully terminate failed pods that opt-in, scheduled on unreachable nodes", func() {
+		unreachableNode := testingnode.MakeNode("unreachable-node-failed-pod").
+			NotReady().
+			Taints(corev1.Taint{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule}).
+			Obj()
+		util.MustCreate(ctx, k8sClient, unreachableNode)
+		ginkgo.DeferCleanup(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, unreachableNode, true)
+		})
+
+		matchingPod := matchingPodWrapper.Clone().
+			NodeName(unreachableNode.Name).
+			StatusPhase(corev1.PodFailed).
+			Obj()
+		util.MustCreate(ctx, k8sClient, matchingPod)
+		gomega.Expect(k8sClient.Delete(ctx, matchingPod)).To(gomega.Succeed())
+
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: matchingPod.Name, Namespace: matchingPod.Namespace}, matchingPod)).
+				To(utiltesting.BeNotFoundError())
+		}, forcefulTerminationCheckTimeout, util.Interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("should forcefully terminate succeeded pods that opt-in, scheduled on unreachable nodes", func() {
+		unreachableNode := testingnode.MakeNode("unreachable-node-succeeded-pod").
+			NotReady().
+			Taints(corev1.Taint{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule}).
+			Obj()
+		util.MustCreate(ctx, k8sClient, unreachableNode)
+		ginkgo.DeferCleanup(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, unreachableNode, true)
+		})
+
+		matchingPod := matchingPodWrapper.Clone().
+			NodeName(unreachableNode.Name).
+			StatusPhase(corev1.PodSucceeded).
+			Obj()
+		util.MustCreate(ctx, k8sClient, matchingPod)
+		gomega.Expect(k8sClient.Delete(ctx, matchingPod)).To(gomega.Succeed())
+
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: matchingPod.Name, Namespace: matchingPod.Namespace}, matchingPod)).
+				To(utiltesting.BeNotFoundError())
+		}, forcefulTerminationCheckTimeout, util.Interval).Should(gomega.Succeed())
+	})
 })


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This handles the case where the pod is already in a final phase when the kubelet goes down. This unblocks JobSet's that delete Job's with foreground cascade.

#### Which issue(s) this PR fixes:
Fixes #10847

#### Special notes for your reviewer:
I think this will also be an issue when the pod is in Succeeded phase (which IMO can happen), so I handled both.

**AI Assisted:** I made the changes to tests with Gemini.

#### Does this PR introduce a user-facing change?
```release-note
FailureRecovery: Forcefully delete pods that are Failed/Succeeded and scheduled on unreachable nodes.
This unblocks cases like a JobSet deleting a Job with foreground cascade being stuck because a pod in a terminal phase exists on one of the unhealthy nodes.
```
