### PR TITLE
fix: avoid duplicate tolerations when one uses the default Operator

### DIFF
--- a/pkg/podset/podset.go
+++ b/pkg/podset/podset.go
@@ -130,7 +130,9 @@ func (podSetInfo *PodSetInfo) Merge(o PodSetInfo) error {
 
 	// make sure we don't duplicate tolerations
 	for _, t := range o.Tolerations {
-		if slices.Index(podSetInfo.Tolerations, t) == -1 {
+		if !slices.ContainsFunc(podSetInfo.Tolerations, func(e corev1.Toleration) bool {
+			return tolerationsEqual(e, t)
+		}) {
 			podSetInfo.Tolerations = append(podSetInfo.Tolerations, t)
 		}
 	}
@@ -141,6 +143,20 @@ func (podSetInfo *PodSetInfo) Merge(o PodSetInfo) error {
 		}
 	}
 	return nil
+}
+
+// tolerationsEqual reports whether two tolerations describe the same toleration
+func tolerationsEqual(a, b corev1.Toleration) bool {
+	// Normalize Operator before comparing: the Kubernetes API defaults an empty
+	// Operator to "Equal", so Operator: "" and Operator: "Equal" describe the
+	// same toleration and must compare as equal here.
+	if a.Operator == "" {
+		a.Operator = corev1.TolerationOpEqual
+	}
+	if b.Operator == "" {
+		b.Operator = corev1.TolerationOpEqual
+	}
+	return a.MatchToleration(&b)
 }
 
 // AddOrUpdateLabel adds or updates the label identified by k with value v

--- a/pkg/podset/podset.go
+++ b/pkg/podset/podset.go
@@ -33,6 +33,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
 	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
+	utiltolerations "sigs.k8s.io/kueue/pkg/util/tolerations"
 )
 
 var (
@@ -131,7 +132,7 @@ func (podSetInfo *PodSetInfo) Merge(o PodSetInfo) error {
 	// make sure we don't duplicate tolerations
 	for _, t := range o.Tolerations {
 		if !slices.ContainsFunc(podSetInfo.Tolerations, func(e corev1.Toleration) bool {
-			return tolerationsEqual(e, t)
+			return utiltolerations.Equal(e, t)
 		}) {
 			podSetInfo.Tolerations = append(podSetInfo.Tolerations, t)
 		}
@@ -143,20 +144,6 @@ func (podSetInfo *PodSetInfo) Merge(o PodSetInfo) error {
 		}
 	}
 	return nil
-}
-
-// tolerationsEqual reports whether two tolerations describe the same toleration
-func tolerationsEqual(a, b corev1.Toleration) bool {
-	// Normalize Operator before comparing: the Kubernetes API defaults an empty
-	// Operator to "Equal", so Operator: "" and Operator: "Equal" describe the
-	// same toleration and must compare as equal here.
-	if a.Operator == "" {
-		a.Operator = corev1.TolerationOpEqual
-	}
-	if b.Operator == "" {
-		b.Operator = corev1.TolerationOpEqual
-	}
-	return a.MatchToleration(&b)
 }
 
 // AddOrUpdateLabel adds or updates the label identified by k with value v

--- a/pkg/podset/podset_test.go
+++ b/pkg/podset/podset_test.go
@@ -358,6 +358,17 @@ func TestMergeRestore(t *testing.T) {
 				Obj(),
 			wantRestoreChanges: true,
 		},
+		"don't duplicate tolerations that differ only by empty vs Equal Operator": {
+			podSet: basePodSet.DeepCopy(),
+			info: PodSetInfo{
+				Tolerations: []corev1.Toleration{{
+					Key:    "t0",
+					Value:  "t0v",
+					Effect: corev1.TaintEffectNoSchedule,
+				}},
+			},
+			wantPodSet: basePodSet.DeepCopy(),
+		},
 		"conflicting label": {
 			podSet: basePodSet.DeepCopy(),
 			info: PodSetInfo{

--- a/pkg/podset/podset_test.go
+++ b/pkg/podset/podset_test.go
@@ -273,6 +273,17 @@ func TestMergeRestore(t *testing.T) {
 		}).
 		Obj()
 
+	podSetWithoutOperator := utiltestingapi.MakePodSet("", 1).
+		NodeSelector(map[string]string{"ns0": "ns0v"}).
+		Labels(map[string]string{"l0": "l0v"}).
+		Annotations(map[string]string{"a0": "a0v"}).
+		Toleration(corev1.Toleration{
+			Key:    "t0",
+			Value:  "t0v",
+			Effect: corev1.TaintEffectNoSchedule,
+		}).
+		Obj()
+
 	cases := map[string]struct {
 		podSet             *kueue.PodSet
 		info               PodSetInfo
@@ -368,6 +379,18 @@ func TestMergeRestore(t *testing.T) {
 				}},
 			},
 			wantPodSet: basePodSet.DeepCopy(),
+		},
+		"don't duplicate tolerations that differ only by Equal vs empty Operator": {
+			podSet: podSetWithoutOperator.DeepCopy(),
+			info: PodSetInfo{
+				Tolerations: []corev1.Toleration{{
+					Key:      "t0",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "t0v",
+					Effect:   corev1.TaintEffectNoSchedule,
+				}},
+			},
+			wantPodSet: podSetWithoutOperator.DeepCopy(),
 		},
 		"conflicting label": {
 			podSet: basePodSet.DeepCopy(),

--- a/pkg/util/tolerations/tolerations.go
+++ b/pkg/util/tolerations/tolerations.go
@@ -1,0 +1,32 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tolerations
+
+import corev1 "k8s.io/api/core/v1"
+
+// Equal reports whether two tolerations describe the same toleration.
+// The Kubernetes API defaults an empty Operator to "Equal", so Operator: ""
+// and Operator: "Equal" describe the same toleration and compare as equal.
+func Equal(a, b corev1.Toleration) bool {
+	if a.Operator == "" {
+		a.Operator = corev1.TolerationOpEqual
+	}
+	if b.Operator == "" {
+		b.Operator = corev1.TolerationOpEqual
+	}
+	return a.MatchToleration(&b)
+}

--- a/pkg/util/tolerations/tolerations_test.go
+++ b/pkg/util/tolerations/tolerations_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tolerations
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestEqual(t *testing.T) {
+	withEqualOperator := corev1.Toleration{
+		Key:      "t0",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "t0v",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+	withoutOperator := corev1.Toleration{
+		Key:    "t0",
+		Value:  "t0v",
+		Effect: corev1.TaintEffectNoSchedule,
+	}
+	differentKey := corev1.Toleration{
+		Key:      "t1",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "t0v",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+
+	cases := map[string]struct {
+		a, b   corev1.Toleration
+		wantEq bool
+	}{
+		"empty vs Equal operator": {
+			a:      withEqualOperator,
+			b:      withoutOperator,
+			wantEq: true,
+		},
+		"Equal vs empty operator": {
+			a:      withoutOperator,
+			b:      withEqualOperator,
+			wantEq: true,
+		},
+		"same toleration (empty)": {
+			a:      withoutOperator,
+			b:      withoutOperator,
+			wantEq: true,
+		},
+		"same toleration (not empty)": {
+			a:      withEqualOperator,
+			b:      withEqualOperator,
+			wantEq: true,
+		},
+		"different tolerations": {
+			a:      withEqualOperator,
+			b:      differentKey,
+			wantEq: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := Equal(tc.a, tc.b); got != tc.wantEq {
+				t.Errorf("Equal() = %v, want %v", got, tc.wantEq)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

`PodSetInfo.Merge` deduplicates a `ResourceFlavor`'s tolerations against the workload's existing ones via struct `==`, which treats `Operator: ""` and `Operator: "Equal"` as different , while in the k8s API it defaults the empty operator to `Equal`. 

A workload toleration written one way and a flavor toleration written the other slip through dedup and both get appended
```
# e.g
# RF
tolerations:
  - effect: NoSchedule
    key: some-toleration-key
    value: some-toleration-value
    operator: Equal

# Job
tolerations:
  - effect: NoSchedule
    key: some-toleration-key
    value: some-toleration-value
```

which causes the next Pod/Job update to be rejected by `validateOnlyAddedTolerations` in clusters where a mutating webhook collapses the duplicate between Kueue's read and write — leaving pods `scheduleGated`.

Kueue would emit the following error log:
```
Pod "<name>" is invalid: spec.tolerations: Forbidden: existing toleration can not be modified except its tolerationSeconds
```

This PR normalizes the empty operator to `Equal` before comparing, so the two forms are properly deduplicated.

## Testing

Added the UT without the code change in `pkg/podset/podset.go`, and it was failing locally
```
Unexpected template (-want/+got):
          v1.PodTemplateSpec{
          	ObjectMeta: {Labels: {"l0": "l0v"}, Annotations: {"a0": "a0v"}},
          	Spec: v1.PodSpec{
          		... // 21 identical fields
          		Affinity:      nil,
          		SchedulerName: "",
          		Tolerations: []v1.Toleration{
          			{Key: "t0", Operator: "Equal", Value: "t0v", Effect: "NoSchedule", ...},
        + 			{Key: "t0", Value: "t0v", Effect: "NoSchedule"},
          		},
          		HostAliases:       nil,
          		PriorityClassName: "",
          		... // 16 identical fields
          	},
          }
```

```release-note
Scheduling: Fixed a bug where Kueue could inject duplicate tolerations when a
ResourceFlavor toleration and a PodTemplate toleration differed only by `operator: ""`
versus `operator: "Equal"`, which represent the same Kubernetes toleration. This could
cause update rejections and leave Pods `scheduleGated`.
```