### PR TITLE
Wrap k8s client update calls with gomega Eventually to increase relia…

### DIFF
--- a/test/e2e/sequential/baseline/visibility_server_test.go
+++ b/test/e2e/sequential/baseline/visibility_server_test.go
@@ -77,16 +77,20 @@ var _ = ginkgo.Describe("Visibility Server", ginkgo.Label("feature:visibility"),
 
 	ginkgo.AfterEach(func() {
 		ginkgo.By("Restoring the original deployment")
-		latestDeployment := &appsv1.Deployment{}
-		gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: kueueManagerName, Namespace: kueueNS}, latestDeployment)).To(gomega.Succeed())
-		latestDeployment.Spec = originalDeployment.Spec
-		gomega.Expect(k8sClient.Update(ctx, latestDeployment)).To(gomega.Succeed())
+		gomega.Eventually(func(g gomega.Gomega) {
+			latestDeployment := &appsv1.Deployment{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: kueueManagerName, Namespace: kueueNS}, latestDeployment)).To(gomega.Succeed())
+			latestDeployment.Spec = originalDeployment.Spec
+			g.Expect(k8sClient.Update(ctx, latestDeployment)).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		ginkgo.By("Restoring the original service")
-		latestService := &corev1.Service{}
-		gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: kueueVisibilityServerName, Namespace: kueueNS}, latestService)).To(gomega.Succeed())
-		latestService.Spec.Ports = originalService.Spec.Ports
-		gomega.Expect(k8sClient.Update(ctx, latestService)).To(gomega.Succeed())
+		gomega.Eventually(func(g gomega.Gomega) {
+			latestService := &corev1.Service{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: kueueVisibilityServerName, Namespace: kueueNS}, latestService)).To(gomega.Succeed())
+			latestService.Spec.Ports = originalService.Spec.Ports
+			g.Expect(k8sClient.Update(ctx, latestService)).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		util.WaitForKueueAvailabilityNoRestartCountCheck(ctx, k8sClient)
 
@@ -182,32 +186,32 @@ var _ = ginkgo.Describe("Visibility Server", ginkgo.Label("feature:visibility"),
 		}
 		util.MustCreate(ctx, k8sClient, tokenReviewerBinding)
 
-		patchedDeployment := originalDeployment.DeepCopy()
-
 		ginkgo.By("Mounting the ConfigMap and the Custom SA Token Secret")
-		patchedDeployment.Spec.Template.Spec.Volumes = append(patchedDeployment.Spec.Template.Spec.Volumes,
-			corev1.Volume{
-				Name:         kubeconfigVolName,
-				VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: configMapName}}},
-			},
-			corev1.Volume{
-				Name:         customSAVolName,
-				VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: customSecretName}},
-			},
-		)
-
-		for i, c := range patchedDeployment.Spec.Template.Spec.Containers {
-			if c.Name == "manager" {
-				container := &patchedDeployment.Spec.Template.Spec.Containers[i]
-				container.VolumeMounts = append(c.VolumeMounts,
-					corev1.VolumeMount{Name: kubeconfigVolName, MountPath: "/etc/kubeconfig", ReadOnly: true},
-					corev1.VolumeMount{Name: customSAVolName, MountPath: customSAMountPath, ReadOnly: true},
-				)
-				container.Args = append(c.Args, "--kubeconfig=/etc/kubeconfig/config")
+		gomega.Eventually(func(g gomega.Gomega) {
+			patchedDeployment := &appsv1.Deployment{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: kueueManagerName, Namespace: kueueNS}, patchedDeployment)).To(gomega.Succeed())
+			patchedDeployment.Spec.Template.Spec.Volumes = append(patchedDeployment.Spec.Template.Spec.Volumes,
+				corev1.Volume{
+					Name:         kubeconfigVolName,
+					VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: configMapName}}},
+				},
+				corev1.Volume{
+					Name:         customSAVolName,
+					VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: customSecretName}},
+				},
+			)
+			for i, c := range patchedDeployment.Spec.Template.Spec.Containers {
+				if c.Name == "manager" {
+					container := &patchedDeployment.Spec.Template.Spec.Containers[i]
+					container.VolumeMounts = append(c.VolumeMounts,
+						corev1.VolumeMount{Name: kubeconfigVolName, MountPath: "/etc/kubeconfig", ReadOnly: true},
+						corev1.VolumeMount{Name: customSAVolName, MountPath: customSAMountPath, ReadOnly: true},
+					)
+					container.Args = append(c.Args, "--kubeconfig=/etc/kubeconfig/config")
+				}
 			}
-		}
-
-		gomega.Expect(k8sClient.Update(ctx, patchedDeployment)).To(gomega.Succeed())
+			g.Expect(k8sClient.Update(ctx, patchedDeployment)).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		util.WaitForKueueAvailabilityNoRestartCountCheck(ctx, k8sClient)
 
 		// NEGATIVE TEST: The request is authenticated via TokenReview, but the visibility server
@@ -243,23 +247,29 @@ var _ = ginkgo.Describe("Visibility Server", ginkgo.Label("feature:visibility"),
 
 	ginkgo.It("Should use the custom port from the --visibility-server-port flag", func() {
 		ginkgo.By("Updating the visibility-server service's targetPort")
-		patchedService := originalService.DeepCopy()
-		for i, p := range patchedService.Spec.Ports {
-			if p.Name == "https" {
-				patchedService.Spec.Ports[i].TargetPort = intstr.FromInt32(customVisibilityPort)
+		gomega.Eventually(func(g gomega.Gomega) {
+			patchedService := &corev1.Service{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: kueueVisibilityServerName, Namespace: kueueNS}, patchedService)).To(gomega.Succeed())
+			for i, p := range patchedService.Spec.Ports {
+				if p.Name == "https" {
+					patchedService.Spec.Ports[i].TargetPort = intstr.FromInt32(customVisibilityPort)
+				}
 			}
-		}
-		gomega.Expect(k8sClient.Update(ctx, patchedService)).To(gomega.Succeed())
+			g.Expect(k8sClient.Update(ctx, patchedService)).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		ginkgo.By("Updating the visibility-server deployment's port")
-		patchedDeployment := originalDeployment.DeepCopy()
-		for i, c := range patchedDeployment.Spec.Template.Spec.Containers {
-			if c.Name == "manager" {
-				container := &patchedDeployment.Spec.Template.Spec.Containers[i]
-				container.Args = append(c.Args, fmt.Sprintf("--visibility-server-port=%d", customVisibilityPort))
+		gomega.Eventually(func(g gomega.Gomega) {
+			patchedDeployment := &appsv1.Deployment{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: kueueManagerName, Namespace: kueueNS}, patchedDeployment)).To(gomega.Succeed())
+			for i, c := range patchedDeployment.Spec.Template.Spec.Containers {
+				if c.Name == "manager" {
+					container := &patchedDeployment.Spec.Template.Spec.Containers[i]
+					container.Args = append(c.Args, fmt.Sprintf("--visibility-server-port=%d", customVisibilityPort))
+				}
 			}
-		}
-		gomega.Expect(k8sClient.Update(ctx, patchedDeployment)).To(gomega.Succeed())
+			g.Expect(k8sClient.Update(ctx, patchedDeployment)).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		util.WaitForKueueAvailabilityNoRestartCountCheck(ctx, k8sClient)
 
 		ginkgo.By("Verifying requests succeed on the custom port")
@@ -284,13 +294,16 @@ var _ = ginkgo.Describe("Visibility Server", ginkgo.Label("feature:visibility"),
 		})
 
 		ginkgo.By("Updating the visibility-server service's targetPort")
-		patchedService := originalService.DeepCopy()
-		for i, p := range patchedService.Spec.Ports {
-			if p.Name == "https" {
-				patchedService.Spec.Ports[i].TargetPort = intstr.FromInt32(customVisibilityPort)
+		gomega.Eventually(func(g gomega.Gomega) {
+			patchedService := &corev1.Service{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: kueueVisibilityServerName, Namespace: kueueNS}, patchedService)).To(gomega.Succeed())
+			for i, p := range patchedService.Spec.Ports {
+				if p.Name == "https" {
+					patchedService.Spec.Ports[i].TargetPort = intstr.FromInt32(customVisibilityPort)
+				}
 			}
-		}
-		gomega.Expect(k8sClient.Update(ctx, patchedService)).To(gomega.Succeed())
+			g.Expect(k8sClient.Update(ctx, patchedService)).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		ginkgo.By("Verifying requests succeed on the custom port")
 		gomega.Eventually(func(g gomega.Gomega) {


### PR DESCRIPTION
…bility of the calls

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10865

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
