### PR TITLE
Adding extended and baseline components for Helm in Makefile-test.mk 

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -167,10 +167,6 @@ test-tas-e2e-baseline: setup-e2e-env run-test-tas-e2e-baseline-$(E2E_KIND_VERSIO
 .PHONY: test-tas-e2e-extended
 test-tas-e2e-extended: setup-e2e-env kind-ray-project-mini-image-build run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
-.PHONY: test-tas-e2e-helm
-test-tas-e2e-helm: E2E_USE_HELM=true
-test-tas-e2e-helm: test-tas-e2e
-
 .PHONY: test-e2e-certmanager
 test-e2e-certmanager: setup-e2e-env run-test-e2e-certmanager-$(E2E_KIND_VERSION:kindest/node:v%=%)
 

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -161,11 +161,18 @@ test-multikueue-e2e-sequential: setup-e2e-env test-multikueue-e2e-parallel-build
 test-multikueue-e2e-helm: E2E_USE_HELM=true
 test-multikueue-e2e-helm: test-multikueue-e2e
 
+.PHONY: test-tas-e2e
+test-tas-e2e: test-tas-e2e-baseline test-tas-e2e-extended
+
 .PHONY: test-tas-e2e-baseline
 test-tas-e2e-baseline: setup-e2e-env run-test-tas-e2e-baseline-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-tas-e2e-extended
 test-tas-e2e-extended: setup-e2e-env kind-ray-project-mini-image-build run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
+
+.PHONY: test-tas-e2e-helm
+test-tas-e2e-helm: E2E_USE_HELM=true
+test-tas-e2e-helm: test-tas-e2e
 
 .PHONY: test-tas-e2e-baseline-helm
 test-tas-e2e-baseline-helm: E2E_USE_HELM=true

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -167,6 +167,14 @@ test-tas-e2e-baseline: setup-e2e-env run-test-tas-e2e-baseline-$(E2E_KIND_VERSIO
 .PHONY: test-tas-e2e-extended
 test-tas-e2e-extended: setup-e2e-env kind-ray-project-mini-image-build run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
+.PHONY: test-tas-e2e-baseline-helm
+test-tas-e2e-baseline-helm: E2E_USE_HELM=true
+test-tas-e2e-baseline-helm: test-tas-e2e-baseline
+
+.PHONY: test-tas-e2e-extended-helm
+test-tas-e2e-extended-helm: E2E_USE_HELM=true
+test-tas-e2e-extended-helm: test-tas-e2e-extended
+
 .PHONY: test-e2e-certmanager
 test-e2e-certmanager: setup-e2e-env run-test-e2e-certmanager-$(E2E_KIND_VERSION:kindest/node:v%=%)
 

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -161,9 +161,6 @@ test-multikueue-e2e-sequential: setup-e2e-env test-multikueue-e2e-parallel-build
 test-multikueue-e2e-helm: E2E_USE_HELM=true
 test-multikueue-e2e-helm: test-multikueue-e2e
 
-.PHONY: test-tas-e2e
-test-tas-e2e: test-tas-e2e-baseline test-tas-e2e-extended
-
 .PHONY: test-tas-e2e-baseline
 test-tas-e2e-baseline: setup-e2e-env run-test-tas-e2e-baseline-$(E2E_KIND_VERSION:kindest/node:v%=%)
 


### PR DESCRIPTION
What type of PR is this?
/kind cleanup
/area tas
/area testing

What this PR does / why we need it:
Adds two missing Helm-specific Makefile targets for TAS e2e tests:
- `test-tas-e2e-baseline-helm` — runs `test-tas-e2e-baseline` with `E2E_USE_HELM=true`
- `test-tas-e2e-extended-helm` — runs `test-tas-e2e-extended` with `E2E_USE_HELM=true`

These targets mirror the existing `test-multikueue-e2e-helm` pattern and were missing as a follow-up to the previous TAS e2e PR.

Also removes the now-redundant `test-tas-e2e-helm` target that delegated to the combined `test-tas-e2e`, replacing it with the two granular helm targets above.

Which issue this PR fixes:
Follow-up to the PR that introduced `test-tas-e2e-baseline` and `test-tas-e2e-extended`.
Part of  #11091 

Special notes for your reviewer:
Pattern follows the existing `test-multikueue-e2e-helm` convention — sets `E2E_USE_HELM=true` and delegates to the non-helm base target.

Does this PR introduce a user-facing change?
```release-note
NONE
```

