### PR TITLE
[ConcurrentAdmission] Clean up unit tests

### DIFF
--- a/pkg/controller/concurrentadmission/controller_test.go
+++ b/pkg/controller/concurrentadmission/controller_test.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/pkg/workload/concurrentadmission"
 )
 
@@ -91,8 +92,6 @@ func TestReconcile(t *testing.T) {
 		wantParentWorkload   *kueue.Workload
 		wantVariantWorkloads []kueue.Workload
 		req                  reconcile.Request
-		wantResult           reconcile.Result
-		wantErr              bool
 	}{
 		"workload not found": {
 			req: reconcile.Request{
@@ -101,91 +100,83 @@ func TestReconcile(t *testing.T) {
 					Name:      "non-existing",
 				},
 			},
-			wantResult: reconcile.Result{},
-			wantErr:    false,
 		},
 		"workload is not parent or variant": {
 			parentWorkload:     utiltestingapi.MakeWorkload("wl", "default").Obj(),
 			wantParentWorkload: utiltestingapi.MakeWorkload("wl", "default").Obj(),
-			wantResult:         reconcile.Result{},
-			wantErr:            false,
 		},
 		"parent workload without variants creates them": {
-			parentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Obj(),
-			wantParentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Obj(),
 			wantVariantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-spot-545ad", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot-a2342", "default").
 					Queue("lq").
 					AllowedFlavors("spot").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", ""). // UID is ignored in cmp
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", ""). // UID is ignored in cmp
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand-39893", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand-480a3", "default").
 					Queue("lq").
 					AllowedFlavors("on-demand").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Obj(),
 			},
-			wantResult: reconcile.Result{},
-			wantErr:    false,
 		},
 		"parent workload with missing variants; creates missing": {
-			parentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Obj(),
 			variantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq").
 					AllowedFlavors("spot").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", ""). // UID is ignored in cmp
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", ""). // UID is ignored in cmp
 					Obj(),
 			},
-			wantParentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Obj(),
 			wantVariantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq").
 					AllowedFlavors("spot").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", ""). // UID is ignored in cmp
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", ""). // UID is ignored in cmp
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand-39893", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand-480a3", "default").
 					Queue("lq").
 					AllowedFlavors("on-demand").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Obj(),
 			},
-			wantResult: reconcile.Result{},
-			wantErr:    false,
 		},
 		"admitted variant syncs admission to parent": {
-			parentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Obj(),
 			variantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq").
 					AllowedFlavors("spot").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					SimpleReserveQuota("cq", "spot", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq").
 					AllowedFlavors("on-demand").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Obj(),
 			},
-			wantParentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Admission(utiltestingapi.MakeAdmission("cq", "main").
@@ -201,7 +192,7 @@ func TestReconcile(t *testing.T) {
 					Type:    kueue.WorkloadAdmitted,
 					Status:  metav1.ConditionTrue,
 					Reason:  "Admitted",
-					Message: "The variant parent-variant-spot is admitted",
+					Message: "The variant wl-variant-spot is admitted",
 				}).
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
@@ -211,25 +202,23 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 			wantVariantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq").
 					AllowedFlavors("spot").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					SimpleReserveQuota("cq", "spot", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq").
 					AllowedFlavors("on-demand").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Obj(),
 			},
-			wantResult: reconcile.Result{},
-			wantErr:    false,
 		},
 		"no variant admitted; parent admitted; evict parent": {
-			parentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Request(corev1.ResourceCPU, "1").
@@ -237,20 +226,20 @@ func TestReconcile(t *testing.T) {
 				AdmittedAt(true, metav1.Now().Time).
 				Obj(),
 			variantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq").
 					AllowedFlavors("spot").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq").
 					AllowedFlavors("on-demand").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					Obj(),
 			},
-			wantParentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Request(corev1.ResourceCPU, "1").
@@ -264,24 +253,22 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 			wantVariantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq").
 					AllowedFlavors("spot").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq").
 					AllowedFlavors("on-demand").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					Obj(),
 			},
-			wantResult: reconcile.Result{},
-			wantErr:    false,
 		},
 		"admitted variant evicted; parent has quota; evict parent and wait": {
-			parentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Request(corev1.ResourceCPU, "1").
@@ -289,10 +276,10 @@ func TestReconcile(t *testing.T) {
 				AdmittedAt(true, metav1.Now().Time).
 				Obj(),
 			variantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq").
 					AllowedFlavors("spot").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
 					SimpleReserveQuota("cq", "spot", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
@@ -304,15 +291,15 @@ func TestReconcile(t *testing.T) {
 					}).
 					Active(true).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq").
 					AllowedFlavors("on-demand").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					Active(false).
 					Obj(),
 			},
-			wantParentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Request(corev1.ResourceCPU, "1").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
@@ -326,11 +313,11 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 			wantVariantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq").
 					AllowedFlavors("spot").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					SimpleReserveQuota("cq", "spot", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Condition(metav1.Condition{
@@ -341,28 +328,26 @@ func TestReconcile(t *testing.T) {
 					}).
 					Active(true).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq").
 					AllowedFlavors("on-demand").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					Active(false).
 					Obj(),
 			},
-			wantResult: reconcile.Result{},
-			wantErr:    false,
 		},
 		"admitted variant evicted; parent has no quota reservation; clear variant reservation": {
-			parentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Request(corev1.ResourceCPU, "1").
 				Obj(),
 			variantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq").
 					AllowedFlavors("spot").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
 					SimpleReserveQuota("cq", "spot", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
@@ -374,25 +359,25 @@ func TestReconcile(t *testing.T) {
 					}).
 					Active(true).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq").
 					AllowedFlavors("on-demand").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					Active(false).
 					Obj(),
 			},
-			wantParentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Request(corev1.ResourceCPU, "1").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Obj(),
 			wantVariantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq").
 					AllowedFlavors("spot").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					SimpleReserveQuota("cq", "spot", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Condition(metav1.Condition{
@@ -421,46 +406,44 @@ func TestReconcile(t *testing.T) {
 					}).
 					Active(true).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq").
 					AllowedFlavors("on-demand").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					Active(true).
 					Obj(),
 			},
-			wantResult: reconcile.Result{},
-			wantErr:    false,
 		},
 		"with minTargetFlavor=reservation, variant admitted on spot, deactivate on-demand": {
-			parentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq-migration").
 				Request(corev1.ResourceCPU, "1").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Obj(),
 			variantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-reservation", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-reservation", "default").
 					Queue("lq-migration").
 					AllowedFlavors("reservation").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq-migration").
 					AllowedFlavors("on-demand").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq-migration").
 					AllowedFlavors("spot").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					SimpleReserveQuota("cq-migration", "spot", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Obj(),
 			},
-			wantParentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq-migration").
 				Request(corev1.ResourceCPU, "1").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
@@ -477,7 +460,7 @@ func TestReconcile(t *testing.T) {
 					Type:    kueue.WorkloadAdmitted,
 					Status:  metav1.ConditionTrue,
 					Reason:  "Admitted",
-					Message: "The variant parent-variant-spot is admitted",
+					Message: "The variant wl-variant-spot is admitted",
 				}).
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
@@ -487,58 +470,58 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 			wantVariantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-reservation", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-reservation", "default").
 					Queue("lq-migration").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("reservation").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
-					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
-					Queue("lq-migration").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
+					Queue("lq-migration").
 					AllowedFlavors("on-demand").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					Active(false).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq-migration").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("spot").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					SimpleReserveQuota("cq-migration", "spot", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Obj(),
 			},
 		},
 		"with minTargetFlavor=reservation, variant admitted on on-demand, deactivate spot": {
-			parentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq-migration").
 				Request(corev1.ResourceCPU, "1").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Obj(),
 			variantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-reservation", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-reservation", "default").
 					Queue("lq-migration").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("reservation").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
-					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
-					Queue("lq-migration").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
+					Queue("lq-migration").
 					AllowedFlavors("on-demand").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					SimpleReserveQuota("cq-migration", "on-demand", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq-migration").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("spot").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					Obj(),
 			},
-			wantParentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq-migration").
 				Request(corev1.ResourceCPU, "1").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
@@ -555,7 +538,7 @@ func TestReconcile(t *testing.T) {
 					Type:    kueue.WorkloadAdmitted,
 					Status:  metav1.ConditionTrue,
 					Reason:  "Admitted",
-					Message: "The variant parent-variant-on-demand is admitted",
+					Message: "The variant wl-variant-on-demand is admitted",
 				}).
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
@@ -565,58 +548,58 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 			wantVariantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-reservation", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-reservation", "default").
 					Queue("lq-migration").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("reservation").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
-					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
-					Queue("lq-migration").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
+					Queue("lq-migration").
 					AllowedFlavors("on-demand").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					SimpleReserveQuota("cq-migration", "on-demand", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq-migration").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("spot").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					Active(false).
 					Obj(),
 			},
 		},
 		"with minTargetFlavor=reservation, variant admitted on reservation, deactivate spot and on-demand": {
-			parentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq-migration").
 				Request(corev1.ResourceCPU, "1").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Obj(),
 			variantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-reservation", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-reservation", "default").
 					Queue("lq-migration").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("reservation").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					SimpleReserveQuota("cq-migration", "reservation", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq-migration").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("on-demand").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
-					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
-					Queue("lq-migration").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq-migration").
 					AllowedFlavors("spot").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					Obj(),
 			},
-			wantParentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq-migration").
 				Request(corev1.ResourceCPU, "1").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
@@ -633,7 +616,7 @@ func TestReconcile(t *testing.T) {
 					Type:    kueue.WorkloadAdmitted,
 					Status:  metav1.ConditionTrue,
 					Reason:  "Admitted",
-					Message: "The variant parent-variant-reservation is admitted",
+					Message: "The variant wl-variant-reservation is admitted",
 				}).
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
@@ -643,59 +626,59 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 			wantVariantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-reservation", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-reservation", "default").
 					Queue("lq-migration").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("reservation").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					SimpleReserveQuota("cq-migration", "reservation", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq-migration").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("on-demand").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					Active(false).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq-migration").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("spot").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					Active(false).
 					Obj(),
 			},
 		},
 		"without minTargetFlavor, variant admitted on spot, nothing deactivated": {
-			parentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq-migration-no-constraint").
 				Request(corev1.ResourceCPU, "1").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Obj(),
 			variantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-reservation", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-reservation", "default").
 					Queue("lq-migration-no-constraint").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("reservation").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
-					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
-					Queue("lq-migration-no-constraint").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
+					Queue("lq-migration-no-constraint").
 					AllowedFlavors("on-demand").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
-					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
-					Queue("lq-migration-no-constraint").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq-migration-no-constraint").
 					AllowedFlavors("spot").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					SimpleReserveQuota("cq-migration-no-constraint", "spot", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Obj(),
 			},
-			wantParentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq-migration-no-constraint").
 				Request(corev1.ResourceCPU, "1").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
@@ -712,7 +695,7 @@ func TestReconcile(t *testing.T) {
 					Type:    kueue.WorkloadAdmitted,
 					Status:  metav1.ConditionTrue,
 					Reason:  "Admitted",
-					Message: "The variant parent-variant-spot is admitted",
+					Message: "The variant wl-variant-spot is admitted",
 				}).
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
@@ -722,57 +705,57 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 			wantVariantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-reservation", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-reservation", "default").
 					Queue("lq-migration-no-constraint").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("reservation").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
-					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
-					Queue("lq-migration-no-constraint").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
+					Queue("lq-migration-no-constraint").
 					AllowedFlavors("on-demand").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
-					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
-					Queue("lq-migration-no-constraint").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq-migration-no-constraint").
 					AllowedFlavors("spot").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					SimpleReserveQuota("cq-migration-no-constraint", "spot", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Obj(),
 			},
 		},
 		"without minTargetFlavor, variant admitted on on-demand, deactivate spot": {
-			parentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq-migration-no-constraint").
 				Request(corev1.ResourceCPU, "1").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Obj(),
 			variantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-reservation", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-reservation", "default").
 					Queue("lq-migration-no-constraint").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("reservation").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
-					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
-					Queue("lq-migration-no-constraint").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
+					Queue("lq-migration-no-constraint").
 					AllowedFlavors("on-demand").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					SimpleReserveQuota("cq-migration-no-constraint", "on-demand", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq-migration-no-constraint").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("spot").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					Obj(),
 			},
-			wantParentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq-migration-no-constraint").
 				Request(corev1.ResourceCPU, "1").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
@@ -789,7 +772,7 @@ func TestReconcile(t *testing.T) {
 					Type:    kueue.WorkloadAdmitted,
 					Status:  metav1.ConditionTrue,
 					Reason:  "Admitted",
-					Message: "The variant parent-variant-on-demand is admitted",
+					Message: "The variant wl-variant-on-demand is admitted",
 				}).
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
@@ -799,58 +782,58 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 			wantVariantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-reservation", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-reservation", "default").
 					Queue("lq-migration-no-constraint").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("reservation").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
-					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
-					Queue("lq-migration-no-constraint").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
+					Queue("lq-migration-no-constraint").
 					AllowedFlavors("on-demand").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					SimpleReserveQuota("cq-migration-no-constraint", "on-demand", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq-migration-no-constraint").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("spot").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					Active(false).
 					Obj(),
 			},
 		},
 		"without minTargetFlavor, variant admitted on reservation, deactivate spot and on-demand": {
-			parentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq-migration-no-constraint").
 				Request(corev1.ResourceCPU, "1").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Obj(),
 			variantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-reservation", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-reservation", "default").
 					Queue("lq-migration-no-constraint").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("reservation").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					SimpleReserveQuota("cq-migration-no-constraint", "reservation", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq-migration-no-constraint").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("on-demand").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
-					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
-					Queue("lq-migration-no-constraint").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq-migration-no-constraint").
 					AllowedFlavors("spot").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					Obj(),
 			},
-			wantParentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq-migration-no-constraint").
 				Request(corev1.ResourceCPU, "1").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
@@ -867,7 +850,7 @@ func TestReconcile(t *testing.T) {
 					Type:    kueue.WorkloadAdmitted,
 					Status:  metav1.ConditionTrue,
 					Reason:  "Admitted",
-					Message: "The variant parent-variant-reservation is admitted",
+					Message: "The variant wl-variant-reservation is admitted",
 				}).
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
@@ -877,32 +860,32 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 			wantVariantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-reservation", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-reservation", "default").
 					Queue("lq-migration-no-constraint").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("reservation").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					SimpleReserveQuota("cq-migration-no-constraint", "reservation", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq-migration-no-constraint").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("on-demand").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					Active(false).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq-migration-no-constraint").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("spot").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					Active(false).
 					Obj(),
 			},
 		},
 		"parent marked finished, mark all variants finished": {
-			parentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Request(corev1.ResourceCPU, "1").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
@@ -914,20 +897,20 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 			variantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("on-demand").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
-					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
-					Queue("lq").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq").
 					AllowedFlavors("spot").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					Obj(),
 			},
-			wantParentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Request(corev1.ResourceCPU, "1").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
@@ -939,11 +922,11 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 			wantVariantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("on-demand").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadFinished,
 						Status:  metav1.ConditionTrue,
@@ -951,11 +934,11 @@ func TestReconcile(t *testing.T) {
 						Message: "Job finished successfully",
 					}).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq").
-					Request(corev1.ResourceCPU, "1").
 					AllowedFlavors("spot").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadFinished,
 						Status:  metav1.ConditionTrue,
@@ -966,53 +949,51 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"parent is not active, propagating deactivation to all variants": {
-			parentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Request(corev1.ResourceCPU, "1").
 				Active(false).
 				Obj(),
 			variantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq").
 					AllowedFlavors("spot").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq").
 					AllowedFlavors("on-demand").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					Obj(),
 			},
-			wantParentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Request(corev1.ResourceCPU, "1").
 				Active(false).
 				Obj(),
 			wantVariantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq").
 					AllowedFlavors("spot").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					Active(false).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq").
 					AllowedFlavors("on-demand").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					Active(false).
 					Obj(),
 			},
-			wantResult: reconcile.Result{},
-			wantErr:    false,
 		},
 		"parent changes WaitForPodsReady from False to True, syncs to admitted variant": {
-			parentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Request(corev1.ResourceCPU, "1").
@@ -1026,11 +1007,11 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 			variantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq").
 					AllowedFlavors("spot").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					SimpleReserveQuota("cq", "spot", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Condition(metav1.Condition{
@@ -1040,14 +1021,14 @@ func TestReconcile(t *testing.T) {
 						Message: "Pods are not ready",
 					}).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq").
 					AllowedFlavors("on-demand").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					Obj(),
 			},
-			wantParentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Request(corev1.ResourceCPU, "1").
@@ -1061,11 +1042,11 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 			wantVariantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq").
 					AllowedFlavors("spot").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					SimpleReserveQuota("cq", "spot", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Condition(metav1.Condition{
@@ -1075,18 +1056,16 @@ func TestReconcile(t *testing.T) {
 						Message: "Pods are ready",
 					}).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq").
 					AllowedFlavors("on-demand").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					Obj(),
 			},
-			wantResult: reconcile.Result{},
-			wantErr:    false,
 		},
 		"parent changes WaitForPodsReady from True to False, syncs to admitted variant": {
-			parentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Request(corev1.ResourceCPU, "1").
@@ -1100,11 +1079,11 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 			variantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq").
 					AllowedFlavors("spot").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					SimpleReserveQuota("cq", "spot", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Condition(metav1.Condition{
@@ -1114,14 +1093,14 @@ func TestReconcile(t *testing.T) {
 						Message: "Pods are ready",
 					}).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq").
 					AllowedFlavors("on-demand").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					Obj(),
 			},
-			wantParentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Request(corev1.ResourceCPU, "1").
@@ -1135,11 +1114,11 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 			wantVariantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq").
 					AllowedFlavors("spot").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					SimpleReserveQuota("cq", "spot", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Condition(metav1.Condition{
@@ -1149,18 +1128,16 @@ func TestReconcile(t *testing.T) {
 						Message: "Pods are not ready",
 					}).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq").
 					AllowedFlavors("on-demand").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					Obj(),
 			},
-			wantResult: reconcile.Result{},
-			wantErr:    false,
 		},
 		"parent not admitted, variant admitted, parent changes WaitForPodsReady from True to False, syncs to variant and admits parent": {
-			parentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Request(corev1.ResourceCPU, "1").
@@ -1172,11 +1149,11 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 			variantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq").
 					AllowedFlavors("spot").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					SimpleReserveQuota("cq", "spot", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Condition(metav1.Condition{
@@ -1186,14 +1163,14 @@ func TestReconcile(t *testing.T) {
 						Message: "Pods are ready",
 					}).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq").
 					AllowedFlavors("on-demand").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					Obj(),
 			},
-			wantParentWorkload: utiltestingapi.MakeWorkload("parent-12345", "default").
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
 				Request(corev1.ResourceCPU, "1").
@@ -1210,7 +1187,7 @@ func TestReconcile(t *testing.T) {
 					Type:    kueue.WorkloadAdmitted,
 					Status:  metav1.ConditionTrue,
 					Reason:  "Admitted",
-					Message: "The variant parent-variant-spot is admitted",
+					Message: "The variant wl-variant-spot is admitted",
 				}).
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
@@ -1226,11 +1203,11 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 			wantVariantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("parent-variant-spot", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq").
 					AllowedFlavors("spot").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					SimpleReserveQuota("cq", "spot", metav1.Now().Time).
 					AdmittedAt(true, metav1.Now().Time).
 					Condition(metav1.Condition{
@@ -1240,15 +1217,13 @@ func TestReconcile(t *testing.T) {
 						Message: "Pods are not ready",
 					}).
 					Obj(),
-				*utiltestingapi.MakeWorkload("parent-variant-on-demand", "default").
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq").
 					AllowedFlavors("on-demand").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
-					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent-12345", "").
 					Obj(),
 			},
-			wantResult: reconcile.Result{},
-			wantErr:    false,
 		},
 	}
 
@@ -1292,7 +1267,11 @@ func TestReconcile(t *testing.T) {
 			}
 
 			for i := range tc.variantWorkloads {
-				_ = qManager.AddOrUpdateWorkload(ctrl.Log, tc.variantWorkloads[i].DeepCopy())
+				if workload.IsAdmissible(&tc.variantWorkloads[i]) {
+					if err := qManager.AddOrUpdateWorkload(ctrl.Log, tc.variantWorkloads[i].DeepCopy()); err != nil {
+						t.Fatalf("Failed to add workload to qManager: %v", err)
+					}
+				}
 			}
 
 			r := &variantReconciler{
@@ -1315,12 +1294,11 @@ func TestReconcile(t *testing.T) {
 			}
 
 			got, err := r.Reconcile(t.Context(), req)
-			if (err != nil) != tc.wantErr {
-				t.Errorf("Reconcile() error = %v, wantErr %v", err, tc.wantErr)
-				return
+			if err != nil {
+				t.Fatalf("Reconcile() unexpected error: %v", err)
 			}
-			if !cmp.Equal(got, tc.wantResult) {
-				t.Errorf("Reconcile() got = %v, want %v", got, tc.wantResult)
+			if !cmp.Equal(got, reconcile.Result{}) {
+				t.Errorf("Reconcile() got = %v, want empty result", got)
 			}
 
 			if tc.wantParentWorkload != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
- Removes redundant `wantResult`, `wantErr` fields
- Removes `parent-` prefix from parent Workload names to mimic production better
- Orders Workload builder methods consistently

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
