### PR TITLE
[ConcurrentAdmission] Add CQ validation webhook to exclude StrictFIFO when using ConcurrentAdmission

### DIFF
--- a/pkg/webhooks/clusterqueue_webhook.go
+++ b/pkg/webhooks/clusterqueue_webhook.go
@@ -246,6 +246,11 @@ func validateConcurrentAdmissionPolicy(cq *kueue.ClusterQueue, path *field.Path)
 			"cannot have more than 16 resource flavors in the ResourceGroup when ConcurrentAdmissionPolicy is defined"))
 	}
 
+	if cq.Spec.QueueingStrategy == kueue.StrictFIFO {
+		allErrs = append(allErrs, field.Invalid(path.Child("queueingStrategy"), cq.Spec.QueueingStrategy,
+			"StrictFIFO queueing strategy cannot be used when ConcurrentAdmissionPolicy is defined"))
+	}
+
 	return allErrs
 }
 

--- a/pkg/webhooks/clusterqueue_webhook_test.go
+++ b/pkg/webhooks/clusterqueue_webhook_test.go
@@ -391,6 +391,19 @@ func TestValidateClusterQueue(t *testing.T) {
 				Obj(),
 		},
 		{
+			name: "ConcurrentAdmissionPolicy with StrictFIFO queueing strategy is invalid",
+			clusterQueue: utiltestingapi.MakeClusterQueue("cluster-queue").
+				ConcurrentAdmissionPolicy(kueue.ConcurrentAdmissionTryPreferredFlavors).
+				QueueingStrategy(kueue.StrictFIFO).
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("flavor1").Resource("cpu", "1").Obj()).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(specPath.Child("queueingStrategy"), kueue.StrictFIFO, "StrictFIFO queueing strategy cannot be used when ConcurrentAdmissionPolicy is defined"),
+			},
+			wantDetail:   "StrictFIFO queueing strategy cannot be used when ConcurrentAdmissionPolicy is defined",
+			wantBadValue: string(kueue.StrictFIFO),
+		},
+		{
 			name: "ConcurrentAdmissionPolicy with more than one ResourceGroup",
 			clusterQueue: utiltestingapi.MakeClusterQueue("cluster-queue").
 				ConcurrentAdmissionPolicy(kueue.ConcurrentAdmissionTryPreferredFlavors).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
According to the [KEP](https://github.com/kubernetes-sigs/kueue/pull/8861/changes) ConcurrentAdmission cannot be combined with StrictFIFO

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
