### PR TITLE
fix(kueueviz): use plural workloadpriorityclasses in ClusterRole RBAC

### DIFF
--- a/charts/kueue/templates/kueueviz/clusterrole.yaml
+++ b/charts/kueue/templates/kueueviz/clusterrole.yaml
@@ -30,7 +30,7 @@ rules:
     resources: ["pods", "events", "nodes"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["kueue.x-k8s.io"]
-    resources: ["workloadpriorityclass"]
+    resources: ["workloadpriorityclasses"]
     verbs: ["get", "list", "watch"]
 {{- if ne .Values.kueueViz.backend.auth.mode "Disabled" }}
   - apiGroups: ["authentication.k8s.io"]

--- a/config/components/kueueviz/clusterrole.yaml
+++ b/config/components/kueueviz/clusterrole.yaml
@@ -11,5 +11,5 @@ rules:
     resources: ["pods", "events", "nodes"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["kueue.x-k8s.io"]
-    resources: ["workloadpriorityclass"]
+    resources: ["workloadpriorityclasses"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## What

Fixes the KueueViz ClusterRole to use the plural form `workloadpriorityclasses` instead of the singular `workloadpriorityclass` in the RBAC resources field.

## Why

Kubernetes RBAC `resources` requires the **plural** form of the resource name. The singular form silently matches nothing, so the KueueViz backend has no access to `WorkloadPriorityClass` objects.

The main controller role in `templates/rbac/role.yaml` correctly uses the plural form — this was just missed in the KueueViz clusterrole.

## Changes

- `config/components/kueueviz/clusterrole.yaml`: `workloadpriorityclass` → `workloadpriorityclasses`
- `charts/kueue/templates/kueueviz/clusterrole.yaml`: same fix in the generated Helm template

```release-note
KueueViz: Fixed RBAC permissions for WorkloadPriorityClass objects by using the correct plural workloadpriorityclasses resource name.
```