### PR TITLE
chore: fix typo error in admission and workload docs

### DIFF
--- a/site/content/en/docs/concepts/admission.md
+++ b/site/content/en/docs/concepts/admission.md
@@ -16,7 +16,7 @@ It involves verifying:
 
 Kueue implements this through a two-phase admission cycle: 
 
-1. **Quota Reservation:** When a user submits a Workload, it enters a LocalQueue first. This LocalQueue points to a ClusterQueue which is responsible for managing the available resources. The Kueue checks if the targeted ClusterQueue's available quota and resource flavors can accomodate requested resources (CPU, memory, GPUs, etc.). If the quota is available, the Kueue reserves resources for this Workload and prevents other Workloads from using the same resources. This phase also includes checking the availability of physical resources when 
+1. **Quota Reservation:** When a user submits a Workload, it enters a LocalQueue first. This LocalQueue points to a ClusterQueue which is responsible for managing the available resources. The Kueue checks if the targeted ClusterQueue's available quota and resource flavors can accommodate requested resources (CPU, memory, GPUs, etc.). If the quota is available, the Kueue reserves resources for this Workload and prevents other Workloads from using the same resources. This phase also includes checking the availability of physical resources when 
     Topology-Aware Scheduling is enabled.
 
 2. **Admission Checks:** Await for [AdmissionChecks](/docs/concepts/admission_check) configured in the ClusterQueue. Checks can be either built-in such as [MultiKueue](/docs/concepts/multikueue/) or [ProvisioningRequest](/docs/concepts/admission_check/provisioning_request/), or user-created plugins.

--- a/site/content/en/docs/concepts/workload.md
+++ b/site/content/en/docs/concepts/workload.md
@@ -197,7 +197,7 @@ This can bypass the strict validation rules causing issues with duplicated envir
 - [MultiKueue: remove the limitation that the external dispatches need to use kueue-admission field manager ](https://github.com/kubernetes-sigs/kueue/issues/6185)
 Using ServerSideApply blocked the ability for Workload Status to be modified from external controllers.
 Once the field e.g. `.status.nominatedClusterNames` was modified and owned by the controller (regardless if Kueue or external one) it can not be modified or cleared by the other.
-This effectively prevent External Dispatching mechanism to work properly in multi cluster enviroment.
+This effectively prevent External Dispatching mechanism to work properly in multi cluster environment.
 
 ## What's next
 


### PR DESCRIPTION
Fix spelling errors in:
  - `site/content/en/docs/concepts/admission.md`
  - `site/content/en/docs/concepts/workload.md`

#### Does this PR introduce a user-facing change?

```release-note
None
```