### PR TITLE
Deduplicate kubectl image

### DIFF
--- a/cmd/experimental/kueue-populator/charts/kueue-populator/templates/_helpers.tpl
+++ b/cmd/experimental/kueue-populator/charts/kueue-populator/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{/*
+Kubectl image used by Helm hooks and tests.
+*/}}
+{{- define "kueue-populator.kubectlImage" -}}
+registry.k8s.io/kubectl:v1.33.6
+{{- end -}}

--- a/cmd/experimental/kueue-populator/charts/kueue-populator/templates/setup-hook.yaml
+++ b/cmd/experimental/kueue-populator/charts/kueue-populator/templates/setup-hook.yaml
@@ -127,7 +127,7 @@ spec:
       serviceAccountName: {{ .Release.Name }}-kueue-hook-sa
       containers:
       - name: kubectl-apply
-        image: registry.k8s.io/kubectl:v1.33.6
+        image: {{ include "kueue-populator.kubectlImage" . }}
         command:
         - kubectl
         - apply

--- a/cmd/experimental/kueue-populator/charts/kueue-populator/templates/tests/test-kueue-status.yaml
+++ b/cmd/experimental/kueue-populator/charts/kueue-populator/templates/tests/test-kueue-status.yaml
@@ -10,7 +10,7 @@ spec:
   serviceAccountName: "{{ .Release.Name }}-test-sa"
   containers:
     - name: check-kueue-deployments
-      image: registry.k8s.io/kubectl:v1.33.6
+      image: {{ include "kueue-populator.kubectlImage" . }}
       command: ["kubectl"]
       args: [
         "wait",

--- a/cmd/experimental/kueue-populator/charts/kueue-populator/templates/tests/test-populator-resources.yaml
+++ b/cmd/experimental/kueue-populator/charts/kueue-populator/templates/tests/test-populator-resources.yaml
@@ -10,7 +10,7 @@ spec:
   serviceAccountName: "{{ .Release.Name }}-test-sa"
   containers:
     - name: check-populator-resources
-      image: registry.k8s.io/kubectl:v1.33.6
+      image: {{ include "kueue-populator.kubectlImage" . }}
       command: ["kubectl"]
       args:
         - get


### PR DESCRIPTION

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Deduplicates the kubectl image costant used by kueue-populator Helm hooks and tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #7992

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
