### PR TITLE
Added feat for Inadmissible Workloads Metrics

### DIFF
--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -331,7 +331,7 @@ func (m *Manager) AddClusterQueue(ctx context.Context, cq *kueue.ClusterQueue) e
 
 	notifyRetryInadmissibleWithoutLock(m, sets.New(cqImpl.name))
 	reportPendingWorkloads(m, cqImpl.name)
-
+	reportCQQueuedWorkloads(m, cqImpl)
 	if addedWorkloads {
 		m.Broadcast()
 	}
@@ -627,6 +627,8 @@ func (m *Manager) AddOrUpdateWorkloadWithoutLock(log logr.Logger, w *kueue.Workl
 	m.preemptionExpectations.ObservedUID(log, client.ObjectKeyFromObject(w), w.UID)
 	reportLQPendingWorkloads(m, q)
 	reportCQPendingWorkloads(m, cq)
+	reportCQQueuedWorkloads(m, cq)
+	reportLQQueuedWorkloads(m, q)
 	m.Broadcast()
 	log.V(5).Info("Added/updated workload in queues; Broadcast successful.")
 	return nil
@@ -665,7 +667,9 @@ func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reas
 
 	added := cq.RequeueIfNotPresent(ctx, info, reason)
 	reportCQPendingWorkloads(m, cq)
+	reportCQQueuedWorkloads(m, cq)
 	reportLQPendingWorkloads(m, q)
+	reportLQQueuedWorkloads(m, q)
 	if added {
 		m.Broadcast()
 	}
@@ -716,6 +720,8 @@ func (m *Manager) deleteWorkloadWithoutLock(log logr.Logger, wlKey workload.Refe
 	if cq != nil {
 		cq.Delete(log, wlKey)
 		reportCQPendingWorkloads(m, cq)
+		reportCQQueuedWorkloads(m, cq)
+		reportLQQueuedWorkloads(m, q)
 	}
 	reportLQPendingWorkloads(m, q)
 
@@ -903,17 +909,18 @@ func (m *Manager) queueSecondPass(ctx context.Context, w *kueue.Workload, iterat
 	}
 }
 
-// ResyncGaugeMetrics re-reports pending and finished workload gauge metrics.
 func (m *Manager) ResyncGaugeMetrics() {
 	m.RLock()
 	defer m.RUnlock()
 	for _, cq := range m.hm.ClusterQueues() {
 		reportCQPendingWorkloads(m, cq)
+		reportCQQueuedWorkloads(m, cq) // ADD — cq is in scope here
 		reportCQFinishedWorkloads(cq, m.roleTracker, m.customLabels)
 	}
 	if m.lqMetrics.IsEnabled() {
 		for _, lq := range m.localQueues {
 			reportLQPendingWorkloads(m, lq)
+			reportLQQueuedWorkloads(m, lq)
 			reportLQFinishedWorkloads(m, lq)
 		}
 	}

--- a/pkg/cache/queue/queued_metrics.go
+++ b/pkg/cache/queue/queued_metrics.go
@@ -1,0 +1,93 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/metrics"
+	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
+)
+
+const (
+	// Fallback reason when no valid condition is present
+	reasonPending = "Pending"
+)
+
+// Extracts the scheduling-relevant reason from a workload's QuotaReserved condition.
+func workloadQueueReason(wl *kueue.Workload) string {
+	cond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
+	if cond == nil || cond.Status == metav1.ConditionTrue || cond.Reason == "" {
+		return reasonPending
+	}
+	return cond.Reason
+}
+
+// Counts pending workloads in a ClusterQueue grouped by reason.
+func cqQueuedReasonCounts(cq *ClusterQueue) map[string]int {
+	counts := make(map[string]int)
+	for _, info := range cq.Snapshot() {
+		counts[workloadQueueReason(info.Obj)]++
+	}
+	return counts
+}
+
+// Counts pending workloads in a LocalQueue grouped by reason.
+func lqQueuedReasonCounts(q *LocalQueue) map[string]int {
+	counts := make(map[string]int)
+	for _, info := range q.items {
+		counts[workloadQueueReason(info.Obj)]++
+	}
+	return counts
+}
+
+// Publishes queued workload metrics for a ClusterQueue.
+// Must be called with at least a read lock held on the Manager.
+func reportCQQueuedWorkloads(m *Manager, cq *ClusterQueue) {
+	customLabelValues := m.customLabels.CQGet(cq.name)
+	metrics.ReportQueuedWorkloads(
+		cq.name,
+		cqQueuedReasonCounts(cq),
+		customLabelValues,
+		m.roleTracker,
+	)
+}
+
+// Publishes queued workload metrics for a LocalQueue.
+// No-ops when LocalQueue metrics are disabled.
+// Must be called with at least a read lock held on the Manager.
+func reportLQQueuedWorkloads(m *Manager, q *LocalQueue) {
+	if !m.lqMetrics.IsEnabled() {
+		return
+	}
+
+	ns, name := utilqueue.MustParseLocalQueueReference(q.Key)
+
+	lqRef := metrics.LocalQueueReference{
+		Name:      name,
+		Namespace: ns,
+	}
+	customLabelValues := m.customLabels.LQGet(q.Key)
+	metrics.ReportLocalQueueQueuedWorkloads(
+		lqRef,
+		lqQueuedReasonCounts(q),
+		customLabelValues,
+		m.roleTracker,
+	)
+}

--- a/pkg/cache/queue/queued_metrics_test.go
+++ b/pkg/cache/queue/queued_metrics_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+func TestWorkloadQueueReason(t *testing.T) {
+	cases := []struct {
+		name       string
+		conditions []metav1.Condition
+		want       string
+	}{
+		{
+			name:       "no conditions → Pending",
+			conditions: nil,
+			want:       "Pending",
+		},
+		{
+			name: "QuotaReserved=True → Pending (admitted, should not be here)",
+			conditions: []metav1.Condition{
+				{
+					Type:   kueue.WorkloadQuotaReserved,
+					Status: metav1.ConditionTrue,
+					Reason: "QuotaReserved",
+				},
+			},
+			want: "Pending",
+		},
+		{
+			name: "QuotaReserved=False Reason=Inadmissible",
+			conditions: []metav1.Condition{
+				{
+					Type:   kueue.WorkloadQuotaReserved,
+					Status: metav1.ConditionFalse,
+					Reason: "Inadmissible",
+				},
+			},
+			want: "Inadmissible",
+		},
+		{
+			name: "QuotaReserved=False Reason=Waiting",
+			conditions: []metav1.Condition{
+				{
+					Type:   kueue.WorkloadQuotaReserved,
+					Status: metav1.ConditionFalse,
+					Reason: "Waiting",
+				},
+			},
+			want: "Waiting",
+		},
+		{
+			name: "QuotaReserved=False Reason=FlavorMismatch",
+			conditions: []metav1.Condition{
+				{
+					Type:   kueue.WorkloadQuotaReserved,
+					Status: metav1.ConditionFalse,
+					Reason: "FlavorMismatch",
+				},
+			},
+			want: "FlavorMismatch",
+		},
+		{
+			name: "QuotaReserved=False empty Reason → Pending",
+			conditions: []metav1.Condition{
+				{
+					Type:   kueue.WorkloadQuotaReserved,
+					Status: metav1.ConditionFalse,
+					Reason: "",
+				},
+			},
+			want: "Pending",
+		},
+		{
+			name: "future unknown reason is passed through",
+			conditions: []metav1.Condition{
+				{
+					Type:   kueue.WorkloadQuotaReserved,
+					Status: metav1.ConditionFalse,
+					Reason: "SomeFutureReason",
+				},
+			},
+			want: "SomeFutureReason",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wl := utiltestingapi.MakeWorkload("wl", "ns").Obj()
+			wl.Status.Conditions = tc.conditions
+			got := workloadQueueReason(wl)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("workloadQueueReason() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLQQueuedReasonCounts(t *testing.T) {
+	makeInfo := func(reason string) *workload.Info {
+		wl := utiltestingapi.MakeWorkload("wl-"+reason, "ns").Obj()
+		if reason != "" {
+			wl.Status.Conditions = []metav1.Condition{
+				{
+					Type:   kueue.WorkloadQuotaReserved,
+					Status: metav1.ConditionFalse,
+					Reason: reason,
+				},
+			}
+		}
+		return workload.NewInfo(wl)
+	}
+
+	q := &LocalQueue{
+		items: map[workload.Reference]*workload.Info{
+			"ns/wl-Pending":        makeInfo(""),
+			"ns/wl-Inadmissible":   makeInfo("Inadmissible"),
+			"ns/wl-FlavorMismatch": makeInfo("FlavorMismatch"),
+			"ns/wl-Waiting":        makeInfo("Waiting"),
+		},
+	}
+
+	want := map[string]int{
+		"Pending":        1,
+		"Inadmissible":   1,
+		"FlavorMismatch": 1,
+		"Waiting":        1,
+	}
+
+	got := lqQueuedReasonCounts(q)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("lqQueuedReasonCounts() mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -93,6 +93,14 @@ var (
 	LocalQueuePendingWorkloads *prometheus.GaugeVec
 
 	// +metricsdoc:group=clusterqueue
+	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",reason="reason from the workload QuotaReserved condition (Pending, Inadmissible, Waiting, FlavorMismatch)",replica_role="one of `leader`, `follower`, or `standalone`"
+	QueuedWorkloads *prometheus.GaugeVec
+
+	// +metricsdoc:group=localqueue
+	// +metricsdoc:labels=name="the name of the LocalQueue",namespace="the namespace of the LocalQueue",reason="reason from the workload QuotaReserved condition (Pending, Inadmissible, Waiting, FlavorMismatch)",replica_role="one of `leader`, `follower`, or `standalone`"
+	LocalQueueQueuedWorkloads *prometheus.GaugeVec
+
+	// +metricsdoc:group=clusterqueue
 	// +metricsdoc:labels=cluster_queue="the name of the ClusterQueue",replica_role="one of `leader`, `follower`, or `standalone`"
 	FinishedWorkloads *prometheus.GaugeVec
 
@@ -367,6 +375,32 @@ The label 'result' can have the following values:
 		}, append([]string{"name", "namespace", "status", "replica_role"}, extraLabels...),
 	)
 	trackGaugeVec(LocalQueuePendingWorkloads, gaugeCleanupScopeLocalQueue)
+
+	QueuedWorkloads = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: constants.KueueName,
+			Name:      "queued_workloads",
+			Help: `The number of queued workloads per 'cluster_queue' and 'reason'.
+'reason' maps 1:1 to the Reason field of the workload's QuotaReserved status condition:
+- "Pending" means the workload is waiting for available resources.
+- "Inadmissible" means the LocalQueue or ClusterQueue doesn't exist or is inactive.
+- "Waiting" means the workload is blocked pending admission checks.
+- "FlavorMismatch" means no ResourceFlavor matches the workload's requirements.
+New reasons added in future Kueue versions will appear automatically as new label values.`,
+		}, append([]string{"cluster_queue", "reason", "replica_role"}, extraLabels...),
+	)
+	trackGaugeVec(QueuedWorkloads, gaugeCleanupScopeClusterQueue)
+
+	LocalQueueQueuedWorkloads = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: constants.KueueName,
+			Name:      "local_queue_queued_workloads",
+			Help: `The number of queued workloads per 'local_queue' and 'reason'.
+'reason' maps 1:1 to the Reason field of the workload's QuotaReserved status condition.
+See kueue_queued_workloads for the full list of possible reason values.`,
+		}, append([]string{"name", "namespace", "reason", "replica_role"}, extraLabels...),
+	)
+	trackGaugeVec(LocalQueueQueuedWorkloads, gaugeCleanupScopeLocalQueue)
 
 	FinishedWorkloads = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -955,6 +989,38 @@ func ReportLocalQueuePendingWorkloads(lq LocalQueueReference, active, inadmissib
 	LocalQueuePendingWorkloads.WithLabelValues(inadmissibleLabels...).Set(float64(inadmissible))
 }
 
+// ReportQueuedWorkloads sets the queued workload count broken down by condition
+// reason for the given ClusterQueue. reasonCounts maps Reason string -> count.
+// Any reason not present in reasonCounts will not update an existing series,
+// so callers should pass the full snapshot on every call.
+func ReportQueuedWorkloads(
+	cqName kueue.ClusterQueueReference,
+	reasonCounts map[string]int,
+	customLabelValues []string,
+	tracker *roletracker.RoleTracker,
+) {
+	role := roletracker.GetRole(tracker)
+	for reason, count := range reasonCounts {
+		labels := append([]string{string(cqName), reason, role}, customLabelValues...)
+		QueuedWorkloads.WithLabelValues(labels...).Set(float64(count))
+	}
+}
+
+// ReportLocalQueueQueuedWorkloads sets the queued workload count broken down
+// by condition reason for the given LocalQueue.
+func ReportLocalQueueQueuedWorkloads(
+	lq LocalQueueReference,
+	reasonCounts map[string]int,
+	customLabelValues []string,
+	tracker *roletracker.RoleTracker,
+) {
+	role := roletracker.GetRole(tracker)
+	for reason, count := range reasonCounts {
+		labels := append([]string{string(lq.Name), lq.Namespace, reason, role}, customLabelValues...)
+		LocalQueueQueuedWorkloads.WithLabelValues(labels...).Set(float64(count))
+	}
+}
+
 func ReportEvictedWorkloads(cqName kueue.ClusterQueueReference, evictionReason, underlyingCause, priorityClass string, customLabelValues []string, tracker *roletracker.RoleTracker) {
 	labels := append([]string{string(cqName), evictionReason, underlyingCause, priorityClass, roletracker.GetRole(tracker)}, customLabelValues...)
 	EvictedWorkloadsTotal.WithLabelValues(labels...).Inc()
@@ -999,6 +1065,7 @@ func ClearClusterQueueMetrics(cq kueue.ClusterQueueReference) {
 	AdmissionWaitTime.DeletePartialMatch(prometheus.Labels{"cluster_queue": cqName})
 	AdmissionChecksWaitTime.DeletePartialMatch(prometheus.Labels{"cluster_queue": cqName})
 	QueuedUntilReadyWaitTime.DeletePartialMatch(prometheus.Labels{"cluster_queue": cqName})
+	QueuedWorkloads.DeletePartialMatch(prometheus.Labels{"cluster_queue": cqName})
 	AdmittedUntilReadyWaitTime.DeletePartialMatch(prometheus.Labels{"cluster_queue": cqName})
 	EvictedWorkloadsTotal.DeletePartialMatch(prometheus.Labels{"cluster_queue": cqName})
 	EvictedWorkloadsOnceTotal.DeletePartialMatch(prometheus.Labels{"cluster_queue": cqName})
@@ -1025,6 +1092,7 @@ func ClearLocalQueueMetrics(lq LocalQueueReference) {
 	LocalQueueQueuedUntilReadyWaitTime.DeletePartialMatch(lbls)
 	LocalQueueAdmittedUntilReadyWaitTime.DeletePartialMatch(lbls)
 	LocalQueueEvictedWorkloadsTotal.DeletePartialMatch(lbls)
+	LocalQueueQueuedWorkloads.DeletePartialMatch(lbls)
 }
 
 func ClearCohortMetrics(cohortName kueue.CohortReference) {
@@ -1275,6 +1343,7 @@ func Register() {
 		AdmissionWaitTime,
 		AdmissionChecksWaitTime,
 		QueuedUntilReadyWaitTime,
+		QueuedWorkloads,
 		AdmittedUntilReadyWaitTime,
 		EvictedWorkloadsTotal,
 		EvictedWorkloadsOnceTotal,
@@ -1309,6 +1378,7 @@ func RegisterLQMetrics() {
 		LocalQueueQuotaReservedWaitTime,
 		LocalQueueAdmittedWorkloadsTotal,
 		LocalQueueAdmissionWaitTime,
+		LocalQueueQueuedWorkloads,
 		LocalQueueAdmissionChecksWaitTime,
 		LocalQueueQueuedUntilReadyWaitTime,
 		LocalQueueAdmittedUntilReadyWaitTime,

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -70,7 +70,8 @@ const (
 	StatusFinished      = "finished"
 
 	// SchedulingHashUnknown indicates the scheduling hash could not be computed.
-	SchedulingHashUnknown = "unknown"
+	SchedulingHashUnknown        = "unknown"
+	WorkloadReasonFlavorMismatch = "FlavorMismatch"
 )
 
 var (

--- a/test/e2e/singlecluster/metrics_test.go
+++ b/test/e2e/singlecluster/metrics_test.go
@@ -19,6 +19,7 @@ package singlecluster
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -26,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -554,6 +556,113 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Label("area:singlecluster", "feature:m
 
 			ginkgo.By("checking that eviction and preemption metrics are no longer available", func() {
 				util.ExpectMetricsNotToBeAvailable(ctx, cfg, restClient, curlPod.Name, curlContainerName, metrics)
+			})
+		})
+	})
+	ginkgo.When("workload configuration is incorrect", func() {
+		var (
+			clusterQueue *kueue.ClusterQueue
+			localQueue   *kueue.LocalQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			clusterQueue = utiltestingapi.MakeClusterQueue("").
+				GeneratedName("test-cq-miscfg-").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).
+						Resource(corev1.ResourceCPU, "1").
+						Obj(),
+				).
+				Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+
+			localQueue = utiltestingapi.MakeLocalQueue("", ns.Name).
+				GeneratedName("test-lq-miscfg-").
+				ClusterQueue(clusterQueue.Name).
+				Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+		})
+
+		ginkgo.AfterEach(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, localQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		})
+
+		ginkgo.It("should count workload with missing LocalQueue as Inadmissible in queued_workloads", func() {
+			wl := utiltestingapi.MakeWorkload("missing-lq-wl", ns.Name).
+				Queue("this-local-queue-does-not-exist").
+				PodSets(*utiltestingapi.MakePodSet("ps1", 1).Obj()).
+				RequestAndLimit(corev1.ResourceCPU, "1").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+			defer util.ExpectObjectToBeDeleted(ctx, k8sClient, wl, true)
+
+			// Workload must be marked Inadmissible by the workload reconciler
+			// because its LocalQueue does not exist.
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+				g.Expect(wl.Status.Conditions).To(gomega.ContainElement(
+					gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Type":   gomega.Equal(string(kueue.WorkloadQuotaReserved)),
+						"Status": gomega.Equal(metav1.ConditionFalse),
+						"Reason": gomega.Equal("Inadmissible"),
+					}),
+				))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			metrics := [][]string{
+				{"kueue_queued_workloads", "Inadmissible"},
+			}
+			ginkgo.By("checking kueue_queued_workloads with reason=Inadmissible is present", func() {
+				util.ExpectMetricsToBeAvailable(ctx, cfg, restClient,
+					curlPod.Name, curlContainerName, metrics)
+			})
+		})
+
+		ginkgo.It("should count workload with flavor mismatch in queued_workloads with reason=FlavorMismatch", func() {
+			// This toleration will never match any ResourceFlavor, causing a mismatch.
+			wl := utiltestingapi.MakeWorkload("flavor-mismatch-wl", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				PodSets(*utiltestingapi.MakePodSet("ps1", 1).
+					Toleration(corev1.Toleration{
+						Key:      "nonexistent-taint-key",
+						Operator: corev1.TolerationOpExists,
+						Effect:   corev1.TaintEffectNoSchedule,
+					}).
+					Obj(),
+				).
+				RequestAndLimit(corev1.ResourceCPU, "1").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+			defer util.ExpectObjectToBeDeleted(ctx, k8sClient, wl, true)
+
+			metrics := [][]string{
+				{"kueue_queued_workloads", clusterQueue.Name, "FlavorMismatch"},
+				{"kueue_local_queue_queued_workloads", ns.Name, localQueue.Name, "FlavorMismatch"},
+			}
+			ginkgo.By("checking kueue_queued_workloads with reason=FlavorMismatch is present", func() {
+				util.ExpectMetricsToBeAvailable(ctx, cfg, restClient,
+					curlPod.Name, curlContainerName, metrics)
+			})
+		})
+
+		ginkgo.It("should count normal pending workload in queued_workloads with reason=Pending", func() {
+			// Request more CPU than the CQ provides — workload stays Pending.
+			wl := utiltestingapi.MakeWorkload("resource-starved-wl", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				PodSets(*utiltestingapi.MakePodSet("ps1", 1).Obj()).
+				RequestAndLimit(corev1.ResourceCPU, "999").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+			defer util.ExpectObjectToBeDeleted(ctx, k8sClient, wl, true)
+
+			metrics := [][]string{
+				{"kueue_queued_workloads", clusterQueue.Name, "Pending"},
+				{"kueue_local_queue_queued_workloads", ns.Name, localQueue.Name, "Pending"},
+			}
+			ginkgo.By("checking kueue_queued_workloads with reason=Pending is present", func() {
+				util.ExpectMetricsToBeAvailable(ctx, cfg, restClient,
+					curlPod.Name, curlContainerName, metrics)
 			})
 		})
 	})


### PR DESCRIPTION
Kueue Issue #10852 — Reason-based Queued Workload Metrics
Problem

Existing metrics only exposed queued workloads as active or inadmissible, without indicating why workloads were not admitted, making debugging and alerting difficult.

Solution

Added two new Prometheus metrics with a reason label derived from the QuotaReserved condition:

kueue_queued_workloads (ClusterQueue level)
kueue_local_queue_queued_workloads (LocalQueue level)

These metrics categorize all non-admitted workloads (active, inadmissible, inflight) by reason, with a fallback to "Pending" when no reason is available.

Changes
Added reason extraction and aggregation logic
Introduced new metrics and reporting functions
Integrated reporting into queue manager
Added E2E tests for key scenarios (Inadmissible, FlavorMismatch, Pending)
Impact

Improves observability by enabling reason-based monitoring, alerting, and faster debugging of scheduling issues.