### PR TITLE
Automated cherry pick of #10783: fix: Fix TAS stateWithLeader aggregation for grouped podsets

### DIFF
--- a/pkg/cache/scheduler/tas_balanced_placement.go
+++ b/pkg/cache/scheduler/tas_balanced_placement.go
@@ -264,7 +264,7 @@ func findBestDomainsForBalancedPlacement(s *TASFlavorSnapshot, params *topologyA
 		}
 		threshold := balanceThresholdValue(sliceCount, selectedDomainsCount, lastDomainWithLeader, lastDomain)
 		if threshold >= bestThreshold {
-			s.pruneDomainsBelowThreshold(requestedLevelSiblingDomains, threshold, params.sliceSize, params.sliceLevelIdx, params.requestedLevelIdx)
+			s.pruneDomainsBelowThreshold(requestedLevelSiblingDomains, threshold, params.sliceSize, params.sliceLevelIdx, params.requestedLevelIdx, params.leaderCount > 0)
 			_, requestedLevelDomainCount, _, _ := evaluateGreedyAssignment(s, requestedLevelSiblingDomains, sliceCount, params.leaderCount)
 			if threshold > bestThreshold || (threshold == bestThreshold && requestedLevelDomainCount < bestDomainCountOnRequestedLevel) {
 				bestThreshold = threshold
@@ -318,7 +318,7 @@ func clearState(d *domain) {
 	}
 }
 
-func (s *TASFlavorSnapshot) pruneDomainsBelowThreshold(domains []*domain, threshold int32, sliceSize int32, sliceLevelIdx int, level int) {
+func (s *TASFlavorSnapshot) pruneDomainsBelowThreshold(domains []*domain, threshold int32, sliceSize int32, sliceLevelIdx int, level int, leaderRequired bool) {
 	for _, d := range domains {
 		for _, c := range d.children {
 			if c.sliceStateWithLeader < threshold {
@@ -327,7 +327,7 @@ func (s *TASFlavorSnapshot) pruneDomainsBelowThreshold(domains []*domain, thresh
 		}
 	}
 	for _, d := range domains {
-		s.fillInCountsHelper(d, sliceSize, sliceLevelIdx, level)
+		s.fillInCountsHelper(d, sliceSize, sliceLevelIdx, level, leaderRequired)
 		if d.sliceStateWithLeader < threshold {
 			clearState(d)
 		}

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -4983,6 +4983,240 @@ func TestFindTopologyAssignments(t *testing.T) {
 				},
 			},
 		},
+		"find topology assignment for grouped podsets skips domain where only workers fit without leader": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("small-used").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "small").
+					Label(corev1.LabelHostname, "small-used").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2800m"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("small-free").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "small").
+					Label(corev1.LabelHostname, "small-free").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2800m"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("large-free").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "large").
+					Label(corev1.LabelHostname, "large-free").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("6"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("filler", "test-ns").
+					NodeName("small-used").
+					StatusPhase(corev1.PodRunning).
+					Request(corev1.ResourceCPU, "2500m").
+					Obj(),
+			},
+			levels: defaultThreeLevels,
+			podSets: []PodSetTestCase{
+				{
+					podSetName: "leader",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasRackLabel),
+					},
+					requests: resources.Requests{
+						corev1.ResourceCPU: 2500,
+					},
+					podSetGroupName: new("sameGroup"),
+					count:           1,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: defaultOneLevel,
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"large-free"}},
+						},
+					},
+				},
+				{
+					podSetName: "workers",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasRackLabel),
+					},
+					requests: resources.Requests{
+						corev1.ResourceCPU: 2500,
+					},
+					podSetGroupName: new("sameGroup"),
+					count:           1,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: defaultOneLevel,
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"large-free"}},
+						},
+					},
+				},
+			},
+		},
+		"find topology assignment for grouped podsets skips domain where mixed-size workers only fit without leader": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("small-used").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "small").
+					Label(corev1.LabelHostname, "small-used").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2800m"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("small-free").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "small").
+					Label(corev1.LabelHostname, "small-free").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2800m"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("large-free").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "large").
+					Label(corev1.LabelHostname, "large-free").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("6"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("filler", "test-ns").
+					NodeName("small-used").
+					StatusPhase(corev1.PodRunning).
+					Request(corev1.ResourceCPU, "2500m").
+					Obj(),
+			},
+			levels: defaultThreeLevels,
+			podSets: []PodSetTestCase{
+				{
+					podSetName: "leader",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasRackLabel),
+					},
+					requests: resources.Requests{
+						corev1.ResourceCPU: 2500,
+					},
+					podSetGroupName: new("sameGroup"),
+					count:           1,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: defaultOneLevel,
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"large-free"}},
+						},
+					},
+				},
+				{
+					podSetName: "workers",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasRackLabel),
+					},
+					requests: resources.Requests{
+						corev1.ResourceCPU: 500,
+					},
+					podSetGroupName: new("sameGroup"),
+					count:           2,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: defaultOneLevel,
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 2, Values: []string{"large-free"}},
+						},
+					},
+				},
+			},
+		},
+		"find topology assignment for grouped podsets keeps tight domain when leader and workers fit together": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("small-used").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "small").
+					Label(corev1.LabelHostname, "small-used").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2800m"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("small-free").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "small").
+					Label(corev1.LabelHostname, "small-free").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2800m"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("large-free").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "large").
+					Label(corev1.LabelHostname, "large-free").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("6"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("filler", "test-ns").
+					NodeName("small-used").
+					StatusPhase(corev1.PodRunning).
+					Request(corev1.ResourceCPU, "2500m").
+					Obj(),
+			},
+			levels: defaultThreeLevels,
+			podSets: []PodSetTestCase{
+				{
+					podSetName: "leader",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasRackLabel),
+					},
+					requests: resources.Requests{
+						corev1.ResourceCPU: 1000,
+					},
+					podSetGroupName: new("sameGroup"),
+					count:           1,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: defaultOneLevel,
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"small-free"}},
+						},
+					},
+				},
+				{
+					podSetName: "workers",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasRackLabel),
+					},
+					requests: resources.Requests{
+						corev1.ResourceCPU: 1000,
+					},
+					podSetGroupName: new("sameGroup"),
+					count:           1,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: defaultOneLevel,
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"small-free"}},
+						},
+					},
+				},
+			},
+		},
 		"find topology assignment for two podsets with the same group - no fit": {
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1").

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -5033,7 +5033,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					requests: resources.Requests{
 						corev1.ResourceCPU: 2500,
 					},
-					podSetGroupName: new("sameGroup"),
+					podSetGroupName: ptr.To("sameGroup"),
 					count:           1,
 					wantAssignment: &tas.TopologyAssignment{
 						Levels: defaultOneLevel,
@@ -5050,7 +5050,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					requests: resources.Requests{
 						corev1.ResourceCPU: 2500,
 					},
-					podSetGroupName: new("sameGroup"),
+					podSetGroupName: ptr.To("sameGroup"),
 					count:           1,
 					wantAssignment: &tas.TopologyAssignment{
 						Levels: defaultOneLevel,
@@ -5111,7 +5111,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					requests: resources.Requests{
 						corev1.ResourceCPU: 2500,
 					},
-					podSetGroupName: new("sameGroup"),
+					podSetGroupName: ptr.To("sameGroup"),
 					count:           1,
 					wantAssignment: &tas.TopologyAssignment{
 						Levels: defaultOneLevel,
@@ -5128,7 +5128,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					requests: resources.Requests{
 						corev1.ResourceCPU: 500,
 					},
-					podSetGroupName: new("sameGroup"),
+					podSetGroupName: ptr.To("sameGroup"),
 					count:           2,
 					wantAssignment: &tas.TopologyAssignment{
 						Levels: defaultOneLevel,
@@ -5189,7 +5189,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					requests: resources.Requests{
 						corev1.ResourceCPU: 1000,
 					},
-					podSetGroupName: new("sameGroup"),
+					podSetGroupName: ptr.To("sameGroup"),
 					count:           1,
 					wantAssignment: &tas.TopologyAssignment{
 						Levels: defaultOneLevel,
@@ -5206,7 +5206,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					requests: resources.Requests{
 						corev1.ResourceCPU: 1000,
 					},
-					podSetGroupName: new("sameGroup"),
+					podSetGroupName: ptr.To("sameGroup"),
 					count:           1,
 					wantAssignment: &tas.TopologyAssignment{
 						Levels: defaultOneLevel,

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1496,7 +1496,7 @@ func (s *TASFlavorSnapshot) fillInCounts(requirements *topologyAssignmentPodRequ
 		leaf.stateWithLeader = requirements.requests.CountIn(remainingCapacity)
 	}
 	for _, root := range s.roots {
-		s.fillInCountsHelper(root, state.sliceSize, state.sliceLevelIdx, 0)
+		s.fillInCountsHelper(root, state.sliceSize, state.sliceLevelIdx, 0, state.leaderCount > 0)
 	}
 }
 
@@ -1509,7 +1509,7 @@ func belongsToRequiredDomain(leaf *leafDomain, requiredReplacementDomain utiltas
 	return strings.HasPrefix(string(utiltas.DomainID(leaf.levelValues)), string(requiredReplacementDomain))
 }
 
-func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, sliceLevelIdx int, level int) {
+func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, sliceLevelIdx int, level int, leaderRequired bool) {
 	// logic for a leaf
 	if len(domain.children) == 0 {
 		if level == sliceLevelIdx {
@@ -1528,17 +1528,28 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 	leaderState := int32(0)
 
 	for _, child := range domain.children {
-		s.fillInCountsHelper(child, sliceSize, sliceLevelIdx, level+1)
-		childrenCapacity += child.state
+		s.fillInCountsHelper(child, sliceSize, sliceLevelIdx, level+1, leaderRequired)
+		childState := child.state
+		childStateWithLeader := child.stateWithLeader
+		childrenCapacity += childState
 		sliceCapacity += child.sliceState
-		minStateWithLeaderDifference = min(child.state-child.stateWithLeader, minStateWithLeaderDifference)
-		minSliceStateWithLeaderDifference = min(child.sliceState-child.sliceStateWithLeader, minSliceStateWithLeaderDifference)
+		if !leaderRequired || child.leaderState > 0 {
+			minStateWithLeaderDifference = min(childState-childStateWithLeader, minStateWithLeaderDifference)
+			minSliceStateWithLeaderDifference = min(child.sliceState-child.sliceStateWithLeader, minSliceStateWithLeaderDifference)
+		}
 		leaderState = max(child.leaderState, leaderState)
 	}
 	domain.state = childrenCapacity
-	domain.stateWithLeader = childrenCapacity - minStateWithLeaderDifference
+	if minStateWithLeaderDifference == math.MaxInt32 {
+		domain.stateWithLeader = 0
+	} else {
+		domain.stateWithLeader = childrenCapacity - minStateWithLeaderDifference
+	}
 	domain.leaderState = leaderState
-	sliceStateWithLeader := sliceCapacity - minSliceStateWithLeaderDifference
+	sliceStateWithLeader := int32(0)
+	if minSliceStateWithLeaderDifference != math.MaxInt32 {
+		sliceStateWithLeader = sliceCapacity - minSliceStateWithLeaderDifference
+	}
 
 	if level == sliceLevelIdx {
 		// initialize the sliceState for the requested slice level.

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1540,16 +1540,14 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 		leaderState = max(child.leaderState, leaderState)
 	}
 	domain.state = childrenCapacity
+	sliceStateWithLeader := int32(0)
 	if minStateWithLeaderDifference == math.MaxInt32 {
 		domain.stateWithLeader = 0
 	} else {
 		domain.stateWithLeader = childrenCapacity - minStateWithLeaderDifference
-	}
-	domain.leaderState = leaderState
-	sliceStateWithLeader := int32(0)
-	if minSliceStateWithLeaderDifference != math.MaxInt32 {
 		sliceStateWithLeader = sliceCapacity - minSliceStateWithLeaderDifference
 	}
+	domain.leaderState = leaderState
 
 	if level == sliceLevelIdx {
 		// initialize the sliceState for the requested slice level.

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1522,7 +1522,7 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 	// logic for a parent
 	childrenCapacity := int32(0)
 	sliceCapacity := int32(0)
-	hasWithLeaderCapacityContributor = false
+	hasWithLeaderCapacityContributor := false
 	minStateWithLeaderDifference := int32(math.MaxInt32)
 	minSliceStateWithLeaderDifference := int32(math.MaxInt32)
 	leaderState := int32(0)

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1522,7 +1522,7 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 	// logic for a parent
 	childrenCapacity := int32(0)
 	sliceCapacity := int32(0)
-
+	hasWithLeaderCapacityContributor = false
 	minStateWithLeaderDifference := int32(math.MaxInt32)
 	minSliceStateWithLeaderDifference := int32(math.MaxInt32)
 	leaderState := int32(0)
@@ -1534,6 +1534,7 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 		childrenCapacity += childState
 		sliceCapacity += child.sliceState
 		if !leaderRequired || child.leaderState > 0 {
+			hasWithLeaderCapacityContributor = true
 			minStateWithLeaderDifference = min(childState-childStateWithLeader, minStateWithLeaderDifference)
 			minSliceStateWithLeaderDifference = min(child.sliceState-child.sliceStateWithLeader, minSliceStateWithLeaderDifference)
 		}
@@ -1541,11 +1542,11 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 	}
 	domain.state = childrenCapacity
 	sliceStateWithLeader := int32(0)
-	if minStateWithLeaderDifference == math.MaxInt32 {
-		domain.stateWithLeader = 0
-	} else {
+	if hasWithLeaderCapacityContributor {
 		domain.stateWithLeader = childrenCapacity - minStateWithLeaderDifference
 		sliceStateWithLeader = sliceCapacity - minSliceStateWithLeaderDifference
+	} else {
+		domain.stateWithLeader = 0
 	}
 	domain.leaderState = leaderState
 


### PR DESCRIPTION
Cherry pick of #10783 on release-0.16.

#10783: fix: Fix TAS stateWithLeader aggregation for grouped podsets

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
TAS: Fix handling of PodSet groups which could lead in some scenarios to empty topologyAssignment.
```