### PR TITLE
Automated cherry pick of #10858:  Rename `Group` to `GroupNameLabel` and add `PrebuiltWorkloadLabel` to testing wrappers   

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -42,7 +42,6 @@ import (
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
@@ -159,7 +158,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			worker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Obj(),
 			},
@@ -491,7 +490,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			wantWorker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Obj(),
 			},
@@ -617,7 +616,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			wantWorker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Obj(),
 			},
@@ -654,7 +653,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			worker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Obj(),
 			},
@@ -698,7 +697,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			wantWorker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Obj(),
 			},
@@ -724,7 +723,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			worker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Active(0).
 					Obj(),
@@ -775,7 +774,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			wantWorker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Obj(),
 			},
@@ -803,7 +802,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			worker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Active(1).
 					Obj(),
@@ -854,7 +853,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			wantWorker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Active(1).
 					Obj(),
@@ -925,7 +924,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			wantWorker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Obj(),
 			},
@@ -994,7 +993,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			wantWorker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Obj(),
 			},
@@ -1032,7 +1031,7 @@ func TestWlReconcile(t *testing.T) {
 
 			worker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Active(1).
 					Obj(),
 			},
@@ -1069,7 +1068,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			wantWorker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Active(1).
 					Obj(),
 			},
@@ -1107,7 +1106,7 @@ func TestWlReconcile(t *testing.T) {
 
 			worker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Active(1).
 					Obj(),
 			},
@@ -1142,7 +1141,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			wantWorker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Active(1).
 					Obj(),
 			},
@@ -1176,7 +1175,7 @@ func TestWlReconcile(t *testing.T) {
 
 			worker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
 					Obj(),
 			},
@@ -1215,7 +1214,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			wantWorker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
 					Obj(),
 			},
@@ -1241,7 +1240,7 @@ func TestWlReconcile(t *testing.T) {
 
 			worker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
 					Obj(),
 			},
@@ -1280,7 +1279,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			wantWorker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
 					Obj(),
 			},
@@ -1308,7 +1307,7 @@ func TestWlReconcile(t *testing.T) {
 
 			worker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
 					Obj(),
 			},
@@ -1428,7 +1427,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			worker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Obj(),
 			},
 		},
@@ -1462,7 +1461,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			worker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Obj(),
 			},
 			useSecondWorker: true,
@@ -1475,7 +1474,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			worker2Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Obj(),
 			},
 			wantManagersWorkloads: []kueue.Workload{
@@ -1501,7 +1500,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			wantWorker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Obj(),
 			},
 
@@ -1548,7 +1547,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			worker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Obj(),
 			},
 			useSecondWorker: true,
@@ -1582,7 +1581,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			wantWorker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Obj(),
 			},
 		},
@@ -1614,7 +1613,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			worker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Obj(),
 			},
 			useSecondWorker: true,
@@ -1667,7 +1666,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			worker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Obj(),
 			},
 			useSecondWorker: true,
@@ -1696,7 +1695,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			wantWorker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Obj(),
 			},
 		},
@@ -1733,7 +1732,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			worker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Obj(),
 			},
 			useSecondWorker: true,
@@ -1790,7 +1789,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			worker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Obj(),
 			},
 			useSecondWorker: true,
@@ -1819,7 +1818,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 			wantWorker1Jobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{

--- a/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter_test.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingaw "sigs.k8s.io/kueue/pkg/util/testingjobs/appwrapper"
@@ -78,7 +77,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerAppWrappers: []awv1beta2.AppWrapper{
 				*baseAppWrapperBuilder.DeepCopy().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},
@@ -89,7 +88,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerAppWrappers: []awv1beta2.AppWrapper{
 				*baseAppWrapperBuilder.DeepCopy().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					SetPhase(awv1beta2.AppWrapperSuspended).
 					Obj(),
@@ -106,7 +105,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerAppWrappers: []awv1beta2.AppWrapper{
 				*baseAppWrapperBuilder.DeepCopy().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					SetPhase(awv1beta2.AppWrapperSuspended).
 					Obj(),
@@ -118,7 +117,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerAppWrappers: []awv1beta2.AppWrapper{
 				*baseAppWrapperBuilder.DeepCopy().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					SetPhase(awv1beta2.AppWrapperSuspended).
 					Obj(),
@@ -135,7 +134,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerAppWrappers: []awv1beta2.AppWrapper{
 				*baseAppWrapperBuilder.DeepCopy().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					SetPhase(awv1beta2.AppWrapperSuspended).
 					Obj(),
@@ -144,7 +143,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		"remote appwrapper is deleted": {
 			workerAppWrappers: []awv1beta2.AppWrapper{
 				*baseAppWrapperBuilder.DeepCopy().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},

--- a/pkg/controller/jobs/job/job_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter_test.go
@@ -35,7 +35,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
@@ -81,7 +80,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerJobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},
@@ -92,7 +91,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerJobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Active(2).
 					Obj(),
@@ -106,7 +105,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerJobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Active(2).
 					Obj(),
@@ -120,7 +119,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerJobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					Active(2).
@@ -136,7 +135,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerJobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					Active(2).
@@ -149,7 +148,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerJobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
 					Obj(),
@@ -165,7 +164,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerJobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
 					Obj(),
@@ -177,7 +176,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerJobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Active(2).
 					Obj(),
@@ -192,7 +191,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerJobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Active(2).
 					Obj(),
@@ -204,7 +203,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerJobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
 					Obj(),
@@ -221,7 +220,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerJobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
 					Obj(),
@@ -230,7 +229,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		"remote job is deleted": {
 			workerJobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Active(2).
 					Obj(),
@@ -406,7 +405,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 			want: want{
 				localJob: newJob().ManagedBy("parent").Obj(),
 				remoteJob: newJob().Label(kueue.MultiKueueOriginLabel, "").
-					Label(constants.PrebuiltWorkloadLabel, "").
+					PrebuiltWorkloadLabel("").
 					ManagedBy("parent").
 					Obj(),
 			},
@@ -424,7 +423,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 			want: want{
 				localJob: newJob().ManagedBy("parent").Obj(),
 				remoteJob: newJob().Label(kueue.MultiKueueOriginLabel, "").
-					Label(constants.PrebuiltWorkloadLabel, "").
+					PrebuiltWorkloadLabel("").
 					Obj(),
 			},
 		},
@@ -599,7 +598,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 					Obj()).Build(),
 				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					Label(constants.PrebuiltWorkloadLabel, "test-workload").
+					PrebuiltWorkloadLabel("test-workload").
 					Condition(runningJobCondition).
 					Obj()).Build(),
 				key:          client.ObjectKeyFromObject(newJob().Obj()),
@@ -612,7 +611,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 					Obj(),
 				remoteJob: newJob().
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					Label(constants.PrebuiltWorkloadLabel, "test-workload").
+					PrebuiltWorkloadLabel("test-workload").
 					Condition(runningJobCondition).
 					Obj(),
 			},
@@ -629,7 +628,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 					Obj()).Build(),
 				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					Label(constants.PrebuiltWorkloadLabel, "test-workload").
+					PrebuiltWorkloadLabel("test-workload").
 					Condition(runningJobCondition).
 					Obj()).Build(),
 				key:          client.ObjectKeyFromObject(newJob().Obj()),
@@ -643,7 +642,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 					Obj(),
 				remoteJob: newJob().
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					Label(constants.PrebuiltWorkloadLabel, "test-workload").
+					PrebuiltWorkloadLabel("test-workload").
 					Condition(runningJobCondition).
 					Obj(),
 			},
@@ -672,7 +671,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 				remoteJob: newJob().
 					ResourceVersion("2").
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					Label(constants.PrebuiltWorkloadLabel, "test-workload-new").
+					PrebuiltWorkloadLabel("test-workload-new").
 					Condition(runningJobCondition).
 					Obj(),
 			},
@@ -717,7 +716,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 					Obj()).Build(),
 				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					Label(constants.PrebuiltWorkloadLabel, "test-workload").
+					PrebuiltWorkloadLabel("test-workload").
 					Condition(runningJobCondition).
 					Obj()).Build(),
 				key:          client.ObjectKeyFromObject(newJob().Obj()),
@@ -732,7 +731,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 				remoteJob: newJob().
 					ResourceVersion("2").
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					Label(constants.PrebuiltWorkloadLabel, jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration("test", "", gvk, 0)).
+					PrebuiltWorkloadLabel(jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration("test", "", gvk, 0)).
 					Parallelism(22).
 					Condition(runningJobCondition).
 					Obj(),
@@ -750,7 +749,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 					Obj()).Build(),
 				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					Label(constants.PrebuiltWorkloadLabel, "test-workload").
+					PrebuiltWorkloadLabel("test-workload").
 					Condition(runningJobCondition).
 					Obj()).Build(),
 				key:          client.ObjectKeyFromObject(newJob().Obj()),
@@ -765,7 +764,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 				remoteJob: newJob().
 					ResourceVersion("1").
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					Label(constants.PrebuiltWorkloadLabel, "test-workload").
+					PrebuiltWorkloadLabel("test-workload").
 					Parallelism(1).
 					Condition(runningJobCondition).
 					Obj(),
@@ -783,7 +782,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 					Obj()).Build(),
 				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					Label(constants.PrebuiltWorkloadLabel, "test-workload").
+					PrebuiltWorkloadLabel("test-workload").
 					Condition(runningJobCondition).
 					Obj()).
 					WithInterceptorFuncs(interceptor.Funcs{
@@ -803,7 +802,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 					Obj(),
 				remoteJob: newJob().
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					Label(constants.PrebuiltWorkloadLabel, "test-workload").
+					PrebuiltWorkloadLabel("test-workload").
 					Condition(runningJobCondition).
 					Obj(),
 			},
@@ -820,7 +819,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 					Obj()).Build(),
 				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					Label(constants.PrebuiltWorkloadLabel, "test-workload").
+					PrebuiltWorkloadLabel("test-workload").
 					Condition(runningJobCondition).
 					Obj()).
 					WithInterceptorFuncs(interceptor.Funcs{
@@ -839,7 +838,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 					Obj(),
 				remoteJob: newJob().
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					Label(constants.PrebuiltWorkloadLabel, "test-workload").
+					PrebuiltWorkloadLabel("test-workload").
 					Condition(runningJobCondition).
 					Obj(),
 			},

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -58,7 +58,7 @@ const (
 var (
 	labelsPath                    = field.NewPath("metadata", "labels")
 	queueNameLabelPath            = labelsPath.Key(constants.QueueLabel)
-	prebuiltWlNameLabelPath       = labelsPath.Key(constants.PrebuiltWorkloadLabel)
+	prebuiltWorkloadLabelPath     = labelsPath.Key(constants.PrebuiltWorkloadLabel)
 	maxExecTimeLabelPath          = labelsPath.Key(constants.MaxExecTimeSecondsLabel)
 	workloadPriorityClassNamePath = labelsPath.Key(constants.WorkloadPriorityClassLabel)
 )
@@ -178,11 +178,11 @@ func TestValidateCreate(t *testing.T) {
 			job: testingutil.MakeJob("job", "default").
 				Parallelism(4).
 				Completions(4).
-				Label(constants.PrebuiltWorkloadLabel, "workload name").
+				PrebuiltWorkloadLabel("workload name").
 				Indexed(true).
 				Obj(),
 			wantValidationErrs: field.ErrorList{
-				field.Invalid(prebuiltWlNameLabelPath, "workload name", invalidRFC1123Message),
+				field.Invalid(prebuiltWorkloadLabelPath, "workload name", invalidRFC1123Message),
 			},
 		},
 		{
@@ -190,7 +190,7 @@ func TestValidateCreate(t *testing.T) {
 			job: testingutil.MakeJob("job", "default").
 				Parallelism(4).
 				Completions(4).
-				Label(constants.PrebuiltWorkloadLabel, "workload-name").
+				PrebuiltWorkloadLabel("workload-name").
 				Indexed(true).
 				Obj(),
 			wantValidationErrs: nil,
@@ -559,13 +559,13 @@ func TestValidateUpdate(t *testing.T) {
 			name: "immutable prebuilt workload ",
 			oldJob: testingutil.MakeJob("job", "default").
 				Suspend(true).
-				Label(constants.PrebuiltWorkloadLabel, "old-workload").
+				PrebuiltWorkloadLabel("old-workload").
 				Obj(),
 			newJob: testingutil.MakeJob("job", "default").
 				Suspend(false).
-				Label(constants.PrebuiltWorkloadLabel, "new-workload").
+				PrebuiltWorkloadLabel("new-workload").
 				Obj(),
-			wantValidationErrs: apivalidation.ValidateImmutableField("new-workload", "old-workload", prebuiltWlNameLabelPath),
+			wantValidationErrs: apivalidation.ValidateImmutableField("new-workload", "old-workload", prebuiltWorkloadLabelPath),
 		},
 		{
 			name: "immutable queue name not suspend",

--- a/pkg/controller/jobs/jobset/jobset_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/jobset/jobset_multikueue_adapter_test.go
@@ -30,7 +30,6 @@ import (
 	jobsetapi "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingjobset "sigs.k8s.io/kueue/pkg/util/testingjobs/jobset"
@@ -73,7 +72,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerJobSets: []jobsetapi.JobSet{
 				*baseJobSetBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},
@@ -84,7 +83,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerJobSets: []jobsetapi.JobSet{
 				*baseJobSetBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					JobsStatus(
 						jobsetapi.ReplicatedJobStatus{
@@ -122,7 +121,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerJobSets: []jobsetapi.JobSet{
 				*baseJobSetBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					JobsStatus(
 						jobsetapi.ReplicatedJobStatus{
@@ -147,7 +146,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerJobSets: []jobsetapi.JobSet{
 				*baseJobSetBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					JobsStatus(
@@ -187,7 +186,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerJobSets: []jobsetapi.JobSet{
 				*baseJobSetBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					JobsStatus(
@@ -208,7 +207,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		"remote jobset is deleted": {
 			workerJobSets: []jobsetapi.JobSet{
 				*baseJobSetBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					JobsStatus(
 						jobsetapi.ReplicatedJobStatus{

--- a/pkg/controller/jobs/jobset/jobset_webhook_test.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook_test.go
@@ -43,7 +43,8 @@ const (
 )
 
 var (
-	labelsPath         = field.NewPath("metadata", "labels")
+	metadataPath       = field.NewPath("metadata")
+	labelsPath         = metadataPath.Child("labels")
 	queueNameLabelPath = labelsPath.Key(constants.QueueLabel)
 )
 
@@ -66,7 +67,7 @@ func TestValidateCreate(t *testing.T) {
 		},
 		{
 			name:    "with prebuilt workload",
-			job:     testingutil.MakeJobSet("job", "default").Queue("queue").Label(constants.PrebuiltWorkloadLabel, "prebuilt-workload").Obj(),
+			job:     testingutil.MakeJobSet("job", "default").Queue("queue").PrebuiltWorkloadLabel("prebuilt-workload").Obj(),
 			wantErr: nil,
 		},
 		{

--- a/pkg/controller/jobs/kubeflow/jobs/jaxjob/jaxjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/jaxjob/jaxjob_multikueue_adapter_test.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/kubeflowjob"
 	"sigs.k8s.io/kueue/pkg/util/slices"
@@ -75,7 +74,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerJAXJobs: []kftraining.JAXJob{
 				*jaxJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},
@@ -86,7 +85,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerJAXJobs: []kftraining.JAXJob{
 				*jaxJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
 					Obj(),
@@ -102,7 +101,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerJAXJobs: []kftraining.JAXJob{
 				*jaxJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
 					Obj(),
@@ -116,7 +115,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerJAXJobs: []kftraining.JAXJob{
 				*jaxJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
@@ -133,7 +132,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerJAXJobs: []kftraining.JAXJob{
 				*jaxJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
@@ -143,7 +142,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		"remote jaxjob is deleted": {
 			workerJAXJobs: []kftraining.JAXJob{
 				*jaxJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},

--- a/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_multikueue_adapter_test.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/kubeflowjob"
 	"sigs.k8s.io/kueue/pkg/util/slices"
@@ -76,7 +75,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerPaddleJobs: []kftraining.PaddleJob{
 				*paddleJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},
@@ -87,7 +86,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerPaddleJobs: []kftraining.PaddleJob{
 				*paddleJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
 					Obj(),
@@ -103,7 +102,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerPaddleJobs: []kftraining.PaddleJob{
 				*paddleJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
 					Obj(),
@@ -117,7 +116,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerPaddleJobs: []kftraining.PaddleJob{
 				*paddleJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
@@ -134,7 +133,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerPaddleJobs: []kftraining.PaddleJob{
 				*paddleJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
@@ -144,7 +143,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		"remote PaddleJob is deleted": {
 			workerPaddleJobs: []kftraining.PaddleJob{
 				*paddleJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},

--- a/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorch_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorch_multikueue_adapter_test.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/kubeflowjob"
 	"sigs.k8s.io/kueue/pkg/util/slices"
@@ -75,7 +74,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerPyTorchJobs: []kftraining.PyTorchJob{
 				*pyTorchJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},
@@ -86,7 +85,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerPyTorchJobs: []kftraining.PyTorchJob{
 				*pyTorchJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
 					Obj(),
@@ -102,7 +101,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerPyTorchJobs: []kftraining.PyTorchJob{
 				*pyTorchJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
 					Obj(),
@@ -116,7 +115,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerPyTorchJobs: []kftraining.PyTorchJob{
 				*pyTorchJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
@@ -133,7 +132,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerPyTorchJobs: []kftraining.PyTorchJob{
 				*pyTorchJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
@@ -143,7 +142,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		"remote pytorchjob is deleted": {
 			workerPyTorchJobs: []kftraining.PyTorchJob{
 				*pyTorchJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},

--- a/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_multikueue_adapter_test.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/kubeflowjob"
 	"sigs.k8s.io/kueue/pkg/util/slices"
@@ -75,7 +74,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerTFJobs: []kftraining.TFJob{
 				*tfJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},
@@ -86,7 +85,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerTFJobs: []kftraining.TFJob{
 				*tfJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
 					Obj(),
@@ -102,7 +101,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerTFJobs: []kftraining.TFJob{
 				*tfJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
 					Obj(),
@@ -116,7 +115,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerTFJobs: []kftraining.TFJob{
 				*tfJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
@@ -133,7 +132,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerTFJobs: []kftraining.TFJob{
 				*tfJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
@@ -143,7 +142,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		"remote tfjob is deleted": {
 			workerTFJobs: []kftraining.TFJob{
 				*tfJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},

--- a/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_multikueue_adapter_test.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/kubeflowjob"
 	"sigs.k8s.io/kueue/pkg/util/slices"
@@ -75,7 +74,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerXGBoostJobs: []kftraining.XGBoostJob{
 				*xgboostJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},
@@ -86,7 +85,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerXGBoostJobs: []kftraining.XGBoostJob{
 				*xgboostJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
 					Obj(),
@@ -102,7 +101,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerXGBoostJobs: []kftraining.XGBoostJob{
 				*xgboostJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
 					Obj(),
@@ -116,7 +115,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerXGBoostJobs: []kftraining.XGBoostJob{
 				*xgboostJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
@@ -134,7 +133,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerXGBoostJobs: []kftraining.XGBoostJob{
 				*xgboostJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
@@ -144,7 +143,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		"remote XgBoostJob is deleted": {
 			workerXGBoostJobs: []kftraining.XGBoostJob{
 				*xgboostJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_pod_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_pod_reconciler_test.go
@@ -122,9 +122,9 @@ func TestPodReconciler(t *testing.T) {
 					Label(leaderworkersetv1.GroupIndexLabelKey, "0").
 					Queue("queue").
 					ManagedByKueueLabel().
-					Group(GetWorkloadName(types.UID(testUID), "lws", "0")).
+					GroupNameLabel(GetWorkloadName(types.UID(testUID), "lws", "0")).
 					GroupTotalCount("1").
-					PrebuiltWorkload(GetWorkloadName(types.UID(testUID), "lws", "0")).
+					PrebuiltWorkloadLabel(GetWorkloadName(types.UID(testUID), "lws", "0")).
 					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 					Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
 					Annotation(podconstants.RoleHashAnnotation, string(kueue.DefaultPodSetName)).
@@ -150,9 +150,9 @@ func TestPodReconciler(t *testing.T) {
 					Label(leaderworkersetv1.GroupIndexLabelKey, "0").
 					Queue("queue").
 					ManagedByKueueLabel().
-					Group(GetWorkloadName(types.UID(testUID), "lws", "0")).
+					GroupNameLabel(GetWorkloadName(types.UID(testUID), "lws", "0")).
 					GroupTotalCount("1").
-					PrebuiltWorkload(GetWorkloadName(types.UID(testUID), "lws", "0")).
+					PrebuiltWorkloadLabel(GetWorkloadName(types.UID(testUID), "lws", "0")).
 					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 					Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
 					Annotation(leaderworkersetv1.LeaderPodNameAnnotationKey, "lws-0").
@@ -179,9 +179,9 @@ func TestPodReconciler(t *testing.T) {
 					Label(leaderworkersetv1.GroupIndexLabelKey, "0").
 					Queue("queue").
 					ManagedByKueueLabel().
-					Group(GetWorkloadName(types.UID(testUID), "lws", "0")).
+					GroupNameLabel(GetWorkloadName(types.UID(testUID), "lws", "0")).
 					GroupTotalCount("1").
-					PrebuiltWorkload(GetWorkloadName(types.UID(testUID), "lws", "0")).
+					PrebuiltWorkloadLabel(GetWorkloadName(types.UID(testUID), "lws", "0")).
 					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 					Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
 					Annotation(podconstants.RoleHashAnnotation, leaderPodSetName).
@@ -208,9 +208,9 @@ func TestPodReconciler(t *testing.T) {
 					Label(leaderworkersetv1.GroupIndexLabelKey, "0").
 					Queue("queue").
 					ManagedByKueueLabel().
-					Group(GetWorkloadName(types.UID(testUID), "lws", "0")).
+					GroupNameLabel(GetWorkloadName(types.UID(testUID), "lws", "0")).
 					GroupTotalCount("1").
-					PrebuiltWorkload(GetWorkloadName(types.UID(testUID), "lws", "0")).
+					PrebuiltWorkloadLabel(GetWorkloadName(types.UID(testUID), "lws", "0")).
 					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 					Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
 					Annotation(leaderworkersetv1.LeaderPodNameAnnotationKey, "lws-0").

--- a/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter_test.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingmpijob "sigs.k8s.io/kueue/pkg/util/testingjobs/mpijob"
@@ -72,7 +71,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},
@@ -83,7 +82,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					StatusConditions(kfmpi.JobCondition{Type: kfmpi.JobSucceeded, Status: corev1.ConditionTrue}).
 					Obj(),
@@ -99,7 +98,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					StatusConditions(kfmpi.JobCondition{Type: kfmpi.JobSucceeded, Status: corev1.ConditionTrue}).
 					Obj(),
@@ -113,7 +112,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					StatusConditions(kfmpi.JobCondition{Type: kfmpi.JobSucceeded, Status: corev1.ConditionTrue}).
@@ -130,7 +129,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					StatusConditions(kfmpi.JobCondition{Type: kfmpi.JobSucceeded, Status: corev1.ConditionTrue}).
@@ -140,7 +139,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		"remote mpijob is deleted": {
 			workerMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},

--- a/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
@@ -66,7 +66,7 @@ func TestValidateCreate(t *testing.T) {
 		},
 		{
 			name:    "with prebuilt workload",
-			job:     testingutil.MakeMPIJob("job", "default").Queue("queue").Label(constants.PrebuiltWorkloadLabel, "prebuilt-workload").Obj(),
+			job:     testingutil.MakeMPIJob("job", "default").Queue("queue").PrebuiltWorkloadLabel("prebuilt-workload").Obj(),
 			wantErr: nil,
 		},
 		{

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -678,7 +678,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
 					Annotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -689,7 +689,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
 					Annotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -701,7 +701,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
 					Annotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -712,7 +712,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
 					Annotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -753,7 +753,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
 					Annotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
 					Obj(),
@@ -767,7 +767,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
 					Annotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
 					Obj(),
@@ -807,7 +807,7 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -817,7 +817,7 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -828,7 +828,7 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -838,7 +838,7 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -879,7 +879,7 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -889,7 +889,7 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -916,7 +916,7 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -926,7 +926,7 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -964,7 +964,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -973,7 +973,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -983,7 +983,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -992,7 +992,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -1036,7 +1036,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -1045,7 +1045,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -1054,7 +1054,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					NodeSelector(corev1.LabelArchStable, "arm64").
 					Label(constants.PodSetLabel, podUID).
@@ -1065,7 +1065,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					NodeSelector(corev1.LabelArchStable, "arm64").
 					Label(constants.PodSetLabel, podUID).
@@ -1132,7 +1132,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -1141,7 +1141,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -1150,7 +1150,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -1159,7 +1159,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -1201,7 +1201,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -1210,7 +1210,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -1219,7 +1219,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					ManagedByKueueLabel().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -1227,7 +1227,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod2").
 					ManagedByKueueLabel().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -1281,14 +1281,14 @@ func TestReconciler(t *testing.T) {
 				Clone().
 				ManagedByKueueLabel().
 				KueueFinalizer().
-				Group("test-group").
+				GroupNameLabel("test-group").
 				GroupTotalCount("2").
 				Obj()},
 			wantPods: []corev1.Pod{*basePodWrapper.
 				Clone().
 				ManagedByKueueLabel().
 				KueueFinalizer().
-				Group("test-group").
+				GroupNameLabel("test-group").
 				GroupTotalCount("2").
 				Obj()},
 			workloads: []kueue.Workload{
@@ -1339,7 +1339,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("test-queue").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -1349,7 +1349,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("test-queue").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -1360,7 +1360,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("test-queue").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -1370,7 +1370,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("test-queue").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -1412,7 +1412,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					KueueFinalizer().
 					ManagedByKueueLabel().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -1421,7 +1421,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					ManagedByKueueLabel().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -1495,7 +1495,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("test-queue").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -1505,7 +1505,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("new-test-queue").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -1516,7 +1516,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("test-queue").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -1526,7 +1526,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("new-test-queue").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -1542,7 +1542,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					Queue("test-queue").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -1551,7 +1551,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					Queue("test-queue").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -1598,7 +1598,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					StatusPhase(corev1.PodFailed).
 					Obj(),
@@ -1608,7 +1608,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					Obj(),
 			},
@@ -1617,7 +1617,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					StatusPhase(corev1.PodFailed).
 					Obj(),
@@ -1626,7 +1626,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					Label(constants.PodSetLabel, podUID).
 					Annotation(kueue.WorkloadAnnotation, "test-group").
@@ -1688,7 +1688,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					Label(constants.PodSetLabel, podUID).
 					StatusPhase(corev1.PodRunning).
@@ -1698,7 +1698,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodFailed).
 					Obj(),
@@ -1707,7 +1707,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod3").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -1717,7 +1717,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					Obj(),
 			},
@@ -1742,7 +1742,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					Label(constants.PodSetLabel, podUID).
 					StatusPhase(corev1.PodRunning).
@@ -1751,7 +1751,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod2").
 					ManagedByKueueLabel().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodFailed).
 					Obj(),
@@ -1760,7 +1760,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod3").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -1769,7 +1769,7 @@ func TestReconciler(t *testing.T) {
 					Name("replacement").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					Label(constants.PodSetLabel, podUID).
 					Annotation(kueue.WorkloadAnnotation, "test-group").
@@ -1818,7 +1818,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
 					Obj(),
@@ -1827,7 +1827,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -1836,7 +1836,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod3").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -1845,7 +1845,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					ManagedByKueueLabel().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
 					Obj(),
@@ -1853,7 +1853,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod2").
 					ManagedByKueueLabel().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -1861,7 +1861,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod3").
 					ManagedByKueueLabel().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -1918,7 +1918,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					StatusPhase(corev1.PodRunning).
 					Delete().
@@ -1929,7 +1929,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					StatusPhase(corev1.PodRunning).
 					Delete().
@@ -1997,7 +1997,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					StatusPhase(corev1.PodFailed).
 					Delete().
@@ -2008,7 +2008,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					StatusPhase(corev1.PodFailed).
 					Delete().
@@ -2098,7 +2098,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					Queue("test-queue").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					NodeName("test-node").
 					GroupTotalCount("2").
 					Delete().
@@ -2109,7 +2109,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					Queue("test-queue").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					NodeName("test-node").
 					GroupTotalCount("2").
 					Delete().
@@ -2121,7 +2121,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					Queue("test-queue").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					NodeName("test-node").
 					GroupTotalCount("2").
 					Delete().
@@ -2132,7 +2132,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					Queue("test-queue").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					NodeName("test-node").
 					GroupTotalCount("2").
 					Delete().
@@ -2186,7 +2186,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Delete().
 					Obj(),
@@ -2195,7 +2195,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Delete().
 					Obj(),
@@ -2205,7 +2205,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Delete().
 					Obj(),
@@ -2214,7 +2214,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Delete().
 					Obj(),
@@ -2267,7 +2267,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Delete().
 					Obj(),
@@ -2277,7 +2277,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Delete().
 					Obj(),
@@ -2334,7 +2334,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -2343,7 +2343,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -2352,7 +2352,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					ManagedByKueueLabel().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -2360,7 +2360,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod2").
 					ManagedByKueueLabel().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -2376,7 +2376,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -2384,7 +2384,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -2395,7 +2395,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -2403,7 +2403,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -2442,7 +2442,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -2450,7 +2450,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
 					Obj(),
@@ -2461,14 +2461,14 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
 					ManagedByKueueLabel().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
 					Obj(),
@@ -2492,7 +2492,7 @@ func TestReconciler(t *testing.T) {
 					Annotation(podconstants.RetriableInGroupAnnotationKey, podconstants.RetriableInGroupAnnotationValue).
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodFailed).
 					Obj(),
@@ -2501,7 +2501,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -2510,7 +2510,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod3").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					Request(corev1.ResourceMemory, "1Gi").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodFailed).
@@ -2521,7 +2521,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Annotation(podconstants.RetriableInGroupAnnotationKey, podconstants.RetriableInGroupAnnotationValue).
 					ManagedByKueueLabel().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodFailed).
 					Obj(),
@@ -2529,7 +2529,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod2").
 					ManagedByKueueLabel().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -2537,7 +2537,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod3").
 					ManagedByKueueLabel().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					Request(corev1.ResourceMemory, "1Gi").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodFailed).
@@ -2615,7 +2615,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodFailed).
 					Obj(),
@@ -2624,7 +2624,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodRunning).
 					Obj(),
@@ -2633,7 +2633,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod3").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					Request(corev1.ResourceMemory, "1Gi").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodSucceeded).
@@ -2644,7 +2644,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodFailed).
 					Obj(),
@@ -2653,7 +2653,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodRunning).
 					Obj(),
@@ -2662,7 +2662,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod3").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					Request(corev1.ResourceMemory, "1Gi").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodSucceeded).
@@ -2727,7 +2727,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					PodGroupServingAnnotation().
 					StatusPhase(corev1.PodFailed).
@@ -2737,7 +2737,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					PodGroupServingAnnotation().
 					StatusPhase(corev1.PodRunning).
@@ -2747,7 +2747,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod3").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					Request(corev1.ResourceMemory, "1Gi").
 					GroupTotalCount("3").
 					PodGroupServingAnnotation().
@@ -2759,7 +2759,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					PodGroupServingAnnotation().
 					StatusPhase(corev1.PodFailed).
@@ -2769,7 +2769,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					PodGroupServingAnnotation().
 					StatusPhase(corev1.PodRunning).
@@ -2779,7 +2779,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod3").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					Request(corev1.ResourceMemory, "1Gi").
 					GroupTotalCount("3").
 					PodGroupServingAnnotation().
@@ -2845,7 +2845,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					CreationTimestamp(now).
 					Obj(),
@@ -2855,7 +2855,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					CreationTimestamp(now.Add(time.Minute)).
 					Obj(),
@@ -2866,7 +2866,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					CreationTimestamp(now).
 					Obj(),
@@ -2910,7 +2910,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now).
 					Obj(),
@@ -2920,7 +2920,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(time.Minute)).
 					Obj(),
@@ -2930,7 +2930,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					CreationTimestamp(now.Add(time.Minute * 2)).
 					GroupTotalCount("2").
 					Obj(),
@@ -2941,7 +2941,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now).
 					Obj(),
@@ -2951,7 +2951,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(time.Minute)).
 					Obj(),
@@ -3000,7 +3000,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now).
 					Obj(),
@@ -3010,7 +3010,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					CreationTimestamp(now.Add(time.Minute * 2)).
 					GroupTotalCount("2").
 					Obj(),
@@ -3020,7 +3020,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now).
 					Obj(),
@@ -3089,7 +3089,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					CreationTimestamp(now).
 					Obj(),
@@ -3100,7 +3100,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					CreationTimestamp(now.Add(time.Minute)).
 					GroupTotalCount("1").
 					Obj(),
@@ -3110,7 +3110,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					CreationTimestamp(now.Add(time.Minute)).
 					GroupTotalCount("1").
 					Obj(),
@@ -3120,7 +3120,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					CreationTimestamp(now).
 					Obj(),
@@ -3131,7 +3131,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					CreationTimestamp(now.Add(time.Minute)).
 					GroupTotalCount("1").
 					Obj(),
@@ -3141,7 +3141,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					CreationTimestamp(now.Add(time.Minute)).
 					GroupTotalCount("1").
 					Obj(),
@@ -3182,7 +3182,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now).
 					Obj(),
@@ -3192,7 +3192,7 @@ func TestReconciler(t *testing.T) {
 					UID("pod2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					CreationTimestamp(now.Add(time.Minute)).
 					GroupTotalCount("2").
 					Obj(),
@@ -3202,7 +3202,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					CreationTimestamp(now.Add(time.Minute)).
 					GroupTotalCount("2").
 					Obj(),
@@ -3212,7 +3212,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now).
 					Obj(),
@@ -3222,7 +3222,7 @@ func TestReconciler(t *testing.T) {
 					UID("pod2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					CreationTimestamp(now.Add(time.Minute)).
 					GroupTotalCount("2").
 					Obj(),
@@ -3276,7 +3276,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					CreationTimestamp(now).
 					Obj(),
@@ -3286,7 +3286,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueSchedulingGate().
 					Finalizer("kubernetes").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					CreationTimestamp(now.Add(time.Minute)).
 					Delete().
@@ -3298,7 +3298,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					CreationTimestamp(now).
 					Obj(),
@@ -3308,7 +3308,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueSchedulingGate().
 					Finalizer("kubernetes").
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					CreationTimestamp(now.Add(time.Minute)).
 					Delete().
@@ -3349,7 +3349,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("group").
+					GroupNameLabel("group").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodPending).
 					Delete().
@@ -3360,7 +3360,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("group").
+					GroupNameLabel("group").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodPending).
 					Delete().
@@ -3397,7 +3397,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod1").
 					ManagedByKueueLabel().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
 					Obj(),
@@ -3407,7 +3407,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					Delete().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -3415,7 +3415,7 @@ func TestReconciler(t *testing.T) {
 					Name("replacement-for-pod1").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -3424,7 +3424,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod1").
 					ManagedByKueueLabel().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
 					Obj(),
@@ -3434,7 +3434,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					Delete().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -3442,7 +3442,7 @@ func TestReconciler(t *testing.T) {
 					Name("replacement-for-pod1").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -3504,7 +3504,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod1").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					Obj(),
 				*basePodWrapper.
@@ -3513,7 +3513,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					Delete().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					Obj(),
 				*basePodWrapper.
@@ -3521,7 +3521,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod3").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					Obj(),
 			},
@@ -3531,7 +3531,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod1").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					StatusConditions(corev1.PodCondition{
 						Type:    "TerminationTarget",
@@ -3546,7 +3546,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					Delete().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					Obj(),
 				*basePodWrapper.
@@ -3554,7 +3554,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod3").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("3").
 					StatusConditions(corev1.PodCondition{
 						Type:    "TerminationTarget",
@@ -3641,7 +3641,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod1").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					Obj(),
 			},
@@ -3651,7 +3651,7 @@ func TestReconciler(t *testing.T) {
 					Name("pod1").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					StatusConditions(corev1.PodCondition{
 						Type:    "TerminationTarget",
@@ -3726,7 +3726,7 @@ func TestReconciler(t *testing.T) {
 					Name("active-pod").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("4").
 					Obj(),
 				*basePodWrapper.
@@ -3734,7 +3734,7 @@ func TestReconciler(t *testing.T) {
 					Name("finished-with-error").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("4").
 					StatusPhase(corev1.PodFailed).
 					StatusConditions(corev1.PodCondition{
@@ -3749,7 +3749,7 @@ func TestReconciler(t *testing.T) {
 					Name("deleted").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("4").
 					StatusPhase(corev1.PodFailed).
 					DeletionTimestamp(now.Add(-4 * time.Minute)).
@@ -3765,7 +3765,7 @@ func TestReconciler(t *testing.T) {
 					Name("finished-with-error2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("4").
 					StatusPhase(corev1.PodFailed).
 					StatusConditions(corev1.PodCondition{
@@ -3780,7 +3780,7 @@ func TestReconciler(t *testing.T) {
 					Name("replacement1").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("4").
 					Obj(),
 				*basePodWrapper.
@@ -3788,7 +3788,7 @@ func TestReconciler(t *testing.T) {
 					Name("replacement2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("4").
 					Obj(),
 			},
@@ -3798,14 +3798,14 @@ func TestReconciler(t *testing.T) {
 					Name("active-pod").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("4").
 					Obj(),
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error").
 					ManagedByKueueLabel().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("4").
 					StatusPhase(corev1.PodFailed).
 					StatusConditions(corev1.PodCondition{
@@ -3820,7 +3820,7 @@ func TestReconciler(t *testing.T) {
 					Name("finished-with-error2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("4").
 					StatusPhase(corev1.PodFailed).
 					StatusConditions(corev1.PodCondition{
@@ -3835,7 +3835,7 @@ func TestReconciler(t *testing.T) {
 					Name("replacement1").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("4").
 					Obj(),
 				*basePodWrapper.
@@ -3843,7 +3843,7 @@ func TestReconciler(t *testing.T) {
 					Name("replacement2").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("4").
 					Obj(),
 			},
@@ -3910,7 +3910,7 @@ func TestReconciler(t *testing.T) {
 					Name("active-pod").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -3918,7 +3918,7 @@ func TestReconciler(t *testing.T) {
 					Name("finished-with-error").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
 					StatusConditions(corev1.PodCondition{
@@ -3933,7 +3933,7 @@ func TestReconciler(t *testing.T) {
 					Name("replacement").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -3943,7 +3943,7 @@ func TestReconciler(t *testing.T) {
 					Name("active-pod").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -3951,7 +3951,7 @@ func TestReconciler(t *testing.T) {
 					Name("finished-with-error").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
 					StatusConditions(corev1.PodCondition{
@@ -3966,7 +3966,7 @@ func TestReconciler(t *testing.T) {
 					Name("replacement").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -4011,7 +4011,7 @@ func TestReconciler(t *testing.T) {
 					Name("finished-with-error").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
 					StatusConditions(corev1.PodCondition{
@@ -4025,7 +4025,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("finished-with-error-no-finalizer").
 					ManagedByKueueLabel().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
 					StatusConditions(corev1.PodCondition{
@@ -4040,7 +4040,7 @@ func TestReconciler(t *testing.T) {
 					Name("replacement").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -4050,7 +4050,7 @@ func TestReconciler(t *testing.T) {
 					Name("finished-with-error").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
 					StatusConditions(corev1.PodCondition{
@@ -4064,7 +4064,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("finished-with-error-no-finalizer").
 					ManagedByKueueLabel().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
 					StatusConditions(corev1.PodCondition{
@@ -4079,7 +4079,7 @@ func TestReconciler(t *testing.T) {
 					Name("replacement").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -4185,7 +4185,7 @@ func TestReconciler(t *testing.T) {
 					Label("dontCopyKey", "dontCopyValue").
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupIndex("0").
 					GroupTotalCount("2").
 					Obj(),
@@ -4198,7 +4198,7 @@ func TestReconciler(t *testing.T) {
 					Label("dontCopyKey", "dontCopyValue").
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupIndex("1").
 					GroupTotalCount("2").
 					Obj(),
@@ -4244,7 +4244,7 @@ func TestReconciler(t *testing.T) {
 				ManagedByKueueLabel().
 				KueueFinalizer().
 				KueueSchedulingGate().
-				Group("test-group").
+				GroupNameLabel("test-group").
 				GroupIndex("1").
 				GroupTotalCount("1").
 				Obj(),
@@ -4258,7 +4258,7 @@ func TestReconciler(t *testing.T) {
 				ManagedByKueueLabel().
 				KueueFinalizer().
 				KueueSchedulingGate().
-				Group("test-group").
+				GroupNameLabel("test-group").
 				GroupIndex("-1").
 				GroupTotalCount("1").
 				Obj(),
@@ -4275,7 +4275,7 @@ func TestReconciler(t *testing.T) {
 					Label("dontCopyKey", "dontCopyValue").
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -4287,7 +4287,7 @@ func TestReconciler(t *testing.T) {
 					Label("dontCopyKey", "dontCopyValue").
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -4385,7 +4385,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -4394,7 +4394,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -4475,7 +4475,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodRunning).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Label(constants.PodSetLabel, podUID).
 					CreationTimestamp(now.Add(-time.Hour)).
@@ -4487,7 +4487,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					Delete().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Annotation(kueue.WorkloadAnnotation, "test-group").
@@ -4498,7 +4498,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now).
 					Annotation(kueue.WorkloadAnnotation, "test-group").
@@ -4527,7 +4527,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodRunning).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Label(constants.PodSetLabel, podUID).
 					CreationTimestamp(now.Add(-time.Hour)).
@@ -4537,7 +4537,7 @@ func TestReconciler(t *testing.T) {
 					Name("replacement").
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Label(constants.PodSetLabel, podUID).
 					Annotation(kueue.WorkloadAnnotation, "test-group").
@@ -4583,7 +4583,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -4593,7 +4593,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -4620,7 +4620,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -4630,7 +4630,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -4658,7 +4658,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -4668,7 +4668,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -4695,7 +4695,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -4705,7 +4705,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -4739,7 +4739,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -4749,7 +4749,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					Delete().
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
@@ -4777,7 +4777,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -4788,7 +4788,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Delete().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -4822,7 +4822,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -4833,7 +4833,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					Delete().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -4867,7 +4867,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -4877,7 +4877,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -4919,7 +4919,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -4930,7 +4930,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					Delete().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -4969,7 +4969,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -4979,7 +4979,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -5019,7 +5019,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -5029,7 +5029,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -5070,7 +5070,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -5080,7 +5080,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -5122,7 +5122,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -5132,7 +5132,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -5165,7 +5165,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -5175,7 +5175,7 @@ func TestReconciler(t *testing.T) {
 					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
@@ -5210,7 +5210,7 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -5220,7 +5220,7 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -5239,7 +5239,7 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusConditions(corev1.PodCondition{
 						Type:    ConditionTypeTerminationTarget,
@@ -5255,7 +5255,7 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusConditions(corev1.PodCondition{
 						Type:    ConditionTypeTerminationTarget,
@@ -5305,7 +5305,7 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -5315,7 +5315,7 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -5335,7 +5335,7 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusConditions(corev1.PodCondition{
 						Type:    ConditionTypeTerminationTarget,
@@ -5351,7 +5351,7 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusConditions(corev1.PodCondition{
 						Type:    ConditionTypeTerminationTarget,
@@ -5401,7 +5401,7 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 				*basePodWrapper.
@@ -5411,7 +5411,7 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -5432,7 +5432,7 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusConditions(corev1.PodCondition{
 						Type:    ConditionTypeTerminationTarget,
@@ -5448,7 +5448,7 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					StatusConditions(corev1.PodCondition{
 						Type:    ConditionTypeTerminationTarget,
@@ -5504,7 +5504,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					ManagedByKueueLabel().
 					KueueFinalizer().
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					Obj(),
 			},
@@ -5651,7 +5651,7 @@ func TestReconciler(t *testing.T) {
 					}
 				}
 				if tc.wantPods != nil {
-					if diff := cmp.Diff(tc.wantPods, gotPods.Items, podCmpOpts...); diff != "" && tc.wantPods != nil {
+					if diff := cmp.Diff(tc.wantPods, gotPods.Items, podCmpOpts...); diff != "" {
 						t.Errorf("Pods after reconcile (-want,+got):\n%s", diff)
 					}
 				}
@@ -5915,7 +5915,7 @@ func TestReconciler_DeletePodAfterTransientErrorsOnUpdateOrDeleteOps(t *testing.
 			Clone().
 			ManagedByKueueLabel().
 			KueueFinalizer().
-			Group("test-group").
+			GroupNameLabel("test-group").
 			GroupTotalCount("2").
 			CreationTimestamp(now).
 			Obj(),
@@ -5924,7 +5924,7 @@ func TestReconciler_DeletePodAfterTransientErrorsOnUpdateOrDeleteOps(t *testing.
 			Name("pod2").
 			ManagedByKueueLabel().
 			KueueFinalizer().
-			Group("test-group").
+			GroupNameLabel("test-group").
 			CreationTimestamp(now.Add(time.Minute)).
 			GroupTotalCount("2").
 			Obj(),
@@ -5933,7 +5933,7 @@ func TestReconciler_DeletePodAfterTransientErrorsOnUpdateOrDeleteOps(t *testing.
 			Name("excessPod").
 			ManagedByKueueLabel().
 			KueueFinalizer().
-			Group("test-group").
+			GroupNameLabel("test-group").
 			CreationTimestamp(now.Add(time.Minute * 2)).
 			GroupTotalCount("2").
 			Obj(),

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter_test.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
@@ -56,7 +55,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 
 	podGroupWithWl := basePodBuilder.
 		Clone().
-		Label(constants.PrebuiltWorkloadLabel, "wl1").
+		PrebuiltWorkloadLabel("wl1").
 		Label(kueue.MultiKueueOriginLabel, "origin1").
 		MakePodGroupWrappers(groupSize)
 
@@ -83,7 +82,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerPods: []corev1.Pod{
 				*basePodBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},
@@ -94,7 +93,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerPods: []corev1.Pod{
 				*basePodBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					StatusPhase(corev1.PodRunning).
 					StatusConditions(corev1.PodCondition{Type: corev1.PodReady, Status: corev1.ConditionTrue}).
@@ -112,7 +111,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerPods: []corev1.Pod{
 				*basePodBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					StatusPhase(corev1.PodRunning).
 					StatusConditions(corev1.PodCondition{Type: corev1.PodReady, Status: corev1.ConditionTrue}).
@@ -122,7 +121,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		"remote pod is deleted": {
 			workerPods: []corev1.Pod{
 				*basePodBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -369,11 +369,11 @@ func TestDefault(t *testing.T) {
 			namespaceSelector: defaultNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
-				Group("test-group").
+				GroupNameLabel("test-group").
 				Obj(),
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
-				Group("test-group").
+				GroupNameLabel("test-group").
 				RoleHash("a9f06f3a").
 				ManagedByKueueLabel().
 				KueueSchedulingGate().
@@ -390,11 +390,11 @@ func TestDefault(t *testing.T) {
 			namespaceSelector: defaultNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
-				Group("test-group").
+				GroupNameLabel("test-group").
 				Obj(),
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
-				Group("test-group").
+				GroupNameLabel("test-group").
 				RoleHash("a9f06f3a").
 				ManagedByKueueLabel().
 				KueueSchedulingGate().
@@ -730,7 +730,7 @@ func TestValidateCreate(t *testing.T) {
 		"pod with group name and no group total count": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
-				Group("test-group").
+				GroupNameLabel("test-group").
 				Obj(),
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -754,7 +754,7 @@ func TestValidateCreate(t *testing.T) {
 		"pod with 0 group total count": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
-				Group("test-group").
+				GroupNameLabel("test-group").
 				GroupTotalCount("0").
 				Obj(),
 			wantErr: field.ErrorList{
@@ -767,7 +767,7 @@ func TestValidateCreate(t *testing.T) {
 		"pod with empty group total count": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
-				Group("test-group").
+				GroupNameLabel("test-group").
 				GroupTotalCount("").
 				Obj(),
 			wantErr: field.ErrorList{
@@ -780,7 +780,7 @@ func TestValidateCreate(t *testing.T) {
 		"pod with incorrect group name": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
-				Group("notAdns1123Subdomain*").
+				GroupNameLabel("notAdns1123Subdomain*").
 				GroupTotalCount("2").
 				Obj(),
 			wantErr: field.ErrorList{
@@ -811,20 +811,20 @@ func TestValidateCreate(t *testing.T) {
 		},
 		"prebuilt workload for pod": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
-				PrebuiltWorkload("workload-name").
+				PrebuiltWorkloadLabel("workload-name").
 				Obj(),
 		},
 		"prebuilt workload for pod group valid": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
-				PrebuiltWorkload("group-name").
-				Group("group-name").
+				PrebuiltWorkloadLabel("group-name").
+				GroupNameLabel("group-name").
 				GroupTotalCount("3").
 				Obj(),
 		},
 		"prebuilt workload for pod group invalid": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
-				PrebuiltWorkload("workload-name").
-				Group("group-name").
+				PrebuiltWorkloadLabel("workload-name").
+				GroupNameLabel("group-name").
 				GroupTotalCount("3").
 				Obj(),
 			wantErr: field.ErrorList{
@@ -902,10 +902,10 @@ func TestValidateUpdate(t *testing.T) {
 				Obj(),
 		},
 		"pod with group name and no group total count": {
-			oldPod: testingpod.MakePod("test-pod", "test-ns").Group("test-group").Obj(),
+			oldPod: testingpod.MakePod("test-pod", "test-ns").GroupNameLabel("test-group").Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
-				Group("test-group").
+				GroupNameLabel("test-group").
 				Obj(),
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -915,10 +915,10 @@ func TestValidateUpdate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"pod with 0 group total count": {
-			oldPod: testingpod.MakePod("test-pod", "test-ns").Group("test-group").Obj(),
+			oldPod: testingpod.MakePod("test-pod", "test-ns").GroupNameLabel("test-group").Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
-				Group("test-group").
+				GroupNameLabel("test-group").
 				GroupTotalCount("0").
 				Obj(),
 			wantErr: field.ErrorList{
@@ -929,10 +929,10 @@ func TestValidateUpdate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"pod with empty group total count": {
-			oldPod: testingpod.MakePod("test-pod", "test-ns").Group("test-group").Obj(),
+			oldPod: testingpod.MakePod("test-pod", "test-ns").GroupNameLabel("test-group").Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
-				Group("test-group").
+				GroupNameLabel("test-group").
 				GroupTotalCount("").
 				Obj(),
 			wantErr: field.ErrorList{
@@ -944,11 +944,11 @@ func TestValidateUpdate(t *testing.T) {
 		},
 		"pod group name is changed": {
 			oldPod: testingpod.MakePod("test-pod", "test-ns").
-				Group("test-group").
+				GroupNameLabel("test-group").
 				GroupTotalCount("2").
 				Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
-				Group("test-group-new").
+				GroupNameLabel("test-group-new").
 				GroupTotalCount("2").
 				Obj(),
 			wantErr: field.ErrorList{
@@ -962,18 +962,18 @@ func TestValidateUpdate(t *testing.T) {
 			oldPod: testingpod.MakePod("test-pod", "test-ns").
 				Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
-				Group("test-group-new").
+				GroupNameLabel("test-group-new").
 				GroupTotalCount("2").
 				Obj(),
 		},
 		"retriable in group annotation is removed": {
 			oldPod: testingpod.MakePod("test-pod", "test-ns").
-				Group("test-group").
+				GroupNameLabel("test-group").
 				GroupTotalCount("2").
 				Annotation(podconstants.RetriableInGroupAnnotationKey, podconstants.RetriableInGroupAnnotationValue).
 				Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
-				Group("test-group").
+				GroupNameLabel("test-group").
 				GroupTotalCount("2").
 				Obj(),
 			wantErr: field.ErrorList{
@@ -985,12 +985,12 @@ func TestValidateUpdate(t *testing.T) {
 		},
 		"retriable in group annotation is changed from false to true": {
 			oldPod: testingpod.MakePod("test-pod", "test-ns").
-				Group("test-group").
+				GroupNameLabel("test-group").
 				GroupTotalCount("2").
 				Annotation(podconstants.RetriableInGroupAnnotationKey, podconstants.RetriableInGroupAnnotationValue).
 				Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
-				Group("test-group").
+				GroupNameLabel("test-group").
 				GroupTotalCount("2").
 				Annotation(podconstants.RetriableInGroupAnnotationKey, "true").
 				Obj(),
@@ -1003,14 +1003,14 @@ func TestValidateUpdate(t *testing.T) {
 		},
 		"prebuilt workload for pod group invalid": {
 			oldPod: testingpod.MakePod("test-pod", "test-ns").
-				PrebuiltWorkload("group-name").
-				Group("group-name").
+				PrebuiltWorkloadLabel("group-name").
+				GroupNameLabel("group-name").
 				GroupTotalCount("3").
 				KueueSchedulingGate().
 				Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
-				PrebuiltWorkload("group-name-new").
-				Group("group-name").
+				PrebuiltWorkloadLabel("group-name-new").
+				GroupNameLabel("group-name").
 				GroupTotalCount("3").
 				KueueSchedulingGate().
 				Obj(),

--- a/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
@@ -72,7 +71,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerRayClusters: []rayv1.RayCluster{
 				*rayClusterBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},
@@ -83,7 +82,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerRayClusters: []rayv1.RayCluster{
 				*rayClusterBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					StatusConditions(metav1.Condition{Type: string(rayv1.HeadPodReady), Status: metav1.ConditionStatus(corev1.ConditionTrue)}).
 					Obj(),
@@ -99,7 +98,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerRayClusters: []rayv1.RayCluster{
 				*rayClusterBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					StatusConditions(metav1.Condition{Type: string(rayv1.HeadPodReady), Status: metav1.ConditionStatus(corev1.ConditionTrue)}).
 					Obj(),
@@ -113,7 +112,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerRayClusters: []rayv1.RayCluster{
 				*rayClusterBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					StatusConditions(metav1.Condition{Type: string(rayv1.HeadPodReady), Status: metav1.ConditionStatus(corev1.ConditionTrue)}).
@@ -130,7 +129,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerRayClusters: []rayv1.RayCluster{
 				*rayClusterBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					StatusConditions(metav1.Condition{Type: string(rayv1.HeadPodReady), Status: metav1.ConditionStatus(corev1.ConditionTrue)}).
@@ -140,7 +139,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		"remote raycluster is deleted": {
 			workerRayClusters: []rayv1.RayCluster{
 				*rayClusterBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},

--- a/pkg/controller/jobs/rayjob/rayjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_multikueue_adapter_test.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingrayjob "sigs.k8s.io/kueue/pkg/util/testingjobs/rayjob"
@@ -71,7 +70,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerRayJobs: []rayv1.RayJob{
 				*rayJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},
@@ -82,7 +81,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerRayJobs: []rayv1.RayJob{
 				*rayJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					JobDeploymentStatus(rayv1.JobDeploymentStatusComplete).
 					Obj(),
@@ -98,7 +97,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerRayJobs: []rayv1.RayJob{
 				*rayJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					JobDeploymentStatus(rayv1.JobDeploymentStatusComplete).
 					Obj(),
@@ -112,7 +111,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerRayJobs: []rayv1.RayJob{
 				*rayJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					JobDeploymentStatus(rayv1.JobDeploymentStatusComplete).
@@ -129,7 +128,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerRayJobs: []rayv1.RayJob{
 				*rayJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					JobDeploymentStatus(rayv1.JobDeploymentStatusComplete).
@@ -139,7 +138,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		"remote rayjob is deleted": {
 			workerRayJobs: []rayv1.RayJob{
 				*rayJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},

--- a/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter_test.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingstatefulset "sigs.k8s.io/kueue/pkg/util/testingjobs/statefulset"
@@ -69,7 +68,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerStatefulSets: []appsv1.StatefulSet{
 				*utiltestingstatefulset.MakeStatefulSet("statefulset1", TestNamespace).
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-uid").
 					Obj(),
@@ -81,7 +80,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerStatefulSets: []appsv1.StatefulSet{
 				*utiltestingstatefulset.MakeStatefulSet("statefulset1", TestNamespace).
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					StatusReplicas(3).
 					ReadyReplicas(2).
@@ -96,7 +95,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerStatefulSets: []appsv1.StatefulSet{
 				*utiltestingstatefulset.MakeStatefulSet("statefulset1", TestNamespace).
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					StatusReplicas(3).
 					ReadyReplicas(2).
@@ -106,7 +105,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		"remote statefulset is deleted": {
 			workerStatefulSets: []appsv1.StatefulSet{
 				*utiltestingstatefulset.MakeStatefulSet("statefulset1", TestNamespace).
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					StatusReplicas(3).
 					ReadyReplicas(2).

--- a/pkg/controller/jobs/statefulset/statefulset_pod_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_pod_reconciler_test.go
@@ -122,9 +122,9 @@ func TestPodReconciler(t *testing.T) {
 					OwnerReference("sts", gvk).
 					Queue("queue").
 					ManagedByKueueLabel().
-					Group(GetWorkloadName("sts-uid", "sts")).
+					GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
 					GroupTotalCount("3").
-					PrebuiltWorkload(GetWorkloadName("sts-uid", "sts")).
+					PrebuiltWorkloadLabel(GetWorkloadName("sts-uid", "sts")).
 					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 					Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
 					Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
@@ -149,10 +149,10 @@ func TestPodReconciler(t *testing.T) {
 					OwnerReference("sts", gvk).
 					Queue("queue").
 					ManagedByKueueLabel().
-					Group(GetWorkloadName("sts-uid", "sts")).
+					GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
 					GroupTotalCount("3").
 					Label(controllerconstants.WorkloadPriorityClassLabel, "high-priority").
-					PrebuiltWorkload(GetWorkloadName("sts-uid", "sts")).
+					PrebuiltWorkloadLabel(GetWorkloadName("sts-uid", "sts")).
 					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 					Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
 					Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
@@ -171,7 +171,7 @@ func TestPodReconciler(t *testing.T) {
 				OwnerReference("sts", gvk).
 				Queue("queue").
 				ManagedByKueueLabel().
-				Group(GetWorkloadName("sts-uid", "sts")).
+				GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
 				GroupTotalCount("3").
 				Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 				Obj(),
@@ -180,7 +180,7 @@ func TestPodReconciler(t *testing.T) {
 					OwnerReference("sts", gvk).
 					Queue("queue").
 					ManagedByKueueLabel().
-					Group(GetWorkloadName("sts-uid", "sts")).
+					GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
 					GroupTotalCount("3").
 					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 					Obj(),
@@ -196,7 +196,7 @@ func TestPodReconciler(t *testing.T) {
 				OwnerReference("sts", gvk).
 				Queue("old-queue").
 				ManagedByKueueLabel().
-				Group(GetWorkloadName("sts-uid", "sts")).
+				GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
 				GroupTotalCount("3").
 				Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 				Obj(),
@@ -205,7 +205,7 @@ func TestPodReconciler(t *testing.T) {
 					OwnerReference("sts", gvk).
 					Queue("new-queue").
 					ManagedByKueueLabel().
-					Group(GetWorkloadName("sts-uid", "sts")).
+					GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
 					GroupTotalCount("3").
 					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 					Obj(),
@@ -221,7 +221,7 @@ func TestPodReconciler(t *testing.T) {
 				OwnerReference("sts", gvk).
 				Queue("queue").
 				ManagedByKueueLabel().
-				Group(GetWorkloadName("", "sts")).
+				GroupNameLabel(GetWorkloadName("", "sts")).
 				GroupTotalCount("3").
 				Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 				Obj(),
@@ -233,7 +233,7 @@ func TestPodReconciler(t *testing.T) {
 					OwnerReference("sts", gvk).
 					Queue("queue").
 					ManagedByKueueLabel().
-					Group(GetWorkloadName("", "sts")).
+					GroupNameLabel(GetWorkloadName("", "sts")).
 					GroupTotalCount("3").
 					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 					Obj(),
@@ -257,9 +257,9 @@ func TestPodReconciler(t *testing.T) {
 					OwnerReference("sts", gvk).
 					Queue("queue").
 					ManagedByKueueLabel().
-					Group(GetWorkloadName("", "sts")).
+					GroupNameLabel(GetWorkloadName("", "sts")).
 					GroupTotalCount("3").
-					PrebuiltWorkload(GetWorkloadName("", "sts")).
+					PrebuiltWorkloadLabel(GetWorkloadName("", "sts")).
 					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 					Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
 					Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
@@ -282,9 +282,9 @@ func TestPodReconciler(t *testing.T) {
 				*testingjobspod.MakePod("pod", "ns").
 					OwnerReference("sts", gvk).
 					ManagedByKueueLabel().
-					Group(GetWorkloadName("sts-uid", "sts")).
+					GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
 					GroupTotalCount("3").
-					PrebuiltWorkload(GetWorkloadName("sts-uid", "sts")).
+					PrebuiltWorkloadLabel(GetWorkloadName("sts-uid", "sts")).
 					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 					Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
 					Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -81,31 +81,31 @@ func TestReconciler(t *testing.T) {
 				DeepCopy(),
 			pods: []corev1.Pod{
 				*testingjobspod.MakePod("pod1", "ns").
-					Label(podconstants.GroupNameLabel, GetWorkloadName("sts-uid", "sts")).
+					GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
 					KueueFinalizer().
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
 				*testingjobspod.MakePod("pod2", "ns").
-					Label(podconstants.GroupNameLabel, GetWorkloadName("sts-uid", "sts")).
+					GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
 					Obj(),
 				*testingjobspod.MakePod("pod3", "ns").
-					Label(podconstants.GroupNameLabel, GetWorkloadName("sts-uid", "sts")).
+					GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
 					KueueFinalizer().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingjobspod.MakePod("pod1", "ns").
-					Label(podconstants.GroupNameLabel, GetWorkloadName("sts-uid", "sts")).
+					GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
 				*testingjobspod.MakePod("pod2", "ns").
-					Label(podconstants.GroupNameLabel, GetWorkloadName("sts-uid", "sts")).
+					GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
 					StatusPhase(corev1.PodFailed).
 					Obj(),
 				*testingjobspod.MakePod("pod3", "ns").
-					Label(podconstants.GroupNameLabel, GetWorkloadName("sts-uid", "sts")).
+					GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
 					KueueFinalizer().
 					Obj(),
 			},
@@ -125,18 +125,18 @@ func TestReconciler(t *testing.T) {
 				DeepCopy(),
 			pods: []corev1.Pod{
 				*testingjobspod.MakePod("pod1", "ns").
-					Label(podconstants.GroupNameLabel, GetWorkloadName("sts-uid", "sts")).
+					GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
 					Label(appsv1.ControllerRevisionHashLabelKey, "1").
 					Gate(podconstants.SchedulingGateName).
 					KueueFinalizer().
 					Obj(),
 				*testingjobspod.MakePod("pod2", "ns").
-					Label(podconstants.GroupNameLabel, GetWorkloadName("sts-uid", "sts")).
+					GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
 					Label(appsv1.ControllerRevisionHashLabelKey, "1").
 					KueueFinalizer().
 					Obj(),
 				*testingjobspod.MakePod("pod3", "ns").
-					Label(podconstants.GroupNameLabel, GetWorkloadName("sts-uid", "sts")).
+					GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
 					Label(appsv1.ControllerRevisionHashLabelKey, "2").
 					Gate(podconstants.SchedulingGateName).
 					KueueFinalizer().
@@ -144,15 +144,15 @@ func TestReconciler(t *testing.T) {
 			},
 			wantPods: []corev1.Pod{
 				*testingjobspod.MakePod("pod1", "ns").
-					Label(podconstants.GroupNameLabel, GetWorkloadName("sts-uid", "sts")).
+					GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
 					Label(appsv1.ControllerRevisionHashLabelKey, "1").
 					Obj(),
 				*testingjobspod.MakePod("pod2", "ns").
-					Label(podconstants.GroupNameLabel, GetWorkloadName("sts-uid", "sts")).
+					GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
 					Label(appsv1.ControllerRevisionHashLabelKey, "1").
 					Obj(),
 				*testingjobspod.MakePod("pod3", "ns").
-					Label(podconstants.GroupNameLabel, GetWorkloadName("sts-uid", "sts")).
+					GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
 					Label(appsv1.ControllerRevisionHashLabelKey, "2").
 					Gate(podconstants.SchedulingGateName).
 					KueueFinalizer().
@@ -333,7 +333,7 @@ func TestReconciler(t *testing.T) {
 			},
 			pods: []corev1.Pod{
 				*testingjobspod.MakePod("pod1", "ns").
-					Label(podconstants.GroupNameLabel, GetWorkloadName("", "sts")).
+					GroupNameLabel(GetWorkloadName("", "sts")).
 					Obj(),
 			},
 			wantStatefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
@@ -342,7 +342,7 @@ func TestReconciler(t *testing.T) {
 				DeepCopy(),
 			wantPods: []corev1.Pod{
 				*testingjobspod.MakePod("pod1", "ns").
-					Label(podconstants.GroupNameLabel, GetWorkloadName("", "sts")).
+					GroupNameLabel(GetWorkloadName("", "sts")).
 					Label(controllerconstants.QueueLabel, "lq").
 					Obj(),
 			},
@@ -369,7 +369,7 @@ func TestReconciler(t *testing.T) {
 			},
 			pods: []corev1.Pod{
 				*testingjobspod.MakePod("pod1", "ns").
-					Label(podconstants.GroupNameLabel, GetWorkloadName("", "sts")).
+					GroupNameLabel(GetWorkloadName("", "sts")).
 					KueueFinalizer().
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
@@ -381,7 +381,7 @@ func TestReconciler(t *testing.T) {
 				DeepCopy(),
 			wantPods: []corev1.Pod{
 				*testingjobspod.MakePod("pod1", "ns").
-					Label(podconstants.GroupNameLabel, GetWorkloadName("", "sts")).
+					GroupNameLabel(GetWorkloadName("", "sts")).
 					StatusPhase(corev1.PodSucceeded).
 					Obj(),
 			},
@@ -405,7 +405,7 @@ func TestReconciler(t *testing.T) {
 				DeepCopy(),
 			pods: []corev1.Pod{
 				*testingjobspod.MakePod("pod1", "ns").
-					Label(podconstants.GroupNameLabel, GetWorkloadName("sts-uid", "sts")).
+					GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
 					KueueFinalizer().
 					DeletionTimestamp(now).
 					Obj(),

--- a/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter_test.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingtrainjob "sigs.k8s.io/kueue/pkg/util/testingjobs/trainjob"
@@ -73,7 +72,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerTrainJobs: []kftrainerapi.TrainJob{
 				*baseTrainJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),
 			},
@@ -84,7 +83,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerTrainJobs: []kftrainerapi.TrainJob{
 				*baseTrainJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					JobsStatus(
 						testingtrainjob.MakeJobStatusWrapper("replicated-job-1").
@@ -118,7 +117,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerTrainJobs: []kftrainerapi.TrainJob{
 				*baseTrainJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					JobsStatus(
 						testingtrainjob.MakeJobStatusWrapper("replicated-job-1").
@@ -141,7 +140,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			workerTrainJobs: []kftrainerapi.TrainJob{
 				*baseTrainJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					JobsStatus(
@@ -177,7 +176,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerTrainJobs: []kftrainerapi.TrainJob{
 				*baseTrainJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Suspend(true).
 					JobsStatus(
@@ -196,7 +195,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		"remote trainjob is deleted": {
 			workerTrainJobs: []kftrainerapi.TrainJob{
 				*baseTrainJobBuilder.Clone().
-					Label(constants.PrebuiltWorkloadLabel, "wl1").
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					JobsStatus(
 						testingtrainjob.MakeJobStatusWrapper("replicated-job-1").

--- a/pkg/util/testingjobs/appwrapper/wrappers.go
+++ b/pkg/util/testingjobs/appwrapper/wrappers.go
@@ -84,6 +84,11 @@ func (aw *AppWrapperWrapper) Queue(q string) *AppWrapperWrapper {
 	return aw.Label(constants.QueueLabel, q)
 }
 
+// PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the AppWrapperWrapper
+func (aw *AppWrapperWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *AppWrapperWrapper {
+	return aw.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
 // Name updates the name of the AppWrapper
 func (aw *AppWrapperWrapper) Name(n string) *AppWrapperWrapper {
 	aw.ObjectMeta.Name = n

--- a/pkg/util/testingjobs/jaxjob/wrappers.go
+++ b/pkg/util/testingjobs/jaxjob/wrappers.go
@@ -146,6 +146,11 @@ func (j *JAXJobWrapper) Queue(queue string) *JAXJobWrapper {
 	return j
 }
 
+// PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the job
+func (j *JAXJobWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *JAXJobWrapper {
+	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
 // Request adds a resource request to the default container.
 func (j *JAXJobWrapper) Request(replicaType kftraining.ReplicaType, r corev1.ResourceName, v string) *JAXJobWrapper {
 	j.Spec.JAXReplicaSpecs[replicaType].Template.Spec.Containers[0].Resources.Requests[r] = resource.MustParse(v)

--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -150,6 +150,11 @@ func (j *JobWrapper) Queue(queue kueue.LocalQueueName) *JobWrapper {
 	return j.Label(constants.QueueLabel, string(queue))
 }
 
+// PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the job
+func (j *JobWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *JobWrapper {
+	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
 // Label sets the label key and value
 func (j *JobWrapper) Label(key, value string) *JobWrapper {
 	if j.Labels == nil {

--- a/pkg/util/testingjobs/jobset/wrappers.go
+++ b/pkg/util/testingjobs/jobset/wrappers.go
@@ -138,6 +138,11 @@ func (j *JobSetWrapper) Queue(queue string) *JobSetWrapper {
 	return j.Label(constants.QueueLabel, queue)
 }
 
+// PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the JobSet.
+func (j *JobSetWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *JobSetWrapper {
+	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
 // Request adds a resource request to the first container of the target replicatedJob.
 func (j *JobSetWrapper) Request(replicatedJobName string, r corev1.ResourceName, v string) *JobSetWrapper {
 	for i, replicatedJob := range j.Spec.ReplicatedJobs {

--- a/pkg/util/testingjobs/leaderworkerset/wrappers.go
+++ b/pkg/util/testingjobs/leaderworkerset/wrappers.go
@@ -85,6 +85,11 @@ func (w *LeaderWorkerSetWrapper) Queue(q string) *LeaderWorkerSetWrapper {
 	return w.Label(constants.QueueLabel, q)
 }
 
+// PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the LeaderWorkerSet.
+func (w *LeaderWorkerSetWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *LeaderWorkerSetWrapper {
+	return w.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
 // Name updated the name of the LeaderWorkerSet
 func (w *LeaderWorkerSetWrapper) Name(n string) *LeaderWorkerSetWrapper {
 	w.ObjectMeta.Name = n

--- a/pkg/util/testingjobs/mpijob/wrappers_mpijob.go
+++ b/pkg/util/testingjobs/mpijob/wrappers_mpijob.go
@@ -171,6 +171,11 @@ func (j *MPIJobWrapper) Queue(queue string) *MPIJobWrapper {
 	return j
 }
 
+// PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the job
+func (j *MPIJobWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *MPIJobWrapper {
+	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
 // Request adds a resource request to the default container.
 func (j *MPIJobWrapper) Request(replicaType kfmpi.MPIReplicaType, r corev1.ResourceName, v string) *MPIJobWrapper {
 	j.Spec.MPIReplicaSpecs[replicaType].Template.Spec.Containers[0].Resources.Requests[r] = resource.MustParse(v)

--- a/pkg/util/testingjobs/paddlejob/wrappers.go
+++ b/pkg/util/testingjobs/paddlejob/wrappers.go
@@ -148,6 +148,11 @@ func (j *PaddleJobWrapper) Queue(queue string) *PaddleJobWrapper {
 	return j
 }
 
+// PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the job.
+func (j *PaddleJobWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *PaddleJobWrapper {
+	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
 // Request adds a resource request to the default container.
 func (j *PaddleJobWrapper) Request(replicaType kftraining.ReplicaType, r corev1.ResourceName, v string) *PaddleJobWrapper {
 	j.Spec.PaddleReplicaSpecs[replicaType].Template.Spec.Containers[0].Resources.Requests[r] = resource.MustParse(v)

--- a/pkg/util/testingjobs/pod/wrappers.go
+++ b/pkg/util/testingjobs/pod/wrappers.go
@@ -71,7 +71,7 @@ func (p *PodWrapper) Obj() *corev1.Pod {
 func (p *PodWrapper) MakeGroup(count int) []*corev1.Pod {
 	var pods []*corev1.Pod
 	for i := range count {
-		pod := p.Clone().Group(p.Pod.Name).GroupTotalCount(strconv.Itoa(count))
+		pod := p.Clone().GroupNameLabel(p.Pod.Name).GroupTotalCount(strconv.Itoa(count))
 		pod.Pod.Name += fmt.Sprintf("-%d", i)
 		pods = append(pods, pod.Obj())
 	}
@@ -81,7 +81,7 @@ func (p *PodWrapper) MakeGroup(count int) []*corev1.Pod {
 func (p *PodWrapper) MakePodGroupWrappers(count int) []*PodWrapper {
 	var pods []*PodWrapper
 	for i := range count {
-		pod := p.Clone().Group(p.Pod.Name).GroupTotalCount(strconv.Itoa(count))
+		pod := p.Clone().GroupNameLabel(p.Pod.Name).GroupTotalCount(strconv.Itoa(count))
 		pod.Pod.Name += fmt.Sprintf("-%d", i)
 		pods = append(pods, pod)
 	}
@@ -93,7 +93,7 @@ func (p *PodWrapper) MakeIndexedGroup(count int) []*corev1.Pod {
 	var pods []*corev1.Pod
 	for i := range count {
 		pod := p.Clone().
-			Group(p.Pod.Name).
+			GroupNameLabel(p.Pod.Name).
 			GroupTotalCount(strconv.Itoa(count)).
 			GroupIndex(strconv.Itoa(i))
 		pod.Pod.Name += fmt.Sprintf("-%d", i)
@@ -116,7 +116,7 @@ func (p *PodWrapper) SuspendedByParent(controller string) *PodWrapper {
 	return p.Annotation(podconstants.SuspendedByParentAnnotation, controller)
 }
 
-func (p *PodWrapper) PrebuiltWorkload(name string) *PodWrapper {
+func (p *PodWrapper) PrebuiltWorkloadLabel(name string) *PodWrapper {
 	return p.Label(controllerconsts.PrebuiltWorkloadLabel, name)
 }
 
@@ -138,8 +138,8 @@ func (p *PodWrapper) Namespace(n string) *PodWrapper {
 	return p
 }
 
-// Group updates the pod.GroupNameLabel of the Pod
-func (p *PodWrapper) Group(g string) *PodWrapper {
+// GroupNameLabel updates GroupNameLabel of the Pod
+func (p *PodWrapper) GroupNameLabel(g string) *PodWrapper {
 	return p.Label(podconstants.GroupNameLabel, g)
 }
 

--- a/pkg/util/testingjobs/pytorchjob/wrappers_pytorchjob.go
+++ b/pkg/util/testingjobs/pytorchjob/wrappers_pytorchjob.go
@@ -175,6 +175,11 @@ func (j *PyTorchJobWrapper) Queue(queue string) *PyTorchJobWrapper {
 	return j
 }
 
+// PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the job
+func (j *PyTorchJobWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *PyTorchJobWrapper {
+	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
 // Request adds a resource request to the default container.
 func (j *PyTorchJobWrapper) Request(replicaType kftraining.ReplicaType, r corev1.ResourceName, v string) *PyTorchJobWrapper {
 	j.Spec.PyTorchReplicaSpecs[replicaType].Template.Spec.Containers[0].Resources.Requests[r] = resource.MustParse(v)

--- a/pkg/util/testingjobs/raycluster/wrappers.go
+++ b/pkg/util/testingjobs/raycluster/wrappers.go
@@ -133,6 +133,11 @@ func (j *ClusterWrapper) Queue(queue string) *ClusterWrapper {
 	return j
 }
 
+// PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the job
+func (j *ClusterWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *ClusterWrapper {
+	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
 func (j *ClusterWrapper) SetAnnotation(key, content string) *ClusterWrapper {
 	j.Annotations[key] = content
 	return j

--- a/pkg/util/testingjobs/rayjob/wrappers.go
+++ b/pkg/util/testingjobs/rayjob/wrappers.go
@@ -112,6 +112,11 @@ func (j *JobWrapper) Queue(queue string) *JobWrapper {
 	return j
 }
 
+// PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the job
+func (j *JobWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *JobWrapper {
+	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
 func (j *JobWrapper) RequestWorkerGroup(name corev1.ResourceName, quantity string) *JobWrapper {
 	c := &j.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0]
 	if c.Resources.Requests == nil {

--- a/pkg/util/testingjobs/rayservice/wrappers.go
+++ b/pkg/util/testingjobs/rayservice/wrappers.go
@@ -109,6 +109,11 @@ func (j *ServiceWrapper) Queue(queue string) *ServiceWrapper {
 	return j
 }
 
+// PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of RayService
+func (j *ServiceWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *ServiceWrapper {
+	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
 // Request adds a resource request to the default container.
 func (j *ServiceWrapper) Request(rayType rayv1.RayNodeType, r corev1.ResourceName, v string) *ServiceWrapper {
 	switch rayType {

--- a/pkg/util/testingjobs/statefulset/wrappers.go
+++ b/pkg/util/testingjobs/statefulset/wrappers.go
@@ -107,6 +107,11 @@ func (ss *StatefulSetWrapper) Queue(q string) *StatefulSetWrapper {
 	return ss.Label(controllerconstants.QueueLabel, q)
 }
 
+// PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the StatefulSet
+func (ss *StatefulSetWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *StatefulSetWrapper {
+	return ss.Label(controllerconstants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
 // Name updated the name of the StatefulSet
 func (ss *StatefulSetWrapper) Name(n string) *StatefulSetWrapper {
 	ss.ObjectMeta.Name = n

--- a/pkg/util/testingjobs/tfjob/wrappers_tfjob.go
+++ b/pkg/util/testingjobs/tfjob/wrappers_tfjob.go
@@ -175,6 +175,11 @@ func (j *TFJobWrapper) Queue(queue string) *TFJobWrapper {
 	return j
 }
 
+// PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the job
+func (j *TFJobWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *TFJobWrapper {
+	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
 // Request adds a resource request to the default container.
 func (j *TFJobWrapper) Request(replicaType kftraining.ReplicaType, r corev1.ResourceName, v string) *TFJobWrapper {
 	j.Spec.TFReplicaSpecs[replicaType].Template.Spec.Containers[0].Resources.Requests[r] = resource.MustParse(v)

--- a/pkg/util/testingjobs/trainjob/wrappers.go
+++ b/pkg/util/testingjobs/trainjob/wrappers.go
@@ -126,6 +126,11 @@ func (t *TrainJobWrapper) Queue(queue string) *TrainJobWrapper {
 	return t
 }
 
+// PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the TrainJob.
+func (t *TrainJobWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *TrainJobWrapper {
+	return t.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
 // ManagedBy sets the managedby field of the TrainJob.
 func (t *TrainJobWrapper) ManagedBy(managedBy string) *TrainJobWrapper {
 	t.Spec.ManagedBy = ptr.To(managedBy)

--- a/pkg/util/testingjobs/xgboostjob/wrappers.go
+++ b/pkg/util/testingjobs/xgboostjob/wrappers.go
@@ -148,6 +148,11 @@ func (j *XGBoostJobWrapper) Queue(queue string) *XGBoostJobWrapper {
 	return j
 }
 
+// PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the job
+func (j *XGBoostJobWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *XGBoostJobWrapper {
+	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
 // Request updates a resource request to the default container.
 func (j *XGBoostJobWrapper) Request(replicaType kftraining.ReplicaType, r corev1.ResourceName, v string) *XGBoostJobWrapper {
 	j.Spec.XGBReplicaSpecs[replicaType].Template.Spec.Containers[0].Resources.Requests[r] = resource.MustParse(v)

--- a/test/e2e/singlecluster/job_test.go
+++ b/test/e2e/singlecluster/job_test.go
@@ -226,7 +226,7 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 			var wl *kueue.Workload
 			ginkgo.By("Create the pebuilt workload and the job adopting it", func() {
 				sampleJob = (&testingjob.JobWrapper{Job: *sampleJob}).
-					Label(constants.PrebuiltWorkloadLabel, "prebuilt-wl").
+					PrebuiltWorkloadLabel("prebuilt-wl").
 					BackoffLimit(0).
 					Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletionFailOnExit).
 					TerminationGracePeriod(1).

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -344,7 +344,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:batch", "area:jobs")
 	ginkgo.When("The parent job is managed by kueue", func() {
 		ginkgo.It("Should suspend a job if the parent workload does not exist", func() {
 			ginkgo.By("creating the parent job")
-			parentJob := testingjob.MakeJob(parentJobName, ns.Name).Label(constants.PrebuiltWorkloadLabel, "missing").Obj()
+			parentJob := testingjob.MakeJob(parentJobName, ns.Name).PrebuiltWorkloadLabel("missing").Obj()
 			util.MustCreate(ctx, k8sClient, parentJob)
 
 			ginkgo.By("Creating the child job which uses the parent workload annotation")
@@ -447,7 +447,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:batch", "area:jobs")
 		ginkgo.It("Should get suspended if the workload is not found", func() {
 			job := testingjob.MakeJob("job", ns.Name).
 				Queue("main").
-				Label(constants.PrebuiltWorkloadLabel, "missing-workload").
+				PrebuiltWorkloadLabel("missing-workload").
 				Obj()
 			util.MustCreate(ctx, k8sClient, job)
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -466,7 +466,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:batch", "area:jobs")
 
 			job := testingjob.MakeJob("job", ns.Name).
 				Queue("main").
-				Label(constants.PrebuiltWorkloadLabel, "wl").
+				PrebuiltWorkloadLabel("wl").
 				Containers(*container.DeepCopy()).
 				Obj()
 
@@ -515,7 +515,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:batch", "area:jobs")
 
 			job := testingjob.MakeJob("job", ns.Name).
 				Queue("main").
-				Label(constants.PrebuiltWorkloadLabel, "wl").
+				PrebuiltWorkloadLabel("wl").
 				Containers(*container.DeepCopy()).
 				Obj()
 			util.MustCreate(ctx, k8sClient, job)

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -618,7 +618,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 				pod := testingpod.MakePod(podName, ns.Name).
 					Request(corev1.ResourceCPU, "1").
 					Queue(lq.Name).
-					PrebuiltWorkload(workloadName).
+					PrebuiltWorkloadLabel(workloadName).
 					Obj()
 
 				ginkgo.By("Creating pod with queue-name", func() {
@@ -682,13 +682,13 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 			ginkgo.It("Should ungate pods when admitted and finalize Pods when succeeded", func() {
 				ginkgo.By("Creating pods with queue name")
 				pod1 := testingpod.MakePod("test-pod1", ns.Name).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Queue("test-queue").
 					Label("dontCopyKey", "dontCopyValue").
 					Obj()
 				pod2 := testingpod.MakePod("test-pod2", ns.Name).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Request(corev1.ResourceCPU, "1").
 					Queue("test-queue").
@@ -768,7 +768,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 			ginkgo.It("Should ungate pods when admitted with fast admission", func() {
 				ginkgo.By("Creating pod1 and delaying creation of pod2")
 				pod1 := testingpod.MakePod("test-pod1", ns.Name).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
 					Queue("test-queue").
@@ -810,7 +810,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 				})
 
 				pod2 := testingpod.MakePod("test-pod2", ns.Name).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
 					Queue("test-queue").
@@ -838,12 +838,12 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 			ginkgo.It("Should keep the running pod group with the queue name if workload is evicted", framework.SlowSpec, func() {
 				ginkgo.By("Creating pods with queue name")
 				pod1 := testingpod.MakePod("test-pod1", ns.Name).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Queue("test-queue").
 					Obj()
 				pod2 := testingpod.MakePod("test-pod2", ns.Name).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Queue("test-queue").
 					Obj()
@@ -941,7 +941,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 				})
 
 				replacementPod := testingpod.MakePod("test-pod2-replace", ns.Name).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Queue("test-queue").
 					Obj()
@@ -1001,7 +1001,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 				ginkgo.By("Creating a single pod with queue and group names")
 
 				pod := testingpod.MakePod("test-pod", ns.Name).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					Queue("test-queue").
 					Obj()
@@ -1064,7 +1064,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 
 				ginkgo.By("Creating a replacement pod in the group")
 				replacementPod := testingpod.MakePod("replacement-test-pod", ns.Name).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					Queue("test-queue").
 					Obj()
@@ -1107,7 +1107,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 
 				ginkgo.By("Creating a second replacement pod in the group")
 				replacementPod2 := testingpod.MakePod("replacement-test-pod2", ns.Name).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("1").
 					Queue("test-queue").
 					Obj()
@@ -1142,12 +1142,12 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 			ginkgo.It("Should finish the group if one Pod has the `retriable-in-group: false` annotation", framework.SlowSpec, func() {
 				ginkgo.By("Creating pods with queue name")
 				pod1 := testingpod.MakePod("test-pod1", ns.Name).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Queue("test-queue").
 					Obj()
 				pod2 := testingpod.MakePod("test-pod2", ns.Name).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Request(corev1.ResourceCPU, "1").
 					Queue("test-queue").
@@ -1223,7 +1223,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 
 				// Create replacement pod with 'retriable-in-group' = false annotation
 				replacementPod2 := testingpod.MakePod("replacement-test-pod2", ns.Name).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Image("test-image", nil).
 					Annotation(podconstants.RetriableInGroupAnnotationKey, podconstants.RetriableInGroupAnnotationValue).
@@ -1255,18 +1255,18 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 			ginkgo.It("Should finalize and delete excess pods", framework.SlowSpec, func() {
 				ginkgo.By("Creating pods with queue name")
 				pod1 := testingpod.MakePod("test-pod1", ns.Name).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Queue("test-queue").
 					Obj()
 				pod2 := testingpod.MakePod("test-pod2", ns.Name).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Request(corev1.ResourceCPU, "1").
 					Queue("test-queue").
 					Obj()
 				excessBasePod := testingpod.MakePod("excess-pod", ns.Name).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Request(corev1.ResourceCPU, "1").
 					Queue("test-queue")
@@ -1348,7 +1348,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 				pods := make([]*corev1.Pod, podCount)
 				for i := range pods {
 					pods[i] = testingpod.MakePod(fmt.Sprintf("test-pod-%d", i), ns.Name).
-						Group("test-group").
+						GroupNameLabel("test-group").
 						GroupTotalCount(strconv.Itoa(podCount)).
 						Request(corev1.ResourceCPU, "1").
 						Queue("test-queue").
@@ -1402,13 +1402,13 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 			ginkgo.It("Should finalize workload if pods are absent", func() {
 				ginkgo.By("Creating pods with queue name")
 				pod1 := testingpod.MakePod("test-pod1", ns.Name).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Request(corev1.ResourceCPU, "1").
 					Queue("test-queue").
 					Obj()
 				pod2 := testingpod.MakePod("test-pod2", ns.Name).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					Request(corev1.ResourceCPU, "2").
 					Queue("test-queue").
@@ -1458,7 +1458,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 				podGroupName := "pod-group"
 
 				pod := testingpod.MakePod("pod", ns.Name).
-					Group(podGroupName).
+					GroupNameLabel(podGroupName).
 					GroupTotalCount("1").
 					Queue(lq.Name).
 					Request(corev1.ResourceCPU, "1").
@@ -1548,7 +1548,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 				})
 
 				replacementPod := testingpod.MakePod("replacement-pod", ns.Name).
-					Group(podGroupName).
+					GroupNameLabel(podGroupName).
 					GroupTotalCount("1").
 					Queue(lq.Name).
 					Request(corev1.ResourceCPU, "1").
@@ -1576,14 +1576,14 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 			ginkgo.It("Should ungate pod after Succeeded phase when serving workload is enabled", framework.SlowSpec, func() {
 				ginkgo.By("Creating pods with queue name")
 				pod1 := testingpod.MakePod("test-pod1", ns.Name).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					PodGroupServingAnnotation().
 					Request(corev1.ResourceCPU, "1").
 					Queue("test-queue").
 					Obj()
 				pod2 := testingpod.MakePod("test-pod2", ns.Name).
-					Group("test-group").
+					GroupNameLabel("test-group").
 					GroupTotalCount("2").
 					PodGroupServingAnnotation().
 					Request(corev1.ResourceCPU, "1").
@@ -1659,7 +1659,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 
 				ginkgo.By("recreate pod2", func() {
 					pod2 = testingpod.MakePod("test-pod2", ns.Name).
-						Group("test-group").
+						GroupNameLabel("test-group").
 						GroupTotalCount("2").
 						Request(corev1.ResourceCPU, "1").
 						Queue("test-queue").
@@ -1681,19 +1681,19 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 				)
 
 				pod1 := testingpod.MakePod("test-pod-1", ns.Name).
-					Group(workloadName).
+					GroupNameLabel(workloadName).
 					GroupTotalCount("2").
 					Request(corev1.ResourceCPU, "1").
 					Queue(lq.Name).
-					PrebuiltWorkload(workloadName).
+					PrebuiltWorkloadLabel(workloadName).
 					RoleHash("leader").
 					Obj()
 				pod2 := testingpod.MakePod("test-pod-2", ns.Name).
-					Group(workloadName).
+					GroupNameLabel(workloadName).
 					GroupTotalCount("2").
 					Request(corev1.ResourceCPU, "2").
 					Queue(lq.Name).
-					PrebuiltWorkload(workloadName).
+					PrebuiltWorkloadLabel(workloadName).
 					RoleHash("worker").
 					Obj()
 
@@ -1876,7 +1876,7 @@ var _ = ginkgo.Describe("Pod controller interacting with scheduler", ginkgo.Labe
 		util.MustCreate(ctx, k8sClient, localQueue)
 
 		basePod := testingpod.MakePod("pod", ns.Name).
-			Group("dev-pods").
+			GroupNameLabel("dev-pods").
 			GroupTotalCount("4").
 			Queue(localQueue.Name).
 			// requesting a resource that is not covered by cluster queue,
@@ -2101,7 +2101,7 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 		ginkgo.It("should deactivate and evict workload due exceeding backoffLimitCount", framework.SlowSpec, func() {
 			podGroupName := "pod-group"
 			pod := testingpod.MakePod("pod", ns.Name).
-				Group(podGroupName).
+				GroupNameLabel(podGroupName).
 				GroupTotalCount("1").
 				Queue(lq.Name).
 				Request(corev1.ResourceCPU, "1").


### PR DESCRIPTION
Cherry pick of #10858 on release-0.16.

#10858:  Rename `Group` to `GroupNameLabel` and add `PrebuiltWorkloadLabel` to testing wrappers   

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```