### PR TITLE
Add reconnect backoff guardrail to suppress redundant cluster reconciles

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	inventoryv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
 	"sigs.k8s.io/cluster-inventory-api/pkg/credentials"
@@ -99,8 +100,11 @@ type remoteClient struct {
 	origin       string
 	adapters     map[string]jobframework.MultiKueueAdapter
 
-	connecting         atomic.Bool
-	failedConnAttempts uint
+	connecting           atomic.Bool
+	failedConnAttempts   uint
+	retryConnNextAttempt metav1.Time
+
+	clock clock.Clock
 
 	// For unit testing only. There is now need of creating fully functional remote clients in the unit tests
 	// and creating valid kubeconfig content is not trivial.
@@ -116,6 +120,7 @@ func newRemoteClient(localClient client.Client, wlUpdateCh, watchEndedCh chan<- 
 		localClient:  localClient,
 		origin:       origin,
 		adapters:     adapters,
+		clock:        clock.RealClock{},
 	}
 	rc.connecting.Store(true)
 	return rc
@@ -148,19 +153,39 @@ func (*workloadKueueWatcher) WorkloadKeysFor(o runtime.Object) ([]types.Namespac
 	return []types.NamespacedName{client.ObjectKeyFromObject(wl)}, nil
 }
 
+func (rc *remoteClient) resetFailedConnAttempt() {
+	rc.failedConnAttempts = 0
+	rc.retryConnNextAttempt = metav1.Time{}
+}
+
+func (rc *remoteClient) increaseFailedConnAttempt() *time.Duration {
+	rc.failedConnAttempts++
+	d := retryAfter(rc.failedConnAttempts)
+	rc.retryConnNextAttempt = metav1.NewTime(rc.clock.Now().Add(d))
+	return &d
+}
+
 // setConfig - will try to recreate the k8s client and restart watching if the new config is different than
 // the one currently used or a reconnect was requested.
 // If the encountered error is not permanent the duration after which a retry should be done is returned.
 func (rc *remoteClient) setConfig(watchCtx context.Context, config *clientConfig) (*time.Duration, error) {
 	configChanged := !equality.Semantic.DeepEqual(config, rc.config)
-	if !configChanged && !rc.connecting.Load() {
+	connecting := rc.connecting.Load()
+	if !configChanged && !connecting {
 		return nil, nil
 	}
 
 	rc.StopWatchers()
+
 	if configChanged {
 		rc.config = config
-		rc.failedConnAttempts = 0
+		rc.resetFailedConnAttempt()
+	}
+
+	if connecting {
+		if untilNextAttempt := rc.retryConnNextAttempt.Sub(rc.clock.Now()); untilNextAttempt > 0 {
+			return &untilNextAttempt, nil
+		}
 	}
 
 	builder := newClientWithWatch
@@ -177,8 +202,7 @@ func (rc *remoteClient) setConfig(watchCtx context.Context, config *clientConfig
 	watchCtx, rc.watchCancel = context.WithCancel(watchCtx)
 	err = rc.startWatcher(watchCtx, kueue.GroupVersion.WithKind("Workload").GroupKind().String(), &workloadKueueWatcher{})
 	if err != nil {
-		rc.failedConnAttempts++
-		return new(retryAfter(rc.failedConnAttempts)), err
+		return rc.increaseFailedConnAttempt(), err
 	}
 
 	// add a watch for all the adapters implementing multiKueueWatcher
@@ -192,13 +216,12 @@ func (rc *remoteClient) setConfig(watchCtx context.Context, config *clientConfig
 			// not being able to setup a watcher is not ideal but we can function with only the wl watcher.
 			ctrl.LoggerFrom(watchCtx).Error(err, "Unable to start the watcher", "kind", kind)
 			// however let's not accept this for now.
-			rc.failedConnAttempts++
-			return new(retryAfter(rc.failedConnAttempts)), err
+			return rc.increaseFailedConnAttempt(), err
 		}
 	}
 
 	rc.connecting.Store(false)
-	rc.failedConnAttempts = 0
+	rc.resetFailedConnAttempt()
 	return nil, nil
 }
 
@@ -420,6 +443,9 @@ func (c *clustersReconciler) setRemoteClientConfig(ctx context.Context, clusterN
 	if retryAfter, err := client.setConfig(clientCtx, config); err != nil {
 		ctrl.LoggerFrom(ctx).Error(err, "failed to set kubeConfig in the remote client")
 		return retryAfter, err
+	} else if retryAfter != nil {
+		ctrl.LoggerFrom(ctx).V(2).Info("reconnect deferred, backoff not elapsed", "retryAfter", retryAfter, "failedAttempts", client.failedConnAttempts)
+		return retryAfter, nil
 	}
 	return nil, nil
 }
@@ -470,6 +496,8 @@ func (c *clustersReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 		} else {
 			return reconcile.Result{RequeueAfter: ptr.Deref(retryAfter, 0)}, nil
 		}
+	} else if retryAfter != nil {
+		return reconcile.Result{RequeueAfter: ptr.Deref(retryAfter, 0)}, nil
 	}
 
 	return reconcile.Result{}, client.IgnoreNotFound(c.updateStatus(ctx, cluster, true, "Active", "Connected"))

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -37,6 +37,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/utils/clock"
+	testingclock "k8s.io/utils/clock/testing"
 	inventoryv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -84,6 +86,7 @@ func newTestClient(ctx context.Context, kubeconfig []byte, restConfig *rest.Conf
 		config:      &clientConfig{Kubeconfig: kubeconfig, RestConfig: restConfig},
 		localClient: localClient,
 		watchCancel: watchCancel,
+		clock:       clock.RealClock{},
 
 		builderOverride: fakeClientBuilder(ctx),
 	}
@@ -736,6 +739,116 @@ func TestUpdateConfig(t *testing.T) {
 					return true
 				})); diff != "" {
 				t.Errorf("unexpected controllers (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestReconnectBackoff(t *testing.T) {
+	now := time.Now()
+
+	type step struct {
+		advance            time.Duration
+		wantBuildCalls     int
+		wantFailedAttempts uint
+		wantRequeueAfter   time.Duration
+	}
+
+	cases := map[string]struct {
+		kubeconfig string
+		steps      []step
+	}{
+		"double reconcile within backoff window does not advance attempts": {
+			kubeconfig: testKubeconfig("nowatch"),
+			steps: []step{
+				{advance: 0, wantBuildCalls: 1, wantFailedAttempts: 1, wantRequeueAfter: 5 * time.Second},
+				{advance: 0, wantBuildCalls: 0, wantFailedAttempts: 1, wantRequeueAfter: 5 * time.Second},
+				{advance: 2 * time.Second, wantBuildCalls: 0, wantFailedAttempts: 1, wantRequeueAfter: 3 * time.Second},
+			},
+		},
+		"backoff progresses once window elapses": {
+			kubeconfig: testKubeconfig("nowatch"),
+			steps: []step{
+				{advance: 0, wantBuildCalls: 1, wantFailedAttempts: 1, wantRequeueAfter: 5 * time.Second},
+				{advance: 5 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 2, wantRequeueAfter: 10 * time.Second},
+				{advance: 10 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 3, wantRequeueAfter: 20 * time.Second},
+			},
+		},
+		"deferred reconciles between failures do not consume backoff slots": {
+			kubeconfig: testKubeconfig("nowatch"),
+			steps: []step{
+				{advance: 0, wantBuildCalls: 1, wantFailedAttempts: 1, wantRequeueAfter: 5 * time.Second},
+				{advance: 0, wantBuildCalls: 0, wantFailedAttempts: 1, wantRequeueAfter: 5 * time.Second},
+				{advance: 5 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 2, wantRequeueAfter: 10 * time.Second},
+				{advance: 0, wantBuildCalls: 0, wantFailedAttempts: 2, wantRequeueAfter: 10 * time.Second},
+				{advance: 10 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 3, wantRequeueAfter: 20 * time.Second},
+			},
+		},
+		"backoff saturates at retryMaxSteps": {
+			kubeconfig: testKubeconfig("nowatch"),
+			steps: []step{
+				{advance: 0, wantBuildCalls: 1, wantFailedAttempts: 1, wantRequeueAfter: 5 * time.Second},
+				{advance: 5 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 2, wantRequeueAfter: 10 * time.Second},
+				{advance: 10 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 3, wantRequeueAfter: 20 * time.Second},
+				{advance: 20 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 4, wantRequeueAfter: 40 * time.Second},
+				{advance: 40 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 5, wantRequeueAfter: 80 * time.Second},
+				{advance: 80 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 6, wantRequeueAfter: 160 * time.Second},
+				{advance: 160 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 7, wantRequeueAfter: 320 * time.Second},
+				{advance: 320 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 8, wantRequeueAfter: 320 * time.Second},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			fc := testingclock.NewFakeClock(now)
+
+			cluster := utiltestingapi.MakeMultiKueueCluster("worker1").
+				KubeConfig(kueue.SecretLocationType, "worker1").
+				Generation(1).
+				Obj()
+			secret := makeTestSecret("worker1", tc.kubeconfig)
+
+			builder := getClientBuilder(ctx)
+			builder = builder.WithObjects(cluster, &secret)
+			builder = builder.WithStatusSubresource(&kueue.MultiKueueCluster{})
+			c := builder.Build()
+
+			adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
+			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileCreds{}, nil)
+			reconciler.rootContext = ctx
+
+			var buildCalls int
+			inner := fakeClientBuilder(ctx)
+			reconciler.builderOverride = func(cfg *clientConfig, opts client.Options) (client.WithWatch, error) {
+				buildCalls++
+				return inner(cfg, opts)
+			}
+
+			rc := newRemoteClient(c, reconciler.wlUpdateCh, reconciler.watchEndedCh, defaultOrigin, "worker1", adapters)
+			rc.clock = fc
+			rc.builderOverride = reconciler.builderOverride
+			reconciler.remoteClients["worker1"] = rc
+
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "worker1"}}
+
+			for i, s := range tc.steps {
+				fc.Step(s.advance)
+				before := buildCalls
+				res, err := reconciler.Reconcile(ctx, req)
+				if err != nil {
+					t.Fatalf("step %d: unexpected reconcile error: %v", i, err)
+				}
+				if got := buildCalls - before; got != s.wantBuildCalls {
+					t.Errorf("step %d: builder invocations: want %d, got %d", i, s.wantBuildCalls, got)
+				}
+				if rc.failedConnAttempts != s.wantFailedAttempts {
+					t.Errorf("step %d: failedConnAttempts: want %d, got %d", i, s.wantFailedAttempts, rc.failedConnAttempts)
+				}
+				if res.RequeueAfter != s.wantRequeueAfter {
+					t.Errorf("step %d: RequeueAfter: want %v, got %v", i, s.wantRequeueAfter, res.RequeueAfter)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Add reconnect backoff guardrail to suppress redundant cluster reconciles
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Discovered when working on #10926 
Related to #10950 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MultiKueue: Add reconnect backoff guardrail to suppress redundant cluster reconciles for the MultiKueueCluster reconciler.
```
