### PR TITLE
Turn clustersReconciler into predicate.Predicate to use the object as…

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -30,6 +30,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -367,6 +368,7 @@ type clustersReconciler struct {
 
 	clusterProfileCreds clusterProfileCreds
 
+	logName     string
 	roleTracker *roletracker.RoleTracker
 }
 
@@ -385,6 +387,7 @@ var _ clusterProfileCreds = (*NoOpClusterProfileCreds)(nil)
 
 var _ manager.Runnable = (*clustersReconciler)(nil)
 var _ reconcile.Reconciler = (*clustersReconciler)(nil)
+var _ predicate.Predicate = (*clustersReconciler)(nil)
 
 func (c *clustersReconciler) Start(ctx context.Context) error {
 	c.rootContext = ctx
@@ -714,8 +717,13 @@ func newClustersReconciler(
 		fsWatcher:           fsWatcher,
 		adapters:            adapters,
 		clusterProfileCreds: cpCreds,
+		logName:             "multikueuecluster-reconciler",
 		roleTracker:         roleTracker,
 	}
+}
+
+func (c *clustersReconciler) logger() logr.Logger {
+	return roletracker.WithReplicaRole(ctrl.Log.WithName(c.logName), c.roleTracker)
 }
 
 func (c *clustersReconciler) setupWithManager(mgr ctrl.Manager) error {
@@ -741,63 +749,13 @@ func (c *clustersReconciler) setupWithManager(mgr ctrl.Manager) error {
 		},
 	}
 
-	filterLog := mgr.GetLogger().WithName("MultiKueueCluster filter")
-	filter := predicate.Funcs{
-		CreateFunc: func(ce event.CreateEvent) bool {
-			if cluster, isCluster := ce.Object.(*kueue.MultiKueueCluster); isCluster {
-				if cluster.Spec.ClusterSource.KubeConfig != nil && cluster.Spec.ClusterSource.KubeConfig.LocationType == kueue.PathLocationType {
-					err := c.fsWatcher.AddOrUpdate(cluster.Name, cluster.Spec.ClusterSource.KubeConfig.Location)
-					if err != nil {
-						filterLog.Error(err, "AddOrUpdate FS watch", "cluster", klog.KObj(cluster))
-					}
-				}
-			}
-			return true
-		},
-		UpdateFunc: func(ue event.UpdateEvent) bool {
-			clusterNew, isClusterNew := ue.ObjectNew.(*kueue.MultiKueueCluster)
-			clusterOld, isClusterOld := ue.ObjectOld.(*kueue.MultiKueueCluster)
-			if !isClusterNew || !isClusterOld {
-				return true
-			}
-
-			clusterNewHasKubeConfigPath := clusterNew.Spec.ClusterSource.KubeConfig != nil && clusterNew.Spec.ClusterSource.KubeConfig.LocationType == kueue.PathLocationType
-			clusterOldHasKubeConfigPath := clusterOld.Spec.ClusterSource.KubeConfig != nil && clusterOld.Spec.ClusterSource.KubeConfig.LocationType == kueue.PathLocationType
-			if clusterOldHasKubeConfigPath && !clusterNewHasKubeConfigPath {
-				err := c.fsWatcher.Remove(clusterOld.Name)
-				if err != nil {
-					filterLog.Error(err, "Remove FS watch", "cluster", klog.KObj(clusterOld))
-				}
-			}
-
-			if clusterNewHasKubeConfigPath {
-				err := c.fsWatcher.AddOrUpdate(clusterNew.Name, clusterNew.Spec.ClusterSource.KubeConfig.Location)
-				if err != nil {
-					filterLog.Error(err, "AddOrUpdate FS watch", "cluster", klog.KObj(clusterNew))
-				}
-			}
-			return true
-		},
-		DeleteFunc: func(de event.DeleteEvent) bool {
-			if cluster, isCluster := de.Object.(*kueue.MultiKueueCluster); isCluster {
-				if cluster.Spec.ClusterSource.KubeConfig != nil && cluster.Spec.ClusterSource.KubeConfig.LocationType == kueue.PathLocationType {
-					err := c.fsWatcher.Remove(cluster.Name)
-					if err != nil {
-						filterLog.Error(err, "Remove FS watch", "cluster", klog.KObj(cluster))
-					}
-				}
-			}
-			return true
-		},
-	}
-
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
 		Named("multikueue_cluster").
 		For(&kueue.MultiKueueCluster{}).
 		Watches(&corev1.Secret{}, &secretHandler{client: c.localClient}).
 		WatchesRawSource(source.Channel(c.watchEndedCh, syncHndl)).
 		WatchesRawSource(source.Channel(c.fsWatcher.reconcile, fsWatcherHndl)).
-		WithEventFilter(filter).
+		WithEventFilter(c).
 		WithOptions(controller.Options{
 			LogConstructor: roletracker.NewLogConstructor(c.roleTracker, "multikueue-cluster"),
 		})
@@ -811,6 +769,65 @@ func (c *clustersReconciler) setupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return controllerBuilder.Complete(c)
+}
+
+func (c *clustersReconciler) Generic(e event.GenericEvent) bool {
+	return false
+}
+
+func (c *clustersReconciler) Create(e event.CreateEvent) bool {
+	if cluster, isCluster := e.Object.(*kueue.MultiKueueCluster); isCluster {
+		log := c.logger().WithValues("multiKueueCluster", klog.KObj(cluster))
+		log.V(5).Info("MultiKueueCluster create event")
+		if cluster.Spec.ClusterSource.KubeConfig != nil && cluster.Spec.ClusterSource.KubeConfig.LocationType == kueue.PathLocationType {
+			err := c.fsWatcher.AddOrUpdate(cluster.Name, cluster.Spec.ClusterSource.KubeConfig.Location)
+			if err != nil {
+				log.Error(err, "AddOrUpdate FS watch")
+			}
+		}
+	}
+	return true
+}
+
+func (c *clustersReconciler) Update(e event.UpdateEvent) bool {
+	clusterNew, isClusterNew := e.ObjectNew.(*kueue.MultiKueueCluster)
+	clusterOld, isClusterOld := e.ObjectOld.(*kueue.MultiKueueCluster)
+	if !isClusterNew || !isClusterOld {
+		return true
+	}
+	log := c.logger().WithValues("multiKueueCluster", klog.KObj(clusterNew))
+	log.V(5).Info("MultiKueueCluster update event")
+
+	clusterNewHasKubeConfigPath := clusterNew.Spec.ClusterSource.KubeConfig != nil && clusterNew.Spec.ClusterSource.KubeConfig.LocationType == kueue.PathLocationType
+	clusterOldHasKubeConfigPath := clusterOld.Spec.ClusterSource.KubeConfig != nil && clusterOld.Spec.ClusterSource.KubeConfig.LocationType == kueue.PathLocationType
+	if clusterOldHasKubeConfigPath && !clusterNewHasKubeConfigPath {
+		err := c.fsWatcher.Remove(clusterOld.Name)
+		if err != nil {
+			log.Error(err, "Remove FS watch")
+		}
+	}
+
+	if clusterNewHasKubeConfigPath {
+		err := c.fsWatcher.AddOrUpdate(clusterNew.Name, clusterNew.Spec.ClusterSource.KubeConfig.Location)
+		if err != nil {
+			log.Error(err, "AddOrUpdate FS watch")
+		}
+	}
+	return true
+}
+
+func (c *clustersReconciler) Delete(e event.DeleteEvent) bool {
+	if cluster, isCluster := e.Object.(*kueue.MultiKueueCluster); isCluster {
+		log := c.logger().WithValues("multiKueueCluster", klog.KObj(cluster))
+		log.V(5).Info("MultiKueueCluster delete event")
+		if cluster.Spec.ClusterSource.KubeConfig != nil && cluster.Spec.ClusterSource.KubeConfig.LocationType == kueue.PathLocationType {
+			err := c.fsWatcher.Remove(cluster.Name)
+			if err != nil {
+				log.Error(err, "Remove FS watch")
+			}
+		}
+	}
+	return true
 }
 
 type secretHandler struct {

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -40,6 +40,8 @@ import (
 	inventoryv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -921,6 +923,124 @@ func TestValidateKubeconfig(t *testing.T) {
 			err := validateKubeconfig(raw)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("wantErr=%v, got err: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestClustersReconcilerEventFilters(t *testing.T) {
+	baseCluster := utiltestingapi.MakeMultiKueueCluster("worker1").
+		KubeConfig(kueue.SecretLocationType, "secret1").Generation(1).Obj()
+	baseClusterWithPath := utiltestingapi.MakeMultiKueueCluster("worker1").
+		KubeConfig(kueue.PathLocationType, "/tmp/worker1.kubeconfig").Generation(1).Obj()
+
+	deletingCluster := baseCluster.DeepCopy()
+	now := metav1.Now()
+	deletingCluster.DeletionTimestamp = &now
+
+	cases := map[string]struct {
+		invoke        func(p predicate.Predicate) bool
+		wantReconcile bool
+	}{
+		"create cluster with secret location triggers reconcile": {
+			invoke: func(p predicate.Predicate) bool {
+				return p.Create(event.CreateEvent{Object: baseCluster})
+			},
+			wantReconcile: true,
+		},
+		"create cluster with path location triggers reconcile": {
+			invoke: func(p predicate.Predicate) bool {
+				return p.Create(event.CreateEvent{Object: baseClusterWithPath})
+			},
+			wantReconcile: true,
+		},
+		"update cluster spec change triggers reconcile": {
+			invoke: func(p predicate.Predicate) bool {
+				return p.Update(event.UpdateEvent{
+					ObjectOld: baseCluster,
+					ObjectNew: utiltestingapi.MakeMultiKueueCluster("worker1").
+						KubeConfig(kueue.SecretLocationType, "secret2").Generation(2).Obj(),
+				})
+			},
+			wantReconcile: true,
+		},
+		"update cluster status only change does not skip reconcile": {
+			invoke: func(p predicate.Predicate) bool {
+				return p.Update(event.UpdateEvent{
+					ObjectOld: baseCluster,
+					ObjectNew: utiltestingapi.MakeMultiKueueCluster("worker1").
+						KubeConfig(kueue.SecretLocationType, "secret1").Generation(1).
+						Active(metav1.ConditionTrue, "Active", "Connected", 1).
+						Obj(),
+				})
+			},
+			wantReconcile: true,
+		},
+		"update cluster deletion timestamp triggers reconcile": {
+			invoke: func(p predicate.Predicate) bool {
+				return p.Update(event.UpdateEvent{
+					ObjectOld: baseCluster,
+					ObjectNew: deletingCluster,
+				})
+			},
+			wantReconcile: true,
+		},
+		"update cluster no change does not skip reconcile": {
+			invoke: func(p predicate.Predicate) bool {
+				return p.Update(event.UpdateEvent{
+					ObjectOld: baseCluster,
+					ObjectNew: baseCluster.DeepCopy(),
+				})
+			},
+			wantReconcile: true,
+		},
+		"update cluster path location changed to secret triggers reconcile": {
+			invoke: func(p predicate.Predicate) bool {
+				return p.Update(event.UpdateEvent{
+					ObjectOld: baseClusterWithPath,
+					ObjectNew: baseCluster,
+				})
+			},
+			wantReconcile: true,
+		},
+		"update non-cluster objects triggers reconcile": {
+			invoke: func(p predicate.Predicate) bool {
+				return p.Update(event.UpdateEvent{
+					ObjectOld: &corev1.Secret{},
+					ObjectNew: &corev1.Secret{},
+				})
+			},
+			wantReconcile: true,
+		},
+		"delete cluster with secret location triggers reconcile": {
+			invoke: func(p predicate.Predicate) bool {
+				return p.Delete(event.DeleteEvent{Object: baseCluster})
+			},
+			wantReconcile: true,
+		},
+		"delete cluster with path location triggers reconcile": {
+			invoke: func(p predicate.Predicate) bool {
+				return p.Delete(event.DeleteEvent{Object: baseClusterWithPath})
+			},
+			wantReconcile: true,
+		},
+		"generic event does not trigger reconcile": {
+			invoke: func(p predicate.Predicate) bool {
+				return p.Generic(event.GenericEvent{Object: baseCluster})
+			},
+			wantReconcile: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			c := getClientBuilder(ctx).Build()
+			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, newKubeConfigFSWatcher(), nil, &NoOpClusterProfileCreds{}, nil)
+			reconciler.rootContext = ctx
+
+			if got := tc.invoke(reconciler); got != tc.wantReconcile {
+				t.Errorf("unexpected reconcile decision: want %v, got %v", tc.wantReconcile, got)
 			}
 		})
 	}


### PR DESCRIPTION
… EventFilter, add unit test for clustersReconciler TestReconcileEventFilters

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area multikueue
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Turn clustersReconciler into predicate.Predicate to use the object as EventFilter, add unit test for clustersReconciler TestReconcileEventFilters
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Prep PR for #11001 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Observability: fix the missing "replica-role" information from the logs generated by the controller managing the
MultiKueueCluster instances.
```
