### PR TITLE
[ConcurrentAdmission] Add indexer to ConcurrentAdmission controller

### DIFF
--- a/pkg/controller/concurrentadmission/controller.go
+++ b/pkg/controller/concurrentadmission/controller.go
@@ -42,6 +42,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -207,17 +208,10 @@ func (r *variantReconciler) getVariantsForParent(ctx context.Context, parent *ku
 		return nil, fmt.Errorf("workload %s/%s is not a parent variant", parent.Namespace, parent.Name)
 	}
 	list := &kueue.WorkloadList{}
-	if err := r.client.List(ctx, list, client.InNamespace(parent.Namespace)); err != nil {
-		// TODO: Index variants
+	if err := r.client.List(ctx, list, client.InNamespace(parent.Namespace), client.MatchingFields{indexer.OwnerReferenceUID: string(parent.UID)}); err != nil {
 		return nil, err
 	}
-	variants := make([]kueue.Workload, 0)
-	for i := range list.Items {
-		if concurrentadmission.GetParentWorkloadName(&list.Items[i]) == parent.Name {
-			variants = append(variants, list.Items[i])
-		}
-	}
-	return variants, nil
+	return list.Items, nil
 }
 
 func (r *variantReconciler) getClusterQueue(ctx context.Context, wl *kueue.Workload) (*kueue.ClusterQueue, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Use an already existing indexer `OwnerReferenceUID` to filter Workloads that belong to the a particular Parent Workload

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10904

#### Special notes for your reviewer:
The existing UTs confirm this change works, without additional tests 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
