### PR TITLE
helm: add /tmp emptyDir volume for visibility server self-signed certs

### DIFF
--- a/charts/kueue/templates/manager/manager.yaml
+++ b/charts/kueue/templates/manager/manager.yaml
@@ -91,6 +91,8 @@ spec:
         - mountPath: /controller_manager_config.yaml
           name: manager-config
           subPath: controller_manager_config.yaml
+        - mountPath: /tmp
+          name: tmp
         {{- if .Values.enableCertManager }}
         - mountPath: /etc/kueue/metrics/certs
           name: metrics-certs
@@ -151,3 +153,5 @@ spec:
       - name: visibility
         emptyDir: {}
       {{- end }}
+      - name: tmp
+        emptyDir: {}


### PR DESCRIPTION
## What this PR does

Adds a `/tmp` emptyDir volume mount to the manager deployment template so the visibility server can write its self-signed certificates when `readOnlyRootFilesystem: true` (the Helm chart default) and `enableCertManager: false`.

## Why

When `readOnlyRootFilesystem` is `true` (default since v0.17.2) and cert-manager is disabled, the visibility server tries to write `/tmp/apiserver.crt` but fails with:

```
error creating self-signed certificates: open /tmp/apiserver.crt: read-only file system
```

The chart already provides a `/visibility` emptyDir volume, but the server binary writes to `/tmp` which is on the read-only root filesystem.

## Changes

- Add `volumeMount` for `/tmp` → `tmp` volume in the manager container
- Add `tmp` emptyDir volume to the pod spec

```release-note
Fix visibility server crash with "read-only file system" error when readOnlyRootFilesystem is true and enableCertManager is false by adding a /tmp emptyDir volume mount.
```