### PR TITLE
Add event-driven DeviceClass tracking for extended resources

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -316,8 +316,10 @@ func main() {
 		queueOptions = append(queueOptions, qcache.WithResourceTransformations(cfg.Resources.Transformations))
 	}
 	var draMapper *dra.ResourceMapper
+	var draBackedResources *dra.ExtendedResourceCache
 	if features.Enabled(features.KueueDRAIntegration) {
 		draMapper = dra.NewResourceMapper()
+		draBackedResources = dra.NewExtendedResourceCache()
 		if cfg.Resources != nil && len(cfg.Resources.DeviceClassMappings) > 0 {
 			if err := draMapper.PopulateFromConfiguration(cfg.Resources.DeviceClassMappings); err != nil {
 				setupLog.Error(err, "Failed to initialize DRA mapper from configuration")
@@ -344,6 +346,9 @@ func main() {
 
 	preemptionExpectations := preemptexpectations.New()
 	queueOptions = append(queueOptions, qcache.WithPreemptionExpectations(preemptionExpectations))
+	if draBackedResources != nil {
+		queueOptions = append(queueOptions, qcache.WithDRABackedResources(draBackedResources))
+	}
 	queues := qcache.NewManager(mgr.GetClient(), cCache, requeuer, queueOptions...)
 
 	if err := setupIndexes(ctx, mgr, &cfg); err != nil {
@@ -383,6 +388,7 @@ func main() {
 		PreemptionExpectations: preemptionExpectations,
 		CustomLabels:           customLabels,
 		DRAMapper:              draMapper,
+		DRABackedResources:     draBackedResources,
 	}
 	if err := setupControllers(ctx, mgr, cCache, queues, &cfg, serverVersionFetcher, controllerOpts); err != nil {
 		setupLog.Error(err, "Unable to setup controllers")

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -125,6 +125,12 @@ func WithResourceMetrics(enabled bool) Option {
 	}
 }
 
+func WithDRABackedResources(cache *dra.ExtendedResourceCache) Option {
+	return func(m *Manager) {
+		m.draBackedResources = cache
+	}
+}
+
 // SetDRAReconcileChannel sets the DRA reconcile channel after manager creation.
 func (m *Manager) SetDRAReconcileChannel(ch chan<- event.TypedGenericEvent[*kueue.Workload]) {
 	m.draReconcileChannel = ch
@@ -165,6 +171,7 @@ type Manager struct {
 	workloadUpdateWatchers []WorkloadUpdateWatcher
 
 	draReconcileChannel chan<- event.TypedGenericEvent[*kueue.Workload]
+	draBackedResources  *dra.ExtendedResourceCache
 
 	roleTracker            *roletracker.RoleTracker
 	customLabels           *metrics.CustomLabels
@@ -485,7 +492,7 @@ func (m *Manager) addLocalQueueLocked(ctx context.Context, q *kueue.LocalQueue) 
 		}
 
 		log := ctrl.LoggerFrom(ctx).WithValues("workload", klog.KObj(&w))
-		if dra.NeedsDRAReconcile(&w) {
+		if dra.NeedsDRAReconcile(&w, m.draBackedResources) {
 			// Collect DRA workloads to send outside the lock; DeepCopy keeps a
 			// stable pointer since the range variable is reused each iteration.
 			draWorkloads = append(draWorkloads, w.DeepCopy())

--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -44,6 +44,7 @@ type SetupControllersOpts struct {
 	PreemptionExpectations *expectations.Store
 	CustomLabels           *metrics.CustomLabels
 	DRAMapper              *dra.ResourceMapper
+	DRABackedResources     *dra.ExtendedResourceCache
 }
 
 // SetupControllers sets up the core controllers. It returns the name of the
@@ -108,6 +109,7 @@ func SetupControllers(mgr ctrl.Manager, qManager *qcache.Manager, cc *schdcache.
 		WithWorkloadCustomLabels(opts.CustomLabels),
 		WithAdmissionFairSharing(cfg.AdmissionFairSharing),
 		WithDRAMapper(opts.DRAMapper),
+		WithDRABackedResources(opts.DRABackedResources),
 	)
 	if features.Enabled(features.KueueDRAIntegration) {
 		qManager.SetDRAReconcileChannel(workloadRec.GetDRAReconcileChannel())

--- a/pkg/controller/core/indexer/indexer.go
+++ b/pkg/controller/core/indexer/indexer.go
@@ -30,6 +30,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
+	utilresource "sigs.k8s.io/kueue/pkg/util/resource"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 )
 
@@ -44,6 +45,7 @@ const (
 	WorkloadAdmissionCheckKey            = "status.admissionChecks"
 	WorkloadPriorityClassKey             = "spec.priorityClassRef"
 	DeviceClassExtendedResourceNameIndex = "spec.extendedResourceName"
+	WorkloadExtendedResourceKey          = "spec.extendedResources"
 	// WorkloadSliceNameKey is an index for pods by their workload slice name annotation.
 	// Used to find pods belonging to an elastic workload slice chain.
 	WorkloadSliceNameKey = "metadata.workloadSliceName"
@@ -214,6 +216,32 @@ func IndexWorkloadPriorityClass(obj client.Object) []string {
 	return []string{wl.Spec.PriorityClassRef.Name}
 }
 
+// IndexWorkloadExtendedResources indexes Workloads by the extended resource names
+// in their container requests. Used by the DeviceClass handler to find workloads
+// affected by a specific DeviceClass change.
+func IndexWorkloadExtendedResources(obj client.Object) []string {
+	wl, ok := obj.(*kueue.Workload)
+	if !ok {
+		return nil
+	}
+	resNames := sets.New[string]()
+	for _, ps := range wl.Spec.PodSets {
+		for _, containers := range [][]corev1.Container{ps.Template.Spec.InitContainers, ps.Template.Spec.Containers} {
+			for _, c := range containers {
+				for name, qty := range c.Resources.Requests {
+					if !qty.IsZero() && utilresource.IsExtendedResourceName(name) {
+						resNames.Insert(string(name))
+					}
+				}
+			}
+		}
+	}
+	if resNames.Len() > 0 {
+		return resNames.UnsortedList()
+	}
+	return nil
+}
+
 // IndexDeviceClassExtendedResourceName indexes DeviceClasses by spec.extendedResourceName.
 func IndexDeviceClassExtendedResourceName(obj client.Object) []string {
 	dc, ok := obj.(*resourceapi.DeviceClass)
@@ -267,6 +295,9 @@ func Setup(ctx context.Context, indexer client.FieldIndexer) error {
 	if features.Enabled(features.KueueDRAIntegrationExtendedResource) {
 		if err := indexer.IndexField(ctx, &resourceapi.DeviceClass{}, DeviceClassExtendedResourceNameIndex, IndexDeviceClassExtendedResourceName); err != nil && !apimeta.IsNoMatchError(err) {
 			return fmt.Errorf("setting index on extendedResourceName for DeviceClass: %w", err)
+		}
+		if err := indexer.IndexField(ctx, &kueue.Workload{}, WorkloadExtendedResourceKey, IndexWorkloadExtendedResources); err != nil {
+			return fmt.Errorf("setting index on extended resources for Workload: %w", err)
 		}
 	}
 	return nil

--- a/pkg/controller/core/indexer/indexer_test.go
+++ b/pkg/controller/core/indexer/indexer_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -693,6 +694,112 @@ func TestSetupToleratesNoMatchErrorForDeviceClass(t *testing.T) {
 			err := Setup(t.Context(), tc.indexer)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("Setup() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestIndexWorkloadExtendedResources(t *testing.T) {
+	container := func(name string, requests corev1.ResourceList) corev1.Container {
+		return corev1.Container{
+			Name:      name,
+			Resources: corev1.ResourceRequirements{Requests: requests},
+		}
+	}
+
+	cases := map[string]struct {
+		obj  client.Object
+		want []string
+	}{
+		"non-Workload returns nil": {
+			obj:  makeLocalQueue("lq", "ns", "cq"),
+			want: nil,
+		},
+		"workload with only cpu and memory": {
+			obj: func() client.Object {
+				wl := makeWorkload("wl", "ns")
+				wl.Spec.PodSets = []kueue.PodSet{{
+					Name:  "main",
+					Count: 1,
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{container("c", corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							})},
+						},
+					},
+				}}
+				return wl
+			}(),
+			want: nil,
+		},
+		"workload with single extended resource": {
+			obj: func() client.Object {
+				wl := makeWorkload("wl", "ns")
+				wl.Spec.PodSets = []kueue.PodSet{{
+					Name:  "main",
+					Count: 1,
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{container("c", corev1.ResourceList{
+								"nvidia.com/gpu": resource.MustParse("1"),
+							})},
+						},
+					},
+				}}
+				return wl
+			}(),
+			want: []string{"nvidia.com/gpu"},
+		},
+		"workload with multiple extended resources": {
+			obj: func() client.Object {
+				wl := makeWorkload("wl", "ns")
+				wl.Spec.PodSets = []kueue.PodSet{{
+					Name:  "main",
+					Count: 1,
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								container("c1", corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")}),
+								container("c2", corev1.ResourceList{"google.com/tpu": resource.MustParse("2")}),
+							},
+						},
+					},
+				}}
+				return wl
+			}(),
+			want: []string{"google.com/tpu", "nvidia.com/gpu"},
+		},
+		"duplicate extended resource across containers is deduplicated": {
+			obj: func() client.Object {
+				wl := makeWorkload("wl", "ns")
+				wl.Spec.PodSets = []kueue.PodSet{{
+					Name:  "main",
+					Count: 1,
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								container("c1", corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")}),
+								container("c2", corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("2")}),
+							},
+						},
+					},
+				}}
+				return wl
+			}(),
+			want: []string{"nvidia.com/gpu"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := IndexWorkloadExtendedResources(tc.obj)
+			if diff := cmp.Diff(tc.want, got,
+				cmpopts.SortSlices(func(a, b string) bool { return a < b }),
+				cmpopts.EquateEmpty(),
+			); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -27,6 +27,7 @@ import (
 	gocmp "github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -147,6 +148,12 @@ func WithDRAMapper(value *dra.ResourceMapper) Option {
 	}
 }
 
+func WithDRABackedResources(value *dra.ExtendedResourceCache) Option {
+	return func(r *WorkloadReconciler) {
+		r.draBackedResources = value
+	}
+}
+
 type WorkloadUpdateWatcher interface {
 	NotifyWorkloadUpdate(oldWl, newWl *kueue.Workload)
 }
@@ -164,6 +171,7 @@ type WorkloadReconciler struct {
 	workloadRetention      *workloadRetentionConfig
 	draReconcileChannel    chan event.TypedGenericEvent[*kueue.Workload]
 	draMapper              *dra.ResourceMapper
+	draBackedResources     *dra.ExtendedResourceCache
 	admissionFSConfig      *config.AdmissionFairSharing
 	roleTracker            *roletracker.RoleTracker
 	preemptionExpectations *expectations.Store
@@ -302,7 +310,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 		return ctrl.Result{}, nil
 	}
-	if workload.Status(&wl) == workload.StatusPending && dra.NeedsDRAReconcile(&wl) {
+	if workload.Status(&wl) == workload.StatusPending && dra.NeedsDRAReconcile(&wl, r.draBackedResources) {
 		workload.AdjustResources(ctx, r.client, &wl)
 		if workload.HasResourceClaim(&wl) {
 			log.V(3).Info("Workload is inadmissible because it uses resource claims which is not supported")
@@ -1135,7 +1143,7 @@ func (r *WorkloadReconciler) Create(e event.TypedCreateEvent[*kueue.Workload]) b
 	wlCopy := e.Object.DeepCopy()
 	workload.AdjustResources(ctx, r.client, wlCopy)
 
-	if dra.NeedsDRAReconcile(e.Object) {
+	if dra.NeedsDRAReconcile(e.Object, r.draBackedResources) {
 		log.V(2).Info("Skipping DRA workload in Create event - will be handled in Reconcile")
 		return true
 	}
@@ -1236,7 +1244,7 @@ func (r *WorkloadReconciler) Update(e event.TypedUpdateEvent[*kueue.Workload]) b
 		})
 	case prevStatus == workload.StatusPending && status == workload.StatusPending:
 		switch {
-		case dra.NeedsDRAReconcile(e.ObjectNew):
+		case dra.NeedsDRAReconcile(e.ObjectNew, r.draBackedResources):
 			log.V(2).Info("Skipping queue update for DRA workload - handled in Reconcile")
 		default:
 			if err := r.queues.AddOrUpdateWorkload(log, wlCopy); err != nil {
@@ -1276,7 +1284,7 @@ func (r *WorkloadReconciler) Update(e event.TypedUpdateEvent[*kueue.Workload]) b
 			// reconciler, we would execute it on every run, which might mess up the state.
 			if immediate {
 				switch {
-				case dra.NeedsDRAReconcile(e.ObjectNew):
+				case dra.NeedsDRAReconcile(e.ObjectNew, r.draBackedResources):
 					log.V(2).Info("Skipping immediate requeue for DRA workload - handled in Reconcile")
 				default:
 					if err := r.queues.AddOrUpdateWorkloadWithoutLock(log, wlCopy); err != nil {
@@ -1361,7 +1369,8 @@ func (r *WorkloadReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.Conf
 	ruh := &resourceUpdatesHandler{r: r}
 	wqh := &workloadQueueHandler{r: r}
 	deh := &draEventHandler{}
-	return builder.TypedControllerManagedBy[reconcile.Request](mgr).
+	dch := &deviceClassHandler{r: r}
+	bld := builder.TypedControllerManagedBy[reconcile.Request](mgr).
 		Named("workload_controller").
 		WatchesRawSource(source.TypedKind(
 			mgr.GetCache(),
@@ -1378,8 +1387,17 @@ func (r *WorkloadReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.Conf
 		Watches(&corev1.LimitRange{}, ruh).
 		Watches(&nodev1.RuntimeClass{}, ruh).
 		Watches(&kueue.ClusterQueue{}, wqh).
-		Watches(&kueue.LocalQueue{}, wqh).
-		Complete(WithLeadingManager(mgr, r, &kueue.Workload{}, cfg))
+		Watches(&kueue.LocalQueue{}, wqh)
+	if features.Enabled(features.KueueDRAIntegrationExtendedResource) {
+		if _, err := mgr.GetRESTMapper().RESTMapping(resourcev1.SchemeGroupVersion.WithKind("DeviceClass").GroupKind()); err != nil && apimeta.IsNoMatchError(err) {
+			r.logger().V(2).Info("DeviceClass API not available, skipping DeviceClass watcher")
+		} else if err != nil {
+			return err
+		} else {
+			bld = bld.Watches(&resourcev1.DeviceClass{}, dch)
+		}
+	}
+	return bld.Complete(WithLeadingManager(mgr, r, &kueue.Workload{}, cfg))
 }
 
 // admittedNotReadyWorkload returns the underlying cause and remaining time for
@@ -1472,7 +1490,7 @@ func (h *resourceUpdatesHandler) queueReconcileForPending(ctx context.Context, q
 		log.V(5).Info("Queue reconcile for")
 		workload.AdjustResources(ctrl.LoggerInto(ctx, log), h.r.client, wlCopy)
 
-		if dra.NeedsDRAReconcile(wlCopy) {
+		if dra.NeedsDRAReconcile(wlCopy, h.r.draBackedResources) {
 			req := reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      wlCopy.Name,
@@ -1624,4 +1642,76 @@ func (h *draEventHandler) Generic(ctx context.Context, e event.TypedGenericEvent
 // GetDRAReconcileChannel returns the DRA reconcile channel for connecting to the queue manager.
 func (r *WorkloadReconciler) GetDRAReconcileChannel() chan<- event.TypedGenericEvent[*kueue.Workload] {
 	return r.draReconcileChannel
+}
+
+type deviceClassHandler struct {
+	r *WorkloadReconciler
+}
+
+func (h *deviceClassHandler) Create(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	dc := e.Object.(*resourcev1.DeviceClass)
+	if ern := extendedResourceName(dc); ern != "" {
+		h.r.draBackedResources.Add(corev1.ResourceName(ern), dc.Name)
+		h.reconcileWorkloads(ctx, q, ern)
+	}
+}
+
+func (h *deviceClassHandler) Update(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	oldDC := e.ObjectOld.(*resourcev1.DeviceClass)
+	newDC := e.ObjectNew.(*resourcev1.DeviceClass)
+	if oldERN := extendedResourceName(oldDC); oldERN != "" {
+		h.r.draBackedResources.Remove(corev1.ResourceName(oldERN), oldDC.Name)
+	}
+	if newERN := extendedResourceName(newDC); newERN != "" {
+		h.r.draBackedResources.Add(corev1.ResourceName(newERN), newDC.Name)
+	}
+	h.reconcileWorkloads(ctx, q, extendedResourceName(oldDC), extendedResourceName(newDC))
+}
+
+func (h *deviceClassHandler) Delete(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	dc := e.Object.(*resourcev1.DeviceClass)
+	if ern := extendedResourceName(dc); ern != "" {
+		h.r.draBackedResources.Remove(corev1.ResourceName(ern), dc.Name)
+		h.reconcileWorkloads(ctx, q, ern)
+	}
+}
+
+func (h *deviceClassHandler) Generic(_ context.Context, _ event.GenericEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func extendedResourceName(dc *resourcev1.DeviceClass) string {
+	if dc.Spec.ExtendedResourceName != nil {
+		return *dc.Spec.ExtendedResourceName
+	}
+	return ""
+}
+
+func (h *deviceClassHandler) reconcileWorkloads(ctx context.Context, q workqueue.TypedRateLimitingInterface[reconcile.Request], resourceNames ...string) {
+	log := h.r.logger()
+
+	// Requeue only workloads that request the affected extended resources.
+	for _, name := range resourceNames {
+		if name == "" {
+			continue
+		}
+		lst := kueue.WorkloadList{}
+		err := h.r.client.List(ctx, &lst,
+			client.MatchingFields{
+				indexer.WorkloadExtendedResourceKey: name,
+				indexer.WorkloadQuotaReservedKey:    string(metav1.ConditionFalse),
+			},
+		)
+		if err != nil {
+			log.Error(err, "Could not list workloads for extended resource", "resource", name)
+			continue
+		}
+		for _, w := range lst.Items {
+			q.AddAfter(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      w.Name,
+					Namespace: w.Namespace,
+				},
+			}, time.Second)
+		}
+	}
 }

--- a/pkg/dra/extended_resource_cache.go
+++ b/pkg/dra/extended_resource_cache.go
@@ -1,0 +1,70 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dra
+
+import (
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// ExtendedResourceCache tracks which extended resource names are backed by DRA
+// DeviceClasses. Maps each resource name to the set of DeviceClass names that
+// declare it, so that deleting one DeviceClass doesn't remove the resource if
+// another DeviceClass still backs it.
+type ExtendedResourceCache struct {
+	lock      sync.RWMutex
+	resources map[corev1.ResourceName]sets.Set[string]
+}
+
+// NewExtendedResourceCache creates a new ExtendedResourceCache.
+func NewExtendedResourceCache() *ExtendedResourceCache {
+	return &ExtendedResourceCache{
+		resources: make(map[corev1.ResourceName]sets.Set[string]),
+	}
+}
+
+// Has returns true if the resource name is backed by at least one DRA DeviceClass.
+func (c *ExtendedResourceCache) Has(name corev1.ResourceName) bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return len(c.resources[name]) > 0
+}
+
+// Add registers that a DeviceClass backs the given extended resource name.
+func (c *ExtendedResourceCache) Add(resourceName corev1.ResourceName, deviceClassName string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.resources[resourceName] == nil {
+		c.resources[resourceName] = sets.New[string]()
+	}
+	c.resources[resourceName].Insert(deviceClassName)
+}
+
+// Remove unregisters a DeviceClass from the given extended resource name.
+// The resource name is removed from the cache only when no DeviceClasses back it.
+func (c *ExtendedResourceCache) Remove(resourceName corev1.ResourceName, deviceClassName string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if s, ok := c.resources[resourceName]; ok {
+		s.Delete(deviceClassName)
+		if s.Len() == 0 {
+			delete(c.resources, resourceName)
+		}
+	}
+}

--- a/pkg/dra/extended_resource_cache_test.go
+++ b/pkg/dra/extended_resource_cache_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dra
+
+import (
+	"testing"
+)
+
+func TestExtendedResourceCache(t *testing.T) {
+	cache := NewExtendedResourceCache()
+
+	t.Run("empty cache", func(t *testing.T) {
+		if cache.Has("nvidia.com/gpu") {
+			t.Error("expected false when cache is empty")
+		}
+	})
+
+	t.Run("add single DeviceClass", func(t *testing.T) {
+		cache.Add("nvidia.com/gpu", "gpu.nvidia.com")
+		if !cache.Has("nvidia.com/gpu") {
+			t.Error("expected true for nvidia.com/gpu")
+		}
+		if cache.Has("google.com/tpu") {
+			t.Error("expected false for google.com/tpu")
+		}
+	})
+
+	t.Run("add multiple DeviceClasses", func(t *testing.T) {
+		cache.Add("google.com/tpu", "tpu.google.com")
+		if !cache.Has("nvidia.com/gpu") {
+			t.Error("expected true for nvidia.com/gpu")
+		}
+		if !cache.Has("google.com/tpu") {
+			t.Error("expected true for google.com/tpu")
+		}
+	})
+
+	t.Run("remove DeviceClass", func(t *testing.T) {
+		cache.Remove("nvidia.com/gpu", "gpu.nvidia.com")
+		if cache.Has("nvidia.com/gpu") {
+			t.Error("expected false after removing gpu DeviceClass")
+		}
+		if !cache.Has("google.com/tpu") {
+			t.Error("expected true for tpu that still exists")
+		}
+	})
+
+	t.Run("multiple DeviceClasses backing same resource", func(t *testing.T) {
+		cache.Add("nvidia.com/gpu", "gpu-a.nvidia.com")
+		cache.Add("nvidia.com/gpu", "gpu-b.nvidia.com")
+		if !cache.Has("nvidia.com/gpu") {
+			t.Error("expected true with two DeviceClasses backing gpu")
+		}
+		cache.Remove("nvidia.com/gpu", "gpu-a.nvidia.com")
+		if !cache.Has("nvidia.com/gpu") {
+			t.Error("expected true with one DeviceClass still backing gpu")
+		}
+		cache.Remove("nvidia.com/gpu", "gpu-b.nvidia.com")
+		if cache.Has("nvidia.com/gpu") {
+			t.Error("expected false after all DeviceClasses removed")
+		}
+	})
+
+	t.Run("remove non-existent DeviceClass is no-op", func(t *testing.T) {
+		cache.Remove("nonexistent.com/resource", "nonexistent.example.com")
+		if cache.Has("nonexistent.com/resource") {
+			t.Error("expected false for non-existent resource")
+		}
+	})
+}

--- a/pkg/dra/extended_resources.go
+++ b/pkg/dra/extended_resources.go
@@ -35,13 +35,9 @@ import (
 )
 
 // NeedsDRAReconcile returns true if the workload needs DRA processing in Reconcile.
-// Fast in-memory check with no API calls. Uses a broad format-based filter
-// (IsExtendedResourceName) which may over-trigger for non-DRA extended resources,
-// but this only costs one extra Reconcile that finds no DeviceClass and queues normally.
-//
-// Note: there is no DeviceClass watcher. If a DeviceClass is created after a workload
-// was marked inadmissible, requeuing depends on the next QueueInadmissibleWorkloads event.
-func NeedsDRAReconcile(wl *kueue.Workload) bool {
+// For extended resources, checks the provided cache to confirm the resource
+// is backed by a DeviceClass before triggering DRA reconciliation.
+func NeedsDRAReconcile(wl *kueue.Workload, erCache *ExtendedResourceCache) bool {
 	if !features.Enabled(features.KueueDRAIntegration) {
 		return features.Enabled(features.KueueDRARejectWorkloadsWhenDRADisabled) && workload.HasDRA(wl)
 	}
@@ -56,7 +52,7 @@ func NeedsDRAReconcile(wl *kueue.Workload) bool {
 		for _, containers := range [][]corev1.Container{ps.Template.Spec.InitContainers, ps.Template.Spec.Containers} {
 			for _, c := range containers {
 				for name, qty := range c.Resources.Requests {
-					if !qty.IsZero() && utilresource.IsExtendedResourceName(name) {
+					if !qty.IsZero() && utilresource.IsExtendedResourceName(name) && erCache.Has(name) {
 						return true
 					}
 				}

--- a/pkg/dra/extended_resources_test.go
+++ b/pkg/dra/extended_resources_test.go
@@ -33,6 +33,7 @@ import (
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 	utilresource "sigs.k8s.io/kueue/pkg/util/resource"
 )
 
@@ -510,6 +511,197 @@ func TestResolveExtendedResourceQuota(t *testing.T) {
 				if diff := cmp.Diff(tt.wantReplaced, gotReplaced, opts...); diff != "" {
 					t.Errorf("ResolveExtendedResourceQuota() replacedExtendedResources mismatch (-want +got):\n%s", diff)
 				}
+			}
+		})
+	}
+}
+
+func TestNeedsDRAReconcile(t *testing.T) {
+	tests := []struct {
+		name            string
+		workload        *kueue.Workload
+		cachedResources map[corev1.ResourceName]string
+		draGate         bool
+		erGate          bool
+		want            bool
+	}{
+		{
+			name: "workload with RCT always needs DRA reconcile",
+			workload: &kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "c"}},
+								ResourceClaims: []corev1.PodResourceClaim{{
+									Name:                      "gpu",
+									ResourceClaimTemplateName: new("gpu-template"),
+								}},
+							},
+						},
+					}},
+				},
+			},
+			draGate: true,
+			erGate:  true,
+			want:    true,
+		},
+		{
+			name: "extended resource not in cache returns false",
+			workload: &kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name: "c",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											"example.com/gpu": resource.MustParse("1"),
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
+			draGate: true,
+			erGate:  true,
+			want:    false,
+		},
+		{
+			name: "extended resource in cache returns true",
+			workload: &kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name: "c",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											"example.com/gpu": resource.MustParse("1"),
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
+			cachedResources: map[corev1.ResourceName]string{
+				"example.com/gpu": "gpu.example.com",
+			},
+			draGate: true,
+			erGate:  true,
+			want:    true,
+		},
+		{
+			name: "DRA gate disabled returns false",
+			workload: &kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name: "c",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											"example.com/gpu": resource.MustParse("1"),
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
+			cachedResources: map[corev1.ResourceName]string{
+				"example.com/gpu": "gpu.example.com",
+			},
+			draGate: false,
+			erGate:  false,
+			want:    false,
+		},
+		{
+			name: "ER gate disabled returns false for extended resource",
+			workload: &kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name: "c",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											"example.com/gpu": resource.MustParse("1"),
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
+			cachedResources: map[corev1.ResourceName]string{
+				"example.com/gpu": "gpu.example.com",
+			},
+			draGate: true,
+			erGate:  false,
+			want:    false,
+		},
+		{
+			name: "cpu and memory only returns false",
+			workload: &kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name: "c",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("1"),
+											corev1.ResourceMemory: resource.MustParse("1Gi"),
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
+			draGate: true,
+			erGate:  true,
+			want:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.KueueDRAIntegration, tc.draGate)
+			features.SetFeatureGateDuringTest(t, features.KueueDRAIntegrationExtendedResource, tc.erGate)
+			cache := NewExtendedResourceCache()
+			for resName, dcName := range tc.cachedResources {
+				cache.Add(resName, dcName)
+			}
+
+			got := NeedsDRAReconcile(tc.workload, cache)
+			if got != tc.want {
+				t.Errorf("NeedsDRAReconcile() = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/test/e2e/config/dra/baseline/controller_manager_config.yaml
+++ b/test/e2e/config/dra/baseline/controller_manager_config.yaml
@@ -27,3 +27,6 @@ resources:
   - name: gpu
     deviceClassNames:
     - gpu.example.com
+  - name: gpu-late-dc
+    deviceClassNames:
+    - gpu-late-dc.example.com

--- a/test/e2e/dra/baseline/dra_test.go
+++ b/test/e2e/dra/baseline/dra_test.go
@@ -709,4 +709,102 @@ var _ = ginkgo.Describe("DRA", func() {
 			util.ExpectJobToBeCompleted(ctx, k8sClient, job)
 		})
 	})
+
+	ginkgo.When("Late DeviceClass creation with Extended Resources", func() {
+		var (
+			resourceFlavor *kueue.ResourceFlavor
+			clusterQueue   *kueue.ClusterQueue
+			localQueue     *kueue.LocalQueue
+		)
+
+		const (
+			extendedResourceName       = "example.com/gpu"
+			lateDeviceClassName        = "gpu-late-dc.example.com"
+			lateDeviceClassLogicalName = "gpu-late-dc"
+		)
+
+		ginkgo.BeforeEach(func() {
+			resourceFlavor = utiltestingapi.MakeResourceFlavor("late-dc-flavor-" + ns.Name).Obj()
+			util.MustCreate(ctx, k8sClient, resourceFlavor)
+
+			clusterQueue = utiltestingapi.MakeClusterQueue("late-dc-cq-" + ns.Name).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).
+						Resource(corev1.ResourceCPU, "4").
+						Resource(corev1.ResourceName(lateDeviceClassLogicalName), "4").
+						Obj()).
+				Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+
+			localQueue = utiltestingapi.MakeLocalQueue("late-dc-lq", ns.Name).
+				ClusterQueue(clusterQueue.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+		})
+
+		ginkgo.AfterEach(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, resourceFlavor, true)
+		})
+
+		ginkgo.It("Should admit job after DeviceClass is created", func() {
+			ginkgo.By("Creating Job with extended resource request before DeviceClass exists")
+			job := testingjob.MakeJob("late-dc-job", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceName(extendedResourceName), "1").
+				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+				Obj()
+			util.MustCreate(ctx, k8sClient, job)
+
+			wlLookupKey := types.NamespacedName{
+				Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+				Namespace: ns.Name,
+			}
+
+			ginkgo.By("Verifying job remains suspended (no DeviceClass, no translation)")
+			createdJob := &batchv1.Job{}
+			gomega.Consistently(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), createdJob)).To(gomega.Succeed())
+				g.Expect(createdJob.Spec.Suspend).To(gomega.Equal(new(true)))
+			}, util.ShortConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+
+			ginkgo.By("Creating DeviceClass with extendedResourceName")
+			deviceClass := &resourceapi.DeviceClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: lateDeviceClassName,
+				},
+				Spec: resourceapi.DeviceClassSpec{
+					Selectors: []resourceapi.DeviceSelector{
+						{
+							CEL: &resourceapi.CELDeviceSelector{
+								Expression: "device.driver == '" + draconsts.DriverName + "'",
+							},
+						},
+					},
+					ExtendedResourceName: ptr.To(extendedResourceName),
+				},
+			}
+			util.MustCreate(ctx, k8sClient, deviceClass)
+			defer func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, deviceClass, true)
+			}()
+
+			ginkgo.By("Verifying workload is admitted with logical name as quota key")
+			createdWorkload := &kueue.Workload{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(createdWorkload)).To(gomega.BeTrue())
+				g.Expect(createdWorkload.Status.Admission).NotTo(gomega.BeNil())
+
+				assignment := createdWorkload.Status.Admission.PodSetAssignments[0]
+				g.Expect(assignment.ResourceUsage).To(gomega.HaveKey(corev1.ResourceName(lateDeviceClassLogicalName)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Verifying job is unsuspended")
+			util.ExpectJobUnsuspended(ctx, k8sClient, client.ObjectKeyFromObject(job))
+
+			ginkgo.By("Verifying job completes successfully")
+			util.ExpectJobToBeCompleted(ctx, k8sClient, job)
+		})
+	})
 })

--- a/test/integration/singlecluster/controller/dra/dra_test.go
+++ b/test/integration/singlecluster/controller/dra/dra_test.go
@@ -1253,4 +1253,232 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
+
+	ginkgo.When("Event-driven DeviceClass tracking for Extended Resources", func() {
+		var (
+			ns             *corev1.Namespace
+			resourceFlavor *kueue.ResourceFlavor
+			clusterQueue   *kueue.ClusterQueue
+			localQueue     *kueue.LocalQueue
+		)
+
+		const (
+			extendedResourceName = "example.com/gpu"
+			logicalName          = "gpu-claims"
+			deviceClassName      = "gpu.example.com"
+		)
+
+		ginkgo.BeforeAll(func() {
+			fwk.StopManager(ctx)
+			fwk.StartManager(ctx, cfg, managerSetup(func(c *config.Configuration) {
+				c.Resources.DeviceClassMappings = append(c.Resources.DeviceClassMappings, config.DeviceClassMapping{
+					Name:             logicalName,
+					DeviceClassNames: []corev1.ResourceName{deviceClassName},
+				})
+			}))
+		})
+
+		ginkgo.AfterAll(func() {
+			fwk.StopManager(ctx)
+			fwk.StartManager(ctx, cfg, managerSetup(nil))
+		})
+
+		ginkgo.BeforeEach(func() {
+			ns = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "dra-dc-tracking-"},
+			}
+			gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+
+			resourceFlavor = utiltestingapi.MakeResourceFlavor("").Obj()
+			resourceFlavor.GenerateName = "rf-dc-tracking-"
+			gomega.Expect(k8sClient.Create(ctx, resourceFlavor)).To(gomega.Succeed())
+
+			clusterQueue = &kueue.ClusterQueue{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "dc-tracking-cq-"},
+				Spec: kueue.ClusterQueueSpec{
+					NamespaceSelector: &metav1.LabelSelector{},
+					ResourceGroups: []kueue.ResourceGroup{{
+						CoveredResources: []corev1.ResourceName{logicalName},
+						Flavors: []kueue.FlavorQuotas{{
+							Name: kueue.ResourceFlavorReference(resourceFlavor.Name),
+							Resources: []kueue.ResourceQuota{{
+								Name:         logicalName,
+								NominalQuota: resource.MustParse("8"),
+							}},
+						}},
+					}},
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).To(gomega.Succeed())
+			util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
+
+			localQueue = utiltestingapi.MakeLocalQueue("dc-tracking-lq", ns.Name).
+				ClusterQueue(clusterQueue.Name).Obj()
+			gomega.Expect(k8sClient.Create(ctx, localQueue)).To(gomega.Succeed())
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, resourceFlavor, true)
+		})
+
+		ginkgo.It("Should requeue inadmissible workload when DeviceClass is created", func() {
+			ginkgo.By("Creating workload before DeviceClass exists")
+			wl := utiltestingapi.MakeWorkload("dc-create-wl", ns.Name).
+				Queue("dc-tracking-lq").
+				Request(corev1.ResourceName(extendedResourceName), "2").
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+			ginkgo.By("Verifying workload is pending (no DeviceClass, no translation)")
+			util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
+
+			ginkgo.By("Creating DeviceClass with extendedResourceName")
+			deviceClass := &resourcev1.DeviceClass{
+				ObjectMeta: metav1.ObjectMeta{Name: deviceClassName},
+				Spec: resourcev1.DeviceClassSpec{
+					ExtendedResourceName: ptr.To(extendedResourceName),
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, deviceClass)).To(gomega.Succeed())
+			defer func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, deviceClass, true)
+			}()
+
+			ginkgo.By("Verifying workload is requeued and admitted with logical name as quota key")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeTrue())
+				g.Expect(updatedWl.Status.Admission).NotTo(gomega.BeNil())
+				g.Expect(updatedWl.Status.Admission.PodSetAssignments).To(gomega.HaveLen(1))
+
+				assignment := updatedWl.Status.Admission.PodSetAssignments[0]
+				g.Expect(assignment.ResourceUsage).To(gomega.HaveKey(corev1.ResourceName(logicalName)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("Should not admit new workload after DeviceClass is deleted", func() {
+			ginkgo.By("Creating DeviceClass")
+			deviceClass := &resourcev1.DeviceClass{
+				ObjectMeta: metav1.ObjectMeta{Name: deviceClassName},
+				Spec: resourcev1.DeviceClassSpec{
+					ExtendedResourceName: ptr.To(extendedResourceName),
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, deviceClass)).To(gomega.Succeed())
+
+			ginkgo.By("Creating first workload and verifying admission")
+			wl1 := utiltestingapi.MakeWorkload("dc-delete-wl1", ns.Name).
+				Queue("dc-tracking-lq").
+				Request(corev1.ResourceName(extendedResourceName), "2").
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl1)).To(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), &updatedWl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeTrue())
+				assignment := updatedWl.Status.Admission.PodSetAssignments[0]
+				g.Expect(assignment.ResourceUsage).To(gomega.HaveKey(corev1.ResourceName(logicalName)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Deleting DeviceClass")
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, deviceClass, true)
+
+			ginkgo.By("Creating second workload and verifying it is not admitted")
+			wl2 := utiltestingapi.MakeWorkload("dc-delete-wl2", ns.Name).
+				Queue("dc-tracking-lq").
+				Request(corev1.ResourceName(extendedResourceName), "2").
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl2)).To(gomega.Succeed())
+
+			util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
+		})
+
+		ginkgo.It("Should requeue inadmissible workload when DeviceClass extendedResourceName is updated", func() {
+			const newExtendedResourceName = "example.com/tpu"
+
+			ginkgo.By("Creating DeviceClass with extendedResourceName for gpu")
+			deviceClass := &resourcev1.DeviceClass{
+				ObjectMeta: metav1.ObjectMeta{Name: deviceClassName},
+				Spec: resourcev1.DeviceClassSpec{
+					ExtendedResourceName: ptr.To(extendedResourceName),
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, deviceClass)).To(gomega.Succeed())
+			defer func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, deviceClass, true)
+			}()
+
+			ginkgo.By("Creating workload requesting tpu (no matching DeviceClass yet)")
+			wl := utiltestingapi.MakeWorkload("dc-update-wl", ns.Name).
+				Queue("dc-tracking-lq").
+				Request(corev1.ResourceName(newExtendedResourceName), "2").
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+			ginkgo.By("Verifying workload is pending")
+			util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
+
+			ginkgo.By("Updating DeviceClass extendedResourceName to tpu")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var dc resourcev1.DeviceClass
+				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: deviceClassName}, &dc)).To(gomega.Succeed())
+				dc.Spec.ExtendedResourceName = ptr.To(newExtendedResourceName)
+				g.Expect(k8sClient.Update(ctx, &dc)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Verifying workload is requeued and admitted")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeTrue())
+				g.Expect(updatedWl.Status.Admission).NotTo(gomega.BeNil())
+				assignment := updatedWl.Status.Admission.PodSetAssignments[0]
+				g.Expect(assignment.ResourceUsage).To(gomega.HaveKey(corev1.ResourceName(logicalName)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("Should requeue inadmissible workload when DeviceClass extendedResourceName is added", func() {
+			ginkgo.By("Creating DeviceClass without extendedResourceName")
+			deviceClass := &resourcev1.DeviceClass{
+				ObjectMeta: metav1.ObjectMeta{Name: deviceClassName},
+				Spec:       resourcev1.DeviceClassSpec{},
+			}
+			gomega.Expect(k8sClient.Create(ctx, deviceClass)).To(gomega.Succeed())
+			defer func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, deviceClass, true)
+			}()
+
+			ginkgo.By("Creating workload requesting extended resource")
+			wl := utiltestingapi.MakeWorkload("dc-add-ern-wl", ns.Name).
+				Queue("dc-tracking-lq").
+				Request(corev1.ResourceName(extendedResourceName), "2").
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+			ginkgo.By("Verifying workload is pending")
+			util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
+
+			ginkgo.By("Updating DeviceClass to add extendedResourceName")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var dc resourcev1.DeviceClass
+				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: deviceClassName}, &dc)).To(gomega.Succeed())
+				dc.Spec.ExtendedResourceName = ptr.To(extendedResourceName)
+				g.Expect(k8sClient.Update(ctx, &dc)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Verifying workload is requeued and admitted")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeTrue())
+				g.Expect(updatedWl.Status.Admission).NotTo(gomega.BeNil())
+				assignment := updatedWl.Status.Admission.PodSetAssignments[0]
+				g.Expect(assignment.ResourceUsage).To(gomega.HaveKey(corev1.ResourceName(logicalName)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
 })

--- a/test/integration/singlecluster/controller/dra/suite_test.go
+++ b/test/integration/singlecluster/controller/dra/suite_test.go
@@ -54,6 +54,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.KueueDRAIntegration, true)
+	features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.KueueDRAIntegrationExtendedResource, true)
 
 	fwk = &framework.Framework{
 		WebhookPath: util.WebhookPath,
@@ -130,7 +131,7 @@ func managerSetup(modifyConfig func(*config.Configuration)) framework.ManagerSet
 			queues,
 			cCache,
 			controllersCfg,
-			core.SetupControllersOpts{PreemptionExpectations: preemptionExpectations, DRAMapper: draMapper},
+			core.SetupControllersOpts{PreemptionExpectations: preemptionExpectations, DRAMapper: draMapper, DRABackedResources: dra.NewExtendedResourceCache()},
 		)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 


### PR DESCRIPTION
Signed-off-by: Pannaga Rao Bhoja Ramamanohara

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

Adds event-driven DeviceClass tracking with a DRABackedResources cache and workload index by extended resource names, ensuring only DRA-backed workloads enter the DRA path and only affected workloads are requeued on DeviceClass changes

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes-sigs/kueue/pull/11552

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
DRA: Fix the performance of determining if a Workload should be handled using DRA Extended Resources, 
using an event-driven maintained cache of DRA Extended Resources.
```
