### PR TITLE
cmd/experimental/agent/skills: Convert skills to directory layout

### DIFF
--- a/Makefile-verify.mk
+++ b/Makefile-verify.mk
@@ -15,6 +15,8 @@
 ##@ Verify
 
 GO_FMT ?= gofmt
+CONTAINER_ENGINE ?= $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
+SKILLSAW_IMAGE ?= ghcr.io/stbenjam/skillsaw:0.6.0
 VERIFY_NPROCS ?= 8
 # Output sync mode for parallel verification. Set to empty to disable.
 # Requires GNU Make 4.0+. Values: target, line, recurse, or empty.
@@ -89,7 +91,7 @@ verify-tree-prereqs: verify-go-prereqs verify-docs-prereqs verify-helm-prereqs
 ## Read-only verification targets that should not mutate the repo.
 ## Add new check-only targets here.
 verify-checks: ## Phase 2 (parallel): checks that should run after generation completes.
-verify-checks: verify-ci-lint verify-lint-api verify-fmt-verify verify-shell-lint verify-helm-verify verify-helm-unit-test verify-npm-depcheck verify-kustomize-build
+verify-checks: verify-ci-lint verify-lint-api verify-fmt-verify verify-shell-lint verify-helm-verify verify-helm-unit-test verify-npm-depcheck verify-kustomize-build verify-skills-lint
 
 # ---- Shared check recipes -------------------------------------------------
 # Each recipe is stored in a variable so that both the lightweight standalone
@@ -154,6 +156,11 @@ define _kustomize_build_verify_recipe
 $(KUSTOMIZE) build config/alpha-enabled > /dev/null
 endef
 
+# Validates skills against https://agentskills.io/specification
+define _skills_lint_recipe
+$(CONTAINER_ENGINE) run --rm -v $(PROJECT_DIR):/workspace:Z $(SKILLSAW_IMAGE) --strict cmd/experimental/agent/skills/
+endef
+
 
 # ---- verify-* wrappers (generation prereqs + shared recipe) ---------------
 
@@ -188,6 +195,10 @@ verify-npm-depcheck: verify-tree-prereqs prepare-release-branch ## Depcheck afte
 .PHONY: verify-kustomize-build
 verify-kustomize-build: verify-tree-prereqs kustomize ## Verify alpha-enabled manifests render after generation
 	$(_kustomize_build_verify_recipe)
+
+.PHONY: verify-skills-lint
+verify-skills-lint: ## Lint agent skills with skillsaw
+	$(_skills_lint_recipe)
 
 # ---- Standalone targets (lightweight, for local use) ----------------------
 
@@ -238,6 +249,10 @@ npm-depcheck: ## Verify frontend and e2e npm dependencies.
 .PHONY: kustomize-build-verify
 kustomize-build-verify: kustomize ## Validate alpha-enabled manifests render.
 	$(_kustomize_build_verify_recipe)
+
+.PHONY: skills-lint
+skills-lint: ## Lint agent skills with skillsaw.
+	$(_skills_lint_recipe)
 
 .PHONY: verify-website-links
 verify-website-links: ## Check for broken internal links on the public website.

--- a/cmd/experimental/agent/skills/README.md
+++ b/cmd/experimental/agent/skills/README.md
@@ -2,10 +2,6 @@
 
 | Skill | Triggers on |
 |---|---|
-| [kueue-who-preempted](kueue-who-preempted.md) | "who preempted my workload", "why was my workload evicted", "what kicked out my job", preemption investigation |
-| [kueue-lineage](kueue-lineage.md) | "what pods are running for my workload", "trace workload to pods", "show me the jobs for this workload", lineage/ownership questions |
-| [kueue-flake-debugger](kueue-flake-debugger.md) | "debug a flake", "investigate test failure", "test timed out", "CI flake" |
-
-@kueue-who-preempted.md
-@kueue-lineage.md
-@kueue-flake-debugger.md
+| [kueue-who-preempted](kueue-who-preempted/SKILL.md) | "who preempted my workload", "why was my workload evicted", "what kicked out my job", preemption investigation |
+| [kueue-lineage](kueue-lineage/SKILL.md) | "what pods are running for my workload", "trace workload to pods", "show me the jobs for this workload", lineage/ownership questions |
+| [kueue-flake-debugger](kueue-flake-debugger/SKILL.md) | "debug a flake", "investigate test failure", "test timed out", "CI flake" |

--- a/cmd/experimental/agent/skills/kueue-flake-debugger/SKILL.md
+++ b/cmd/experimental/agent/skills/kueue-flake-debugger/SKILL.md
@@ -1,15 +1,9 @@
 ---
 name: kueue-flake-debugger
-description: Expertise in debugging Kueue flakes
+description: Debug Kueue CI flakes. Use when a user asks to debug a flake, investigate a test failure, a test timeout, or a CI flake. Analyzes Prow build logs, kube-scheduler logs, kubelet logs, and test code to identify root causes.
 ---
 
-# Kueue flake debugger
-
 You are an expert in Kueue which is the project for Workload orchestration.
-
-## Expertise
-
-- Deep understanding of Kueue.
 
 ## Flake debugging
 

--- a/cmd/experimental/agent/skills/kueue-lineage/SKILL.md
+++ b/cmd/experimental/agent/skills/kueue-lineage/SKILL.md
@@ -1,4 +1,7 @@
-# Skill: Trace Workload Lineage to Pods
+---
+name: kueue-lineage
+description: Trace workload lineage to pods. Use when a user wants to trace lineage across any tier such as workload to pods, pod to workload, or job to workload. The user may provide a resource at any level (Workload, Job, Pod, JobSet, etc.) and this skill produces the full tree from Workload down to Pods.
+---
 
 Use this when a user wants to trace lineage across any tier: workload → pods, pod → workload, job → workload, etc. The user may provide a resource at **any level** (Workload, Job, Pod, JobSet, etc.) — always produce the full tree from Workload down to Pods.
 

--- a/cmd/experimental/agent/skills/kueue-who-preempted/SKILL.md
+++ b/cmd/experimental/agent/skills/kueue-who-preempted/SKILL.md
@@ -1,4 +1,7 @@
-# Skill: Who Preempted My Workload
+---
+name: kueue-who-preempted
+description: Identify what preempted a workload. Use when a user asks why their workload was evicted or preempted, or wants to identify what preempted it. Investigates Kubernetes events, workload status conditions, and controller logs to trace preemption.
+---
 
 Use this when a user asks why their workload was evicted or preempted, or wants to identify what preempted it.
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Converts agent skills from flat `.md` files to a directory layout (`<skill-name>/SKILL.md`)
with YAML frontmatter containing `name` and `description` fields. This aligns with the
skillsaw tool's expected format and enables structured linting.

Changes:
- Rename `kueue-who-preempted.md` → `kueue-who-preempted/SKILL.md` with frontmatter
- Rename `kueue-lineage.md` → `kueue-lineage/SKILL.md` with frontmatter
- Rename `kueue-flake-debugger.md` → `kueue-flake-debugger/SKILL.md` with frontmatter
- Update `README.md` links to new paths, remove `@` include directives
- Add `verify-skills-lint` / `skills-lint` Make targets using skillsaw container

#### Which issue(s) this PR fixes:

Fixes #11061

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

---
> **AI Assistance Disclosure**: This pull request was created with the assistance of AI (Claude Code by Anthropic).