### PR TITLE
Use LongTimeout for worker1 reconnect check after apiserver restart

### DIFF
--- a/test/e2e/multikueuesequential/e2e_test.go
+++ b/test/e2e/multikueuesequential/e2e_test.go
@@ -351,7 +351,7 @@ var _ = ginkgo.Describe("MultiKueue Sequential", func() {
 							Message: "Connected",
 						},
 						util.IgnoreConditionTimestampsAndObservedGeneration)))
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Waiting for kube-system to become available again", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10926 

#### Special notes for your reviewer:
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_kueue/10921/pull-kueue-test-e2e-multikueue-sequential-main/2051295881319157760

The PR fixes "MultiKueue Sequential when The connection to a worker cluster is unreliable Should update the cluster status to reflect the connection state" test, because after the test fail, the failure propagated into other tests, so fixing this will resolve issues with other tests as well. 

Test times out at 13:55:12, because manager cluster failed to connect to worker1 cluster apiserver  in MediumTimeout. 

It fails to connect at 13:54:37, but at 13:55:17 it succeeded. 
```
# ./artifacts/run-test-e2e-multikueue-sequential-1.35.0/kind-manager-worker/pods/kueue-system_kueue-controller-manager-7b5ff6c954-hnf2x_5d0dd006-e7ff-4107-ab42-e8c32aeaf91f/manager/0.log
2026-05-04T13:54:37.648166952Z stderr F 2026-05-04T13:54:37.64795336Z	ERROR	multikueue-cluster	multikueue/multikueuecluster.go:467	setting client config	{"replica-role": "leader", "name": "worker1", "reconcileID": "817ac025-61d4-46a6-8dcc-9b151a93140d", "retryAfter": "40s", "error": "unable to retrieve the complete list of server APIs: kueue.x-k8s.io/v1beta2: no matches for kueue.x-k8s.io/v1beta2, Resource="}
<...>
2026-05-04T13:55:17.673297679Z stderr F 2026-05-04T13:55:17.673085757Z	LEVEL(-2)	multikueue/multikueuecluster.go:216	Starting watch	{"clusterName": "worker1", "watchKind": "Workload.kueue.x-k8s.io"}
```

By increasing the timeout, we increase stability of the test, under such conditions. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
