### PR TITLE
Automated cherry pick of #11011: Increase flaky pull-kueue-test-e2e-multikueue-main timeout and verbosity.
#11081: Improve formatting of objects in ginkgo failed multikueue asserts

### DIFF
--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -29,7 +29,6 @@ import (
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	"github.com/onsi/gomega/format"
 	awv1beta2 "github.com/project-codeflare/appwrapper/api/v1beta2"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -1012,18 +1011,22 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			ginkgo.By("Checking that the workload is created and admitted in the manager cluster", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sManagerClient.Get(ctx, wlKey, managerWl)).To(gomega.Succeed())
-					g.Expect(workload.IsAdmitted(managerWl)).To(gomega.BeTrue(), assertMsg("Workload not admitted in manager", wlKey))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(managerWl)).To(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed(), assertWlMsg("Workload not admitted in manager", managerWl))
 			})
 
 			ginkgo.By("Checking that the workload is created on worker1", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sWorker1Client.Get(ctx, wlKey, workerWorkload)).To(gomega.Succeed())
-					g.Expect(workload.IsAdmitted(workerWorkload)).To(gomega.BeTrue(), assertMsg("Workload not admitted in worker1", wlKey))
+					g.Expect(workload.IsAdmitted(workerWorkload)).To(gomega.BeTrue())
 					g.Expect(workerWorkload.Spec).To(gomega.BeComparableTo(managerWl.Spec))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed(), assertWlMsg("Workload not admitted in worker1", workerWorkload))
+			})
 
-					g.Expect(k8sWorker2Client.Get(ctx, wlKey, workerWorkload)).To(utiltesting.BeNotFoundError(), assertMsg("Workload present in worker2", wlKey))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			ginkgo.By("Checking that the workload is not created on worker2", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sWorker2Client.Get(ctx, wlKey, workerWorkload)).To(utiltesting.BeNotFoundError())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed(), assertWlMsg("Workload present in worker2", workerWorkload))
 			})
 
 			ginkgo.By("Switching worker cluster queues' resources to enforce re-admission on the worker2", func() {
@@ -1057,18 +1060,22 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			ginkgo.By("Checking that the workload is re-admitted in worker2", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sManagerClient.Get(ctx, wlKey, managerWl)).To(gomega.Succeed())
-					g.Expect(managerWl.Status.ClusterName).To(gomega.HaveValue(gomega.Equal(workerCluster2.Name)), assertMsg("Workload not Admitted in worker2", wlKey))
-				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+					g.Expect(managerWl.Status.ClusterName).To(gomega.HaveValue(gomega.Equal(workerCluster2.Name)))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed(), assertWlMsg("Workload not Admitted in worker2", managerWl))
 			})
 
 			ginkgo.By("Checking that the workload is created in worker2", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sWorker2Client.Get(ctx, wlKey, workerWorkload)).To(gomega.Succeed())
-					g.Expect(workload.IsAdmitted(workerWorkload)).To(gomega.BeTrue(), assertMsg("Workload not Admitted in worker2", wlKey))
+					g.Expect(workload.IsAdmitted(workerWorkload)).To(gomega.BeTrue())
 					g.Expect(workerWorkload.Spec).To(gomega.BeComparableTo(managerWl.Spec))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed(), assertWlMsg("Workload not Admitted in worker2", workerWorkload))
+			})
 
-					g.Expect(k8sWorker1Client.Get(ctx, wlKey, workerWorkload)).To(utiltesting.BeNotFoundError(), assertMsg("Workload present in worker1", wlKey))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			ginkgo.By("Checking that the workload is not created in worker1", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sWorker1Client.Get(ctx, wlKey, workerWorkload)).To(utiltesting.BeNotFoundError())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed(), assertWlMsg("Workload present in worker1", workerWorkload))
 			})
 		})
 
@@ -1606,23 +1613,24 @@ func expectJobToBeCreatedAndManagedBy(ctx context.Context, c client.Client, job 
 	}, util.Timeout, util.Interval).Should(gomega.Succeed())
 }
 
-func assertMsg(msg string, wlKey client.ObjectKey) func() string {
+func assertWlMsg(msg string, wl *kueue.Workload) func() string {
 	return func() string {
-		output := &strings.Builder{}
-		fmt.Fprintln(output, msg)
-		withClusterWl(output, wlKey, "Manager", k8sManagerClient)
-		withClusterWl(output, wlKey, "Worker1", k8sWorker1Client)
-		withClusterWl(output, wlKey, "Worker2", k8sWorker2Client)
-		return output.String()
+		wlKey := client.ObjectKeyFromObject(wl)
+		return strings.Join([]string{
+			util.AssertMsg(msg, wl)(),
+			util.AssertMsg("Manager", getWorkload(k8sManagerClient, wlKey))(),
+			util.AssertMsg("Worker1", getWorkload(k8sWorker1Client, wlKey))(),
+			util.AssertMsg("Worker2", getWorkload(k8sWorker2Client, wlKey))(),
+		}, "\n")
 	}
 }
 
-func withClusterWl(output *strings.Builder, wlKey client.ObjectKey, cName string, cClient client.Client) {
+func getWorkload(c client.Client, wlKey client.ObjectKey) *kueue.Workload {
 	wl := &kueue.Workload{}
-	if err := cClient.Get(ctx, wlKey, wl); err == nil {
-		fmt.Fprintln(output, cName, "Workload:", format.Object(wl.ObjectMeta, 1))
-		fmt.Fprintln(output, cName, "Status:", format.Object(wl.Status, 1))
-	} else {
-		fmt.Fprintln(output, "Workload not present in:", cName, "Error:", err)
+	err := c.Get(ctx, wlKey, wl)
+	if err != nil {
+		gomega.Expect(client.IgnoreNotFound(err)).NotTo(gomega.HaveOccurred())
+		return nil
 	}
+	return wl
 }

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	kfmpi "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
@@ -27,6 +29,7 @@ import (
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	awv1beta2 "github.com/project-codeflare/appwrapper/api/v1beta2"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -1054,7 +1057,33 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			ginkgo.By("Checking that the workload is re-admitted in worker2", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sManagerClient.Get(ctx, wlKey, managerWl)).To(gomega.Succeed())
-					g.Expect(managerWl.Status.ClusterName).To(gomega.HaveValue(gomega.Equal(workerCluster2.Name)), util.AssertMsg("Manager Workload is not admitted in worker2", managerWl))
+					g.Expect(managerWl.Status.ClusterName).To(
+						gomega.HaveValue(gomega.Equal(workerCluster2.Name)),
+						func() string {
+							var output strings.Builder
+							fmt.Fprintln(&output, "Workload not Admitted in worker2")
+							fmt.Fprintln(&output, "Manager Workload:", format.Object(workerWorkload.ObjectMeta, 1))
+							fmt.Fprintln(&output, "Manager Status:", format.Object(workerWorkload.Status, 1))
+
+							workerWl := &kueue.Workload{}
+
+							if err := k8sWorker1Client.Get(ctx, wlKey, workerWl); err == nil {
+								fmt.Fprintln(&output, "Worker1 Workload:", format.Object(workerWl.ObjectMeta, 1))
+								fmt.Fprintln(&output, "Worker1 Status:", format.Object(workerWl.Status, 1))
+							} else {
+								fmt.Fprintln(&output, "Workload not present in worker1:", err)
+							}
+
+							if err := k8sWorker2Client.Get(ctx, wlKey, workerWl); err == nil {
+								fmt.Fprintln(&output, "Worker2 Workload:", format.Object(workerWl.ObjectMeta, 1))
+								fmt.Fprintln(&output, "Worker2 Status:", format.Object(workerWl.Status, 1))
+							} else {
+								fmt.Fprintln(&output, "Workload not present in worker2:", err)
+							}
+
+							return output.String()
+						},
+					)
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -1012,17 +1012,17 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			ginkgo.By("Checking that the workload is created and admitted in the manager cluster", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sManagerClient.Get(ctx, wlKey, managerWl)).To(gomega.Succeed())
-					g.Expect(workload.IsAdmitted(managerWl)).To(gomega.BeTrue(), util.AssertMsg("Workload not admitted in manager", managerWl))
+					g.Expect(workload.IsAdmitted(managerWl)).To(gomega.BeTrue(), assertMsg("Workload not admitted in manager", wlKey))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Checking that the workload is created on worker1", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sWorker1Client.Get(ctx, wlKey, workerWorkload)).To(gomega.Succeed())
-					g.Expect(workload.IsAdmitted(workerWorkload)).To(gomega.BeTrue(), util.AssertMsg("Workload not admitted in worker1", workerWorkload))
+					g.Expect(workload.IsAdmitted(workerWorkload)).To(gomega.BeTrue(), assertMsg("Workload not admitted in worker1", wlKey))
 					g.Expect(workerWorkload.Spec).To(gomega.BeComparableTo(managerWl.Spec))
 
-					g.Expect(k8sWorker2Client.Get(ctx, wlKey, workerWorkload)).To(utiltesting.BeNotFoundError(), util.AssertMsg("Workload present in worker2", workerWorkload))
+					g.Expect(k8sWorker2Client.Get(ctx, wlKey, workerWorkload)).To(utiltesting.BeNotFoundError(), assertMsg("Workload present in worker2", wlKey))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -1057,43 +1057,17 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			ginkgo.By("Checking that the workload is re-admitted in worker2", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sManagerClient.Get(ctx, wlKey, managerWl)).To(gomega.Succeed())
-					g.Expect(managerWl.Status.ClusterName).To(
-						gomega.HaveValue(gomega.Equal(workerCluster2.Name)),
-						func() string {
-							var output strings.Builder
-							fmt.Fprintln(&output, "Workload not Admitted in worker2")
-							fmt.Fprintln(&output, "Manager Workload:", format.Object(workerWorkload.ObjectMeta, 1))
-							fmt.Fprintln(&output, "Manager Status:", format.Object(workerWorkload.Status, 1))
-
-							workerWl := &kueue.Workload{}
-
-							if err := k8sWorker1Client.Get(ctx, wlKey, workerWl); err == nil {
-								fmt.Fprintln(&output, "Worker1 Workload:", format.Object(workerWl.ObjectMeta, 1))
-								fmt.Fprintln(&output, "Worker1 Status:", format.Object(workerWl.Status, 1))
-							} else {
-								fmt.Fprintln(&output, "Workload not present in worker1:", err)
-							}
-
-							if err := k8sWorker2Client.Get(ctx, wlKey, workerWl); err == nil {
-								fmt.Fprintln(&output, "Worker2 Workload:", format.Object(workerWl.ObjectMeta, 1))
-								fmt.Fprintln(&output, "Worker2 Status:", format.Object(workerWl.Status, 1))
-							} else {
-								fmt.Fprintln(&output, "Workload not present in worker2:", err)
-							}
-
-							return output.String()
-						},
-					)
+					g.Expect(managerWl.Status.ClusterName).To(gomega.HaveValue(gomega.Equal(workerCluster2.Name)), assertMsg("Workload not Admitted in worker2", wlKey))
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Checking that the workload is created in worker2", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sWorker2Client.Get(ctx, wlKey, workerWorkload)).To(gomega.Succeed())
-					g.Expect(workload.IsAdmitted(workerWorkload)).To(gomega.BeTrue(), util.AssertMsg("Workload not Admitted in worker2", workerWorkload))
+					g.Expect(workload.IsAdmitted(workerWorkload)).To(gomega.BeTrue(), assertMsg("Workload not Admitted in worker2", wlKey))
 					g.Expect(workerWorkload.Spec).To(gomega.BeComparableTo(managerWl.Spec))
 
-					g.Expect(k8sWorker1Client.Get(ctx, wlKey, workerWorkload)).To(utiltesting.BeNotFoundError(), util.AssertMsg("Workload present in worker1", workerWorkload))
+					g.Expect(k8sWorker1Client.Get(ctx, wlKey, workerWorkload)).To(utiltesting.BeNotFoundError(), assertMsg("Workload present in worker1", wlKey))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
@@ -1630,4 +1604,25 @@ func expectJobToBeCreatedAndManagedBy(ctx context.Context, c client.Client, job 
 		g.Expect(c.Get(ctx, client.ObjectKeyFromObject(job), createdJob)).To(gomega.Succeed())
 		g.Expect(ptr.Deref(createdJob.Spec.ManagedBy, "")).To(gomega.Equal(managedBy))
 	}, util.Timeout, util.Interval).Should(gomega.Succeed())
+}
+
+func assertMsg(msg string, wlKey client.ObjectKey) func() string {
+	return func() string {
+		output := &strings.Builder{}
+		fmt.Fprintln(output, msg)
+		withClusterWl(output, wlKey, "Manager", k8sManagerClient)
+		withClusterWl(output, wlKey, "Worker1", k8sWorker1Client)
+		withClusterWl(output, wlKey, "Worker2", k8sWorker2Client)
+		return output.String()
+	}
+}
+
+func withClusterWl(output *strings.Builder, wlKey client.ObjectKey, cName string, cClient client.Client) {
+	wl := &kueue.Workload{}
+	if err := cClient.Get(ctx, wlKey, wl); err == nil {
+		fmt.Fprintln(output, cName, "Workload:", format.Object(wl.ObjectMeta, 1))
+		fmt.Fprintln(output, cName, "Status:", format.Object(wl.Status, 1))
+	} else {
+		fmt.Fprintln(output, "Workload not present in:", cName, "Error:", err)
+	}
 }

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/google/go-cmp/cmp/cmpopts"

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -1058,7 +1058,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sManagerClient.Get(ctx, wlKey, managerWl)).To(gomega.Succeed())
 					g.Expect(managerWl.Status.ClusterName).To(gomega.HaveValue(gomega.Equal(workerCluster2.Name)), assertMsg("Workload not Admitted in worker2", wlKey))
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Checking that the workload is created in worker2", func() {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -164,7 +164,11 @@ func AssertMsg[T runtime.Object](message string, objs ...T) func() string {
 		var output strings.Builder
 		fmt.Fprintln(&output, message)
 		for _, obj := range objs {
-			fmt.Fprintln(&output, format.Object(obj, 1))
+			objYAML, ok := formatK8sObject(obj)
+			if !ok {
+				objYAML = format.Object(obj, 1)
+			}
+			fmt.Fprintln(&output, objYAML)
 		}
 		return output.String()
 	}


### PR DESCRIPTION
Cherry pick of #11011 #11081 on release-0.16.

#11011: Increase flaky pull-kueue-test-e2e-multikueue-main timeout and verbosity.
#11081: Improve formatting of objects in ginkgo failed multikueue asserts

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup
/kind flake


```release-note
NONE
```