### PR TITLE
fix: Seed second-pass with all prior flavors

### DIFF
--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -670,9 +670,7 @@ func (a *FlavorAssigner) assignFlavors(log logr.Logger, counts []int32) Assignme
 		groupFlavors := make(ResourceAssignment)
 		for _, ips := range podSets {
 			// Seed the dedup memo with every prior-pass assignment, not just one.
-			for resName, fa := range ips.podSetAssignment.Flavors {
-				groupFlavors[resName] = fa
-			}
+			maps.Copy(groupFlavors, ips.podSetAssignment.Flavors)
 		}
 		var groupStatus Status
 		for resName, quantity := range requests {

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -669,9 +669,9 @@ func (a *FlavorAssigner) assignFlavors(log logr.Logger, counts []int32) Assignme
 
 		groupFlavors := make(ResourceAssignment)
 		for _, ips := range podSets {
-			for resName := range ips.podSetAssignment.Flavors {
-				groupFlavors[resName] = ips.podSetAssignment.Flavors[resName]
-				break
+			// Seed the dedup memo with every prior-pass assignment, not just one.
+			for resName, fa := range ips.podSetAssignment.Flavors {
+				groupFlavors[resName] = fa
 			}
 		}
 		var groupStatus Status

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -428,6 +428,66 @@ func TestScheduleForTAS(t *testing.T) {
 				utiltesting.MakeEventRecord("default", "foo", "Admitted", corev1.EventTypeNormal).Obj(),
 			},
 		},
+		"workload in CQ with ProvisioningRequest; second pass; multi-resource workload fully consumes quota": {
+			// Verifies the second pass does not re-fit a multi-resource
+			// workload against quota that already includes its own first-pass
+			// reservation.
+			nodes:           defaultSingleNode,
+			admissionChecks: []kueue.AdmissionCheck{defaultProvCheck},
+			topologies:      []kueue.Topology{defaultSingleLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{defaultTASFlavor},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("tas-main").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("tas-default").
+						Resource(corev1.ResourceCPU, "1").
+						Resource(corev1.ResourceMemory, "1Gi").Obj()).
+					AdmissionChecks(kueue.AdmissionCheckReference(defaultProvCheck.Name)).
+					Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("foo", "default").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "1").
+						Request(corev1.ResourceMemory, "1Gi").
+						Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(
+								utiltestingapi.MakePodSetAssignment("one").
+									Assignment(corev1.ResourceCPU, "tas-default", "1000m").
+									Assignment(corev1.ResourceMemory, "tas-default", "1Gi").
+									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+									Obj(),
+							).
+							Obj(), now,
+					).
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:  "prov-check",
+						State: kueue.CheckStateReady,
+					}).
+					Obj(),
+			},
+			wantNewAssignments: map[workload.Reference]kueue.Admission{
+				"default/foo": *utiltestingapi.MakeAdmission("tas-main").
+					PodSets(
+						utiltestingapi.MakePodSetAssignment("one").
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
+							Assignment(corev1.ResourceMemory, "tas-default", "1Gi").
+							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
+							TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
+					).
+					Obj(),
+			},
+			eventCmpOpts: cmp.Options{eventIgnoreMessage},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "foo", "Admitted", corev1.EventTypeNormal).Obj(),
+			},
+		},
 		"workload in CQ with two TAS flavors, only the second is using Provisioning Admission Check": {
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("x1").
@@ -3108,6 +3168,12 @@ func TestScheduleForTAS(t *testing.T) {
 				for _, w := range testWls {
 					if workload.IsAdmitted(&w) && !workload.HasUnhealthyNodes(&w) {
 						initiallyAdmittedWorkloads.Insert(workload.Key(&w))
+					}
+				}
+				// Reserved workloads must contribute their usage to the snapshot, mirroring production.
+				for i := range testWls {
+					if workload.HasQuotaReservation(&testWls[i]) {
+						cqCache.AddOrUpdateWorkload(log, &testWls[i])
 					}
 				}
 				for _, w := range testWls {


### PR DESCRIPTION
The seed loop in flavorassigner.assignFlavors copied just the first preexisting flavor per PodSet. For multi-resource workloads on the second pass, the remaining resources fell through to fitsResourceQuota, which double-counts the workload's own first-pass reservation.

The TAS scheduler test framework now also seeds reserved-but-not-admitted workloads into the cqCache so the regression is observable in unit tests.

---------

Assisted with Claude Code

#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

This PR fixes a duplicated resource allocation issues caused by a flavor assignment bug for multi-resource workloads.

The seed loop in `flavorassigner.assignFlavors` only copied the first preexisting flavor for each `PodSet`. On the second scheduling pass, the remaining resources were treated as unassigned and fell through to `fitsResourceQuota`, which caused the workload's own first-pass reservation to be double-counted.

The fix preserves all preexisting flavor assignments for the `PodSet`, so the second pass correctly accounts for the workload's already reserved resources.

#### Which issue(s) this PR fixes:

Fixes #9048

#### Special notes for your reviewer:

This PR also updates the TAS scheduler test framework to seed reserved-but-not-admitted workloads into the `cqCache`, making this regression observable in unit tests.

#### Does this PR introduce a user-facing change?

```release-note
TAS: Fixed a bug where multi-resource workloads, such as workloads requesting both CPU and memory,
could fail admission during second-pass scheduling for ProvisioningRequests or NodeHotSwap because one
resource's usage was double-counted against quota.
```