### PR TITLE
Prevent integer overflow in ResourceValue

### DIFF
--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -99,11 +99,30 @@ func (r Requests) ToResourceList() corev1.ResourceList {
 	return ret
 }
 
+var (
+	maxMilliValue = *resource.NewMilliQuantity(math.MaxInt64, resource.DecimalSI)
+	minMilliValue = *resource.NewMilliQuantity(math.MinInt64, resource.DecimalSI)
+	maxValue      = *resource.NewQuantity(math.MaxInt64, resource.DecimalSI)
+	minValue      = *resource.NewQuantity(math.MinInt64, resource.DecimalSI)
+)
+
 // ResourceValue returns the integer value for the resource name.
 // It's milli-units for CPU and absolute units for everything else.
 func ResourceValue(name corev1.ResourceName, q resource.Quantity) int64 {
 	if name == corev1.ResourceCPU {
+		if q.Cmp(maxMilliValue) > 0 {
+			return math.MaxInt64
+		}
+		if q.Cmp(minMilliValue) < 0 {
+			return math.MinInt64
+		}
 		return q.MilliValue()
+	}
+	if q.Cmp(maxValue) > 0 {
+		return math.MaxInt64
+	}
+	if q.Cmp(minValue) < 0 {
+		return math.MinInt64
 	}
 	return q.Value()
 }

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	resourcehelpers "k8s.io/component-helpers/resource"
 	"k8s.io/utils/ptr"
+
+	utilmath "sigs.k8s.io/kueue/pkg/util/math"
 )
 
 // The following resources calculations are inspired on
@@ -99,30 +101,11 @@ func (r Requests) ToResourceList() corev1.ResourceList {
 	return ret
 }
 
-var (
-	maxMilliValue = *resource.NewMilliQuantity(math.MaxInt64, resource.DecimalSI)
-	minMilliValue = *resource.NewMilliQuantity(math.MinInt64, resource.DecimalSI)
-	maxValue      = *resource.NewQuantity(math.MaxInt64, resource.DecimalSI)
-	minValue      = *resource.NewQuantity(math.MinInt64, resource.DecimalSI)
-)
-
 // ResourceValue returns the integer value for the resource name.
 // It's milli-units for CPU and absolute units for everything else.
 func ResourceValue(name corev1.ResourceName, q resource.Quantity) int64 {
 	if name == corev1.ResourceCPU {
-		if q.Cmp(maxMilliValue) > 0 {
-			return math.MaxInt64
-		}
-		if q.Cmp(minMilliValue) < 0 {
-			return math.MinInt64
-		}
-		return q.MilliValue()
-	}
-	if q.Cmp(maxValue) > 0 {
-		return math.MaxInt64
-	}
-	if q.Cmp(minValue) < 0 {
-		return math.MinInt64
+		return utilmath.SafeMilliValue(q)
 	}
 	return q.Value()
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -5786,6 +5786,52 @@ func TestSchedule(t *testing.T) {
 				"eng-beta": {"eng-beta/preemptor"},
 			},
 		},
+		"prevent integer overflow in ResourceValue conversion to MilliValue": {
+			additionalClusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("overflow-cq").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "10").Obj()).
+					Obj(),
+			},
+			additionalLocalQueues: []kueue.LocalQueue{
+				*utiltestingapi.MakeLocalQueue("overflow-queue", "default").ClusterQueue("overflow-cq").Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("vuln-wl", "default").
+					Queue("overflow-queue").
+					PodSets(
+						*utiltestingapi.MakePodSet("ps1", 1).Request(corev1.ResourceCPU, "9223372036854776").Obj(),
+					).Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("vuln-wl", "default").
+					Queue("overflow-queue").
+					PodSets(
+						*utiltestingapi.MakePodSet("ps1", 1).Request(corev1.ResourceCPU, "9223372036854776").Obj(),
+					).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             "Pending",
+						Message:            "couldn't assign flavors to pod set ps1: insufficient quota for cpu in flavor default, previously considered podsets requests (0) + current podset request (9223372036854775807m) > maximum capacity (10)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "ps1",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("9223372036854775807m"),
+						},
+					}).
+					Obj(),
+			},
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"overflow-cq": {"default/vuln-wl"},
+			},
+			eventCmpOpts: ignoreEventMessageCmpOpts,
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "vuln-wl", "Pending", corev1.EventTypeWarning).Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		for _, enabled := range []bool{false, true} {

--- a/pkg/util/math/math.go
+++ b/pkg/util/math/math.go
@@ -17,7 +17,6 @@ limitations under the License.
 package math
 
 import (
-	"math"
 	stdmath "math"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -36,17 +35,17 @@ func SaturatingAdd(a, b int64) int64 {
 }
 
 var (
-	maxMilliValue = *resource.NewMilliQuantity(math.MaxInt64, resource.DecimalSI)
-	minMilliValue = *resource.NewMilliQuantity(math.MinInt64, resource.DecimalSI)
+	maxMilliValue = *resource.NewMilliQuantity(stdmath.MaxInt64, resource.DecimalSI)
+	minMilliValue = *resource.NewMilliQuantity(stdmath.MinInt64, resource.DecimalSI)
 )
 
 // SafeMilliValue returns the integer milli-value for the resource quantity, clamped to math.MinInt64 and math.MaxInt64.
 func SafeMilliValue(q resource.Quantity) int64 {
 	if q.Cmp(maxMilliValue) > 0 {
-		return math.MaxInt64
+		return stdmath.MaxInt64
 	}
 	if q.Cmp(minMilliValue) < 0 {
-		return math.MinInt64
+		return stdmath.MinInt64
 	}
 	return q.MilliValue()
 }

--- a/pkg/util/math/math.go
+++ b/pkg/util/math/math.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package math
 
-import stdmath "math"
+import (
+	"math"
+	stdmath "math"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
 
 // SaturatingAdd adds two int64s, returning math.MaxInt64 or math.MinInt64 if the
 // result would overflow or underflow.
@@ -28,4 +33,20 @@ func SaturatingAdd(a, b int64) int64 {
 		return stdmath.MinInt64
 	}
 	return a + b
+}
+
+var (
+	maxMilliValue = *resource.NewMilliQuantity(math.MaxInt64, resource.DecimalSI)
+	minMilliValue = *resource.NewMilliQuantity(math.MinInt64, resource.DecimalSI)
+)
+
+// SafeMilliValue returns the integer milli-value for the resource quantity, clamped to math.MinInt64 and math.MaxInt64.
+func SafeMilliValue(q resource.Quantity) int64 {
+	if q.Cmp(maxMilliValue) > 0 {
+		return math.MaxInt64
+	}
+	if q.Cmp(minMilliValue) < 0 {
+		return math.MinInt64
+	}
+	return q.MilliValue()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Automatic vulnerability scanner flagged that conversion to milivalue could result in int64 overflow.

Confirmed that with unit test: in case of a workload requesting a huge amount of CPU, after the conversion the ResourceValue got negative and the workload got admitted.

Fixed the issue by checking if the value would overflow before converting.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed vulnerability where workload with CPU requests close to max int64 would lead to integer overflow when converting to milicpu and break quota limits.
```
