### PR TITLE
dra: graduate KueueDRAIntegration to beta

### DIFF
--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -64,8 +64,13 @@ tags, and then generate with `hack/update-toc.sh`.
     - [E2E Test](#e2e-test)
   - [Graduation Criteria](#graduation-criteria)
     - [Alpha](#alpha)
+      - [KueueDRAIntegration (v0.14)](#kueuedraintegration-v014)
+      - [KueueDRAIntegrationExtendedResource (v0.17)](#kueuedraintegrationextendedresource-v017)
     - [Beta](#beta)
+      - [KueueDRAIntegration (v0.18)](#kueuedraintegration-v018)
+      - [KueueDRAIntegrationExtendedResource](#kueuedraintegrationextendedresource)
     - [GA](#ga)
+      - [KueueDRAIntegration](#kueuedraintegration)
 - [Implementation History](#implementation-history)
 - [Drawbacks](#drawbacks)
 - [Alternatives](#alternatives)
@@ -1004,24 +1009,38 @@ Use existing dra-example-driver or Kubernetes test driver for e2e testing.
 
 #### Alpha
 
-- the implementation behind the feature gate flag in alpha
+##### KueueDRAIntegration (v0.14)
+
+- ResourceClaimTemplate-based DRA quota accounting
 - support v1 API of DRA in core k8s
 - initial e2e tests for baseline scenario
-- support for Extended Resources (alpha in k8s 1.35)
+
+##### KueueDRAIntegrationExtendedResource (v0.17)
+
+- DeviceClass auto-discovery via field indexer on `extendedResourceName`
+- extended resource detection and resource translation
+- double-counting prevention with `deviceClassMappings`
 
 #### Beta
 
-- the feature gate in Beta
-- all known bugs are fixed
+##### KueueDRAIntegration (v0.18)
+
+- feature gate enabled by default
 - support integration with MultiKueue
 - e2e tests
-- TAS + DRA testing and support as a graduation requirement
+- CEL expression validation against ResourceSlice devices
+
+##### KueueDRAIntegrationExtendedResource
+
+- user adoption feedback
 - re-evaluate event-driven DeviceClass tracking for late DeviceClass creation
 - re-evaluate post-scheduling quota reconciliation for DeviceClass drift
 - re-evaluate the need for indexing of resourceSlices for CEL performance lookups
 - re-evaluate event-driven ResourceSlice tracking for late ResourceSlice creation
 
 #### GA
+
+##### KueueDRAIntegration
 
 - the feature gate in stable
 - integration with TopologyAwareScheduling
@@ -1037,6 +1056,7 @@ Use existing dra-example-driver or Kubernetes test driver for e2e testing.
 - Integration with Admission Fair Sharing: April 2026 — added integration tests and documentation
   confirming DRA logical resources work with existing `AdmissionFairSharing.ResourceWeights`
 - CEL expression validation support added: April 2026 by @kannon92
+- Promoted KueueDRAIntegration to Beta: May 2026 by @sohankunkerkar
 
 **Key Design Evolution:**
 - **Original Design**: Standalone DynamicResourceAllocationConfig CRD with runtime ambiguity resolution

--- a/keps/2941-DRA/kep.yaml
+++ b/keps/2941-DRA/kep.yaml
@@ -19,17 +19,17 @@ replaces:
   - "https://github.com/kubernetes-sigs/kueue/pull/3071"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.17"
+latest-milestone: "v0.18"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v0.13"
-  beta:
+  alpha: "v0.14"
+  beta: "v0.18"
   stable:
 
 # The following PRR answers are required at alpha release

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -503,7 +503,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.15"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	KueueDRAIntegration: {
-		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
 	},
 	DynamicResourceAllocation: {
 		{Version: version.MustParse("0.14"), Default: false, PreRelease: featuregate.Alpha},

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -115,9 +115,9 @@
     version: "0.17"
 - name: KueueDRAIntegration
   versionedSpecs:
-  - default: false
+  - default: true
     lockToDefault: false
-    preRelease: Alpha
+    preRelease: Beta
     version: "0.18"
 - name: KueueDRAIntegrationExtendedResource
   versionedSpecs:

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -115,9 +115,9 @@
     version: "0.17"
 - name: KueueDRAIntegration
   versionedSpecs:
-  - default: false
+  - default: true
     lockToDefault: false
-    preRelease: Alpha
+    preRelease: Beta
     version: "0.18"
 - name: KueueDRAIntegrationExtendedResource
   versionedSpecs:


### PR DESCRIPTION
Promote the KueueDRAIntegration feature gate from alpha to beta, enabling it by default in v0.18. This covers ResourceClaimTemplate-based DRA quota accounting with deviceClassMappings.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/8243

#### Special notes for your reviewer:
Before we consider this PR, we need to land the Partitionable Devices feature first.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
DRA: Promote KueueDRAIntegration feature gate to beta
```
