### PR TITLE
Only reconcile cluster updates on spec changes or deletion

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -841,7 +841,10 @@ func (c *clustersReconciler) Update(e event.UpdateEvent) bool {
 			log.Error(err, "AddOrUpdate FS watch")
 		}
 	}
-	return true
+	if !clusterNew.DeletionTimestamp.IsZero() {
+		return true
+	}
+	return clusterOld.Generation != clusterNew.Generation
 }
 
 func (c *clustersReconciler) Delete(e event.DeleteEvent) bool {

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -1077,7 +1077,7 @@ func TestClustersReconcilerEventFilters(t *testing.T) {
 			},
 			wantReconcile: true,
 		},
-		"update cluster status only change does not skip reconcile": {
+		"update cluster status only change skips reconcile": {
 			invoke: func(p predicate.Predicate) bool {
 				return p.Update(event.UpdateEvent{
 					ObjectOld: baseCluster,
@@ -1087,7 +1087,7 @@ func TestClustersReconcilerEventFilters(t *testing.T) {
 						Obj(),
 				})
 			},
-			wantReconcile: true,
+			wantReconcile: false,
 		},
 		"update cluster deletion timestamp triggers reconcile": {
 			invoke: func(p predicate.Predicate) bool {
@@ -1098,20 +1098,22 @@ func TestClustersReconcilerEventFilters(t *testing.T) {
 			},
 			wantReconcile: true,
 		},
-		"update cluster no change does not skip reconcile": {
+		"update cluster no change skips reconcile": {
 			invoke: func(p predicate.Predicate) bool {
 				return p.Update(event.UpdateEvent{
 					ObjectOld: baseCluster,
 					ObjectNew: baseCluster.DeepCopy(),
 				})
 			},
-			wantReconcile: true,
+			wantReconcile: false,
 		},
 		"update cluster path location changed to secret triggers reconcile": {
 			invoke: func(p predicate.Predicate) bool {
+				objNew := baseCluster.DeepCopy()
+				objNew.SetGeneration(2)
 				return p.Update(event.UpdateEvent{
 					ObjectOld: baseClusterWithPath,
-					ObjectNew: baseCluster,
+					ObjectNew: objNew,
 				})
 			},
 			wantReconcile: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Only reconcile multikueue cluster updates on spec changes or deletion

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Discovered when working on #10926
Related to #10950

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MultiKueue: improved performance by avoiding unnecessary MultiKueueCluster reconciliations.
MultiKueueCluster updates now trigger reconciliation only when the spec changes or the object is deleted.
```
