### PR TITLE
charts: fix periodSeconds using initialDelaySeconds value in probes

### DIFF
--- a/charts/kueue/templates/manager/manager.yaml
+++ b/charts/kueue/templates/manager/manager.yaml
@@ -54,7 +54,7 @@ spec:
             path: /healthz
             port: 8081
           initialDelaySeconds: {{ .Values.controllerManager.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.controllerManager.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.controllerManager.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.controllerManager.livenessProbe.timeoutSeconds }}
           failureThreshold: {{ .Values.controllerManager.livenessProbe.failureThreshold }}
           successThreshold: {{ .Values.controllerManager.livenessProbe.successThreshold }}
@@ -74,7 +74,7 @@ spec:
             path: /readyz
             port: 8081
           initialDelaySeconds: {{ .Values.controllerManager.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.controllerManager.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.controllerManager.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.controllerManager.readinessProbe.timeoutSeconds }}
           failureThreshold: {{ .Values.controllerManager.readinessProbe.failureThreshold }}
           successThreshold: {{ .Values.controllerManager.readinessProbe.successThreshold }}


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:
Fixes a copy-paste error in `charts/kueue/templates/manager/manager.yaml` where both the livenessProbe and readinessProbe `periodSeconds` fields incorrectly referenced `.Values.controllerManager.{liveness,readiness}Probe.initialDelaySeconds` instead of `.periodSeconds`.

**Before (line 57):**
```yaml
periodSeconds: {{ .Values.controllerManager.livenessProbe.initialDelaySeconds }}
```

**After:**
```yaml
periodSeconds: {{ .Values.controllerManager.livenessProbe.periodSeconds }}
```

Same fix applied to the readinessProbe on line 77.

## Which issue(s) this PR fixes:
Related to issue 10932

## Does this PR introduce a user-facing change?
```release-note
Helm: Fixed manager probe templates so periodSeconds correctly uses the configured periodSeconds value,
rather than initialDelaySeconds.
```