### PR TITLE
Ensure generate-apiref waits for generate-code to avoid flaky verify …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -471,7 +471,7 @@ kueuectl:
 	CGO_ENABLED=$(CGO_ENABLED) $(GO_BUILD_ENV) $(GO_CMD) build -ldflags="$(LD_FLAGS)" -o $(BIN_DIR)/kubectl-kueue cmd/kueuectl/main.go
 
 .PHONY: generate-apiref
-generate-apiref: genref
+generate-apiref: genref generate-code
 	cd $(PROJECT_DIR)/hack/genref/ && $(GENREF) -o $(PROJECT_DIR)/site/content/en/docs/reference
 
 ##@ Documentation


### PR DESCRIPTION
…runs.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Ensure generate-apiref waits for generate-code to avoid flaky verify runs.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11000 

#### Special notes for your reviewer:
https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_kueue/10999/pull-kueue-verify-main/2052265488649555968/build-log.txt

We can see there is a problem with genref docs generation, my theory is because we run make in parallel, `code-generation` target could be ran in parralel with `generate-apiref`, and that is why `make verify` failed. I think we should ensure that `generate-apiref` waits until code generation complete.

`verify-checks` -> `verify-ci-lint` -> `verify-tree-prereqs` -> `verify-docs-prereqs` -> `generate-apiref` 

```
make -j 8 --output-sync=target verify-checks
<...>
cd /home/prow/go/src/sigs.k8s.io/kueue/hack/genref/ && /home/prow/go/src/sigs.k8s.io/kueue/bin/genref -o /home/prow/go/src/sigs.k8s.io/kueue/site/content/en/docs/reference
I0507 06:00:34.503998   25635 main.go:142] Parsing go packages in sigs.k8s.io/kueue/apis/kueue/v1beta1
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
