### PR TITLE
Introduce Amount struct to deal with quotas overflow

### DIFF
--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -961,11 +961,11 @@ func getUsage(frq resources.FlavorResourceQuantities, cq *clusterQueue) []kueue.
 				used := frq[fr]
 				rUsage := kueue.ResourceUsage{
 					Name:  rName,
-					Total: resources.ResourceQuantity(rName, used),
+					Total: resources.ResourceQuantity(rName, used.Int64()),
 				}
 				// Enforce `borrowed=0` if the clusterQueue doesn't belong to a cohort.
 				if cq.HasParent() {
-					borrowed := used - rQuota.Nominal
+					borrowed := used.Sub(rQuota.Nominal).Int64()
 					if borrowed > 0 {
 						rUsage.Borrowed = resources.ResourceQuantity(rName, borrowed)
 					}
@@ -1026,7 +1026,7 @@ func filterLocalQueueUsage(orig resources.FlavorResourceQuantities, resourceGrou
 				fr := resources.FlavorResource{Flavor: fName, Resource: rName}
 				outFlvUsage.Resources = append(outFlvUsage.Resources, kueue.LocalQueueResourceUsage{
 					Name:  rName,
-					Total: resources.ResourceQuantity(rName, orig[fr]),
+					Total: resources.ResourceQuantity(rName, orig[fr].Int64()),
 				})
 			}
 			// The resourceUsages should be in a stable order to avoid endless creation of update events.

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -1531,10 +1531,9 @@ func TestCacheWorkloadOperations(t *testing.T) {
 					UsedResources: cq.resourceNode.Usage,
 				}
 			}
-			cmpFilter := func(a, b resources.FlavorResourceQuantities) bool { return len(a) != 0 || len(b) != 0 }
 			cmpOpts := []cmp.Option{
 				cmpopts.EquateEmpty(),
-				cmp.FilterValues(cmpFilter, cmp.Comparer(equalFlavorResourceQuantitiesIgnoringZero)),
+				cmp.FilterValues(func(a, b resources.FlavorResourceQuantities) bool { return len(a) != 0 || len(b) != 0 }, cmp.Comparer(equalFlavorResourceQuantitiesIgnoringZero)),
 			}
 			if diff := cmp.Diff(step.wantResults, gotResult, cmpOpts...); diff != "" {
 				t.Errorf("Unexpected clusterQueues (-want,+got):\n%s", diff)
@@ -2622,12 +2621,11 @@ func TestCacheQueueOperations(t *testing.T) {
 					cacheQueues[qKey] = cacheQ
 				}
 			}
-			cmpFilter := func(a, b resources.FlavorResourceQuantities) bool { return len(a) != 0 || len(b) != 0 }
 			cmpOpts := []cmp.Option{
 				cmp.AllowUnexported(LocalQueue{}),
 				cmpopts.EquateEmpty(),
 				cmpopts.IgnoreTypes(sync.RWMutex{}),
-				cmp.FilterValues(cmpFilter, cmp.Comparer(equalFlavorResourceQuantitiesIgnoringZero)),
+				cmp.FilterValues(func(a, b resources.FlavorResourceQuantities) bool { return len(a) != 0 || len(b) != 0 }, cmp.Comparer(equalFlavorResourceQuantitiesIgnoringZero)),
 			}
 			if diff := cmp.Diff(tc.wantLocalQueues, cacheQueues, cmpOpts...); diff != "" {
 				t.Errorf("Unexpected localQueues (-want,+got):\n%s", diff)
@@ -3038,25 +3036,12 @@ func TestIsAddedCheckWorkload(t *testing.T) {
 	}
 }
 
-func normalizeFlavorResourceQuantities(in resources.FlavorResourceQuantities) resources.FlavorResourceQuantities {
-	out := make(resources.FlavorResourceQuantities, len(in))
-	for k, v := range in {
-		if v.CmpInt64(0) != 0 {
-			out[k] = v
-		}
-	}
-	return out
-}
-
 func equalFlavorResourceQuantitiesIgnoringZero(a, b resources.FlavorResourceQuantities) bool {
-	na := normalizeFlavorResourceQuantities(a)
-	nb := normalizeFlavorResourceQuantities(b)
-	if len(na) != len(nb) {
-		return false
+	if len(b) > len(a) {
+		a, b = b, a
 	}
-	for k, av := range na {
-		bv, ok := nb[k]
-		if !ok || !av.Equal(bv) {
+	for k, av := range a {
+		if av.Cmp(b[k]) != 0 {
 			return false
 		}
 	}

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -451,11 +451,11 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					FlavorFungibility:             defaultFlavorFungibility,
 					resourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
-							{Flavor: "default", Resource: corev1.ResourceCPU}: 5000,
+							{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(5000),
 						},
 					},
 					AdmittedUsage: resources.FlavorResourceQuantities{
-						{Flavor: "default", Resource: corev1.ResourceCPU}: 5000,
+						{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(5000),
 					},
 					Status:     active,
 					Preemption: defaultPreemption,
@@ -903,12 +903,12 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AllocatableResourceGeneration: 1,
 					FlavorFungibility:             defaultFlavorFungibility,
 					AdmittedUsage: resources.FlavorResourceQuantities{
-						{Flavor: "f1", Resource: corev1.ResourceCPU}: 1000,
+						{Flavor: "f1", Resource: corev1.ResourceCPU}: resources.NewAmount(1000),
 					},
 					FairWeight: defaultWeight,
 					resourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
-							{Flavor: "f1", Resource: corev1.ResourceCPU}: 2000,
+							{Flavor: "f1", Resource: corev1.ResourceCPU}: resources.NewAmount(2000),
 						},
 					},
 					Workloads: map[workload.Reference]*workload.Info{
@@ -1179,8 +1179,8 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				"one": {
 					Workloads: sets.New[workload.Reference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
-						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
+						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: resources.NewAmount(10),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:      resources.NewAmount(15),
 					},
 				},
 				"two": {
@@ -1204,8 +1204,8 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				"one": {
 					Workloads: sets.New[workload.Reference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
-						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
+						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: resources.NewAmount(10),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:      resources.NewAmount(15),
 					},
 				},
 				"two": {
@@ -1228,8 +1228,8 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				"one": {
 					Workloads: sets.New[workload.Reference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
-						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
+						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: resources.NewAmount(10),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:      resources.NewAmount(15),
 					},
 				},
 				"two": {
@@ -1252,8 +1252,8 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				"one": {
 					Workloads: sets.New[workload.Reference]("/a"),
 					UsedResources: resources.FlavorResourceQuantities{
-						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
+						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: resources.NewAmount(10),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:      resources.NewAmount(15),
 					},
 				},
 				"two": {
@@ -1274,8 +1274,8 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				"one": {
 					Workloads: sets.New[workload.Reference]("/a"),
 					UsedResources: resources.FlavorResourceQuantities{
-						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
+						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: resources.NewAmount(10),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:      resources.NewAmount(15),
 					},
 				},
 				"two": {
@@ -1296,8 +1296,8 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				"one": {
 					Workloads: sets.New[workload.Reference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
-						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
+						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: resources.NewAmount(10),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:      resources.NewAmount(15),
 					},
 				},
 				"two": {
@@ -1319,17 +1319,14 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			},
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
-					Workloads: sets.New[workload.Reference]("/b"),
-					UsedResources: resources.FlavorResourceQuantities{
-						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 0,
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:      0,
-					},
+					Workloads:     sets.New[workload.Reference]("/b"),
+					UsedResources: resources.FlavorResourceQuantities{},
 				},
 				"two": {
 					Workloads: sets.New[workload.Reference]("/a", "/c"),
 					UsedResources: resources.FlavorResourceQuantities{
-						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
+						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: resources.NewAmount(10),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:      resources.NewAmount(15),
 					},
 				},
 			},
@@ -1350,8 +1347,8 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				"one": {
 					Workloads: sets.New[workload.Reference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
-						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
+						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: resources.NewAmount(10),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:      resources.NewAmount(15),
 					},
 				},
 				"two": {
@@ -1374,8 +1371,8 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				"one": {
 					Workloads: sets.New[workload.Reference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
-						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
+						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: resources.NewAmount(10),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:      resources.NewAmount(15),
 					},
 				},
 				"two": {
@@ -1393,11 +1390,8 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			},
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
-					Workloads: sets.New[workload.Reference]("/b"),
-					UsedResources: resources.FlavorResourceQuantities{
-						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 0,
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:      0,
-					},
+					Workloads:     sets.New[workload.Reference]("/b"),
+					UsedResources: resources.FlavorResourceQuantities{},
 				},
 				"two": {
 					Workloads: sets.New[workload.Reference]("/c"),
@@ -1412,11 +1406,8 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			},
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
-					Workloads: sets.New[workload.Reference]("/b"),
-					UsedResources: resources.FlavorResourceQuantities{
-						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 0,
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:      0,
-					},
+					Workloads:     sets.New[workload.Reference]("/b"),
+					UsedResources: resources.FlavorResourceQuantities{},
 				},
 				"two": {
 					Workloads: sets.New[workload.Reference]("/c"),
@@ -1433,8 +1424,8 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				"one": {
 					Workloads: sets.New[workload.Reference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
-						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
+						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: resources.NewAmount(10),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:      resources.NewAmount(15),
 					},
 				},
 				"two": {
@@ -1471,8 +1462,8 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				"one": {
 					Workloads: sets.New[workload.Reference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
-						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
+						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: resources.NewAmount(10),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:      resources.NewAmount(15),
 					},
 				},
 				"two": {
@@ -1498,8 +1489,8 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				"one": {
 					Workloads: sets.New[workload.Reference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
-						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
+						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: resources.NewAmount(10),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:      resources.NewAmount(15),
 					},
 				},
 				"two": {
@@ -1540,7 +1531,12 @@ func TestCacheWorkloadOperations(t *testing.T) {
 					UsedResources: cq.resourceNode.Usage,
 				}
 			}
-			if diff := cmp.Diff(step.wantResults, gotResult, cmpopts.EquateEmpty()); diff != "" {
+			cmpFilter := func(a, b resources.FlavorResourceQuantities) bool { return len(a) != 0 || len(b) != 0 }
+			cmpOpts := []cmp.Option{
+				cmpopts.EquateEmpty(),
+				cmp.FilterValues(cmpFilter, cmp.Comparer(equalFlavorResourceQuantitiesIgnoringZero)),
+			}
+			if diff := cmp.Diff(step.wantResults, gotResult, cmpOpts...); diff != "" {
 				t.Errorf("Unexpected clusterQueues (-want,+got):\n%s", diff)
 			}
 			if diff := cmp.Diff(wantQueuesAssigned, cache.workloadAssignedQueues, cmpopts.EquateEmpty()); diff != "" {
@@ -2327,12 +2323,12 @@ func TestCacheQueueOperations(t *testing.T) {
 					reservingWorkloads: 1,
 					admittedWorkloads:  1,
 					totalReserved: resources.FlavorResourceQuantities{
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("2")),
-						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("8Gi")),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.NewAmount(resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("2"))),
+						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.NewAmount(resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("8Gi"))),
 					},
 					admittedUsage: resources.FlavorResourceQuantities{
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("2")),
-						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("8Gi")),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.NewAmount(resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("2"))),
+						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.NewAmount(resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("8Gi"))),
 					},
 				},
 				"ns2/beta": {
@@ -2340,10 +2336,10 @@ func TestCacheQueueOperations(t *testing.T) {
 					reservingWorkloads: 2,
 					admittedWorkloads:  1,
 					totalReserved: resources.FlavorResourceQuantities{
-						{Flavor: "model-a", Resource: "example.com/gpu"}: resources.ResourceValue("example.com/gpu", resource.MustParse("7")),
+						{Flavor: "model-a", Resource: "example.com/gpu"}: resources.NewAmount(resources.ResourceValue("example.com/gpu", resource.MustParse("7"))),
 					},
 					admittedUsage: resources.FlavorResourceQuantities{
-						{Flavor: "model-a", Resource: "example.com/gpu"}: resources.ResourceValue("example.com/gpu", resource.MustParse("2")),
+						{Flavor: "model-a", Resource: "example.com/gpu"}: resources.NewAmount(resources.ResourceValue("example.com/gpu", resource.MustParse("2"))),
 					},
 				},
 				"ns1/gamma": {
@@ -2351,8 +2347,8 @@ func TestCacheQueueOperations(t *testing.T) {
 					reservingWorkloads: 1,
 					admittedWorkloads:  0,
 					totalReserved: resources.FlavorResourceQuantities{
-						{Flavor: "ondemand", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("5")),
-						{Flavor: "ondemand", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("16Gi")),
+						{Flavor: "ondemand", Resource: corev1.ResourceCPU}:    resources.NewAmount(resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("5"))),
+						{Flavor: "ondemand", Resource: corev1.ResourceMemory}: resources.NewAmount(resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("16Gi"))),
 					},
 				},
 			},
@@ -2383,14 +2379,14 @@ func TestCacheQueueOperations(t *testing.T) {
 					reservingWorkloads: 1,
 					admittedWorkloads:  1,
 					totalReserved: resources.FlavorResourceQuantities{
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("2")),
-						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("8Gi")),
-						{Flavor: "model-a", Resource: "example.com/gpu"}:  resources.ResourceValue("example.com/gpu", resource.MustParse("0")),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.NewAmount(resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("2"))),
+						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.NewAmount(resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("8Gi"))),
+						{Flavor: "model-a", Resource: "example.com/gpu"}:  resources.NewAmount(resources.ResourceValue("example.com/gpu", resource.MustParse("0"))),
 					},
 					admittedUsage: resources.FlavorResourceQuantities{
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("2")),
-						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("8Gi")),
-						{Flavor: "model-a", Resource: "example.com/gpu"}:  resources.ResourceValue("example.com/gpu", resource.MustParse("0")),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.NewAmount(resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("2"))),
+						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.NewAmount(resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("8Gi"))),
+						{Flavor: "model-a", Resource: "example.com/gpu"}:  resources.NewAmount(resources.ResourceValue("example.com/gpu", resource.MustParse("0"))),
 					},
 				},
 				"ns2/beta": {
@@ -2398,14 +2394,14 @@ func TestCacheQueueOperations(t *testing.T) {
 					reservingWorkloads: 2,
 					admittedWorkloads:  1,
 					totalReserved: resources.FlavorResourceQuantities{
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
-						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
-						{Flavor: "model-a", Resource: "example.com/gpu"}:  resources.ResourceValue("example.com/gpu", resource.MustParse("7")),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.NewAmount(resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("0"))),
+						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.NewAmount(resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("0"))),
+						{Flavor: "model-a", Resource: "example.com/gpu"}:  resources.NewAmount(resources.ResourceValue("example.com/gpu", resource.MustParse("7"))),
 					},
 					admittedUsage: resources.FlavorResourceQuantities{
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
-						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
-						{Flavor: "model-a", Resource: "example.com/gpu"}:  resources.ResourceValue("example.com/gpu", resource.MustParse("2")),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.NewAmount(resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("0"))),
+						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.NewAmount(resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("0"))),
+						{Flavor: "model-a", Resource: "example.com/gpu"}:  resources.NewAmount(resources.ResourceValue("example.com/gpu", resource.MustParse("2"))),
 					},
 				},
 				"ns1/gamma": {
@@ -2413,8 +2409,8 @@ func TestCacheQueueOperations(t *testing.T) {
 					reservingWorkloads: 1,
 					admittedWorkloads:  0,
 					totalReserved: resources.FlavorResourceQuantities{
-						{Flavor: "ondemand", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("5")),
-						{Flavor: "ondemand", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("16Gi")),
+						{Flavor: "ondemand", Resource: corev1.ResourceCPU}:    resources.NewAmount(resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("5"))),
+						{Flavor: "ondemand", Resource: corev1.ResourceMemory}: resources.NewAmount(resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("16Gi"))),
 					},
 				},
 			},
@@ -2431,12 +2427,12 @@ func TestCacheQueueOperations(t *testing.T) {
 					reservingWorkloads: 1,
 					admittedWorkloads:  1,
 					totalReserved: resources.FlavorResourceQuantities{
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("2")),
-						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("8Gi")),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.NewAmount(resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("2"))),
+						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.NewAmount(resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("8Gi"))),
 					},
 					admittedUsage: resources.FlavorResourceQuantities{
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("2")),
-						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("8Gi")),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.NewAmount(resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("2"))),
+						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.NewAmount(resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("8Gi"))),
 					},
 				},
 				"ns2/beta": {
@@ -2444,10 +2440,10 @@ func TestCacheQueueOperations(t *testing.T) {
 					reservingWorkloads: 2,
 					admittedWorkloads:  1,
 					totalReserved: resources.FlavorResourceQuantities{
-						{Flavor: "model-a", Resource: "example.com/gpu"}: resources.ResourceValue("example.com/gpu", resource.MustParse("7")),
+						{Flavor: "model-a", Resource: "example.com/gpu"}: resources.NewAmount(resources.ResourceValue("example.com/gpu", resource.MustParse("7"))),
 					},
 					admittedUsage: resources.FlavorResourceQuantities{
-						{Flavor: "model-a", Resource: "example.com/gpu"}: resources.ResourceValue("example.com/gpu", resource.MustParse("2")),
+						{Flavor: "model-a", Resource: "example.com/gpu"}: resources.NewAmount(resources.ResourceValue("example.com/gpu", resource.MustParse("2"))),
 					},
 				},
 				"ns1/gamma": {
@@ -2455,8 +2451,8 @@ func TestCacheQueueOperations(t *testing.T) {
 					reservingWorkloads: 1,
 					admittedWorkloads:  0,
 					totalReserved: resources.FlavorResourceQuantities{
-						{Flavor: "ondemand", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("5")),
-						{Flavor: "ondemand", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("16Gi")),
+						{Flavor: "ondemand", Resource: corev1.ResourceCPU}:    resources.NewAmount(resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("5"))),
+						{Flavor: "ondemand", Resource: corev1.ResourceMemory}: resources.NewAmount(resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("16Gi"))),
 					},
 				},
 			},
@@ -2483,12 +2479,12 @@ func TestCacheQueueOperations(t *testing.T) {
 					reservingWorkloads: 1,
 					admittedWorkloads:  1,
 					totalReserved: resources.FlavorResourceQuantities{
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("2")),
-						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("8Gi")),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.NewAmount(resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("2"))),
+						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.NewAmount(resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("8Gi"))),
 					},
 					admittedUsage: resources.FlavorResourceQuantities{
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("2")),
-						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("8Gi")),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.NewAmount(resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("2"))),
+						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.NewAmount(resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("8Gi"))),
 					},
 				},
 				"ns2/beta": {
@@ -2519,12 +2515,12 @@ func TestCacheQueueOperations(t *testing.T) {
 					reservingWorkloads: 0,
 					admittedWorkloads:  0,
 					totalReserved: resources.FlavorResourceQuantities{
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
-						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.NewAmount(resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("0"))),
+						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.NewAmount(resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("0"))),
 					},
 					admittedUsage: resources.FlavorResourceQuantities{
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
-						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
+						{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.NewAmount(resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("0"))),
+						{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.NewAmount(resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("0"))),
 					},
 				},
 				"ns2/beta": {
@@ -2532,10 +2528,10 @@ func TestCacheQueueOperations(t *testing.T) {
 					reservingWorkloads: 2,
 					admittedWorkloads:  1,
 					totalReserved: resources.FlavorResourceQuantities{
-						{Flavor: "model-a", Resource: "example.com/gpu"}: resources.ResourceValue("example.com/gpu", resource.MustParse("7")),
+						{Flavor: "model-a", Resource: "example.com/gpu"}: resources.NewAmount(resources.ResourceValue("example.com/gpu", resource.MustParse("7"))),
 					},
 					admittedUsage: resources.FlavorResourceQuantities{
-						{Flavor: "model-a", Resource: "example.com/gpu"}: resources.ResourceValue("example.com/gpu", resource.MustParse("2")),
+						{Flavor: "model-a", Resource: "example.com/gpu"}: resources.NewAmount(resources.ResourceValue("example.com/gpu", resource.MustParse("2"))),
 					},
 				},
 				"ns1/gamma": {
@@ -2543,8 +2539,8 @@ func TestCacheQueueOperations(t *testing.T) {
 					reservingWorkloads: 1,
 					admittedWorkloads:  0,
 					totalReserved: resources.FlavorResourceQuantities{
-						{Flavor: "ondemand", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("5")),
-						{Flavor: "ondemand", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("16Gi")),
+						{Flavor: "ondemand", Resource: corev1.ResourceCPU}:    resources.NewAmount(resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("5"))),
+						{Flavor: "ondemand", Resource: corev1.ResourceMemory}: resources.NewAmount(resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("16Gi"))),
 					},
 				},
 			},
@@ -2565,8 +2561,8 @@ func TestCacheQueueOperations(t *testing.T) {
 					reservingWorkloads: 1,
 					admittedWorkloads:  0,
 					totalReserved: resources.FlavorResourceQuantities{
-						{Flavor: "ondemand", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("5")),
-						{Flavor: "ondemand", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("16Gi")),
+						{Flavor: "ondemand", Resource: corev1.ResourceCPU}:    resources.NewAmount(resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("5"))),
+						{Flavor: "ondemand", Resource: corev1.ResourceMemory}: resources.NewAmount(resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("16Gi"))),
 					},
 				},
 			},
@@ -2587,10 +2583,10 @@ func TestCacheQueueOperations(t *testing.T) {
 					reservingWorkloads: 2,
 					admittedWorkloads:  1,
 					totalReserved: resources.FlavorResourceQuantities{
-						{Flavor: "model-a", Resource: "example.com/gpu"}: resources.ResourceValue("example.com/gpu", resource.MustParse("7")),
+						{Flavor: "model-a", Resource: "example.com/gpu"}: resources.NewAmount(resources.ResourceValue("example.com/gpu", resource.MustParse("7"))),
 					},
 					admittedUsage: resources.FlavorResourceQuantities{
-						{Flavor: "model-a", Resource: "example.com/gpu"}: resources.ResourceValue("example.com/gpu", resource.MustParse("2")),
+						{Flavor: "model-a", Resource: "example.com/gpu"}: resources.NewAmount(resources.ResourceValue("example.com/gpu", resource.MustParse("2"))),
 					},
 				},
 				"ns1/gamma": {
@@ -2598,8 +2594,8 @@ func TestCacheQueueOperations(t *testing.T) {
 					reservingWorkloads: 1,
 					admittedWorkloads:  0,
 					totalReserved: resources.FlavorResourceQuantities{
-						{Flavor: "ondemand", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("5")),
-						{Flavor: "ondemand", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("16Gi")),
+						{Flavor: "ondemand", Resource: corev1.ResourceCPU}:    resources.NewAmount(resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("5"))),
+						{Flavor: "ondemand", Resource: corev1.ResourceMemory}: resources.NewAmount(resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("16Gi"))),
 					},
 				},
 			},
@@ -2626,7 +2622,14 @@ func TestCacheQueueOperations(t *testing.T) {
 					cacheQueues[qKey] = cacheQ
 				}
 			}
-			if diff := cmp.Diff(tc.wantLocalQueues, cacheQueues, cmp.AllowUnexported(LocalQueue{}), cmpopts.EquateEmpty(), cmpopts.IgnoreTypes(sync.RWMutex{})); diff != "" {
+			cmpFilter := func(a, b resources.FlavorResourceQuantities) bool { return len(a) != 0 || len(b) != 0 }
+			cmpOpts := []cmp.Option{
+				cmp.AllowUnexported(LocalQueue{}),
+				cmpopts.EquateEmpty(),
+				cmpopts.IgnoreTypes(sync.RWMutex{}),
+				cmp.FilterValues(cmpFilter, cmp.Comparer(equalFlavorResourceQuantitiesIgnoringZero)),
+			}
+			if diff := cmp.Diff(tc.wantLocalQueues, cacheQueues, cmpOpts...); diff != "" {
 				t.Errorf("Unexpected localQueues (-want,+got):\n%s", diff)
 			}
 		})
@@ -3035,6 +3038,31 @@ func TestIsAddedCheckWorkload(t *testing.T) {
 	}
 }
 
+func normalizeFlavorResourceQuantities(in resources.FlavorResourceQuantities) resources.FlavorResourceQuantities {
+	out := make(resources.FlavorResourceQuantities, len(in))
+	for k, v := range in {
+		if v.CmpInt64(0) != 0 {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+func equalFlavorResourceQuantitiesIgnoringZero(a, b resources.FlavorResourceQuantities) bool {
+	na := normalizeFlavorResourceQuantities(a)
+	nb := normalizeFlavorResourceQuantities(b)
+	if len(na) != len(nb) {
+		return false
+	}
+	for k, av := range na {
+		bv, ok := nb[k]
+		if !ok || !av.Equal(bv) {
+			return false
+		}
+	}
+	return true
+}
+
 func messageOrEmpty(err error) string {
 	if err == nil {
 		return ""
@@ -3348,10 +3376,10 @@ func TestCohortCycles(t *testing.T) {
 		gotResource := cache.hm.Cohort("cohort").getResourceNode()
 		wantResource := resourceNode{
 			Quotas: map[resources.FlavorResource]ResourceQuota{
-				{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 10_000},
+				{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: resources.NewAmount(10_000)},
 			},
 			SubtreeQuota: resources.FlavorResourceQuantities{
-				{Flavor: "arm", Resource: corev1.ResourceCPU}: 15_000,
+				{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(15_000),
 			},
 			Usage: resources.FlavorResourceQuantities{},
 		}
@@ -3384,10 +3412,10 @@ func TestCohortCycles(t *testing.T) {
 		gotResource := cache.hm.Cohort("cohort").getResourceNode()
 		wantResource := resourceNode{
 			Quotas: map[resources.FlavorResource]ResourceQuota{
-				{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 10_000},
+				{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: resources.NewAmount(10_000)},
 			},
 			SubtreeQuota: resources.FlavorResourceQuantities{
-				{Flavor: "arm", Resource: corev1.ResourceCPU}: 15_000,
+				{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(15_000),
 			},
 			Usage: resources.FlavorResourceQuantities{},
 		}
@@ -3405,10 +3433,10 @@ func TestCohortCycles(t *testing.T) {
 		gotResource = cache.hm.Cohort("cohort").getResourceNode()
 		wantResource = resourceNode{
 			Quotas: map[resources.FlavorResource]ResourceQuota{
-				{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 10_000},
+				{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: resources.NewAmount(10_000)},
 			},
 			SubtreeQuota: resources.FlavorResourceQuantities{
-				{Flavor: "arm", Resource: corev1.ResourceCPU}: 10_000,
+				{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 			},
 			Usage: resources.FlavorResourceQuantities{},
 		}
@@ -3439,7 +3467,7 @@ func TestCohortCycles(t *testing.T) {
 			wantRoot1 := resourceNode{
 				Quotas: map[resources.FlavorResource]ResourceQuota{},
 				SubtreeQuota: resources.FlavorResourceQuantities{
-					{Flavor: "arm", Resource: corev1.ResourceCPU}: 10_000,
+					{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 				},
 				Usage: resources.FlavorResourceQuantities{},
 			}
@@ -3469,7 +3497,7 @@ func TestCohortCycles(t *testing.T) {
 			wantRoot2 := resourceNode{
 				Quotas: map[resources.FlavorResource]ResourceQuota{},
 				SubtreeQuota: resources.FlavorResourceQuantities{
-					{Flavor: "arm", Resource: corev1.ResourceCPU}: 10_000,
+					{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 				},
 				Usage: resources.FlavorResourceQuantities{},
 			}
@@ -3508,7 +3536,7 @@ func TestCohortCycles(t *testing.T) {
 		wantRoot := resourceNode{
 			Quotas: map[resources.FlavorResource]ResourceQuota{},
 			SubtreeQuota: resources.FlavorResourceQuantities{
-				{Flavor: "arm", Resource: corev1.ResourceCPU}: 10_000,
+				{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 			},
 			Usage: resources.FlavorResourceQuantities{},
 		}
@@ -3541,7 +3569,7 @@ func TestCohortCycles(t *testing.T) {
 			wantRoot := resourceNode{
 				Quotas: map[resources.FlavorResource]ResourceQuota{},
 				SubtreeQuota: resources.FlavorResourceQuantities{
-					{Flavor: "arm", Resource: corev1.ResourceCPU}: 10_000,
+					{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 				},
 				Usage: resources.FlavorResourceQuantities{},
 			}
@@ -3596,12 +3624,12 @@ func TestDeleteCohortUpdatesAncestorSubtreeQuota(t *testing.T) {
 			deleteName: "child",
 			wantBefore: map[kueue.CohortReference]resources.FlavorResourceQuantities{
 				"root": {
-					{Flavor: "default", Resource: corev1.ResourceCPU}: 15_000,
+					{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(15_000),
 				},
 			},
 			wantAfter: map[kueue.CohortReference]resources.FlavorResourceQuantities{
 				"root": {
-					{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+					{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 				},
 			},
 		},
@@ -3622,18 +3650,18 @@ func TestDeleteCohortUpdatesAncestorSubtreeQuota(t *testing.T) {
 			deleteName: "leaf",
 			wantBefore: map[kueue.CohortReference]resources.FlavorResourceQuantities{
 				"mid": {
-					{Flavor: "default", Resource: corev1.ResourceCPU}: 8_000,
+					{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(8_000),
 				},
 				"root": {
-					{Flavor: "default", Resource: corev1.ResourceCPU}: 18_000,
+					{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(18_000),
 				},
 			},
 			wantAfter: map[kueue.CohortReference]resources.FlavorResourceQuantities{
 				"mid": {
-					{Flavor: "default", Resource: corev1.ResourceCPU}: 5_000,
+					{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(5_000),
 				},
 				"root": {
-					{Flavor: "default", Resource: corev1.ResourceCPU}: 15_000,
+					{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(15_000),
 				},
 			},
 		},
@@ -3658,12 +3686,12 @@ func TestDeleteCohortUpdatesAncestorSubtreeQuota(t *testing.T) {
 			deleteName: "mid",
 			wantBefore: map[kueue.CohortReference]resources.FlavorResourceQuantities{
 				"root": {
-					{Flavor: "default", Resource: corev1.ResourceCPU}: 22_000,
+					{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(22_000),
 				},
 			},
 			wantAfter: map[kueue.CohortReference]resources.FlavorResourceQuantities{
 				"root": {
-					{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+					{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 				},
 			},
 		},

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
 	"sigs.k8s.io/kueue/pkg/util/api"
+	utilmath "sigs.k8s.io/kueue/pkg/util/math"
 	"sigs.k8s.io/kueue/pkg/util/queue"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	stringsutils "sigs.k8s.io/kueue/pkg/util/strings"
@@ -223,9 +224,12 @@ func (c *clusterQueue) updateQuotasAndResourceGroups(in []kueue.ResourceGroup) b
 	c.resourceNode.Quotas = createResourceQuotas(in)
 
 	// Start at 1, for backwards compatibility.
+	// Use maps.EqualFunc with ResourceQuota.Equal for the Quotas map: it holds
+	// resources.Amount values whose unexported fields cause k8s
+	// equality.Semantic.DeepEqual (a forked reflect-based DeepEqual) to panic.
 	return c.AllocatableResourceGeneration == 0 ||
 		!equality.Semantic.DeepEqual(oldRG, c.ResourceGroups) ||
-		!equality.Semantic.DeepEqual(oldQuotas, c.resourceNode.Quotas)
+		!maps.EqualFunc(oldQuotas, c.resourceNode.Quotas, ResourceQuota.Equal)
 }
 
 func (c *clusterQueue) updateQueueStatus(log logr.Logger) {
@@ -527,17 +531,17 @@ func (c *clusterQueue) reportResourceMetrics(fairSharingEnabled bool) {
 	cqName := string(c.Name)
 	for fr, quota := range c.resourceNode.Quotas {
 		fName, rName := string(fr.Flavor), string(fr.Resource)
-		nominal := resourceFloat(fr.Resource, quota.Nominal)
+		nominal := resourceFloat(fr.Resource, quota.Nominal.Int64())
 		var borrowing, lending float64
 		if quota.BorrowingLimit != nil {
-			borrowing = resourceFloat(fr.Resource, *quota.BorrowingLimit)
+			borrowing = resourceFloat(fr.Resource, quota.BorrowingLimit.Int64())
 		}
 		if quota.LendingLimit != nil {
-			lending = resourceFloat(fr.Resource, *quota.LendingLimit)
+			lending = resourceFloat(fr.Resource, quota.LendingLimit.Int64())
 		}
 		metrics.ReportClusterQueueQuotas(cohort, cqName, fName, rName, nominal, borrowing, lending, c.customMetricLabelValues, c.roleTracker)
-		metrics.ReportClusterQueueResourceReservations(cohort, cqName, fName, rName, resourceFloat(fr.Resource, c.resourceNode.Usage[fr]), c.customMetricLabelValues, c.roleTracker)
-		metrics.ReportClusterQueueResourceUsage(cohort, cqName, fName, rName, resourceFloat(fr.Resource, c.AdmittedUsage[fr]), c.customMetricLabelValues, c.roleTracker)
+		metrics.ReportClusterQueueResourceReservations(cohort, cqName, fName, rName, resourceFloat(fr.Resource, c.resourceNode.Usage[fr].Int64()), c.customMetricLabelValues, c.roleTracker)
+		metrics.ReportClusterQueueResourceUsage(cohort, cqName, fName, rName, resourceFloat(fr.Resource, c.AdmittedUsage[fr].Int64()), c.customMetricLabelValues, c.roleTracker)
 	}
 	if fairSharingEnabled {
 		c.reportWeightedShare(cohort)
@@ -611,8 +615,9 @@ func (c *clusterQueue) updateWorkloadTASUsage(log logr.Logger, wi *workload.Info
 }
 
 func updateFlavorUsage(newUsage resources.FlavorResourceQuantities, oldUsage resources.FlavorResourceQuantities, op usageOp) {
+	sign := int64(op.asSignedOne())
 	for fr, q := range newUsage {
-		oldUsage[fr] += q * int64(op.asSignedOne())
+		oldUsage[fr] = oldUsage[fr].AddInt64(utilmath.SaturatingMul(sign, q.Int64()))
 	}
 }
 

--- a/pkg/cache/scheduler/clusterqueue_snapshot.go
+++ b/pkg/cache/scheduler/clusterqueue_snapshot.go
@@ -121,7 +121,7 @@ func (c *ClusterQueueSnapshot) updateTASUsage(usage workload.TASUsage, op usageO
 
 func (c *ClusterQueueSnapshot) Fits(usage workload.Usage) bool {
 	for fr, q := range usage.Quota {
-		if c.Available(fr) < q.Int64() {
+		if c.Available(fr).Cmp(q) < 0 {
 			return false
 		}
 	}
@@ -141,25 +141,25 @@ func (c *ClusterQueueSnapshot) QuotaFor(fr resources.FlavorResource) ResourceQuo
 }
 
 func (c *ClusterQueueSnapshot) Borrowing(fr resources.FlavorResource) bool {
-	return c.BorrowingWith(fr, 0)
+	return c.BorrowingWith(fr, resources.NewAmount(0))
 }
 
-func (c *ClusterQueueSnapshot) BorrowingWith(fr resources.FlavorResource, val int64) bool {
-	return c.QuotaFor(fr).Nominal.Cmp(c.ResourceNode.Usage[fr].AddInt64(val)) < 0
+func (c *ClusterQueueSnapshot) BorrowingWith(fr resources.FlavorResource, val resources.Amount) bool {
+	return c.QuotaFor(fr).Nominal.Cmp(c.ResourceNode.Usage[fr].Add(val)) < 0
 }
 
 // Available returns the current capacity available, before preempting
 // any workloads. Includes local capacity and capacity borrowed from
 // Cohort. When the ClusterQueue/Cohort is in debt, Available
 // will return 0.
-func (c *ClusterQueueSnapshot) Available(fr resources.FlavorResource) int64 {
-	return max(0, available(c, fr))
+func (c *ClusterQueueSnapshot) Available(fr resources.FlavorResource) resources.Amount {
+	return resources.MaxAmount(resources.NewAmount(0), available(c, fr))
 }
 
 // PotentialAvailable returns the largest workload this ClusterQueue could
 // possibly admit, accounting for its capacity and capacity borrowed
 // its from Cohort.
-func (c *ClusterQueueSnapshot) PotentialAvailable(fr resources.FlavorResource) int64 {
+func (c *ClusterQueueSnapshot) PotentialAvailable(fr resources.FlavorResource) resources.Amount {
 	return potentialAvailable(c, fr)
 }
 

--- a/pkg/cache/scheduler/clusterqueue_snapshot.go
+++ b/pkg/cache/scheduler/clusterqueue_snapshot.go
@@ -121,7 +121,7 @@ func (c *ClusterQueueSnapshot) updateTASUsage(usage workload.TASUsage, op usageO
 
 func (c *ClusterQueueSnapshot) Fits(usage workload.Usage) bool {
 	for fr, q := range usage.Quota {
-		if c.Available(fr) < q {
+		if c.Available(fr) < q.Int64() {
 			return false
 		}
 	}
@@ -145,7 +145,7 @@ func (c *ClusterQueueSnapshot) Borrowing(fr resources.FlavorResource) bool {
 }
 
 func (c *ClusterQueueSnapshot) BorrowingWith(fr resources.FlavorResource, val int64) bool {
-	return c.ResourceNode.Usage[fr]+val > c.QuotaFor(fr).Nominal
+	return c.QuotaFor(fr).Nominal.Cmp(c.ResourceNode.Usage[fr].AddInt64(val)) < 0
 }
 
 // Available returns the current capacity available, before preempting

--- a/pkg/cache/scheduler/cohort_metrics.go
+++ b/pkg/cache/scheduler/cohort_metrics.go
@@ -104,8 +104,8 @@ func (c *Cache) collectCohortMetricPoints(cohortName kueue.CohortReference, simu
 			points = append(points, cohortMetricPoint{
 				cohortName:      ancestor.Name,
 				flavorResource:  fr,
-				quotaQty:        ancestorSubtreeQuota[fr],
-				reservationsQty: ancestorSubtreeReservations[fr],
+				quotaQty:        ancestorSubtreeQuota[fr].Int64(),
+				reservationsQty: ancestorSubtreeReservations[fr].Int64(),
 			})
 		}
 	}
@@ -172,7 +172,7 @@ func (m subtreeReservationMemo) total(ch *cohort) resources.FlavorResourceQuanti
 
 func accumulateReservations(total, usage resources.FlavorResourceQuantities) {
 	for fr, qty := range usage {
-		total[fr] += qty
+		total[fr] = total[fr].Add(qty)
 	}
 }
 

--- a/pkg/cache/scheduler/cohort_metrics_test.go
+++ b/pkg/cache/scheduler/cohort_metrics_test.go
@@ -113,12 +113,12 @@ func TestRecordCohortMetrics_Guards(t *testing.T) {
 					{
 						cohort: cohortLeft,
 						fr:     fr,
-						quota:  resourceFloat(fr.Resource, cache.hm.Cohort(cohortLeft).resourceNode.SubtreeQuota[fr]),
+						quota:  resourceFloat(fr.Resource, cache.hm.Cohort(cohortLeft).resourceNode.SubtreeQuota[fr].Int64()),
 					},
 					{
 						cohort: cohortRoot,
 						fr:     fr,
-						quota:  resourceFloat(fr.Resource, cache.hm.Cohort(cohortRoot).resourceNode.SubtreeQuota[fr]),
+						quota:  resourceFloat(fr.Resource, cache.hm.Cohort(cohortRoot).resourceNode.SubtreeQuota[fr].Int64()),
 					},
 				}
 			},
@@ -415,7 +415,7 @@ type usageChange struct {
 // to its Cohort.
 func addTestUsage(cache *Cache, fr []usageChange) {
 	for _, val := range fr {
-		cache.hm.ClusterQueue(val.cqName).resourceNode.Usage[val.fr] = val.val
+		cache.hm.ClusterQueue(val.cqName).resourceNode.Usage[val.fr] = resources.NewAmount(val.val)
 	}
 }
 

--- a/pkg/cache/scheduler/cohort_snapshot.go
+++ b/pkg/cache/scheduler/cohort_snapshot.go
@@ -88,5 +88,5 @@ func (c *CohortSnapshot) fairWeight() float64 {
 }
 
 func (c *CohortSnapshot) BorrowingWith(fr resources.FlavorResource, val int64) bool {
-	return c.ResourceNode.Usage[fr]+val > c.ResourceNode.SubtreeQuota[fr]
+	return c.ResourceNode.SubtreeQuota[fr].Cmp(c.ResourceNode.Usage[fr].AddInt64(val)) < 0
 }

--- a/pkg/cache/scheduler/cohort_snapshot.go
+++ b/pkg/cache/scheduler/cohort_snapshot.go
@@ -87,6 +87,6 @@ func (c *CohortSnapshot) fairWeight() float64 {
 	return c.FairWeight
 }
 
-func (c *CohortSnapshot) BorrowingWith(fr resources.FlavorResource, val int64) bool {
-	return c.ResourceNode.SubtreeQuota[fr].Cmp(c.ResourceNode.Usage[fr].AddInt64(val)) < 0
+func (c *CohortSnapshot) BorrowingWith(fr resources.FlavorResource, val resources.Amount) bool {
+	return c.ResourceNode.SubtreeQuota[fr].Cmp(c.ResourceNode.Usage[fr].Add(val)) < 0
 }

--- a/pkg/cache/scheduler/fair_sharing.go
+++ b/pkg/cache/scheduler/fair_sharing.go
@@ -144,11 +144,11 @@ func dominantResourceShare(node dominantResourceShareNode, wlReq resources.Flavo
 	}
 
 	var borrowedFRs []resources.FlavorResource
-	borrowing := make(map[corev1.ResourceName]int64, len(node.getResourceNode().SubtreeQuota))
+	borrowing := make(map[corev1.ResourceName]resources.Amount, len(node.getResourceNode().SubtreeQuota))
 	for fr, quota := range node.getResourceNode().SubtreeQuota {
-		amountBorrowed := wlReq[fr].Add(node.getResourceNode().Usage[fr]).Sub(quota).Int64()
-		if amountBorrowed > 0 {
-			borrowing[fr.Resource] += amountBorrowed
+		amountBorrowed := wlReq[fr].Add(node.getResourceNode().Usage[fr]).Sub(quota)
+		if amountBorrowed.CmpInt64(0) > 0 {
+			borrowing[fr.Resource] = borrowing[fr.Resource].Add(amountBorrowed)
 			borrowedFRs = append(borrowedFRs, fr)
 		}
 	}
@@ -160,8 +160,8 @@ func dominantResourceShare(node dominantResourceShareNode, wlReq resources.Flavo
 
 	lendable := calculateLendable(node.parentHRN())
 	for rName, b := range borrowing {
-		if lr := lendable[rName]; lr > 0 {
-			ratio := float64(b) * 1000.0 / float64(lr)
+		if lr := lendable[rName]; lr.CmpInt64(0) > 0 {
+			ratio := float64(b.Int64()) * 1000.0 / float64(lr.Int64())
 			// Use alphabetical order to get a deterministic resource name.
 			if ratio > drs.unweightedRatio || (ratio == drs.unweightedRatio && rName < drs.dominantResource) {
 				drs.unweightedRatio = ratio
@@ -174,18 +174,18 @@ func dominantResourceShare(node dominantResourceShareNode, wlReq resources.Flavo
 
 // calculateLendable aggregates capacity for resources across all
 // FlavorResources.
-func calculateLendable(node hierarchicalResourceNode) map[corev1.ResourceName]int64 {
+func calculateLendable(node hierarchicalResourceNode) map[corev1.ResourceName]resources.Amount {
 	// walk to root
 	root := node
 	for root.HasParent() {
 		root = root.parentHRN()
 	}
 
-	lendable := make(map[corev1.ResourceName]int64, len(root.getResourceNode().SubtreeQuota))
+	lendable := make(map[corev1.ResourceName]resources.Amount, len(root.getResourceNode().SubtreeQuota))
 	// The root's SubtreeQuota contains all FlavorResources,
 	// as we accumulate even 0s in accumulateFromChild.
 	for fr := range root.getResourceNode().SubtreeQuota {
-		lendable[fr.Resource] += potentialAvailable(node, fr)
+		lendable[fr.Resource] = lendable[fr.Resource].Add(potentialAvailable(node, fr))
 	}
 	return lendable
 }

--- a/pkg/cache/scheduler/fair_sharing.go
+++ b/pkg/cache/scheduler/fair_sharing.go
@@ -75,7 +75,7 @@ func (d DRS) IsBorrowing() bool {
 // FlavorResource present in requestedFRs.
 func (d DRS) IsBorrowingOn(requestedFRs resources.FlavorResourceQuantities) bool {
 	for _, fr := range d.borrowedFRs {
-		if requestedFRs[fr] > 0 {
+		if requestedFRs[fr].CmpInt64(0) > 0 {
 			return true
 		}
 	}
@@ -146,7 +146,7 @@ func dominantResourceShare(node dominantResourceShareNode, wlReq resources.Flavo
 	var borrowedFRs []resources.FlavorResource
 	borrowing := make(map[corev1.ResourceName]int64, len(node.getResourceNode().SubtreeQuota))
 	for fr, quota := range node.getResourceNode().SubtreeQuota {
-		amountBorrowed := wlReq[fr] + node.getResourceNode().Usage[fr] - quota
+		amountBorrowed := wlReq[fr].Add(node.getResourceNode().Usage[fr]).Sub(quota).Int64()
 		if amountBorrowed > 0 {
 			borrowing[fr.Resource] += amountBorrowed
 			borrowedFRs = append(borrowedFRs, fr)

--- a/pkg/cache/scheduler/fair_sharing_test.go
+++ b/pkg/cache/scheduler/fair_sharing_test.go
@@ -60,8 +60,8 @@ func TestDominantResourceShare(t *testing.T) {
 	}{
 		"no cohort": {
 			usage: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: corev1.ResourceCPU}: 1_000,
-				{Flavor: "default", Resource: "example.com/gpu"}:  2,
+				{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
+				{Flavor: "default", Resource: "example.com/gpu"}:  resources.NewAmount(2),
 			},
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
 				ResourceGroup(
@@ -82,8 +82,8 @@ func TestDominantResourceShare(t *testing.T) {
 		},
 		"usage below nominal": {
 			usage: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: corev1.ResourceCPU}: 1_000,
-				{Flavor: "default", Resource: "example.com/gpu"}:  2,
+				{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
+				{Flavor: "default", Resource: "example.com/gpu"}:  resources.NewAmount(2),
 			},
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
 				Cohort("test-cohort").
@@ -129,8 +129,8 @@ func TestDominantResourceShare(t *testing.T) {
 		},
 		"usage above nominal": {
 			usage: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: corev1.ResourceCPU}: 3_000,
-				{Flavor: "default", Resource: "example.com/gpu"}:  7,
+				{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(3_000),
+				{Flavor: "default", Resource: "example.com/gpu"}:  resources.NewAmount(7),
 			},
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
 				Cohort("test-cohort").
@@ -176,7 +176,7 @@ func TestDominantResourceShare(t *testing.T) {
 		},
 		"usage slightly above nominal in a cohort with large quotas": {
 			usage: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: "example.com/gpu"}: 501,
+				{Flavor: "default", Resource: "example.com/gpu"}: resources.NewAmount(501),
 			},
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
 				Cohort("test-cohort").
@@ -220,7 +220,7 @@ func TestDominantResourceShare(t *testing.T) {
 		},
 		"usage way above nominal in a cohort with large quotas and weights": {
 			usage: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: "example.com/gpu"}: 800,
+				{Flavor: "default", Resource: "example.com/gpu"}: resources.NewAmount(800),
 			},
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
 				Cohort("test-cohort").
@@ -264,8 +264,8 @@ func TestDominantResourceShare(t *testing.T) {
 		},
 		"one resource above nominal": {
 			usage: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: corev1.ResourceCPU}: 3_000,
-				{Flavor: "default", Resource: "example.com/gpu"}:  3,
+				{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(3_000),
+				{Flavor: "default", Resource: "example.com/gpu"}:  resources.NewAmount(3),
 			},
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
 				Cohort("test-cohort").
@@ -311,8 +311,8 @@ func TestDominantResourceShare(t *testing.T) {
 		},
 		"usage with workload above nominal": {
 			usage: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: corev1.ResourceCPU}: 1_000,
-				{Flavor: "default", Resource: "example.com/gpu"}:  2,
+				{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
+				{Flavor: "default", Resource: "example.com/gpu"}:  resources.NewAmount(2),
 			},
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
 				Cohort("test-cohort").
@@ -333,8 +333,8 @@ func TestDominantResourceShare(t *testing.T) {
 						Obj(),
 				).Obj(),
 			flvResQ: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: corev1.ResourceCPU}: 4_000,
-				{Flavor: "default", Resource: "example.com/gpu"}:  4,
+				{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(4_000),
+				{Flavor: "default", Resource: "example.com/gpu"}:  resources.NewAmount(4),
 			},
 			want: []fairSharingResult{
 				{
@@ -362,8 +362,8 @@ func TestDominantResourceShare(t *testing.T) {
 		},
 		"A resource with zero lendable": {
 			usage: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: corev1.ResourceCPU}: 1_000,
-				{Flavor: "default", Resource: "example.com/gpu"}:  1,
+				{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
+				{Flavor: "default", Resource: "example.com/gpu"}:  resources.NewAmount(1),
 			},
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
 				Cohort("test-cohort").
@@ -384,8 +384,8 @@ func TestDominantResourceShare(t *testing.T) {
 						Obj(),
 				).Obj(),
 			flvResQ: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: corev1.ResourceCPU}: 4_000,
-				{Flavor: "default", Resource: "example.com/gpu"}:  4,
+				{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(4_000),
+				{Flavor: "default", Resource: "example.com/gpu"}:  resources.NewAmount(4),
 			},
 			want: []fairSharingResult{
 				{
@@ -413,8 +413,8 @@ func TestDominantResourceShare(t *testing.T) {
 		},
 		"multiple flavors": {
 			usage: resources.FlavorResourceQuantities{
-				{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 15_000,
-				{Flavor: "spot", Resource: corev1.ResourceCPU}:      5_000,
+				{Flavor: "on-demand", Resource: corev1.ResourceCPU}: resources.NewAmount(15_000),
+				{Flavor: "spot", Resource: corev1.ResourceCPU}:      resources.NewAmount(5_000),
 			},
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
 				Cohort("test-cohort").
@@ -436,7 +436,7 @@ func TestDominantResourceShare(t *testing.T) {
 						Obj(),
 				).Obj(),
 			flvResQ: resources.FlavorResourceQuantities{
-				{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10_000,
+				{Flavor: "on-demand", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 			},
 			want: []fairSharingResult{
 				{
@@ -464,7 +464,7 @@ func TestDominantResourceShare(t *testing.T) {
 		},
 		"above nominal with integer weight": {
 			usage: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: "example.com/gpu"}: 7,
+				{Flavor: "default", Resource: "example.com/gpu"}: resources.NewAmount(7),
 			},
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
 				Cohort("test-cohort").
@@ -508,7 +508,7 @@ func TestDominantResourceShare(t *testing.T) {
 		},
 		"above nominal with decimal weight": {
 			usage: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: "example.com/gpu"}: 7,
+				{Flavor: "default", Resource: "example.com/gpu"}: resources.NewAmount(7),
 			},
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
 				Cohort("test-cohort").
@@ -552,7 +552,7 @@ func TestDominantResourceShare(t *testing.T) {
 		},
 		"above nominal with zero weight": {
 			usage: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: "example.com/gpu"}: 7,
+				{Flavor: "default", Resource: "example.com/gpu"}: resources.NewAmount(7),
 			},
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
 				Cohort("test-cohort").
@@ -596,7 +596,7 @@ func TestDominantResourceShare(t *testing.T) {
 		},
 		"cohort has resource share": {
 			usage: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: "example.com/gpu"}: 10,
+				{Flavor: "default", Resource: "example.com/gpu"}: resources.NewAmount(10),
 			},
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
 				Cohort("child-cohort").
@@ -640,7 +640,7 @@ func TestDominantResourceShare(t *testing.T) {
 		},
 		"resource share defined for resources only available at the root cohort": {
 			usage: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: "example.com/gpu"}: 10,
+				{Flavor: "default", Resource: "example.com/gpu"}: resources.NewAmount(10),
 			},
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
 				Cohort("child-cohort").
@@ -687,7 +687,7 @@ func TestDominantResourceShare(t *testing.T) {
 			// from view of child-cohort are 50. So, they get
 			// different FairSharing values.
 			usage: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: "example.com/gpu"}: 10,
+				{Flavor: "default", Resource: "example.com/gpu"}: resources.NewAmount(10),
 			},
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
 				Cohort("child-cohort").
@@ -759,7 +759,7 @@ func TestDominantResourceShare(t *testing.T) {
 			i := 0
 			for fr, v := range tc.usage {
 				admission := utiltestingapi.MakeAdmission("cq")
-				quantity := resources.ResourceQuantity(fr.Resource, v)
+				quantity := resources.ResourceQuantity(fr.Resource, v.Int64())
 				admission.PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
 					Assignment(fr.Resource, fr.Flavor, quantity.String()).
 					Obj())
@@ -845,31 +845,31 @@ func TestIsBorrowingOn(t *testing.T) {
 		wantBorrowing            bool
 	}{
 		"borrows on requested flavor": {
-			usage:                    resources.FlavorResourceQuantities{cpuDefault: 3_000},
-			requestedFRs:             resources.FlavorResourceQuantities{cpuDefault: 1_000},
+			usage:                    resources.FlavorResourceQuantities{cpuDefault: resources.NewAmount(3_000)},
+			requestedFRs:             resources.FlavorResourceQuantities{cpuDefault: resources.NewAmount(1_000)},
 			wantBorrowingOnRequested: true,
 			wantBorrowing:            true,
 		},
 		"borrows on unrequested flavor only": {
-			usage:                    resources.FlavorResourceQuantities{cpuDefault: 1_000, gpuDefault: 7},
-			requestedFRs:             resources.FlavorResourceQuantities{cpuDefault: 1_000},
+			usage:                    resources.FlavorResourceQuantities{cpuDefault: resources.NewAmount(1_000), gpuDefault: resources.NewAmount(7)},
+			requestedFRs:             resources.FlavorResourceQuantities{cpuDefault: resources.NewAmount(1_000)},
 			wantBorrowingOnRequested: false,
 			wantBorrowing:            true,
 		},
 		"borrows on both, requests one": {
-			usage:                    resources.FlavorResourceQuantities{cpuDefault: 3_000, gpuDefault: 7},
-			requestedFRs:             resources.FlavorResourceQuantities{gpuDefault: 1},
+			usage:                    resources.FlavorResourceQuantities{cpuDefault: resources.NewAmount(3_000), gpuDefault: resources.NewAmount(7)},
+			requestedFRs:             resources.FlavorResourceQuantities{gpuDefault: resources.NewAmount(1)},
 			wantBorrowingOnRequested: true,
 			wantBorrowing:            true,
 		},
 		"no borrowing": {
-			usage:                    resources.FlavorResourceQuantities{cpuDefault: 1_000, gpuDefault: 2},
-			requestedFRs:             resources.FlavorResourceQuantities{cpuDefault: 1_000},
+			usage:                    resources.FlavorResourceQuantities{cpuDefault: resources.NewAmount(1_000), gpuDefault: resources.NewAmount(2)},
+			requestedFRs:             resources.FlavorResourceQuantities{cpuDefault: resources.NewAmount(1_000)},
 			wantBorrowingOnRequested: false,
 			wantBorrowing:            false,
 		},
 		"nil requestedFRs": {
-			usage:                    resources.FlavorResourceQuantities{cpuDefault: 3_000},
+			usage:                    resources.FlavorResourceQuantities{cpuDefault: resources.NewAmount(3_000)},
 			requestedFRs:             nil,
 			wantBorrowingOnRequested: false,
 			wantBorrowing:            true,
@@ -908,7 +908,7 @@ func TestIsBorrowingOn(t *testing.T) {
 			i := 0
 			for fr, v := range tc.usage {
 				admission := utiltestingapi.MakeAdmission("cq")
-				quantity := resources.ResourceQuantity(fr.Resource, v)
+				quantity := resources.ResourceQuantity(fr.Resource, v.Int64())
 				admission.PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
 					Assignment(fr.Resource, fr.Flavor, quantity.String()).
 					Obj())

--- a/pkg/cache/scheduler/fair_sharing_test.go
+++ b/pkg/cache/scheduler/fair_sharing_test.go
@@ -732,6 +732,58 @@ func TestDominantResourceShare(t *testing.T) {
 				},
 			},
 		},
+		// When the lending CQ holds an "exabyte-scale" quota (1E CPU), AmountFromQuantity
+		// returns Unlimited (math.MaxInt64 sentinel). calculateLendable then aggregates
+		// potentialAvailable and lendable["cpu"] saturates to Unlimited (MaxInt64).
+		// The ratio float64(b.Int64())*1000/float64(lr.Int64()) evaluates to a tiny
+		// positive finite number; math.Ceil rounds it up to 1. This test pins that
+		// behaviour and guards against NaN/Inf regressions.
+		"borrowing against unlimited lendable capacity (exabyte-scale quota)": {
+			usage: resources.FlavorResourceQuantities{
+				{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000), // 1 CPU
+			},
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
+				Cohort("test-cohort").
+				FairWeight(resource.MustParse("1")).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("default").
+						ResourceQuotaWrapper("cpu").NominalQuota("0").Append().
+						Obj(),
+				).Obj(),
+			lendingClusterQueue: utiltestingapi.MakeClusterQueue("lending-cq").
+				Cohort("test-cohort").
+				FairWeight(resource.MustParse("1")).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("default").
+						// "1E" CPU overflows int64 milliCPU → AmountFromQuantity returns Unlimited.
+						ResourceQuotaWrapper("cpu").NominalQuota("1E").Append().
+						Obj(),
+				).Obj(),
+			want: []fairSharingResult{
+				{
+					Name:     "cq",
+					NodeType: nodeTypeCq,
+					// ratio = float64(1000)*1000/float64(MaxInt64) ≈ 1.09e-13; math.Ceil → 1.
+					DrValue:   1,
+					DrName:    corev1.ResourceCPU,
+					Borrowing: true,
+				},
+				{
+					Name:      "lending-cq",
+					NodeType:  nodeTypeCq,
+					DrValue:   0,
+					DrName:    "",
+					Borrowing: false,
+				},
+				{
+					Name:      "test-cohort",
+					NodeType:  nodeTypeCohort,
+					DrValue:   0,
+					DrName:    "",
+					Borrowing: false,
+				},
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/cache/scheduler/localqueue.go
+++ b/pkg/cache/scheduler/localqueue.go
@@ -81,8 +81,8 @@ func (q *LocalQueue) reportResourceMetrics(cqQuotas map[resources.FlavorResource
 	lqRef := metrics.LocalQueueReference{Name: name, Namespace: namespace}
 	for fr := range cqQuotas {
 		fName, rName := string(fr.Flavor), string(fr.Resource)
-		metrics.ReportLocalQueueResourceReservations(lqRef, fName, rName, resourceFloat(fr.Resource, q.totalReserved[fr]), q.customMetricLabelValues, tracker)
-		metrics.ReportLocalQueueResourceUsage(lqRef, fName, rName, resourceFloat(fr.Resource, q.admittedUsage[fr]), q.customMetricLabelValues, tracker)
+		metrics.ReportLocalQueueResourceReservations(lqRef, fName, rName, resourceFloat(fr.Resource, q.totalReserved[fr].Int64()), q.customMetricLabelValues, tracker)
+		metrics.ReportLocalQueueResourceUsage(lqRef, fName, rName, resourceFloat(fr.Resource, q.admittedUsage[fr].Int64()), q.customMetricLabelValues, tracker)
 	}
 }
 

--- a/pkg/cache/scheduler/resource.go
+++ b/pkg/cache/scheduler/resource.go
@@ -19,6 +19,7 @@ package scheduler
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/resources"
@@ -57,17 +58,10 @@ func (q ResourceQuota) Equal(other ResourceQuota) bool {
 	if !q.Nominal.Equal(other.Nominal) {
 		return false
 	}
-	if !equalAmountPtr(q.BorrowingLimit, other.BorrowingLimit) {
+	if !ptr.Equal(q.BorrowingLimit, other.BorrowingLimit) {
 		return false
 	}
-	return equalAmountPtr(q.LendingLimit, other.LendingLimit)
-}
-
-func equalAmountPtr(a, b *resources.Amount) bool {
-	if a == nil || b == nil {
-		return a == b
-	}
-	return a.Equal(*b)
+	return ptr.Equal(q.LendingLimit, other.LendingLimit)
 }
 
 func createResourceQuotas(kueueRgs []kueue.ResourceGroup) map[resources.FlavorResource]ResourceQuota {

--- a/pkg/cache/scheduler/resource.go
+++ b/pkg/cache/scheduler/resource.go
@@ -43,9 +43,31 @@ func (rg *ResourceGroup) Clone() ResourceGroup {
 }
 
 type ResourceQuota struct {
-	Nominal        int64
-	BorrowingLimit *int64
-	LendingLimit   *int64
+	Nominal        resources.Amount
+	BorrowingLimit *resources.Amount
+	LendingLimit   *resources.Amount
+}
+
+// Equal reports whether two ResourceQuota values are equal, using
+// resources.Amount semantics for the Nominal/BorrowingLimit/LendingLimit
+// fields. This is preferred over k8s equality.Semantic.DeepEqual, which
+// uses a forked reflect that panics on structs with unexported fields
+// from another package (see resources.Amount).
+func (q ResourceQuota) Equal(other ResourceQuota) bool {
+	if !q.Nominal.Equal(other.Nominal) {
+		return false
+	}
+	if !equalAmountPtr(q.BorrowingLimit, other.BorrowingLimit) {
+		return false
+	}
+	return equalAmountPtr(q.LendingLimit, other.LendingLimit)
+}
+
+func equalAmountPtr(a, b *resources.Amount) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.Equal(*b)
 }
 
 func createResourceQuotas(kueueRgs []kueue.ResourceGroup) map[resources.FlavorResource]ResourceQuota {
@@ -58,13 +80,13 @@ func createResourceQuotas(kueueRgs []kueue.ResourceGroup) map[resources.FlavorRe
 		for _, kueueFlavor := range kueueRg.Flavors {
 			for _, kueueQuota := range kueueFlavor.Resources {
 				quota := ResourceQuota{
-					Nominal: resources.ResourceValue(kueueQuota.Name, kueueQuota.NominalQuota),
+					Nominal: resources.AmountFromQuantity(kueueQuota.Name, kueueQuota.NominalQuota),
 				}
 				if kueueQuota.BorrowingLimit != nil {
-					quota.BorrowingLimit = new(resources.ResourceValue(kueueQuota.Name, *kueueQuota.BorrowingLimit))
+					quota.BorrowingLimit = new(resources.AmountFromQuantity(kueueQuota.Name, *kueueQuota.BorrowingLimit))
 				}
 				if kueueQuota.LendingLimit != nil {
-					quota.LendingLimit = new(resources.ResourceValue(kueueQuota.Name, *kueueQuota.LendingLimit))
+					quota.LendingLimit = new(resources.AmountFromQuantity(kueueQuota.Name, *kueueQuota.LendingLimit))
 				}
 				quotas[resources.FlavorResource{Flavor: kueueFlavor.Name, Resource: kueueQuota.Name}] = quota
 			}

--- a/pkg/cache/scheduler/resource_node.go
+++ b/pkg/cache/scheduler/resource_node.go
@@ -23,6 +23,7 @@ import (
 
 	"sigs.k8s.io/kueue/pkg/cache/hierarchy"
 	"sigs.k8s.io/kueue/pkg/resources"
+	utilmath "sigs.k8s.io/kueue/pkg/util/math"
 )
 
 // resourceNode is the shared representation of Quotas and Usage, used
@@ -33,7 +34,8 @@ type resourceNode struct {
 	Quotas map[resources.FlavorResource]ResourceQuota
 	// SubtreeQuota is the sum of the node's quota, as well as
 	// resources available from its children, constrained by
-	// LendingLimits.
+	// LendingLimits. It uses Amount because individual quotas (or their
+	// aggregation) may saturate to Unlimited.
 	SubtreeQuota resources.FlavorResourceQuantities
 	// Usage is the quantity which counts against this node's
 	// SubtreeQuota. For ClusterQueues, this is simply its
@@ -65,7 +67,10 @@ func (r resourceNode) Clone() resourceNode {
 // this capacity will never be lent out to the parent Cohort.
 func (r resourceNode) localQuota(fr resources.FlavorResource) int64 {
 	if lendingLimit := r.Quotas[fr].LendingLimit; lendingLimit != nil {
-		return max(0, r.SubtreeQuota[fr]-*lendingLimit)
+		// SubtreeQuota - LendingLimit, saturated to int64 and clamped at 0.
+		// Returning int64 here is fine: the caller compares it against int64
+		// Usage values.
+		return max(0, r.SubtreeQuota[fr].Sub(*lendingLimit).Int64())
 	}
 	return 0
 }
@@ -89,7 +94,7 @@ type flatResourceNode interface {
 // how much guaranteed quota in this flavor exceeds usage.
 // This quota is available at this node but is not visible at its parent.
 func LocalAvailable(node flatResourceNode, fr resources.FlavorResource) int64 {
-	return max(0, node.getResourceNode().localQuota(fr)-node.getResourceNode().Usage[fr])
+	return max(0, node.getResourceNode().localQuota(fr)-node.getResourceNode().Usage[fr].Int64())
 }
 
 // available determines how much capacity remains for the current
@@ -104,29 +109,33 @@ func LocalAvailable(node flatResourceNode, fr resources.FlavorResource) int64 {
 func available(node hierarchicalResourceNode, fr resources.FlavorResource) int64 {
 	r := node.getResourceNode()
 	if !node.HasParent() {
-		return r.SubtreeQuota[fr] - r.Usage[fr]
+		return r.SubtreeQuota[fr].SubInt64(r.Usage[fr].Int64()).Int64()
 	}
 	parentAvailable := available(node.parentHRN(), fr)
 
 	if borrowingLimit := r.Quotas[fr].BorrowingLimit; borrowingLimit != nil {
-		storedInParent := r.SubtreeQuota[fr] - r.localQuota(fr)
-		usedInParent := max(0, r.Usage[fr]-r.localQuota(fr))
-		withMaxFromParent := storedInParent - usedInParent + *borrowingLimit
+		// All of these can be Unlimited; Amount methods propagate that.
+		storedInParent := r.SubtreeQuota[fr].SubInt64(r.localQuota(fr))
+		usedInParent := max(0, r.Usage[fr].Int64()-r.localQuota(fr))
+		withMaxFromParent := storedInParent.SubInt64(usedInParent).Add(*borrowingLimit).Int64()
 		parentAvailable = min(withMaxFromParent, parentAvailable)
 	}
-	return LocalAvailable(node, fr) + parentAvailable
+	return utilmath.SaturatingAdd(LocalAvailable(node, fr), parentAvailable)
 }
 
 // potentialAvailable returns the maximum capacity available to this node,
 // assuming no usage, while respecting BorrowingLimits.
+//
+// Uses saturating arithmetic so sums of large (potentially MaxAmount) quotas
+// from this node and its ancestors never wrap around int64.
 func potentialAvailable(node hierarchicalResourceNode, fr resources.FlavorResource) int64 {
 	r := node.getResourceNode()
 	if !node.HasParent() {
-		return r.SubtreeQuota[fr]
+		return r.SubtreeQuota[fr].Int64()
 	}
-	available := r.localQuota(fr) + potentialAvailable(node.parentHRN(), fr)
+	available := utilmath.SaturatingAdd(r.localQuota(fr), potentialAvailable(node.parentHRN(), fr))
 	if borrowingLimit := r.Quotas[fr].BorrowingLimit; borrowingLimit != nil {
-		maxWithBorrowing := r.SubtreeQuota[fr] + *borrowingLimit
+		maxWithBorrowing := r.SubtreeQuota[fr].Add(*borrowingLimit).Int64()
 		available = min(maxWithBorrowing, available)
 	}
 	return available
@@ -134,26 +143,32 @@ func potentialAvailable(node hierarchicalResourceNode, fr resources.FlavorResour
 
 // addUsage adds usage to the current node, and bubbles up usage to
 // its Cohort when usage exceeds localQuota.
-func addUsage(node hierarchicalResourceNode, fr resources.FlavorResource, val int64) {
+func addUsage(node hierarchicalResourceNode, fr resources.FlavorResource, val resources.Amount) {
 	r := node.getResourceNode()
 	localAvailable := LocalAvailable(node, fr)
-	r.Usage[fr] += val
-	if node.HasParent() && val > localAvailable {
-		deltaParentUsage := val - localAvailable
+	r.Usage[fr] = r.Usage[fr].Add(val)
+	if r.Usage[fr].CmpInt64(0) == 0 {
+		delete(r.Usage, fr)
+	}
+	if node.HasParent() && val.CmpInt64(localAvailable) > 0 {
+		deltaParentUsage := val.SubInt64(localAvailable)
 		addUsage(node.parentHRN(), fr, deltaParentUsage)
 	}
 }
 
 // removeUsage removes usage from the current node, and removes usage
 // past localQuota that it was storing in its Cohort.
-func removeUsage(node hierarchicalResourceNode, fr resources.FlavorResource, val int64) {
+func removeUsage(node hierarchicalResourceNode, fr resources.FlavorResource, val resources.Amount) {
 	r := node.getResourceNode()
-	usageStoredInParent := r.Usage[fr] - r.localQuota(fr)
-	r.Usage[fr] -= val
+	usageStoredInParent := r.Usage[fr].Int64() - r.localQuota(fr)
+	r.Usage[fr] = r.Usage[fr].Sub(val)
+	if r.Usage[fr].CmpInt64(0) == 0 {
+		delete(r.Usage, fr)
+	}
 	if usageStoredInParent <= 0 || !node.HasParent() {
 		return
 	}
-	deltaParentUsage := min(val, usageStoredInParent)
+	deltaParentUsage := resources.MinAmount(val, resources.NewAmount(usageStoredInParent))
 	removeUsage(node.parentHRN(), fr, deltaParentUsage)
 }
 
@@ -209,10 +224,15 @@ func updateCohortTreeResourcesIfNoCycle(cohort *cohort) {
 
 func accumulateFromChild(parent *cohort, child flatResourceNode) {
 	for fr, childQuota := range child.getResourceNode().SubtreeQuota {
-		parent.resourceNode.SubtreeQuota[fr] += childQuota - child.getResourceNode().localQuota(fr)
+		delta := childQuota.SubInt64(child.getResourceNode().localQuota(fr))
+		// Add saturates at MaxInt64 on overflow, so large children never wrap the parent SubtreeQuota negative.
+		parent.resourceNode.SubtreeQuota[fr] = parent.resourceNode.SubtreeQuota[fr].Add(delta)
 	}
 	for fr, childUsage := range child.getResourceNode().Usage {
-		parent.resourceNode.Usage[fr] += max(0, childUsage-child.getResourceNode().localQuota(fr))
+		parent.resourceNode.Usage[fr] = parent.resourceNode.Usage[fr].AddInt64(max(0, childUsage.Int64()-child.getResourceNode().localQuota(fr)))
+		if parent.resourceNode.Usage[fr].CmpInt64(0) == 0 {
+			delete(parent.resourceNode.Usage, fr)
+		}
 	}
 }
 
@@ -224,10 +244,10 @@ func QuantitiesFitInQuota(node flatResourceNode, requests resources.FlavorResour
 	fits := true
 	remainingRequests := make(resources.FlavorResourceQuantities, len(requests))
 	for fr, v := range requests {
-		if node.getResourceNode().Usage[fr]+v > node.getResourceNode().SubtreeQuota[fr] {
+		if node.getResourceNode().SubtreeQuota[fr].Cmp(node.getResourceNode().Usage[fr].Add(v)) < 0 {
 			fits = false
 		}
-		remainingRequests[fr] = max(0, v-LocalAvailable(node, fr))
+		remainingRequests[fr] = resources.NewAmount(max(0, v.Int64()-LocalAvailable(node, fr)))
 	}
 	return fits, remainingRequests
 }
@@ -236,7 +256,7 @@ func QuantitiesFitInQuota(node flatResourceNode, requests resources.FlavorResour
 // nominal quota in any resource flavor out of a set of resource flavours.
 func IsWithinNominalInResources(node flatResourceNode, frs sets.Set[resources.FlavorResource]) bool {
 	for fr := range frs {
-		if node.getResourceNode().Usage[fr] > node.getResourceNode().SubtreeQuota[fr] {
+		if node.getResourceNode().SubtreeQuota[fr].Cmp(node.getResourceNode().Usage[fr]) < 0 {
 			return false
 		}
 	}

--- a/pkg/cache/scheduler/resource_node.go
+++ b/pkg/cache/scheduler/resource_node.go
@@ -23,7 +23,6 @@ import (
 
 	"sigs.k8s.io/kueue/pkg/cache/hierarchy"
 	"sigs.k8s.io/kueue/pkg/resources"
-	utilmath "sigs.k8s.io/kueue/pkg/util/math"
 )
 
 // resourceNode is the shared representation of Quotas and Usage, used
@@ -65,14 +64,11 @@ func (r resourceNode) Clone() resourceNode {
 // localQuota is the capacity which is only visible to the subtree
 // defined by this node due to lending limits. As a consequence,
 // this capacity will never be lent out to the parent Cohort.
-func (r resourceNode) localQuota(fr resources.FlavorResource) int64 {
+func (r resourceNode) localQuota(fr resources.FlavorResource) resources.Amount {
 	if lendingLimit := r.Quotas[fr].LendingLimit; lendingLimit != nil {
-		// SubtreeQuota - LendingLimit, saturated to int64 and clamped at 0.
-		// Returning int64 here is fine: the caller compares it against int64
-		// Usage values.
-		return max(0, r.SubtreeQuota[fr].Sub(*lendingLimit).Int64())
+		return resources.MaxAmount(resources.NewAmount(0), r.SubtreeQuota[fr].Sub(*lendingLimit))
 	}
-	return 0
+	return resources.NewAmount(0)
 }
 
 // hierarchicalResourceNode extends flatResourceNode
@@ -93,8 +89,9 @@ type flatResourceNode interface {
 // LocalAvailable returns, for a given node and resource flavor,
 // how much guaranteed quota in this flavor exceeds usage.
 // This quota is available at this node but is not visible at its parent.
-func LocalAvailable(node flatResourceNode, fr resources.FlavorResource) int64 {
-	return max(0, node.getResourceNode().localQuota(fr)-node.getResourceNode().Usage[fr].Int64())
+func LocalAvailable(node flatResourceNode, fr resources.FlavorResource) resources.Amount {
+	r := node.getResourceNode()
+	return resources.MaxAmount(resources.NewAmount(0), r.localQuota(fr).Sub(r.Usage[fr]))
 }
 
 // available determines how much capacity remains for the current
@@ -106,21 +103,22 @@ func LocalAvailable(node flatResourceNode, fr resources.FlavorResource) int64 {
 // This function may return a negative number in the case of
 // overadmission - e.g. capacity was removed or the node moved to
 // another Cohort.
-func available(node hierarchicalResourceNode, fr resources.FlavorResource) int64 {
+func available(node hierarchicalResourceNode, fr resources.FlavorResource) resources.Amount {
 	r := node.getResourceNode()
 	if !node.HasParent() {
-		return r.SubtreeQuota[fr].SubInt64(r.Usage[fr].Int64()).Int64()
+		return r.SubtreeQuota[fr].Sub(r.Usage[fr])
 	}
 	parentAvailable := available(node.parentHRN(), fr)
 
 	if borrowingLimit := r.Quotas[fr].BorrowingLimit; borrowingLimit != nil {
 		// All of these can be Unlimited; Amount methods propagate that.
-		storedInParent := r.SubtreeQuota[fr].SubInt64(r.localQuota(fr))
-		usedInParent := max(0, r.Usage[fr].Int64()-r.localQuota(fr))
-		withMaxFromParent := storedInParent.SubInt64(usedInParent).Add(*borrowingLimit).Int64()
-		parentAvailable = min(withMaxFromParent, parentAvailable)
+		lq := r.localQuota(fr)
+		storedInParent := r.SubtreeQuota[fr].Sub(lq)
+		usedInParent := resources.MaxAmount(resources.NewAmount(0), r.Usage[fr].Sub(lq))
+		withMaxFromParent := storedInParent.Sub(usedInParent).Add(*borrowingLimit)
+		parentAvailable = resources.MinAmount(withMaxFromParent, parentAvailable)
 	}
-	return utilmath.SaturatingAdd(LocalAvailable(node, fr), parentAvailable)
+	return LocalAvailable(node, fr).Add(parentAvailable)
 }
 
 // potentialAvailable returns the maximum capacity available to this node,
@@ -128,17 +126,17 @@ func available(node hierarchicalResourceNode, fr resources.FlavorResource) int64
 //
 // Uses saturating arithmetic so sums of large (potentially MaxAmount) quotas
 // from this node and its ancestors never wrap around int64.
-func potentialAvailable(node hierarchicalResourceNode, fr resources.FlavorResource) int64 {
+func potentialAvailable(node hierarchicalResourceNode, fr resources.FlavorResource) resources.Amount {
 	r := node.getResourceNode()
 	if !node.HasParent() {
-		return r.SubtreeQuota[fr].Int64()
+		return r.SubtreeQuota[fr]
 	}
-	available := utilmath.SaturatingAdd(r.localQuota(fr), potentialAvailable(node.parentHRN(), fr))
+	avail := r.localQuota(fr).Add(potentialAvailable(node.parentHRN(), fr))
 	if borrowingLimit := r.Quotas[fr].BorrowingLimit; borrowingLimit != nil {
-		maxWithBorrowing := r.SubtreeQuota[fr].Add(*borrowingLimit).Int64()
-		available = min(maxWithBorrowing, available)
+		maxWithBorrowing := r.SubtreeQuota[fr].Add(*borrowingLimit)
+		avail = resources.MinAmount(maxWithBorrowing, avail)
 	}
-	return available
+	return avail
 }
 
 // addUsage adds usage to the current node, and bubbles up usage to
@@ -147,11 +145,8 @@ func addUsage(node hierarchicalResourceNode, fr resources.FlavorResource, val re
 	r := node.getResourceNode()
 	localAvailable := LocalAvailable(node, fr)
 	r.Usage[fr] = r.Usage[fr].Add(val)
-	if r.Usage[fr].CmpInt64(0) == 0 {
-		delete(r.Usage, fr)
-	}
-	if node.HasParent() && val.CmpInt64(localAvailable) > 0 {
-		deltaParentUsage := val.SubInt64(localAvailable)
+	if node.HasParent() && val.Cmp(localAvailable) > 0 {
+		deltaParentUsage := val.Sub(localAvailable)
 		addUsage(node.parentHRN(), fr, deltaParentUsage)
 	}
 }
@@ -160,15 +155,12 @@ func addUsage(node hierarchicalResourceNode, fr resources.FlavorResource, val re
 // past localQuota that it was storing in its Cohort.
 func removeUsage(node hierarchicalResourceNode, fr resources.FlavorResource, val resources.Amount) {
 	r := node.getResourceNode()
-	usageStoredInParent := r.Usage[fr].Int64() - r.localQuota(fr)
+	usageStoredInParent := r.Usage[fr].Sub(r.localQuota(fr))
 	r.Usage[fr] = r.Usage[fr].Sub(val)
-	if r.Usage[fr].CmpInt64(0) == 0 {
-		delete(r.Usage, fr)
-	}
-	if usageStoredInParent <= 0 || !node.HasParent() {
+	if usageStoredInParent.CmpInt64(0) <= 0 || !node.HasParent() {
 		return
 	}
-	deltaParentUsage := resources.MinAmount(val, resources.NewAmount(usageStoredInParent))
+	deltaParentUsage := resources.MinAmount(val, usageStoredInParent)
 	removeUsage(node.parentHRN(), fr, deltaParentUsage)
 }
 
@@ -224,15 +216,13 @@ func updateCohortTreeResourcesIfNoCycle(cohort *cohort) {
 
 func accumulateFromChild(parent *cohort, child flatResourceNode) {
 	for fr, childQuota := range child.getResourceNode().SubtreeQuota {
-		delta := childQuota.SubInt64(child.getResourceNode().localQuota(fr))
+		delta := childQuota.Sub(child.getResourceNode().localQuota(fr))
 		// Add saturates at MaxInt64 on overflow, so large children never wrap the parent SubtreeQuota negative.
 		parent.resourceNode.SubtreeQuota[fr] = parent.resourceNode.SubtreeQuota[fr].Add(delta)
 	}
 	for fr, childUsage := range child.getResourceNode().Usage {
-		parent.resourceNode.Usage[fr] = parent.resourceNode.Usage[fr].AddInt64(max(0, childUsage.Int64()-child.getResourceNode().localQuota(fr)))
-		if parent.resourceNode.Usage[fr].CmpInt64(0) == 0 {
-			delete(parent.resourceNode.Usage, fr)
-		}
+		delta := resources.MaxAmount(resources.NewAmount(0), childUsage.Sub(child.getResourceNode().localQuota(fr)))
+		parent.resourceNode.Usage[fr] = parent.resourceNode.Usage[fr].Add(delta)
 	}
 }
 
@@ -247,7 +237,7 @@ func QuantitiesFitInQuota(node flatResourceNode, requests resources.FlavorResour
 		if node.getResourceNode().SubtreeQuota[fr].Cmp(node.getResourceNode().Usage[fr].Add(v)) < 0 {
 			fits = false
 		}
-		remainingRequests[fr] = resources.NewAmount(max(0, v.Int64()-LocalAvailable(node, fr)))
+		remainingRequests[fr] = resources.MaxAmount(resources.NewAmount(0), v.Sub(LocalAvailable(node, fr)))
 	}
 	return fits, remainingRequests
 }

--- a/pkg/cache/scheduler/resource_node_test.go
+++ b/pkg/cache/scheduler/resource_node_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 
+	"sigs.k8s.io/kueue/pkg/resources"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 )
@@ -54,9 +55,9 @@ func TestCohortLendable(t *testing.T) {
 		t.Fatal("Failed to add CQ to cache", err)
 	}
 
-	wantLendable := map[corev1.ResourceName]int64{
-		corev1.ResourceCPU: 10_000,
-		"example.com/gpu":  3,
+	wantLendable := map[corev1.ResourceName]resources.Amount{
+		corev1.ResourceCPU: resources.NewAmount(10_000),
+		"example.com/gpu":  resources.NewAmount(3),
 	}
 
 	lendable := calculateLendable(cache.hm.Cohort("test-cohort"))

--- a/pkg/cache/scheduler/resource_test.go
+++ b/pkg/cache/scheduler/resource_test.go
@@ -49,19 +49,19 @@ func TestAvailable(t *testing.T) {
 					).Obj(),
 			},
 			usage: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
-				"cq1": {{Flavor: "red", Resource: "cpu"}: 1000},
+				"cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(1000)},
 				"cq2": {
-					{Flavor: "red", Resource: "cpu"}:  2_500,
-					{Flavor: "blue", Resource: "cpu"}: 1_000,
+					{Flavor: "red", Resource: "cpu"}:  resources.NewAmount(2_500),
+					{Flavor: "blue", Resource: "cpu"}: resources.NewAmount(1_000),
 				},
 			},
 			wantAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
-				"cq1": {{Flavor: "red", Resource: "cpu"}: 0},
-				"cq2": {{Flavor: "red", Resource: "cpu"}: 2_500, {Flavor: "blue", Resource: "cpu"}: 9_000},
+				"cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(0)},
+				"cq2": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(2_500), {Flavor: "blue", Resource: "cpu"}: resources.NewAmount(9_000)},
 			},
 			wantPotentiallyAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
-				"cq1": {{Flavor: "red", Resource: "cpu"}: 0},
-				"cq2": {{Flavor: "red", Resource: "cpu"}: 5_000, {Flavor: "blue", Resource: "cpu"}: 10_000},
+				"cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(0)},
+				"cq2": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(5_000), {Flavor: "blue", Resource: "cpu"}: resources.NewAmount(10_000)},
 			},
 		},
 		"cqs with cohort": {
@@ -84,16 +84,16 @@ func TestAvailable(t *testing.T) {
 					).Cohort,
 			},
 			usage: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
-				"cq1": {{Flavor: "red", Resource: "cpu"}: 1000},
-				"cq2": {{Flavor: "red", Resource: "cpu"}: 500},
+				"cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(1000)},
+				"cq2": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(500)},
 			},
 			wantAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
-				"cq1": {{Flavor: "red", Resource: "cpu"}: 28_000},
-				"cq2": {{Flavor: "red", Resource: "cpu"}: 28_500},
+				"cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(28_000)},
+				"cq2": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(28_500)},
 			},
 			wantPotentiallyAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
-				"cq1": {{Flavor: "red", Resource: "cpu"}: 29_000},
-				"cq2": {{Flavor: "red", Resource: "cpu"}: 30_000},
+				"cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(29_000)},
+				"cq2": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(30_000)},
 			},
 		},
 		"cq borrows from cohort": {
@@ -110,9 +110,9 @@ func TestAvailable(t *testing.T) {
 						*utiltestingapi.MakeFlavorQuotas("red").Resource("cpu", "10").Obj(),
 					).Cohort,
 			},
-			usage:                    map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{"cq1": {{Flavor: "red", Resource: "cpu"}: 11_000}},
-			wantAvailable:            map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{"cq1": {{Flavor: "red", Resource: "cpu"}: 9_000}},
-			wantPotentiallyAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{"cq1": {{Flavor: "red", Resource: "cpu"}: 20_000}},
+			usage:                    map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{"cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(11_000)}},
+			wantAvailable:            map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{"cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(9_000)}},
+			wantPotentiallyAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{"cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(20_000)}},
 		},
 		"cq oversubscription spills into cohort": {
 			clusterQueues: []kueue.ClusterQueue{
@@ -134,21 +134,21 @@ func TestAvailable(t *testing.T) {
 					).Cohort,
 			},
 			usage: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
-				"cq1": {{Flavor: "red", Resource: "cpu"}: 31_000},
+				"cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(31_000)},
 			},
 			wantAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
-				"cq1": {{Flavor: "red", Resource: "cpu"}: 0},
+				"cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(0)},
 				// even though cq2 doesn't borrow/lend
 				// resources from Cohort, the
 				// misbehaving cq1's usage spills into
 				// its available, to prevent
 				// overadmission for (red,cpu) within
 				// the CohortTree.
-				"cq2": {{Flavor: "red", Resource: "cpu"}: 0},
+				"cq2": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(0)},
 			},
 			wantPotentiallyAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
-				"cq1": {{Flavor: "red", Resource: "cpu"}: 20_000},
-				"cq2": {{Flavor: "red", Resource: "cpu"}: 10_000},
+				"cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(20_000)},
+				"cq2": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(10_000)},
 			},
 		},
 		"lending and borrowing limits respected": {
@@ -180,27 +180,27 @@ func TestAvailable(t *testing.T) {
 					).Cohort,
 			},
 			usage: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
-				"cq1": {{Flavor: "red", Resource: "cpu"}: 20_000},
-				"cq2": {{Flavor: "red", Resource: "cpu"}: 10_000},
-				"cq3": {{Flavor: "red", Resource: "cpu"}: 6_000},
+				"cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(20_000)},
+				"cq2": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(10_000)},
+				"cq3": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(6_000)},
 			},
 			wantAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				// cq1 uses 20k, cq2 uses 10k, and
 				// cq3 uses 1k (not counting first 5k
 				// in guaranteedQuota), resulting in
 				// 4k left of potential 35k.
-				"cq1": {{Flavor: "red", Resource: "cpu"}: 4_000},
+				"cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(4_000)},
 				// cq2 has access to only 2k of the
 				// remaining 4k due to its borrowing
 				// limit.
-				"cq2": {{Flavor: "red", Resource: "cpu"}: 2_000},
+				"cq2": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(2_000)},
 				// 40k - (20k + 10k + 6k) = 4k
-				"cq3": {{Flavor: "red", Resource: "cpu"}: 4_000},
+				"cq3": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(4_000)},
 			},
 			wantPotentiallyAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
-				"cq1": {{Flavor: "red", Resource: "cpu"}: 35_000},
-				"cq2": {{Flavor: "red", Resource: "cpu"}: 12_000},
-				"cq3": {{Flavor: "red", Resource: "cpu"}: 40_000},
+				"cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(35_000)},
+				"cq2": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(12_000)},
+				"cq3": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(40_000)},
 			},
 		},
 		"hierarchical cohort": {
@@ -235,19 +235,19 @@ func TestAvailable(t *testing.T) {
 					).Cohort,
 			},
 			usage: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
-				"cq1": {{Flavor: "red", Resource: "cpu"}: 10_000},
-				"cq2": {{Flavor: "red", Resource: "cpu"}: 5_000},
+				"cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(10_000)},
+				"cq2": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(5_000)},
 			},
 			wantAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				// 30k available - 10k usage.
 				// no capacity/usage from right subtree
-				"cq1": {{Flavor: "red", Resource: "cpu"}: 20_000},
+				"cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(20_000)},
 				// 40k available - 15k usage.
-				"cq2": {{Flavor: "red", Resource: "cpu"}: 25_000},
+				"cq2": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(25_000)},
 			},
 			wantPotentiallyAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
-				"cq1": {{Flavor: "red", Resource: "cpu"}: 30_000},
-				"cq2": {{Flavor: "red", Resource: "cpu"}: 40_000},
+				"cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(30_000)},
+				"cq2": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(40_000)},
 			},
 		},
 		"hierarchical cohort respects borrowing limit": {
@@ -288,16 +288,16 @@ func TestAvailable(t *testing.T) {
 			},
 			wantAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				// 30k in "left" subtree + 5k limit above tree
-				"left-cq1": {{Flavor: "red", Resource: "cpu"}: 35_000},
+				"left-cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(35_000)},
 				// 10k + 5k lending limit
-				"left-cq2": {{Flavor: "red", Resource: "cpu"}: 15_000},
+				"left-cq2": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(15_000)},
 				// all 50k in "root" subtree
-				"right-cq": {{Flavor: "red", Resource: "cpu"}: 50_000},
+				"right-cq": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(50_000)},
 			},
 			wantPotentiallyAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
-				"left-cq1": {{Flavor: "red", Resource: "cpu"}: 35_000},
-				"left-cq2": {{Flavor: "red", Resource: "cpu"}: 15_000},
-				"right-cq": {{Flavor: "red", Resource: "cpu"}: 50_000},
+				"left-cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(35_000)},
+				"left-cq2": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(15_000)},
+				"right-cq": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(50_000)},
 			},
 		},
 		"hierarchical cohort respects lending limit": {
@@ -342,19 +342,19 @@ func TestAvailable(t *testing.T) {
 					).Cohort,
 			},
 			wantAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
-				"left-cq1": {{Flavor: "red", Resource: "cpu"}: 20_000},
+				"left-cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(20_000)},
 				// only 5k of left-cq1's resources are available,
 				// plus 10k of its own.
-				"left-cq2": {{Flavor: "red", Resource: "cpu"}: 15_000},
+				"left-cq2": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(15_000)},
 				// 5k lending limit from left to root.
-				"right-cq": {{Flavor: "red", Resource: "cpu"}: 5_000},
-				"root-cq":  {{Flavor: "red", Resource: "cpu"}: 5_000},
+				"right-cq": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(5_000)},
+				"root-cq":  {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(5_000)},
 			},
 			wantPotentiallyAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
-				"left-cq1": {{Flavor: "red", Resource: "cpu"}: 20_000},
-				"left-cq2": {{Flavor: "red", Resource: "cpu"}: 15_000},
-				"right-cq": {{Flavor: "red", Resource: "cpu"}: 5_000},
-				"root-cq":  {{Flavor: "red", Resource: "cpu"}: 5_000},
+				"left-cq1": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(20_000)},
+				"left-cq2": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(15_000)},
+				"right-cq": {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(5_000)},
+				"root-cq":  {{Flavor: "red", Resource: "cpu"}: resources.NewAmount(5_000)},
 			},
 		},
 	}
@@ -386,8 +386,8 @@ func TestAvailable(t *testing.T) {
 					gotAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)
 					gotPotentiallyAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)
 					for fr := range cq.ResourceNode.Quotas {
-						gotAvailable[cq.Name][fr] = cq.Available(fr)
-						gotPotentiallyAvailable[cq.Name][fr] = potentialAvailable(cq, fr)
+						gotAvailable[cq.Name][fr] = resources.NewAmount(cq.Available(fr))
+						gotPotentiallyAvailable[cq.Name][fr] = resources.NewAmount(potentialAvailable(cq, fr))
 					}
 				}
 				// before adding usage, available == potentiallyAvailable
@@ -412,8 +412,8 @@ func TestAvailable(t *testing.T) {
 					gotAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)
 					gotPotentiallyAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)
 					for fr := range cq.ResourceNode.Quotas {
-						gotAvailable[cq.Name][fr] = cq.Available(fr)
-						gotPotentiallyAvailable[cq.Name][fr] = potentialAvailable(cq, fr)
+						gotAvailable[cq.Name][fr] = resources.NewAmount(cq.Available(fr))
+						gotPotentiallyAvailable[cq.Name][fr] = resources.NewAmount(potentialAvailable(cq, fr))
 					}
 				}
 				if diff := cmp.Diff(tc.wantAvailable, gotAvailable); diff != "" {
@@ -437,8 +437,8 @@ func TestAvailable(t *testing.T) {
 					gotAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)
 					gotPotentiallyAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)
 					for fr := range cq.ResourceNode.Quotas {
-						gotAvailable[cq.Name][fr] = cq.Available(fr)
-						gotPotentiallyAvailable[cq.Name][fr] = potentialAvailable(cq, fr)
+						gotAvailable[cq.Name][fr] = resources.NewAmount(cq.Available(fr))
+						gotPotentiallyAvailable[cq.Name][fr] = resources.NewAmount(potentialAvailable(cq, fr))
 					}
 				}
 				// once again, available == potentiallyAvailable

--- a/pkg/cache/scheduler/resource_test.go
+++ b/pkg/cache/scheduler/resource_test.go
@@ -386,8 +386,8 @@ func TestAvailable(t *testing.T) {
 					gotAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)
 					gotPotentiallyAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)
 					for fr := range cq.ResourceNode.Quotas {
-						gotAvailable[cq.Name][fr] = resources.NewAmount(cq.Available(fr))
-						gotPotentiallyAvailable[cq.Name][fr] = resources.NewAmount(potentialAvailable(cq, fr))
+						gotAvailable[cq.Name][fr] = cq.Available(fr)
+						gotPotentiallyAvailable[cq.Name][fr] = potentialAvailable(cq, fr)
 					}
 				}
 				// before adding usage, available == potentiallyAvailable
@@ -412,8 +412,8 @@ func TestAvailable(t *testing.T) {
 					gotAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)
 					gotPotentiallyAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)
 					for fr := range cq.ResourceNode.Quotas {
-						gotAvailable[cq.Name][fr] = resources.NewAmount(cq.Available(fr))
-						gotPotentiallyAvailable[cq.Name][fr] = resources.NewAmount(potentialAvailable(cq, fr))
+						gotAvailable[cq.Name][fr] = cq.Available(fr)
+						gotPotentiallyAvailable[cq.Name][fr] = potentialAvailable(cq, fr)
 					}
 				}
 				if diff := cmp.Diff(tc.wantAvailable, gotAvailable); diff != "" {
@@ -437,8 +437,8 @@ func TestAvailable(t *testing.T) {
 					gotAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)
 					gotPotentiallyAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)
 					for fr := range cq.ResourceNode.Quotas {
-						gotAvailable[cq.Name][fr] = resources.NewAmount(cq.Available(fr))
-						gotPotentiallyAvailable[cq.Name][fr] = resources.NewAmount(potentialAvailable(cq, fr))
+						gotAvailable[cq.Name][fr] = cq.Available(fr)
+						gotPotentiallyAvailable[cq.Name][fr] = potentialAvailable(cq, fr)
 					}
 				}
 				// once again, available == potentiallyAvailable

--- a/pkg/cache/scheduler/snapshot_test.go
+++ b/pkg/cache/scheduler/snapshot_test.go
@@ -830,11 +830,11 @@ func TestSnapshot(t *testing.T) {
 							ResourceNode: resourceNode{
 								Quotas: map[resources.FlavorResource]ResourceQuota{
 									{Flavor: "tas-flavor", Resource: corev1.ResourceCPU}: {
-										Nominal: 100_000,
+										Nominal: resources.NewAmount(100_000),
 									},
 								},
 								SubtreeQuota: resources.FlavorResourceQuantities{
-									{Flavor: "tas-flavor", Resource: corev1.ResourceCPU}: 100_000,
+									{Flavor: "tas-flavor", Resource: corev1.ResourceCPU}: resources.NewAmount(100_000),
 								},
 							},
 							FlavorFungibility: defaultFlavorFungibility,

--- a/pkg/cache/scheduler/snapshot_test.go
+++ b/pkg/cache/scheduler/snapshot_test.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/cache/hierarchy"
@@ -219,14 +218,14 @@ func TestSnapshot(t *testing.T) {
 					Name: "borrowing",
 					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
-							{Flavor: "demand", Resource: corev1.ResourceCPU}: 10_000,
-							{Flavor: "spot", Resource: corev1.ResourceCPU}:   10_000,
-							{Flavor: "default", Resource: "example.com/gpu"}: 15,
+							{Flavor: "demand", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
+							{Flavor: "spot", Resource: corev1.ResourceCPU}:   resources.NewAmount(10_000),
+							{Flavor: "default", Resource: "example.com/gpu"}: resources.NewAmount(15),
 						},
 						SubtreeQuota: resources.FlavorResourceQuantities{
-							{Flavor: "demand", Resource: corev1.ResourceCPU}: 100_000,
-							{Flavor: "spot", Resource: corev1.ResourceCPU}:   300_000,
-							{Flavor: "default", Resource: "example.com/gpu"}: 50,
+							{Flavor: "demand", Resource: corev1.ResourceCPU}: resources.NewAmount(100_000),
+							{Flavor: "spot", Resource: corev1.ResourceCPU}:   resources.NewAmount(300_000),
+							{Flavor: "default", Resource: "example.com/gpu"}: resources.NewAmount(50),
 						},
 					},
 				}
@@ -248,15 +247,15 @@ func TestSnapshot(t *testing.T) {
 								},
 								ResourceNode: resourceNode{
 									Quotas: map[resources.FlavorResource]ResourceQuota{
-										{Flavor: "demand", Resource: corev1.ResourceCPU}: {Nominal: 100_000},
-										{Flavor: "spot", Resource: corev1.ResourceCPU}:   {Nominal: 200_000},
+										{Flavor: "demand", Resource: corev1.ResourceCPU}: {Nominal: resources.NewAmount(100_000)},
+										{Flavor: "spot", Resource: corev1.ResourceCPU}:   {Nominal: resources.NewAmount(200_000)},
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "demand", Resource: "cpu"}: 100_000,
-										{Flavor: "spot", Resource: "cpu"}:   200_000,
+										{Flavor: "demand", Resource: "cpu"}: resources.NewAmount(100_000),
+										{Flavor: "spot", Resource: "cpu"}:   resources.NewAmount(200_000),
 									},
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "demand", Resource: corev1.ResourceCPU}: 10_000,
+										{Flavor: "demand", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 									},
 								},
 								FlavorFungibility: defaultFlavorFungibility,
@@ -293,16 +292,16 @@ func TestSnapshot(t *testing.T) {
 								},
 								ResourceNode: resourceNode{
 									Quotas: map[resources.FlavorResource]ResourceQuota{
-										{Flavor: "spot", Resource: corev1.ResourceCPU}:   {Nominal: 100_000},
-										{Flavor: "default", Resource: "example.com/gpu"}: {Nominal: 50},
+										{Flavor: "spot", Resource: corev1.ResourceCPU}:   {Nominal: resources.NewAmount(100_000)},
+										{Flavor: "default", Resource: "example.com/gpu"}: {Nominal: resources.NewAmount(50)},
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "spot", Resource: "cpu"}:                100_000,
-										{Flavor: "default", Resource: "example.com/gpu"}: 50,
+										{Flavor: "spot", Resource: "cpu"}:                resources.NewAmount(100_000),
+										{Flavor: "default", Resource: "example.com/gpu"}: resources.NewAmount(50),
 									},
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "spot", Resource: corev1.ResourceCPU}:   10_000,
-										{Flavor: "default", Resource: "example.com/gpu"}: 15,
+										{Flavor: "spot", Resource: corev1.ResourceCPU}:   resources.NewAmount(10_000),
+										{Flavor: "default", Resource: "example.com/gpu"}: resources.NewAmount(15),
 									},
 								},
 								FlavorFungibility: defaultFlavorFungibility,
@@ -351,10 +350,10 @@ func TestSnapshot(t *testing.T) {
 								},
 								ResourceNode: resourceNode{
 									Quotas: map[resources.FlavorResource]ResourceQuota{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: {Nominal: 100_000},
+										{Flavor: "default", Resource: corev1.ResourceCPU}: {Nominal: resources.NewAmount(100_000)},
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: "cpu"}: 100_000,
+										{Flavor: "default", Resource: "cpu"}: resources.NewAmount(100_000),
 									},
 									Usage: resources.FlavorResourceQuantities{},
 								},
@@ -484,11 +483,11 @@ func TestSnapshot(t *testing.T) {
 					Name: "lending",
 					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
-							{Flavor: "arm", Resource: corev1.ResourceCPU}: 10_000,
+							{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 						},
 						SubtreeQuota: resources.FlavorResourceQuantities{
-							{Flavor: "arm", Resource: corev1.ResourceCPU}: 10_000,
-							{Flavor: "x86", Resource: corev1.ResourceCPU}: 20_000,
+							{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
+							{Flavor: "x86", Resource: corev1.ResourceCPU}: resources.NewAmount(20_000),
 						},
 					},
 				}
@@ -510,16 +509,16 @@ func TestSnapshot(t *testing.T) {
 								},
 								ResourceNode: resourceNode{
 									Quotas: map[resources.FlavorResource]ResourceQuota{
-										{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 10_000, BorrowingLimit: nil, LendingLimit: ptr.To[int64](5_000)},
-										{Flavor: "x86", Resource: corev1.ResourceCPU}: {Nominal: 20_000, BorrowingLimit: nil, LendingLimit: ptr.To[int64](10_000)},
+										{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: resources.NewAmount(10_000), BorrowingLimit: nil, LendingLimit: new(resources.NewAmount(5_000))},
+										{Flavor: "x86", Resource: corev1.ResourceCPU}: {Nominal: resources.NewAmount(20_000), BorrowingLimit: nil, LendingLimit: new(resources.NewAmount(10_000))},
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "arm", Resource: corev1.ResourceCPU}: 10_000,
-										{Flavor: "x86", Resource: corev1.ResourceCPU}: 20_000,
+										{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
+										{Flavor: "x86", Resource: corev1.ResourceCPU}: resources.NewAmount(20_000),
 									},
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "arm", Resource: corev1.ResourceCPU}: 15_000,
-										{Flavor: "x86", Resource: corev1.ResourceCPU}: 10_000,
+										{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(15_000),
+										{Flavor: "x86", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 									},
 								},
 								FlavorFungibility: defaultFlavorFungibility,
@@ -572,12 +571,12 @@ func TestSnapshot(t *testing.T) {
 								},
 								ResourceNode: resourceNode{
 									Quotas: map[resources.FlavorResource]ResourceQuota{
-										{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 10_000, BorrowingLimit: nil, LendingLimit: ptr.To[int64](5_000)},
-										{Flavor: "x86", Resource: corev1.ResourceCPU}: {Nominal: 20_000, BorrowingLimit: nil, LendingLimit: ptr.To[int64](10_000)},
+										{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: resources.NewAmount(10_000), BorrowingLimit: nil, LendingLimit: new(resources.NewAmount(5_000))},
+										{Flavor: "x86", Resource: corev1.ResourceCPU}: {Nominal: resources.NewAmount(20_000), BorrowingLimit: nil, LendingLimit: new(resources.NewAmount(10_000))},
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "arm", Resource: corev1.ResourceCPU}: 10_000,
-										{Flavor: "x86", Resource: corev1.ResourceCPU}: 20_000,
+										{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
+										{Flavor: "x86", Resource: corev1.ResourceCPU}: resources.NewAmount(20_000),
 									},
 									Usage: resources.FlavorResourceQuantities{},
 								},
@@ -628,14 +627,14 @@ func TestSnapshot(t *testing.T) {
 							Name: "cohort",
 							ResourceNode: resourceNode{
 								Quotas: map[resources.FlavorResource]ResourceQuota{
-									{Flavor: "arm", Resource: corev1.ResourceCPU}:  {Nominal: 10_000, BorrowingLimit: nil, LendingLimit: nil},
-									{Flavor: "x86", Resource: corev1.ResourceCPU}:  {Nominal: 20_000, BorrowingLimit: nil, LendingLimit: nil},
-									{Flavor: "mips", Resource: corev1.ResourceCPU}: {Nominal: 42_000, BorrowingLimit: nil, LendingLimit: nil},
+									{Flavor: "arm", Resource: corev1.ResourceCPU}:  {Nominal: resources.NewAmount(10_000), BorrowingLimit: nil, LendingLimit: nil},
+									{Flavor: "x86", Resource: corev1.ResourceCPU}:  {Nominal: resources.NewAmount(20_000), BorrowingLimit: nil, LendingLimit: nil},
+									{Flavor: "mips", Resource: corev1.ResourceCPU}: {Nominal: resources.NewAmount(42_000), BorrowingLimit: nil, LendingLimit: nil},
 								},
 								SubtreeQuota: resources.FlavorResourceQuantities{
-									{Flavor: "arm", Resource: corev1.ResourceCPU}:  13_000,
-									{Flavor: "x86", Resource: corev1.ResourceCPU}:  25_000,
-									{Flavor: "mips", Resource: corev1.ResourceCPU}: 42_000,
+									{Flavor: "arm", Resource: corev1.ResourceCPU}:  resources.NewAmount(13_000),
+									{Flavor: "x86", Resource: corev1.ResourceCPU}:  resources.NewAmount(25_000),
+									{Flavor: "mips", Resource: corev1.ResourceCPU}: resources.NewAmount(42_000),
 								},
 							},
 							FairWeight: defaultWeight,
@@ -653,12 +652,12 @@ func TestSnapshot(t *testing.T) {
 							},
 							ResourceNode: resourceNode{
 								Quotas: map[resources.FlavorResource]ResourceQuota{
-									{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 7_000, BorrowingLimit: nil, LendingLimit: ptr.To[int64](3_000)},
-									{Flavor: "x86", Resource: corev1.ResourceCPU}: {Nominal: 5_000, BorrowingLimit: nil, LendingLimit: nil},
+									{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: resources.NewAmount(7_000), BorrowingLimit: nil, LendingLimit: new(resources.NewAmount(3_000))},
+									{Flavor: "x86", Resource: corev1.ResourceCPU}: {Nominal: resources.NewAmount(5_000), BorrowingLimit: nil, LendingLimit: nil},
 								},
 								SubtreeQuota: resources.FlavorResourceQuantities{
-									{Flavor: "arm", Resource: corev1.ResourceCPU}: 7_000,
-									{Flavor: "x86", Resource: corev1.ResourceCPU}: 5_000,
+									{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(7_000),
+									{Flavor: "x86", Resource: corev1.ResourceCPU}: resources.NewAmount(5_000),
 								},
 							},
 							FlavorFungibility: defaultFlavorFungibility,
@@ -715,7 +714,7 @@ func TestSnapshot(t *testing.T) {
 							Name: "nocycle",
 							ResourceNode: resourceNode{
 								SubtreeQuota: resources.FlavorResourceQuantities{
-									{Flavor: "arm", Resource: corev1.ResourceCPU}: 0,
+									{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(0),
 								},
 							},
 							FairWeight: defaultWeight,
@@ -733,10 +732,10 @@ func TestSnapshot(t *testing.T) {
 							},
 							ResourceNode: resourceNode{
 								Quotas: map[resources.FlavorResource]ResourceQuota{
-									{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 0},
+									{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: resources.NewAmount(0)},
 								},
 								SubtreeQuota: resources.FlavorResourceQuantities{
-									{Flavor: "arm", Resource: corev1.ResourceCPU}: 0,
+									{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(0),
 								},
 							},
 							FlavorFungibility: defaultFlavorFungibility,
@@ -1007,9 +1006,9 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 					Name: "cohort",
 					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
-							{Flavor: "default", Resource: corev1.ResourceCPU}:  0,
-							{Flavor: "alpha", Resource: corev1.ResourceMemory}: 0,
-							{Flavor: "beta", Resource: corev1.ResourceMemory}:  0,
+							{Flavor: "default", Resource: corev1.ResourceCPU}:  resources.NewAmount(0),
+							{Flavor: "alpha", Resource: corev1.ResourceMemory}: resources.NewAmount(0),
+							{Flavor: "beta", Resource: corev1.ResourceMemory}:  resources.NewAmount(0),
 						},
 						SubtreeQuota: initialCohortResources,
 					},
@@ -1028,14 +1027,14 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								FairWeight:        defaultWeight,
 								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}:  0,
-										{Flavor: "alpha", Resource: corev1.ResourceMemory}: 0,
-										{Flavor: "beta", Resource: corev1.ResourceMemory}:  0,
+										{Flavor: "default", Resource: corev1.ResourceCPU}:  resources.NewAmount(0),
+										{Flavor: "alpha", Resource: corev1.ResourceMemory}: resources.NewAmount(0),
+										{Flavor: "beta", Resource: corev1.ResourceMemory}:  resources.NewAmount(0),
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}:  6_000,
-										{Flavor: "alpha", Resource: corev1.ResourceMemory}: utiltesting.Gi * 6,
-										{Flavor: "beta", Resource: corev1.ResourceMemory}:  utiltesting.Gi * 6,
+										{Flavor: "default", Resource: corev1.ResourceCPU}:  resources.NewAmount(6_000),
+										{Flavor: "alpha", Resource: corev1.ResourceMemory}: resources.NewAmount(utiltesting.Gi * 6),
+										{Flavor: "beta", Resource: corev1.ResourceMemory}:  resources.NewAmount(utiltesting.Gi * 6),
 									},
 								},
 							},
@@ -1048,10 +1047,10 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								AllocatableResourceGeneration: 1,
 								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(0),
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 6_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(6_000),
 									},
 								},
 							},
@@ -1067,9 +1066,9 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 					Name: "cohort",
 					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
-							{Flavor: "default", Resource: corev1.ResourceCPU}:  2_000,
-							{Flavor: "alpha", Resource: corev1.ResourceMemory}: utiltesting.Gi,
-							{Flavor: "beta", Resource: corev1.ResourceMemory}:  utiltesting.Gi,
+							{Flavor: "default", Resource: corev1.ResourceCPU}:  resources.NewAmount(2_000),
+							{Flavor: "alpha", Resource: corev1.ResourceMemory}: resources.NewAmount(utiltesting.Gi),
+							{Flavor: "beta", Resource: corev1.ResourceMemory}:  resources.NewAmount(utiltesting.Gi),
 						},
 						SubtreeQuota: initialCohortResources,
 					},
@@ -1091,14 +1090,14 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								FairWeight:        defaultWeight,
 								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}:  0,
-										{Flavor: "alpha", Resource: corev1.ResourceMemory}: utiltesting.Gi,
-										{Flavor: "beta", Resource: corev1.ResourceMemory}:  utiltesting.Gi,
+										{Flavor: "default", Resource: corev1.ResourceCPU}:  resources.NewAmount(0),
+										{Flavor: "alpha", Resource: corev1.ResourceMemory}: resources.NewAmount(utiltesting.Gi),
+										{Flavor: "beta", Resource: corev1.ResourceMemory}:  resources.NewAmount(utiltesting.Gi),
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}:  6_000,
-										{Flavor: "alpha", Resource: corev1.ResourceMemory}: utiltesting.Gi * 6,
-										{Flavor: "beta", Resource: corev1.ResourceMemory}:  utiltesting.Gi * 6,
+										{Flavor: "default", Resource: corev1.ResourceCPU}:  resources.NewAmount(6_000),
+										{Flavor: "alpha", Resource: corev1.ResourceMemory}: resources.NewAmount(utiltesting.Gi * 6),
+										{Flavor: "beta", Resource: corev1.ResourceMemory}:  resources.NewAmount(utiltesting.Gi * 6),
 									},
 								},
 							},
@@ -1114,10 +1113,10 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								AllocatableResourceGeneration: 1,
 								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 2_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 6_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(6_000),
 									},
 								},
 							},
@@ -1133,9 +1132,9 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 					Name: "cohort",
 					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
-							{Flavor: "default", Resource: corev1.ResourceCPU}:  3_000,
-							{Flavor: "alpha", Resource: corev1.ResourceMemory}: 0,
-							{Flavor: "beta", Resource: corev1.ResourceMemory}:  utiltesting.Gi,
+							{Flavor: "default", Resource: corev1.ResourceCPU}:  resources.NewAmount(3_000),
+							{Flavor: "alpha", Resource: corev1.ResourceMemory}: resources.NewAmount(0),
+							{Flavor: "beta", Resource: corev1.ResourceMemory}:  resources.NewAmount(utiltesting.Gi),
 						},
 						SubtreeQuota: initialCohortResources,
 					},
@@ -1157,14 +1156,14 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								FairWeight:        defaultWeight,
 								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}:  1_000,
-										{Flavor: "alpha", Resource: corev1.ResourceMemory}: 0,
-										{Flavor: "beta", Resource: corev1.ResourceMemory}:  utiltesting.Gi,
+										{Flavor: "default", Resource: corev1.ResourceCPU}:  resources.NewAmount(1_000),
+										{Flavor: "alpha", Resource: corev1.ResourceMemory}: resources.NewAmount(0),
+										{Flavor: "beta", Resource: corev1.ResourceMemory}:  resources.NewAmount(utiltesting.Gi),
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}:  6_000,
-										{Flavor: "alpha", Resource: corev1.ResourceMemory}: utiltesting.Gi * 6,
-										{Flavor: "beta", Resource: corev1.ResourceMemory}:  utiltesting.Gi * 6,
+										{Flavor: "default", Resource: corev1.ResourceCPU}:  resources.NewAmount(6_000),
+										{Flavor: "alpha", Resource: corev1.ResourceMemory}: resources.NewAmount(utiltesting.Gi * 6),
+										{Flavor: "beta", Resource: corev1.ResourceMemory}:  resources.NewAmount(utiltesting.Gi * 6),
 									},
 								},
 							},
@@ -1179,10 +1178,10 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								FairWeight:        defaultWeight,
 								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 2_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 6_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(6_000),
 									},
 								},
 							},
@@ -1318,7 +1317,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					Name: "lend",
 					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
-							{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
+							{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(0),
 						},
 						SubtreeQuota: initialCohortResources,
 					},
@@ -1337,10 +1336,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								FairWeight:        defaultWeight,
 								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(0),
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 									},
 								},
 							},
@@ -1352,10 +1351,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								FairWeight:        defaultWeight,
 								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(0),
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 									},
 								},
 							},
@@ -1371,7 +1370,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					Name: "lend",
 					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
-							{Flavor: "default", Resource: corev1.ResourceCPU}: 1_000,
+							{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
 						},
 						SubtreeQuota: initialCohortResources,
 					},
@@ -1390,10 +1389,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								FairWeight:        defaultWeight,
 								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 7_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(7_000),
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 									},
 								},
 							},
@@ -1406,10 +1405,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								AllocatableResourceGeneration: 1,
 								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 4_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(4_000),
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 									},
 								},
 							},
@@ -1425,7 +1424,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					Name: "lend",
 					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
-							{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
+							{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(0),
 						},
 						SubtreeQuota: initialCohortResources,
 					},
@@ -1444,10 +1443,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								FairWeight:        defaultWeight,
 								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 6_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(6_000),
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 									},
 								},
 							},
@@ -1460,10 +1459,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								AllocatableResourceGeneration: 1,
 								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 4_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(4_000),
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 									},
 								},
 							},
@@ -1479,7 +1478,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					Name: "lend",
 					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
-							{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
+							{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(0),
 						},
 						SubtreeQuota: initialCohortResources,
 					},
@@ -1498,10 +1497,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								FairWeight:        defaultWeight,
 								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 1_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 									},
 								},
 							},
@@ -1514,10 +1513,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								AllocatableResourceGeneration: 1,
 								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 4_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(4_000),
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 									},
 								},
 							},
@@ -1534,7 +1533,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					Name: "lend",
 					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
-							{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
+							{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(0),
 						},
 						SubtreeQuota: initialCohortResources,
 					},
@@ -1553,10 +1552,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								FairWeight:        defaultWeight,
 								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 1_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 									},
 								},
 							},
@@ -1569,10 +1568,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								AllocatableResourceGeneration: 1,
 								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(0),
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 									},
 								},
 							},
@@ -1589,7 +1588,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					Name: "lend",
 					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
-							{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
+							{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(0),
 						},
 						SubtreeQuota: initialCohortResources,
 					},
@@ -1608,10 +1607,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								FairWeight:        defaultWeight,
 								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 6_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(6_000),
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 									},
 								},
 							},
@@ -1623,10 +1622,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								FairWeight:        defaultWeight,
 								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(0),
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 									},
 								},
 							},
@@ -1643,7 +1642,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					Name: "lend",
 					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
-							{Flavor: "default", Resource: corev1.ResourceCPU}: 3_000,
+							{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(3_000),
 						},
 						SubtreeQuota: initialCohortResources,
 					},
@@ -1662,10 +1661,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								FairWeight:        defaultWeight,
 								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 9_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(9_000),
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 									},
 								},
 							},
@@ -1678,10 +1677,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								AllocatableResourceGeneration: 1,
 								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(0),
 									},
 									SubtreeQuota: resources.FlavorResourceQuantities{
-										{Flavor: "default", Resource: corev1.ResourceCPU}: 10_000,
+										{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 									},
 								},
 							},

--- a/pkg/controller/core/cohort_controller_test.go
+++ b/pkg/controller/core/cohort_controller_test.go
@@ -219,7 +219,7 @@ func TestCohortReconcileLifecycle(t *testing.T) {
 		}
 
 		wantQuotas := resources.FlavorResourceQuantities{
-			{Flavor: "red", Resource: "cpu"}: 10_000,
+			{Flavor: "red", Resource: "cpu"}: resources.NewAmount(10_000),
 		}
 		if diff := cmp.Diff(wantQuotas, cohortSnap.ResourceNode.SubtreeQuota); diff != "" {
 			t.Fatalf("unexpected quota (-want +got) %s", diff)
@@ -263,7 +263,7 @@ func TestCohortReconcileLifecycle(t *testing.T) {
 		}
 
 		wantQuotas := resources.FlavorResourceQuantities{
-			{Flavor: "red", Resource: "cpu"}: 5_000,
+			{Flavor: "red", Resource: "cpu"}: resources.NewAmount(5_000),
 		}
 		if diff := cmp.Diff(wantQuotas, cohortSnap.ResourceNode.SubtreeQuota); diff != "" {
 			t.Fatalf("unexpected quota (-want +got) %s", diff)

--- a/pkg/resources/amount.go
+++ b/pkg/resources/amount.go
@@ -115,8 +115,9 @@ func (a Amount) AddInt64(v int64) Amount {
 }
 
 // Sub returns a - b. If a is Unlimited and b is bounded, the result stays
-// Unlimited. If both are Unlimited (which shouldn't happen in normal cohort
-// math), the result is bounded zero.
+// Unlimited. If b is Unlimited and a is bounded, the result is math.MinInt64
+// (callers treat any negative as "no available capacity").
+// Sub(Unlimited, Unlimited) returns bounded zero.
 func (a Amount) Sub(b Amount) Amount {
 	if a.isUnlimited() && b.isUnlimited() {
 		return Amount{}
@@ -175,6 +176,14 @@ func (a Amount) CmpInt64(v int64) int {
 // MinAmount returns the smaller of a and b.
 func MinAmount(a, b Amount) Amount {
 	if a.Cmp(b) < 0 {
+		return a
+	}
+	return b
+}
+
+// MaxAmount returns the larger of a and b.
+func MaxAmount(a, b Amount) Amount {
+	if a.Cmp(b) > 0 {
 		return a
 	}
 	return b

--- a/pkg/resources/amount.go
+++ b/pkg/resources/amount.go
@@ -1,0 +1,196 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"math"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	utilmath "sigs.k8s.io/kueue/pkg/util/math"
+)
+
+// Amount is the safe representation of a quota amount used for ClusterQueue
+// and Cohort math (Nominal, BorrowingLimit, LendingLimit, SubtreeQuota).
+//
+// It is a value type so that:
+//   - "1E" CPU quotas (whose milliCPU value overflows int64) cannot collapse
+//     to 0, since AmountFromQuantity returns Unlimited instead;
+//   - cohort aggregation can't wrap around int64 - Add of an Unlimited yields
+//     Unlimited, and bounded arithmetic saturates rather than overflowing;
+//   - the type system funnels quota arithmetic through methods, so a future
+//     contributor can't accidentally fall back to raw "+" / "-" on quota
+//     values and silently re-introduce the overflow.
+//
+// Keep usage values (which are bounded by what real workloads consume) as
+// int64. Mixed Amount-vs-int64 arithmetic uses the *Int64 methods.
+//
+// math.MaxInt64 is the sentinel for "unlimited"; bounded amounts must never
+// equal math.MaxInt64 (AmountFromQuantity enforces this at the quota boundary).
+type Amount struct {
+	value int64
+}
+
+// Unlimited represents an effectively-infinite quota amount. It is the result
+// of AmountFromQuantity for a quantity whose canonical int64 representation
+// would overflow, and any Amount arithmetic involving Unlimited stays
+// Unlimited.
+var Unlimited = Amount{value: math.MaxInt64}
+
+// NewAmount returns a bounded Amount with the given int64 value.
+func NewAmount(v int64) Amount {
+	return Amount{value: v}
+}
+
+// maxCPUQuantityForAmount is the largest CPU resource.Quantity whose value in
+// milliCPU still fits in int64 (math.MaxInt64 / 1000 cores).
+var maxCPUQuantityForAmount = *resource.NewQuantity(math.MaxInt64/1000, resource.DecimalSI)
+
+// maxNonCPUQuantityForAmount is the largest non-CPU resource.Quantity whose
+// absolute value fits in int64.
+var maxNonCPUQuantityForAmount = *resource.NewQuantity(math.MaxInt64, resource.DecimalSI)
+
+// AmountFromQuantity converts a resource.Quantity into an Amount, returning
+// Unlimited when the canonical value would overflow int64.
+//
+// This is the safe constructor that all quota-side conversion (Nominal,
+// BorrowingLimit, LendingLimit) must use. ResourceValue is preserved for
+// non-quota call sites (workload requests) where the historical
+// truncate-on-overflow behavior is what existing tests document.
+func AmountFromQuantity(name corev1.ResourceName, q resource.Quantity) Amount {
+	if name == corev1.ResourceCPU {
+		if q.Cmp(maxCPUQuantityForAmount) >= 0 {
+			return Unlimited
+		}
+		return Amount{value: q.MilliValue()}
+	}
+	if q.Cmp(maxNonCPUQuantityForAmount) >= 0 {
+		return Unlimited
+	}
+	return Amount{value: q.Value()}
+}
+
+// isUnlimited reports whether a is the Unlimited sentinel.
+func (a Amount) isUnlimited() bool { return a.value == math.MaxInt64 }
+
+// Int64 returns the int64 representation of a. Unlimited is math.MaxInt64;
+// this is only correct at consumption boundaries (metrics, formatting,
+// comparisons that already saturate). Don't use Int64 inside quota arithmetic
+// - use the Amount methods instead.
+func (a Amount) Int64() int64 {
+	return a.value
+}
+
+// Add returns a + b, propagating Unlimited and saturating bounded overflow at
+// math.MaxInt64.
+func (a Amount) Add(b Amount) Amount {
+	if a.isUnlimited() || b.isUnlimited() {
+		return Unlimited
+	}
+	return Amount{value: utilmath.SaturatingAdd(a.value, b.value)}
+}
+
+// AddInt64 returns a + v.
+func (a Amount) AddInt64(v int64) Amount {
+	if a.isUnlimited() {
+		return a
+	}
+	return Amount{value: utilmath.SaturatingAdd(a.value, v)}
+}
+
+// Sub returns a - b. If a is Unlimited and b is bounded, the result stays
+// Unlimited. If both are Unlimited (which shouldn't happen in normal cohort
+// math), the result is bounded zero.
+func (a Amount) Sub(b Amount) Amount {
+	if a.isUnlimited() && b.isUnlimited() {
+		return Amount{}
+	}
+	if a.isUnlimited() {
+		return Unlimited
+	}
+	if b.isUnlimited() {
+		return Amount{value: math.MinInt64}
+	}
+	return Amount{value: utilmath.SaturatingSub(a.value, b.value)}
+}
+
+// SubInt64 returns a - v.
+func (a Amount) SubInt64(v int64) Amount {
+	if a.isUnlimited() {
+		return a
+	}
+	return Amount{value: utilmath.SaturatingSub(a.value, v)}
+}
+
+// Cmp returns -1 / 0 / +1 like bytes.Compare. Two Unlimited values compare
+// equal; Unlimited is greater than any bounded value.
+func (a Amount) Cmp(b Amount) int {
+	switch {
+	case a.isUnlimited() && b.isUnlimited():
+		return 0
+	case a.isUnlimited():
+		return 1
+	case b.isUnlimited():
+		return -1
+	case a.value < b.value:
+		return -1
+	case a.value > b.value:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// CmpInt64 returns -1 / 0 / +1 for a vs the bounded value v.
+func (a Amount) CmpInt64(v int64) int {
+	if a.isUnlimited() {
+		return 1
+	}
+	switch {
+	case a.value < v:
+		return -1
+	case a.value > v:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// MinAmount returns the smaller of a and b.
+func MinAmount(a, b Amount) Amount {
+	if a.Cmp(b) < 0 {
+		return a
+	}
+	return b
+}
+
+// String formats the Amount; Unlimited is printed as "<unlimited>".
+func (a Amount) String() string {
+	if a.isUnlimited() {
+		return "<unlimited>"
+	}
+	return strconv.FormatInt(a.value, 10)
+}
+
+// Equal lets go-cmp and other reflection-based comparators treat Amount as a
+// comparable value type without requiring cmpopts.EquateComparable everywhere
+// quotas appear in test fixtures.
+func (a Amount) Equal(b Amount) bool {
+	return a == b
+}

--- a/pkg/resources/amount_test.go
+++ b/pkg/resources/amount_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"math"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// TestAmountFromQuantity exercises the safe quota-construction path that
+// replaced raw ResourceValue for ClusterQueue/Cohort quotas. Compared with
+// TestResourceValueDecimalExponent (which documents the unsafe legacy
+// behavior) this test pins the saturating semantics that fix issue #9843:
+//
+//   - "1E" CPU no longer collapses to 0; it returns Unlimited so the
+//     scheduler treats the quota as effectively unbounded instead of zero.
+//   - Normal-sized quotas keep their exact pre-existing values, including
+//     the milliCPU scale.
+//   - Non-CPU "1E" still fits in int64 and is returned as a bounded Amount.
+//   - A quantity past the int64 ceiling for the resource returns Unlimited
+//     rather than wrapping or rounding to zero.
+func TestAmountFromQuantity(t *testing.T) {
+	cases := map[string]struct {
+		resource      corev1.ResourceName
+		quantity      string
+		wantUnlimited bool
+		wantValue     int64
+	}{
+		"cpu small value preserved": {
+			resource:  corev1.ResourceCPU,
+			quantity:  "2",
+			wantValue: 2_000,
+		},
+		"cpu sub-cpu preserved": {
+			resource:  corev1.ResourceCPU,
+			quantity:  "500m",
+			wantValue: 500,
+		},
+		"cpu 1P preserved (no overflow)": {
+			resource:  corev1.ResourceCPU,
+			quantity:  "1P",
+			wantValue: 1_000_000_000_000_000_000,
+		},
+		"cpu 1E becomes Unlimited (was 0 with raw ResourceValue)": {
+			resource:      corev1.ResourceCPU,
+			quantity:      "1E",
+			wantUnlimited: true,
+		},
+		"cpu 10P becomes Unlimited": {
+			resource:      corev1.ResourceCPU,
+			quantity:      "10P",
+			wantUnlimited: true,
+		},
+		"memory small value preserved": {
+			resource:  corev1.ResourceMemory,
+			quantity:  "512Mi",
+			wantValue: 512 * 1024 * 1024,
+		},
+		"memory 1E preserved (fits in int64)": {
+			resource:  corev1.ResourceMemory,
+			quantity:  "1E",
+			wantValue: 1_000_000_000_000_000_000,
+		},
+		"memory past int64 becomes Unlimited": {
+			resource:      corev1.ResourceMemory,
+			quantity:      "10E",
+			wantUnlimited: true,
+		},
+		"extended resource preserved": {
+			resource:  corev1.ResourceName("example.com/gpu"),
+			quantity:  "8",
+			wantValue: 8,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			q := resource.MustParse(tc.quantity)
+			got := AmountFromQuantity(tc.resource, q)
+			if got.isUnlimited() != tc.wantUnlimited {
+				t.Fatalf("AmountFromQuantity(%s, %s).IsUnlimited() = %v, want %v",
+					tc.resource, tc.quantity, got.isUnlimited(), tc.wantUnlimited)
+			}
+			if !tc.wantUnlimited && got.Int64() != tc.wantValue {
+				t.Errorf("AmountFromQuantity(%s, %s) = %d, want %d",
+					tc.resource, tc.quantity, got.Int64(), tc.wantValue)
+			}
+		})
+	}
+}
+
+// TestAmountArithmetic pins the unlimited-propagation and saturation rules
+// that prevent cohort math from overflowing, matching mimowo's request that
+// quota arithmetic be funneled through an abstraction rather than relying on
+// raw int64.
+func TestAmountArithmetic(t *testing.T) {
+	testCases := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "Add propagates Unlimited",
+			run: func(t *testing.T) {
+				got := NewAmount(5).Add(Unlimited)
+				if !got.isUnlimited() {
+					t.Errorf("bounded + Unlimited should be Unlimited, got %v", got)
+				}
+			},
+		},
+		{
+			name: "Add saturates on bounded overflow becomes Unlimited",
+			run: func(t *testing.T) {
+				got := NewAmount(math.MaxInt64 - 5).Add(NewAmount(100))
+				if !got.isUnlimited() {
+					t.Errorf("bounded saturated overflow should become Unlimited (MaxInt64 sentinel), got %v", got)
+				}
+			},
+		},
+		{
+			name: "Sub of Unlimited stays Unlimited",
+			run: func(t *testing.T) {
+				got := Unlimited.SubInt64(1000)
+				if !got.isUnlimited() {
+					t.Errorf("Unlimited - bounded should stay Unlimited, got %v", got)
+				}
+			},
+		},
+		{
+			name: "Cmp - Unlimited greater than any bounded",
+			run: func(t *testing.T) {
+				// MaxInt64 is the Unlimited sentinel; use MaxInt64-1 for a bounded value.
+				if Unlimited.CmpInt64(math.MaxInt64-1) <= 0 {
+					t.Errorf("Unlimited should compare greater than MaxInt64-1")
+				}
+				if NewAmount(math.MaxInt64-1).Cmp(Unlimited) >= 0 {
+					t.Errorf("MaxInt64-1 should compare less than Unlimited")
+				}
+			},
+		},
+		{
+			name: "Cmp - two Unlimited equal",
+			run: func(t *testing.T) {
+				left, right := Unlimited, Unlimited
+				if got := left.Cmp(right); got != 0 {
+					t.Errorf("Unlimited.Cmp(Unlimited) = %d, want 0", got)
+				}
+			},
+		},
+		{
+			name: "AddInt64 saturates",
+			run: func(t *testing.T) {
+				got := NewAmount(math.MaxInt64 - 1).AddInt64(100)
+				if got.Int64() != math.MaxInt64 {
+					t.Errorf("got %d, want MaxInt64", got.Int64())
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, tc.run)
+	}
+}

--- a/pkg/resources/amount_test.go
+++ b/pkg/resources/amount_test.go
@@ -106,16 +106,13 @@ func TestAmountFromQuantity(t *testing.T) {
 }
 
 // TestAmountArithmetic pins the unlimited-propagation and saturation rules
-// that prevent cohort math from overflowing, matching mimowo's request that
-// quota arithmetic be funneled through an abstraction rather than relying on
-// raw int64.
+// that prevent cohort math from overflowing. Quota arithmetic must funnel
+// through Amount rather than raw int64 so these invariants hold globally.
 func TestAmountArithmetic(t *testing.T) {
-	testCases := []struct {
-		name string
-		run  func(t *testing.T)
+	testCases := map[string]struct {
+		run func(t *testing.T)
 	}{
-		{
-			name: "Add propagates Unlimited",
+		"Add propagates Unlimited": {
 			run: func(t *testing.T) {
 				got := NewAmount(5).Add(Unlimited)
 				if !got.isUnlimited() {
@@ -123,8 +120,7 @@ func TestAmountArithmetic(t *testing.T) {
 				}
 			},
 		},
-		{
-			name: "Add saturates on bounded overflow becomes Unlimited",
+		"Add saturates on bounded overflow becomes Unlimited": {
 			run: func(t *testing.T) {
 				got := NewAmount(math.MaxInt64 - 5).Add(NewAmount(100))
 				if !got.isUnlimited() {
@@ -132,8 +128,7 @@ func TestAmountArithmetic(t *testing.T) {
 				}
 			},
 		},
-		{
-			name: "Sub of Unlimited stays Unlimited",
+		"Sub of Unlimited stays Unlimited": {
 			run: func(t *testing.T) {
 				got := Unlimited.SubInt64(1000)
 				if !got.isUnlimited() {
@@ -141,8 +136,7 @@ func TestAmountArithmetic(t *testing.T) {
 				}
 			},
 		},
-		{
-			name: "Cmp - Unlimited greater than any bounded",
+		"Cmp - Unlimited greater than any bounded": {
 			run: func(t *testing.T) {
 				// MaxInt64 is the Unlimited sentinel; use MaxInt64-1 for a bounded value.
 				if Unlimited.CmpInt64(math.MaxInt64-1) <= 0 {
@@ -153,8 +147,7 @@ func TestAmountArithmetic(t *testing.T) {
 				}
 			},
 		},
-		{
-			name: "Cmp - two Unlimited equal",
+		"Cmp - two Unlimited equal": {
 			run: func(t *testing.T) {
 				left, right := Unlimited, Unlimited
 				if got := left.Cmp(right); got != 0 {
@@ -162,8 +155,29 @@ func TestAmountArithmetic(t *testing.T) {
 				}
 			},
 		},
-		{
-			name: "AddInt64 saturates",
+		"Sub Unlimited minus Unlimited yields zero": {
+			run: func(t *testing.T) {
+				// Intentional edge case: Unlimited - Unlimited = 0.
+				// This arises in localQuota when SubtreeQuota == LendingLimit == Unlimited,
+				// meaning the node lends everything and retains nothing locally.
+				got := Unlimited.Sub(Unlimited)
+				if got.isUnlimited() {
+					t.Errorf("Unlimited.Sub(Unlimited) should be bounded zero, got Unlimited")
+				}
+				if got.Int64() != 0 {
+					t.Errorf("Unlimited.Sub(Unlimited) = %d, want 0", got.Int64())
+				}
+			},
+		},
+		"Sub bounded minus Unlimited yields MinInt64": {
+			run: func(t *testing.T) {
+				got := NewAmount(1000).Sub(Unlimited)
+				if got.Int64() != math.MinInt64 {
+					t.Errorf("bounded.Sub(Unlimited) = %d, want MinInt64", got.Int64())
+				}
+			},
+		},
+		"AddInt64 saturates": {
 			run: func(t *testing.T) {
 				got := NewAmount(math.MaxInt64 - 1).AddInt64(100)
 				if got.Int64() != math.MaxInt64 {
@@ -173,7 +187,7 @@ func TestAmountArithmetic(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, tc.run)
+	for name, tc := range testCases {
+		t.Run(name, tc.run)
 	}
 }

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -149,6 +149,16 @@ func ResourceQuantityString(name corev1.ResourceName, v int64) string {
 	return rq.String()
 }
 
+// AmountQuantityString formats an Amount as a Kubernetes resource quantity
+// string. Unlimited amounts are formatted as "<unlimited>" rather than as
+// the raw math.MaxInt64 sentinel.
+func AmountQuantityString(name corev1.ResourceName, a Amount) string {
+	if a.Equal(Unlimited) {
+		return Unlimited.String()
+	}
+	return ResourceQuantityString(name, a.Int64())
+}
+
 // GreaterKeys returns keys where the receiver is greater than other.
 func (r Requests) GreaterKeys(other Requests) []corev1.ResourceName {
 	if len(r) == 0 || len(other) == 0 {

--- a/pkg/resources/resource.go
+++ b/pkg/resources/resource.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -34,12 +35,12 @@ func (fr FlavorResource) String() string {
 	return fmt.Sprintf(`{"Flavor":"%s","Resource":"%s"}`, string(fr.Flavor), string(fr.Resource))
 }
 
-type FlavorResourceQuantities map[FlavorResource]int64
+type FlavorResourceQuantities map[FlavorResource]Amount
 
 func (frq FlavorResourceQuantities) MarshalJSON() ([]byte, error) {
 	temp := make(map[string]int64, len(frq))
-	for flavourResource, num := range frq {
-		temp[flavourResource.String()] = num
+	for flavorResource, num := range frq {
+		temp[flavorResource.String()] = num.Int64()
 	}
 	return json.Marshal(temp)
 }
@@ -47,15 +48,29 @@ func (frq FlavorResourceQuantities) MarshalJSON() ([]byte, error) {
 func (frq FlavorResourceQuantities) FlattenFlavors() Requests {
 	result := Requests{}
 	for key, val := range frq {
-		result[key.Resource] += val
+		result[key.Resource] += val.Int64()
 	}
 	return result
 }
 
+// Clone returns a shallow copy of the map.
+func (frq FlavorResourceQuantities) Clone() FlavorResourceQuantities {
+	if frq == nil {
+		return nil
+	}
+	out := make(FlavorResourceQuantities, len(frq))
+	maps.Copy(out, frq)
+	return out
+}
+
+// Sub returns a new map with element-wise subtraction. Missing keys on either
+// side are treated as bounded zero, except the result is omitted only when
+// the operand is missing on the receiver side. (Symmetric difference is not
+// the goal here; this matches the semantics of the prior map Sub.)
 func (frq FlavorResourceQuantities) Sub(other FlavorResourceQuantities) FlavorResourceQuantities {
 	result := make(FlavorResourceQuantities, len(frq))
 	for fr, qty := range frq {
-		result[fr] = qty - other[fr]
+		result[fr] = qty.Sub(other[fr])
 	}
 	return result
 }

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -40,7 +40,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/scheduler/preemption/classical"
 	preemptioncommon "sigs.k8s.io/kueue/pkg/scheduler/preemption/common"
 	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
-	utilmath "sigs.k8s.io/kueue/pkg/util/math"
 	"sigs.k8s.io/kueue/pkg/util/orderedgroups"
 	"sigs.k8s.io/kueue/pkg/util/tas"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -526,7 +525,7 @@ type FlavorAssignment struct {
 }
 
 type preemptionOracle interface {
-	SimulatePreemption(log logr.Logger, cq *schdcache.ClusterQueueSnapshot, wl workload.Info, fr resources.FlavorResource, quantity int64) (preemptioncommon.PreemptionPossibility, int)
+	SimulatePreemption(log logr.Logger, cq *schdcache.ClusterQueueSnapshot, wl workload.Info, fr resources.FlavorResource, quantity resources.Amount) (preemptioncommon.PreemptionPossibility, int)
 }
 
 type FlavorAssigner struct {
@@ -890,7 +889,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 			// Check considering the flavor usage by previous pod sets.
 			fr := resources.FlavorResource{Flavor: fName, Resource: rName}
 
-			preemptionMode, borrow, s := a.fitsResourceQuota(log, fr, assignmentUsage[fr].Int64(), val, resQuota)
+			preemptionMode, borrow, s := a.fitsResourceQuota(log, fr, assignmentUsage[fr], val, resQuota)
 			if s != nil {
 				flavorQuotaReasons = append(flavorQuotaReasons, s.reasons...)
 				status.reasons = append(status.reasons, s.reasons...)
@@ -1068,38 +1067,44 @@ func flavorSelector(spec *corev1.PodSpec, allowedKeys sets.Set[string]) nodeaffi
 // if borrowing is required when preempting.
 // If the flavor doesn't satisfy limits immediately (when waiting or preemption
 // could help), it returns a Status with reasons.
-func (a *FlavorAssigner) fitsResourceQuota(log logr.Logger, fr resources.FlavorResource, assumedUsage int64, requestUsage int64, rQuota schdcache.ResourceQuota) (preemptionMode, int, *Status) {
+func (a *FlavorAssigner) fitsResourceQuota(
+	log logr.Logger,
+	fr resources.FlavorResource,
+	assumedUsage resources.Amount,
+	requestUsage int64,
+	rQuota schdcache.ResourceQuota,
+) (preemptionMode, int, *Status) {
 	var status Status
 
 	available := a.cq.Available(fr)
 	maxCapacity := a.cq.PotentialAvailable(fr)
 
-	val := utilmath.SaturatingAdd(assumedUsage, requestUsage)
+	val := assumedUsage.AddInt64(requestUsage)
 
 	// No Fit
-	if val > maxCapacity {
+	if val.Cmp(maxCapacity) > 0 {
 		status.appendf(
 			"insufficient quota for %s in flavor %s, previously considered podsets requests (%s) + current podset request (%s) > maximum capacity (%s)",
 			fr.Resource,
 			fr.Flavor,
-			resources.ResourceQuantityString(fr.Resource, assumedUsage),
+			resources.AmountQuantityString(fr.Resource, assumedUsage),
 			resources.ResourceQuantityString(fr.Resource, requestUsage),
-			resources.ResourceQuantityString(fr.Resource, maxCapacity),
+			resources.AmountQuantityString(fr.Resource, maxCapacity),
 		)
 		return noFit, 0, &status
 	}
 
 	borrow, mayReclaimInHierarchy := classical.FindHeightOfLowestSubtreeThatFits(a.cq, fr, val)
 	// Fit
-	if val <= available {
+	if val.Cmp(available) <= 0 {
 		return fit, borrow, nil
 	}
 
 	// Preempt
 	status.appendf("insufficient unused quota for %s in flavor %s, %s more needed",
-		fr.Resource, fr.Flavor, resources.ResourceQuantityString(fr.Resource, val-available))
+		fr.Resource, fr.Flavor, resources.AmountQuantityString(fr.Resource, val.Sub(available)))
 
-	if rQuota.Nominal.CmpInt64(val) >= 0 || mayReclaimInHierarchy || a.canPreemptWhileBorrowing() {
+	if rQuota.Nominal.Cmp(val) >= 0 || mayReclaimInHierarchy || a.canPreemptWhileBorrowing() {
 		preemptionPossiblity, borrowAfterPreemptions := a.oracle.SimulatePreemption(log, a.cq, *a.wl, fr, val)
 		mode := fromPreemptionPossibility(preemptionPossiblity)
 		return mode, borrowAfterPreemptions, &status

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -236,7 +236,7 @@ func (a *Assignment) TotalRequestsFor(log logr.Logger, wl *workload.Info) resour
 				continue
 			}
 			flv := a.PodSets[i].Flavors[res].Name
-			usage[resources.FlavorResource{Flavor: flv, Resource: res}] += q
+			usage[resources.FlavorResource{Flavor: flv, Resource: res}] = usage[resources.FlavorResource{Flavor: flv, Resource: res}].AddInt64(q)
 		}
 	}
 	return usage
@@ -781,7 +781,7 @@ func (a *Assignment) append(requests resources.Requests, psAssignment *PodSetAss
 			requestAmount -= oldRequest
 		}
 
-		a.Usage.Quota[fr] += requestAmount
+		a.Usage.Quota[fr] = a.Usage.Quota[fr].AddInt64(requestAmount)
 		flavorIdx[resource] = flvAssignment.TriedFlavorIdx
 	}
 	a.LastState.LastTriedFlavorIdx = append(a.LastState.LastTriedFlavorIdx, flavorIdx)
@@ -890,7 +890,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 			// Check considering the flavor usage by previous pod sets.
 			fr := resources.FlavorResource{Flavor: fName, Resource: rName}
 
-			preemptionMode, borrow, s := a.fitsResourceQuota(log, fr, assignmentUsage[fr], val, resQuota)
+			preemptionMode, borrow, s := a.fitsResourceQuota(log, fr, assignmentUsage[fr].Int64(), val, resQuota)
 			if s != nil {
 				flavorQuotaReasons = append(flavorQuotaReasons, s.reasons...)
 				status.reasons = append(status.reasons, s.reasons...)
@@ -1099,7 +1099,7 @@ func (a *FlavorAssigner) fitsResourceQuota(log logr.Logger, fr resources.FlavorR
 	status.appendf("insufficient unused quota for %s in flavor %s, %s more needed",
 		fr.Resource, fr.Flavor, resources.ResourceQuantityString(fr.Resource, val-available))
 
-	if val <= rQuota.Nominal || mayReclaimInHierarchy || a.canPreemptWhileBorrowing() {
+	if rQuota.Nominal.CmpInt64(val) >= 0 || mayReclaimInHierarchy || a.canPreemptWhileBorrowing() {
 		preemptionPossiblity, borrowAfterPreemptions := a.oracle.SimulatePreemption(log, a.cq, *a.wl, fr, val)
 		mode := fromPreemptionPossibility(preemptionPossiblity)
 		return mode, borrowAfterPreemptions, &status

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -159,7 +159,7 @@ func (f *testOracle) SimulatePreemption(
 	cq *schdcache.ClusterQueueSnapshot,
 	wl workload.Info,
 	fr resources.FlavorResource,
-	quantity int64,
+	quantity resources.Amount,
 ) (preemptioncommon.PreemptionPossibility, int) {
 	if f.simulationResult != nil {
 		if result, ok := f.simulationResult[fr]; ok {

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -243,8 +243,8 @@ func TestAssignFlavors(t *testing.T) {
 					},
 				},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "default", Resource: corev1.ResourceCPU}:    1_000,
-					{Flavor: "default", Resource: corev1.ResourceMemory}: utiltesting.Mi,
+					{Flavor: "default", Resource: corev1.ResourceCPU}:    resources.NewAmount(1_000),
+					{Flavor: "default", Resource: corev1.ResourceMemory}: resources.NewAmount(utiltesting.Mi),
 				}},
 			},
 		},
@@ -283,7 +283,7 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "tainted", Resource: corev1.ResourceCPU}: 1_000,
+					{Flavor: "tainted", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
 				}},
 			},
 		},
@@ -314,7 +314,7 @@ func TestAssignFlavors(t *testing.T) {
 					},
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "taint_and_toleration", Resource: corev1.ResourceCPU}: 1_000,
+					{Flavor: "taint_and_toleration", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
 				}},
 			},
 		},
@@ -331,7 +331,7 @@ func TestAssignFlavors(t *testing.T) {
 						Obj(),
 				).Obj(),
 			clusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: corev1.ResourceCPU}: 3_000,
+				{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(3_000),
 			},
 			wantRepMode: Preempt,
 			wantAssignment: Assignment{
@@ -355,7 +355,7 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "default", Resource: corev1.ResourceCPU}: 2_000,
+					{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 				}},
 			},
 		},
@@ -413,8 +413,8 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "two", Resource: corev1.ResourceCPU}:      3_000,
-					{Flavor: "b_one", Resource: corev1.ResourceMemory}: 10 * utiltesting.Mi,
+					{Flavor: "two", Resource: corev1.ResourceCPU}:      resources.NewAmount(3_000),
+					{Flavor: "b_one", Resource: corev1.ResourceMemory}: resources.NewAmount(10 * utiltesting.Mi),
 				}},
 			},
 		},
@@ -479,7 +479,7 @@ func TestAssignFlavors(t *testing.T) {
 						Count: 1,
 					}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "two", Resource: corev1.ResourceCPU}: 9_000,
+					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(9_000),
 				}},
 			},
 		},
@@ -558,9 +558,9 @@ func TestAssignFlavors(t *testing.T) {
 						Count: 1,
 					}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "two", Resource: corev1.ResourceCPU}:    5_000,
-					{Flavor: "two", Resource: corev1.ResourceMemory}: 5,
-					{Flavor: "two", Resource: "example.com/gpu"}:     4,
+					{Flavor: "two", Resource: corev1.ResourceCPU}:    resources.NewAmount(5_000),
+					{Flavor: "two", Resource: corev1.ResourceMemory}: resources.NewAmount(5),
+					{Flavor: "two", Resource: "example.com/gpu"}:     resources.NewAmount(4),
 				}},
 			},
 		},
@@ -664,7 +664,7 @@ func TestAssignFlavors(t *testing.T) {
 			).Obj(),
 
 			clusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 1_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
 			},
 
 			wantAssignment: Assignment{
@@ -742,9 +742,9 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "two", Resource: corev1.ResourceCPU}:    3_000,
-					{Flavor: "two", Resource: corev1.ResourceMemory}: 10 * utiltesting.Mi,
-					{Flavor: "b_one", Resource: "example.com/gpu"}:   3,
+					{Flavor: "two", Resource: corev1.ResourceCPU}:    resources.NewAmount(3_000),
+					{Flavor: "two", Resource: corev1.ResourceMemory}: resources.NewAmount(10 * utiltesting.Mi),
+					{Flavor: "b_one", Resource: "example.com/gpu"}:   resources.NewAmount(3),
 				}},
 			},
 		},
@@ -773,7 +773,7 @@ func TestAssignFlavors(t *testing.T) {
 			).Cohort("test-cohort").
 				Obj(),
 			clusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "two", Resource: corev1.ResourceMemory}: 10 * utiltesting.Mi,
+				{Flavor: "two", Resource: corev1.ResourceMemory}: resources.NewAmount(10 * utiltesting.Mi),
 			},
 			secondaryClusterQueue: utiltestingapi.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
@@ -784,7 +784,7 @@ func TestAssignFlavors(t *testing.T) {
 				Cohort("test-cohort").
 				Obj(),
 			secondaryClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "b_one", Resource: "example.com/gpu"}: 2,
+				{Flavor: "b_one", Resource: "example.com/gpu"}: resources.NewAmount(2),
 			},
 			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
 				{Flavor: "two", Resource: corev1.ResourceMemory}: {preemptioncommon.Preempt, 1},
@@ -831,9 +831,9 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Borrowing: 1,
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "two", Resource: corev1.ResourceCPU}:    3_000,
-					{Flavor: "two", Resource: corev1.ResourceMemory}: 10 * utiltesting.Mi,
-					{Flavor: "b_one", Resource: "example.com/gpu"}:   3,
+					{Flavor: "two", Resource: corev1.ResourceCPU}:    resources.NewAmount(3_000),
+					{Flavor: "two", Resource: corev1.ResourceMemory}: resources.NewAmount(10 * utiltesting.Mi),
+					{Flavor: "b_one", Resource: "example.com/gpu"}:   resources.NewAmount(3),
 				}},
 			},
 		},
@@ -919,7 +919,7 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "two", Resource: corev1.ResourceCPU}: 3_000,
+					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(3_000),
 				}},
 			},
 		},
@@ -976,7 +976,7 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "two", Resource: corev1.ResourceCPU}: 1_000,
+					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
 				}},
 			},
 		},
@@ -1038,8 +1038,8 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "two", Resource: corev1.ResourceCPU}:    1_000,
-					{Flavor: "two", Resource: corev1.ResourceMemory}: utiltesting.Mi,
+					{Flavor: "two", Resource: corev1.ResourceCPU}:    resources.NewAmount(1_000),
+					{Flavor: "two", Resource: corev1.ResourceMemory}: resources.NewAmount(utiltesting.Mi),
 				}},
 			},
 		},
@@ -1103,7 +1103,7 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "one", Resource: corev1.ResourceCPU}: 1_000,
+					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
 				}},
 			},
 		},
@@ -1219,8 +1219,8 @@ func TestAssignFlavors(t *testing.T) {
 					},
 				},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "one", Resource: corev1.ResourceCPU}: 3_000,
-					{Flavor: "two", Resource: corev1.ResourceCPU}: 5_000,
+					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(3_000),
+					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(5_000),
 				}},
 			},
 		},
@@ -1288,8 +1288,8 @@ func TestAssignFlavors(t *testing.T) {
 				},
 				Borrowing: 1,
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "default", Resource: corev1.ResourceCPU}:    10_000,
-					{Flavor: "default", Resource: corev1.ResourceMemory}: 5 * utiltesting.Gi,
+					{Flavor: "default", Resource: corev1.ResourceCPU}:    resources.NewAmount(10_000),
+					{Flavor: "default", Resource: corev1.ResourceMemory}: resources.NewAmount(5 * utiltesting.Gi),
 				}},
 			},
 		},
@@ -1314,7 +1314,7 @@ func TestAssignFlavors(t *testing.T) {
 				Cohort("test-cohort").
 				Obj(),
 			secondaryClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 9_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(9_000),
 			},
 			wantAssignment: Assignment{
 				PodSets: []PodSetAssignment{{
@@ -1349,7 +1349,7 @@ func TestAssignFlavors(t *testing.T) {
 				).Cohort("test-cohort").
 				Obj(),
 			clusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 9_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(9_000),
 			},
 			secondaryClusterQueue: utiltestingapi.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
@@ -1360,7 +1360,7 @@ func TestAssignFlavors(t *testing.T) {
 				Cohort("test-cohort").
 				Obj(),
 			secondaryClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 9_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(9_000),
 			},
 			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: {preemptioncommon.Preempt, 1},
@@ -1389,7 +1389,7 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Borrowing: 1,
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
+					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 				}},
 			},
 		},
@@ -1406,7 +1406,7 @@ func TestAssignFlavors(t *testing.T) {
 						Obj(),
 				).Obj(),
 			clusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 1_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
 			},
 			wantRepMode: Preempt,
 			wantAssignment: Assignment{
@@ -1430,7 +1430,7 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
+					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 				}},
 			},
 		},
@@ -1447,7 +1447,7 @@ func TestAssignFlavors(t *testing.T) {
 						Obj(),
 				).Cohort("test-cohort").Obj(),
 			clusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 			},
 			secondaryClusterQueue: utiltestingapi.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
@@ -1458,7 +1458,7 @@ func TestAssignFlavors(t *testing.T) {
 				Cohort("test-cohort").
 				Obj(),
 			secondaryClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 8_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(8_000),
 			},
 			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: {preemptioncommon.Preempt, 1},
@@ -1487,7 +1487,7 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Borrowing: 1,
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
+					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 				}},
 			},
 		},
@@ -1509,8 +1509,8 @@ func TestAssignFlavors(t *testing.T) {
 						Obj(),
 				).Obj(),
 			clusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 3_000,
-				{Flavor: "two", Resource: corev1.ResourceCPU}: 3_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(3_000),
+				{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(3_000),
 			},
 			wantRepMode: Preempt,
 			wantAssignment: Assignment{
@@ -1542,7 +1542,7 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "two", Resource: corev1.ResourceCPU}: 2_000,
+					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 				}},
 			},
 		},
@@ -1571,8 +1571,8 @@ func TestAssignFlavors(t *testing.T) {
 						Obj(),
 				).Obj(),
 			clusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}:     3_000,
-				{Flavor: "tainted", Resource: corev1.ResourceCPU}: 3_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}:     resources.NewAmount(3_000),
+				{Flavor: "tainted", Resource: corev1.ResourceCPU}: resources.NewAmount(3_000),
 			},
 			wantRepMode: Preempt,
 			wantAssignment: Assignment{
@@ -1633,8 +1633,8 @@ func TestAssignFlavors(t *testing.T) {
 					},
 				},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "one", Resource: corev1.ResourceCPU}:     2_000,
-					{Flavor: "tainted", Resource: corev1.ResourceCPU}: 10_000,
+					{Flavor: "one", Resource: corev1.ResourceCPU}:     resources.NewAmount(2_000),
+					{Flavor: "tainted", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 				}},
 			},
 		},
@@ -1691,7 +1691,7 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "default", Resource: corev1.ResourceCPU}: 1_000,
+					{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
 				}},
 			},
 			wantRepMode: Fit,
@@ -1727,8 +1727,8 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "default", Resource: corev1.ResourceCPU}: 1_000,
-					{Flavor: "default", Resource: "example.com/gpu"}:  0,
+					{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
+					{Flavor: "default", Resource: "example.com/gpu"}:  resources.NewAmount(0),
 				}},
 			},
 			wantRepMode: Fit,
@@ -1765,8 +1765,8 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 3,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "default", Resource: corev1.ResourcePods}: 3,
-					{Flavor: "default", Resource: corev1.ResourceCPU}:  3_000,
+					{Flavor: "default", Resource: corev1.ResourcePods}: resources.NewAmount(3),
+					{Flavor: "default", Resource: corev1.ResourceCPU}:  resources.NewAmount(3_000),
 				}},
 			},
 			wantRepMode: Fit,
@@ -1842,8 +1842,8 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 3,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "default", Resource: corev1.ResourcePods}: 3,
-					{Flavor: "default", Resource: corev1.ResourceCPU}:  3_000,
+					{Flavor: "default", Resource: corev1.ResourcePods}: resources.NewAmount(3),
+					{Flavor: "default", Resource: corev1.ResourceCPU}:  resources.NewAmount(3_000),
 				}},
 			},
 			wantRepMode: Fit,
@@ -1882,8 +1882,8 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 5,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "default", Resource: corev1.ResourcePods}: 5,
-					{Flavor: "default", Resource: corev1.ResourceCPU}:  5_000,
+					{Flavor: "default", Resource: corev1.ResourcePods}: resources.NewAmount(5),
+					{Flavor: "default", Resource: corev1.ResourceCPU}:  resources.NewAmount(5_000),
 				}},
 			},
 			wantRepMode: Fit,
@@ -1909,7 +1909,7 @@ func TestAssignFlavors(t *testing.T) {
 						Obj(),
 				).Obj(),
 			clusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 			},
 			wantRepMode: Preempt,
 			wantAssignment: Assignment{
@@ -1935,8 +1935,8 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "one", Resource: "cpu"}:  9_000,
-					{Flavor: "one", Resource: "pods"}: 1,
+					{Flavor: "one", Resource: "cpu"}:  resources.NewAmount(9_000),
+					{Flavor: "one", Resource: "pods"}: resources.NewAmount(1),
 				}},
 			},
 		},
@@ -1959,7 +1959,7 @@ func TestAssignFlavors(t *testing.T) {
 						Obj(),
 				).Obj(),
 			clusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 			},
 			wantRepMode: Preempt,
 			wantAssignment: Assignment{
@@ -1985,8 +1985,8 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "one", Resource: "cpu"}:  9_000,
-					{Flavor: "one", Resource: "pods"}: 1,
+					{Flavor: "one", Resource: "cpu"}:  resources.NewAmount(9_000),
+					{Flavor: "one", Resource: "pods"}: resources.NewAmount(1),
 				}},
 			},
 		},
@@ -2008,7 +2008,7 @@ func TestAssignFlavors(t *testing.T) {
 						Obj(),
 				).Obj(),
 			clusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 			},
 			wantRepMode: Fit,
 			wantAssignment: Assignment{
@@ -2034,8 +2034,8 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "two", Resource: "cpu"}:  9_000,
-					{Flavor: "two", Resource: "pods"}: 1,
+					{Flavor: "two", Resource: "cpu"}:  resources.NewAmount(9_000),
+					{Flavor: "two", Resource: "pods"}: resources.NewAmount(1),
 				}},
 			},
 		},
@@ -2059,7 +2059,7 @@ func TestAssignFlavors(t *testing.T) {
 				).Cohort("test-cohort").
 				Obj(),
 			clusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 			},
 			secondaryClusterQueue: utiltestingapi.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
@@ -2092,8 +2092,8 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "one", Resource: corev1.ResourceCPU}:  9_000,
-					{Flavor: "one", Resource: corev1.ResourcePods}: 1,
+					{Flavor: "one", Resource: corev1.ResourceCPU}:  resources.NewAmount(9_000),
+					{Flavor: "one", Resource: corev1.ResourcePods}: resources.NewAmount(1),
 				}},
 			},
 		},
@@ -2117,7 +2117,7 @@ func TestAssignFlavors(t *testing.T) {
 				).Cohort("test-cohort").
 				Obj(),
 			clusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 			},
 
 			secondaryClusterQueue: utiltestingapi.MakeClusterQueue("test-secondary-clusterqueue").
@@ -2147,8 +2147,8 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "two", Resource: corev1.ResourceCPU}:  9_000,
-					{Flavor: "two", Resource: corev1.ResourcePods}: 1,
+					{Flavor: "two", Resource: corev1.ResourceCPU}:  resources.NewAmount(9_000),
+					{Flavor: "two", Resource: corev1.ResourcePods}: resources.NewAmount(1),
 				}},
 			},
 		},
@@ -2171,7 +2171,7 @@ func TestAssignFlavors(t *testing.T) {
 				).Cohort("test-cohort").
 				Obj(),
 			clusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 			},
 			secondaryClusterQueue: utiltestingapi.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
@@ -2200,8 +2200,8 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "one", Resource: "cpu"}:  9_000,
-					{Flavor: "one", Resource: "pods"}: 1,
+					{Flavor: "one", Resource: "cpu"}:  resources.NewAmount(9_000),
+					{Flavor: "one", Resource: "pods"}: resources.NewAmount(1),
 				}},
 			},
 		},
@@ -2239,7 +2239,7 @@ func TestAssignFlavors(t *testing.T) {
 				Cohort("test-cohort").
 				Obj(),
 			secondaryClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 10_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 			},
 			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: {preemptioncommon.Preempt, 1},
@@ -2268,7 +2268,7 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "one", Resource: corev1.ResourceCPU}: 12_000,
+					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(12_000),
 				}},
 			},
 		},
@@ -2306,7 +2306,7 @@ func TestAssignFlavors(t *testing.T) {
 				Cohort("test-cohort").
 				Obj(),
 			secondaryClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 10_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 			},
 			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: {preemptioncommon.Preempt, 1},
@@ -2335,7 +2335,7 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "one", Resource: corev1.ResourceCPU}: 12_000,
+					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(12_000),
 				}},
 			},
 		},
@@ -2373,7 +2373,7 @@ func TestAssignFlavors(t *testing.T) {
 				Cohort("test-cohort").
 				Obj(),
 			secondaryClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 10_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 			},
 			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: {preemptioncommon.Preempt, 1},
@@ -2402,7 +2402,7 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "one", Resource: corev1.ResourceCPU}: 12_000,
+					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(12_000),
 				}},
 			},
 		},
@@ -2440,7 +2440,7 @@ func TestAssignFlavors(t *testing.T) {
 				Cohort("test-cohort").
 				Obj(),
 			secondaryClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 10_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 			},
 			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: {preemptioncommon.Preempt, 1},
@@ -2469,7 +2469,7 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "one", Resource: corev1.ResourceCPU}: 12_000,
+					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(12_000),
 				}},
 			},
 		},
@@ -2524,7 +2524,7 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "two", Resource: corev1.ResourceCPU}: 12_000,
+					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(12_000),
 				}},
 			},
 		},
@@ -2579,7 +2579,7 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "two", Resource: corev1.ResourceCPU}: 12_000,
+					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(12_000),
 				}},
 			},
 		},
@@ -2610,7 +2610,7 @@ func TestAssignFlavors(t *testing.T) {
 				Cohort("test-cohort").
 				Obj(),
 			secondaryClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 10_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 			},
 			wantRepMode: NoFit,
 			wantAssignment: Assignment{
@@ -2657,7 +2657,7 @@ func TestAssignFlavors(t *testing.T) {
 				).Cohort("test-cohort").
 				Obj(),
 			clusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 			},
 			secondaryClusterQueue: utiltestingapi.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
@@ -2686,8 +2686,8 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "two", Resource: corev1.ResourceCPU}:  9_000,
-					{Flavor: "two", Resource: corev1.ResourcePods}: 1,
+					{Flavor: "two", Resource: corev1.ResourceCPU}:  resources.NewAmount(9_000),
+					{Flavor: "two", Resource: corev1.ResourcePods}: resources.NewAmount(1),
 				}},
 			},
 		},
@@ -2711,7 +2711,7 @@ func TestAssignFlavors(t *testing.T) {
 				).Cohort("test-cohort").
 				Obj(),
 			clusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 			},
 			secondaryClusterQueue: utiltestingapi.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
@@ -2746,8 +2746,8 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Borrowing: 1,
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "one", Resource: corev1.ResourceCPU}:  9_000,
-					{Flavor: "one", Resource: corev1.ResourcePods}: 1,
+					{Flavor: "one", Resource: corev1.ResourceCPU}:  resources.NewAmount(9_000),
+					{Flavor: "one", Resource: corev1.ResourcePods}: resources.NewAmount(1),
 				}},
 			},
 		},
@@ -2786,7 +2786,7 @@ func TestAssignFlavors(t *testing.T) {
 				Cohort("test-cohort").
 				Obj(),
 			secondaryClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 			},
 			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: {preemptioncommon.NoCandidates, 0},
@@ -2814,7 +2814,7 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Borrowing: 1,
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "two", Resource: corev1.ResourceCPU}: 2_000,
+					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 				}},
 			},
 		},
@@ -2853,7 +2853,7 @@ func TestAssignFlavors(t *testing.T) {
 				Cohort("test-cohort").
 				Obj(),
 			secondaryClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 			},
 			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: {preemptioncommon.NoCandidates, 0},
@@ -2881,7 +2881,7 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Borrowing: 1,
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "two", Resource: corev1.ResourceCPU}: 2_000,
+					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 				}},
 			},
 		},
@@ -2899,7 +2899,7 @@ func TestAssignFlavors(t *testing.T) {
 						Obj(),
 				).Cohort("test-cohort").Obj(),
 			clusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
 			},
 			secondaryClusterQueue: utiltestingapi.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
@@ -2939,8 +2939,8 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Borrowing: 1,
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "one", Resource: corev1.ResourceCPU}:  9_000,
-					{Flavor: "one", Resource: corev1.ResourcePods}: 1,
+					{Flavor: "one", Resource: corev1.ResourceCPU}:  resources.NewAmount(9_000),
+					{Flavor: "one", Resource: corev1.ResourcePods}: resources.NewAmount(1),
 				}},
 			},
 		},
@@ -2971,7 +2971,7 @@ func TestAssignFlavors(t *testing.T) {
 				Cohort("test-cohort").
 				Obj(),
 			secondaryClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 10_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 			},
 			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: {preemptioncommon.Preempt, 1},
@@ -3000,7 +3000,7 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "one", Resource: corev1.ResourceCPU}: 12_000,
+					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(12_000),
 				}},
 			},
 		},
@@ -3031,7 +3031,7 @@ func TestAssignFlavors(t *testing.T) {
 				Cohort("test-cohort").
 				Obj(),
 			secondaryClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 10_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 			},
 			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: {preemptioncommon.Preempt, 1},
@@ -3060,7 +3060,7 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "one", Resource: corev1.ResourceCPU}: 12_000,
+					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(12_000),
 				}},
 			},
 		},
@@ -3091,7 +3091,7 @@ func TestAssignFlavors(t *testing.T) {
 				Cohort("test-cohort").
 				Obj(),
 			secondaryClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 10_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 			},
 			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: {preemptioncommon.NoCandidates, 0},
@@ -3118,7 +3118,7 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "two", Resource: corev1.ResourceCPU}: 12_000,
+					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(12_000),
 				}},
 			},
 		},
@@ -3149,7 +3149,7 @@ func TestAssignFlavors(t *testing.T) {
 				Cohort("test-cohort").
 				Obj(),
 			secondaryClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 10_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
 			},
 			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: {preemptioncommon.NoCandidates, 0},
@@ -3176,7 +3176,7 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "two", Resource: corev1.ResourceCPU}: 12_000,
+					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(12_000),
 				}},
 			},
 		},
@@ -3240,8 +3240,8 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "two", Resource: corev1.ResourceCPU}:    1_000,
-					{Flavor: "two", Resource: corev1.ResourceMemory}: 0,
+					{Flavor: "two", Resource: corev1.ResourceCPU}:    resources.NewAmount(1_000),
+					{Flavor: "two", Resource: corev1.ResourceMemory}: resources.NewAmount(0),
 				}},
 			},
 		},
@@ -3408,10 +3408,10 @@ func TestReclaimBeforePriorityPreemption(t *testing.T) {
 		"Select first flavor which fits": {
 			workloadRequests: utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request("gpu", "10"),
 			testClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "uno", Resource: "gpu"}: 1,
+				{Flavor: "uno", Resource: "gpu"}: resources.NewAmount(1),
 			},
 			otherClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "due", Resource: "gpu"}: 1,
+				{Flavor: "due", Resource: "gpu"}: resources.NewAmount(1),
 			},
 			wantMode:      Fit,
 			wantAssigment: rfMap{"gpu": "tre"},
@@ -3419,11 +3419,11 @@ func TestReclaimBeforePriorityPreemption(t *testing.T) {
 		"Select first flavor where gpu reclamation is possible": {
 			workloadRequests: utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request("gpu", "10"),
 			testClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "uno", Resource: "gpu"}: 1,
+				{Flavor: "uno", Resource: "gpu"}: resources.NewAmount(1),
 			},
 			otherClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "due", Resource: "gpu"}: 1,
-				{Flavor: "tre", Resource: "gpu"}: 1,
+				{Flavor: "due", Resource: "gpu"}: resources.NewAmount(1),
+				{Flavor: "tre", Resource: "gpu"}: resources.NewAmount(1),
 			},
 			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
 				{Flavor: "uno", Resource: "gpu"}: {preemptioncommon.Preempt, 0},
@@ -3435,11 +3435,11 @@ func TestReclaimBeforePriorityPreemption(t *testing.T) {
 		"Select first flavor when flavor fungibility is disabled": {
 			workloadRequests: utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request("gpu", "10"),
 			testClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "uno", Resource: "gpu"}: 1,
+				{Flavor: "uno", Resource: "gpu"}: resources.NewAmount(1),
 			},
 			otherClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "due", Resource: "gpu"}: 1,
-				{Flavor: "tre", Resource: "gpu"}: 1,
+				{Flavor: "due", Resource: "gpu"}: resources.NewAmount(1),
+				{Flavor: "tre", Resource: "gpu"}: resources.NewAmount(1),
 			},
 			flavorFungibility: &kueue.FlavorFungibility{
 				WhenCanPreempt: kueue.MayStopSearch,
@@ -3450,11 +3450,11 @@ func TestReclaimBeforePriorityPreemption(t *testing.T) {
 		"Select first flavor when flavor fungibility is disabled; using deprecated WhenCanPreempt=MayStopSearch": {
 			workloadRequests: utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request("gpu", "10"),
 			testClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "uno", Resource: "gpu"}: 1,
+				{Flavor: "uno", Resource: "gpu"}: resources.NewAmount(1),
 			},
 			otherClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "due", Resource: "gpu"}: 1,
-				{Flavor: "tre", Resource: "gpu"}: 1,
+				{Flavor: "due", Resource: "gpu"}: resources.NewAmount(1),
+				{Flavor: "tre", Resource: "gpu"}: resources.NewAmount(1),
 			},
 			flavorFungibility: &kueue.FlavorFungibility{
 				WhenCanPreempt: kueue.MayStopSearch,
@@ -3465,9 +3465,9 @@ func TestReclaimBeforePriorityPreemption(t *testing.T) {
 		"Select first flavor where priority based preemption is possible": {
 			workloadRequests: utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request("gpu", "10"),
 			testClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "uno", Resource: "gpu"}: 1,
-				{Flavor: "due", Resource: "gpu"}: 1,
-				{Flavor: "tre", Resource: "gpu"}: 1,
+				{Flavor: "uno", Resource: "gpu"}: resources.NewAmount(1),
+				{Flavor: "due", Resource: "gpu"}: resources.NewAmount(1),
+				{Flavor: "tre", Resource: "gpu"}: resources.NewAmount(1),
 			},
 			wantMode:      Preempt,
 			wantAssigment: rfMap{"gpu": "uno"},
@@ -3475,13 +3475,13 @@ func TestReclaimBeforePriorityPreemption(t *testing.T) {
 		"Select second flavor where gpu reclamation is possible, as compute Fits": {
 			workloadRequests: utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request("gpu", "10").Request("compute", "10"),
 			testClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "uno", Resource: "gpu"}:     1,
-				{Flavor: "uno", Resource: "compute"}: 1,
-				{Flavor: "due", Resource: "compute"}: 1,
+				{Flavor: "uno", Resource: "gpu"}:     resources.NewAmount(1),
+				{Flavor: "uno", Resource: "compute"}: resources.NewAmount(1),
+				{Flavor: "due", Resource: "compute"}: resources.NewAmount(1),
 			},
 			otherClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "due", Resource: "gpu"}: 1,
-				{Flavor: "tre", Resource: "gpu"}: 1,
+				{Flavor: "due", Resource: "gpu"}: resources.NewAmount(1),
+				{Flavor: "tre", Resource: "gpu"}: resources.NewAmount(1),
 			},
 			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
 				{Flavor: "uno", Resource: "gpu"}: {preemptioncommon.Preempt, 0},
@@ -3619,7 +3619,7 @@ func TestDeletedFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
-					{Flavor: "flavor", Resource: corev1.ResourceCPU}: 3_000,
+					{Flavor: "flavor", Resource: corev1.ResourceCPU}: resources.NewAmount(3_000),
 				}},
 			},
 		},
@@ -3779,10 +3779,10 @@ func TestHierarchical(t *testing.T) {
 		"Select the top flavor": {
 			workloadRequests: utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "4"),
 			testClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 4_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(4_000),
 			},
 			otherClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "two", Resource: corev1.ResourceCPU}: 4_000,
+				{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(4_000),
 			},
 			wantMode:      Fit,
 			wantAssigment: rfMap{corev1.ResourceCPU: "three"},
@@ -3790,7 +3790,7 @@ func TestHierarchical(t *testing.T) {
 		"Select the first flavor which fits": {
 			workloadRequests: utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "4"),
 			testClusterQueueUsage: resources.FlavorResourceQuantities{
-				{Flavor: "one", Resource: corev1.ResourceCPU}: 4_000,
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(4_000),
 			},
 			wantMode:      Fit,
 			wantAssigment: rfMap{corev1.ResourceCPU: "two"},
@@ -4250,8 +4250,8 @@ func TestAssignment_TotalRequestsFor(t *testing.T) {
 					Obj()),
 			},
 			want: resources.FlavorResourceQuantities{ // Want quantities for 2 pods.
-				resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceCPU}:    2 * 1000,
-				resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceMemory}: 2 * 1048576,
+				resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceCPU}:    resources.NewAmount(2 * 1000),
+				resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceMemory}: resources.NewAmount(2 * 1048576),
 			},
 		},
 		"WorkloadWithPartialAdmission": {
@@ -4279,8 +4279,8 @@ func TestAssignment_TotalRequestsFor(t *testing.T) {
 					Obj()),
 			},
 			want: resources.FlavorResourceQuantities{ // Want quantity for 1 pod.
-				resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceCPU}:    1000,
-				resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceMemory}: 1048576,
+				resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceCPU}:    resources.NewAmount(1000),
+				resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceMemory}: resources.NewAmount(1048576),
 			},
 		},
 		"WorkloadWithReplacement": {
@@ -4313,8 +4313,8 @@ func TestAssignment_TotalRequestsFor(t *testing.T) {
 					Obj()),
 			},
 			want: resources.FlavorResourceQuantities{
-				resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceCPU}:    2 * 1000,
-				resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceMemory}: 2 * 1048576,
+				resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceCPU}:    resources.NewAmount(2 * 1000),
+				resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceMemory}: resources.NewAmount(2 * 1048576),
 			},
 		},
 		"WorkloadWithZeroQuantityResourceNotInClusterQueueSkipsResourceWithoutFlavor": {
@@ -4343,8 +4343,8 @@ func TestAssignment_TotalRequestsFor(t *testing.T) {
 					Obj()),
 			},
 			want: resources.FlavorResourceQuantities{
-				resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceCPU}:    2 * 1000,
-				resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceMemory}: 2 * 1048576,
+				resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceCPU}:    resources.NewAmount(2 * 1000),
+				resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceMemory}: resources.NewAmount(2 * 1048576),
 			},
 		},
 		"WorkloadWithMultiplePodSetsOneUnchangedReplacement": {
@@ -4407,8 +4407,8 @@ func TestAssignment_TotalRequestsFor(t *testing.T) {
 				// coordinator: (3 - 1) * 2 CPU = 4 (need 2 more pods worth of resources)
 				// Total CPU: 0 + 4000m = 4000m
 				// Total Memory: 0 + 4Mi = 4Mi
-				resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceCPU}:    4 * 1000,
-				resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceMemory}: 4 * 1048576,
+				resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceCPU}:    resources.NewAmount(4 * 1000),
+				resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceMemory}: resources.NewAmount(4 * 1048576),
 			},
 		},
 	}

--- a/pkg/scheduler/preemption/classical/hierarchical_preemption.go
+++ b/pkg/scheduler/preemption/classical/hierarchical_preemption.go
@@ -218,16 +218,16 @@ func getNodeHeight(node *schdcache.CohortSnapshot) int {
 // that fits additional val of resource fr. If no such subtree exists, it returns
 // height the whole cohort hierarchy. Note that height of a trivial subtree
 // with only one node is 0. It also returns if the returned subtree is smaller than the whole cohort tree.
-func FindHeightOfLowestSubtreeThatFits(c *schdcache.ClusterQueueSnapshot, fr resources.FlavorResource, val int64) (int, bool) {
+func FindHeightOfLowestSubtreeThatFits(c *schdcache.ClusterQueueSnapshot, fr resources.FlavorResource, val resources.Amount) (int, bool) {
 	if !c.BorrowingWith(fr, val) || !c.HasParent() {
 		return 0, c.HasParent()
 	}
-	remaining := val - schdcache.LocalAvailable(c, fr)
+	remaining := val.Sub(schdcache.LocalAvailable(c, fr))
 	for trackingNode := range c.PathParentToRoot() {
 		if !trackingNode.BorrowingWith(fr, remaining) {
 			return getNodeHeight(trackingNode), trackingNode.HasParent()
 		}
-		remaining -= schdcache.LocalAvailable(trackingNode, fr)
+		remaining = remaining.Sub(schdcache.LocalAvailable(trackingNode, fr))
 	}
 	// no fit found
 	return getNodeHeight(c.Parent().Root()), false

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -617,10 +617,10 @@ func cqIsBorrowing(cq *schdcache.ClusterQueueSnapshot, frsNeedPreemption sets.Se
 // if it belongs to one.
 func workloadFits(preemptionCtx *preemptionCtx, allowBorrowing bool) bool {
 	for fr, v := range preemptionCtx.workloadUsage.Quota {
-		if !allowBorrowing && preemptionCtx.preemptorCQ.BorrowingWith(fr, v) {
+		if !allowBorrowing && preemptionCtx.preemptorCQ.BorrowingWith(fr, v.Int64()) {
 			return false
 		}
-		if v > preemptionCtx.preemptorCQ.Available(fr) {
+		if v.Int64() > preemptionCtx.preemptorCQ.Available(fr) {
 			return false
 		}
 	}
@@ -644,7 +644,7 @@ func workloadFitsForFairSharing(preemptionCtx *preemptionCtx) bool {
 // for all flavor-resources needing preemption.
 func queueUnderNominalInResourcesNeedingPreemption(preemptionCtx *preemptionCtx) bool {
 	for fr := range preemptionCtx.frsNeedPreemption {
-		if preemptionCtx.preemptorCQ.ResourceNode.Usage[fr] >= preemptionCtx.preemptorCQ.QuotaFor(fr).Nominal {
+		if preemptionCtx.preemptorCQ.QuotaFor(fr).Nominal.Cmp(preemptionCtx.preemptorCQ.ResourceNode.Usage[fr]) <= 0 {
 			return false
 		}
 	}

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -617,10 +617,10 @@ func cqIsBorrowing(cq *schdcache.ClusterQueueSnapshot, frsNeedPreemption sets.Se
 // if it belongs to one.
 func workloadFits(preemptionCtx *preemptionCtx, allowBorrowing bool) bool {
 	for fr, v := range preemptionCtx.workloadUsage.Quota {
-		if !allowBorrowing && preemptionCtx.preemptorCQ.BorrowingWith(fr, v.Int64()) {
+		if !allowBorrowing && preemptionCtx.preemptorCQ.BorrowingWith(fr, v) {
 			return false
 		}
-		if v.Int64() > preemptionCtx.preemptorCQ.Available(fr) {
+		if v.Cmp(preemptionCtx.preemptorCQ.Available(fr)) > 0 {
 			return false
 		}
 	}

--- a/pkg/scheduler/preemption/preemption_oracle.go
+++ b/pkg/scheduler/preemption/preemption_oracle.go
@@ -52,7 +52,7 @@ func (p *PreemptionOracle) SimulatePreemption(
 		preemptorCQ:       p.snapshot.ClusterQueue(wl.ClusterQueue),
 		snapshot:          p.snapshot,
 		frsNeedPreemption: sets.New(fr),
-		workloadUsage:     workload.Usage{Quota: resources.FlavorResourceQuantities{fr: quantity}},
+		workloadUsage:     workload.Usage{Quota: resources.FlavorResourceQuantities{fr: resources.NewAmount(quantity)}},
 	})
 
 	if len(candidates) == 0 {

--- a/pkg/scheduler/preemption/preemption_oracle.go
+++ b/pkg/scheduler/preemption/preemption_oracle.go
@@ -43,7 +43,7 @@ func (p *PreemptionOracle) SimulatePreemption(
 	cq *schdcache.ClusterQueueSnapshot,
 	wl workload.Info,
 	fr resources.FlavorResource,
-	quantity int64,
+	quantity resources.Amount,
 ) (preemptioncommon.PreemptionPossibility, int) {
 	candidates := p.preemptor.getTargets(&preemptionCtx{
 		clock:             p.preemptor.clock,
@@ -52,7 +52,7 @@ func (p *PreemptionOracle) SimulatePreemption(
 		preemptorCQ:       p.snapshot.ClusterQueue(wl.ClusterQueue),
 		snapshot:          p.snapshot,
 		frsNeedPreemption: sets.New(fr),
-		workloadUsage:     workload.Usage{Quota: resources.FlavorResourceQuantities{fr: resources.NewAmount(quantity)}},
+		workloadUsage:     workload.Usage{Quota: resources.FlavorResourceQuantities{fr: quantity}},
 	})
 
 	if len(candidates) == 0 {

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -52,7 +52,7 @@ import (
 var snapCmpOpts = cmp.Options{
 	// ignore zero values during comparison, as we consider
 	// zero FlavorResource usage to be same as no map entry.
-	cmpopts.IgnoreMapEntries(func(_ resources.FlavorResource, v int64) bool { return v == 0 }),
+	cmpopts.IgnoreMapEntries(func(_ resources.FlavorResource, v resources.Amount) bool { return v.CmpInt64(0) == 0 }),
 	cmp.AllowUnexported(hierarchy.Manager[*schdcache.ClusterQueueSnapshot, *schdcache.CohortSnapshot]{}),
 	cmpopts.IgnoreFields(hierarchy.Manager[*schdcache.ClusterQueueSnapshot, *schdcache.CohortSnapshot]{}, "cohortFactory"),
 	cmpopts.IgnoreFields(schdcache.CohortSnapshot{}, "Cohort"),

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -656,10 +656,10 @@ func quotaResourcesToReserve(e *entry, cq *schdcache.ClusterQueueSnapshot) resou
 			if cqQuota.BorrowingLimit == nil {
 				reservedUsage[fr] = usage
 			} else {
-				reservedUsage[fr] = min(usage, cqQuota.Nominal+*cqQuota.BorrowingLimit-cq.ResourceNode.Usage[fr])
+				reservedUsage[fr] = resources.MinAmount(usage, cqQuota.Nominal.Add(*cqQuota.BorrowingLimit).Sub(cq.ResourceNode.Usage[fr]))
 			}
 		} else {
-			reservedUsage[fr] = max(0, min(usage, cqQuota.Nominal-cq.ResourceNode.Usage[fr]))
+			reservedUsage[fr] = resources.NewAmount(max(0, resources.MinAmount(usage, cqQuota.Nominal.Sub(cq.ResourceNode.Usage[fr])).Int64()))
 		}
 	}
 	return reservedUsage

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -659,7 +659,7 @@ func quotaResourcesToReserve(e *entry, cq *schdcache.ClusterQueueSnapshot) resou
 				reservedUsage[fr] = resources.MinAmount(usage, cqQuota.Nominal.Add(*cqQuota.BorrowingLimit).Sub(cq.ResourceNode.Usage[fr]))
 			}
 		} else {
-			reservedUsage[fr] = resources.NewAmount(max(0, resources.MinAmount(usage, cqQuota.Nominal.Sub(cq.ResourceNode.Usage[fr])).Int64()))
+			reservedUsage[fr] = resources.MaxAmount(resources.NewAmount(0), resources.MinAmount(usage, cqQuota.Nominal.Sub(cq.ResourceNode.Usage[fr])))
 		}
 	}
 	return reservedUsage

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -7391,8 +7391,8 @@ func TestEntryComparerLess(t *testing.T) {
 				{parentCohort: cohort, workloadKey: "default/borrowing"}: schdcache.BorrowingDRS(cpuDefault),
 			},
 			requestedFRs: map[workload.Reference]resources.FlavorResourceQuantities{
-				"default/nominal":   {cpuDefault: 1},
-				"default/borrowing": {cpuDefault: 1},
+				"default/nominal":   {cpuDefault: resources.NewAmount(1)},
+				"default/borrowing": {cpuDefault: resources.NewAmount(1)},
 			},
 			wantLess: true,
 		},
@@ -7421,8 +7421,8 @@ func TestEntryComparerLess(t *testing.T) {
 				{parentCohort: cohort, workloadKey: "default/borrow-b"}: schdcache.BorrowingDRS(cpuDefault),
 			},
 			requestedFRs: map[workload.Reference]resources.FlavorResourceQuantities{
-				"default/borrow-a": {cpuDefault: 1},
-				"default/borrow-b": {cpuDefault: 1},
+				"default/borrow-a": {cpuDefault: resources.NewAmount(1)},
+				"default/borrow-b": {cpuDefault: resources.NewAmount(1)},
 			},
 			wantLess: false,
 		},
@@ -7529,72 +7529,72 @@ func TestResourcesToReserve(t *testing.T) {
 			name:           "Reserved memory and gpu less than assignment usage, assignment preempts",
 			assignmentMode: flavorassigner.Preempt,
 			assignmentUsage: resources.FlavorResourceQuantities{
-				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 50,
-				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   6,
+				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: resources.NewAmount(50),
+				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   resources.NewAmount(6),
 			},
 			cqUsage: resources.FlavorResourceQuantities{
-				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 60,
-				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}:      50,
-				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   6,
-				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:                   2,
+				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: resources.NewAmount(60),
+				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}:      resources.NewAmount(50),
+				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   resources.NewAmount(6),
+				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:                   resources.NewAmount(2),
 			},
 			wantReserved: resources.FlavorResourceQuantities{
-				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 40,
-				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   4,
+				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: resources.NewAmount(40),
+				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   resources.NewAmount(4),
 			},
 		},
 		{
 			name:           "Reserved memory equal assignment usage, assignment preempts",
 			assignmentMode: flavorassigner.Preempt,
 			assignmentUsage: resources.FlavorResourceQuantities{
-				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 30,
-				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   2,
+				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: resources.NewAmount(30),
+				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   resources.NewAmount(2),
 			},
 			cqUsage: resources.FlavorResourceQuantities{
-				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 60,
-				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}:      50,
-				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   2,
-				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:                   2,
+				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: resources.NewAmount(60),
+				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}:      resources.NewAmount(50),
+				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   resources.NewAmount(2),
+				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:                   resources.NewAmount(2),
 			},
 			wantReserved: resources.FlavorResourceQuantities{
-				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 30,
-				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   2,
+				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: resources.NewAmount(30),
+				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   resources.NewAmount(2),
 			},
 		},
 		{
 			name:           "Reserved memory equal assignment usage, assignment fits",
 			assignmentMode: flavorassigner.Fit,
 			assignmentUsage: resources.FlavorResourceQuantities{
-				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 50,
-				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   2,
+				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: resources.NewAmount(50),
+				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   resources.NewAmount(2),
 			},
 			cqUsage: resources.FlavorResourceQuantities{
-				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 60,
-				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}:      50,
-				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   2,
-				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:                   2,
+				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: resources.NewAmount(60),
+				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}:      resources.NewAmount(50),
+				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   resources.NewAmount(2),
+				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:                   resources.NewAmount(2),
 			},
 			wantReserved: resources.FlavorResourceQuantities{
-				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 50,
-				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   2,
+				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: resources.NewAmount(50),
+				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   resources.NewAmount(2),
 			},
 		},
 		{
 			name:           "Reserved memory is 0, CQ is borrowing, assignment preempts without borrowing",
 			assignmentMode: flavorassigner.Preempt,
 			assignmentUsage: resources.FlavorResourceQuantities{
-				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}: 50,
-				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:              2,
+				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}: resources.NewAmount(50),
+				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:              resources.NewAmount(2),
 			},
 			cqUsage: resources.FlavorResourceQuantities{
-				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 60,
-				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}:      60,
-				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   2,
-				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:                   10,
+				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: resources.NewAmount(60),
+				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}:      resources.NewAmount(60),
+				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   resources.NewAmount(2),
+				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:                   resources.NewAmount(10),
 			},
 			wantReserved: resources.FlavorResourceQuantities{
-				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}: 0,
-				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:              0,
+				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}: resources.NewAmount(0),
+				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:              resources.NewAmount(0),
 			},
 		},
 		{
@@ -7602,18 +7602,18 @@ func TestResourcesToReserve(t *testing.T) {
 			assignmentMode: flavorassigner.Preempt,
 			borrowing:      1,
 			assignmentUsage: resources.FlavorResourceQuantities{
-				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}: 50,
-				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:              2,
+				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}: resources.NewAmount(50),
+				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:              resources.NewAmount(2),
 			},
 			cqUsage: resources.FlavorResourceQuantities{
-				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 60,
-				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}:      60,
-				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   2,
-				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:                   10,
+				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: resources.NewAmount(60),
+				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}:      resources.NewAmount(60),
+				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   resources.NewAmount(2),
+				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:                   resources.NewAmount(10),
 			},
 			wantReserved: resources.FlavorResourceQuantities{
-				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}: 40,
-				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:              2,
+				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}: resources.NewAmount(40),
+				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:              resources.NewAmount(2),
 			},
 		},
 		{
@@ -7621,18 +7621,18 @@ func TestResourcesToReserve(t *testing.T) {
 			assignmentMode: flavorassigner.Preempt,
 			borrowing:      1,
 			assignmentUsage: resources.FlavorResourceQuantities{
-				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 50,
-				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:                   2,
+				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: resources.NewAmount(50),
+				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:                   resources.NewAmount(2),
 			},
 			cqUsage: resources.FlavorResourceQuantities{
-				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 60,
-				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}:      60,
-				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   2,
-				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:                   10,
+				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: resources.NewAmount(60),
+				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}:      resources.NewAmount(60),
+				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   resources.NewAmount(2),
+				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:                   resources.NewAmount(10),
 			},
 			wantReserved: resources.FlavorResourceQuantities{
-				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 50,
-				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:                   2,
+				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: resources.NewAmount(50),
+				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:                   resources.NewAmount(2),
 			},
 		},
 	}
@@ -7671,7 +7671,7 @@ func TestResourcesToReserve(t *testing.T) {
 
 			i := 0
 			for fr, v := range tc.cqUsage {
-				quantity := resources.ResourceQuantity(fr.Resource, v)
+				quantity := resources.ResourceQuantity(fr.Resource, v.Int64())
 				admission := utiltestingapi.MakeAdmission("cq").
 					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
 						Assignment(fr.Resource, fr.Flavor, quantity.String()).

--- a/pkg/util/math/math.go
+++ b/pkg/util/math/math.go
@@ -34,6 +34,18 @@ func SaturatingAdd(a, b int64) int64 {
 	return a + b
 }
 
+// SaturatingSub subtracts b from a, returning math.MaxInt64 or math.MinInt64 if
+// the result would overflow or underflow.
+func SaturatingSub(a, b int64) int64 {
+	if b < 0 && a > stdmath.MaxInt64+b {
+		return stdmath.MaxInt64
+	}
+	if b > 0 && a < stdmath.MinInt64+b {
+		return stdmath.MinInt64
+	}
+	return a - b
+}
+
 var (
 	maxMilliValue = *resource.NewMilliQuantity(stdmath.MaxInt64, resource.DecimalSI)
 	minMilliValue = *resource.NewMilliQuantity(stdmath.MinInt64, resource.DecimalSI)

--- a/pkg/util/math/math_test.go
+++ b/pkg/util/math/math_test.go
@@ -53,3 +53,27 @@ func TestSaturatingMul(t *testing.T) {
 		})
 	}
 }
+
+func TestSaturatingSub(t *testing.T) {
+	cases := map[string]struct {
+		a    int64
+		b    int64
+		want int64
+	}{
+		"normal subtraction":              {a: 10, b: 3, want: 7},
+		"zero":                            {a: 5, b: 5, want: 0},
+		"negative result":                 {a: 3, b: 10, want: -7},
+		"underflow: MinInt64 - 1":         {a: stdmath.MinInt64, b: 1, want: stdmath.MinInt64},
+		"underflow: MinInt64 - large":     {a: stdmath.MinInt64, b: stdmath.MaxInt64, want: stdmath.MinInt64},
+		"overflow: MaxInt64 - (-1)":       {a: stdmath.MaxInt64, b: -1, want: stdmath.MaxInt64},
+		"overflow: MaxInt64 - MinInt64":   {a: stdmath.MaxInt64, b: stdmath.MinInt64, want: stdmath.MaxInt64},
+		"subtract negative: 0 - MinInt64": {a: 0, b: stdmath.MinInt64, want: stdmath.MaxInt64},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := SaturatingSub(tc.a, tc.b); got != tc.want {
+				t.Errorf("SaturatingSub(%d, %d) = %d, want %d", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -387,7 +387,7 @@ func (i *Info) FlavorResourceUsage() resources.FlavorResourceQuantities {
 	for _, psReqs := range i.TotalRequests {
 		for res, q := range psReqs.Requests {
 			flv := psReqs.Flavors[res]
-			total[resources.FlavorResource{Flavor: flv, Resource: res}] += q
+			total[resources.FlavorResource{Flavor: flv, Resource: res}] = total[resources.FlavorResource{Flavor: flv, Resource: res}].AddInt64(q)
 		}
 	}
 	return total

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1050,8 +1050,8 @@ func TestFlavorResourceUsage(t *testing.T) {
 				}},
 			},
 			want: resources.FlavorResourceQuantities{
-				{Flavor: "", Resource: "cpu"}:             1_000,
-				{Flavor: "", Resource: "example.com/gpu"}: 3,
+				{Flavor: "", Resource: "cpu"}:             resources.NewAmount(1_000),
+				{Flavor: "", Resource: "example.com/gpu"}: resources.NewAmount(3),
 			},
 		},
 		"one podset, multiple flavors": {
@@ -1068,8 +1068,8 @@ func TestFlavorResourceUsage(t *testing.T) {
 				}},
 			},
 			want: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: "cpu"}:         1_000,
-				{Flavor: "gpu", Resource: "example.com/gpu"}: 3,
+				{Flavor: "default", Resource: "cpu"}:         resources.NewAmount(1_000),
+				{Flavor: "gpu", Resource: "example.com/gpu"}: resources.NewAmount(3),
 			},
 		},
 		"multiple podsets, multiple flavors": {
@@ -1106,10 +1106,10 @@ func TestFlavorResourceUsage(t *testing.T) {
 				},
 			},
 			want: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: "cpu"}:             3_000,
-				{Flavor: "default", Resource: "memory"}:          2 * utiltesting.Gi,
-				{Flavor: "model_a", Resource: "example.com/gpu"}: 3,
-				{Flavor: "model_b", Resource: "example.com/gpu"}: 1,
+				{Flavor: "default", Resource: "cpu"}:             resources.NewAmount(3_000),
+				{Flavor: "default", Resource: "memory"}:          resources.NewAmount(2 * utiltesting.Gi),
+				{Flavor: "model_a", Resource: "example.com/gpu"}: resources.NewAmount(3),
+				{Flavor: "model_b", Resource: "example.com/gpu"}: resources.NewAmount(1),
 			},
 		},
 	}

--- a/test/integration/singlecluster/scheduler/quotacheckstrategy/quota_check_strategy_test.go
+++ b/test/integration/singlecluster/scheduler/quotacheckstrategy/quota_check_strategy_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -148,15 +147,8 @@ var _ = ginkgo.Describe("Quota check strategy", ginkgo.Ordered, ginkgo.ContinueO
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 
-			createdWl := &kueue.Workload{}
 			wlKey := client.ObjectKeyFromObject(wl)
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, wlKey, createdWl)).To(gomega.Succeed())
-				g.Expect(workload.IsAdmitted(createdWl)).To(gomega.BeTrue(), "expected workload to be admitted with very large nominal quota")
-				cond := apimeta.FindStatusCondition(createdWl.Status.Conditions, kueue.WorkloadQuotaReserved)
-				g.Expect(cond).NotTo(gomega.BeNil())
-				g.Expect(cond.Message).NotTo(gomega.ContainSubstring("maximum capacity (0)"))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.ExpectWorkloadsToBeAdmittedByKeys(ctx, k8sClient, wlKey)
 		})
 	})
 	ginkgo.When("quota check strategy is set to IgnoreUndeclared and feature gate is disabled", func() {

--- a/test/integration/singlecluster/scheduler/quotacheckstrategy/quota_check_strategy_test.go
+++ b/test/integration/singlecluster/scheduler/quotacheckstrategy/quota_check_strategy_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -46,7 +47,6 @@ var _ = ginkgo.Describe("Quota check strategy", ginkgo.Ordered, ginkgo.ContinueO
 		)
 
 		ginkgo.BeforeAll(func() {
-			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.QuotaCheckStrategy, true)
 			fwk.StartManager(ctx, cfg, managerAndSchedulerSetup(
 				configapi.QuotaCheckIgnoreUndeclared,
 				&configapi.AdmissionFairSharing{
@@ -61,6 +61,7 @@ var _ = ginkgo.Describe("Quota check strategy", ginkgo.Ordered, ginkgo.ContinueO
 		})
 
 		ginkgo.BeforeEach(func() {
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.QuotaCheckStrategy, true)
 			ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "quota-check-strategy-")
 
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
@@ -131,6 +132,30 @@ var _ = ginkgo.Describe("Quota check strategy", ginkgo.Ordered, ginkgo.ContinueO
 			gomega.Eventually(func(g gomega.Gomega) {
 				penalty := qManager.AfsEntryPenalties.Peek(lqKey)
 				g.Expect(penalty).NotTo(gomega.HaveKey(corev1.ResourceName("example.com/gpu")))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+		ginkgo.It("should admit workload when nominalQuota is 1E for cpu", func() {
+			updatedCq := &kueue.ClusterQueue{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), updatedCq)).To(gomega.Succeed())
+				updatedCq.Spec.ResourceGroups[0].Flavors[0].Resources[0].NominalQuota = resource.MustParse("1E")
+				g.Expect(k8sClient.Update(ctx, updatedCq)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			wl := utiltestingapi.MakeWorkload("wl-1", ns.Name).
+				Queue(kueue.LocalQueueName(lq.Name)).
+				Request(corev1.ResourceCPU, "3").
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+			createdWl := &kueue.Workload{}
+			wlKey := client.ObjectKeyFromObject(wl)
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, createdWl)).To(gomega.Succeed())
+				g.Expect(workload.IsAdmitted(createdWl)).To(gomega.BeTrue(), "expected workload to be admitted with very large nominal quota")
+				cond := apimeta.FindStatusCondition(createdWl.Status.Conditions, kueue.WorkloadQuotaReserved)
+				g.Expect(cond).NotTo(gomega.BeNil())
+				g.Expect(cond.Message).NotTo(gomega.ContainSubstring("maximum capacity (0)"))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

Introduce a dedicated resources.Amount struct for quota arithmetic and migrate quota storage to Amount in scheduler quota paths (Nominal/BorrowingLimit/LendingLimit and SubtreeQuota).
AmountFromQuantity will treat out-of-range quota quantities (for example 1E CPU in milli units) as Unlimited, and all quota math and comparisons will be done through Amount methods so cohort aggregation cannot overflow.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9843 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
