### PR TITLE
helm: use fullname template for FlowSchema priorityLevelConfiguration reference

### DIFF
--- a/charts/kueue/templates/visibility-apf/flowschema.yaml
+++ b/charts/kueue/templates/visibility-apf/flowschema.yaml
@@ -29,7 +29,7 @@ spec:
     type: ByUser
   matchingPrecedence: 9000
   priorityLevelConfiguration:
-    name: kueue-visibility
+    name: '{{ include "kueue.fullname" . }}-visibility'
   rules:
     - resourceRules:
         - apiGroups:

--- a/config/components/visibility-apf/flowschema.yaml
+++ b/config/components/visibility-apf/flowschema.yaml
@@ -8,7 +8,7 @@ spec:
     type: ByUser
   matchingPrecedence: 9000
   priorityLevelConfiguration:
-    name: kueue-visibility
+    name: visibility
   rules:
     - resourceRules:
         - apiGroups:

--- a/hack/processing-plan.yaml
+++ b/hack/processing-plan.yaml
@@ -149,6 +149,9 @@ files:
         value: '"{{ .Release.Namespace }}"'
         onFileCondition: '.metadata.namespace != "kube-system"'
       - type: APPEND
+        key: .spec.priorityLevelConfiguration.name
+        value: '"{{ include \"kueue.fullname\" . }}-"'
+      - type: APPEND
         key: .spec.service.name
         value: '"{{ include \"kueue.fullname\" . }}-"'
       - type: UPDATE


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:
The FlowSchema's `spec.priorityLevelConfiguration.name` was hardcoded as `kueue-visibility` instead of using the Helm fullname template. When `fullnameOverride` or `nameOverride` is set in Helm values, the FlowSchema references a non-existent PriorityLevelConfiguration, breaking the visibility API's API Priority and Fairness configuration.

## Which issue(s) this PR fixes:
Fixes kubernetes-sigs/kueue#10934

## Changes:
1. **`config/components/visibility-apf/flowschema.yaml`**: Changed `priorityLevelConfiguration.name` from `kueue-visibility` to `visibility` (consistent with how `metadata.name` is handled — kustomize nameReference propagates the prefix automatically)
2. **`hack/processing-plan.yaml`**: Added an APPEND operation for `.spec.priorityLevelConfiguration.name` so the yaml-processor generates the correct Helm template
3. **`charts/kueue/templates/visibility-apf/flowschema.yaml`**: Updated the generated template to use `{{ include "kueue.fullname" . }}-visibility` instead of the hardcoded value

```release-note
Helm: Fixed the FlowSchema priorityLevelConfiguration reference to use the Helm fullname template, preventing APF configuration from breaking when fullnameOverride or nameOverride is set.
```