### PR TITLE
Prevent requeuing inadmissible workloads.

### DIFF
--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -642,8 +642,9 @@ func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reas
 	var w kueue.Workload
 	// Always get the newest workload to avoid requeuing the out-of-date obj.
 	err := m.client.Get(ctx, client.ObjectKeyFromObject(info.Obj), &w)
-	// Since the client is cached, the only possible error is NotFound
-	if apierrors.IsNotFound(err) || workload.HasQuotaReservation(&w) {
+	// Since the client is cached, the only possible error is NotFound.
+	// We should not requeue a workload that is not admissible.
+	if apierrors.IsNotFound(err) || !workload.IsAdmissible(&w) {
 		return false
 	}
 

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -969,57 +969,94 @@ func TestStatus(t *testing.T) {
 }
 
 func TestRequeueWorkloadStrictFIFO(t *testing.T) {
+	now := time.Now()
 	cq := utiltestingapi.MakeClusterQueue("cq").Obj()
 	queues := []*kueue.LocalQueue{
 		utiltestingapi.MakeLocalQueue("foo", "").ClusterQueue("cq").Obj(),
 		utiltestingapi.MakeLocalQueue("bar", "").Obj(),
 	}
-	cases := []struct {
+	cases := map[string]struct {
 		workload     *kueue.Workload
 		inClient     bool
 		inQueue      bool
 		wantRequeued bool
 	}{
-		{
-			workload: utiltestingapi.MakeWorkload("existing_queue_and_obj", "").
+		"existing queue and obj": {
+			workload: utiltestingapi.MakeWorkload("wl", "").
 				Queue("foo").
 				Obj(),
 			inClient:     true,
 			wantRequeued: true,
 		},
-		{
-			workload: utiltestingapi.MakeWorkload("non_existing_queue", "").Queue("baz").Obj(),
-			inClient: true,
+		"non existing queue": {
+			workload:     utiltestingapi.MakeWorkload("wl", "").Queue("baz").Obj(),
+			inClient:     true,
+			inQueue:      false,
+			wantRequeued: false,
 		},
-		{
-			workload: utiltestingapi.MakeWorkload("non_existing_cluster_queue", "").
+		"non existing cluster queue": {
+			workload: utiltestingapi.MakeWorkload("wl", "").
 				Queue("bar").
 				Obj(),
-			inClient: true,
+			inClient:     true,
+			inQueue:      false,
+			wantRequeued: false,
 		},
-		{
-			workload: utiltestingapi.MakeWorkload("not_in_client", "").
+		"not in client": {
+			workload: utiltestingapi.MakeWorkload("wl", "").
 				Queue("foo").
 				Obj(),
+			inClient:     false,
+			inQueue:      false,
+			wantRequeued: false,
 		},
-		{
-			workload: utiltestingapi.MakeWorkload("already_in_queue", "").
+		"has no quota reservation": {
+			workload: utiltestingapi.MakeWorkload("wl", "").
+				Queue("foo").
+				ReserveQuotaAt(&kueue.Admission{ClusterQueue: kueue.ClusterQueueReference(cq.Name)}, now).
+				Obj(),
+			inClient:     true,
+			inQueue:      true,
+			wantRequeued: false,
+		},
+		"finished": {
+			workload: utiltestingapi.MakeWorkload("wl", "").
+				Queue("foo").
+				Finished().
+				Obj(),
+			inClient:     true,
+			inQueue:      true,
+			wantRequeued: false,
+		},
+		"deactivated": {
+			workload: utiltestingapi.MakeWorkload("wl", "").
+				Queue("foo").
+				Active(false).
+				Obj(),
+			inClient:     true,
+			inQueue:      true,
+			wantRequeued: false,
+		},
+		"already in queue": {
+			workload: utiltestingapi.MakeWorkload("wl", "").
 				Queue("foo").
 				Obj(),
-			inClient: true,
-			inQueue:  true,
+			inClient:     true,
+			inQueue:      true,
+			wantRequeued: false,
 		},
-		{
-			workload: utiltestingapi.MakeWorkload("already_admitted", "").
+		"already admitted": {
+			workload: utiltestingapi.MakeWorkload("wl", "").
 				Queue("foo").
 				Admission(&kueue.Admission{}).
 				Obj(),
-			inClient: true,
-			inQueue:  true,
+			inClient:     true,
+			inQueue:      true,
+			wantRequeued: false,
 		},
 	}
-	for _, tc := range cases {
-		t.Run(tc.workload.Name, func(t *testing.T) {
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
 			cl := utiltesting.NewFakeClient()
 			ctx, log := utiltesting.ContextWithLog(t)
 			queueOptions := []Option{WithPreemptionExpectations(preemptexpectations.New())}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Prevent requeuing inadmissible workloads.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #10901

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Scheduling: Fixed a bug where in-flight workloads that were concurrently marked as finished (`Finished=True`) or deactivated could be requeued by Kueue's scheduler, causing re-scheduling attempts which were interfering with the scheduling of other workloads.
```
