### PR TITLE
Improve formatting of objects in ginkgo failed multikueue asserts

### DIFF
--- a/test/e2e/multikueue/baseline/e2e_test.go
+++ b/test/e2e/multikueue/baseline/e2e_test.go
@@ -29,7 +29,6 @@ import (
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	"github.com/onsi/gomega/format"
 	awv1beta2 "github.com/project-codeflare/appwrapper/api/v1beta2"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -1391,18 +1390,22 @@ app = HelloWorld.bind()`,
 			ginkgo.By("Checking that the workload is created and admitted in the manager cluster", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sManagerClient.Get(ctx, wlKey, managerWl)).To(gomega.Succeed())
-					g.Expect(workload.IsAdmitted(managerWl)).To(gomega.BeTrue(), assertMsg("Workload not admitted in manager", wlKey))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(managerWl)).To(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed(), assertWlMsg("Workload not admitted in manager", managerWl))
 			})
 
 			ginkgo.By("Checking that the workload is created on worker1", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sWorker1Client.Get(ctx, wlKey, workerWorkload)).To(gomega.Succeed())
-					g.Expect(workload.IsAdmitted(workerWorkload)).To(gomega.BeTrue(), assertMsg("Workload not admitted in worker1", wlKey))
+					g.Expect(workload.IsAdmitted(workerWorkload)).To(gomega.BeTrue())
 					g.Expect(workerWorkload.Spec).To(gomega.BeComparableTo(managerWl.Spec))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed(), assertWlMsg("Workload not admitted in worker1", workerWorkload))
+			})
 
-					g.Expect(k8sWorker2Client.Get(ctx, wlKey, workerWorkload)).To(utiltesting.BeNotFoundError(), assertMsg("Workload present in worker2", wlKey))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			ginkgo.By("Checking that the workload is not created on worker2", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sWorker2Client.Get(ctx, wlKey, workerWorkload)).To(utiltesting.BeNotFoundError())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed(), assertWlMsg("Workload present in worker2", workerWorkload))
 			})
 
 			ginkgo.By("Switching worker cluster queues' resources to enforce re-admission on the worker2", func() {
@@ -1436,18 +1439,22 @@ app = HelloWorld.bind()`,
 			ginkgo.By("Checking that the workload is re-admitted in worker2", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sManagerClient.Get(ctx, wlKey, managerWl)).To(gomega.Succeed())
-					g.Expect(managerWl.Status.ClusterName).To(gomega.HaveValue(gomega.Equal(workerCluster2.Name)), assertMsg("Workload not Admitted in worker2", wlKey))
-				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+					g.Expect(managerWl.Status.ClusterName).To(gomega.HaveValue(gomega.Equal(workerCluster2.Name)))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed(), assertWlMsg("Workload not Admitted in worker2", managerWl))
 			})
 
 			ginkgo.By("Checking that the workload is created in worker2", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sWorker2Client.Get(ctx, wlKey, workerWorkload)).To(gomega.Succeed())
-					g.Expect(workload.IsAdmitted(workerWorkload)).To(gomega.BeTrue(), assertMsg("Workload not Admitted in worker2", wlKey))
+					g.Expect(workload.IsAdmitted(workerWorkload)).To(gomega.BeTrue())
 					g.Expect(workerWorkload.Spec).To(gomega.BeComparableTo(managerWl.Spec))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed(), assertWlMsg("Workload not Admitted in worker2", workerWorkload))
+			})
 
-					g.Expect(k8sWorker1Client.Get(ctx, wlKey, workerWorkload)).To(utiltesting.BeNotFoundError(), assertMsg("Workload present in worker1", wlKey))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			ginkgo.By("Checking that the workload is not created in worker1", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sWorker1Client.Get(ctx, wlKey, workerWorkload)).To(utiltesting.BeNotFoundError())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed(), assertWlMsg("Workload present in worker1", workerWorkload))
 			})
 		})
 
@@ -1985,23 +1992,24 @@ func expectJobToBeCreatedAndManagedBy(ctx context.Context, c client.Client, job 
 	}, util.Timeout, util.Interval).Should(gomega.Succeed())
 }
 
-func assertMsg(msg string, wlKey client.ObjectKey) func() string {
+func assertWlMsg(msg string, wl *kueue.Workload) func() string {
 	return func() string {
-		output := &strings.Builder{}
-		fmt.Fprintln(output, msg)
-		withClusterWl(output, wlKey, "Manager", k8sManagerClient)
-		withClusterWl(output, wlKey, "Worker1", k8sWorker1Client)
-		withClusterWl(output, wlKey, "Worker2", k8sWorker2Client)
-		return output.String()
+		wlKey := client.ObjectKeyFromObject(wl)
+		return strings.Join([]string{
+			util.AssertMsg(msg, wl)(),
+			util.AssertMsg("Manager", getWorkload(k8sManagerClient, wlKey))(),
+			util.AssertMsg("Worker1", getWorkload(k8sWorker1Client, wlKey))(),
+			util.AssertMsg("Worker2", getWorkload(k8sWorker2Client, wlKey))(),
+		}, "\n")
 	}
 }
 
-func withClusterWl(output *strings.Builder, wlKey client.ObjectKey, cName string, cClient client.Client) {
+func getWorkload(c client.Client, wlKey client.ObjectKey) *kueue.Workload {
 	wl := &kueue.Workload{}
-	if err := cClient.Get(ctx, wlKey, wl); err == nil {
-		fmt.Fprintln(output, cName, "Workload:", format.Object(wl.ObjectMeta, 1))
-		fmt.Fprintln(output, cName, "Status:", format.Object(wl.Status, 1))
-	} else {
-		fmt.Fprintln(output, "Workload not present in:", cName, "Error:", err)
+	err := c.Get(ctx, wlKey, wl)
+	if err != nil {
+		gomega.Expect(client.IgnoreNotFound(err)).NotTo(gomega.HaveOccurred())
+		return nil
 	}
+	return wl
 }

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -174,7 +174,11 @@ func AssertMsg[T runtime.Object](message string, objs ...T) func() string {
 		var output strings.Builder
 		fmt.Fprintln(&output, message)
 		for _, obj := range objs {
-			fmt.Fprintln(&output, format.Object(obj, 1))
+			objYAML, ok := formatK8sObject(obj)
+			if !ok {
+				objYAML = format.Object(obj, 1)
+			}
+			fmt.Fprintln(&output, objYAML)
 		}
 		return output.String()
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area testing

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Improve formatting of objects in ginkgo failed multikueue asserts

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11063

#### Special notes for your reviewer:

```
Workload not admitted in manager
metadata:
  creationTimestamp: "2026-05-11T11:05:28Z"
  finalizers:
  - kueue.x-k8s.io/resource-in-use
  generation: 1
  labels:
    kueue.x-k8s.io/job-uid: 6812c1a7-f945-405a-a7a0-fad33f7b4b8f
  managedFields:
  - apiVersion: kueue.x-k8s.io/v1beta2
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:labels:
          f:kueue.x-k8s.io/job-uid: {}
      f:status:
        f:admission:
          f:clusterQueue: {}
          f:podSetAssignments:
            k:{"name":"main"}:
              .: {}
              f:count: {}
              f:flavors:
                f:cpu: {}
                f:example.com/gpu-h100: {}
                f:memory: {}
              f:name: {}
              f:resourceUsage:
                f:cpu: {}
                f:example.com/gpu-h100: {}
                f:memory: {}
        f:admissionChecks:
          k:{"name":"ac1-tcjjm"}:
            .: {}
            f:lastTransitionTime: {}
            f:message: {}
            f:name: {}
            f:state: {}
        f:clusterName: {}
        f:conditions:
          k:{"type":"Admitted"}:
            .: {}
            f:lastTransitionTime: {}
            f:message: {}
            f:observedGeneration: {}
            f:reason: {}
            f:status: {}
            f:type: {}
          k:{"type":"QuotaReserved"}:
            .: {}
            f:lastTransitionTime: {}
            f:message: {}
            f:observedGeneration: {}
            f:reason: {}
            f:status: {}
            f:type: {}
    manager: kueue-admission
    operation: Apply
    subresource: status
    time: "2026-05-11T11:05:28Z"
  - apiVersion: kueue.x-k8s.io/v1beta2
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:finalizers:
          .: {}
          v:"kueue.x-k8s.io/resource-in-use": {}
        f:labels:
          .: {}
          f:kueue.x-k8s.io/job-uid: {}
        f:ownerReferences:
          .: {}
          k:{"uid":"6812c1a7-f945-405a-a7a0-fad33f7b4b8f"}: {}
      f:spec:
        .: {}
        f:active: {}
        f:podSets:
          .: {}
          k:{"name":"main"}:
            .: {}
            f:count: {}
            f:name: {}
            f:template:
              .: {}
              f:metadata:
                .: {}
                f:labels:
                  .: {}
                  f:batch.kubernetes.io/job-name: {}
              f:spec:
                .: {}
                f:containers:
                  .: {}
                  k:{"name":"c"}:
                    .: {}
                    f:image: {}
                    f:imagePullPolicy: {}
                    f:name: {}
                    f:resources:
                      .: {}
                      f:limits:
                        .: {}
                        f:cpu: {}
                        f:example.com/gpu-h100: {}
                        f:memory: {}
                      f:requests:
                        .: {}
                        f:cpu: {}
                        f:example.com/gpu-h100: {}
                        f:memory: {}
                    f:terminationMessagePath: {}
                    f:terminationMessagePolicy: {}
                f:dnsPolicy: {}
                f:restartPolicy: {}
                f:schedulerName: {}
                f:securityContext: {}
                f:terminationGracePeriodSeconds: {}
            f:topologyRequest:
              .: {}
              f:podIndexLabel: {}
        f:priority: {}
        f:priorityClassRef:
          .: {}
          f:group: {}
          f:kind: {}
          f:name: {}
        f:queueName: {}
    manager: kueue
    operation: Update
    time: "2026-05-11T11:05:28Z"
  - apiVersion: kueue.x-k8s.io/v1beta2
    fieldsType: FieldsV1
    fieldsV1:
      f:status:
        .: {}
        f:admissionChecks:
          .: {}
          k:{"name":"ac1-tcjjm"}:
            .: {}
            f:lastTransitionTime: {}
            f:name: {}
    manager: kueue
    operation: Update
    subresource: status
    time: "2026-05-11T11:05:28Z"
  name: job-job-832e0
  namespace: multikueue-w4cl2
  ownerReferences:
  - apiVersion: batch/v1
    blockOwnerDeletion: true
    controller: true
    kind: Job
    name: job
    uid: 6812c1a7-f945-405a-a7a0-fad33f7b4b8f
  resourceVersion: "4429"
  uid: 31761fe9-faf4-42c9-80fa-0d99d2a26e30
spec:
  active: true
  podSets:
  - count: 1
    name: main
    template:
      metadata:
        labels:
          batch.kubernetes.io/job-name: job
      spec:
        containers:
        - image: registry.k8s.io/pause:non-existing
          imagePullPolicy: IfNotPresent
          name: c
          resources:
            limits:
              cpu: 100m
              example.com/gpu-h100: "2"
              memory: 100M
            requests:
              cpu: 100m
              example.com/gpu-h100: "2"
              memory: 100M
          terminationMessagePath: /dev/termination-log
          terminationMessagePolicy: File
        dnsPolicy: ClusterFirst
        restartPolicy: Never
        schedulerName: default-scheduler
        securityContext: {}
        terminationGracePeriodSeconds: 30
    topologyRequest:
      podIndexLabel: batch.kubernetes.io/job-completion-index
  priority: 100
  priorityClassRef:
    group: kueue.x-k8s.io
    kind: WorkloadPriorityClass
    name: low-workload-n9g7s
  queueName: q1-77kpr
status:
  admission:
    clusterQueue: q1-77kpr
    podSetAssignments:
    - count: 1
      flavors:
        cpu: default-tp2rx
        example.com/gpu-h100: default-tp2rx
        memory: default-tp2rx
      name: main
      resourceUsage:
        cpu: 100m
        example.com/gpu-h100: "2"
        memory: 100M
  admissionChecks:
  - lastTransitionTime: "2026-05-11T11:05:28Z"
    message: The workload got reservation on "worker1-kqn4x"
    name: ac1-tcjjm
    state: Ready
  clusterName: worker1-kqn4x
  conditions:
  - lastTransitionTime: "2026-05-11T11:05:28Z"
    message: Quota reserved in ClusterQueue q1-77kpr
    observedGeneration: 1
    reason: QuotaReserved
    status: "True"
    type: QuotaReserved
  - lastTransitionTime: "2026-05-11T11:05:28Z"
    message: The workload is admitted
    observedGeneration: 1
    reason: Admitted
    status: "True"
    type: Admitted
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
