### PR TITLE
TAS: fix delete predicate to reconcile terminal pods

### DIFF
--- a/pkg/controller/tas/non_tas_usage_controller.go
+++ b/pkg/controller/tas/non_tas_usage_controller.go
@@ -109,7 +109,11 @@ func (r *NonTasUsageReconciler) Update(e event.TypedUpdateEvent[*corev1.Pod]) bo
 }
 
 func (r *NonTasUsageReconciler) Delete(e event.TypedDeleteEvent[*corev1.Pod]) bool {
-	return belongsToNonTASCache(e.Object)
+	// Don't filter on terminal phase: if the informer skips the Running→Terminated
+	// Update and delivers only the Delete event with the pod already Succeeded/Failed,
+	// the pod's usage would never be removed from the cache. DeletePodByKey is
+	// idempotent, so double-removal is safe.
+	return len(e.Object.Spec.NodeName) > 0 && !utiltas.IsTAS(e.Object)
 }
 
 func (r *NonTasUsageReconciler) Generic(event.TypedGenericEvent[*corev1.Pod]) bool {

--- a/pkg/controller/tas/non_tas_usage_controller_test.go
+++ b/pkg/controller/tas/non_tas_usage_controller_test.go
@@ -76,7 +76,7 @@ func TestBelongsToNonTASCache(t *testing.T) {
 	}
 }
 
-func TestNonTasUsageReconcilerCreateDelete(t *testing.T) {
+func TestNonTasUsageReconcilerCreate(t *testing.T) {
 	reconciler := &NonTasUsageReconciler{}
 
 	tests := []struct {
@@ -114,6 +114,50 @@ func TestNonTasUsageReconcilerCreateDelete(t *testing.T) {
 			if got := reconciler.Create(event.TypedCreateEvent[*corev1.Pod]{Object: tc.pod}); got != tc.want {
 				t.Errorf("Create() = %v, want %v", got, tc.want)
 			}
+		})
+	}
+}
+
+func TestNonTasUsageReconcilerDelete(t *testing.T) {
+	reconciler := &NonTasUsageReconciler{}
+
+	// Delete should return true for any scheduled non-TAS pod regardless of phase,
+	// so that we always attempt to remove it from the cache. The informer may deliver
+	// the Delete event with the pod already Succeeded if it missed the Running→Succeeded
+	// Update; without reconciling in that case, the pod's usage would never be subtracted.
+	// DeletePodByKey is idempotent, so double-removal is safe.
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{
+			name: "scheduled non-TAS pod",
+			pod:  testingpod.MakePod("pod", "ns").NodeName("node-a").Obj(),
+			want: true,
+		},
+		{
+			name: "unscheduled pod",
+			pod:  testingpod.MakePod("pod", "ns").Obj(),
+			want: false,
+		},
+		{
+			name: "scheduled TAS pod",
+			pod: testingpod.MakePod("pod", "ns").
+				NodeName("node-a").
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, "rack").
+				Obj(),
+			want: false,
+		},
+		{
+			name: "terminated scheduled non-TAS pod",
+			pod:  testingpod.MakePod("pod", "ns").NodeName("node-a").StatusPhase(corev1.PodSucceeded).Obj(),
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			if got := reconciler.Delete(event.TypedDeleteEvent[*corev1.Pod]{Object: tc.pod}); got != tc.want {
 				t.Errorf("Delete() = %v, want %v", got, tc.want)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
The NonTasUsageReconciler.Delete predicate was delegating to belongsToNonTASCache, which filters out terminated pods (Succeeded/Failed). This created a correctness hole: if the informer skips the Running→Terminated Update event and delivers only the Delete event with the pod already in a terminal phase, the predicate returns false and no reconciliation is triggered — leaving the pod's resource usage permanently stuck in the non-TAS cache.

#### The Fix:
Broaden the Delete predicate to pass through any scheduled non-TAS pod regardless of phase. 
The Create predicate is intentionally left unchanged — there's no value in tracking a pod that was already terminal when the cache first saw it.

Related to get tests passing for: https://github.com/kubernetes-sigs/kueue/pull/10806

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Fixed cache cleanup for non-TAS Pods that reach a terminal phase without Kueue observing the expected status update, preventing stale Pod usage from remaining in the TAS cache.
```
