### PR TITLE
Deduplicate kubectl Helm test containers

### DIFF
--- a/cmd/experimental/kueue-populator/charts/kueue-populator/templates/tests/test-kueue-status.yaml
+++ b/cmd/experimental/kueue-populator/charts/kueue-populator/templates/tests/test-kueue-status.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   serviceAccountName: "{{ .Release.Name }}-test-sa"
   containers:
-    - name: check-kueue-controller-manager
+    - name: check-kueue-deployments
       image: registry.k8s.io/kubectl:v1.33.6
       command: ["kubectl"]
       args: [
@@ -17,15 +17,6 @@ spec:
         "--for=condition=Available",
         "--timeout=60s",
         "deployment/{{ .Release.Name }}-controller-manager",
-        "-n", "{{ .Release.Namespace }}"
-      ]
-    - name: check-kueue-populator
-      image: registry.k8s.io/kubectl:v1.33.6
-      command: ["kubectl"]
-      args: [
-        "wait",
-        "--for=condition=Available",
-        "--timeout=60s",
         "deployment/{{ .Release.Name }}-kueue-populator",
         "-n", "{{ .Release.Namespace }}"
       ]

--- a/cmd/experimental/kueue-populator/charts/kueue-populator/templates/tests/test-populator-resources.yaml
+++ b/cmd/experimental/kueue-populator/charts/kueue-populator/templates/tests/test-populator-resources.yaml
@@ -9,26 +9,21 @@ metadata:
 spec:
   serviceAccountName: "{{ .Release.Name }}-test-sa"
   containers:
-    - name: check-clusterqueue
+    - name: check-populator-resources
       image: registry.k8s.io/kubectl:v1.33.6
       command: ["kubectl"]
-      args: ["get", "clusterqueues.kueue.x-k8s.io", "{{ .Values.kueuePopulator.config.clusterQueue.name }}"]
+      args:
+        - get
+        - clusterqueues.kueue.x-k8s.io/{{ .Values.kueuePopulator.config.clusterQueue.name }}
 {{- if .Values.kueuePopulator.config.resourceFlavor }}
-    - name: check-resourceflavor
-      image: registry.k8s.io/kubectl:v1.33.6
-      command: ["kubectl"]
-      args: ["get", "resourceflavors.kueue.x-k8s.io", "tas-gpu-default"]
+        - resourceflavors.kueue.x-k8s.io/tas-gpu-default
 {{- end }}
 {{- if .Values.kueuePopulator.config.topology }}
 {{- if .Values.kueuePopulator.config.topology.levels }}
-    - name: check-topology
-      image: registry.k8s.io/kubectl:v1.33.6
-      command: ["kubectl"]
-      args: ["get", "topologies.kueue.x-k8s.io", "default"]
+        - topologies.kueue.x-k8s.io/default
 {{- end }}
 {{- end }}
-    - name: check-localqueue-default
-      image: registry.k8s.io/kubectl:v1.33.6
-      command: ["kubectl"]
-      args: ["get", "localqueues.kueue.x-k8s.io", "-n", "default", "{{ .Values.kueuePopulator.config.localQueue.name }}"]
+        - localqueues.kueue.x-k8s.io/{{ .Values.kueuePopulator.config.localQueue.name }}
+        - -n
+        - default
   restartPolicy: OnFailure


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
Deduplicates kubectl containers in the kueue-populator helm tests by:
- grouping the two deployment readiness checks in one `kubectl wait`
- grouping the populator resource checks in one `kubectl get`

Before:

```console
$ helm template oci://us-central1-docker.pkg.dev/k8s-staging-images/kueue/charts/kueue-populator --set enableKueueViz=true --version 0.15.0 | grep registry.k8s.io
        image: "registry.k8s.io/kueue/kueue-populator:v0.15.0"
        image: registry.k8s.io/kubectl:v1.33.6
        image: registry.k8s.io/kubectl:v1.33.6
        image: registry.k8s.io/kubectl:v1.33.6
        image: registry.k8s.io/kubectl:v1.33.6
        image: registry.k8s.io/kubectl:v1.33.6
        image: registry.k8s.io/kubectl:v1.33.6
```
After:
```console
$ helm template ./cmd/experimental/kueue-populator/charts/kueue-populator --set enableKueueViz=true --set kueuePopulator.image.repository=registry.k8s.io/kueue/kueue-populator --set kueuePopulator.image.tag=v0.15.0 | grep registry.k8s.io
          image: "registry.k8s.io/kueue/kueue-populator:v0.15.0"
          image: registry.k8s.io/kubectl:v1.33.6
          image: registry.k8s.io/kubectl:v1.33.6
          image: registry.k8s.io/kubectl:v1.33.6
```

#### Which issue(s) this PR fixes:
Fixes #7992

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```