### PR TITLE
Improve docs for namespace management

### DIFF
--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -138,6 +138,8 @@ managerConfig:
     #    backoffBaseSeconds: 60
     #    backoffMaxSeconds: 3600
     #manageJobsWithoutQueueName: true
+    # See "Opt-in Namespace Management" for guidance on namespace management:
+    # https://kueue.sigs.k8s.io/docs/tasks/manage/enforce_job_management/opt_in_namespace_management/
     #managedJobsNamespaceSelector:
     #  matchExpressions:
     #    - key: kubernetes.io/metadata.name

--- a/site/content/en/docs/tasks/manage/enforce_job_management/opt_in_namespace_management.md
+++ b/site/content/en/docs/tasks/manage/enforce_job_management/opt_in_namespace_management.md
@@ -34,19 +34,43 @@ kubectl label namespace my-namespace managed-by-kueue=true
 
 ### Step 2: Configure the Selector
 
-Configure the `managedJobsNamespaceSelector` in your Kueue Configuration to match the labeled namespaces. Use `matchLabels` to select namespaces that you have explicitly labeled:
+Configure the `managedJobsNamespaceSelector` in your Kueue Configuration with `matchLabels` or `matchExpressions`.
 
-```yaml
-apiVersion: config.kueue.x-k8s.io/v1beta2
-kind: Configuration
-metadata:
-  name: config
-  namespace: kueue-system
-manageJobsWithoutQueueName: true
-managedJobsNamespaceSelector:
-  matchLabels:
-    managed-by-kueue: "true"
-```
+1. Use `matchLabels` to select labeled namespaces:
+
+   ```yaml
+   apiVersion: config.kueue.x-k8s.io/v1beta2
+   kind: Configuration
+   metadata:
+     name: config
+     namespace: kueue-system
+   manageJobsWithoutQueueName: true
+   managedJobsNamespaceSelector:
+     matchLabels:
+       managed-by-kueue: "true"
+   ```
+
+2. Use `matchExpressions` to explicitly select the namespaces you want kueue to manage:
+
+   ```yaml
+   managedJobsNamespaceSelector:
+     matchExpressions:
+     - key: kubernetes.io/metadata.name
+       operator: In
+       values: [ production, training, inference ]
+   ```
+
+3. Use `matchExpressions` with the `NotIn` operator for the inverse selection, i.e. select all namespaces you do not want kueue to manage:
+
+   ```yaml
+   managedJobsNamespaceSelector:
+     matchExpressions:
+     - key: kubernetes.io/metadata.name
+       operator: NotIn
+       values: [ kube-system, kueue-system ]
+   ```
+
+   Exclusion of `kube-system` and `kueue-system` is the default behaviour of kueue. For production environments consider explicitly selecting the namespaces you want kueue to manage, otherwise you have to exclude all system components your cluster (CNI, CSI, monitoring, gitops, etc).
 
 ### Step 3: Enable the Feature Gate
 

--- a/site/content/en/docs/tasks/manage/productization/_index.md
+++ b/site/content/en/docs/tasks/manage/productization/_index.md
@@ -11,3 +11,7 @@ For a streamlined installation and simplified upgrades, we recommend deploying K
 You can customize the deployment with a local `values.yaml` file to fit your environment.  
 See the [Helm chart installation guide](/docs/installation/#install-by-helm) for full instructions.
 {{% /alert %}}
+
+For production deployments, you may also want to review
+[Opt-in Namespace Management](/docs/tasks/manage/enforce_job_management/opt_in_namespace_management/),
+which restricts Kueue to explicitly labeled namespaces.

--- a/site/content/en/docs/tasks/run/plain_pods.md
+++ b/site/content/en/docs/tasks/run/plain_pods.md
@@ -22,32 +22,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
    and enable the `pod` integration.
 
    To allow Kubernetes system pods to be successfully scheduled, you must limit the scope of the `pod` integration.
-   The recomended mechanism for doing this is using the `managedJobsNamespaceSelector`.
-
-   One approach is to only enable management only for specific namespaces:
-   ```yaml
-   apiVersion: config.kueue.x-k8s.io/v1beta2
-   kind: Configuration
-   managedJobsNamespaceSelector:
-     matchLabels:
-      kueue-managed: "true"
-   integrations:
-     frameworks:
-      - "pod"
-   ```
-   An alternate approach is to exempt system namespaces from management:
-   ```yaml
-   apiVersion: config.kueue.x-k8s.io/v1beta2
-   kind: Configuration
-   managedJobsNamespaceSelector:
-      matchExpressions:
-      - key: kubernetes.io/metadata.name
-        operator: NotIn
-        values: [ kube-system, kueue-system ]
-   integrations:
-     frameworks:
-      - "pod"
-   ```
+   On production environments it is recommended [to use the `managedJobsNamespaceSelector`](/docs/tasks/manage/enforce_job_management/opt_in_namespace_management).
 
 {{% alert title="Note" color="primary" %}}
   Prior to Kueue v0.10, the Configuration fields `integrations.podOptions.namespaceSelector`


### PR DESCRIPTION
1. Change the comment in helm values to select labeled namespaces and point to the docs.
2. Remove operator: NotIn values: [ kube-system, kueue-system ] from plain_pods.md
3. In opt_in_namespace_management.md add the pattern of having an explicit list of namespaces managed by kueue.
4. In tasks/manage/productization add a link to opt_in_namespace_management.md. Moving the file would break existing links.

/kind documentation

/area website

Related issue: #11006 

```release-note
NONE
```
