### PR TITLE
Delete test-tas-e2e and test-tas-e2e-helm targets

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -161,18 +161,11 @@ test-multikueue-e2e-sequential: setup-e2e-env test-multikueue-e2e-parallel-build
 test-multikueue-e2e-helm: E2E_USE_HELM=true
 test-multikueue-e2e-helm: test-multikueue-e2e
 
-.PHONY: test-tas-e2e
-test-tas-e2e: test-tas-e2e-baseline test-tas-e2e-extended
-
 .PHONY: test-tas-e2e-baseline
 test-tas-e2e-baseline: setup-e2e-env run-test-tas-e2e-baseline-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-tas-e2e-extended
 test-tas-e2e-extended: setup-e2e-env kind-ray-project-mini-image-build run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
-
-.PHONY: test-tas-e2e-helm
-test-tas-e2e-helm: E2E_USE_HELM=true
-test-tas-e2e-helm: test-tas-e2e
 
 .PHONY: test-tas-e2e-baseline-helm
 test-tas-e2e-baseline-helm: E2E_USE_HELM=true


### PR DESCRIPTION
What type of PR is this?
/kind cleanup
/area testing

What this PR does / why we need it:
Removes the test-tas-e2e phony target from Makefile-test.mk, which was a wrapper that called test-tas-e2e-baseline and test-tas-e2e-extended together. The individual targets (test-tas-e2e-baseline, test-tas-e2e-extended) remain available and can be invoked directly or composed as needed.

Which issue this PR fixes:
Part of https://github.com/kubernetes-sigs/kueue/issues/10995

Special notes for your reviewer:
This is a minor Makefile cleanup. The underlying test targets are untouched — only the combined wrapper target is removed.

Does this PR introduce a user-facing change?
```release-note
NONE
```
