### PR TITLE
KEP-693: fix milestones in metadata

### DIFF
--- a/keps/693-multikueue/kep.yaml
+++ b/keps/693-multikueue/kep.yaml
@@ -23,7 +23,7 @@ latest-milestone: "v0.17"
 milestone:
   alpha: "v0.6"
   beta: "v0.8"
-  stable: "v0.17"
+  stable: TBD
 
 feature-gates:
   - MultiKueue


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

/area multikueue

#### What this PR does / why we need it:

Fix `milestones.stable` metadata in the MultiKueue KEP (KEP-693).
Currently it says `stable: 0.17` which suggests we're already stable, which contradicts the source of truth:

https://github.com/kubernetes-sigs/kueue/blob/0cb39029b5fd81edb495daa46eac62c9610a41d8/pkg/features/kube_features.go#L415-L418

#### Which issue(s) this PR fixes:

none

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
