### PR TITLE
Reduce LFC fragmentation for single pod workloads

### DIFF
--- a/pkg/cache/scheduler/tas_balanced_placement.go
+++ b/pkg/cache/scheduler/tas_balanced_placement.go
@@ -35,16 +35,16 @@ func evaluateGreedyAssignment(s *TASFlavorSnapshot, domains []*domain, sliceCoun
 	remainingLeaderCount := leaderCount
 	idx := 0
 	if leaderCount > 0 {
-		sortedWithLeader = s.sortedDomainsWithLeader(domains, false)
+		sortedWithLeader = s.sortedDomainsWithLeader(domains, false, false)
 		for ; remainingLeaderCount > 0 && idx < len(sortedWithLeader) && sortedWithLeader[idx].leaderState > 0; idx++ {
 			selectedDomainsCount++
 			lastDomainWithLeader = sortedWithLeader[idx]
 			remainingLeaderCount -= sortedWithLeader[idx].leaderState
 			remainingSliceCount -= sortedWithLeader[idx].sliceStateWithLeader
 		}
-		sortedWithoutLeader = s.sortedDomains(sortedWithLeader[idx:], false)
+		sortedWithoutLeader = s.sortedDomains(sortedWithLeader[idx:], false, false)
 	} else {
-		sortedWithoutLeader = s.sortedDomains(domains, false)
+		sortedWithoutLeader = s.sortedDomains(domains, false, false)
 	}
 
 	if remainingLeaderCount > 0 {
@@ -159,7 +159,7 @@ func placeSlicesOnDomainsBalanced(s *TASFlavorSnapshot, domains []*domain, slice
 	if sliceCount < int32(len(resultDomains))*threshold {
 		return nil, "TAS Balanced Placement: Not enough slices to meet the threshold"
 	}
-	resultDomains = s.sortedDomainsWithLeader(resultDomains, false)
+	resultDomains = s.sortedDomainsWithLeader(resultDomains, false, false)
 	extraSlicesLeft := sliceCount - int32(len(resultDomains))*threshold
 	leadersLeft := leaderCount
 	var extraSlicesToTake int32

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -83,6 +83,11 @@ type domain struct {
 	sliceStateWithLeader int32
 	leaderState          int32
 
+	// minNonZeroLeafState is the smallest state>0 among leaves in this subtree
+	// (or math.MaxInt32 if all empty). LFC sorts by this to prefer subtrees
+	// containing a nearly-full host.
+	minNonZeroLeafState int32
+
 	// levelValues stores the mapping from domain ID back to the
 	// ordered list of values
 	levelValues []string
@@ -832,6 +837,8 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 			return nil, fmt.Sprintf("invalid podSetUpdate for PodSet %s, error: %s", workersTasPodSetRequests.PodSet.Name, err.Error())
 		}
 	}
+	// preferPartialDomains for single-pod to fit them on the tightest non-empty leaf
+	preferPartialDomains := state.count == 1
 
 	// If slice topology is not requested then we can assume that slice is a single pod
 	sliceSize, reason := getSliceSizeWithSinglePodAsDefault(workersTasPodSetRequests.PodSet.TopologyRequest)
@@ -930,7 +937,7 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	for ; currentLevelIdx < min(len(s.domainsPerLevel)-1, state.sliceLevelIdx) && !useBalancedPlacement; currentLevelIdx++ {
 		// If we are "above" the requested slice topology level and we don't run the balanced placement algorithm,
 		// we're greedily assigning pods/slices to all domains without checking what we've assigned to parent domains.
-		sortedLowerDomains := s.sortedDomains(s.lowerLevelDomains(currFitDomain), state.unconstrained)
+		sortedLowerDomains := s.sortedDomains(s.lowerLevelDomains(currFitDomain), state.unconstrained, preferPartialDomains)
 		currFitDomain = s.updateCountsToMinimumGeneric(sortedLowerDomains, state.count, state.leaderCount, state.sliceSize, state.unconstrained, true)
 	}
 
@@ -951,7 +958,7 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 		}
 		newCurrFitDomain := make([]*domain, 0)
 		for _, domain := range currFitDomain {
-			sortedLowerDomains := s.sortedDomains(domain.children, state.unconstrained)
+			sortedLowerDomains := s.sortedDomains(domain.children, state.unconstrained, preferPartialDomains)
 
 			if sliceSizeOnLevel > 1 {
 				// For inner slice layers, recompute sliceState on the
@@ -1242,7 +1249,8 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 		return 0, nil, fmt.Sprintf("no topology domains at level: %s", s.levelKeys[searchLevelIdx])
 	}
 	levelDomains := slices.Collect(maps.Values(domains))
-	sortedDomain := s.sortedDomainsWithLeader(levelDomains, state.unconstrained)
+	preferPartialDomains := state.count == 1
+	sortedDomain := s.sortedDomainsWithLeader(levelDomains, state.unconstrained, preferPartialDomains)
 	topDomain := sortedDomain[0]
 
 	sliceCount := state.count / state.sliceSize
@@ -1301,7 +1309,7 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 
 		// At this point we have assigned all leaders, so we sort remaining domains based on worker capacity
 		// and assign remaining workers.
-		sortedDomain = s.sortedDomains(sortedDomain[idx:], state.unconstrained)
+		sortedDomain = s.sortedDomains(sortedDomain[idx:], state.unconstrained, preferPartialDomains)
 		for idx := 0; remainingSliceCount > 0 && idx < len(sortedDomain); idx++ {
 			domain := sortedDomain[idx]
 			if useBestFitAlgorithm(state.unconstrained) && sortedDomain[idx].sliceState >= remainingSliceCount {
@@ -1508,12 +1516,20 @@ func (s *TASFlavorSnapshot) lowerLevelDomains(domains []*domain) []*domain {
 	return result
 }
 
-func (s *TASFlavorSnapshot) sortedDomainsWithLeader(domains []*domain, unconstrained bool) []*domain {
+// sortedDomainsWithLeader sorts like sortedDomains but gives leaderState
+// (descending) the highest priority.
+func (s *TASFlavorSnapshot) sortedDomainsWithLeader(domains []*domain, unconstrained bool, preferPartialDomains bool) []*domain {
 	isLeastFreeCapacity := useLeastFreeCapacityAlgorithm(unconstrained)
+	partialDomainPreference := isLeastFreeCapacity && preferPartialDomains
 	result := slices.Clone(domains)
 	slices.SortFunc(result, func(a, b *domain) int {
 		if a.leaderState != b.leaderState {
 			return cmp.Compare(b.leaderState, a.leaderState)
+		}
+
+		// LFC + single-pod: prefer subtrees containing a nearly-full leaf.
+		if partialDomainPreference && a.minNonZeroLeafState != b.minNonZeroLeafState {
+			return cmp.Compare(a.minNonZeroLeafState, b.minNonZeroLeafState)
 		}
 
 		if a.sliceStateWithLeader != b.sliceStateWithLeader {
@@ -1534,17 +1550,21 @@ func (s *TASFlavorSnapshot) sortedDomainsWithLeader(domains []*domain, unconstra
 	return result
 }
 
-// This function sorts domains based on a specified algorithm: BestFit or LeastFreeCapacity.
-//
-// The sorting criteria are:
-// - **BestFit**: `sliceState` (descending), `state` (ascending), `levelValues` (ascending)
-// - **LeastFreeCapacity**: `sliceState` (ascending), `state` (ascending), `levelValues` (ascending)
-//
-// `state` is always sorted ascending. This prioritizes domains that can accommodate slices with minimal leftover pod capacity.
-func (s *TASFlavorSnapshot) sortedDomains(domains []*domain, unconstrained bool) []*domain {
+// sortedDomains orders domains for placement.
+// BestFit: sliceState desc, state asc, levelValues asc.
+// LFC: sliceState asc, state asc, levelValues asc.
+// LFC + preferPartialDomains: minNonZeroLeafState asc is prepended as the
+// highest-priority key.
+func (s *TASFlavorSnapshot) sortedDomains(domains []*domain, unconstrained bool, preferPartialDomains bool) []*domain {
 	isLeastFreeCapacity := useLeastFreeCapacityAlgorithm(unconstrained)
+	partialDomainPreference := isLeastFreeCapacity && preferPartialDomains
 	result := slices.Clone(domains)
 	slices.SortFunc(result, func(a, b *domain) int {
+		// LFC + single-pod: prefer subtrees containing a nearly-full leaf.
+		if partialDomainPreference && a.minNonZeroLeafState != b.minNonZeroLeafState {
+			return cmp.Compare(a.minNonZeroLeafState, b.minNonZeroLeafState)
+		}
+
 		if a.sliceState != b.sliceState {
 			if isLeastFreeCapacity {
 				// Start from the domain with the least amount of free resources.
@@ -1574,6 +1594,7 @@ func (s *TASFlavorSnapshot) fillInCounts(requirements *topologyAssignmentPodRequ
 		domain.sliceState = 0
 		domain.sliceStateWithLeader = 0
 		domain.leaderState = 0
+		domain.minNonZeroLeafState = 0
 	}
 	for _, leaf := range s.leaves {
 		state.stats.TotalNodes++
@@ -1658,6 +1679,7 @@ func belongsToRequiredDomain(leaf *leafDomain, requiredReplacementDomain utiltas
 func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, sliceLevelIdx int, level int, sliceSizeAtLevel map[int]int32, leaderRequired bool) {
 	// logic for a leaf
 	if len(domain.children) == 0 {
+		domain.minNonZeroLeafState = cmp.Or(domain.state, math.MaxInt32)
 		if level == sliceLevelIdx {
 			// initialize the sliceState if leaf is the request slice level
 			domain.sliceState = domain.state / sliceSize
@@ -1672,6 +1694,7 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 	minStateWithLeaderDifference := int32(math.MaxInt32)
 	minSliceStateWithLeaderDifference := int32(math.MaxInt32)
 	leaderState := int32(0)
+	domain.minNonZeroLeafState = math.MaxInt32
 
 	// When multi-layer constraints exist, children at a constrained level
 	// can only contribute pods in multiples of the inner slice size.
@@ -1698,6 +1721,7 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 			minSliceStateWithLeaderDifference = min(child.sliceState-child.sliceStateWithLeader, minSliceStateWithLeaderDifference)
 		}
 		leaderState = max(child.leaderState, leaderState)
+		domain.minNonZeroLeafState = min(child.minNonZeroLeafState, domain.minNonZeroLeafState)
 	}
 	domain.state = childrenCapacity
 	sliceStateWithLeader := int32(0)

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scheduler
 
 import (
+	"math"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -438,9 +439,10 @@ func TestSortedDomainsWithLeader(t *testing.T) {
 	levels := []string{"block"}
 
 	testCases := map[string]struct {
-		domains       []*domain
-		unconstrained bool
-		wantOrder     []string
+		domains              []*domain
+		unconstrained        bool
+		preferPartialDomains bool
+		wantOrder            []string
 	}{
 		"leaderState descending: domains that can host leader come first": {
 			domains: []*domain{
@@ -495,6 +497,35 @@ func TestSortedDomainsWithLeader(t *testing.T) {
 			unconstrained: false,
 			wantOrder:     []string{"a", "b", "c"},
 		},
+		"LFC: minNonZeroLeafState ascending after leaderState": {
+			domains: []*domain{
+				{id: "tight-child", leaderState: 1, minNonZeroLeafState: 1, sliceStateWithLeader: 10, stateWithLeader: 20, levelValues: []string{"a"}},
+				{id: "loose-child", leaderState: 1, minNonZeroLeafState: 5, sliceStateWithLeader: 8, stateWithLeader: 16, levelValues: []string{"b"}},
+			},
+			unconstrained:        true,
+			preferPartialDomains: true,
+			wantOrder:            []string{"tight-child", "loose-child"},
+		},
+		"LFC: minNonZeroLeafState ignored when preferPartialDomains is false": {
+			domains: []*domain{
+				{id: "tight-child", leaderState: 1, minNonZeroLeafState: 1, sliceStateWithLeader: 10, stateWithLeader: 20, levelValues: []string{"a"}},
+				{id: "loose-child", leaderState: 1, minNonZeroLeafState: 5, sliceStateWithLeader: 8, stateWithLeader: 16, levelValues: []string{"b"}},
+			},
+			unconstrained:        true,
+			preferPartialDomains: false,
+			// Without preferPartialDomains, LFC sorts sliceStateWithLeader ascending: 8 < 10
+			wantOrder: []string{"loose-child", "tight-child"},
+		},
+		"BestFit: minNonZeroLeafState ignored": {
+			domains: []*domain{
+				{id: "tight-child", leaderState: 1, minNonZeroLeafState: 1, sliceStateWithLeader: 5, stateWithLeader: 20, levelValues: []string{"a"}},
+				{id: "loose-child", leaderState: 1, minNonZeroLeafState: 10, sliceStateWithLeader: 10, stateWithLeader: 16, levelValues: []string{"b"}},
+			},
+			unconstrained:        false,
+			preferPartialDomains: true,
+			// BestFit sorts sliceStateWithLeader descending: 10 > 5
+			wantOrder: []string{"loose-child", "tight-child"},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -502,7 +533,87 @@ func TestSortedDomainsWithLeader(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
 			s := newTASFlavorSnapshot(log, "test", levels, nil)
 
-			sorted := s.sortedDomainsWithLeader(tc.domains, tc.unconstrained)
+			sorted := s.sortedDomainsWithLeader(tc.domains, tc.unconstrained, tc.preferPartialDomains)
+
+			gotOrder := make([]string, len(sorted))
+			for i, d := range sorted {
+				gotOrder[i] = string(d.id)
+			}
+
+			if diff := cmp.Diff(tc.wantOrder, gotOrder); diff != "" {
+				t.Errorf("unexpected domain order (-want,+got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestSortedDomains(t *testing.T) {
+	levels := []string{"block"}
+
+	testCases := map[string]struct {
+		domains              []*domain
+		unconstrained        bool
+		preferPartialDomains bool
+		wantOrder            []string
+	}{
+		"BestFit: minNonZeroLeafState ignored even with preferPartialDomains": {
+			domains: []*domain{
+				{id: "tight-child", minNonZeroLeafState: 1, sliceState: 5, state: 20, levelValues: []string{"a"}},
+				{id: "loose-child", minNonZeroLeafState: 10, sliceState: 10, state: 20, levelValues: []string{"b"}},
+			},
+			unconstrained:        false,
+			preferPartialDomains: true,
+			// BestFit sorts sliceState descending: 10 > 5
+			wantOrder: []string{"loose-child", "tight-child"},
+		},
+		"LFC: minNonZeroLeafState ascending with preferPartialDomains": {
+			domains: []*domain{
+				{id: "tight-child", minNonZeroLeafState: 1, sliceState: 10, state: 20, levelValues: []string{"a"}},
+				{id: "loose-child", minNonZeroLeafState: 5, sliceState: 8, state: 16, levelValues: []string{"b"}},
+			},
+			unconstrained:        true,
+			preferPartialDomains: true,
+			// LFC sorts minNonZeroLeafState ascending: 1 < 5
+			wantOrder: []string{"tight-child", "loose-child"},
+		},
+		"LFC: minNonZeroLeafState ignored without preferPartialDomains": {
+			domains: []*domain{
+				{id: "tight-child", minNonZeroLeafState: 1, sliceState: 10, state: 20, levelValues: []string{"a"}},
+				{id: "loose-child", minNonZeroLeafState: 5, sliceState: 8, state: 16, levelValues: []string{"b"}},
+			},
+			unconstrained:        true,
+			preferPartialDomains: false,
+			// Without preferPartialDomains, LFC sorts sliceState ascending: 8 < 10
+			wantOrder: []string{"loose-child", "tight-child"},
+		},
+		"LFC: minNonZeroLeafState tiebreak falls back to sliceState": {
+			domains: []*domain{
+				{id: "more-slices", minNonZeroLeafState: 3, sliceState: 10, state: 20, levelValues: []string{"a"}},
+				{id: "fewer-slices", minNonZeroLeafState: 3, sliceState: 5, state: 10, levelValues: []string{"b"}},
+			},
+			unconstrained:        true,
+			preferPartialDomains: true,
+			// Equal minNonZeroLeafState → LFC sliceState ascending: 5 < 10
+			wantOrder: []string{"fewer-slices", "more-slices"},
+		},
+		"LFC: all-zero children use MaxInt32 and sort last": {
+			domains: []*domain{
+				{id: "all-full", minNonZeroLeafState: math.MaxInt32, sliceState: 5, state: 10, levelValues: []string{"a"}},
+				{id: "has-partial", minNonZeroLeafState: 2, sliceState: 8, state: 16, levelValues: []string{"b"}},
+			},
+			unconstrained:        true,
+			preferPartialDomains: true,
+			// MaxInt32 > 2, so has-partial sorts first
+			wantOrder: []string{"has-partial", "all-full"},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
+			s := newTASFlavorSnapshot(log, "test", levels, nil)
+
+			sorted := s.sortedDomains(tc.domains, tc.unconstrained, tc.preferPartialDomains)
 
 			gotOrder := make([]string, len(sorted))
 			for i, d := range sorted {

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -5964,6 +5964,111 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 			})
 		})
 	})
+
+	ginkgo.When("LeastFreeCapacity profile prefers the globally tightest non-empty leaf", framework.SlowSpec, func() {
+		var (
+			topology     *kueue.Topology
+			tasFlavor    *kueue.ResourceFlavor
+			clusterQueue *kueue.ClusterQueue
+			localQueue   *kueue.LocalQueue
+			nodes        []corev1.Node
+		)
+
+		// Topology (block → rack → host), with asymmetric per-rack/per-host
+		// capacity:
+		//
+		//   block-a / rack-a1 / host-a1   capacity 1   ← globally tightest leaf
+		//   block-a / rack-a2 / host-a2   capacity 8
+		//   block-b / rack-b1 / host-b1   capacity 4
+		//   block-b / rack-b2 / host-b2   capacity 4
+		//
+		// Aggregate sliceState (counted as host count × per-host capacity):
+		//   block-a = 9, block-b = 8.
+		//
+		// Without the new minNonZeroLeafState sort key, LFC at the block
+		// level prefers the smaller aggregate (block-b, 8 < 9) and the
+		// workload lands on a host inside block-b. With the new key,
+		// block-a wins (minNZL = 1 < 4) and the workload lands on host-a1
+		// — the globally tightest non-empty leaf.
+		ginkgo.BeforeEach(func() {
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.TASProfileMixed, true)
+
+			makeNode := func(name, block, rack string, podCapacity int64) corev1.Node {
+				return *testingnode.MakeNode(name).
+					Label("node-group", "tas").
+					Label(utiltesting.DefaultBlockTopologyLevel, block).
+					Label(utiltesting.DefaultRackTopologyLevel, rack).
+					Label(corev1.LabelHostname, name).
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("8"),
+						corev1.ResourceMemory: resource.MustParse("8Gi"),
+						corev1.ResourcePods:   *resource.NewQuantity(podCapacity, resource.DecimalSI),
+					}).
+					Ready().
+					Obj()
+			}
+			nodes = []corev1.Node{
+				makeNode("host-a1", "block-a", "rack-a1", 1),
+				makeNode("host-a2", "block-a", "rack-a2", 8),
+				makeNode("host-b1", "block-b", "rack-b1", 4),
+				makeNode("host-b2", "block-b", "rack-b2", 4),
+			}
+			util.CreateNodesWithStatus(ctx, k8sClient, nodes)
+
+			topology = utiltestingapi.MakeDefaultThreeLevelTopology("default")
+			util.MustCreate(ctx, k8sClient, topology)
+
+			tasFlavor = utiltestingapi.MakeResourceFlavor("tas-flavor-lfc").
+				NodeLabel("node-group", "tas").
+				TopologyName("default").Obj()
+			util.MustCreate(ctx, k8sClient, tasFlavor)
+
+			clusterQueue = utiltestingapi.MakeClusterQueue("cq-lfc").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas(tasFlavor.Name).
+					Resource(corev1.ResourceCPU, "100").
+					Obj()).Obj()
+			util.MustCreate(ctx, k8sClient, clusterQueue)
+
+			localQueue = utiltestingapi.MakeLocalQueue("lq-lfc", ns.Name).
+				ClusterQueue(clusterQueue.Name).Obj()
+			util.MustCreate(ctx, k8sClient, localQueue)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+			for i := range nodes {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, &nodes[i], true)
+			}
+		})
+
+		ginkgo.It("a single-pod workload lands on the globally tightest non-empty host", func() {
+			// Slice-topology-only request triggers the multi-level descent
+			// loop in findTopologyAssignment under LFC; count == 1 enables
+			// the partial-domain preference gate.
+			wl := utiltestingapi.MakeWorkload("wl-single", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "1").Obj()
+			wl.Spec.PodSets[0].Count = 1
+			wl.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
+				PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+				PodSetSliceSize:             ptr.To[int32](1),
+			}
+			util.MustCreate(ctx, k8sClient, wl)
+
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+
+			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+			ta := utiltas.InternalFrom(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment)
+			gomega.Expect(ta.Domains).To(gomega.HaveLen(1))
+			hostnameIdx := slices.Index(ta.Levels, corev1.LabelHostname)
+			gomega.Expect(hostnameIdx).To(gomega.BeNumerically(">=", 0))
+			gomega.Expect(ta.Domains[0].Values[hostnameIdx]).To(gomega.Equal("host-a1"),
+				"single-pod LFC workload should land on host-a1 (capacity 1, globally tightest non-empty leaf), not on a host inside block-b which has the lower aggregate sliceState")
+		})
+	})
 })
 
 // Tests the "Retain" resource transformation strategy: regular CPU requests are


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area tas

#### What this PR does / why we need it:

When the LeastFreeCapacity places a single pod workload that fits inside one host, the existing sort keys operate only at the level being sorted without visibility into partially full nodes, so TAS may spread single pod workloads across domains based on least free capacity rather than stacking them on the same nodes, fragmenting capacity 

#### Which issue(s) this PR fixes:

Adds one new sort key minNonZeroLeafState which represents the smallest free node capacity among leaves in this subtree, such that TAS will pick the subtree containing the tightest non empty node

#### Does this PR introduce a user-facing change?
No 

```release-note
Reduce LFC fragmentation for single pod workloads
```
