### PR TITLE
fix: Avoid nil pointer panic for fairshare ordering

### DIFF
--- a/pkg/scheduler/preemption/fairsharing/ordering.go
+++ b/pkg/scheduler/preemption/fairsharing/ordering.go
@@ -100,6 +100,7 @@ func (t *TargetClusterQueueOrdering) Iter() iter.Seq[*TargetClusterQueue] {
 					return
 				}
 			}
+			return
 		}
 
 		root := t.preemptorCq.Parent().Root()

--- a/pkg/scheduler/preemption/fairsharing/ordering_test.go
+++ b/pkg/scheduler/preemption/fairsharing/ordering_test.go
@@ -50,7 +50,7 @@ func TestMakeClusterQueueOrdering(t *testing.T) {
 		actions   []string
 		wantOrder []kueue.ClusterQueueReference
 	}{
-		"no cohort: preemptor CQ yielded for in-CQ preemption": {
+		"no cohort: preemptor CQ yielded for in-CQ preemption; repro for nil pointer panic issue": {
 			clusterQueues: []*kueue.ClusterQueue{
 				utiltestingapi.MakeClusterQueue("preemptor").
 					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
@@ -249,8 +249,7 @@ func TestMakeClusterQueueOrdering(t *testing.T) {
 				}
 				actionIdx++
 				if len(gotOrder) > 50 {
-					t.Fatal("exceeded 50 iterations, likely an infinite loop")
-					break
+					t.Error("exceeded 50 iterations, likely an infinite loop")
 				}
 			}
 

--- a/pkg/scheduler/preemption/fairsharing/ordering_test.go
+++ b/pkg/scheduler/preemption/fairsharing/ordering_test.go
@@ -1,0 +1,262 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fairsharing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	clocktesting "k8s.io/utils/clock/testing"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+func TestMakeClusterQueueOrdering(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	clk := clocktesting.NewFakeClock(now)
+
+	cases := map[string]struct {
+		clusterQueues []*kueue.ClusterQueue
+		cohorts       []*kueue.Cohort
+		// admitted workloads create resource usage in target CQs (making them borrow).
+		// The same workloads are used as preemption candidates.
+		admitted    []kueue.Workload
+		preemptorCQ kueue.ClusterQueueReference
+		// candidateCQs restricts which admitted workloads become candidates (by CQ name).
+		candidateCQs []kueue.ClusterQueueReference
+		// actions controls per-iteration behavior: "drop" calls DropQueue, anything else calls PopWorkload.
+		actions   []string
+		wantOrder []kueue.ClusterQueueReference
+	}{
+		"no cohort: preemptor CQ yielded for in-CQ preemption": {
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("preemptor").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "4").Obj()).
+					Obj(),
+			},
+			admitted: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl1", "ns").Request(corev1.ResourceCPU, "1").
+					SimpleReserveQuota("preemptor", "default", now).Obj(),
+			},
+			preemptorCQ:  "preemptor",
+			candidateCQs: []kueue.ClusterQueueReference{"preemptor"},
+			wantOrder:    []kueue.ClusterQueueReference{"preemptor"},
+		},
+		"non-borrowing CQ is pruned even with candidates": {
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("preemptor").Cohort("all").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "4").Obj()).Obj(),
+				// "target" is within its nominal quota (2 < 5), so DRS = 0 (not borrowing).
+				utiltestingapi.MakeClusterQueue("target").Cohort("all").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "5").Obj()).Obj(),
+			},
+			admitted: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("t1", "ns").Request(corev1.ResourceCPU, "2").
+					SimpleReserveQuota("target", "default", now).Obj(),
+			},
+			preemptorCQ:  "preemptor",
+			candidateCQs: []kueue.ClusterQueueReference{"target"},
+			wantOrder:    nil,
+		},
+		"higher DRS CQ returned before lower DRS CQ": {
+			// Cohort "all": preemptor(nominal=4), high(nominal=2, usage=5), low(nominal=2, usage=3).
+			// DRS(high) > DRS(low), so "high" is yielded first.
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("preemptor").Cohort("all").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "4").Obj()).Obj(),
+				utiltestingapi.MakeClusterQueue("high").Cohort("all").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "2").Obj()).Obj(),
+				utiltestingapi.MakeClusterQueue("low").Cohort("all").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "2").Obj()).Obj(),
+			},
+			admitted: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("h1", "ns").Request(corev1.ResourceCPU, "5").
+					SimpleReserveQuota("high", "default", now).Obj(),
+				*utiltestingapi.MakeWorkload("l1", "ns").Request(corev1.ResourceCPU, "3").
+					SimpleReserveQuota("low", "default", now).Obj(),
+			},
+			preemptorCQ:  "preemptor",
+			candidateCQs: []kueue.ClusterQueueReference{"high", "low"},
+			wantOrder:    []kueue.ClusterQueueReference{"high", "low"},
+		},
+		"CQ with highest DRS returned again while it still has candidates": {
+			// "high" has 2 candidates; it keeps its high DRS across iterations (DRS
+			// is based on actual resource usage, not candidate count), so it is
+			// returned twice before "low" is returned.
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("preemptor").Cohort("all").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "4").Obj()).Obj(),
+				utiltestingapi.MakeClusterQueue("high").Cohort("all").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "2").Obj()).Obj(),
+				utiltestingapi.MakeClusterQueue("low").Cohort("all").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "2").Obj()).Obj(),
+			},
+			admitted: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("h1", "ns").Request(corev1.ResourceCPU, "3").
+					SimpleReserveQuota("high", "default", now).Obj(),
+				*utiltestingapi.MakeWorkload("h2", "ns").Request(corev1.ResourceCPU, "2").
+					SimpleReserveQuota("high", "default", now).Obj(),
+				*utiltestingapi.MakeWorkload("l1", "ns").Request(corev1.ResourceCPU, "3").
+					SimpleReserveQuota("low", "default", now).Obj(),
+			},
+			preemptorCQ:  "preemptor",
+			candidateCQs: []kueue.ClusterQueueReference{"high", "low"},
+			wantOrder:    []kueue.ClusterQueueReference{"high", "high", "low"},
+		},
+		"drop queue prevents CQ from being returned again": {
+			// Same setup as above; calling DropQueue on the first "high" occurrence
+			// skips its second candidate and moves immediately to "low".
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("preemptor").Cohort("all").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "4").Obj()).Obj(),
+				utiltestingapi.MakeClusterQueue("high").Cohort("all").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "2").Obj()).Obj(),
+				utiltestingapi.MakeClusterQueue("low").Cohort("all").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "2").Obj()).Obj(),
+			},
+			admitted: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("h1", "ns").Request(corev1.ResourceCPU, "3").
+					SimpleReserveQuota("high", "default", now).Obj(),
+				*utiltestingapi.MakeWorkload("h2", "ns").Request(corev1.ResourceCPU, "2").
+					SimpleReserveQuota("high", "default", now).Obj(),
+				*utiltestingapi.MakeWorkload("l1", "ns").Request(corev1.ResourceCPU, "3").
+					SimpleReserveQuota("low", "default", now).Obj(),
+			},
+			preemptorCQ:  "preemptor",
+			candidateCQs: []kueue.ClusterQueueReference{"high", "low"},
+			// Drop "high" on first occurrence; PopWorkload for "low".
+			actions:   []string{"drop", "pop"},
+			wantOrder: []kueue.ClusterQueueReference{"high", "low"},
+		},
+		"hierarchical cohorts: higher-DRS subtree visited first": {
+			// Tree:
+			//           root
+			//          /    \
+			//    left-cohort  right-cohort
+			//        |              |
+			//     left-cq        right-cq       preemptor-cq
+			//   (usage=5>2)     (usage=3>2)     (usage=0, nominal=4)
+			//
+			// left-cohort has higher aggregate DRS, so left-cq is returned first.
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("preemptor-cq").Cohort("root").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "4").Obj()).Obj(),
+				utiltestingapi.MakeClusterQueue("left-cq").Cohort("left-cohort").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "2").Obj()).Obj(),
+				utiltestingapi.MakeClusterQueue("right-cq").Cohort("right-cohort").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "2").Obj()).Obj(),
+			},
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root").Obj(),
+				utiltestingapi.MakeCohort("left-cohort").Parent("root").Obj(),
+				utiltestingapi.MakeCohort("right-cohort").Parent("root").Obj(),
+			},
+			admitted: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("lc1", "ns").Request(corev1.ResourceCPU, "5").
+					SimpleReserveQuota("left-cq", "default", now).Obj(),
+				*utiltestingapi.MakeWorkload("rc1", "ns").Request(corev1.ResourceCPU, "3").
+					SimpleReserveQuota("right-cq", "default", now).Obj(),
+			},
+			preemptorCQ:  "preemptor-cq",
+			candidateCQs: []kueue.ClusterQueueReference{"left-cq", "right-cq"},
+			wantOrder:    []kueue.ClusterQueueReference{"left-cq", "right-cq"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, log := utiltesting.ContextWithLog(t)
+			cl := utiltesting.NewClientBuilder().
+				WithLists(&kueue.WorkloadList{Items: tc.admitted}).
+				Build()
+			cqCache := schdcache.New(cl)
+			cqCache.AddOrUpdateResourceFlavor(log, utiltestingapi.MakeResourceFlavor("default").Obj())
+
+			for _, cq := range tc.clusterQueues {
+				if err := cqCache.AddClusterQueue(ctx, cq); err != nil {
+					t.Fatalf("AddClusterQueue(%q): %v", cq.Name, err)
+				}
+			}
+			for _, cohort := range tc.cohorts {
+				if err := cqCache.AddOrUpdateCohort(cohort); err != nil {
+					t.Fatalf("AddOrUpdateCohort(%q): %v", cohort.Name, err)
+				}
+			}
+
+			snapshot, err := cqCache.Snapshot(ctx)
+			if err != nil {
+				t.Fatalf("Snapshot: %v", err)
+			}
+
+			preemptorCQ := snapshot.ClusterQueue(tc.preemptorCQ)
+
+			candidateCQSet := sets.New(tc.candidateCQs...)
+			var candidates []*workload.Info
+			for i := range tc.admitted {
+				info := workload.NewInfo(&tc.admitted[i])
+				if candidateCQSet.Has(info.ClusterQueue) {
+					candidates = append(candidates, info)
+				}
+			}
+
+			ordering := MakeClusterQueueOrdering(preemptorCQ, candidates, log, clk)
+
+			var gotOrder []kueue.ClusterQueueReference
+			actionIdx := 0
+			for target := range ordering.Iter() {
+				gotOrder = append(gotOrder, target.GetTargetCq().GetName())
+				if actionIdx < len(tc.actions) && tc.actions[actionIdx] == "drop" {
+					ordering.DropQueue(target)
+				} else {
+					target.PopWorkload()
+				}
+				actionIdx++
+				if len(gotOrder) > 50 {
+					t.Fatal("exceeded 50 iterations, likely an infinite loop")
+					break
+				}
+			}
+
+			if diff := cmp.Diff(tc.wantOrder, gotOrder, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("ordering mismatch (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/scheduler_fs_test.go
+++ b/pkg/scheduler/scheduler_fs_test.go
@@ -3238,6 +3238,104 @@ func TestScheduleForFairSharing(t *testing.T) {
 					Obj(),
 			},
 		},
+		"fair sharing: in-CQ preemption for CQ without cohort; repro for nil pointer panic": {
+			// Regression test: before the fix, WithinClusterQueue preemption
+			// for a CQ without a Cohort panicked because the ordering code fell
+			// through to Parent().Root() after the no-cohort early-exit block.
+			enableFairSharing: true,
+			additionalClusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("no-cohort-cq").
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
+					}).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default").
+							Resource(corev1.ResourceCPU, "4").Obj(),
+					).Obj(),
+			},
+			additionalLocalQueues: []kueue.LocalQueue{
+				*utiltestingapi.MakeLocalQueue("no-cohort-queue", "default").ClusterQueue("no-cohort-cq").Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("nc-low", "default").
+					Queue("no-cohort-queue").
+					Priority(-1).
+					Request(corev1.ResourceCPU, "4").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("no-cohort-cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "4").Obj()).Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("nc-high", "default").
+					UID("wl-nc-high").
+					JobUID("job-nc-high").
+					Queue("no-cohort-queue").
+					Priority(100).
+					Request(corev1.ResourceCPU, "4").
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("nc-high", "default").
+					UID("wl-nc-high").
+					JobUID("job-nc-high").
+					Queue("no-cohort-queue").
+					Priority(100).
+					Request(corev1.ResourceCPU, "4").
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             "Pending",
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor default, 4 more needed. Pending the preemption of 1 workload(s)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: kueue.DefaultPodSetName,
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("4"),
+						},
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("nc-low", "default").
+					Queue("no-cohort-queue").
+					Priority(-1).
+					Request(corev1.ResourceCPU, "4").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("no-cohort-cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "4").Obj()).Obj(), now).
+					AdmittedAt(true, now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-nc-high, JobUID: job-nc-high) due to prioritization in the ClusterQueue; preemptor path: /no-cohort-cq; preemptee path: /no-cohort-cq",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InClusterQueue",
+						Message:            "Preempted to accommodate a workload (UID: wl-nc-high, JobUID: job-nc-high) due to prioritization in the ClusterQueue; preemptor path: /no-cohort-cq; preemptee path: /no-cohort-cq",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+			},
+			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"no-cohort-cq": {"default/nc-high"},
+			},
+			wantAssignments: map[workload.Reference]kueue.Admission{
+				"default/nc-low": *utiltestingapi.MakeAdmission("no-cohort-cq").
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "4").Obj()).Obj(),
+			},
+			eventCmpOpts: ignoreEventMessageCmpOpts,
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "nc-low", "EvictedDueToPreempted", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "nc-low", "Preempted", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "nc-high", "PreemptedWorkload", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "nc-high", "Pending", corev1.EventTypeWarning).Obj(),
+			},
+		},
 		"PreemptionOverBorrowing with fair sharing: preempt in first flavor instead of borrowing in second": {
 			enableFairSharing: true,
 			additionalClusterQueues: []kueue.ClusterQueue{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

### Root cause (English)

The `Iter()` implementation has a special-case branch for a preemptor `ClusterQueue` **without a parent Cohort** (`!t.preemptorCq.HasParent()`).

In that scenario, `t.preemptorCq.Parent()` is **nil**. If the function does not **return after finishing** the no-parent branch, control will fall through to the general path and execute:

- `root := t.preemptorCq.Parent().Root()`

That dereferences a nil pointer and will **panic**.

<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
FairSharing: fix the bug which can cause nil-pointer panic when FairSharing is enabled on clusters
with ClusterQueues without Cohorts.
```
