### PR TITLE
AgentSkills: Add code-eval skill, that evaluates diff code based on defined rules …

### DIFF
--- a/cmd/experimental/skills/README.md
+++ b/cmd/experimental/skills/README.md
@@ -6,7 +6,7 @@
 | [kueue-lineage](kueue-lineage/SKILL.md) | "what pods are running for my workload", "trace workload to pods", "show me the jobs for this workload", lineage/ownership questions |
 | [kueue-flake-debugger](kueue-flake-debugger/SKILL.md) | "debug a flake", "investigate test failure", "test timed out", "CI flake" |
 | [kueue-release-notes](kueue-release-notes/SKILL.md) | Review or propose a concise PR release note focused on the user-observable change. |
-| [reviewer/](reviewer/README.md) | "review this PR", "review this code", any code review of kueue changes |
+| [reviewer/](reviewer/README.md) | "review this PR", "review this code", "evaluate this diff", "score these commits", "review the changes between", "code quality evaluation", any code review of kueue changes |
 
 ---
 

--- a/cmd/experimental/skills/reviewer/README.md
+++ b/cmd/experimental/skills/reviewer/README.md
@@ -23,6 +23,46 @@ Each skill is independent and can be applied in parallel with the others. When r
 | [api-field-comments](api-field-comments/SKILL.md) | new CRD field missing godoc comment or enum value descriptions |
 | [race-conditions](race-conditions/SKILL.md) | snapshot/mirror field added to protect a reader from a concurrent writer |
 | [visibility-exports](visibility-exports/SKILL.md) | new exported function or method with no callers outside the package |
+| [code-eval](code-eval/SKILL.md) | runs code evaluation and produces a scored report |
+| [architectural-decisions](architectural-decisions/SKILL.md) | domain — unjustified complexity, duplicated logic across types/adapters, scope creep, or misplaced code (see ToC inside) |
+| [buggy-behavior](buggy-behavior/SKILL.md) | domain — logic errors, broken edge cases, feature-gate bugs, deletions that break backwards compatibility during rolling upgrades (see ToC inside) |
+| [code-style](code-style/SKILL.md) | domain — imprecise names, convention drift, reinvented helpers, wrong log verbosity, misaligned test names, typos (see ToC inside) |
+| [comments](comments/SKILL.md) | domain — over-commenting, what-not-why narration, inaccurate comments, missing TODOs on compatibility shims (see ToC inside) |
+| [security](security/SKILL.md) | domain — input-validation gaps, injection, DoS, nil-safety crashes, authz relaxation, info disclosure, supply-chain weakening, webhook safety regressions (see ToC inside) |
+| [imprecise-names](code-style/imprecise-names/SKILL.md) | identifier whose name does not describe exactly what it contains (code-style) |
+| [convention-drift](code-style/convention-drift/SKILL.md) | new code that breaks naming conventions already established in the same file or package (code-style) |
+| [reinvented-helpers](code-style/reinvented-helpers/SKILL.md) | logic that duplicates an existing util/helper function instead of reusing it (code-style) |
+| [wrong-log-verbosity](code-style/wrong-log-verbosity/SKILL.md) | per-reconcile-cycle log lines emitted at `V(2)` (code-style) |
+| [misaligned-test-names](code-style/misaligned-test-names/SKILL.md) | test function names that do not reflect the function or behavior under test (code-style) |
+| [code-style-typos](code-style/code-style-typos/SKILL.md) | typos in identifiers, strings, or any text introduced by the diff (code-style) |
+| [illogical-structure](architectural-decisions/illogical-structure/SKILL.md) | code a future maintainer will struggle to follow, modify, or extend (architectural-decisions) |
+| [nonsensical-decisions](architectural-decisions/nonsensical-decisions/SKILL.md) | unnecessary indirection, mismatched abstractions, confusing data flow (architectural-decisions) |
+| [avoidable-complexity](architectural-decisions/avoidable-complexity/SKILL.md) | solutions more elaborate than the problem requires (architectural-decisions) |
+| [pointless-intermediate-variables](architectural-decisions/pointless-intermediate-variables/SKILL.md) | redundant local variables that add noise without clarity (architectural-decisions) |
+| [duplicated-logic](architectural-decisions/duplicated-logic/SKILL.md) | identical blocks across types/adapters/call sites that should be shared — or new helpers with one caller (architectural-decisions) |
+| [scope-creep](architectural-decisions/scope-creep/SKILL.md) | diffs bundling a bugfix with an unrelated refactor, or over-generalizing a change (architectural-decisions) |
+| [misplaced-logic](architectural-decisions/misplaced-logic/SKILL.md) | code placed somewhere a reader would not expect to find it (architectural-decisions) |
+| [logic-errors](buggy-behavior/logic-errors/SKILL.md) | incorrect conditionals, inverted checks, off-by-one, unhandled edge cases, races, mishandled errors (buggy-behavior) |
+| [deleted-backwards-compatibility-code](buggy-behavior/deleted-backwards-compatibility-code/SKILL.md) | removal or relocation of code that reconciles state owned by previous controller versions (buggy-behavior) |
+| [feature-gate-interaction-bugs](buggy-behavior/feature-gate-interaction-bugs/SKILL.md) | gated behavior whose gate-off path is untested or incorrect (buggy-behavior) |
+| [unnecessary-guard-conditions](buggy-behavior/unnecessary-guard-conditions/SKILL.md) | extra checks that are logically unreachable at the call site (buggy-behavior) |
+| [over-commenting](comments/over-commenting/SKILL.md) | comments that explain what self-documenting code already says (comments) |
+| [wrong-kind-of-comment](comments/wrong-kind-of-comment/SKILL.md) | comments describing *what* instead of *why* (comments) |
+| [inaccurate-comments](comments/inaccurate-comments/SKILL.md) | comments or docstrings that no longer match the code (comments) |
+| [missing-deferred-removal-markers](comments/missing-deferred-removal-markers/SKILL.md) | compatibility shim kept without a deferred-removal comment (comments) |
+| [comment-typos](comments/comment-typos/SKILL.md) | typos and obvious errors in comment text (comments) |
+| [input-validation](security/input-validation/SKILL.md) | missing validation on user-settable CR fields, webhook payloads, labels, annotations, or untrusted deserialization (security) |
+| [injection](security/injection/SKILL.md) | exec/SSRF/template/query/selector built from user-supplied strings (security) |
+| [path-traversal](security/path-traversal/SKILL.md) | file paths or archive extraction without root containment (security) |
+| [resource-bounds-dos](security/resource-bounds-dos/SKILL.md) | uncapped loops/allocations, missing timeouts, reconciler-wedging input, unbounded metric labels (security) |
+| [nil-safety](security/nil-safety/SKILL.md) | unguarded dereferences from malformed CRs; goroutines without recover (security) |
+| [authn-authz-relaxation](security/authn-authz-relaxation/SKILL.md) | webhook token skipping, failurePolicy Ignore, wildcard RBAC, privileged pod specs (security) |
+| [information-disclosure](security/information-disclosure/SKILL.md) | full-object logging, request echoing, credentials in status/annotations, kubeconfig logging (security) |
+| [supply-chain-hygiene](security/supply-chain-hygiene/SKILL.md) | unpinned images, TLS bypass, unjustified replace directives, curl\|sh, moving-tag Actions (security) |
+| [annotation-label-namespace-abuse](security/annotation-label-namespace-abuse/SKILL.md) | generic annotation/label loops that copy or forward values (security) |
+| [feature-gated-insecure-paths](security/feature-gated-insecure-paths/SKILL.md) | gated behavior whose security assumptions fail when accidentally enabled (security) |
+| [integration-adapter-trust-boundary](security/integration-adapter-trust-boundary/SKILL.md) | adapters reading credential-like fields from third-party CRDs without treating them as untrusted (security) |
+| [webhook-safety-regressions](security/webhook-safety-regressions/SKILL.md) | loosened failurePolicy, shortened timeouts, TLS bypass, non-idempotent mutating webhooks (security) |
 
 @table-driven-tests/SKILL.md
 @encapsulate-paired-ops/SKILL.md
@@ -39,3 +79,43 @@ Each skill is independent and can be applied in parallel with the others. When r
 @api-field-comments/SKILL.md
 @race-conditions/SKILL.md
 @visibility-exports/SKILL.md
+@code-eval/SKILL.md
+@architectural-decisions/SKILL.md
+@buggy-behavior/SKILL.md
+@code-style/SKILL.md
+@comments/SKILL.md
+@security/SKILL.md
+@code-style/imprecise-names/SKILL.md
+@code-style/convention-drift/SKILL.md
+@code-style/reinvented-helpers/SKILL.md
+@code-style/wrong-log-verbosity/SKILL.md
+@code-style/misaligned-test-names/SKILL.md
+@code-style/code-style-typos/SKILL.md
+@architectural-decisions/illogical-structure/SKILL.md
+@architectural-decisions/nonsensical-decisions/SKILL.md
+@architectural-decisions/avoidable-complexity/SKILL.md
+@architectural-decisions/pointless-intermediate-variables/SKILL.md
+@architectural-decisions/duplicated-logic/SKILL.md
+@architectural-decisions/scope-creep/SKILL.md
+@architectural-decisions/misplaced-logic/SKILL.md
+@buggy-behavior/logic-errors/SKILL.md
+@buggy-behavior/deleted-backwards-compatibility-code/SKILL.md
+@buggy-behavior/feature-gate-interaction-bugs/SKILL.md
+@buggy-behavior/unnecessary-guard-conditions/SKILL.md
+@comments/over-commenting/SKILL.md
+@comments/wrong-kind-of-comment/SKILL.md
+@comments/inaccurate-comments/SKILL.md
+@comments/missing-deferred-removal-markers/SKILL.md
+@comments/comment-typos/SKILL.md
+@security/input-validation/SKILL.md
+@security/injection/SKILL.md
+@security/path-traversal/SKILL.md
+@security/resource-bounds-dos/SKILL.md
+@security/nil-safety/SKILL.md
+@security/authn-authz-relaxation/SKILL.md
+@security/information-disclosure/SKILL.md
+@security/supply-chain-hygiene/SKILL.md
+@security/annotation-label-namespace-abuse/SKILL.md
+@security/feature-gated-insecure-paths/SKILL.md
+@security/integration-adapter-trust-boundary/SKILL.md
+@security/webhook-safety-regressions/SKILL.md

--- a/cmd/experimental/skills/reviewer/architectural-decisions/SKILL.md
+++ b/cmd/experimental/skills/reviewer/architectural-decisions/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: architectural-decisions
+description: Review a diff for small-scale structural problems — unjustified complexity, duplicated logic, scope creep, or misplaced code.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Architectural Decisions
+
+Use this when reviewing a diff for small-scale structural problems: how code is organized,
+how parts connect, and whether complexity is justified. Complex problems may need complex
+solutions, but every unit of complexity must earn its keep.
+
+## Rules
+
+Each rule in this domain is its own sub-skill. Scan the diff for violations of every
+rule below.
+
+| Rule | Triggers on |
+|---|---|
+| [illogical-structure](./illogical-structure/SKILL.md) | code a future maintainer will struggle to follow, modify, or extend |
+| [nonsensical-decisions](./nonsensical-decisions/SKILL.md) | unnecessary indirection, mismatched abstractions, confusing data flow |
+| [avoidable-complexity](./avoidable-complexity/SKILL.md) | solutions more elaborate than the problem requires |
+| [pointless-intermediate-variables](./pointless-intermediate-variables/SKILL.md) | redundant local variables that add noise without clarity |
+| [duplicated-logic](./duplicated-logic/SKILL.md) | identical blocks across types/adapters/call sites that should be shared — or new helpers with one caller |
+| [scope-creep](./scope-creep/SKILL.md) | diffs bundling a bugfix with an unrelated refactor, or over-generalizing a change |
+| [misplaced-logic](./misplaced-logic/SKILL.md) | code placed somewhere a reader would not expect to find it |
+
+@./illogical-structure/SKILL.md
+@./nonsensical-decisions/SKILL.md
+@./avoidable-complexity/SKILL.md
+@./pointless-intermediate-variables/SKILL.md
+@./duplicated-logic/SKILL.md
+@./scope-creep/SKILL.md
+@./misplaced-logic/SKILL.md
+
+## What not to include
+
+Do not report personal preferences or architectural taste. This skill is for structural
+problems that materially hurt maintainability, simplicity, or evolution of the code.
+
+In particular, do not flag:
+
+- a design choice simply because you would have organized the code differently;
+- small helpers, wrappers, locals, or indirections that are reasonable in context, even if
+  you would personally inline or restructure them;
+- broad redesign ideas unless the current structure creates a concrete maintenance risk,
+  ambiguous ownership, duplicated change burden, or extension hazard.
+
+## How to report
+
+For each finding, cite the exact file and line, name which rule it violates, and
+classify severity (high / medium / low). Severity scales with how much the issue hurts
+maintainability, simplicity, or backward compatibility. Decisions that make the code
+materially harder to extend are high; cosmetic structural nits are low.
+
+Return two sections:
+
+### Findings
+
+A bullet list, one per violation, in this format:
+
+```
+- <High/Medium/Low> | <Finding Title>: <one-sentence explanation grounded in the diff>
+```
+
+### Recommendations
+
+One recommendation per finding above, numbered sequentially within this skill. Each
+recommendation MUST contain all four sections below.
+
+```
+### Recommendation N: <short title>
+
+**Problem**: Describe the specific issue in the diff.
+**Reason**: Explain why this is a problem — what goes wrong or degrades over time.
+**Solution**: Give a concrete, actionable fix. Where possible, show a before/after code snippet.
+**Locations**: List every place this issue occurs, one per line, in `filepath:line` form.
+```

--- a/cmd/experimental/skills/reviewer/architectural-decisions/avoidable-complexity/SKILL.md
+++ b/cmd/experimental/skills/reviewer/architectural-decisions/avoidable-complexity/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: avoidable-complexity
+description: Flag solutions more elaborate than the problem requires — complexity that exists only because the author reached for a pattern.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Avoidable Complexity
+
+**Avoidable complexity** — solutions that are more elaborate than the problem requires.
+Do not flag necessary complexity; do flag complexity that exists only because the
+author reached for a pattern.

--- a/cmd/experimental/skills/reviewer/architectural-decisions/duplicated-logic/SKILL.md
+++ b/cmd/experimental/skills/reviewer/architectural-decisions/duplicated-logic/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: duplicated-logic
+description: Flag identical (or near-identical) blocks across types/adapters/call sites that should live in a shared helper — and newly extracted helpers with only one caller.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Duplicated Logic Across Types/Adapters/Call Sites
+
+**Duplicated logic across types/adapters/call sites** — identical (or near-identical)
+blocks that should live in a single shared helper. Conversely, flag a *newly extracted*
+helper that has only one caller and no clear near-term reuse.

--- a/cmd/experimental/skills/reviewer/architectural-decisions/illogical-structure/SKILL.md
+++ b/cmd/experimental/skills/reviewer/architectural-decisions/illogical-structure/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: illogical-structure
+description: Flag code organization that a future maintainer will struggle to follow, modify, or extend.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Illogical or Hard-to-Maintain Structure
+
+**Illogical or hard-to-maintain structure** — code that a future maintainer will
+struggle to follow, modify, or extend.

--- a/cmd/experimental/skills/reviewer/architectural-decisions/misplaced-logic/SKILL.md
+++ b/cmd/experimental/skills/reviewer/architectural-decisions/misplaced-logic/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: misplaced-logic
+description: Flag code put somewhere a reader would not expect to find it — cleanup scattered across callers, validation deep in business logic.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Misplaced Logic
+
+**Misplaced logic** — code put somewhere a reader would not expect to find it.
+Cleanup belongs inside the `Delete` path, not scattered across callers; validation
+belongs at the trust boundary, not deep in business logic.

--- a/cmd/experimental/skills/reviewer/architectural-decisions/nonsensical-decisions/SKILL.md
+++ b/cmd/experimental/skills/reviewer/architectural-decisions/nonsensical-decisions/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: nonsensical-decisions
+description: Flag unnecessary indirection, mismatched abstractions, or confusing data flow that obscures what the code is doing.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Nonsensical Decisions
+
+**Nonsensical decisions** — unnecessary indirection, mismatched abstractions, or
+confusing data flow that obscures what the code is actually doing.

--- a/cmd/experimental/skills/reviewer/architectural-decisions/pointless-intermediate-variables/SKILL.md
+++ b/cmd/experimental/skills/reviewer/architectural-decisions/pointless-intermediate-variables/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: pointless-intermediate-variables
+description: Flag redundant local variables that add noise without adding clarity.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Pointless Intermediate Variables
+
+**Pointless intermediate variables** — `x := foo.Bar; use(x)` where `use(foo.Bar)` is
+equally clear. Redundant locals add noise without adding clarity.

--- a/cmd/experimental/skills/reviewer/architectural-decisions/scope-creep/SKILL.md
+++ b/cmd/experimental/skills/reviewer/architectural-decisions/scope-creep/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: scope-creep
+description: Flag diffs that bundle a bugfix with an unrelated refactor, or generalize a change to all types when only one type needs it.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Scope Creep
+
+**Scope creep** — diffs that bundle a bugfix with an unrelated refactor, or that
+generalize a change to all types when only one type needs it. Prefer the smallest
+change that resolves the stated problem and nothing else.

--- a/cmd/experimental/skills/reviewer/buggy-behavior/SKILL.md
+++ b/cmd/experimental/skills/reviewer/buggy-behavior/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: buggy-behavior
+description: Review a diff for behavioral defects — logic errors, broken edge cases, feature-gate bugs, and deletions that break backwards compatibility during rolling upgrades.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Buggy Behavior
+
+Use this when reviewing a diff for behavioral defects: logic errors, broken edge cases,
+and changes that break compatibility with objects created by older versions of the
+controller.
+
+## Rules
+
+Each rule in this domain is its own sub-skill. Scan the diff for violations of every
+rule below.
+
+| Rule | Triggers on |
+|---|---|
+| [logic-errors](./logic-errors/SKILL.md) | incorrect conditionals, inverted checks, off-by-one, unhandled edge cases, races, mishandled errors |
+| [deleted-backwards-compatibility-code](./deleted-backwards-compatibility-code/SKILL.md) | removal or relocation of code that reconciles state owned by previous controller versions |
+| [feature-gate-interaction-bugs](./feature-gate-interaction-bugs/SKILL.md) | gated behavior whose gate-off path is untested or incorrect |
+| [unnecessary-guard-conditions](./unnecessary-guard-conditions/SKILL.md) | extra checks that are logically unreachable at the call site |
+
+@./logic-errors/SKILL.md
+@./deleted-backwards-compatibility-code/SKILL.md
+@./feature-gate-interaction-bugs/SKILL.md
+@./unnecessary-guard-conditions/SKILL.md
+
+## How to report
+
+Cite the exact file and line, describe the failure mode (what input triggers it, what
+goes wrong), and classify severity (high / medium / low). Hot-path logic errors and
+deleted compatibility code are high. Untested gate-off paths are typically medium.
+Stray unreachable guards are low.
+
+Return two sections:
+
+### Findings
+
+A bullet list, one per violation, in this format:
+
+```
+- <High/Medium/Low> | <Finding Title>: <one-sentence explanation grounded in the diff>
+```
+
+### Recommendations
+
+One recommendation per finding above, numbered sequentially within this skill. Each
+recommendation MUST contain all four sections below.
+
+```
+### Recommendation N: <short title>
+
+**Problem**: Describe the specific issue in the diff.
+**Reason**: Explain why this is a problem — what goes wrong or degrades over time.
+**Solution**: Give a concrete, actionable fix. Where possible, show a before/after code snippet.
+**Locations**: List every place this issue occurs, one per line, in `filepath:line` form.
+```

--- a/cmd/experimental/skills/reviewer/buggy-behavior/deleted-backwards-compatibility-code/SKILL.md
+++ b/cmd/experimental/skills/reviewer/buggy-behavior/deleted-backwards-compatibility-code/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: deleted-backwards-compatibility-code
+description: Hard blocker — flag removal or relocation of code that manages cluster state owned by previous controller versions.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Deleted Backwards-Compatibility Code
+
+**Deleted backwards-compatibility code** — this is a **hard blocker**. If the diff
+removes or relocates code that manages cluster state owned by previous versions
+(finalizer cleanup, annotation/label migration, ownership reconciliation, CRD field
+handling), think through a rolling upgrade: objects created by the old version must
+still be reconciled to a terminal state by the new version — finalizers removed,
+obsolete annotations dropped, status converged. Deleting finalizer-removal logic, for
+example, will leave pre-existing objects stuck forever.

--- a/cmd/experimental/skills/reviewer/buggy-behavior/feature-gate-interaction-bugs/SKILL.md
+++ b/cmd/experimental/skills/reviewer/buggy-behavior/feature-gate-interaction-bugs/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: feature-gate-interaction-bugs
+description: Flag feature-gated behavior whose gate-off path is incorrect — early returns that skip cleanup, or state set only when on but read unconditionally.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Feature-Gate Interaction Bugs
+
+**Feature-gate interaction bugs** — when the diff adds behavior guarded by a feature
+flag, verify correctness in **both** states. An untested gate-off path is a latent
+bug. Look especially for: early returns that skip required cleanup when the gate is
+off, or new state set only when the gate is on but read unconditionally.

--- a/cmd/experimental/skills/reviewer/buggy-behavior/logic-errors/SKILL.md
+++ b/cmd/experimental/skills/reviewer/buggy-behavior/logic-errors/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: logic-errors
+description: Flag incorrect conditionals, inverted boolean checks, off-by-one errors, unhandled edge cases, race conditions, or mishandled error returns.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Logic Errors
+
+**Logic errors** — incorrect conditionals, inverted boolean checks, off-by-one errors,
+unhandled edge cases (empty slices, nil maps, zero values), race conditions, or
+mishandled error returns. Trace each new branch and ask: what input lands here, and
+is the outcome correct?

--- a/cmd/experimental/skills/reviewer/buggy-behavior/unnecessary-guard-conditions/SKILL.md
+++ b/cmd/experimental/skills/reviewer/buggy-behavior/unnecessary-guard-conditions/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: unnecessary-guard-conditions
+description: Flag extra checks that are logically unreachable at the call site — they add noise and can mask future regressions.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Unnecessary Guard Conditions
+
+**Unnecessary guard conditions** — extra checks that are logically unreachable at the
+call site. They are a mild correctness concern: they add noise, suggest the author
+was uncertain about an invariant, and can mask a future regression that breaks the
+invariant they were silently relying on.

--- a/cmd/experimental/skills/reviewer/code-eval/SKILL.md
+++ b/cmd/experimental/skills/reviewer/code-eval/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: code-eval
+description: Evaluate the quality of a git diff between two commits by delegating per-skill analysis (Code Style, Buggy Behavior, Comments, Architectural Decisions, Security) to subagents, then aggregating their findings and recommendations into a scored report.
+argument-hint: <BaseCommit> <HeadCommit>
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Code Evaluation Skill
+
+Evaluate the quality of a git diff between two commits. Each evaluation skill listed
+below contributes findings and recommendations for one domain of concern; this skill's
+job is to fan out to each one in parallel, then assemble the results into a single
+scored report.
+
+Use this when the user wants a code-quality evaluation. If the user expresses the need
+without providing **BaseCommit** and **HeadCommit**, ask them for both before
+proceeding.
+
+## Arguments
+
+The user invoked this with: $ARGUMENTS
+
+Parse two positional arguments from `$ARGUMENTS`:
+- **BaseCommit** — the base (older) commit
+- **HeadCommit** — the head (newer) commit
+
+## Principles
+
+- Ground every penalty in a specific line or pattern from the diff. No vague criticism.
+- Do not penalize stylistic choices that are consistent with the surrounding code, even if you personally prefer something else.
+- Do not invent bugs that aren't there. If the code looks correct, say so.
+- Reward simplicity. If the diff is clean and well-structured, say so explicitly — a clean diff scores 0 in every domain.
+- Severity matters: backwards-compatibility violations and logic errors on the hot path are more serious than naming nits. Reflect this in point weights.
+- **Higher score = worse code.** Every finding adds points; nothing subtracts. There is no upper cap.
+
+## Step 1 — Retrieve the diff
+
+Run:
+```
+git diff <BaseCommit> <HeadCommit>
+```
+
+Read the full output. This is the **Diff Code** that the subagent evaluators will work
+against.
+
+Also run:
+```
+git diff <BaseCommit> <HeadCommit> --stat
+```
+
+to get a high-level overview of changed files for the final report.
+
+## Step 2 — Fan out to per-domain subagents
+
+For each **domain** in the table below, spawn one subagent **in parallel** (single
+message, multiple Agent tool calls). One subagent per domain — not one per sub-skill.
+Each domain SKILL.md is a table-of-contents over many small rule sub-skills and
+inlines them via `@<rule>/SKILL.md` references. Each subagent must:
+
+1. Read the domain SKILL.md end-to-end. That file pulls in every rule sub-skill in the
+   domain plus the shared "How to report" instructions.
+2. Read the diff between `<BaseCommit>` and `<HeadCommit>` and load enough surrounding
+   context (unchanged lines, nearby functions, imports, existing helpers, log-verbosity
+   conventions in the package) to make grounded judgments.
+3. Identify every violation of any rule sub-skill in the domain.
+4. Classify each violation as **high**, **medium**, or **low**.
+5. Return findings AND recommendations in the format defined in the domain SKILL.md.
+
+Domains:
+| Domain | Domain weight |
+|---|---|
+| [../architectural-decisions/SKILL.md](../architectural-decisions/SKILL.md) | 1.5 |
+| [../code-style/SKILL.md](../code-style/SKILL.md) | 1.0 |
+| [../buggy-behavior/SKILL.md](../buggy-behavior/SKILL.md) | 2.0 |
+| [../comments/SKILL.md](../comments/SKILL.md) | 0.5 |
+| [../security/SKILL.md](../security/SKILL.md) | 2.0 |
+
+The domain weight is a multiplier applied to every finding in that domain — bugs and
+security defects cost more than style issues, comments cost less.
+
+This skill does **not** perform the rule-checking itself. Its job is to dispatch,
+gather, score, and format.
+
+## Step 3 — Reclassify and Score each skill
+
+Each skill starts at **0** points. Every finding **adds** points based on its severity,
+multiplied by the domain weight. There is no cap — the more findings (and the worse
+they are), the higher the score. **A higher score means worse code quality.** A clean
+domain with no findings scores 0.
+
+Base severity weights (before domain multiplier):
+
+- **High** = 15 pt
+- **Medium** = 4 pt
+- **Low** = 1 pt
+
+Per-finding points = base severity weight × domain weight.
+
+Per-domain score = sum of points across all findings in that domain.
+
+Final score = sum of all per-domain scores. No floor, no ceiling.
+
+Use these severity definitions when reviewing or reclassifying subagent findings:
+
+- **High** — the finding describes a concrete defect or design problem with serious impact,
+  such as a hot-path panic, data corruption or loss, broken backward compatibility,
+  incorrect admission or scheduling behavior, security boundary violation, or a public/API
+  semantic mismatch that is likely to mislead maintainers or users.
+- **Medium** — the finding describes a real issue with meaningful but narrower impact,
+  such as a realistic edge-case bug, feature-gate behavior leak, maintainability problem
+  likely to cause follow-up bugs, wrong high-volume log verbosity, or misleading naming or
+  comments that materially reduce readability.
+- **Low** — the finding describes a real but minor issue with limited impact, such as a
+  small convention drift, low-risk structural noise, isolated typo in important text, or
+  minor comment/style issue that is still worth cleaning up.
+
+Each finding could be mislabeled or misclassified, so you must reclassify each finding
+based on the actual impact shown by the diff and surrounding code, not only on the label
+returned by the subagent.
+
+## Step 4 — Produce the report
+
+Output the evaluation in this exact structure (skills and scores are examples; the set
+of skills is whatever appears in the table above):
+
+```
+## Code Evaluation Report
+
+**Commits**: <BaseCommit>..<HeadCommit>
+**Files changed**: (from --stat output)
+
+**Note**: Higher score = worse code. 0 means no findings in that domain.
+
+---
+
+### Skill: Code Style (weight <weight defined in Skills table>)
+**Domain score**: X pt  (sum of all findings below)
+**Findings**: (bullet list of specific observations, in accordance with the rules in the skill file)
+  - <High/Medium/Low> | +x pt | <Finding Title>: <Explanation>
+
+### Skill: Buggy Behavior (weight <weight defined in Skills table>)
+**Domain score**: 0 pt
+**Findings**:
+  - No findings
+
+### Skill: Comments (weight <weight defined in Skills table>)
+**Domain score**: 0 pt
+**Findings**:
+  - No findings
+
+### Skill: Architectural Decisions (weight <weight defined in Skills table>)
+**Domain score**: X pt
+**Findings**:
+  - <High/Medium/Low> | +x pt | <Finding Title>: <Explanation>
+
+### Skill: Security (weight <weight defined in Skills table>)
+**Domain score**: X pt
+**Findings**:
+  - <High/Medium/Low> | +x pt | <Finding Title>: <Explanation>
+
+---
+
+### Final Score: X pt
+(sum of all domain scores — higher is worse; 0 is a clean diff)
+
+---
+
+## Recommendations
+
+(One recommendation per issue found. Only include recommendations whose corresponding finding contributed points. Each recommendation must have all sections below. Recommendations MUST be ordered by severity: all **High** first, then all **Medium**, then all **Low**. Within the same severity, order by the skill order in the table above. Number recommendations sequentially across all skills after sorting by severity.)
+
+### Recommendation N: <short title>
+
+**Severity**: High | Medium | Low
+**Domain**: The skill domain this recommendation came from (e.g., Code Style, Buggy Behavior, Comments, Architectural Decisions, Security).
+**Findings**: The exact finding title(s) this recommendation addresses, copied from the Findings section above.
+**Problem**: Describe the specific issue in the diff.
+**Reason**: Explain why this is a problem — what goes wrong or degrades over time.
+**Solution**: Give a concrete, actionable fix. Where possible, show a before/after code snippet.
+**Locations**: List every place this issue occurs, one per line, in `filepath:line` form.
+```
+
+Rules:
+- The report format above MUST NOT be broken. Headings, ordering, and the four-section
+  recommendation layout are normative.
+- Recommendations come from the subagents — this skill aggregates them, renumbers them
+  globally, and omits any whose corresponding finding added 0 points.
+- Code evaluation MUST promote these principles: **Maintainability, Simplicity,
+  Backward Compatibility**.

--- a/cmd/experimental/skills/reviewer/code-style/SKILL.md
+++ b/cmd/experimental/skills/reviewer/code-style/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: code-style
+description: Review a diff for naming precision, convention drift, reinvented helpers, log-verbosity mistakes, misaligned test names, and typos.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Code Style
+
+Use this when reviewing a diff for naming, convention, and stylistic violations against
+the surrounding code. The goal is consistency with the existing package, not the
+reviewer's personal taste.
+
+## Rules
+
+Each rule in this domain is its own sub-skill. Scan the diff for violations of every
+rule below.
+
+| Rule | Triggers on |
+|---|---|
+| [imprecise-names](./imprecise-names/SKILL.md) | identifier whose name does not describe exactly what it contains |
+| [convention-drift](./convention-drift/SKILL.md) | new code that breaks naming conventions already established in the same file or package |
+| [reinvented-helpers](./reinvented-helpers/SKILL.md) | logic that duplicates an existing util/helper function instead of reusing it |
+| [wrong-log-verbosity](./wrong-log-verbosity/SKILL.md) | per-reconcile-cycle log lines emitted at `V(2)` |
+| [misaligned-test-names](./misaligned-test-names/SKILL.md) | test function names that do not reflect the function or behavior under test |
+| [code-style-typos](./code-style-typos/SKILL.md) | typos in identifiers, strings, or any text introduced by the diff |
+
+@./imprecise-names/SKILL.md
+@./convention-drift/SKILL.md
+@./reinvented-helpers/SKILL.md
+@./wrong-log-verbosity/SKILL.md
+@./misaligned-test-names/SKILL.md
+@./code-style-typos/SKILL.md
+
+## What not to include
+
+Do not report personal preferences or taste-based objections. This skill is about
+consistency, precision, and established local conventions, not about the reviewer's
+favorite naming style or formatting habits.
+
+In particular, do not flag:
+
+- code that is consistent with the surrounding file or package, even if you would have
+  named or structured it differently;
+- short helpers, direct expressions, or naming choices that are reasonable and accurate,
+  even if you would personally prefer a different phrasing;
+- harmless wording differences, minor prose preferences, or cosmetic style opinions with
+  no maintenance or readability impact.
+
+## How to report
+
+Cite the exact file and line, name the convention or rule being violated, and classify
+severity (high / medium / low). Naming-precision issues that introduce semantic
+ambiguity (a name that lies about its contents) are high. Convention drift and
+reinvented helpers are typically medium. Stray typos and minor wording choices are low.
+
+Return two sections:
+
+### Findings
+
+A bullet list, one per violation, in this format:
+
+```
+- <High/Medium/Low> | <Finding Title>: <one-sentence explanation grounded in the diff>
+```
+
+### Recommendations
+
+One recommendation per finding above, numbered sequentially within this skill. Each
+recommendation MUST contain all four sections below.
+
+```
+### Recommendation N: <short title>
+
+**Problem**: Describe the specific issue in the diff.
+**Reason**: Explain why this is a problem — what goes wrong or degrades over time.
+**Solution**: Give a concrete, actionable fix. Where possible, show a before/after code snippet.
+**Locations**: List every place this issue occurs, one per line, in `filepath:line` form.
+```

--- a/cmd/experimental/skills/reviewer/code-style/code-style-typos/SKILL.md
+++ b/cmd/experimental/skills/reviewer/code-style/code-style-typos/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: code-style-typos
+description: Flag typos in identifiers, strings, or any text introduced by the diff.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Typos
+
+**Typos** — in identifiers, strings, or any text introduced by the diff.

--- a/cmd/experimental/skills/reviewer/code-style/convention-drift/SKILL.md
+++ b/cmd/experimental/skills/reviewer/code-style/convention-drift/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: convention-drift
+description: Flag new code that breaks naming conventions already established in the same file or package.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Convention Drift
+
+**Convention drift** — any new code that breaks naming conventions already established
+in the same file or package.

--- a/cmd/experimental/skills/reviewer/code-style/imprecise-names/SKILL.md
+++ b/cmd/experimental/skills/reviewer/code-style/imprecise-names/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: imprecise-names
+description: Flag identifiers whose name does not describe exactly what they contain — drift from package patterns, contradictory contents, misnamed feature gates, asymmetric mirror fields.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Imprecise Names
+
+**Imprecise names** — every new identifier must describe exactly what it contains. A
+reader should not be able to mistake it for something broader or narrower.
+
+- Builder/wrapper methods that drift from the package's existing pattern (e.g. adding
+  `AddLabel(k, v)` when the rest of the package uses `Label(k, v)`).
+- Variables whose contents contradict the name — e.g. a set called
+  `noMoreBorrowingCohorts` that actually contains cohorts which *are* still borrowing.
+- Feature gates whose name does not match what they actually gate. A gate named
+  `SkipFinalizersForServingWorkloads` that controls a different condition is a hard
+  naming violation.
+- Asymmetric mirror fields on a CRD — if `excludeResourcePrefixes` exists, the
+  complement must be `includeResourcePrefixes`, not a freshly invented name.

--- a/cmd/experimental/skills/reviewer/code-style/misaligned-test-names/SKILL.md
+++ b/cmd/experimental/skills/reviewer/code-style/misaligned-test-names/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: misaligned-test-names
+description: Flag unit or integration test function names that do not reflect the function or behavior under test.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Misaligned Test Names
+
+**Misaligned test names** — unit or integration test function names that do not
+reflect the function or behavior under test.

--- a/cmd/experimental/skills/reviewer/code-style/reinvented-helpers/SKILL.md
+++ b/cmd/experimental/skills/reviewer/code-style/reinvented-helpers/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: reinvented-helpers
+description: Flag logic that duplicates an existing util/helper function instead of reusing it.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Reinvented Helpers
+
+**Reinvented helpers** — logic that duplicates an existing util/helper function
+instead of reusing it.

--- a/cmd/experimental/skills/reviewer/code-style/wrong-log-verbosity/SKILL.md
+++ b/cmd/experimental/skills/reviewer/code-style/wrong-log-verbosity/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: wrong-log-verbosity
+description: Flag per-reconcile-cycle log lines emitted at V(2) — recurring reconcile-loop logs must be V(4) or higher.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Wrong Log Verbosity
+
+**Wrong log verbosity** — per-reconcile-cycle log lines emitted at `V(2)`. `V(2)` is
+for coarse-grained lifecycle events; recurring reconcile-loop logs must be `V(4)` or
+higher.

--- a/cmd/experimental/skills/reviewer/comments/SKILL.md
+++ b/cmd/experimental/skills/reviewer/comments/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: comments
+description: Review a diff for comment hygiene — over-commenting, what-not-why narration, inaccurate comments, and missing TODOs on compatibility shims.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Comments
+
+Use this when reviewing a diff for comment hygiene: too many, too few in the wrong
+places, or — worst — comments that lie about what the code does.
+
+## Rules
+
+Each rule in this domain is its own sub-skill. Scan the diff for violations of every
+rule below.
+
+| Rule | Triggers on |
+|---|---|
+| [over-commenting](./over-commenting/SKILL.md) | comments that explain what self-documenting code already says |
+| [wrong-kind-of-comment](./wrong-kind-of-comment/SKILL.md) | comments describing *what* instead of *why* |
+| [inaccurate-comments](./inaccurate-comments/SKILL.md) | comments or docstrings that no longer match the code |
+| [missing-deferred-removal-markers](./missing-deferred-removal-markers/SKILL.md) | compatibility shim kept without a deferred-removal comment |
+| [comment-typos](./comment-typos/SKILL.md) | typos and obvious errors in comment text |
+
+@./over-commenting/SKILL.md
+@./wrong-kind-of-comment/SKILL.md
+@./inaccurate-comments/SKILL.md
+@./missing-deferred-removal-markers/SKILL.md
+@./comment-typos/SKILL.md
+
+## How to report
+
+Cite the exact file and line, describe the problem, and classify severity
+(high / medium / low). Inaccurate comments that will mislead a future maintainer, and
+missing deferred-removal markers on compatibility shims, are high. Over-commenting
+and what-not-why narration are typically low. Full marks are warranted when comments
+are absent or limited to explaining the non-obvious *why* — do not invent findings.
+
+Return two sections:
+
+### Findings
+
+A bullet list, one per violation, in this format:
+
+```
+- <High/Medium/Low> | <Finding Title>: <one-sentence explanation grounded in the diff>
+```
+
+### Recommendations
+
+One recommendation per finding above, numbered sequentially within this skill. Each
+recommendation MUST contain all four sections below.
+
+```
+### Recommendation N: <short title>
+
+**Problem**: Describe the specific issue in the diff.
+**Reason**: Explain why this is a problem — what goes wrong or degrades over time.
+**Solution**: Give a concrete, actionable fix. Where possible, show a before/after code snippet.
+**Locations**: List every place this issue occurs, one per line, in `filepath:line` form.
+```

--- a/cmd/experimental/skills/reviewer/comments/comment-typos/SKILL.md
+++ b/cmd/experimental/skills/reviewer/comments/comment-typos/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: comment-typos
+description: Flag typos and obvious errors in comment text.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Comment Typos
+
+**Typos and obvious errors in comment text.**

--- a/cmd/experimental/skills/reviewer/comments/inaccurate-comments/SKILL.md
+++ b/cmd/experimental/skills/reviewer/comments/inaccurate-comments/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: inaccurate-comments
+description: Flag any comment or docstring that no longer matches the code — these mislead future maintainers who trust them.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Inaccurate Comments
+
+**Inaccurate comments** — any comment or docstring that no longer matches the code.
+Example: a comment that says "first batch of Job pods" on a function that now
+operates on generic Workloads. Inaccurate comments are worse than no comments because
+future maintainers will trust them.

--- a/cmd/experimental/skills/reviewer/comments/missing-deferred-removal-markers/SKILL.md
+++ b/cmd/experimental/skills/reviewer/comments/missing-deferred-removal-markers/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: missing-deferred-removal-markers
+description: Flag temporary or deprecated compatibility-shim code kept in the diff without a deferred-removal comment naming the removal version and a tracking issue.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Missing Required Deferred-Removal Markers on Compatibility Shims
+
+**Missing required deferred-removal markers on compatibility shims** — if the diff
+keeps temporary or deprecated code for backwards-compatibility reasons, a
+deferred-removal comment is **required**, not optional. It must name the exact
+version when the shim can be removed and reference a tracking issue. Match the
+existing convention used elsewhere in the Kueue codebase for marking removable
+shims.

--- a/cmd/experimental/skills/reviewer/comments/over-commenting/SKILL.md
+++ b/cmd/experimental/skills/reviewer/comments/over-commenting/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: over-commenting
+description: Flag comments that explain what self-documenting code already says.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Over-commenting
+
+**Over-commenting** — comments that explain what self-documenting code already says.
+A well-named function does not need a comment restating its name in prose.

--- a/cmd/experimental/skills/reviewer/comments/wrong-kind-of-comment/SKILL.md
+++ b/cmd/experimental/skills/reviewer/comments/wrong-kind-of-comment/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: wrong-kind-of-comment
+description: Flag comments that describe *what* the code does instead of *why* it does it.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Wrong Kind of Comment
+
+**Wrong kind of comment** — comments that describe *what* the code does instead of
+*why* it does it. Useful comments explain non-obvious motivation, hidden constraints,
+or the theoretical background a reader could not infer from the code itself.

--- a/cmd/experimental/skills/reviewer/security/SKILL.md
+++ b/cmd/experimental/skills/reviewer/security/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: security
+description: Review a diff for security issues exploitable by a tenant, neighbouring controller, or malicious workload spec — input validation, injection, DoS, nil-safety, authz, info disclosure, supply chain, webhook safety.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Security
+
+Use this when reviewing a diff for code patterns exploitable by an authenticated
+low-privileged tenant, a compromised neighbouring controller, or a malicious workload
+spec. Kueue is a privileged in-cluster controller with broad watch permissions that
+also sits in the admission path via webhooks — one insecure pattern can crash-loop the
+batch-scheduling surface, leak tenant data, allow quota escape, or enable arbitrary
+code execution.
+
+## Rules
+
+Each rule in this domain is its own sub-skill. Scan the diff for violations of every
+rule below.
+
+| Rule | Triggers on |
+|---|---|
+| [input-validation](./input-validation/SKILL.md) | missing validation on user-settable CR fields, webhook payloads, labels, annotations, or untrusted deserialization |
+| [injection](./injection/SKILL.md) | exec/SSRF/template/query/selector built from user-supplied strings |
+| [path-traversal](./path-traversal/SKILL.md) | file paths or archive extraction without root containment |
+| [resource-bounds-dos](./resource-bounds-dos/SKILL.md) | uncapped loops/allocations, missing timeouts, reconciler-wedging input, unbounded metric labels |
+| [nil-safety](./nil-safety/SKILL.md) | unguarded dereferences from malformed CRs; goroutines without recover |
+| [authn-authz-relaxation](./authn-authz-relaxation/SKILL.md) | webhook token skipping, failurePolicy Ignore, wildcard RBAC, privileged pod specs |
+| [information-disclosure](./information-disclosure/SKILL.md) | full-object logging, request echoing, credentials in status/annotations, kubeconfig logging |
+| [supply-chain-hygiene](./supply-chain-hygiene/SKILL.md) | unpinned images, TLS bypass, unjustified replace directives, curl\|sh, moving-tag Actions |
+| [annotation-label-namespace-abuse](./annotation-label-namespace-abuse/SKILL.md) | generic annotation/label loops that copy or forward values |
+| [feature-gated-insecure-paths](./feature-gated-insecure-paths/SKILL.md) | gated behavior whose security assumptions fail when accidentally enabled |
+| [integration-adapter-trust-boundary](./integration-adapter-trust-boundary/SKILL.md) | adapters reading credential-like fields from third-party CRDs without treating them as untrusted |
+| [webhook-safety-regressions](./webhook-safety-regressions/SKILL.md) | loosened failurePolicy, shortened timeouts, TLS bypass, non-idempotent mutating webhooks |
+
+@./input-validation/SKILL.md
+@./injection/SKILL.md
+@./path-traversal/SKILL.md
+@./resource-bounds-dos/SKILL.md
+@./nil-safety/SKILL.md
+@./authn-authz-relaxation/SKILL.md
+@./information-disclosure/SKILL.md
+@./supply-chain-hygiene/SKILL.md
+@./annotation-label-namespace-abuse/SKILL.md
+@./feature-gated-insecure-paths/SKILL.md
+@./integration-adapter-trust-boundary/SKILL.md
+@./webhook-safety-regressions/SKILL.md
+
+## How to report
+
+Cite the exact file and line, name the rule violated and the relevant CWE/CVE where
+applicable, and classify severity (high / medium / low). Anything that crashes the
+controller, leaks credentials, bypasses authz, or enables injection is high. Missing
+caps, unbounded cardinality, or weakened supply-chain controls are typically medium.
+Stylistic security smells with no concrete exploit path are low.
+
+Return two sections:
+
+### Findings
+
+A bullet list, one per violation, in this format:
+
+```
+- <High/Medium/Low> | <Finding Title>: <one-sentence explanation grounded in the diff, with CWE/CVE where applicable>
+```
+
+### Recommendations
+
+One recommendation per finding above, numbered sequentially within this skill. Each
+recommendation MUST contain all four sections below.
+
+```
+### Recommendation N: <short title>
+
+**Problem**: Describe the specific issue in the diff.
+**Reason**: Explain why this is a problem — what goes wrong or degrades over time.
+**Solution**: Give a concrete, actionable fix. Where possible, show a before/after code snippet.
+**Locations**: List every place this issue occurs, one per line, in `filepath:line` form.
+```

--- a/cmd/experimental/skills/reviewer/security/annotation-label-namespace-abuse/SKILL.md
+++ b/cmd/experimental/skills/reviewer/security/annotation-label-namespace-abuse/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: annotation-label-namespace-abuse
+description: Flag generic loops over obj.Annotations that copy, forward, or echo values — allow tenant injection into reserved kueue.x-k8s.io/ namespace.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Annotation/Label Namespace Abuse
+
+- Generic loops over `obj.Annotations` that copy, forward, or echo values — these
+  allow tenant injection into the reserved `kueue.x-k8s.io/` namespace and leak
+  operator-set values across boundaries. Forwarding between CRs must go through an
+  explicit allowlist.

--- a/cmd/experimental/skills/reviewer/security/authn-authz-relaxation/SKILL.md
+++ b/cmd/experimental/skills/reviewer/security/authn-authz-relaxation/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: authn-authz-relaxation
+description: Flag AuthN/AuthZ relaxation — webhook token skipping, failurePolicy Ignore, missing SubjectAccessReview, wildcard RBAC, privileged pod specs (CWE-269, CWE-287, CWE-306, CWE-862, CWE-863).
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: AuthN / AuthZ Relaxation
+
+- Webhook handlers that skip token validation or trust `X-Forwarded-For` /
+  `X-Remote-User` (CWE-287, CWE-306).
+- New admission webhooks registered with `failurePolicy: Ignore` without explicit,
+  documented justification (CWE-352-class bypass).
+- Privileged operations (cross-namespace reads, secret reads, impersonation) on a
+  tenant's behalf without a preceding `SubjectAccessReview`.
+- New ClusterRoles with wildcard verbs (`*`) or resources (`*`). New RBAC must use
+  minimum verbs and prefer `RoleBinding` over `ClusterRoleBinding` where namespace
+  scope suffices (CWE-269, CWE-862, CWE-863).
+- `Secret` reads via a blanket cluster-wide verb instead of `resourceNames` scoping.
+- Pod specs setting `HostPID`, `HostNetwork`, `HostIPC`, `privileged: true`,
+  `allowPrivilegeEscalation: true`, mounting sensitive host paths
+  (`/etc/kubernetes`, `/var/run/docker.sock`), or dropping `runAsNonRoot: true`.

--- a/cmd/experimental/skills/reviewer/security/feature-gated-insecure-paths/SKILL.md
+++ b/cmd/experimental/skills/reviewer/security/feature-gated-insecure-paths/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: feature-gated-insecure-paths
+description: Flag feature-gated behavior whose security assumptions do not hold in both gate-on and gate-off states; require a comment near the gate check for new alpha attack surface.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Feature-Gated Insecure Paths
+
+- Behavior added behind a feature gate whose security assumptions
+  do not hold when the gate is off **and** when it is on. A feature gate must not ship
+  a path that would be insecure if accidentally enabled. New alpha gates with new
+  attack surface should note the assumption in a code comment near the gate check.

--- a/cmd/experimental/skills/reviewer/security/information-disclosure/SKILL.md
+++ b/cmd/experimental/skills/reviewer/security/information-disclosure/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: information-disclosure
+description: Flag information-disclosure patterns — full-object logging, request echoing, credentials in status/annotations, kubeconfig logging, secret-bearing status (CWE-200, CWE-522, CWE-532, CWE-552).
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Information Disclosure (CWE-200, CWE-522, CWE-532, CWE-552)
+
+- Full Kubernetes objects logged with `%+v` / `%#v`. Required: `klog.KObj(obj)` plus
+  structured key/value pairs.
+- Webhook responses, events, or status fields that echo request bodies, stack traces,
+  or credential-bearing fields.
+- Credentials or tokens persisted in annotations, labels, env vars, or status —
+  credentials belong in mounted Secrets.
+- kubeconfigs logged, echoed in status, or written with
+  `insecure-skip-tls-verify: true`.
+- Visibility-API or metrics queries that widen results past the caller's
+  namespace/queue.
+- Secret-bearing data written to `.status` — status updates are at-least-once, so
+  every retry leaks.

--- a/cmd/experimental/skills/reviewer/security/injection/SKILL.md
+++ b/cmd/experimental/skills/reviewer/security/injection/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: injection
+description: Flag injection vectors from user-supplied strings — exec, SSRF, fmt.Sprintf-built selectors/URLs, template rendering, query concatenation (CWE-78, CWE-94, CWE-918).
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Injection from User-Supplied Strings
+
+- `os/exec` / `exec.Command` with user-controlled arguments (CWE-78, CWE-94).
+- `http.Get` / `http.NewRequest` to URLs built from CR fields (CWE-918 SSRF).
+  Container image refs, init-container pull specs, and webhook target URLs count as
+  untrusted.
+- `fmt.Sprintf` building YAML, JSON, label selectors, field paths, or API server URLs
+  from user input. Require typed marshalling and `labels.SelectorFromSet`.
+- Server-side template rendering of annotation/label values (CWE-94).
+- SQL-like or query-language string concatenation against any external store.

--- a/cmd/experimental/skills/reviewer/security/input-validation/SKILL.md
+++ b/cmd/experimental/skills/reviewer/security/input-validation/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: input-validation
+description: Flag missing input validation at trust boundaries — user-settable CR fields, webhook payloads, labels, annotations, or untrusted deserialization (CWE-20, CWE-502).
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Missing Input Validation at Trust Boundaries
+
+- New user-settable fields on a CR, webhook payload, label, or annotation used without
+  explicit validation (length, regex, enum, parse).
+- Strings from `obj.Spec`, `obj.Annotations`, `obj.Labels`, or webhook request bodies
+  consumed directly. Reconciler code must still nil-check optional fields the webhook
+  has already validated.
+- Untrusted input re-parsed with permissive deserializers
+  (`yaml.Unmarshal(..., interface{})`, `gob`, generic JSON into
+  `map[string]interface{}`). **Hard violation** (CWE-20, CWE-502).

--- a/cmd/experimental/skills/reviewer/security/integration-adapter-trust-boundary/SKILL.md
+++ b/cmd/experimental/skills/reviewer/security/integration-adapter-trust-boundary/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: integration-adapter-trust-boundary
+description: Flag integration adapters reading credential-like fields from third-party CRDs without treating them as untrusted (RayCluster, SparkApplication, JobSet).
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Integration-Adapter Trust Boundary
+
+- Adapters in `pkg/controller/jobs/<framework>/` that newly read credential-like
+  fields from a third-party CRD (`RayCluster` head-node secret refs, `SparkApplication`
+  driver env, JobSet pod template env) without treating those fields as untrusted —
+  validate before forwarding, never log, never copy into Kueue-owned status.

--- a/cmd/experimental/skills/reviewer/security/nil-safety/SKILL.md
+++ b/cmd/experimental/skills/reviewer/security/nil-safety/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: nil-safety
+description: Flag unguarded dereferences of optional pointer fields reachable from a malformed CR, and goroutines without recover (CWE-476).
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Nil-Safety and Crash Resistance (CWE-476)
+
+- Unguarded dereferences of optional pointer fields reachable from a malformed CR
+  (`Workload.Status.Admission`, `ClusterQueue.Spec.Cohort`, optional sub-structs, slice
+  elements). A panic in scheduler cache construction or webhook handling wedges the
+  scheduling loop — treat as **high severity**.
+- Goroutines launched outside the controller-runtime workqueue without a deferred
+  `recover()` or a documented panic policy.

--- a/cmd/experimental/skills/reviewer/security/path-traversal/SKILL.md
+++ b/cmd/experimental/skills/reviewer/security/path-traversal/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: path-traversal
+description: Flag file paths built from user-supplied names without sanitization, symlink-following in tenant dirs, and unvalidated archive extraction (CWE-22).
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Path Traversal
+
+- File paths built from user-supplied names without `filepath.Clean` plus a prefix check
+  against an allowlisted root.
+- Symlinks followed in tenant-controlled directories.
+- Archive extraction without validating each entry stays within the destination root
+  (zip-slip, CWE-22).

--- a/cmd/experimental/skills/reviewer/security/resource-bounds-dos/SKILL.md
+++ b/cmd/experimental/skills/reviewer/security/resource-bounds-dos/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: resource-bounds-dos
+description: Flag missing resource bounds / DoS resistance — uncapped loops or allocations, missing timeouts, reconciler-wedging input, unbounded metric cardinality (CWE-400, CWE-770).
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Resource Bounds / DoS Resistance (CWE-400, CWE-770)
+
+- Loops over user-supplied slices (`PodSets`, `ResourceGroups`, `Flavors`, cohort
+  children, admission checks) without a documented webhook-enforced cap or explicit
+  length check.
+- `make([]T, n)` / `make(map[K]V, n)` where `n` comes from user data without a sanity
+  cap.
+- Outbound API or HTTP calls without `context.WithTimeout` (or a bounded inherited
+  reconcile context).
+- Invalid `.spec.interval`-style fields that could wedge the reconciler for the entire
+  kind (CVE-2022-39272 pattern). Failures from invalid CR content must surface to
+  status, not crash-loop.
+- New metrics with unbounded label cardinality — `workload_name`, `pod_name`,
+  namespace+name composites, annotation values as labels.

--- a/cmd/experimental/skills/reviewer/security/supply-chain-hygiene/SKILL.md
+++ b/cmd/experimental/skills/reviewer/security/supply-chain-hygiene/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: supply-chain-hygiene
+description: Flag supply-chain hygiene gaps — unpinned image refs, TLS bypass, unjustified go.mod replace directives, curl|sh, moving-tag GitHub Actions (CWE-295, CWE-494).
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Supply Chain Hygiene (CWE-295, CWE-494)
+
+- Image references without a digest pin (`image: foo:latest` is a violation; require
+  `@sha256:...`).
+- `InsecureSkipVerify: true`, TLS verification bypass, or `--insecure` flags.
+- `replace` directives in `go.mod` without a tracked issue and a target removal
+  version.
+- `curl | sh`, `wget | bash`, or scripts fetched from a URL inside a Dockerfile or
+  Makefile.
+- Third-party GitHub Actions / CI workflow steps pinned to a moving tag instead of a
+  commit SHA.
+- New direct dependencies without a one-line justification.

--- a/cmd/experimental/skills/reviewer/security/webhook-safety-regressions/SKILL.md
+++ b/cmd/experimental/skills/reviewer/security/webhook-safety-regressions/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: webhook-safety-regressions
+description: Flag webhook safety regressions — loosened failurePolicy, shortened timeoutSeconds, TLS bypass paths, non-idempotent mutating webhooks.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Webhook Safety Regressions
+
+- Validating/mutating webhook changes that loosen `failurePolicy` to `Ignore`,
+  shorten `timeoutSeconds` below the existing default without justification, or add a
+  path that bypasses TLS verification.
+- Non-idempotent mutating webhooks — both a correctness and a security risk under
+  admission retry storms.


### PR DESCRIPTION
…and gives a score from 0 to 100

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
I added code evaluation skills with defined rules that was created based on mimowo comments on PRs. The main purpose of the skill is evaluating code quality and representing code quality in numeric form. This will allow us to determine what LLM prompt techniques improve LLMs coding abilities and what do not. Code evaluation skill also could act as a testing tool for future SKILL that focuses on increasing performance of LLM coding abilities.     

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

tool: claude code
model: Opus 4.7 (1M context) 

### Example 1 

Prompt
```
evaluate code between these commits 4af7becae5c3d6786d112ba023e572ae3113607c c91286c0aaf45d003ec3c8e93b03c3ab28de5f25
```

Output
```
Code Evaluation Report

  Commits: 4af7beca..c91286c0
  Files changed:
  - Makefile-test.mk (+10/0)
  - hack/e2e-common.sh (+395/-33)
  - site/content/en/docs/contribution_guidelines/testing.md (+5/0)
  - site/content/zh-CN/docs/contribution_guidelines/testing.md (+3/0)
  
  Note: Higher score = worse code. 0 means no findings in that domain.

  ---
  Skill: Architectural Decisions (weight 1.5)

  Domain score: 67.5 pt
  Findings:
  - High | +22.5 pt | Massive duplicated install_* preamble: same ~15-line "deployment exists → image → tag → version compare → log" block copied across 9
  installers (appwrapper, jobset, kubeflow, kubeflow_trainer, mpi, kuberay, lws, cert_manager, dra).
  - Medium | +10.5 pt | Scope creep — MPI manifest curl|yq patching: unrelated SSA aggregated-ClusterRole workaround bundled into an idempotency refactor.
  - Medium | +10.5 pt | Scope creep — DRA image tag derivation: changes tag from local to a version-derived string in all modes, not just the dev-reuse path the
  PR is scoped to.
  - Medium | +10.5 pt | install_multicluster uses CRD-existence-only check while seven peers do full version comparison — asymmetric abstraction.
  - Low | +4.5 pt | Pointless rename of positional args in kind_load (e2e_cluster_name/e2e_kubeconfig).
  - Low | +4.5 pt | kubectl_args array reconstructed in three places instead of a thin e2e_kubectl wrapper.
  - Low | +4.5 pt | Cert-manager dual-container-name fallback inline rather than in a shared image-tag helper.

  Skill: Code Style (weight 1.0)

  Domain score: 37 pt
  Findings:
  - High | +15 pt | e2e_is_truthy returns 1 (failure) for truthy inputs — opposite of its name and of bash convention; every call site reads the inverse of what
  it says. 
  - Medium | +7 pt | *"/lws:"* || *"/lws@"* || *"/lws"* — third pattern subsumes first two and also matches unrelated images (e.g., foo/lws-debug).
  - Low | +3 pt | Comment typo "re-installed_version" on hack/e2e-common.sh:86.
  - Low | +3 pt | e2e_image_ref_get_tag violates verb-first convention used by sibling helpers (e2e_deployment_exists, e2e_versions_match, e2e_crd_exists).
  - Low | +3 pt | e2e_cluster_name/e2e_kubeconfig prefix drift in kind_load vs name/kubeconfig everywhere else.
  - Low | +3 pt | local kubeconfig=${2:-} for required args silences arg-missing bugs; inconsistent with local name=$1.
  - Low | +3 pt | force_reinstall carried as the literal strings "true"/"false" and routed through the broken truthy helper rather than a plain [[ ... == "true" 
  ]].

  Skill: Buggy Behavior (weight 2.0)

  Domain score: 54 pt
  Findings:
  - Medium | +14 pt | install_kuberay delete guard is effectively always-true: if e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}" || e2e_is_truthy 
  "${force_reinstall}" — given the inverted helper, at least one operand is always falsy, so the delete runs in every code path. --ignore-not-found=true masks
  the mistake on fresh clusters; on a non-fresh CI cluster it would tear down kuberay unnecessarily.
  - Medium | +14 pt | LWS image match too broad: third pattern picks up any image containing /lws, including foo/lwsxyz, and could pin installed_version to the
  wrong container's tag.
  - Medium | +14 pt | Inconsistent kubectl wait … || true: appwrapper/jobset/kubeflow/kubeflow_trainer fail loud on wait timeouts;
  mpi/kuberay/lws/cert-manager-sidecars swallow them. A non-ready operator now produces a confusing downstream test failure.
  - Low | +6 pt | install_mpi adds curl|yq|kubectl pipeline without ensuring set -o pipefail in callers; a curl failure could feed an empty manifest to kubectl.
  - Low | +6 pt | dra_image_tag silently changes from constant "local" to a version-derived slug whenever DRA_EXAMPLE_DRIVER_VERSION is set — tooling/runbooks
  grepping for the historical tag will silently miss the image.

  Skill: Comments (weight 0.5)

  Domain score: 4.5 pt
  Findings:
  - Low | +1.5 pt | Doc claim "external operators are installed only once" is too strong; the code reinstalls on version mismatch.
  - Low | +1.5 pt | install_kuberay NOTE leads with reused-cluster background rather than the actual why (create -k non-idempotency).
  - Low | +1.5 pt | No comment documenting the deliberately-inverted e2e_is_truthy return semantics — exactly the kind of non-obvious behavior that warrants a
  why-comment.

  Skill: Security (weight 2.0)

  Domain score: 0 pt
  Findings:
  - No findings (dev-only test harness; curl|yq|kubectl uses TLS-verified HTTPS to a pinned ref, array expansions are quoted correctly, no credential/secret/exec
   surface introduced).

  ---
  Final Score: 163 pt

  ---
  Recommendations

  Recommendation 1: Collapse the duplicated install_* idempotency preamble

  Severity: High
  Domain: Architectural Decisions
  Findings: Massive duplicated install_* preamble.
  Problem: Nine install_* functions repeat a near-identical ~15-line block (early-exit on mode/flag, deployment exists, fetch container image, extract tag,
  version compare, branch log).
  Reason: Every future operator copies the same boilerplate. The diff already shows drift between copies — different container-name selectors, "upgrading" vs.
  "reinstalling" wording, the cert-manager dual-container fallback, the /lws triple-pattern. Bug fixes will not propagate uniformly.
  Solution: Add one helper, e.g. e2e_skip_if_installed label kubeconfig ns deployment expected_version selector, returning 0 to short-circuit the caller:
  function install_jobset {
      local name=$1 kubeconfig=${2:-}
      e2e_skip_if_installed "JobSet" "$kubeconfig" "${JOBSET_DEPLOYMENT_NAMESPACE:-jobset-system}" \
          "${JOBSET_CONTROLLER_MANAGER_DEPLOYMENT:-jobset-controller-manager}" \
          "${JOBSET_VERSION:-}" "image~jobset/jobset" && return 0
      cluster_kind_load_image "$name" "$JOBSET_IMAGE"
      kubectl apply --kubeconfig="$kubeconfig" --server-side -f "$JOBSET_MANIFEST"
      kubectl wait --kubeconfig="$kubeconfig" deploy/... --for=condition=available --timeout=5m
  }
  Locations:
  - hack/e2e-common.sh:213-231 (install_appwrapper)
  - hack/e2e-common.sh:250-275 (install_jobset)
  - hack/e2e-common.sh:293-312 (install_kubeflow)
  - hack/e2e-common.sh:329-348 (install_kubeflow_trainer)
  - hack/e2e-common.sh:379-404 (install_mpi)
  - hack/e2e-common.sh:437-457 (install_kuberay)
  - hack/e2e-common.sh:484-509 (install_lws)
  - hack/e2e-common.sh:524-548 (install_cert_manager)
  - hack/e2e-common.sh:577-597 (install_dra_example_driver)

  Recommendation 2: Fix the inverted e2e_is_truthy return convention

  Severity: High
  Domain: Code Style
  Findings: e2e_is_truthy returns 1 (failure) for truthy inputs.
  Problem: The function returns 1 (shell-failure) for 1|true|yes|on|... and 0 (success) for everything else. if e2e_is_truthy "$x"; then ... therefore runs only
  when x is not truthy.
  Reason: A predicate that lies about its sign is the textbook "name lies" defect; every caller has to be read backwards, and at least one already gets it
  functionally wrong (Rec. 3).
  Solution:
  function e2e_is_truthy {
      case "${1:-}" in
          1|true|TRUE|True|yes|YES|Yes|y|Y|on|ON|On) return 0 ;;
          *) return 1 ;;
      esac
  }
  Then flip every call: && e2e_is_truthy X (intended "and is truthy") that currently means "and is NOT truthy" becomes && ! e2e_is_truthy X, and so on. Re-audit
  the kuberay double-call after fixing.
  Locations:
  - hack/e2e-common.sh:91-96 (definition)
  - hack/e2e-common.sh:213, 250, 293, 329, 379, 437, 466 (×2), 484, 524, 560, 577 (call sites)

  Recommendation 3: Fix the install_kuberay delete guard

  Severity: Medium
  Domain: Buggy Behavior
  Findings: install_kuberay delete guard is effectively always-true.
  Problem: if e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}" || e2e_is_truthy "${force_reinstall}"; then kubectl delete -k ... ; fi runs the delete whenever
  either var is falsy. Because force_reinstall is the literal string "false" by default and only flips to "true" inside the dev/non-enforce branch, at least one
  operand is always falsy and the delete always runs.
  Reason: The destructive delete is intended to gate on "force reinstall requested"; today it fires unconditionally. --ignore-not-found=true masks the mistake on
   fresh clusters but does an unnecessary teardown elsewhere, and the next reader will be misled about the actual semantics.
  Solution: After Rec. 2, write the condition straight:
  if e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}" || [[ "${force_reinstall}" == "true" ]]; then
      kubectl ${kubectl_args[@]+"${kubectl_args[@]}"} delete -k "${KUBERAY_MANIFEST}" --ignore-not-found=true
  fi
  Locations:
  - hack/e2e-common.sh:466-468
  
  Recommendation 4: Tighten the LWS image-match patterns

  Severity: Medium
  Domain: Buggy Behavior (also Code Style)
  Findings: LWS image match too broad; third pattern subsumes first two.
  Problem: if [[ "${img}" == *"/lws:"* || "${img}" == *"/lws@"* || "${img}" == *"/lws"* ]] is equivalent to a single overly broad *"/lws"* test, which matches
  images like foo/lws-debug:1.0.
  Reason: Mismatching the wrong container's image silently records a wrong installed_version, then bypasses install or upgrades when it shouldn't.
  Solution:
  if [[ "${img}" == *"/lws:"* || "${img}" == *"/lws@"* ]]; then
  Or anchor to the canonical published image name (e.g. *"sigs.k8s.io/lws/lws-controller-manager"*).
  Locations:
  - hack/e2e-common.sh:492
  
  Recommendation 5: Stop masking kubectl wait failures inconsistently

  Severity: Medium
  Domain: Buggy Behavior
  Findings: Inconsistent kubectl wait … || true.
  Problem: install_mpi, install_kuberay, install_lws, and the cert-manager webhook/cainjector waits append || true while install_appwrapper, install_jobset,
  install_kubeflow, install_kubeflow_trainer do not.
  Reason: Silently continuing past an unhealthy operator turns "MPI operator never became Available" into a far-away test failure. The inconsistency also leaves
  readers unsure which controllers are required.
  Solution: Remove || true from all kubectl wait --for=condition=available calls unless a documented reason exists; if so, add an inline comment and echo a
  warning.
  Locations:
  - hack/e2e-common.sh:416 (install_mpi)
  - hack/e2e-common.sh:470 (install_kuberay)
  - hack/e2e-common.sh:513 (install_lws)
  - hack/e2e-common.sh:552-553 (cert-manager webhook/cainjector)
  
  Recommendation 6: Split the MPI manifest patching out of this PR

  Severity: Medium
  Domain: Architectural Decisions
  Findings: Scope creep — MPI manifest curl|yq patching.
  Problem: install_mpi adds a curl | yq | kubectl pipeline that drops empty rules: [] from aggregated ClusterRoles. The block has a clear NOTE, but it is
  unrelated to "make installs idempotent in dev mode" and changes CI behavior too.
  Reason: Bundling an unrelated bugfix obscures both changes in git blame, complicates reverting either independently, and makes reviewers focused on idempotency
   skim past a SSA workaround.
  Solution: Extract into its own commit/PR; or, if it must ship together, gate the transformation on E2E_MODE=dev so CI behavior is unchanged.
  Locations:
  - hack/e2e-common.sh:407-415

  Recommendation 7: Hoist the DRA image-tag change out of the idempotency refactor

  Severity: Medium
  Domain: Architectural Decisions
  Findings: Scope creep — DRA image tag derivation.
  Problem: dra_image_tag="${expected_version#v}"; dra_image_tag="${dra_image_tag//\//-}" changes the image tag from the constant "local" to a version-derived
  slug in all modes.
  Reason: The PR documentation, env var name, and Makefile additions all scope the work to dev-mode idempotency. Future bisects of DRA failures will skip this
  commit.
  Solution: Split into a separate commit with a message explaining why version-based tagging is required (presumably to allow the new version-compare check to
  work), or gate the new tag on the same E2E_MODE=dev condition.
  Locations:
  - hack/e2e-common.sh:907-911

  Recommendation 8: Align install_multicluster with the rest of the installers

  Severity: Medium
  Domain: Architectural Decisions
  Findings: Inconsistent abstraction in install_multicluster.
  Problem: install_multicluster checks only CRD existence; the other seven installers do deployment + image-tag version comparison.
  Reason: A future reader copying the wrong template adds a silent stale-CRD risk (or over-engineers a fresh installer). The asymmetry is a maintenance hazard.
  Solution: Either accept "object exists, skip" as the canonical pattern and simplify the others (preferred for a dev harness), or pull the version-compare flow
  into a CRD-aware helper that compares metadata.annotations or stored schema version.
  Locations:
  - hack/e2e-common.sh:559-567

  Recommendation 9: Fix typo "re-installed_version"

  Severity: Low
  Domain: Code Style
  Findings: Comment typo "re-installed_version".
  Problem: # When set (truthy), external operators are forcefully re-installed_version even in E2E_MODE=dev.
  Reason: Ungrammatical leftover from a rename; sits directly above the new env var and confuses readers about whether _version is meaningful.
  Solution: # When set (truthy), external operators are forcefully re-installed on every run, even in E2E_MODE=dev.
  Locations:
  - hack/e2e-common.sh:86
  
  Recommendation 10: Rename e2e_image_ref_get_tag to verb-first form

  Severity: Low
  Domain: Code Style
  Findings: e2e_image_ref_get_tag violates the file's verb-first naming convention.
  Problem: Siblings are e2e_deployment_exists, e2e_versions_match, e2e_crd_exists.
  Reason: Convention drift inside the same commit reduces grep-ability.
  Solution: Rename to e2e_get_image_tag (or e2e_image_tag).
  Locations:
  - hack/e2e-common.sh:111 (def); 219, 259, 299, 335, 388, 443, 493, 535, 586 (call sites)

  Recommendation 11: Drop the e2e_ prefix on kind_load locals

  Severity: Low
  Domain: Code Style
  Findings: e2e_cluster_name/e2e_kubeconfig convention drift.
  Problem: kind_load introduces e2e_cluster_name and e2e_kubeconfig while every callee uses bare name / kubeconfig.
  Reason: The prefix adds nothing (entire file is e2e), and the rename inflates the diff. Reverting also restores the original "$1" "$2" call sites unchanged.
  Solution: Revert the rename — call install_X "$1" "$2" as before, or use local cluster_name=$1; local kubeconfig=$2.
  Locations:
  - hack/e2e-common.sh:148-149, 156, 160, 167, 172, 177, 181, 185, 189, 193, 197
  
  Recommendation 12: Don't default required positional args

  Severity: Low
  Domain: Code Style
  Findings: ${2:-} on required positional args.
  Problem: Inconsistent use of local kubeconfig=${2:-} (default-empty) for an argument the function cannot operate without.
  Reason: Hides a caller's bug behind a downstream kubectl error.
  Solution: Use local kubeconfig=$2 for required args, or : "${kubeconfig:?install_*: kubeconfig required}". Reserve ${X:-} for truly optional inputs.
  Locations:
  - hack/e2e-common.sh:208, 245, 288, 324, 374, 427, 479, 519, 574
  
  Recommendation 13: Replace e2e_is_truthy "${force_reinstall}" with a plain compare

  Severity: Low
  Domain: Code Style
  Findings: force_reinstall as string boolean.
  Problem: force_reinstall is set internally to literal strings; routing it through the broken truthy helper compounds Rec. 3.
  Reason: Internal flags should use bash booleans directly; the helper is for user-supplied env vars.
  Solution: if [[ "${force_reinstall}" == "true" ]]; then ...
  Locations:
  - hack/e2e-common.sh:431, 453, 466

  Recommendation 14: Encapsulate kubectl_args construction

  Severity: Low
  Domain: Architectural Decisions
  Findings: kubectl_args rebuilt in three places.
  Problem: e2e_deployment_exists, e2e_crd_exists, and install_kuberay each rebuild the same array preamble.
  Reason: Trivial duplication that will multiply with the next caller.
  Solution:
  function e2e_kubectl { local kc=$1; shift; [[ -n "$kc" ]] && set -- --kubeconfig="$kc" "$@"; kubectl "$@"; }
  Locations:
  - hack/e2e-common.sh:103-108, 131-138, 432-435
  
  Recommendation 15: Move cert-manager's container-name fallback into the shared helper

  Severity: Low
  Domain: Architectural Decisions
  Findings: Cert-manager dual-container-name fallback inline.
  Problem: install_cert_manager hand-rolls a second jsonpath when container name cert-manager returns empty.
  Reason: After Rec. 1 lands, this dual lookup belongs inside the shared image-tag helper, accepting either a container name or an image substring selector.
  Solution: Extend e2e_get_image_tag kubeconfig ns deployment selector... to iterate selectors until one yields non-empty.
  Locations:
  - hack/e2e-common.sh:529-534

  Recommendation 16: Correct the dev-mode docs note

  Severity: Low
  Domain: Comments
  Findings: Doc claim "installed only once" is too strong.
  Problem: The English and Chinese contributor docs say operators "are installed only once" in E2E_MODE=dev; the code in fact upgrades when the installed version
   differs.
  Reason: Contributors who bump KUBEFLOW_MPI_VERSION etc. will be surprised by upgrades despite the doc's promise.
  Solution:
  When reusing a kept cluster in `E2E_MODE=dev`, external operators (MPI, KubeRay, etc.)
  are reinstalled only when their installed version no longer matches the requested one.
  To force reinstalling on every run regardless of version, set
  `E2E_ENFORCE_OPERATOR_UPDATE=true`.
  Locations:
  - site/content/en/docs/contribution_guidelines/testing.md:137-141
  - site/content/zh-CN/docs/contribution_guidelines/testing.md:137-138
  
  Recommendation 17: Lead the install_kuberay NOTE with the actual reason

  Severity: Low
  Domain: Comments
  Findings: install_kuberay NOTE wording.
  Problem: The comment opens with reused-cluster background instead of the load-bearing why (create -k non-idempotency).
  Reason: Why-comments should put the reason for this code first.
  Solution:
  # `kubectl create -k` (used instead of apply per https://github.com/ray-project/kuberay/issues/504)
  # is not idempotent: it exits non-zero if any object already exists. In E2E_MODE=dev we reuse
  # the kind cluster between runs, so we must explicitly delete the previous manifest first
  # whenever an upgrade or forced reinstall is requested.
  Locations:
  - hack/e2e-common.sh:461-464
  
  Recommendation 18: Document or remove the inverted e2e_is_truthy semantics

  Severity: Low
  Domain: Comments
  Findings: No comment explaining the inverted return convention.
  Problem: The function deliberately inverts bash predicate semantics and has no comment saying so.
  Reason: Either fix the function (Rec. 2) — preferred — or, if kept, the inversion deserves an explicit why-comment so the next contributor doesn't reintroduce
  the kuberay-style bug.
  Solution: Fold into Rec. 2 by flipping the return values. If that is rejected, add:
  # Returns 1 (failure) when $1 is truthy, 0 (success) when falsy.
  # Inversion is deliberate so that `cond && e2e_is_truthy x` runs the body when x is NOT truthy.
  Locations:
  - hack/e2e-common.sh:91-96
```

### Example 2 
Prompt
```
evaluate code between these commits c43e788acc787db54809ec01954d6441c80ace5a 0b2c1d0f7675448fc2455904e0d62b4a8130a51d
```

Output 
```
Code Evaluation Report

  Commits: c43e788acc787db54809ec01954d6441c80ace5a..0b2c1d0f7675448fc2455904e0d62b4a8130a51d
  Files changed:
  - pkg/controller/jobframework/reconciler.go (+2/-1)
  - pkg/controller/jobframework/validation.go (+10/-1)
  - pkg/controller/jobframework/validation_test.go (+1/-7)
  - pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go (+30/-15)
  - pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go (+32)
  - pkg/util/equality/podset.go (+11/-1)
  - pkg/util/equality/podset_test.go (+32/-6)
  - test/e2e/singlecluster/leaderworkerset_test.go (+63)

  Note: Higher score = worse code. 0 means no findings in that domain.

  ---
  Skill: Architectural Decisions (weight 1.5)

  Domain score: 25.5 pt
  Findings:
  - Medium | +10.5 pt | Scope creep into shared validation: ValidateImmutablePodGroupPodSpec is permanently nodeSelector-blind, changing the contract for every
  caller (notably StatefulSet at statefulset_webhook.go:173) for an LWS-only feature.
  - Medium | +10.5 pt | Misleading helper name updateWorkload: the new method (leaderworkerset_reconciler.go:336-350) may instead delete the workload when
  podSets differ; the name promises an in-place update.
  - Low | +4.5 pt | Rename createPrebuiltWorkload → createWorkload drops the meaningful "Prebuilt" qualifier that distinguished this controller's
  prebuilt-workload path from the framework's standard construction.

  Skill: Code Style (weight 1.0)

  Domain score: 6 pt
  Findings:
  - Low | +3 pt | Imprecise helper name ignoreNodeSelector: signature reads like a pure filter but mutates the input map in place (validation.go:250-253).
  - Low | +3 pt | Misleading test case name "different requests in node selector with ignoreNodeSelector" — node selectors have no "requests"; the sibling case
  at line 134 carries the same wording (podset_test.go:128-160).

  Skill: Buggy Behavior (weight 2.0)

  Domain score: 64 pt
  Findings:
  - High | +30 pt | Webhook now allows StatefulSet nodeSelector changes but the StatefulSet reconciler does not resync the Workload PodSet — Workload accounting
  drifts from the actual Pod nodeSelector (validation.go:207-212 is shared with statefulset_webhook.go:173; statefulset_reconciler.go:182-247 has no recreate
  path).
  - Medium | +14 pt | EquivalentToWorkload unconditionally appends WithIgnoreNodeSelector() (reconciler.go:1210-1211), flipping equivalence semantics for every
  framework. Tolerations are guarded by IsAdmitted(wl) — nodeSelector should follow the same convention.
  - Medium | +14 pt | LWS PodSet diff triggers hard-delete instead of workload.Finish(..., WorkloadFinishedReasonOutOfSync, ...). Operators lose the audit
  trail/event that the generic prebuilt path emits on out-of-sync recreation (leaderworkerset_reconciler.go:343-345 vs. reconciler.go:1202-1203).
  - Low | +6 pt | Test rename "change nodeTemplate" → "change nodeSelector" drops the only negative-error assertion in the table without replacement; the
  immutability contract for other fields (containers, affinity) loses coverage in this table (validation_test.go:152-156).

  Skill: Comments (weight 0.5)

  Domain score: 8 pt
  Findings:
  - Medium | +3.5 pt | Godoc on ValidateImmutablePodGroupPodSpec still says "no changes are allowed to the PodSpec except fields that required for role-hash
  generation," but nodeSelector is now also permitted (validation.go:207).
  - Low | +1.5 pt | ignoreNodeSelector helper has no "why" comment explaining the LWS recreate contract (validation.go:250).
  - Low | +1.5 pt | New exported WithIgnoreNodeSelector lacks godoc describing the caller contract that the workload must be recreated (podset.go:40).
  - Low | +1.5 pt | TODO above comparePodTemplate mentioning nodeSelectors/tolerations as future work is now stale — both are checked by default with explicit
  opt-out (podset.go:42-44).

  Skill: Security (weight 2.0)

  Domain score: 6 pt
  Findings:
  - Low | +6 pt | Mild DoS amplification: a tenant churning nodeSelector forces the controller into delete+recreate loops on each mutation. Admission is re-run
  each cycle so there is no quota bypass, but the tenant has a cheap multiplier on controller/API-server work (leaderworkerset_reconciler.go:336-350).

  ---
  Final Score: 109.5 pt

  ---
  Recommendations

  Recommendation 1: Make StatefulSet reconciler sync PodSets when nodeSelector changes (or scope the relaxation to LWS)

  Severity: High
  Domain: Buggy Behavior
  Findings: Webhook now allows StatefulSet nodeSelector changes but the StatefulSet reconciler does not resync the Workload PodSet
  Problem: ValidateImmutablePodGroupPodSpec is shared by StatefulSet and LWS. After relaxation, a user can mutate a suspended StatefulSet's nodeSelector, but the
   StatefulSet reconciler does not detect the diff or recreate the Workload — Pods schedule with the new nodeSelector while the Workload's PodSet still carries
  the old one.
  Reason: Kueue's accounting (quota, flavor matching, admission checks) assumes the admitted PodSet matches the runtime PodSpec. Allowing those to drift defeats
  the immutability invariant and produces subtle scheduling mismatches that are hard to triage in production.
  Solution: Make the relaxation opt-in. Add a validation option and pass it only from the LWS webhook:
  // validation.go
  func ValidateImmutablePodGroupPodSpec(new, old *corev1.PodSpec, fp *field.Path, opts ...ValidationOption) field.ErrorList { ... }

  // leaderworkerset webhook
  jobframework.ValidateImmutablePodGroupPodSpec(..., jobframework.WithAllowNodeSelectorMutation())
  Alternative: replicate the LWS delete-and-recreate logic in statefulset_reconciler.reconcileWorkload — but the opt-in option has the smaller blast radius.
  Locations:
  - pkg/controller/jobframework/validation.go:207-212
  - pkg/controller/jobs/statefulset/statefulset_webhook.go:173
  - pkg/controller/jobs/statefulset/statefulset_reconciler.go:182-247
  
  Recommendation 2: Scope WithIgnoreNodeSelector in EquivalentToWorkload to admitted workloads

  Severity: Medium
  Domain: Buggy Behavior
  Findings: EquivalentToWorkload unconditionally appends WithIgnoreNodeSelector()
  Problem: reconciler.go:1210-1211 ignores nodeSelector for every framework. Tolerations are guarded by IsAdmitted(wl) because scheduler-injected fields only
  appear post-admission; nodeSelector should follow the same convention.
  Reason: Before admission, a nodeSelector difference is a real user change and should retire the prebuilt workload via the standard OutOfSync path. Silently
  treating it as equivalent masks intent.
  Solution:
  opts := make([]equality.ComparePodSetsOption, 0, 2)
  if workload.IsAdmitted(wl) {
      opts = append(opts, equality.WithIgnoreTolerations(), equality.WithIgnoreNodeSelector())
  }
  Locations:
  - pkg/controller/jobframework/reconciler.go:1210-1211
  
  Recommendation 3: Use workload.Finish(..., OutOfSync, ...) instead of hard-delete on PodSet drift

  Severity: Medium
  Domain: Buggy Behavior
  Findings: LWS PodSet diff triggers hard-delete instead of workload.Finish
  Problem: The LWS updateWorkload path removes the finalizer and deletes the Workload directly when PodSets diverge, skipping the standard
  WorkloadFinishedReasonOutOfSync event/condition emitted by the generic prebuilt-workload sync.
  Reason: Operators triaging "why did my pods just get evicted" expect a discoverable OutOfSync reason in the Workload status/events. Hard-delete erases that
  audit trail.
  Solution:
  return workload.Finish(ctx, r.client, wl, kueue.WorkloadFinishedReasonOutOfSync,
      "LeaderWorkerSet PodSpec changed; recreating workload", r.clock)
  Keep deleteWorkload for the genuine toDelete (stale workload cleanup) branch only.
  Locations:
  - pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go:343-345
  
  Recommendation 4: Limit the validation relaxation to LWS (architectural scope)

  Severity: Medium
  Domain: Architectural Decisions
  Findings: Scope creep into shared validation
  Problem: The PR is framed as an LWS-only behavior change, but ValidateImmutablePodGroupPodSpec is shared API. Every current and future caller silently inherits
   "nodeSelector is mutable."
  Reason: The contract of an immutability validator should be set by the caller, not by an internal helper's choice of fields. Hidden contract changes propagate
  to integrations that haven't designed for them.
  Solution: Move the nodeSelector masking behind an option (see Recommendation 1's WithAllowNodeSelectorMutation()) and pass it explicitly from the LWS webhook.
  This pairs cleanly with the StatefulSet fix above.
  Locations:
  - pkg/controller/jobframework/validation.go:207-212

  Recommendation 5: Rename updateWorkload to reflect its conditional delete

  Severity: Medium
  Domain: Architectural Decisions
  Findings: Misleading helper name updateWorkload
  Problem: r.updateWorkload can call r.deleteWorkload when PodSets diverge — the name promises in-place update.
  Reason: Hiding a destructive branch behind a benign verb is a maintenance hazard. Future callers will compose it expecting idempotent semantics and may regress
   the recreation path without noticing.
  Solution: Lift the recreation decision into the reconcile loop:
  if !equality.ComparePodSetSlices(podSets, toUpdate[i].Spec.PodSets) {
      return r.deleteWorkload(ctx, toUpdate[i])
  }   
  return r.updateWorkload(ctx, lws, toUpdate[i])
  Or rename to syncWorkload / reconcileWorkloadUpdate to telegraph that it may recreate.
  Locations:
  - pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go:336-350
  - pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go:151-153

  Recommendation 6: Fix inaccurate godoc on ValidateImmutablePodGroupPodSpec

  Severity: Medium
  Domain: Comments
  Findings: Godoc on ValidateImmutablePodGroupPodSpec is now wrong
  Problem: The comment claims the function disallows all PodSpec changes "except fields that required for role-hash generation," but nodeSelector is now also
  masked before comparison.
  Reason: Inaccurate comments are worse than missing ones — a future maintainer will add new "allowed" fields inconsistently with the true contract. The grammar
  ("fields that required") is also broken.
  Solution:
  // ValidateImmutablePodGroupPodSpec validates that the PodSpec is immutable for
  // serving workloads, except for fields used in role-hash generation and
  // nodeSelector (which the LWS reconciler handles by recreating the workload).
  Locations:
  - pkg/controller/jobframework/validation.go:207
  
  Recommendation 7: Restore the rename Prebuilt qualifier (or rename the trio consistently)

  Severity: Low
  Domain: Architectural Decisions
  Findings: Rename createPrebuiltWorkload → createWorkload loses the "Prebuilt" descriptor
  Problem: "Prebuilt" was a useful pointer that this controller constructs workloads outside the framework's standard path. The rename was justified only by
  symmetry with updateWorkload/deleteWorkload.
  Reason: Symmetry that erases meaningful distinctions has negative value for readers.
  Solution: Keep createPrebuiltWorkload, or rename the trio (createPrebuiltWorkload/updatePrebuiltWorkload/deletePrebuiltWorkload).
  Locations:
  - pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go:144,219

  Recommendation 8: Make ignoreNodeSelector non-mutating (and clearer named)

  Severity: Low
  Domain: Code Style
  Findings: Imprecise helper name ignoreNodeSelector
  Problem: The signature func(shape map[string]any) map[string]any reads like a pure transformation, but the function mutates the caller's map.
  Reason: Safe today only because SpecShape returns fresh maps. A future caller passing a shared/cached map will silently corrupt it, and a nil map will panic.
  Solution:
  func withoutNodeSelector(shape map[string]any) map[string]any {
      out := maps.Clone(shape)
      delete(out, "nodeSelector")
      return out
  }
  Or inline the two assignments directly in the caller — locality is obvious.
  Locations:
  - pkg/controller/jobframework/validation.go:250-253
  
  Recommendation 9: Fix misleading test case names referring to "requests in node selector"

  Severity: Low
  Domain: Code Style
  Findings: Misleading test case name "different requests in node selector with ignoreNodeSelector"
  Problem: Both the new case and its sibling at line 134 say "different requests in node selector" — node selectors have no "requests"; the cases differ only in
  NodeSelector values.
  Reason: Test names are scenario documentation. Inaccurate names mislead future readers, especially since the sibling now expects wantEquivalent: false and the
  wording is doubly stale.
  Solution:
  "different node selector across pod sets":                          { ... wantEquivalent: false },
  "different node selector across pod sets with ignoreNodeSelector":  { ... ignoreNodeSelector: true, wantEquivalent: true },
  Locations:
  - pkg/util/equality/podset_test.go:128-144
  - pkg/util/equality/podset_test.go:145-160
  
  Recommendation 10: Restore negative immutability coverage in validation_test.go

  Severity: Low
  Domain: Buggy Behavior
  Findings: Test rename drops the only negative-error assertion in the table
  Problem: The diff converts "change nodeTemplate" (asserting an error) into "change nodeSelector" (asserting no error) and leaves the table without any other
  negative case.
  Reason: No remaining guard against a future change that inadvertently allows containers, affinity, or other immutable fields to mutate.
  Solution: Keep the new positive case and add at least one negative case (e.g., "change affinity" or "change container resources" expecting an error).
  Locations:
  - pkg/controller/jobframework/validation_test.go:152-156

  Recommendation 11: Add a "why" comment on ignoreNodeSelector

  Severity: Low
  Domain: Comments
  Findings: Missing why on ignoreNodeSelector
  Problem: Helper has no comment explaining why nodeSelector is special-cased.
  Reason: Readers must trace to the LWS reconciler's updateWorkload to learn that nodeSelector mutation is permitted because the controller recreates the
  workload. That's exactly the non-obvious-why that justifies a comment.
  Solution:
  // ignoreNodeSelector masks nodeSelector from the immutability check so LWS
  // template updates to nodeSelector are permitted; the reconciler responds by
  // recreating the workload (see leaderworkerset_reconciler.updateWorkload).
  Locations:
  - pkg/controller/jobframework/validation.go:250

  Recommendation 12: Document WithIgnoreNodeSelector caller contract

  Severity: Low
  Domain: Comments
  Findings: Missing godoc on WithIgnoreNodeSelector
  Problem: Exported option has no comment; its caller contract (recreate workload on diff) is non-obvious.
  Reason: Exported API surface should explain when callers should opt in, especially when the option has a paired behavioral obligation.
  Solution:
  // WithIgnoreNodeSelector skips nodeSelector when comparing PodSpecs. Use only
  // when the caller will recreate the workload on nodeSelector change (e.g., the
  // LeaderWorkerSet reconciler).
  func WithIgnoreNodeSelector() ComparePodSetsOption { ... }
  Locations:
  - pkg/util/equality/podset.go:40

  Recommendation 13: Refresh the stale TODO above comparePodTemplate

  Severity: Low
  Domain: Comments
  Findings: Stale TODO mentioning nodeSelectors/tolerations as future work
  Problem: TODO says we should "extend the check to … nodeSelectors(when suspended), tolerations". Both are now checked by default with explicit opt-out.
  Reason: Stale TODOs mislead reviewers about which fields are enforced and what work remains.
  Solution: Either delete or rewrite to point at remaining gaps (priority, affinity, topologySpreadConstraints, …).
  Locations:
  - pkg/util/equality/podset.go:42-44

  Recommendation 14: Emit an event on tenant-driven workload recreation

  Severity: Low
  Domain: Security
  Findings: Reconciler DoS amplification on nodeSelector churn
  Problem: A tenant repeatedly mutating LWS nodeSelector forces delete+recreate cycles; while each cycle re-runs admission (so no quota bypass), the multiplier
  is uncapped.
  Reason: Observability of recreation makes abuse detectable and lets controller-runtime's workqueue rate-limiter and operators react. Each recreate also kills
  running pods — operators should be able to find a breadcrumb.
  Solution:
  if !equality.ComparePodSetSlices(podSets, wl.Spec.PodSets) {
      r.record.Eventf(lws, corev1.EventTypeWarning, "WorkloadRecreated",
          "PodSet template changed; recreating workload")
      return r.deleteWorkload(ctx, wl)
  }
  (Subsumed by Recommendation 3 if you switch to workload.Finish(..., OutOfSync, ...), which already emits the appropriate condition.)
  Locations:
  - pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go:336-350
```


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
