### PR TITLE
tas: improve LWS balanced placement

### DIFF
--- a/pkg/cache/scheduler/tas_balanced_placement.go
+++ b/pkg/cache/scheduler/tas_balanced_placement.go
@@ -69,12 +69,7 @@ func balanceThresholdValue(sliceCount int32, selectedDomainsCount int32, lastDom
 		threshold = min(threshold, lastDomainWithLeader.sliceStateWithLeader)
 	}
 	if lastDomain != nil {
-		// TODO: https://github.com/kubernetes-sigs/kueue/issues/7494
-		// we don't have min(threshold, lastDomain.sliceState) here because
-		// later we prune all nodes with sliceStateWithLeader < threshold
-		// while pruning we don't know which node will host the leader
-		// so we have to leave space on each node
-		threshold = min(threshold, lastDomain.sliceStateWithLeader)
+		threshold = min(threshold, lastDomain.sliceState)
 	}
 	return threshold
 }
@@ -257,19 +252,37 @@ func findBestDomainsForBalancedPlacement(s *TASFlavorSnapshot, params *topologyA
 	var currFitDomain []*domain
 
 	for _, requestedLevelSiblingDomains := range requestedLevelDomainsToConsider {
-		lowerLevelDomains := getLowerLevelDomains(s, requestedLevelSiblingDomains, params.requestedLevelIdx, params.sliceLevelIdx)
+		candidateDomains := cloneDomains(requestedLevelSiblingDomains)
+		lowerLevelDomains := getLowerLevelDomains(s, candidateDomains, params.requestedLevelIdx, params.sliceLevelIdx)
 		fits, selectedDomainsCount, lastDomainWithLeader, lastDomain := evaluateGreedyAssignment(s, lowerLevelDomains, sliceCount, params.leaderCount)
 		if !fits {
 			continue
 		}
 		threshold := balanceThresholdValue(sliceCount, selectedDomainsCount, lastDomainWithLeader, lastDomain)
+		thresholdWithLeaderReservation := threshold
+		if params.leaderCount > 0 && lastDomain != nil {
+			thresholdWithLeaderReservation = min(threshold, lastDomain.sliceStateWithLeader)
+		}
 		if threshold >= bestThreshold {
-			s.pruneDomainsBelowThreshold(requestedLevelSiblingDomains, threshold, params.sliceSize, params.sliceLevelIdx, params.requestedLevelIdx, params.leaderCount > 0)
-			_, requestedLevelDomainCount, _, _ := evaluateGreedyAssignment(s, requestedLevelSiblingDomains, sliceCount, params.leaderCount)
+			s.pruneDomainsBelowThreshold(candidateDomains, threshold, params.sliceSize, params.sliceLevelIdx, params.requestedLevelIdx, params.leaderCount > 0)
+			fitsAfterPruning, requestedLevelDomainCount, _, _ := evaluateGreedyAssignment(s, candidateDomains, sliceCount, params.leaderCount)
+			if !fitsAfterPruning && thresholdWithLeaderReservation < threshold {
+				// Retry with a lower threshold that reserves leader capacity.
+				if thresholdWithLeaderReservation <= 0 || thresholdWithLeaderReservation < bestThreshold {
+					continue
+				}
+				threshold = thresholdWithLeaderReservation
+				candidateDomains = cloneDomains(requestedLevelSiblingDomains)
+				s.pruneDomainsBelowThreshold(candidateDomains, threshold, params.sliceSize, params.sliceLevelIdx, params.requestedLevelIdx, params.leaderCount > 0)
+				fitsAfterPruning, requestedLevelDomainCount, _, _ = evaluateGreedyAssignment(s, candidateDomains, sliceCount, params.leaderCount)
+			}
+			if !fitsAfterPruning {
+				continue
+			}
 			if threshold > bestThreshold || (threshold == bestThreshold && requestedLevelDomainCount < bestDomainCountOnRequestedLevel) {
 				bestThreshold = threshold
 				bestDomainCountOnRequestedLevel = requestedLevelDomainCount
-				currFitDomain = requestedLevelSiblingDomains
+				currFitDomain = candidateDomains
 			}
 		}
 	}
@@ -318,18 +331,52 @@ func clearState(d *domain) {
 	}
 }
 
+func clearLeaderCapacity(d *domain) {
+	d.stateWithLeader = int32(0)
+	d.sliceStateWithLeader = int32(0)
+	d.leaderState = int32(0)
+	for _, child := range d.children {
+		clearLeaderCapacity(child)
+	}
+}
+
+func cloneDomains(domains []*domain) []*domain {
+	result := make([]*domain, len(domains))
+	for i, d := range domains {
+		result[i] = cloneDomain(d, nil)
+	}
+	return result
+}
+
+func cloneDomain(d *domain, parent *domain) *domain {
+	clone := *d
+	clone.parent = parent
+	clone.children = make([]*domain, len(d.children))
+	for i, child := range d.children {
+		clone.children[i] = cloneDomain(child, &clone)
+	}
+	return &clone
+}
+
+func pruneDomainNodeBelowThreshold(d *domain, threshold int32, leaderRequired bool) {
+	if d.sliceState < threshold {
+		clearState(d)
+		return
+	}
+	// The domain can still be used for workers, but not as the leader host at this threshold.
+	if leaderRequired && d.leaderState > 0 && d.sliceStateWithLeader < threshold {
+		clearLeaderCapacity(d)
+	}
+}
+
 func (s *TASFlavorSnapshot) pruneDomainsBelowThreshold(domains []*domain, threshold int32, sliceSize int32, sliceLevelIdx int, level int, leaderRequired bool) {
 	for _, d := range domains {
 		for _, c := range d.children {
-			if c.sliceStateWithLeader < threshold {
-				clearState(c)
-			}
+			pruneDomainNodeBelowThreshold(c, threshold, leaderRequired)
 		}
 	}
 	for _, d := range domains {
 		s.fillInCountsHelper(d, sliceSize, sliceLevelIdx, level, nil, leaderRequired)
-		if d.sliceStateWithLeader < threshold {
-			clearState(d)
-		}
+		pruneDomainNodeBelowThreshold(d, threshold, leaderRequired)
 	}
 }

--- a/pkg/cache/scheduler/tas_balanced_placement_test.go
+++ b/pkg/cache/scheduler/tas_balanced_placement_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
 
@@ -166,6 +167,170 @@ func TestPlaceSlicesOnDomainsBalanced(t *testing.T) {
 				cmpopts.SortSlices(func(a, b *domain) bool { return a.id < b.id }),
 			); diff != "" {
 				t.Errorf("Unexpected domains (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPruneDomainsBelowThreshold(t *testing.T) {
+	domainState := func(d *domain) [5]int32 {
+		return [5]int32{d.state, d.sliceState, d.stateWithLeader, d.sliceStateWithLeader, d.leaderState}
+	}
+
+	testCases := map[string]struct {
+		domains        func() ([]*domain, map[string]*domain)
+		threshold      int32
+		sliceSize      int32
+		sliceLevelIdx  int
+		level          int
+		leaderRequired bool
+		want           map[string][5]int32
+	}{
+		"keeps worker only domain": {
+			domains: func() ([]*domain, map[string]*domain) {
+				leaderLeaf := &domain{id: "leader-leaf", state: 6, sliceState: 6, leaderState: 1, stateWithLeader: 5, sliceStateWithLeader: 5}
+				leaderDomain := &domain{id: "leader-domain", state: 6, sliceState: 6, leaderState: 1, stateWithLeader: 5, sliceStateWithLeader: 5, children: []*domain{leaderLeaf}}
+				leaderLeaf.parent = leaderDomain
+				workerOnlyLeaf := &domain{id: "worker-only-leaf", state: 5, sliceState: 5, leaderState: 1, stateWithLeader: 4, sliceStateWithLeader: 4}
+				workerOnlyDomain := &domain{id: "worker-only-domain", state: 5, sliceState: 5, leaderState: 1, stateWithLeader: 4, sliceStateWithLeader: 4, children: []*domain{workerOnlyLeaf}}
+				workerOnlyLeaf.parent = workerOnlyDomain
+				parentDomain := &domain{id: "parent-domain", children: []*domain{leaderDomain, workerOnlyDomain}}
+				leaderDomain.parent = parentDomain
+				workerOnlyDomain.parent = parentDomain
+				return []*domain{parentDomain}, map[string]*domain{
+					"leaderDomain":     leaderDomain,
+					"parentDomain":     parentDomain,
+					"workerOnlyDomain": workerOnlyDomain,
+					"workerOnlyLeaf":   workerOnlyLeaf,
+				}
+			},
+			threshold:      5,
+			sliceSize:      1,
+			sliceLevelIdx:  2,
+			level:          0,
+			leaderRequired: true,
+			want: map[string][5]int32{
+				"leaderDomain":     {6, 6, 5, 5, 1},
+				"parentDomain":     {11, 11, 10, 10, 1},
+				"workerOnlyDomain": {5, 5, 0, 0, 0},
+				"workerOnlyLeaf":   {5, 5, 0, 0, 0},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			domains, domainsByName := tc.domains()
+			_, log := utiltesting.ContextWithLog(t)
+			s := newTASFlavorSnapshot(log, "dummy", []string{}, nil)
+
+			s.pruneDomainsBelowThreshold(domains, tc.threshold, tc.sliceSize, tc.sliceLevelIdx, tc.level, tc.leaderRequired)
+
+			got := make(map[string][5]int32, len(tc.want))
+			for name := range tc.want {
+				got[name] = domainState(domainsByName[name])
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Unexpected domain state (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFindBestDomainsForBalancedPlacement(t *testing.T) {
+	type domainSpec struct {
+		id                   string
+		parentID             string
+		levelValues          []string
+		state                int32
+		sliceState           int32
+		stateWithLeader      int32
+		sliceStateWithLeader int32
+		leaderState          int32
+	}
+
+	testCases := map[string]struct {
+		domains          []domainSpec
+		params           topologyAssignmentParameters
+		wantThreshold    int32
+		wantDomainsCount int
+	}{
+		"falls back after pruning": {
+			domains: []domainSpec{
+				{id: "b1", levelValues: []string{"b1"}},
+				{id: "b2", levelValues: []string{"b2"}},
+				{id: "b1/r1", parentID: "b1", levelValues: []string{"b1", "r1"}, state: 3, sliceState: 3, stateWithLeader: 2, sliceStateWithLeader: 2, leaderState: 1},
+				{id: "b2/r1", parentID: "b2", levelValues: []string{"b2", "r1"}, state: 2, sliceState: 2, stateWithLeader: 1, sliceStateWithLeader: 1, leaderState: 1},
+				{id: "b2/r2", parentID: "b2", levelValues: []string{"b2", "r2"}, state: 4, sliceState: 4, stateWithLeader: 2, sliceStateWithLeader: 2, leaderState: 1},
+			},
+			params: topologyAssignmentParameters{
+				count:             8,
+				sliceSize:         1,
+				leaderCount:       1,
+				requestedLevelIdx: 0,
+				sliceLevelIdx:     1,
+			},
+			wantThreshold:    1,
+			wantDomainsCount: 2,
+		},
+		"rejects after fallback": {
+			domains: []domainSpec{
+				{id: "b1", levelValues: []string{"b1"}},
+				{id: "b2", levelValues: []string{"b2"}},
+				{id: "b3", levelValues: []string{"b3"}},
+				{id: "b1/r1", parentID: "b1", levelValues: []string{"b1", "r1"}, state: 2, sliceState: 2, stateWithLeader: 1, sliceStateWithLeader: 1, leaderState: 1},
+				{id: "b2/r1", parentID: "b2", levelValues: []string{"b2", "r1"}, state: 3, sliceState: 3, stateWithLeader: 1, sliceStateWithLeader: 1, leaderState: 1},
+				{id: "b2/r2", parentID: "b2", levelValues: []string{"b2", "r2"}, state: 4, sliceState: 4, stateWithLeader: 2, sliceStateWithLeader: 2, leaderState: 1},
+				{id: "b3/r1", parentID: "b3", levelValues: []string{"b3", "r1"}, state: 4, sliceState: 4, stateWithLeader: 3, sliceStateWithLeader: 3, leaderState: 1},
+			},
+			params: topologyAssignmentParameters{
+				count:             12,
+				sliceSize:         1,
+				leaderCount:       1,
+				requestedLevelIdx: 0,
+				sliceLevelIdx:     1,
+			},
+			wantThreshold:    0,
+			wantDomainsCount: 0,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
+			s := newTASFlavorSnapshot(log, "dummy", []string{"block", "rack"}, nil)
+			domainsByID := make(map[string]*domain, len(tc.domains))
+			for _, spec := range tc.domains {
+				d := &domain{
+					id:                   utiltas.TopologyDomainID(spec.id),
+					levelValues:          spec.levelValues,
+					state:                spec.state,
+					sliceState:           spec.sliceState,
+					stateWithLeader:      spec.stateWithLeader,
+					sliceStateWithLeader: spec.sliceStateWithLeader,
+					leaderState:          spec.leaderState,
+				}
+				if len(spec.parentID) == 0 {
+					s.domainsPerLevel[0][d.id] = d
+				} else {
+					parent := domainsByID[spec.parentID]
+					if parent == nil {
+						t.Fatalf("Unknown parent domain %q", spec.parentID)
+					}
+					d.parent = parent
+					parent.children = append(parent.children, d)
+					s.domainsPerLevel[1][d.id] = d
+				}
+				domainsByID[spec.id] = d
+			}
+
+			gotDomains, gotThreshold := findBestDomainsForBalancedPlacement(s, &tc.params)
+
+			if gotThreshold != tc.wantThreshold {
+				t.Errorf("Unexpected threshold: got %d, want %d", gotThreshold, tc.wantThreshold)
+			}
+			if len(gotDomains) != tc.wantDomainsCount {
+				t.Errorf("Unexpected domains count: got %d, want %d", len(gotDomains), tc.wantDomainsCount)
 			}
 		})
 	}

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -3872,6 +3872,87 @@ func TestFindTopologyAssignments(t *testing.T) {
 				},
 			},
 		},
+		//        b1
+		//         |
+		//        r1
+		//    /    |
+		// x1:7  x2:5
+		// request: 10
+		// leaders: 1
+		// expected outcome: x1:5 + leader, x2:5
+		"balanced placement; leader worker set does not reserve leader space on every node": {
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("b1-r1-x1").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "r1").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						"example.com/gpu":   resource.MustParse("7"),
+						corev1.ResourcePods: resource.MustParse("12"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("b1-r1-x2").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "r1").
+					Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{
+						"example.com/gpu":   resource.MustParse("5"),
+						corev1.ResourcePods: resource.MustParse("12"),
+					}).
+					Ready().
+					Obj(),
+			},
+			levels: defaultThreeLevels,
+			podSets: []PodSetTestCase{
+				{
+					podSetName: "leader",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Preferred:                   ptr.To(string(tasRackLabel)),
+						PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+					},
+					requests: resources.Requests{
+						"example.com/gpu": 1,
+					},
+					podSetGroupName: new("sameGroup"),
+					count:           1,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: defaultOneLevel,
+						Domains: []tas.TopologyDomainAssignment{
+							{
+								Count:  1,
+								Values: []string{"x1"},
+							},
+						},
+					},
+				},
+				{
+					podSetName: "workers",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Preferred: ptr.To(string(tasRackLabel)),
+					},
+					requests: resources.Requests{
+						"example.com/gpu": 1,
+					},
+					podSetGroupName: new("sameGroup"),
+					count:           10,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: defaultOneLevel,
+						Domains: []tas.TopologyDomainAssignment{
+							{
+								Count:  5,
+								Values: []string{"x1"},
+							},
+							{
+								Count:  5,
+								Values: []string{"x2"},
+							},
+						},
+					},
+				},
+			},
+		},
 		"block required for podset; rack required for slices; podset fits in a block, but slices do not fit in racks": {
 
 			//         b1


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area tas

#### What this PR does / why we need it:
Improves TAS Balanced Placement for LeaderWorkerSet by avoiding leader reservation on each node.
Domains that cannot meet the threshold while hosting the leader now lose only leader capacity and stay usable, instead of being pruned from worker placement.

For example with `threshold=5` and `leaderRequired=true`:
before pruning:
```
# [state, sliceState, stateWithLeader, sliceStateWithLeader, leaderState]
leader-domain      [6, 6, 5, 5, 1]
worker-only-domain [5, 5, 4, 4, 1]
  ```
after pruning (old):
  ```
leader-domain      [6, 6, 5, 5, 1]
worker-only-domain [0, 0, 0, 0, 0]  ← pruned, even though sliceState=5 meets threshold
parent-domain      [6, 6, 5, 5, 1]
  ```
after pruning (new):
  ```
leader-domain      [6, 6, 5, 5, 1]
worker-only-domain [5, 5, 0, 0, 0]  ← kept for workers with leader capacity cleared 
parent-domain      [11, 11, 10, 10, 1]
  ```
#### Which issue(s) this PR fixes:
Part of #7494

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Improved TAS balanced placement for LeaderWorkerSet: domains that meet the worker threshold stay usable even when they can't host the leader.
```
