### PR TITLE
test: split e2e TAS tests into baseline and extended 

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -162,7 +162,13 @@ test-multikueue-e2e-helm: E2E_USE_HELM=true
 test-multikueue-e2e-helm: test-multikueue-e2e
 
 .PHONY: test-tas-e2e
-test-tas-e2e: setup-e2e-env kind-ray-project-mini-image-build run-test-tas-e2e-$(E2E_KIND_VERSION:kindest/node:v%=%)
+test-tas-e2e: test-tas-e2e-baseline test-tas-e2e-extended
+
+.PHONY: test-tas-e2e-baseline
+test-tas-e2e-baseline: setup-e2e-env run-test-tas-e2e-baseline-$(E2E_KIND_VERSION:kindest/node:v%=%)
+
+.PHONY: test-tas-e2e-extended
+test-tas-e2e-extended: setup-e2e-env kind-ray-project-mini-image-build run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-tas-e2e-helm
 test-tas-e2e-helm: E2E_USE_HELM=true
@@ -246,9 +252,23 @@ run-test-multikueue-e2e-%:
 		E2E_USE_HELM=$(E2E_USE_HELM) \
 		./hack/testing/e2e-multikueue-test.sh
 
-run-test-tas-e2e-%: K8S_VERSION = $(@:run-test-tas-e2e-%=%)
-run-test-tas-e2e-%:
-	@echo Running tas e2e for k8s ${K8S_VERSION}
+run-test-tas-e2e-baseline-%: K8S_VERSION = $(@:run-test-tas-e2e-baseline-%=%)
+run-test-tas-e2e-baseline-%:
+	@echo Running tas e2e baseline for k8s ${K8S_VERSION}
+	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
+		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
+		E2E_MODE=$(E2E_MODE) \
+		E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
+		E2E_ENFORCE_OPERATOR_UPDATE=$(E2E_ENFORCE_OPERATOR_UPDATE) \
+		KIND_CLUSTER_FILE="kind-cluster-tas.yaml" E2E_TARGET_FOLDER="tas/baseline" \
+		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
+		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
+		E2E_USE_HELM=$(E2E_USE_HELM) \
+		./hack/testing/e2e-test.sh
+
+run-test-tas-e2e-extended-%: K8S_VERSION = $(@:run-test-tas-e2e-extended-%=%)
+run-test-tas-e2e-extended-%:
+	@echo Running tas e2e extended for k8s ${K8S_VERSION}
 	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
 		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
 		E2E_MODE=$(E2E_MODE) \
@@ -259,7 +279,7 @@ run-test-tas-e2e-%:
 		LEADERWORKERSET_VERSION=$(LEADERWORKERSET_VERSION) \
 		KUBERAY_VERSION=$(KUBERAY_VERSION) RAY_VERSION=$(RAY_VERSION) RAYMINI_VERSION=$(RAYMINI_VERSION) USE_RAY_FOR_TESTS=$(USE_RAY_FOR_TESTS) \
 		KUBEFLOW_TRAINER_VERSION=$(KUBEFLOW_TRAINER_VERSION) \
-		KIND_CLUSTER_FILE="kind-cluster-tas.yaml" E2E_TARGET_FOLDER="tas" \
+		KIND_CLUSTER_FILE="kind-cluster-tas.yaml" E2E_TARGET_FOLDER="tas/extended" \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
 		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		E2E_USE_HELM=$(E2E_USE_HELM) \

--- a/site/content/en/docs/contribution_guidelines/testing.md
+++ b/site/content/en/docs/contribution_guidelines/testing.md
@@ -57,7 +57,8 @@ For running a subset of tests, see [Running subset of tests](#running-subset-of-
 ```shell
 make kind-image-build
 make test-e2e
-make test-tas-e2e
+make test-tas-e2e-baseline
+make test-tas-e2e-extended
 make test-e2e-sequential-extended
 make test-e2e-sequential-baseline
 make test-e2e-certmanager
@@ -276,7 +277,8 @@ ginkgo.FIt("Should place pods based on the ranks-ordering", func() {
 and then run
 ```shell
 # build and pull image
-make test-tas-e2e
+make test-tas-e2e-baseline
+make test-tas-e2e-extended
 ```
 to test a particular TAS e2e test.
 

--- a/site/content/zh-CN/docs/contribution_guidelines/testing.md
+++ b/site/content/zh-CN/docs/contribution_guidelines/testing.md
@@ -57,7 +57,8 @@ make test-integration
 ```shell
 make kind-image-build
 make test-e2e
-make test-tas-e2e
+make test-tas-e2e-baseline
+make test-tas-e2e-extended
 make test-e2e-sequential-extended
 make test-e2e-sequential-baseline
 make test-e2e-certmanager
@@ -177,7 +178,8 @@ ginkgo.FIt("Should place pods based on the ranks-ordering", func() {
 然后运行
 ```shell
 # 构建并拉取镜像
-make test-tas-e2e
+make test-tas-e2e-baseline
+make test-tas-e2e-extended
 ```
 来测试特定的 TAS e2e 测试。
 

--- a/test/e2e/tas/baseline/helpers_test.go
+++ b/test/e2e/tas/baseline/helpers_test.go
@@ -1,0 +1,23 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package baseline
+
+const (
+	instanceType      = "tas-group"
+	tasNodeGroupLabel = "cloud.provider.com/node-group"
+	extraResource     = "example.com/gpu"
+)

--- a/test/e2e/tas/baseline/job_test.go
+++ b/test/e2e/tas/baseline/job_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tas
+package baseline
 
 import (
 	"fmt"
@@ -36,12 +36,6 @@ import (
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/test/util"
-)
-
-const (
-	instanceType      = "tas-group"
-	tasNodeGroupLabel = "cloud.provider.com/node-group"
-	extraResource     = "example.com/gpu"
 )
 
 var _ = ginkgo.Describe("TopologyAwareScheduling for Job", func() {

--- a/test/e2e/tas/baseline/pod_group_test.go
+++ b/test/e2e/tas/baseline/pod_group_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tas
+package baseline
 
 import (
 	"github.com/onsi/ginkgo/v2"

--- a/test/e2e/tas/baseline/statefulset_test.go
+++ b/test/e2e/tas/baseline/statefulset_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tas
+package baseline
 
 import (
 	"github.com/onsi/ginkgo/v2"

--- a/test/e2e/tas/baseline/suite_test.go
+++ b/test/e2e/tas/baseline/suite_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package baseline
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
+	clientutil "sigs.k8s.io/kueue/pkg/util/client"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var (
+	k8sClient       client.WithWatch
+	ctx             context.Context
+	defaultKueueCfg *configapi.Configuration
+	kindClusterName = os.Getenv("KIND_CLUSTER_NAME")
+)
+
+func TestAPIs(t *testing.T) {
+	util.RunE2ESuite(t, "End To End TAS Baseline Suite")
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	util.SetupLogger()
+
+	var err error
+	k8sClient, _, err = util.CreateClientUsingCluster("")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	ctx = ginkgo.GinkgoT().Context()
+
+	defaultKueueCfg = util.GetKueueConfiguration(ctx, k8sClient)
+
+	waitForAvailableStart := time.Now()
+	util.WaitForKueueAvailability(ctx, k8sClient)
+	ginkgo.GinkgoLogr.Info(
+		"Kueue and all required operators are available in the cluster",
+		"waitingTime", time.Since(waitForAvailableStart),
+	)
+
+	nodes := &corev1.NodeList{}
+	requiredLabels := client.MatchingLabels{}
+	requiredLabelKeys := client.HasLabels{tasNodeGroupLabel}
+	err = k8sClient.List(ctx, nodes, requiredLabels, requiredLabelKeys)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to list nodes for TAS")
+
+	for _, n := range nodes.Items {
+		gomega.Eventually(func(g gomega.Gomega) {
+			node := &corev1.Node{}
+			g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: n.Name}, node)).To(gomega.Succeed())
+			err := clientutil.PatchStatus(ctx, k8sClient, node, func() (bool, error) {
+				node.Status.Capacity[extraResource] = resource.MustParse("1")
+				node.Status.Allocatable[extraResource] = resource.MustParse("1")
+				return true, nil
+			})
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	}
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
+})

--- a/test/e2e/tas/extended/appwrapper_test.go
+++ b/test/e2e/tas/extended/appwrapper_test.go
@@ -14,27 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tas
+package extended
 
 import (
-	"fmt"
-
-	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	awv1beta2 "github.com/project-codeflare/appwrapper/api/v1beta2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
-	testingpytorchjob "sigs.k8s.io/kueue/pkg/util/testingjobs/pytorchjob"
+	awtesting "sigs.k8s.io/kueue/pkg/util/testingjobs/appwrapper"
+	utiltestingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for PyTorchJob", func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", func() {
 	var (
 		ns           *corev1.Namespace
 		topology     *kueue.Topology
@@ -44,7 +43,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for PyTorchJob", func() {
 	)
 
 	ginkgo.BeforeEach(func() {
-		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-tas-pytorchjob-")
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-tas-aw-")
 
 		topology = utiltestingapi.MakeDefaultThreeLevelTopology("datacenter")
 		util.MustCreate(ctx, k8sClient, topology)
@@ -69,7 +68,6 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for PyTorchJob", func() {
 		util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
 	})
 	ginkgo.AfterEach(func() {
-		gomega.Expect(util.DeleteAllPyTorchJobsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
@@ -77,48 +75,31 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for PyTorchJob", func() {
 		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
 	})
 
-	ginkgo.When("Creating a PyTorchJob", func() {
-		ginkgo.It("Should place pods based on the ranks-ordering", func() {
-			const (
-				masterReplicas = 1
-				workerReplicas = 3
-			)
+	ginkgo.When("Creating an AppWrapper", func() {
+		ginkgo.It("Should place pods", func() {
+			numPods := 4
 
-			numPods := masterReplicas + workerReplicas
-
-			pytorchjob := testingpytorchjob.MakePyTorchJob("ranks-pytorch", ns.Name).
+			aw := awtesting.MakeAppWrapper("appwrapper", ns.Name).
+				Component(awtesting.Component{
+					Template: utiltestingjob.MakeJob("job-0", ns.Name).
+						Parallelism(int32(numPods)).
+						Completions(int32(numPods)).
+						RequestAndLimit(corev1.ResourceCPU, "200m").
+						RequestAndLimit(extraResource, "1").
+						Suspend(false).
+						Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+						PodAnnotation(kueue.PodSetPreferredTopologyAnnotation, utiltesting.DefaultRackTopologyLevel).
+						SetTypeMeta().Obj(),
+				}).
 				Queue(localQueue.Name).
-				PyTorchReplicaSpecs(
-					testingpytorchjob.PyTorchReplicaSpecRequirement{
-						ReplicaType:   kftraining.PyTorchJobReplicaTypeMaster,
-						ReplicaCount:  masterReplicas,
-						RestartPolicy: kftraining.RestartPolicyOnFailure,
-						Annotations: map[string]string{
-							kueue.PodSetPreferredTopologyAnnotation: utiltesting.DefaultRackTopologyLevel,
-						},
-						Image: util.GetAgnHostImage(),
-						Args:  util.BehaviorExitFast,
-					},
-					testingpytorchjob.PyTorchReplicaSpecRequirement{
-						ReplicaType:   kftraining.PyTorchJobReplicaTypeWorker,
-						ReplicaCount:  workerReplicas,
-						RestartPolicy: kftraining.RestartPolicyOnFailure,
-						Annotations: map[string]string{
-							kueue.PodSetPreferredTopologyAnnotation: utiltesting.DefaultBlockTopologyLevel,
-						},
-						Image: util.GetAgnHostImage(),
-						Args:  util.BehaviorExitFast,
-					},
-				).
-				RequestAndLimit(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceCPU, "200m").
-				RequestAndLimit(kftraining.PyTorchJobReplicaTypeWorker, extraResource, "1").
 				Obj()
-			util.MustCreate(ctx, k8sClient, pytorchjob)
 
-			ginkgo.By("PyTorchJob is unsuspended", func() {
+			util.MustCreate(ctx, k8sClient, aw)
+
+			ginkgo.By("AppWrapper is unsuspended", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pytorchjob), pytorchjob)).To(gomega.Succeed())
-					g.Expect(pytorchjob.Spec.RunPolicy.Suspend).Should(gomega.Equal(ptr.To(false)))
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(aw), aw)).To(gomega.Succeed())
+					g.Expect(aw.Spec.Suspend).Should(gomega.BeFalse())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -139,28 +120,64 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for PyTorchJob", func() {
 					g.Expect(pods.Items).Should(gomega.HaveLen(numPods))
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
+		})
+
+		ginkgo.It("Should place pods based on the ranks-ordering", func() {
+			numPods := 4
+			wrappedJob := utiltestingjob.MakeJob("ranks-job", ns.Name).
+				Parallelism(int32(numPods)).
+				Completions(int32(numPods)).
+				Indexed(true).
+				Suspend(false).
+				RequestAndLimit(extraResource, "1").
+				PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, utiltesting.DefaultBlockTopologyLevel).
+				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+				SetTypeMeta().
+				Obj()
+			aw := awtesting.MakeAppWrapper("aw-ranks-job", ns.Name).
+				Component(awtesting.Component{Template: wrappedJob}).
+				Queue(localQueue.Name).
+				Obj()
+
+			util.MustCreate(ctx, k8sClient, aw)
+
+			ginkgo.By("AppWrapper is unsuspended, and has all Pods active and ready", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(aw), aw)).To(gomega.Succeed())
+					g.Expect(aw.Spec.Suspend).Should(gomega.BeFalse())
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(aw), aw)).To(gomega.Succeed())
+					g.Expect(aw.Status.Phase).Should(gomega.Equal(awv1beta2.AppWrapperRunning))
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			pods := &corev1.PodList{}
+			ginkgo.By("ensure all pods are created and scheduled", func() {
+				listOpts := &client.ListOptions{
+					FieldSelector: fields.OneTermNotEqualSelector("spec.nodeName", ""),
+				}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name), listOpts)).To(gomega.Succeed())
+					g.Expect(pods.Items).Should(gomega.HaveLen(numPods))
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
 
 			ginkgo.By("verify the assignment of pods are as expected with rank-based ordering", func() {
 				gomega.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
-				gotAssignment := readRankAssignmentsFromPyTorchJobPods(pods.Items)
+				gotAssignment := make(map[string]string, numPods)
+				for _, pod := range pods.Items {
+					index := pod.Labels[batchv1.JobCompletionIndexAnnotation]
+					gotAssignment[index] = pod.Spec.NodeName
+				}
 				wantAssignment := map[string]string{
-					"worker/0": "kind-worker",
-					"worker/1": "kind-worker2",
-					"worker/2": "kind-worker3",
+					"0": "kind-worker",
+					"1": "kind-worker2",
+					"2": "kind-worker3",
+					"3": "kind-worker4",
 				}
 				gomega.Expect(wantAssignment).Should(gomega.BeComparableTo(gotAssignment))
 			})
 		})
 	})
 })
-
-func readRankAssignmentsFromPyTorchJobPods(pods []corev1.Pod) map[string]string {
-	assignment := make(map[string]string, len(pods))
-	for _, pod := range pods {
-		if role := pod.Labels[kftraining.ReplicaTypeLabel]; role == "worker" {
-			key := fmt.Sprintf("%s/%s", role, pod.Labels[kftraining.ReplicaIndexLabel])
-			assignment[key] = pod.Spec.NodeName
-		}
-	}
-	return assignment
-}

--- a/test/e2e/tas/extended/helpers_test.go
+++ b/test/e2e/tas/extended/helpers_test.go
@@ -1,0 +1,23 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extended
+
+const (
+	instanceType      = "tas-group"
+	tasNodeGroupLabel = "cloud.provider.com/node-group"
+	extraResource     = "example.com/gpu"
+)

--- a/test/e2e/tas/extended/hotswap_test.go
+++ b/test/e2e/tas/extended/hotswap_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tas
+package extended
 
 import (
 	"context"

--- a/test/e2e/tas/extended/jobset_test.go
+++ b/test/e2e/tas/extended/jobset_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tas
+package extended
 
 import (
 	"fmt"

--- a/test/e2e/tas/extended/leaderworkerset_test.go
+++ b/test/e2e/tas/extended/leaderworkerset_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tas
+package extended
 
 import (
 	"fmt"

--- a/test/e2e/tas/extended/mpijob_test.go
+++ b/test/e2e/tas/extended/mpijob_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tas
+package extended
 
 import (
 	"fmt"

--- a/test/e2e/tas/extended/pytorch_test.go
+++ b/test/e2e/tas/extended/pytorch_test.go
@@ -14,26 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tas
+package extended
 
 import (
+	"fmt"
+
+	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	awv1beta2 "github.com/project-codeflare/appwrapper/api/v1beta2"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
-	awtesting "sigs.k8s.io/kueue/pkg/util/testingjobs/appwrapper"
-	utiltestingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
+	testingpytorchjob "sigs.k8s.io/kueue/pkg/util/testingjobs/pytorchjob"
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for PyTorchJob", func() {
 	var (
 		ns           *corev1.Namespace
 		topology     *kueue.Topology
@@ -43,7 +44,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", func() {
 	)
 
 	ginkgo.BeforeEach(func() {
-		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-tas-aw-")
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-tas-pytorchjob-")
 
 		topology = utiltestingapi.MakeDefaultThreeLevelTopology("datacenter")
 		util.MustCreate(ctx, k8sClient, topology)
@@ -68,6 +69,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", func() {
 		util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
 	})
 	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteAllPyTorchJobsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
@@ -75,31 +77,48 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", func() {
 		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
 	})
 
-	ginkgo.When("Creating an AppWrapper", func() {
-		ginkgo.It("Should place pods", func() {
-			numPods := 4
+	ginkgo.When("Creating a PyTorchJob", func() {
+		ginkgo.It("Should place pods based on the ranks-ordering", func() {
+			const (
+				masterReplicas = 1
+				workerReplicas = 3
+			)
 
-			aw := awtesting.MakeAppWrapper("appwrapper", ns.Name).
-				Component(awtesting.Component{
-					Template: utiltestingjob.MakeJob("job-0", ns.Name).
-						Parallelism(int32(numPods)).
-						Completions(int32(numPods)).
-						RequestAndLimit(corev1.ResourceCPU, "200m").
-						RequestAndLimit(extraResource, "1").
-						Suspend(false).
-						Image(util.GetAgnHostImage(), util.BehaviorExitFast).
-						PodAnnotation(kueue.PodSetPreferredTopologyAnnotation, utiltesting.DefaultRackTopologyLevel).
-						SetTypeMeta().Obj(),
-				}).
+			numPods := masterReplicas + workerReplicas
+
+			pytorchjob := testingpytorchjob.MakePyTorchJob("ranks-pytorch", ns.Name).
 				Queue(localQueue.Name).
+				PyTorchReplicaSpecs(
+					testingpytorchjob.PyTorchReplicaSpecRequirement{
+						ReplicaType:   kftraining.PyTorchJobReplicaTypeMaster,
+						ReplicaCount:  masterReplicas,
+						RestartPolicy: kftraining.RestartPolicyOnFailure,
+						Annotations: map[string]string{
+							kueue.PodSetPreferredTopologyAnnotation: utiltesting.DefaultRackTopologyLevel,
+						},
+						Image: util.GetAgnHostImage(),
+						Args:  util.BehaviorExitFast,
+					},
+					testingpytorchjob.PyTorchReplicaSpecRequirement{
+						ReplicaType:   kftraining.PyTorchJobReplicaTypeWorker,
+						ReplicaCount:  workerReplicas,
+						RestartPolicy: kftraining.RestartPolicyOnFailure,
+						Annotations: map[string]string{
+							kueue.PodSetPreferredTopologyAnnotation: utiltesting.DefaultBlockTopologyLevel,
+						},
+						Image: util.GetAgnHostImage(),
+						Args:  util.BehaviorExitFast,
+					},
+				).
+				RequestAndLimit(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceCPU, "200m").
+				RequestAndLimit(kftraining.PyTorchJobReplicaTypeWorker, extraResource, "1").
 				Obj()
+			util.MustCreate(ctx, k8sClient, pytorchjob)
 
-			util.MustCreate(ctx, k8sClient, aw)
-
-			ginkgo.By("AppWrapper is unsuspended", func() {
+			ginkgo.By("PyTorchJob is unsuspended", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(aw), aw)).To(gomega.Succeed())
-					g.Expect(aw.Spec.Suspend).Should(gomega.BeFalse())
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pytorchjob), pytorchjob)).To(gomega.Succeed())
+					g.Expect(pytorchjob.Spec.RunPolicy.Suspend).Should(gomega.Equal(ptr.To(false)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -120,64 +139,28 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", func() {
 					g.Expect(pods.Items).Should(gomega.HaveLen(numPods))
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
-		})
-
-		ginkgo.It("Should place pods based on the ranks-ordering", func() {
-			numPods := 4
-			wrappedJob := utiltestingjob.MakeJob("ranks-job", ns.Name).
-				Parallelism(int32(numPods)).
-				Completions(int32(numPods)).
-				Indexed(true).
-				Suspend(false).
-				RequestAndLimit(extraResource, "1").
-				PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, utiltesting.DefaultBlockTopologyLevel).
-				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
-				SetTypeMeta().
-				Obj()
-			aw := awtesting.MakeAppWrapper("aw-ranks-job", ns.Name).
-				Component(awtesting.Component{Template: wrappedJob}).
-				Queue(localQueue.Name).
-				Obj()
-
-			util.MustCreate(ctx, k8sClient, aw)
-
-			ginkgo.By("AppWrapper is unsuspended, and has all Pods active and ready", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(aw), aw)).To(gomega.Succeed())
-					g.Expect(aw.Spec.Suspend).Should(gomega.BeFalse())
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(aw), aw)).To(gomega.Succeed())
-					g.Expect(aw.Status.Phase).Should(gomega.Equal(awv1beta2.AppWrapperRunning))
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			pods := &corev1.PodList{}
-			ginkgo.By("ensure all pods are created and scheduled", func() {
-				listOpts := &client.ListOptions{
-					FieldSelector: fields.OneTermNotEqualSelector("spec.nodeName", ""),
-				}
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name), listOpts)).To(gomega.Succeed())
-					g.Expect(pods.Items).Should(gomega.HaveLen(numPods))
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
-			})
 
 			ginkgo.By("verify the assignment of pods are as expected with rank-based ordering", func() {
 				gomega.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
-				gotAssignment := make(map[string]string, numPods)
-				for _, pod := range pods.Items {
-					index := pod.Labels[batchv1.JobCompletionIndexAnnotation]
-					gotAssignment[index] = pod.Spec.NodeName
-				}
+				gotAssignment := readRankAssignmentsFromPyTorchJobPods(pods.Items)
 				wantAssignment := map[string]string{
-					"0": "kind-worker",
-					"1": "kind-worker2",
-					"2": "kind-worker3",
-					"3": "kind-worker4",
+					"worker/0": "kind-worker",
+					"worker/1": "kind-worker2",
+					"worker/2": "kind-worker3",
 				}
 				gomega.Expect(wantAssignment).Should(gomega.BeComparableTo(gotAssignment))
 			})
 		})
 	})
 })
+
+func readRankAssignmentsFromPyTorchJobPods(pods []corev1.Pod) map[string]string {
+	assignment := make(map[string]string, len(pods))
+	for _, pod := range pods {
+		if role := pod.Labels[kftraining.ReplicaTypeLabel]; role == "worker" {
+			key := fmt.Sprintf("%s/%s", role, pod.Labels[kftraining.ReplicaIndexLabel])
+			assignment[key] = pod.Spec.NodeName
+		}
+	}
+	return assignment
+}

--- a/test/e2e/tas/extended/rayjob_test.go
+++ b/test/e2e/tas/extended/rayjob_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tas
+package extended
 
 import (
 	"github.com/onsi/ginkgo/v2"

--- a/test/e2e/tas/extended/suite_test.go
+++ b/test/e2e/tas/extended/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tas
+package extended
 
 import (
 	"context"
@@ -41,7 +41,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	util.RunE2ESuite(t, "End To End TAS Suite")
+	util.RunE2ESuite(t, "End To End TAS Extended Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {

--- a/test/e2e/tas/extended/trainjob_test.go
+++ b/test/e2e/tas/extended/trainjob_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tas
+package extended
 
 import (
 	"fmt"


### PR DESCRIPTION
What type of PR is this?
/kind cleanup
/area tas
/area testing

What this PR does / why we need it:
Cherry-pick of #11002 into release-0.17.
Splits the TAS e2e test suite into baseline and extended shards
to reduce CI wall-clock time for PRs.

Which issue this PR fixes:
Part of #10995

Special notes for your reviewer:
Cherry-pick of #11002

Does this PR introduce a user-facing change?

```release-note
NONE
```