### PR TITLE
fix: Use non exist image as default image for e2e tests

### DIFF
--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	utiltestingjobs "sigs.k8s.io/kueue/pkg/util/testingjobs"
 	"sigs.k8s.io/kueue/pkg/util/testingjobs/leaderworkerset"
 )
 
@@ -88,7 +89,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					Priority(0).
 					Obj(),
@@ -116,7 +117,7 @@ func TestReconciler(t *testing.T) {
 				LeaderTemplate(corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "c", Image: "pause"},
+							{Name: "c", Image: utiltestingjobs.TestDefaultContainerImage},
 						},
 					},
 				}).
@@ -128,7 +129,7 @@ func TestReconciler(t *testing.T) {
 					LeaderTemplate(corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
-								{Name: "c", Image: "pause"},
+								{Name: "c", Image: utiltestingjobs.TestDefaultContainerImage},
 							},
 						},
 					}).
@@ -146,11 +147,11 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(leaderPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj(),
 						*utiltestingapi.MakePodSet(workerPodSetName, 2).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj(),
 					).
 					Priority(0).
@@ -180,7 +181,7 @@ func TestReconciler(t *testing.T) {
 				LeaderTemplate(corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "c", Image: "pause"},
+							{Name: "c", Image: utiltestingjobs.TestDefaultContainerImage},
 						},
 					},
 				}).
@@ -193,7 +194,7 @@ func TestReconciler(t *testing.T) {
 					LeaderTemplate(corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
-								{Name: "c", Image: "pause"},
+								{Name: "c", Image: utiltestingjobs.TestDefaultContainerImage},
 							},
 						},
 					}).
@@ -211,11 +212,11 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(leaderPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj(),
 						*utiltestingapi.MakePodSet(workerPodSetName, 2).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj(),
 					).
 					Priority(0).
@@ -231,11 +232,11 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(leaderPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj(),
 						*utiltestingapi.MakePodSet(workerPodSetName, 2).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj(),
 					).
 					Priority(0).
@@ -285,7 +286,7 @@ func TestReconciler(t *testing.T) {
 					},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "c", Image: "pause"},
+							{Name: "c", Image: utiltestingjobs.TestDefaultContainerImage},
 						},
 					},
 				}).
@@ -302,7 +303,7 @@ func TestReconciler(t *testing.T) {
 					},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "c", Image: "pause"},
+							{Name: "c", Image: utiltestingjobs.TestDefaultContainerImage},
 						},
 					},
 				}).
@@ -325,7 +326,7 @@ func TestReconciler(t *testing.T) {
 						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
-								{Name: "c", Image: "pause"},
+								{Name: "c", Image: utiltestingjobs.TestDefaultContainerImage},
 							},
 						},
 					}).
@@ -342,7 +343,7 @@ func TestReconciler(t *testing.T) {
 						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
-								{Name: "c", Image: "pause"},
+								{Name: "c", Image: utiltestingjobs.TestDefaultContainerImage},
 							},
 						},
 					}).
@@ -362,13 +363,13 @@ func TestReconciler(t *testing.T) {
 							Annotations(map[string]string{"custom-leader-annotation": "leader-value"}).
 							Labels(map[string]string{"leaderworkerset.sigs.k8s.io/name": testLWS}).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj(),
 						*utiltestingapi.MakePodSet(workerPodSetName, 2).
 							Annotations(map[string]string{"custom-worker-annotation": "worker-value"}).
 							Labels(map[string]string{"leaderworkerset.sigs.k8s.io/name": testLWS}).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj(),
 					).
 					Priority(0).
@@ -399,7 +400,7 @@ func TestReconciler(t *testing.T) {
 					},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "c", Image: "pause"},
+							{Name: "c", Image: utiltestingjobs.TestDefaultContainerImage},
 						},
 					},
 				}).
@@ -411,7 +412,7 @@ func TestReconciler(t *testing.T) {
 					},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "c", Image: "pause"},
+							{Name: "c", Image: utiltestingjobs.TestDefaultContainerImage},
 						},
 					},
 				}).
@@ -428,7 +429,7 @@ func TestReconciler(t *testing.T) {
 						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
-								{Name: "c", Image: "pause"},
+								{Name: "c", Image: utiltestingjobs.TestDefaultContainerImage},
 							},
 						},
 					}).
@@ -440,7 +441,7 @@ func TestReconciler(t *testing.T) {
 						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
-								{Name: "c", Image: "pause"},
+								{Name: "c", Image: utiltestingjobs.TestDefaultContainerImage},
 							},
 						},
 					}).
@@ -458,13 +459,13 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(leaderPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
 							RequiredTopologyRequest("cloud.com/block").
 							Obj(),
 						*utiltestingapi.MakePodSet(workerPodSetName, 2).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
 							RequiredTopologyRequest("cloud.com/block").
 							PodIndexLabel(ptr.To(leaderworkersetv1.WorkerIndexLabelKey)).
@@ -501,7 +502,7 @@ func TestReconciler(t *testing.T) {
 					},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "c", Image: "pause"},
+							{Name: "c", Image: utiltestingjobs.TestDefaultContainerImage},
 						},
 					},
 				}).
@@ -513,7 +514,7 @@ func TestReconciler(t *testing.T) {
 					},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "c", Image: "pause"},
+							{Name: "c", Image: utiltestingjobs.TestDefaultContainerImage},
 						},
 					},
 				}).
@@ -530,7 +531,7 @@ func TestReconciler(t *testing.T) {
 						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
-								{Name: "c", Image: "pause"},
+								{Name: "c", Image: utiltestingjobs.TestDefaultContainerImage},
 							},
 						},
 					}).
@@ -542,7 +543,7 @@ func TestReconciler(t *testing.T) {
 						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
-								{Name: "c", Image: "pause"},
+								{Name: "c", Image: utiltestingjobs.TestDefaultContainerImage},
 							},
 						},
 					}).
@@ -560,12 +561,12 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(leaderPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
 							Obj(),
 						*utiltestingapi.MakePodSet(workerPodSetName, 2).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
 							Obj(),
 					).
@@ -614,7 +615,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					WorkloadPriorityClassRef("high-priority").
 					Priority(5000).
@@ -656,7 +657,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					Priority(0).
 					Obj(),
@@ -674,7 +675,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					Priority(0).
 					Obj(),
@@ -705,7 +706,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					Priority(0).
 					Obj(),
@@ -723,7 +724,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					Priority(0).
 					Obj(),
@@ -765,7 +766,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					Priority(0).
 					Obj(),
@@ -776,7 +777,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					Priority(0).
 					Obj(),
@@ -789,7 +790,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					Priority(0).
 					Obj(),
@@ -828,7 +829,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					Priority(0).
 					Obj(),
@@ -839,7 +840,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					Priority(0).
 					Obj(),
@@ -850,7 +851,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					Priority(0).
 					Obj(),
@@ -863,7 +864,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					Priority(0).
 					Obj(),
@@ -874,7 +875,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					Priority(0).
 					Obj(),
@@ -885,7 +886,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					Priority(0).
 					Obj(),
@@ -908,7 +909,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					Priority(0).
 					Obj(),
@@ -919,7 +920,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					Priority(0).
 					Obj(),
@@ -933,7 +934,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					Priority(0).
 					Obj(),
@@ -967,7 +968,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					Priority(0).
 					Obj(),
@@ -1013,7 +1014,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					Priority(0).
 					Obj(),
@@ -1058,7 +1059,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							RestartPolicy("").
-							Image("pause").
+							Image(utiltestingjobs.TestDefaultContainerImage).
 							Obj()).
 					Priority(0).
 					Obj(),

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	utiltestingjobs "sigs.k8s.io/kueue/pkg/util/testingjobs"
 	testingleaderworkerset "sigs.k8s.io/kueue/pkg/util/testingjobs/leaderworkerset"
 )
 
@@ -1032,14 +1033,14 @@ func TestValidateUpdate(t *testing.T) {
 						Containers: []corev1.Container{
 							{
 								Name:      "c",
-								Image:     "pause",
+								Image:     utiltestingjobs.TestDefaultContainerImage,
 								Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
 							},
 						},
 						InitContainers: []corev1.Container{
 							{
 								Name:      "ic",
-								Image:     "pause",
+								Image:     utiltestingjobs.TestDefaultContainerImage,
 								Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
 							},
 						},
@@ -1091,14 +1092,14 @@ func TestValidateUpdate(t *testing.T) {
 						Containers: []corev1.Container{
 							{
 								Name:      "c",
-								Image:     "pause",
+								Image:     utiltestingjobs.TestDefaultContainerImage,
 								Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
 							},
 						},
 						InitContainers: []corev1.Container{
 							{
 								Name:      "ic",
-								Image:     "pause",
+								Image:     utiltestingjobs.TestDefaultContainerImage,
 								Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
 							},
 						},
@@ -1116,14 +1117,14 @@ func TestValidateUpdate(t *testing.T) {
 						Containers: []corev1.Container{
 							{
 								Name:      "c",
-								Image:     "pause",
+								Image:     utiltestingjobs.TestDefaultContainerImage,
 								Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
 							},
 						},
 						InitContainers: []corev1.Container{
 							{
 								Name:      "ic",
-								Image:     "pause",
+								Image:     utiltestingjobs.TestDefaultContainerImage,
 								Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
 							},
 						},
@@ -1179,7 +1180,7 @@ func TestValidateUpdate(t *testing.T) {
 						Containers: []corev1.Container{
 							{
 								Name:  "c",
-								Image: "pause",
+								Image: utiltestingjobs.TestDefaultContainerImage,
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
 										corev1.ResourceCPU: resource.MustParse("1"),
@@ -1190,7 +1191,7 @@ func TestValidateUpdate(t *testing.T) {
 						InitContainers: []corev1.Container{
 							{
 								Name:      "ic",
-								Image:     "pause",
+								Image:     utiltestingjobs.TestDefaultContainerImage,
 								Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
 							},
 						},
@@ -1218,14 +1219,14 @@ func TestValidateUpdate(t *testing.T) {
 						Containers: []corev1.Container{
 							{
 								Name:      "c",
-								Image:     "pause",
+								Image:     utiltestingjobs.TestDefaultContainerImage,
 								Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
 							},
 						},
 						InitContainers: []corev1.Container{
 							{
 								Name:      "ic",
-								Image:     "pause",
+								Image:     utiltestingjobs.TestDefaultContainerImage,
 								Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
 							},
 						},
@@ -1281,14 +1282,14 @@ func TestValidateUpdate(t *testing.T) {
 						Containers: []corev1.Container{
 							{
 								Name:      "c",
-								Image:     "pause",
+								Image:     utiltestingjobs.TestDefaultContainerImage,
 								Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
 							},
 						},
 						InitContainers: []corev1.Container{
 							{
 								Name:  "ic",
-								Image: "pause",
+								Image: utiltestingjobs.TestDefaultContainerImage,
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
 										corev1.ResourceCPU: resource.MustParse("1"),

--- a/pkg/util/testingjobs/deployment/wrappers.go
+++ b/pkg/util/testingjobs/deployment/wrappers.go
@@ -27,6 +27,7 @@ import (
 
 	"sigs.k8s.io/kueue/pkg/constants"
 	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
+	utiltestingjobs "sigs.k8s.io/kueue/pkg/util/testingjobs"
 )
 
 // DeploymentWrapper wraps a Deployment.
@@ -58,7 +59,7 @@ func MakeDeployment(name, ns string) *DeploymentWrapper {
 					Containers: []corev1.Container{
 						{
 							Name:      "c",
-							Image:     "pause",
+							Image:     utiltestingjobs.TestDefaultContainerImage,
 							Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
 						},
 					},

--- a/pkg/util/testingjobs/jaxjob/wrappers.go
+++ b/pkg/util/testingjobs/jaxjob/wrappers.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
+	utiltestingjobs "sigs.k8s.io/kueue/pkg/util/testingjobs"
 )
 
 // JAXJobWrapper wraps a Job.
@@ -84,7 +85,7 @@ func (j *JAXJobWrapper) JAXReplicaSpecsDefault() *JAXJobWrapper {
 				Containers: []corev1.Container{
 					{
 						Name:    "jax",
-						Image:   "pause",
+						Image:   utiltestingjobs.TestDefaultContainerImage,
 						Command: []string{},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{},

--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -30,6 +30,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingjobs "sigs.k8s.io/kueue/pkg/util/testingjobs"
 )
 
 // JobWrapper wraps a Job.
@@ -52,7 +53,7 @@ func MakeJob(name, ns string) *JobWrapper {
 					Containers: []corev1.Container{
 						{
 							Name:      "c",
-							Image:     "pause",
+							Image:     utiltestingjobs.TestDefaultContainerImage,
 							Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}, Limits: corev1.ResourceList{}},
 						},
 					},

--- a/pkg/util/testingjobs/leaderworkerset/wrappers.go
+++ b/pkg/util/testingjobs/leaderworkerset/wrappers.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
+	utiltestingjobs "sigs.k8s.io/kueue/pkg/util/testingjobs"
 )
 
 // LeaderWorkerSetWrapper wraps a LeaderWorkerSet.
@@ -53,7 +54,7 @@ func MakeLeaderWorkerSet(name, ns string) *LeaderWorkerSetWrapper {
 						Containers: []corev1.Container{
 							{
 								Name:      "c",
-								Image:     "pause",
+								Image:     utiltestingjobs.TestDefaultContainerImage,
 								Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
 							},
 						},

--- a/pkg/util/testingjobs/mpijob/wrappers_mpijob.go
+++ b/pkg/util/testingjobs/mpijob/wrappers_mpijob.go
@@ -27,6 +27,7 @@ import (
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingjobs "sigs.k8s.io/kueue/pkg/util/testingjobs"
 )
 
 // MPIJobWrapper wraps a Job.
@@ -85,7 +86,7 @@ func (j *MPIJobWrapper) GenericLauncherAndWorker() *MPIJobWrapper {
 				Containers: []corev1.Container{
 					{
 						Name:    "mpijob",
-						Image:   "pause",
+						Image:   utiltestingjobs.TestDefaultContainerImage,
 						Command: []string{},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{},
@@ -110,7 +111,7 @@ func (j *MPIJobWrapper) GenericLauncher() *MPIJobWrapper {
 				Containers: []corev1.Container{
 					{
 						Name:    "mpijob",
-						Image:   "pause",
+						Image:   utiltestingjobs.TestDefaultContainerImage,
 						Command: []string{},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{},

--- a/pkg/util/testingjobs/paddlejob/wrappers.go
+++ b/pkg/util/testingjobs/paddlejob/wrappers.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
+	utiltestingjobs "sigs.k8s.io/kueue/pkg/util/testingjobs"
 )
 
 // PaddleJobWrapper wraps a Job.
@@ -80,7 +81,7 @@ func (j *PaddleJobWrapper) PaddleReplicaSpecsDefault() *PaddleJobWrapper {
 				Containers: []corev1.Container{
 					{
 						Name:      "c",
-						Image:     "pause",
+						Image:     utiltestingjobs.TestDefaultContainerImage,
 						Command:   []string{},
 						Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
 					},
@@ -98,7 +99,7 @@ func (j *PaddleJobWrapper) PaddleReplicaSpecsDefault() *PaddleJobWrapper {
 				Containers: []corev1.Container{
 					{
 						Name:      "c",
-						Image:     "pause",
+						Image:     utiltestingjobs.TestDefaultContainerImage,
 						Command:   []string{},
 						Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
 					},

--- a/pkg/util/testingjobs/pod/wrappers.go
+++ b/pkg/util/testingjobs/pod/wrappers.go
@@ -32,6 +32,7 @@ import (
 	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingjobs "sigs.k8s.io/kueue/pkg/util/testingjobs"
 )
 
 // PodWrapper wraps a Pod.
@@ -52,7 +53,7 @@ func MakePod(name, ns string) *PodWrapper {
 			Containers: []corev1.Container{
 				{
 					Name:      "c",
-					Image:     "pause",
+					Image:     utiltestingjobs.TestDefaultContainerImage,
 					Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}, Limits: corev1.ResourceList{}},
 				},
 			},

--- a/pkg/util/testingjobs/pytorchjob/wrappers_pytorchjob.go
+++ b/pkg/util/testingjobs/pytorchjob/wrappers_pytorchjob.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
+	utiltestingjobs "sigs.k8s.io/kueue/pkg/util/testingjobs"
 )
 
 // PyTorchJobWrapper wraps a Job.
@@ -84,7 +85,7 @@ func (j *PyTorchJobWrapper) PyTorchReplicaSpecsOnlyMasterDefault() *PyTorchJobWr
 				Containers: []corev1.Container{
 					{
 						Name:    "pytorch",
-						Image:   "pause",
+						Image:   utiltestingjobs.TestDefaultContainerImage,
 						Command: []string{},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{},
@@ -112,7 +113,7 @@ func (j *PyTorchJobWrapper) PyTorchReplicaSpecsDefault() *PyTorchJobWrapper {
 				Containers: []corev1.Container{
 					{
 						Name:    "pytorch",
-						Image:   "pause",
+						Image:   utiltestingjobs.TestDefaultContainerImage,
 						Command: []string{},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{},

--- a/pkg/util/testingjobs/statefulset/wrappers.go
+++ b/pkg/util/testingjobs/statefulset/wrappers.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingjobs "sigs.k8s.io/kueue/pkg/util/testingjobs"
 )
 
 // StatefulSetWrapper wraps a StatefulSet.
@@ -67,7 +68,7 @@ func MakeStatefulSet(name, ns string) *StatefulSetWrapper {
 					Containers: []corev1.Container{
 						{
 							Name:      "c",
-							Image:     "pause",
+							Image:     utiltestingjobs.TestDefaultContainerImage,
 							Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
 						},
 					},

--- a/pkg/util/testingjobs/tfjob/wrappers_tfjob.go
+++ b/pkg/util/testingjobs/tfjob/wrappers_tfjob.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
+	utiltestingjobs "sigs.k8s.io/kueue/pkg/util/testingjobs"
 )
 
 // TFJobWrapper wraps a Job.
@@ -80,7 +81,7 @@ func (j *TFJobWrapper) TFReplicaSpecsDefault() *TFJobWrapper {
 				Containers: []corev1.Container{
 					{
 						Name:      "c",
-						Image:     "pause",
+						Image:     utiltestingjobs.TestDefaultContainerImage,
 						Command:   []string{},
 						Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
 					},
@@ -98,7 +99,7 @@ func (j *TFJobWrapper) TFReplicaSpecsDefault() *TFJobWrapper {
 				Containers: []corev1.Container{
 					{
 						Name:      "c",
-						Image:     "pause",
+						Image:     utiltestingjobs.TestDefaultContainerImage,
 						Command:   []string{},
 						Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
 					},
@@ -116,7 +117,7 @@ func (j *TFJobWrapper) TFReplicaSpecsDefault() *TFJobWrapper {
 				Containers: []corev1.Container{
 					{
 						Name:      "c",
-						Image:     "pause",
+						Image:     utiltestingjobs.TestDefaultContainerImage,
 						Command:   []string{},
 						Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
 					},

--- a/pkg/util/testingjobs/wrappers_utils.go
+++ b/pkg/util/testingjobs/wrappers_utils.go
@@ -1,0 +1,25 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testingjobs
+
+const (
+	// TestDefaultContainerImage is an intentionally non-existing image used as the
+	// default in test wrappers. It ensures e2e tests fail fast (ImagePullBackOff)
+	// if a real image is not explicitly set, while having no effect on unit or
+	// integration tests that never pull images.
+	TestDefaultContainerImage = "registry.k8s.io/pause:non-existing"
+)

--- a/pkg/util/testingjobs/xgboostjob/wrappers.go
+++ b/pkg/util/testingjobs/xgboostjob/wrappers.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
+	utiltestingjobs "sigs.k8s.io/kueue/pkg/util/testingjobs"
 )
 
 // XGBoostJobWrapper wraps a Job.
@@ -80,7 +81,7 @@ func (j *XGBoostJobWrapper) XGBReplicaSpecsDefault() *XGBoostJobWrapper {
 				Containers: []corev1.Container{
 					{
 						Name:      "c",
-						Image:     "pause",
+						Image:     utiltestingjobs.TestDefaultContainerImage,
 						Command:   []string{},
 						Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
 					},
@@ -98,7 +99,7 @@ func (j *XGBoostJobWrapper) XGBReplicaSpecsDefault() *XGBoostJobWrapper {
 				Containers: []corev1.Container{
 					{
 						Name:      "c",
-						Image:     "pause",
+						Image:     utiltestingjobs.TestDefaultContainerImage,
 						Command:   []string{},
 						Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
 					},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind cleanup
/area testing

/cc @mimowo 

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11003 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
