### PR TITLE
[ConcurrentAdmission] Skip less favorable Variants from being admitted

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -383,14 +383,8 @@ func (s *Scheduler) processEntry(
 	ctx = ctrl.LoggerInto(ctx, log)
 	log.V(2).Info("Attempting to schedule workload")
 
-	if features.Enabled(features.ConcurrentAdmission) {
-		moreFavorableSibling, err := s.findAdmittedMoreFavorableSibling(&e.Info, snapshot)
-		if err != nil {
-			log.Error(err, "Failed to check for more favorable sibling")
-			e.markSkipped(fmt.Sprintf("Error checking for more favorable sibling: %v", err))
-			return
-		}
-		if moreFavorableSibling != nil {
+	if features.Enabled(features.ConcurrentAdmission) && concurrentadmission.IsVariant(e.Obj) {
+		if moreFavorableSibling := s.findAdmittedMoreFavorableSibling(&e.Info, snapshot); moreFavorableSibling != nil {
 			log.V(3).Info("Skipping workload as a more favorable variant is already admitted", "moreFavorableVariant", klog.KObj(moreFavorableSibling.Obj))
 			e.markSkipped("A more favorable variant is already admitted")
 			return
@@ -459,14 +453,8 @@ func (s *Scheduler) processEntry(
 		}
 	}
 
-	if features.Enabled(features.ConcurrentAdmission) {
-		lessFavorableSibling, err := s.findAdmittedLessFavorableSibling(&e.Info, snapshot)
-		if err != nil {
-			log.Error(err, "Failed to check for less favorable sibling")
-			e.markSkipped(fmt.Sprintf("Error checking for less favorable sibling: %v", err))
-			return
-		}
-		if lessFavorableSibling != nil {
+	if features.Enabled(features.ConcurrentAdmission) && concurrentadmission.IsVariant(e.Obj) {
+		if lessFavorableSibling := s.findAdmittedLessFavorableSibling(&e.Info, snapshot); lessFavorableSibling != nil {
 			s.issueMigration(ctx, log, e, lessFavorableSibling)
 			return
 		}
@@ -1122,7 +1110,7 @@ func (s *Scheduler) updateEntryPenalty(log logr.Logger, e *entry, op usageOp) {
 
 // findAdmittedLessFavorableSibling returns an admitted Sibling Workload that has a
 // less favorable Resource Flavor assignment than the provided Workload.
-func (s *Scheduler) findAdmittedLessFavorableSibling(wl *workload.Info, snap *schdcache.Snapshot) (*workload.Info, error) {
+func (s *Scheduler) findAdmittedLessFavorableSibling(wl *workload.Info, snap *schdcache.Snapshot) *workload.Info {
 	return s.findAdmittedSibling(wl, snap, func(siblingIdx, wlIdx int) bool {
 		return siblingIdx > wlIdx // larger index means less favorable
 	})
@@ -1130,7 +1118,7 @@ func (s *Scheduler) findAdmittedLessFavorableSibling(wl *workload.Info, snap *sc
 
 // findAdmittedMoreFavorableSibling returns an admitted Sibling Workload that has a
 // more favorable Resource Flavor assignment than the provided Workload.
-func (s *Scheduler) findAdmittedMoreFavorableSibling(wl *workload.Info, snap *schdcache.Snapshot) (*workload.Info, error) {
+func (s *Scheduler) findAdmittedMoreFavorableSibling(wl *workload.Info, snap *schdcache.Snapshot) *workload.Info {
 	return s.findAdmittedSibling(wl, snap, func(siblingIdx, wlIdx int) bool {
 		return wlIdx > siblingIdx
 	})
@@ -1141,36 +1129,33 @@ func (s *Scheduler) findAdmittedMoreFavorableSibling(wl *workload.Info, snap *sc
 // A Sibling is a Workload belonging to the same Parent Workload (part of the
 // Concurrent Admission feature). Favorability is determined by the order of
 // Resource Flavors defined in the ClusterQueue
-func (s *Scheduler) findAdmittedSibling(wl *workload.Info, snap *schdcache.Snapshot, compareFunc func(siblingIdx, wlIdx int) bool) (*workload.Info, error) {
+func (s *Scheduler) findAdmittedSibling(wl *workload.Info, snap *schdcache.Snapshot, compareFunc func(siblingIdx, wlIdx int) bool) *workload.Info {
 	if !features.Enabled(features.ConcurrentAdmission) {
-		return nil, nil
+		return nil
 	}
 	parentUID := concurrentadmission.GetParentWorkloadUID(wl.Obj)
 	if parentUID == "" {
-		return nil, nil
+		return nil
 	}
 	cq := snap.ClusterQueue(wl.ClusterQueue)
-	if cq == nil {
-		return nil, fmt.Errorf("cluster queue %s not found", wl.ClusterQueue)
-	}
-	if len(cq.ResourceGroups) == 0 {
-		return nil, nil
+	if cq == nil || len(cq.ResourceGroups) == 0 {
+		return nil
 	}
 	flavors := cq.ResourceGroups[0].Flavors
 	wlFlavorIdx, err := getFlavorIndex(wl, flavors)
 	if err != nil {
-		return nil, err
+		return nil
 	}
-	return s.findAdmittedSiblingMatching(wl, cq, parentUID, func(sibling *workload.Info) (bool, error) {
+	return s.findAdmittedSiblingMatching(wl, cq, parentUID, func(sibling *workload.Info) bool {
 		siblingFlavorIdx, err := getFlavorIndex(sibling, flavors)
 		if err != nil {
-			return false, err
+			return false
 		}
-		return compareFunc(siblingFlavorIdx, wlFlavorIdx), nil
+		return compareFunc(siblingFlavorIdx, wlFlavorIdx)
 	})
 }
 
-func (s *Scheduler) findAdmittedSiblingMatching(wl *workload.Info, cq *schdcache.ClusterQueueSnapshot, parentUID types.UID, match func(sibling *workload.Info) (bool, error)) (*workload.Info, error) {
+func (s *Scheduler) findAdmittedSiblingMatching(wl *workload.Info, cq *schdcache.ClusterQueueSnapshot, parentUID types.UID, match func(sibling *workload.Info) bool) *workload.Info {
 	for _, otherWl := range cq.Workloads {
 		if otherWl.Obj.UID == wl.Obj.UID {
 			continue
@@ -1181,15 +1166,12 @@ func (s *Scheduler) findAdmittedSiblingMatching(wl *workload.Info, cq *schdcache
 		if !workload.IsAdmitted(otherWl.Obj) {
 			continue
 		}
-		ok, err := match(otherWl)
-		if err != nil {
-			return nil, err
-		}
+		ok := match(otherWl)
 		if ok {
-			return otherWl, nil
+			return otherWl
 		}
 	}
-	return nil, nil
+	return nil
 }
 
 func getFlavorIndex(wl *workload.Info, flavors []kueue.ResourceFlavorReference) (int, error) {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -382,6 +382,14 @@ func (s *Scheduler) processEntry(
 	ctx = ctrl.LoggerInto(ctx, log)
 	log.V(2).Info("Attempting to schedule workload")
 
+	if features.Enabled(features.ConcurrentAdmission) {
+		if moreFavorableSibling := s.getMoreFavorableSibling(log, &e.Info, snapshot); moreFavorableSibling != nil {
+			log.V(3).Info("Skipping workload as a more favorable variant is already admitted", "moreFavorableVariant", klog.KObj(moreFavorableSibling.Obj))
+			e.markSkipped("A more favorable variant is already admitted")
+			return
+		}
+	}
+
 	mode := e.assignment.RepresentativeMode()
 
 	if features.Enabled(features.TASFailedNodeReplacementFailFast) && workload.HasTopologyAssignmentWithUnhealthyNode(e.Obj) && mode != flavorassigner.Fit {
@@ -1099,7 +1107,7 @@ func (s *Scheduler) updateEntryPenalty(log logr.Logger, e *entry, op usageOp) {
 	}
 }
 
-func (s *Scheduler) getLessFavorableSibling(wl *workload.Info, snap *schdcache.Snapshot) *workload.Info {
+func (s *Scheduler) getSiblingVariant(wl *workload.Info, snap *schdcache.Snapshot, matchFunc func(candidate, sibling kueue.ResourceFlavorReference, flavors []kueue.ResourceFlavorReference) bool) *workload.Info {
 	if !features.Enabled(features.ConcurrentAdmission) {
 		return nil
 	}
@@ -1125,12 +1133,30 @@ func (s *Scheduler) getLessFavorableSibling(wl *workload.Info, snap *schdcache.S
 		}
 		if concurrentadmission.GetParentWorkloadUID(otherWl.Obj) == parentUID && workload.IsAdmitted(otherWl.Obj) {
 			siblingFlavor := concurrentadmission.GetVariantFlavor(otherWl.Obj)
-			if siblingFlavor != "" && isLessFavorable(candidateFlavor, siblingFlavor, flavors) {
+			if siblingFlavor != "" && matchFunc(candidateFlavor, siblingFlavor, flavors) {
 				return otherWl
 			}
 		}
 	}
 	return nil
+}
+
+func (s *Scheduler) getLessFavorableSibling(log logr.Logger, wl *workload.Info, snap *schdcache.Snapshot) *preemption.Target {
+	sibling := s.getSiblingVariant(wl, snap, isLessFavorable)
+	if sibling == nil {
+		return nil
+	}
+	return &preemption.Target{
+		WorkloadInfo: sibling,
+		WorkloadCq:   snap.ClusterQueue(wl.ClusterQueue),
+		Reason:       kueue.WorkloadEvictedByFlavorMigration,
+	}
+}
+
+func (s *Scheduler) getMoreFavorableSibling(log logr.Logger, wl *workload.Info, snap *schdcache.Snapshot) *workload.Info {
+	return s.getSiblingVariant(wl, snap, func(candidate, sibling kueue.ResourceFlavorReference, flavors []kueue.ResourceFlavorReference) bool {
+		return isLessFavorable(sibling, candidate, flavors)
+	})
 }
 
 func isLessFavorable(candidate, sibling kueue.ResourceFlavorReference, flavors []kueue.ResourceFlavorReference) bool {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -460,7 +460,7 @@ func (s *Scheduler) processEntry(
 	}
 
 	if features.Enabled(features.ConcurrentAdmission) {
-		lessFavorableSibling, err := s.findAdmittedLessFavorableSibling(log, &e.Info, snapshot)
+		lessFavorableSibling, err := s.findAdmittedLessFavorableSibling(&e.Info, snapshot)
 		if err != nil {
 			log.Error(err, "Failed to check for less favorable sibling")
 			e.markSkipped(fmt.Sprintf("Error checking for less favorable sibling: %v", err))
@@ -1126,7 +1126,7 @@ func (s *Scheduler) updateEntryPenalty(log logr.Logger, e *entry, op usageOp) {
 // A Sibling is a Workload belonging to the same Parent Workload (part of the
 // Concurrent Admission feature). Favorability is determined by the order of
 // Resource Flavors defined in the ClusterQueue
-func (s *Scheduler) findAdmittedLessFavorableSibling(log logr.Logger, wl *workload.Info, snap *schdcache.Snapshot) (*workload.Info, error) {
+func (s *Scheduler) findAdmittedLessFavorableSibling(wl *workload.Info, snap *schdcache.Snapshot) (*workload.Info, error) {
 	return s.findAdmittedSibling(wl, snap, func(siblingIdx, wlIdx int) bool {
 		return siblingIdx > wlIdx // larger index means less favorable
 	})

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -19,6 +19,7 @@ package scheduler
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -383,7 +384,13 @@ func (s *Scheduler) processEntry(
 	log.V(2).Info("Attempting to schedule workload")
 
 	if features.Enabled(features.ConcurrentAdmission) {
-		if moreFavorableSibling := s.getMoreFavorableSibling(log, &e.Info, snapshot); moreFavorableSibling != nil {
+		moreFavorableSibling, err := s.findAdmittedMoreFavorableSibling(&e.Info, snapshot)
+		if err != nil {
+			log.Error(err, "Failed to check for more favorable sibling")
+			e.markSkipped(fmt.Sprintf("Error checking for more favorable sibling: %v", err))
+			return
+		}
+		if moreFavorableSibling != nil {
 			log.V(3).Info("Skipping workload as a more favorable variant is already admitted", "moreFavorableVariant", klog.KObj(moreFavorableSibling.Obj))
 			e.markSkipped("A more favorable variant is already admitted")
 			return
@@ -453,7 +460,13 @@ func (s *Scheduler) processEntry(
 	}
 
 	if features.Enabled(features.ConcurrentAdmission) {
-		if lessFavorableSibling := s.getLessFavorableSibling(&e.Info, snapshot); lessFavorableSibling != nil {
+		lessFavorableSibling, err := s.findAdmittedLessFavorableSibling(log, &e.Info, snapshot)
+		if err != nil {
+			log.Error(err, "Failed to check for less favorable sibling")
+			e.markSkipped(fmt.Sprintf("Error checking for less favorable sibling: %v", err))
+			return
+		}
+		if lessFavorableSibling != nil {
 			s.issueMigration(ctx, log, e, lessFavorableSibling)
 			return
 		}
@@ -1107,63 +1120,90 @@ func (s *Scheduler) updateEntryPenalty(log logr.Logger, e *entry, op usageOp) {
 	}
 }
 
-func (s *Scheduler) getSiblingVariant(wl *workload.Info, snap *schdcache.Snapshot, matchFunc func(candidate, sibling kueue.ResourceFlavorReference, flavors []kueue.ResourceFlavorReference) bool) *workload.Info {
+// findAdmittedLessFavorableSibling returns an admitted Sibling Workload that has a
+// less favorable Resource Flavor assignment than the provided Workload.
+//
+// A Sibling is a Workload belonging to the same Parent Workload (part of the
+// Concurrent Admission feature). Favorability is determined by the order of
+// Resource Flavors defined in the ClusterQueue
+func (s *Scheduler) findAdmittedLessFavorableSibling(log logr.Logger, wl *workload.Info, snap *schdcache.Snapshot) (*workload.Info, error) {
+	return s.findAdmittedSibling(wl, snap, func(siblingIdx, wlIdx int) bool {
+		return siblingIdx > wlIdx // larger index means less favorable
+	})
+}
+
+// findAdmittedMoreFavorableSibling returns an admitted Sibling Workload that has a
+// more favorable Resource Flavor assignment than the provided Workload.
+//
+// A Sibling is a Workload belonging to the same Parent Workload (part of the
+// Concurrent Admission feature). Favorability is determined by the order of
+// Resource Flavors defined in the ClusterQueue
+func (s *Scheduler) findAdmittedMoreFavorableSibling(wl *workload.Info, snap *schdcache.Snapshot) (*workload.Info, error) {
+	return s.findAdmittedSibling(wl, snap, func(siblingIdx, wlIdx int) bool {
+		return wlIdx > siblingIdx
+	})
+}
+
+// findAdmittedSibling is a helper that finds an admitted sibling workload matching the comparison criteria.
+func (s *Scheduler) findAdmittedSibling(wl *workload.Info, snap *schdcache.Snapshot, compareFunc func(siblingIdx, wlIdx int) bool) (*workload.Info, error) {
 	if !features.Enabled(features.ConcurrentAdmission) {
-		return nil
+		return nil, nil
 	}
 	parentUID := concurrentadmission.GetParentWorkloadUID(wl.Obj)
 	if parentUID == "" {
-		return nil
+		return nil, nil
 	}
-
 	cq := snap.ClusterQueue(wl.ClusterQueue)
-	if cq == nil || len(cq.ResourceGroups) == 0 {
-		return nil
+	if cq == nil {
+		return nil, fmt.Errorf("cluster queue %s not found", wl.ClusterQueue)
+	}
+	if len(cq.ResourceGroups) == 0 {
+		return nil, nil
 	}
 	flavors := cq.ResourceGroups[0].Flavors
-
-	candidateFlavor := concurrentadmission.GetVariantFlavor(wl.Obj)
-	if candidateFlavor == "" {
-		return nil
+	wlFlavorIdx, err := getFlavorIndex(wl, flavors)
+	if err != nil {
+		return nil, err
 	}
+	return s.findAdmittedSiblingMatching(wl, cq, parentUID, func(sibling *workload.Info) (bool, error) {
+		siblingFlavorIdx, err := getFlavorIndex(sibling, flavors)
+		if err != nil {
+			return false, err
+		}
+		return compareFunc(siblingFlavorIdx, wlFlavorIdx), nil
+	})
+}
 
+func (s *Scheduler) findAdmittedSiblingMatching(wl *workload.Info, cq *schdcache.ClusterQueueSnapshot, parentUID types.UID, match func(sibling *workload.Info) (bool, error)) (*workload.Info, error) {
 	for _, otherWl := range cq.Workloads {
 		if otherWl.Obj.UID == wl.Obj.UID {
 			continue
 		}
-		if concurrentadmission.GetParentWorkloadUID(otherWl.Obj) == parentUID && workload.IsAdmitted(otherWl.Obj) {
-			siblingFlavor := concurrentadmission.GetVariantFlavor(otherWl.Obj)
-			if siblingFlavor != "" && matchFunc(candidateFlavor, siblingFlavor, flavors) {
-				return otherWl
-			}
+		if concurrentadmission.GetParentWorkloadUID(otherWl.Obj) != parentUID {
+			continue
+		}
+		if !workload.IsAdmitted(otherWl.Obj) {
+			continue
+		}
+		ok, err := match(otherWl)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			return otherWl, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
-func (s *Scheduler) getLessFavorableSibling(log logr.Logger, wl *workload.Info, snap *schdcache.Snapshot) *preemption.Target {
-	sibling := s.getSiblingVariant(wl, snap, isLessFavorable)
-	if sibling == nil {
-		return nil
+func getFlavorIndex(wl *workload.Info, flavors []kueue.ResourceFlavorReference) (int, error) {
+	flavor := concurrentadmission.GetVariantFlavor(wl.Obj)
+	if flavor == "" {
+		return -1, errors.New("missing variant flavor annotation")
 	}
-	return &preemption.Target{
-		WorkloadInfo: sibling,
-		WorkloadCq:   snap.ClusterQueue(wl.ClusterQueue),
-		Reason:       kueue.WorkloadEvictedByFlavorMigration,
+	idx := slices.Index(flavors, flavor)
+	if idx == -1 {
+		return -1, fmt.Errorf("flavor %s not found in ClusterQueue flavors", flavor)
 	}
-}
-
-func (s *Scheduler) getMoreFavorableSibling(log logr.Logger, wl *workload.Info, snap *schdcache.Snapshot) *workload.Info {
-	return s.getSiblingVariant(wl, snap, func(candidate, sibling kueue.ResourceFlavorReference, flavors []kueue.ResourceFlavorReference) bool {
-		return isLessFavorable(sibling, candidate, flavors)
-	})
-}
-
-func isLessFavorable(candidate, sibling kueue.ResourceFlavorReference, flavors []kueue.ResourceFlavorReference) bool {
-	candidateIdx := slices.Index(flavors, candidate)
-	siblingIdx := slices.Index(flavors, sibling)
-	if candidateIdx == -1 || siblingIdx == -1 {
-		return false
-	}
-	return candidateIdx < siblingIdx
+	return idx, nil
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1122,10 +1122,6 @@ func (s *Scheduler) updateEntryPenalty(log logr.Logger, e *entry, op usageOp) {
 
 // findAdmittedLessFavorableSibling returns an admitted Sibling Workload that has a
 // less favorable Resource Flavor assignment than the provided Workload.
-//
-// A Sibling is a Workload belonging to the same Parent Workload (part of the
-// Concurrent Admission feature). Favorability is determined by the order of
-// Resource Flavors defined in the ClusterQueue
 func (s *Scheduler) findAdmittedLessFavorableSibling(wl *workload.Info, snap *schdcache.Snapshot) (*workload.Info, error) {
 	return s.findAdmittedSibling(wl, snap, func(siblingIdx, wlIdx int) bool {
 		return siblingIdx > wlIdx // larger index means less favorable
@@ -1134,17 +1130,17 @@ func (s *Scheduler) findAdmittedLessFavorableSibling(wl *workload.Info, snap *sc
 
 // findAdmittedMoreFavorableSibling returns an admitted Sibling Workload that has a
 // more favorable Resource Flavor assignment than the provided Workload.
-//
-// A Sibling is a Workload belonging to the same Parent Workload (part of the
-// Concurrent Admission feature). Favorability is determined by the order of
-// Resource Flavors defined in the ClusterQueue
 func (s *Scheduler) findAdmittedMoreFavorableSibling(wl *workload.Info, snap *schdcache.Snapshot) (*workload.Info, error) {
 	return s.findAdmittedSibling(wl, snap, func(siblingIdx, wlIdx int) bool {
 		return wlIdx > siblingIdx
 	})
 }
 
-// findAdmittedSibling is a helper that finds an admitted sibling workload matching the comparison criteria.
+// findAdmittedSibling is a helper that finds an admitted Sibling Workload matching the comparison criteria.
+//
+// A Sibling is a Workload belonging to the same Parent Workload (part of the
+// Concurrent Admission feature). Favorability is determined by the order of
+// Resource Flavors defined in the ClusterQueue
 func (s *Scheduler) findAdmittedSibling(wl *workload.Info, snap *schdcache.Snapshot, compareFunc func(siblingIdx, wlIdx int) bool) (*workload.Info, error) {
 	if !features.Enabled(features.ConcurrentAdmission) {
 		return nil, nil

--- a/pkg/scheduler/scheduler_concurrent_admission_test.go
+++ b/pkg/scheduler/scheduler_concurrent_admission_test.go
@@ -52,8 +52,26 @@ func TestScheduleConcurrentAdmission(t *testing.T) {
 		utiltestingapi.MakeResourceFlavor("on-demand").Obj(),
 		utiltestingapi.MakeResourceFlavor("spot").Obj(),
 	}
-	var clusterQueues []kueue.ClusterQueue
-	var queues []kueue.LocalQueue
+	clusterQueues := []kueue.ClusterQueue{
+		*utiltestingapi.MakeClusterQueue("concurrent-cq").
+			NamespaceSelector(&metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      "dep",
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   []string{"eng"},
+				}},
+			}).
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("on-demand").
+					Resource(corev1.ResourceCPU, "10").Obj(),
+				*utiltestingapi.MakeFlavorQuotas("spot").
+					Resource(corev1.ResourceCPU, "10").Obj(),
+			).
+			Obj(),
+	}
+	queues := []kueue.LocalQueue{
+		*utiltestingapi.MakeLocalQueue("concurrent-queue", "eng-alpha").ClusterQueue("concurrent-cq").Obj(),
+	}
 
 	cases := map[string]struct {
 		featureGates map[featuregate.Feature]bool
@@ -68,26 +86,6 @@ func TestScheduleConcurrentAdmission(t *testing.T) {
 		wantLeft        map[kueue.ClusterQueueReference][]workload.Reference
 	}{
 		"concurrent admission: more favorable variant evicts less favorable sibling": {
-			additionalClusterQueues: []kueue.ClusterQueue{
-				*utiltestingapi.MakeClusterQueue("concurrent-cq").
-					NamespaceSelector(&metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{{
-							Key:      "dep",
-							Operator: metav1.LabelSelectorOpIn,
-							Values:   []string{"eng"},
-						}},
-					}).
-					ResourceGroup(
-						*utiltestingapi.MakeFlavorQuotas("on-demand").
-							Resource(corev1.ResourceCPU, "10").Obj(),
-						*utiltestingapi.MakeFlavorQuotas("spot").
-							Resource(corev1.ResourceCPU, "10").Obj(),
-					).
-					Obj(),
-			},
-			additionalLocalQueues: []kueue.LocalQueue{
-				*utiltestingapi.MakeLocalQueue("concurrent-queue", "eng-alpha").ClusterQueue("concurrent-cq").Obj(),
-			},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("sibling-less-favorable", "eng-alpha").
 					UID("sibling-uid").
@@ -100,14 +98,14 @@ func TestScheduleConcurrentAdmission(t *testing.T) {
 						Obj(), now).
 					AdmittedAt(true, now).
 					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "parent-workload", "parent-uid").
-					Annotation("kueue.x-k8s.io/workload-allowed-resource-flavors", "spot").
+					AllowedFlavors("spot").
 					Obj(),
 				*utiltestingapi.MakeWorkload("candidate-more-favorable", "eng-alpha").
 					UID("candidate-uid").
 					Queue("concurrent-queue").
 					Request(corev1.ResourceCPU, "10").
 					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "parent-workload", "parent-uid").
-					Annotation("kueue.x-k8s.io/workload-allowed-resource-flavors", "on-demand").
+					AllowedFlavors("on-demand").
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
@@ -116,7 +114,7 @@ func TestScheduleConcurrentAdmission(t *testing.T) {
 					Queue("concurrent-queue").
 					Request(corev1.ResourceCPU, "10").
 					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "parent-workload", "parent-uid").
-					Annotation("kueue.x-k8s.io/workload-allowed-resource-flavors", "on-demand").
+					AllowedFlavors("on-demand").
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
@@ -142,7 +140,7 @@ func TestScheduleConcurrentAdmission(t *testing.T) {
 						Obj(), now).
 					AdmittedAt(true, now).
 					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "parent-workload", "parent-uid").
-					Annotation("kueue.x-k8s.io/workload-allowed-resource-flavors", "spot").
+					AllowedFlavors("spot").
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
 						Status:             metav1.ConditionTrue,
@@ -160,6 +158,76 @@ func TestScheduleConcurrentAdmission(t *testing.T) {
 				"eng-alpha/sibling-less-favorable": *utiltestingapi.MakeAdmission("concurrent-cq").
 					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
 						Assignment(corev1.ResourceCPU, "spot", "10").
+						Obj()).
+					Obj(),
+			},
+			featureGates: map[featuregate.Feature]bool{features.ConcurrentAdmission: true},
+		},
+		"concurrent admission: less favorable variant is skipped when more favorable sibling is admitted": {
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("sibling-more-favorable", "eng-alpha").
+					UID("sibling-uid").
+					Queue("concurrent-queue").
+					Request(corev1.ResourceCPU, "10").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("concurrent-cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "10").
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "parent-workload", "parent-uid").
+					AllowedFlavors("on-demand").
+					Obj(),
+				*utiltestingapi.MakeWorkload("candidate-less-favorable", "eng-alpha").
+					UID("candidate-uid").
+					Queue("concurrent-queue").
+					Request(corev1.ResourceCPU, "10").
+					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "parent-workload", "parent-uid").
+					AllowedFlavors("spot").
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("sibling-more-favorable", "eng-alpha").
+					UID("sibling-uid").
+					Queue("concurrent-queue").
+					Request(corev1.ResourceCPU, "10").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("concurrent-cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "10").
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "parent-workload", "parent-uid").
+					AllowedFlavors("on-demand").
+					Obj(),
+				*utiltestingapi.MakeWorkload("candidate-less-favorable", "eng-alpha").
+					UID("candidate-uid").
+					Queue("concurrent-queue").
+					Request(corev1.ResourceCPU, "10").
+					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "parent-workload", "parent-uid").
+					AllowedFlavors("spot").
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             "Pending",
+						Message:            "A more favorable variant is already admitted",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("10"),
+						},
+					}).
+					Obj(),
+			},
+			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"concurrent-cq": {"eng-alpha/candidate-less-favorable"},
+			},
+			wantAssignments: map[workload.Reference]kueue.Admission{
+				"eng-alpha/sibling-more-favorable": *utiltestingapi.MakeAdmission("concurrent-cq").
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "10").
 						Obj()).
 					Obj(),
 			},
@@ -259,6 +327,7 @@ func TestScheduleConcurrentAdmission(t *testing.T) {
 					cmpopts.IgnoreFields(kueue.AdmissionCheckState{}, "LastTransitionTime"),
 					cmpopts.IgnoreFields(kueue.Workload{}, "ObjectMeta.ResourceVersion", "ObjectMeta.CreationTimestamp"),
 					cmpopts.SortSlices(func(a, b metav1.Condition) bool { return a.Type < b.Type }),
+					cmpopts.SortSlices(func(a, b kueue.Workload) bool { return a.Name < b.Name }),
 				}
 
 				if diff := cmp.Diff(tc.wantWorkloads, gotWorkloads.Items, defaultWorkloadCmpOpts); diff != "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Skips less favorable Variants from being admitted, if the more favorable Variant is running. Eventually the less favorable Variant is deactivated by the concurrentadmission controller.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10913

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
