### PR TITLE
test: bump TAS RayJob e2e head CPU and CQ quota for Ray 2.53.0

### DIFF
--- a/test/e2e/tas/rayjob_test.go
+++ b/test/e2e/tas/rayjob_test.go
@@ -59,7 +59,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for RayJob", ginkgo.Ordered, fu
 		clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas(tasFlavor.Name).
-					Resource(corev1.ResourceCPU, "1").
+					Resource(corev1.ResourceCPU, "2").
 					Resource(corev1.ResourceMemory, "8Gi").
 					Resource(extraResource, "8").
 					Obj(),
@@ -103,10 +103,10 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for RayJob", ginkgo.Ordered, fu
 										Name: "head-container",
 										Resources: corev1.ResourceRequirements{
 											Requests: corev1.ResourceList{
-												corev1.ResourceCPU: resource.MustParse("200m"),
+												corev1.ResourceCPU: resource.MustParse("1"),
 											},
 											Limits: corev1.ResourceList{
-												corev1.ResourceCPU: resource.MustParse("200m"),
+												corev1.ResourceCPU: resource.MustParse("1"),
 											},
 										},
 									},


### PR DESCRIPTION
Ray 2.53.0 head pod needs more CPU to initialize reliably on Kind CI nodes. Bump head CPU from 200m to 1 and CQ quota from 1 to 2 to accommodate head (1) + submitter (200m).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Related to https://github.com/kubernetes-sigs/kueue/pull/10959#discussion_r3190947900

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
