### PR TITLE
Fix typo: neccessary -> necessary in TAS KEP

### DIFF
--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -1344,7 +1344,7 @@ about the failed nodes. This information will then be consumed by a new mechanis
 in scheduler where we will try to find a new topology assignment and replace the
 failed node(s) (by changing the assignment only on the affected pods). Initially we plan
 to only replace in the case of a single node failure and if no preemption/reclamation
-is neccessary to fit the workload. Since this mechanism is dedicated
+is necessary to fit the workload. Since this mechanism is dedicated
 to only replace nodes, it will only work for Topologies which specify
 `kubernetes.io/hostname` at the lowest level.
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind documentation
/area tas

#### What this PR does / why we need it:
Fixes a typo (\"neccessary\" -> \"necessary\") in the Topology-Aware Scheduling KEP README.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
Single-word doc typo fix.

#### Does this PR introduce a user-facing change?
\`\`\`release-note
NONE
\`\`\`