### PR TITLE
test: split e2e TAS tests into baseline and extended 

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -161,7 +161,13 @@ test-multikueue-e2e-helm: E2E_USE_HELM=true
 test-multikueue-e2e-helm: test-multikueue-e2e
 
 .PHONY: test-tas-e2e
-test-tas-e2e: setup-e2e-env kind-ray-project-mini-image-build run-test-tas-e2e-$(E2E_KIND_VERSION:kindest/node:v%=%)
+test-tas-e2e: test-tas-e2e-baseline test-tas-e2e-extended
+
+.PHONY: test-tas-e2e-baseline
+test-tas-e2e-baseline: setup-e2e-env run-test-tas-e2e-baseline-$(E2E_KIND_VERSION:kindest/node:v%=%)
+
+.PHONY: test-tas-e2e-extended
+test-tas-e2e-extended: setup-e2e-env kind-ray-project-mini-image-build run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-tas-e2e-helm
 test-tas-e2e-helm: E2E_USE_HELM=true
@@ -240,9 +246,23 @@ run-test-multikueue-e2e-%:
 		E2E_USE_HELM=$(E2E_USE_HELM) \
 		./hack/testing/e2e-multikueue-test.sh
 
-run-test-tas-e2e-%: K8S_VERSION = $(@:run-test-tas-e2e-%=%)
-run-test-tas-e2e-%:
-	@echo Running tas e2e for k8s ${K8S_VERSION}
+run-test-tas-e2e-baseline-%: K8S_VERSION = $(@:run-test-tas-e2e-baseline-%=%)
+run-test-tas-e2e-baseline-%:
+	@echo Running tas e2e baseline for k8s ${K8S_VERSION}
+	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
+		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
+		E2E_MODE=$(E2E_MODE) \
+		E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
+		E2E_ENFORCE_OPERATOR_UPDATE=$(E2E_ENFORCE_OPERATOR_UPDATE) \
+		KIND_CLUSTER_FILE="kind-cluster-tas.yaml" E2E_TARGET_FOLDER="tas/baseline" \
+		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
+		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
+		E2E_USE_HELM=$(E2E_USE_HELM) \
+		./hack/testing/e2e-test.sh
+
+run-test-tas-e2e-extended-%: K8S_VERSION = $(@:run-test-tas-e2e-extended-%=%)
+run-test-tas-e2e-extended-%:
+	@echo Running tas e2e extended for k8s ${K8S_VERSION}
 	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
 		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
 		E2E_MODE=$(E2E_MODE) \
@@ -253,7 +273,7 @@ run-test-tas-e2e-%:
 		LEADERWORKERSET_VERSION=$(LEADERWORKERSET_VERSION) \
 		KUBERAY_VERSION=$(KUBERAY_VERSION) RAY_VERSION=$(RAY_VERSION) RAYMINI_VERSION=$(RAYMINI_VERSION) USE_RAY_FOR_TESTS=$(USE_RAY_FOR_TESTS) \
 		KUBEFLOW_TRAINER_VERSION=$(KUBEFLOW_TRAINER_VERSION) \
-		KIND_CLUSTER_FILE="kind-cluster-tas.yaml" E2E_TARGET_FOLDER="tas" \
+		KIND_CLUSTER_FILE="kind-cluster-tas.yaml" E2E_TARGET_FOLDER="tas/extended" \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
 		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		E2E_USE_HELM=$(E2E_USE_HELM) \

--- a/site/content/en/docs/contribution_guidelines/testing.md
+++ b/site/content/en/docs/contribution_guidelines/testing.md
@@ -57,7 +57,8 @@ For running a subset of tests, see [Running subset of tests](#running-subset-of-
 ```shell
 make kind-image-build
 make test-e2e
-make test-tas-e2e
+make test-tas-e2e-baseline
+make test-tas-e2e-extended
 make test-e2e-sequential-extended
 make test-e2e-sequential-baseline
 make test-e2e-certmanager
@@ -266,7 +267,8 @@ ginkgo.FIt("Should place pods based on the ranks-ordering", func() {
 and then run
 ```shell
 # build and pull image
-make test-tas-e2e
+make test-tas-e2e-baseline
+make test-tas-e2e-extended
 ```
 to test a particular TAS e2e test.
 

--- a/site/content/zh-CN/docs/contribution_guidelines/testing.md
+++ b/site/content/zh-CN/docs/contribution_guidelines/testing.md
@@ -57,7 +57,8 @@ make test-integration
 ```shell
 make kind-image-build
 make test-e2e
-make test-tas-e2e
+make test-tas-e2e-baseline
+make test-tas-e2e-extended
 make test-e2e-sequential-extended
 make test-e2e-sequential-baseline
 make test-e2e-certmanager
@@ -175,7 +176,8 @@ ginkgo.FIt("Should place pods based on the ranks-ordering", func() {
 然后运行
 ```shell
 # 构建并拉取镜像
-make test-tas-e2e
+make test-tas-e2e-baseline
+make test-tas-e2e-extended
 ```
 来测试特定的 TAS e2e 测试。
 

--- a/test/e2e/tas/baseline/helpers_test.go
+++ b/test/e2e/tas/baseline/helpers_test.go
@@ -1,0 +1,23 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package baseline
+
+const (
+	instanceType      = "tas-group"
+	tasNodeGroupLabel = "cloud.provider.com/node-group"
+	extraResource     = "example.com/gpu"
+)

--- a/test/e2e/tas/baseline/job_test.go
+++ b/test/e2e/tas/baseline/job_test.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tase2e
+package baseline
+
 
 import (
 	"fmt"
@@ -36,12 +37,6 @@ import (
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/test/util"
-)
-
-const (
-	instanceType      = "tas-group"
-	tasNodeGroupLabel = "cloud.provider.com/node-group"
-	extraResource     = "example.com/gpu"
 )
 
 var _ = ginkgo.Describe("TopologyAwareScheduling for Job", func() {

--- a/test/e2e/tas/baseline/job_test.go
+++ b/test/e2e/tas/baseline/job_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 package baseline
 
-
 import (
 	"fmt"
 

--- a/test/e2e/tas/baseline/pod_group_test.go
+++ b/test/e2e/tas/baseline/pod_group_test.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tase2e
+package baseline
+
 
 import (
 	"github.com/onsi/ginkgo/v2"

--- a/test/e2e/tas/baseline/pod_group_test.go
+++ b/test/e2e/tas/baseline/pod_group_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 package baseline
 
-
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"

--- a/test/e2e/tas/baseline/statefulset_test.go
+++ b/test/e2e/tas/baseline/statefulset_test.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tase2e
+package baseline
+
 
 import (
 	"github.com/onsi/ginkgo/v2"

--- a/test/e2e/tas/baseline/statefulset_test.go
+++ b/test/e2e/tas/baseline/statefulset_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 package baseline
 
-
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"

--- a/test/e2e/tas/baseline/suite_test.go
+++ b/test/e2e/tas/baseline/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tase2e
+package baseline
 
 import (
 	"context"
@@ -41,7 +41,7 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	util.RunE2ESuite(t, "End To End TAS Suite")
+	util.RunE2ESuite(t, "End To End TAS Baseline Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -56,12 +56,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 	waitForAvailableStart := time.Now()
 	util.WaitForKueueAvailability(ctx, k8sClient)
-	util.WaitForJobSetAvailability(ctx, k8sClient)
-	util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sClient)
-	util.WaitForKubeFlowMPIOperatorAvailability(ctx, k8sClient)
-	util.WaitForAppWrapperAvailability(ctx, k8sClient)
-	util.WaitForLeaderWorkerSetAvailability(ctx, k8sClient)
-	util.WaitForKubeRayOperatorAvailability(ctx, k8sClient)
 	ginkgo.GinkgoLogr.Info(
 		"Kueue and all required operators are available in the cluster",
 		"waitingTime", time.Since(waitForAvailableStart),

--- a/test/e2e/tas/extended/appwrapper_test.go
+++ b/test/e2e/tas/extended/appwrapper_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 package extended
 
-
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"

--- a/test/e2e/tas/extended/appwrapper_test.go
+++ b/test/e2e/tas/extended/appwrapper_test.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tase2e
+package extended
+
 
 import (
 	"github.com/onsi/ginkgo/v2"

--- a/test/e2e/tas/extended/helpers_test.go
+++ b/test/e2e/tas/extended/helpers_test.go
@@ -1,0 +1,23 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extended
+
+const (
+	instanceType      = "tas-group"
+	tasNodeGroupLabel = "cloud.provider.com/node-group"
+	extraResource     = "example.com/gpu"
+)

--- a/test/e2e/tas/extended/hotswap_test.go
+++ b/test/e2e/tas/extended/hotswap_test.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tase2e
+package extended
+
 
 import (
 	"context"

--- a/test/e2e/tas/extended/hotswap_test.go
+++ b/test/e2e/tas/extended/hotswap_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 package extended
 
-
 import (
 	"context"
 	"fmt"

--- a/test/e2e/tas/extended/jobset_test.go
+++ b/test/e2e/tas/extended/jobset_test.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tase2e
+package extended
+
 
 import (
 	"fmt"

--- a/test/e2e/tas/extended/jobset_test.go
+++ b/test/e2e/tas/extended/jobset_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 package extended
 
-
 import (
 	"fmt"
 

--- a/test/e2e/tas/extended/leaderworkerset_test.go
+++ b/test/e2e/tas/extended/leaderworkerset_test.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tase2e
+package extended
+
 
 import (
 	"fmt"

--- a/test/e2e/tas/extended/leaderworkerset_test.go
+++ b/test/e2e/tas/extended/leaderworkerset_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 package extended
 
-
 import (
 	"fmt"
 

--- a/test/e2e/tas/extended/mpijob_test.go
+++ b/test/e2e/tas/extended/mpijob_test.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tase2e
+package extended
+
 
 import (
 	"fmt"

--- a/test/e2e/tas/extended/mpijob_test.go
+++ b/test/e2e/tas/extended/mpijob_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 package extended
 
-
 import (
 	"fmt"
 

--- a/test/e2e/tas/extended/pytorch_test.go
+++ b/test/e2e/tas/extended/pytorch_test.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tase2e
+package extended
+
 
 import (
 	"fmt"

--- a/test/e2e/tas/extended/pytorch_test.go
+++ b/test/e2e/tas/extended/pytorch_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 package extended
 
-
 import (
 	"fmt"
 

--- a/test/e2e/tas/extended/rayjob_test.go
+++ b/test/e2e/tas/extended/rayjob_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 package extended
 
-
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"

--- a/test/e2e/tas/extended/rayjob_test.go
+++ b/test/e2e/tas/extended/rayjob_test.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tase2e
+package extended
+
 
 import (
 	"github.com/onsi/ginkgo/v2"

--- a/test/e2e/tas/extended/suite_test.go
+++ b/test/e2e/tas/extended/suite_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extended
+
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
+	clientutil "sigs.k8s.io/kueue/pkg/util/client"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var (
+	k8sClient       client.WithWatch
+	ctx             context.Context
+	defaultKueueCfg *configapi.Configuration
+	kindClusterName = os.Getenv("KIND_CLUSTER_NAME")
+)
+
+func TestAPIs(t *testing.T) {
+	util.RunE2ESuite(t, "End To End TAS Extended Suite")
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	util.SetupLogger()
+
+	var err error
+	k8sClient, _, err = util.CreateClientUsingCluster("")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	ctx = ginkgo.GinkgoT().Context()
+
+	defaultKueueCfg = util.GetKueueConfiguration(ctx, k8sClient)
+
+	waitForAvailableStart := time.Now()
+	util.WaitForKueueAvailability(ctx, k8sClient)
+	util.WaitForJobSetAvailability(ctx, k8sClient)
+	util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sClient)
+	util.WaitForKubeFlowMPIOperatorAvailability(ctx, k8sClient)
+	util.WaitForAppWrapperAvailability(ctx, k8sClient)
+	util.WaitForLeaderWorkerSetAvailability(ctx, k8sClient)
+	util.WaitForKubeRayOperatorAvailability(ctx, k8sClient)
+	ginkgo.GinkgoLogr.Info(
+		"Kueue and all required operators are available in the cluster",
+		"waitingTime", time.Since(waitForAvailableStart),
+	)
+
+	nodes := &corev1.NodeList{}
+	requiredLabels := client.MatchingLabels{}
+	requiredLabelKeys := client.HasLabels{tasNodeGroupLabel}
+	err = k8sClient.List(ctx, nodes, requiredLabels, requiredLabelKeys)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to list nodes for TAS")
+
+	for _, n := range nodes.Items {
+		gomega.Eventually(func(g gomega.Gomega) {
+			node := &corev1.Node{}
+			g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: n.Name}, node)).To(gomega.Succeed())
+			err := clientutil.PatchStatus(ctx, k8sClient, node, func() (bool, error) {
+				node.Status.Capacity[extraResource] = resource.MustParse("1")
+				node.Status.Allocatable[extraResource] = resource.MustParse("1")
+				return true, nil
+			})
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	}
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
+})

--- a/test/e2e/tas/extended/suite_test.go
+++ b/test/e2e/tas/extended/suite_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 package extended
 
-
 import (
 	"context"
 	"os"

--- a/test/e2e/tas/extended/trainjob_test.go
+++ b/test/e2e/tas/extended/trainjob_test.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tase2e
+package extended
+
 
 import (
 	"fmt"

--- a/test/e2e/tas/extended/trainjob_test.go
+++ b/test/e2e/tas/extended/trainjob_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 package extended
 
-
 import (
 	"fmt"
 


### PR DESCRIPTION
What type of PR is this?
/kind cleanup
/area tas
/area testing

What this PR does / why we need it:
Cherry-pick of #11002 into release-0.16.

Splits the TAS e2e test suite into two shards:
- `baseline` — core TAS tests (job, pod group, statefulset)
- `extended` — integration tests (jobset, mpijob, pytorch, rayjob, trainjob, hotswap, appwrapper, leaderworkerset)

This reduces CI wall-clock time for PRs by running the two shards in parallel.

Which issue this PR fixes
Part of #10995

Special notes for your reviewer
Cherry-pick of #11002.

Does this PR introduce a user-facing change?

```release-note
NONE
```
