### PR TITLE
LWS: add unit tests for queue-name on pod templates

### DIFF
--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
@@ -132,6 +132,39 @@ func TestDefault(t *testing.T) {
 				WorkerTemplateSpecAnnotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
 				Obj(),
 		},
+		"queue-name on templates overridden by top-level queue": {
+			defaultLqExist: true,
+			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "default").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				LeaderTemplateSpecLabel(constants.QueueLabel, "user-queue").
+				WorkerTemplateSpecLabel(constants.QueueLabel, "user-queue").
+				Obj(),
+			want: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "default").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				LeaderTemplateSpecLabel(constants.QueueLabel, "test-queue").
+				LeaderTemplateSpecAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+				LeaderTemplateSpecAnnotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
+				WorkerTemplateSpecLabel(constants.QueueLabel, "test-queue").
+				WorkerTemplateSpecAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+				WorkerTemplateSpecAnnotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
+				WorkerTemplateSpecAnnotation(kueue.PodIndexOffsetAnnotation, "1").
+				Obj(),
+		},
+		"queue-name on worker template overridden when no leader template": {
+			defaultLqExist: true,
+			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "default").
+				Queue("test-queue").
+				WorkerTemplateSpecLabel(constants.QueueLabel, "user-queue").
+				Obj(),
+			want: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "default").
+				Queue("test-queue").
+				WorkerTemplateSpecLabel(constants.QueueLabel, "test-queue").
+				WorkerTemplateSpecAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+				WorkerTemplateSpecAnnotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
+				Obj(),
+		},
 		"LWS with PodSetGroupName set, no offset annotation": {
 			defaultLqExist: true,
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "default").

--- a/test/e2e/singlecluster/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/leaderworkerset_test.go
@@ -842,6 +842,79 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 			})
 		})
 
+		ginkgo.It("should admit and evict correctly when queue-name is set on pod templates", func() {
+			lws := leaderworkersettesting.MakeLeaderWorkerSet("lws", ns.Name).
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				Size(3).
+				Replicas(1).
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				TerminationGracePeriod(1).
+				Queue(lq.Name).
+				WorkerTemplateSpecLabel(ctrlconstants.QueueLabel, "user-queue").
+				Obj()
+
+			ginkgo.By("Create a LeaderWorkerSet with queue-name on worker template", func() {
+				util.MustCreate(ctx, k8sClient, lws)
+			})
+
+			wlLookupKey := util.WorkloadKeyForLeaderWorkerSet(lws, "0")
+
+			ginkgo.By("Checking that the workload is admitted", func() {
+				util.ExpectWorkloadsToBeAdmittedByKeys(ctx, k8sClient, wlLookupKey)
+			})
+
+			ginkgo.By("Waiting for replicas to be ready", func() {
+				createdLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
+					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
+					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(utiltesting.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			createdWorkload := &kueue.Workload{}
+			ginkgo.By("Deactivate the workload to simulate eviction", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+					createdWorkload.Spec.Active = new(false)
+					g.Expect(k8sClient.Update(ctx, createdWorkload)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking that pods are gated after eviction", func() {
+				pods := &corev1.PodList{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.List(ctx, pods, client.MatchingLabels{
+						leaderworkersetv1.SetNameLabelKey: lws.Name,
+					}, client.InNamespace(lws.Namespace))).Should(gomega.Succeed())
+					g.Expect(pods.Items).To(gomega.HaveLen(3))
+					for _, pod := range pods.Items {
+						g.Expect(pod.Spec.SchedulingGates).To(gomega.ContainElement(corev1.PodSchedulingGate{
+							Name: podconstants.SchedulingGateName,
+						}))
+					}
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Delete the LeaderWorkerSet", func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, lws, true)
+			})
+
+			ginkgo.By("Check pods are deleted", func() {
+				pods := &corev1.PodList{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.List(ctx, pods, client.MatchingLabels{
+						leaderworkersetv1.SetNameLabelKey: lws.Name,
+					}, client.InNamespace(lws.Namespace))).Should(gomega.Succeed())
+					g.Expect(pods.Items).To(gomega.BeEmpty())
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Check workload is deleted", func() {
+				util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, createdWorkload, false, util.MediumTimeout)
+			})
+		})
+
 		ginkgo.It("should allow to change queue-name if ReadyReplicas=0", func() {
 			lws := leaderworkersettesting.MakeLeaderWorkerSet("lws", ns.Name).
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/area integrations

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

Adds unit and e2e tests covering the scenario from issue 10965 where a user sets `kueue.x-k8s.io/queue-name` on both the top-level LWS metadata and the leader/worker pod template labels.

#### Behavior verified:

**Unit tests (webhook defaulter):**

Without the changes from PR 4932, both new tests fail — the user-set `user-queue` on pod templates is **not** overridden by the top-level queue-name. This means pods would be created with `queue-name: user-queue`, causing the pod integration to independently manage them and leaving pods stuck in `SchedulingGated`:

<details>
<summary>Full failure output (without PR 4932)</summary>

```
=== RUN   TestDefault
=== RUN   TestDefault/queue-name_on_worker_template_overridden_when_no_leader_template
    leaderworkerset_webhook_test.go:215: Default() mismatch (-want,+got):
          &v1.LeaderWorkerSet{
              ...
              WorkerTemplate: v1.PodTemplateSpec{
                  ObjectMeta: v1.ObjectMeta{
        -             Labels: map[string]string{"kueue.x-k8s.io/queue-name": "test-queue"},
        +             Labels: map[string]string{"kueue.x-k8s.io/queue-name": "user-queue"},
                      Annotations: {"kueue.x-k8s.io/pod-group-serving": "true", "kueue.x-k8s.io/pod-suspending-parent": "leaderworkerset.x-k8s.io/leaderworkerset"},
                  },
              },
          }
=== RUN   TestDefault/queue-name_on_templates_overridden_by_top-level_queue
    leaderworkerset_webhook_test.go:215: Default() mismatch (-want,+got):
          &v1.LeaderWorkerSet{
              ...
              LeaderTemplate: &v1.PodTemplateSpec{
                  ObjectMeta: v1.ObjectMeta{
        -             Labels: map[string]string{"kueue.x-k8s.io/queue-name": "test-queue"},
        +             Labels: map[string]string{"kueue.x-k8s.io/queue-name": "user-queue"},
                      Annotations: {"kueue.x-k8s.io/pod-group-serving": "true", "kueue.x-k8s.io/pod-suspending-parent": "leaderworkerset.x-k8s.io/leaderworkerset"},
                  },
              },
              WorkerTemplate: v1.PodTemplateSpec{
                  ObjectMeta: v1.ObjectMeta{
        -             Labels: map[string]string{"kueue.x-k8s.io/queue-name": "test-queue"},
        +             Labels: map[string]string{"kueue.x-k8s.io/queue-name": "user-queue"},
                      Annotations: {"kueue.x-k8s.io/pod-group-serving": "true", "kueue.x-k8s.io/pod-index-offset": "1", "kueue.x-k8s.io/pod-suspending-parent": "leaderworkerset.x-k8s.io/leaderworkerset"},
                  },
              },
          }
--- FAIL: TestDefault (0.04s)
    --- FAIL: TestDefault/queue-name_on_worker_template_overridden_when_no_leader_template (0.03s)
    --- FAIL: TestDefault/queue-name_on_templates_overridden_by_top-level_queue (0.00s)
FAIL
```

</details>

With PR 4932 (current main), both tests pass — the webhook defaulter correctly overrides `user-queue` with the top-level `test-queue`:

```
=== RUN   TestDefault
=== RUN   TestDefault/queue-name_on_templates_overridden_by_top-level_queue
--- PASS: TestDefault/queue-name_on_templates_overridden_by_top-level_queue (0.03s)
=== RUN   TestDefault/queue-name_on_worker_template_overridden_when_no_leader_template
--- PASS: TestDefault/queue-name_on_worker_template_overridden_when_no_leader_template (0.00s)
PASS
```

**E2e test (manual run on local kind cluster):**

Created an LWS with `kueue.x-k8s.io/queue-name: test-lq` on the top-level and `kueue.x-k8s.io/queue-name: user-queue` on the worker template:

**Step 1 — Admission works, pods NOT stuck in SchedulingGated:**

```
NAME                     READY   STATUS    RESTARTS   AGE
test-lws-queuename-0     1/1     Running   0          43s
test-lws-queuename-0-1   1/1     Running   0          43s

Pod scheduling gates (empty - no gates):
  test-lws-queuename-0: schedulingGates=
  test-lws-queuename-0-1: schedulingGates=

Pod labels (queue-name overridden to test-lq, not user-queue):
  test-lws-queuename-0: queue-name=test-lq
  test-lws-queuename-0-1: queue-name=test-lq

LWS status: 1 ready replicas
  Available=True (AllGroupsReady)

Workload:
  leaderworkerset-test-lws-queuename-0-3d65d   test-lq   test-cq   True
```

**Step 2 — Eviction works, pods properly gated:**

After deactivating the workload (`Spec.Active = false`):

```
NAME                     READY   STATUS            RESTARTS   AGE
test-lws-queuename-0     0/1     SchedulingGated   0          14s
test-lws-queuename-0-1   0/1     SchedulingGated   0          14s

Pod scheduling gates:
  test-lws-queuename-0: [{"name":"kueue.x-k8s.io/admission"},{"name":"kueue.x-k8s.io/topology"}]
  test-lws-queuename-0-1: [{"name":"kueue.x-k8s.io/admission"},{"name":"kueue.x-k8s.io/topology"}]

Workload conditions:
  Evicted=True (Deactivated)
  Admitted=False (NoReservation)
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #10965

#### Special notes for your reviewer:

PR 4932 already fixed the underlying behavior by moving queue-name injection into the webhook defaulter. These tests lock in that behavior and prevent regressions.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```