### PR TITLE
fix expectation ordering in test

### DIFF
--- a/test/integration/singlecluster/controller/core/workload_preemption_eviction_metrics_test.go
+++ b/test/integration/singlecluster/controller/core/workload_preemption_eviction_metrics_test.go
@@ -81,6 +81,7 @@ var _ = ginkgo.Describe("Workload eviction to pending metrics", ginkgo.Label("co
 			Request(corev1.ResourceCPU, "1").
 			Obj()
 		util.MustCreate(ctx, k8sClient, lowWl)
+		util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, lowWl)
 
 		highWl := utiltestingapi.MakeWorkload("high-wl", ns.Name).
 			Queue(kueue.LocalQueueName(q.Name)).
@@ -89,7 +90,6 @@ var _ = ginkgo.Describe("Workload eviction to pending metrics", ginkgo.Label("co
 			Obj()
 		util.MustCreate(ctx, k8sClient, highWl)
 
-		util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, lowWl)
 		util.FinishEvictionForWorkloads(ctx, k8sClient, lowWl)
 
 		util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, highWl)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->/kind failing-test

#### What this PR does / why we need it:
The ordering for this expectation is wrong and caused test failures for unrelated PR: https://github.com/kubernetes-sigs/kueue/pull/10806

You want to wait for quota reservation for the first workload before making the second workload that will preempt it. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
