### PR TITLE
Reduce idleTimeoutSeconds to 10 seconds for RayJob in test

### DIFF
--- a/pkg/util/testingjobs/rayjob/wrappers.go
+++ b/pkg/util/testingjobs/rayjob/wrappers.go
@@ -344,7 +344,7 @@ func (j *JobWrapper) Annotation(key string, value string) *JobWrapper {
 func (j *JobWrapper) EnableInTreeAutoscaling() *JobWrapper {
 	enable := true
 	aggressive := rayv1.UpscalingMode("Aggressive")
-	idleTimeoutSeconds := int32(60)
+	idleTimeoutSeconds := int32(10)
 	j.Spec.RayClusterSpec.EnableInTreeAutoscaling = &enable
 	j.Spec.RayClusterSpec.AutoscalerOptions = &rayv1.AutoscalerOptions{
 		UpscalingMode:      &aggressive,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Previously idleTimeoutSeconds was 60 seconds, a bit too long, reduce to 10 seconds to reduce test run time.

Then change already in 0.17 branch. Bring it back to main branch.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
