### PR TITLE
Automated cherry pick of #11137: Prevent integer overflow in flavorassigner

### DIFF
--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -1040,7 +1040,13 @@ func (a *FlavorAssigner) fitsResourceQuota(log logr.Logger, fr resources.FlavorR
 
 	available := a.cq.Available(fr)
 	maxCapacity := a.cq.PotentialAvailable(fr)
-	val := assumedUsage + requestUsage
+
+	var val int64
+	if requestUsage > 0 && assumedUsage > math.MaxInt64-requestUsage {
+		val = math.MaxInt64
+	} else {
+		val = assumedUsage + requestUsage
+	}
 
 	// No Fit
 	if val > maxCapacity {

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -1042,7 +1042,7 @@ func (a *FlavorAssigner) fitsResourceQuota(log logr.Logger, fr resources.FlavorR
 	maxCapacity := a.cq.PotentialAvailable(fr)
 
 	var val int64
-	if requestUsage > 0 && assumedUsage > math.MaxInt64-requestUsage {
+	if assumedUsage > math.MaxInt64-requestUsage {
 		val = math.MaxInt64
 	} else {
 		val = assumedUsage + requestUsage

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/scheduler/preemption/classical"
 	preemptioncommon "sigs.k8s.io/kueue/pkg/scheduler/preemption/common"
 	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
+	utilmath "sigs.k8s.io/kueue/pkg/util/math"
 	"sigs.k8s.io/kueue/pkg/util/orderedgroups"
 	"sigs.k8s.io/kueue/pkg/util/tas"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -1041,12 +1042,7 @@ func (a *FlavorAssigner) fitsResourceQuota(log logr.Logger, fr resources.FlavorR
 	available := a.cq.Available(fr)
 	maxCapacity := a.cq.PotentialAvailable(fr)
 
-	var val int64
-	if assumedUsage > math.MaxInt64-requestUsage {
-		val = math.MaxInt64
-	} else {
-		val = assumedUsage + requestUsage
-	}
+	val := utilmath.SaturatingAdd(assumedUsage, requestUsage)
 
 	// No Fit
 	if val > maxCapacity {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -5400,6 +5400,59 @@ func TestSchedule(t *testing.T) {
 				utiltesting.MakeEventRecord("default", "high-bop", "Admitted", corev1.EventTypeNormal).Obj(),
 			},
 		},
+		"integer overflow vulnerability in CPU requests": {
+			additionalClusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("overflow-cq").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "10000").Obj()).
+					Obj(),
+			},
+			additionalLocalQueues: []kueue.LocalQueue{
+				*utiltestingapi.MakeLocalQueue("overflow-queue", "default").ClusterQueue("overflow-cq").Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("vuln-wl", "default").
+					Queue("overflow-queue").
+					PodSets(
+						*utiltestingapi.MakePodSet("ps1", 1).Request(corev1.ResourceCPU, "1000000m").Obj(),
+						*utiltestingapi.MakePodSet("ps2", 1).Request(corev1.ResourceCPU, "9223372036854775000m").Obj(),
+					).Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("vuln-wl", "default").
+					Queue("overflow-queue").
+					PodSets(
+						*utiltestingapi.MakePodSet("ps1", 1).Request(corev1.ResourceCPU, "1000000m").Obj(),
+						*utiltestingapi.MakePodSet("ps2", 1).Request(corev1.ResourceCPU, "9223372036854775000m").Obj(),
+					).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             "Pending",
+						Message:            "couldn't assign flavors to pod set ps2: insufficient quota for cpu in flavor default, previously considered podsets requests (1k) + current podset request (9223372036854775) > maximum capacity (10k)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "ps1",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1000000m"),
+						},
+					}, kueue.PodSetRequest{
+						Name: "ps2",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("9223372036854775000m"),
+						},
+					}).
+					Obj(),
+			},
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"overflow-cq": {"default/vuln-wl"},
+			},
+			eventCmpOpts: ignoreEventMessageCmpOpts,
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "vuln-wl", "Pending", corev1.EventTypeWarning).Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		for _, enabled := range []bool{false, true} {

--- a/pkg/util/math/math.go
+++ b/pkg/util/math/math.go
@@ -1,0 +1,31 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package math
+
+import stdmath "math"
+
+// SaturatingAdd adds two int64s, returning math.MaxInt64 or math.MinInt64 if the
+// result would overflow or underflow.
+func SaturatingAdd(a, b int64) int64 {
+	if b > 0 && a > stdmath.MaxInt64-b {
+		return stdmath.MaxInt64
+	}
+	if b < 0 && a < stdmath.MinInt64-b {
+		return stdmath.MinInt64
+	}
+	return a + b
+}

--- a/pkg/util/math/math.go
+++ b/pkg/util/math/math.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:revive // The package name 'math' is intentional for this utility package.
 package math
 
 import stdmath "math"


### PR DESCRIPTION
Cherry pick of #11137 on release-0.16.

#11137: Prevent integer overflow in flavorassigner

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
Fixed vulnerability where two podsets with total requests exceeding max int64 would lead to integer overflow and break quota limits.
```