### PR TITLE
Cherry Pick for test : split e2e singlecluster to baseline and extended PR-11138

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -38,7 +38,7 @@ INTEGRATION_API_LOG_LEVEL ?= 0
 
 # Folder where the e2e tests are located.
 E2E_TARGET ?= ./test/e2e/...
-E2E_K8S_VERSIONS ?= 1.32.11 1.33.7 1.34.3 1.35.0
+E2E_K8S_VERSIONS ?= 1.33.7 1.34.3 1.35.0
 E2E_K8S_VERSION ?= 1.35
 E2E_K8S_FULL_VERSION ?= $(filter $(E2E_K8S_VERSION).%,$(E2E_K8S_VERSIONS))
 # Default to E2E_K8S_VERSION.0 if no match is found
@@ -49,6 +49,7 @@ E2E_USE_HELM ?= false
 E2E_MODE ?= ci
 E2E_SKIP_REINSTALL ?= false
 KUEUE_UPGRADE_FROM_VERSION ?= v0.14.8
+PROMETHEUS_OPERATOR_VERSION ?= v0.89.0
 # When truthy, force re-installing external operators (MPI, Ray, etc.) on each run, even in E2E_MODE=dev.
 E2E_ENFORCE_OPERATOR_UPDATE ?= false
 
@@ -81,7 +82,7 @@ test: gotestsum ## Run tests.
 
 ## Label Taxonomy:
 ##   Controllers: controller:workload, controller:localqueue, controller:clusterqueue, controller:admissioncheck, controller:resourceflavor, controller:provisioning
-##   Job Types: job:batch, job:pod, job:jobset, job:pytorch, job:tensorflow, job:mpi, job:paddle, job:xgboost, job:jax, job:train, job:ray, job:appwrapper
+##   Job Types: job:batch, job:pod, job:jobset, job:pytorch, job:tensorflow, job:mpi, job:paddle, job:xgboost, job:jax, job:train, job:ray, job:appwrapper, job:sparkapplication
 ##   Features: feature:tas, feature:multikueue, feature:provisioning, feature:fairsharing, feature:admissionfairsharing
 ##   Areas: area:core, area:jobs, area:admissionchecks, area:multikueue
 ##
@@ -130,20 +131,16 @@ test-multikueue-integration: compile-crd-manifests envtest ginkgo dep-crds ginkg
 	$(GINKGO) $(INTEGRATION_FILTERS) $(GINKGO_ARGS) $(GOFLAGS) -procs=$(INTEGRATION_NPROCS_MULTIKUEUE) --race --junit-report=multikueue-junit.xml --json-report=multikueue-integration.json --output-interceptor-mode=none --output-dir=$(ARTIFACTS) -v $(INTEGRATION_TARGET_MULTIKUEUE)
 	$(BIN_DIR)/ginkgo-top -i $(ARTIFACTS)/multikueue-integration.json > $(ARTIFACTS)/multikueue-integration-top.yaml
 
-## Label Taxonomy:
-##   Features: appwrapper,certs,deployment,job,fairsharing,jaxjob,jobset,kuberay,kueuectl,leaderworkerset,metrics,pod,pytorchjob,statefulset,tas,trainjob,visibility,e2e_v1beta1,ha
-##
-## Examples:
-##   Run only AppWrapper tests: GINKGO_ARGS="--label-filter=feature:appwrapper" make test-e2e
-##   Run only certs tests: GINKGO_ARGS="--label-filter=feature:certs" make test-e2e
-##   Run only jobset and trainjob tests: GINKGO_ARGS="--label-filter=feature:jobset,feature:trainjob" make test-e2e
-test-e2e: E2E_NPROCS := 4
 .PHONY: test-e2e
-test-e2e: setup-e2e-env kueuectl kind-ray-project-mini-image-build run-test-e2e-singlecluster-$(E2E_KIND_VERSION:kindest/node:v%=%)
+test-e2e: test-e2e-baseline test-e2e-extended
 
-.PHONY: test-e2e-helm
-test-e2e-helm: E2E_USE_HELM=true
-test-e2e-helm: test-e2e
+.PHONY: test-e2e-baseline-helm
+test-e2e-baseline-helm: E2E_USE_HELM=true
+test-e2e-baseline-helm: test-e2e-baseline
+
+.PHONY: test-e2e-extended-helm
+test-e2e-extended-helm: E2E_USE_HELM=true
+test-e2e-extended-helm: test-e2e-extended
 
 .PHONY: test-multikueue-e2e-parallel-builds
 test-multikueue-e2e-parallel-builds:
@@ -159,6 +156,24 @@ test-multikueue-e2e-sequential: setup-e2e-env test-multikueue-e2e-parallel-build
 .PHONY: test-multikueue-e2e-helm
 test-multikueue-e2e-helm: E2E_USE_HELM=true
 test-multikueue-e2e-helm: test-multikueue-e2e
+
+## Label Taxonomy:
+##   Features: appwrapper,jaxjob,jobset,kuberay,leaderworkerset,pytorchjob,tas,trainjob
+##
+## Examples:
+##   Run only AppWrapper tests: GINKGO_ARGS="--label-filter=feature:appwrapper" make test-e2e-extended
+.PHONY: test-e2e-extended
+test-e2e-extended: E2E_NPROCS := 4
+test-e2e-extended: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
+
+## Label Taxonomy:
+##   Features: certs,deployment,job,fairsharing,kueuectl,metrics,pod,statefulset,visibility,e2e_v1beta1,ha
+##
+## Examples:
+##   Run only job tests: GINKGO_ARGS="--label-filter=feature:job" make test-e2e-baseline
+.PHONY: test-e2e-baseline
+test-e2e-baseline: E2E_NPROCS := 4
+test-e2e-baseline: setup-e2e-env kueuectl run-test-e2e-baseline-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-tas-e2e-baseline
 test-tas-e2e-baseline: setup-e2e-env run-test-tas-e2e-baseline-$(E2E_KIND_VERSION:kindest/node:v%=%)
@@ -209,9 +224,27 @@ test-e2e-certmanager-upgrade: setup-e2e-env run-test-e2e-certmanager-upgrade-$(E
 .PHONY: test-e2e-dra
 test-e2e-dra: setup-e2e-env run-test-e2e-dra-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
-run-test-e2e-singlecluster-%: K8S_VERSION = $(@:run-test-e2e-singlecluster-%=%)
-run-test-e2e-singlecluster-%:
-	@echo Running e2e for k8s ${K8S_VERSION}
+.PHONY: test-e2e-multikueue-dra
+test-e2e-multikueue-dra: setup-e2e-env run-test-e2e-multikueue-dra-$(E2E_KIND_VERSION:kindest/node:v%=%)
+
+run-test-e2e-baseline-%: K8S_VERSION = $(@:run-test-e2e-baseline-%=%)
+run-test-e2e-baseline-%:
+	@echo Running baseline e2e for k8s ${K8S_VERSION}
+	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
+		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
+		E2E_MODE=$(E2E_MODE) \
+		E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
+		E2E_ENFORCE_OPERATOR_UPDATE=$(E2E_ENFORCE_OPERATOR_UPDATE) \
+		PROMETHEUS_OPERATOR_VERSION=$(PROMETHEUS_OPERATOR_VERSION) \
+		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="singlecluster/baseline" \
+		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
+		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
+		E2E_USE_HELM=$(E2E_USE_HELM) \
+		./hack/testing/e2e-test.sh
+
+run-test-e2e-extended-%: K8S_VERSION = $(@:run-test-e2e-extended-%=%)
+run-test-e2e-extended-%:
+	@echo Running extended e2e for k8s ${K8S_VERSION}
 	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
 		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
 		E2E_MODE=$(E2E_MODE) \
@@ -223,7 +256,7 @@ run-test-e2e-singlecluster-%:
 		KUBEFLOW_TRAINER_VERSION=$(KUBEFLOW_TRAINER_VERSION) \
 		LEADERWORKERSET_VERSION=$(LEADERWORKERSET_VERSION) \
 		KUBERAY_VERSION=$(KUBERAY_VERSION) RAY_VERSION=$(RAY_VERSION) RAYMINI_VERSION=$(RAYMINI_VERSION) USE_RAY_FOR_TESTS=$(USE_RAY_FOR_TESTS) \
-		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="singlecluster" \
+		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="singlecluster/extended" \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
 		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		E2E_USE_HELM=$(E2E_USE_HELM) \
@@ -242,6 +275,8 @@ run-test-multikueue-e2e-%:
 		KUBEFLOW_MPI_VERSION=$(KUBEFLOW_MPI_VERSION) \
 		KUBERAY_VERSION=$(KUBERAY_VERSION) RAY_VERSION=$(RAY_VERSION) RAYMINI_VERSION=$(RAYMINI_VERSION) USE_RAY_FOR_TESTS=$(USE_RAY_FOR_TESTS) \
 		KUBEFLOW_TRAINER_VERSION=$(KUBEFLOW_TRAINER_VERSION) \
+		LEADERWORKERSET_VERSION=$(LEADERWORKERSET_VERSION) \
+		E2E_TARGET_FOLDER="multikueue/baseline" \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
 		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		E2E_USE_HELM=$(E2E_USE_HELM) \
@@ -286,6 +321,7 @@ run-test-e2e-sequential-baseline-%:
 	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
 	ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
 	E2E_MODE=$(E2E_MODE) \
+	E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
 	E2E_ENFORCE_OPERATOR_UPDATE=$(E2E_ENFORCE_OPERATOR_UPDATE) \
 	KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="sequential/baseline" \
 	TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
@@ -299,7 +335,7 @@ run-test-e2e-sequential-extended-%:
 	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
 	ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
 	E2E_MODE=$(E2E_MODE) \
-		E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
+	E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
 	E2E_ENFORCE_OPERATOR_UPDATE=$(E2E_ENFORCE_OPERATOR_UPDATE) \
 	KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="sequential/extended" \
 	JOBSET_VERSION=$(JOBSET_VERSION) APPWRAPPER_VERSION=$(APPWRAPPER_VERSION) \
@@ -320,6 +356,7 @@ run-test-e2e-certmanager-%:
 		E2E_ENFORCE_OPERATOR_UPDATE=$(E2E_ENFORCE_OPERATOR_UPDATE) \
 		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="certmanager" \
 		CERTMANAGER_VERSION=$(CERTMANAGER_VERSION) \
+		PROMETHEUS_OPERATOR_VERSION=$(PROMETHEUS_OPERATOR_VERSION) \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
 		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		E2E_USE_HELM=$(E2E_USE_HELM) \
@@ -368,6 +405,19 @@ run-test-e2e-dra-%:
 		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		./hack/testing/e2e-test.sh
 
+run-test-e2e-multikueue-dra-%: K8S_VERSION = $(@:run-test-e2e-multikueue-dra-%=%)
+run-test-e2e-multikueue-dra-%:
+	@echo Running multikueue DRA e2e for k8s ${K8S_VERSION}
+	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
+		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
+		E2E_MODE=$(E2E_MODE) \
+		E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
+		E2E_ENFORCE_OPERATOR_UPDATE=$(E2E_ENFORCE_OPERATOR_UPDATE) \
+		DRA_EXAMPLE_DRIVER_VERSION=$(DRA_EXAMPLE_DRIVER_VERSION) \
+		E2E_TARGET_FOLDER="multikueue/dra" \
+		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
+		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
+		./hack/testing/e2e-multikueue-test.sh
 
 run-test-e2e-multikueue-sequential-%: K8S_VERSION = $(@:run-test-e2e-multikueue-sequential-%=%)
 run-test-e2e-multikueue-sequential-%:
@@ -377,7 +427,7 @@ run-test-e2e-multikueue-sequential-%:
 		E2E_MODE=$(E2E_MODE) \
 		E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
 		E2E_ENFORCE_OPERATOR_UPDATE=$(E2E_ENFORCE_OPERATOR_UPDATE) \
-		E2E_TARGET_FOLDER="multikueue-sequential" \
+		E2E_TARGET_FOLDER="multikueue/sequential" \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
 		CLUSTERPROFILE_VERSION=$(CLUSTERPROFILE_VERSION) \
 		CLUSTERPROFILE_PLUGIN_IMAGE_VERSION=$(CLUSTERPROFILE_PLUGIN_IMAGE_VERSION) \
@@ -385,6 +435,39 @@ run-test-e2e-multikueue-sequential-%:
 		E2E_USE_HELM=$(E2E_USE_HELM) \
 		./hack/testing/e2e-multikueue-test.sh
 
+# Run e2e tests against k/k main (latest CI build) with WAS enabled
+K8S_MAIN_NODE_IMAGE ?= k8s-main:latest
+.PHONY: test-e2e-k8s-main-was
+test-e2e-k8s-main-was: setup-e2e-env kueuectl kind-k8s-main-image-build kind-ray-project-mini-image-build run-test-e2e-k8s-main-was
+
+.PHONY: kind-k8s-main-image-build
+kind-k8s-main-image-build: kind
+	@echo "Fetching latest Kubernetes CI build version..."
+	$(eval K8S_CI_VERSION := $(shell curl -sL https://dl.k8s.io/ci/latest.txt))
+	@echo "Building kind node image from k/k main: $(K8S_CI_VERSION)"
+	$(KIND) build node-image --image=$(K8S_MAIN_NODE_IMAGE) \
+		"https://dl.k8s.io/ci/$(K8S_CI_VERSION)/kubernetes-server-linux-$(shell go env GOARCH).tar.gz"
+
+.PHONY: run-test-e2e-k8s-main-was
+run-test-e2e-k8s-main-was:
+	@echo Running e2e for k8s main with WAS enabled
+	E2E_KIND_VERSION="$(K8S_MAIN_NODE_IMAGE)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
+		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
+		E2E_MODE=$(E2E_MODE) \
+		E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
+		APPWRAPPER_VERSION=$(APPWRAPPER_VERSION) \
+		JOBSET_VERSION=$(JOBSET_VERSION) \
+		KUBEFLOW_VERSION=$(KUBEFLOW_VERSION) \
+		KUBEFLOW_TRAINER_VERSION=$(KUBEFLOW_TRAINER_VERSION) \
+		LEADERWORKERSET_VERSION=$(LEADERWORKERSET_VERSION) \
+		KUBERAY_VERSION=$(KUBERAY_VERSION) RAY_VERSION=$(RAY_VERSION) RAYMINI_VERSION=$(RAYMINI_VERSION) USE_RAY_FOR_TESTS=$(USE_RAY_FOR_TESTS) \
+		PROMETHEUS_OPERATOR_VERSION=$(PROMETHEUS_OPERATOR_VERSION) \
+		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="singlecluster" \
+		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
+		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
+		E2E_USE_HELM=$(E2E_USE_HELM) \
+		WAS_ENABLED=true \
+		./hack/testing/e2e-test.sh
 
 SCALABILITY_RUNNER := $(BIN_DIR)/performance-scheduler-runner
 .PHONY: performance-scheduler-runner
@@ -398,6 +481,10 @@ minimalkueue:
 
 ifdef SCALABILITY_CPU_PROFILE
 SCALABILITY_EXTRA_ARGS += --withCPUProfile=true
+endif
+
+ifdef SCALABILITY_MEM_PROFILE
+SCALABILITY_EXTRA_ARGS += --withMemProfile=true
 endif
 
 ifndef NO_SCALABILITY_KUEUE_LOGS
@@ -482,6 +569,42 @@ run-tas-performance-scheduler-in-cluster: envtest performance-scheduler-runner
 		--generatorConfig=$(SCALABILITY_TAS_GENERATOR_CONFIG) \
 		--enableTAS=true \
 		--qps=1000 --burst=2000 --timeout=25m $(SCALABILITY_SCRAPE_ARGS)
+
+##@ Scheduler Performance Testing - Large Scale
+
+SCALABILITY_LARGE_SCALE_GENERATOR_CONFIG ?= $(PROJECT_DIR)/test/performance/scheduler/configs/large-scale/generator.yaml
+SCALABILITY_LARGE_SCALE_RANGE_FILE ?= $(PROJECT_DIR)/test/performance/scheduler/configs/large-scale/rangespec.yaml
+
+.PHONY: run-large-scale-performance-scheduler
+run-large-scale-performance-scheduler: envtest performance-scheduler-runner minimalkueue
+	mkdir -p "$(ARTIFACTS)/$@"
+	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" \
+	$(SCALABILITY_RUNNER) \
+		--o "$(ARTIFACTS)/$@" \
+		--crds=$(PROJECT_DIR)/config/components/crd/bases \
+		--generatorConfig=$(SCALABILITY_LARGE_SCALE_GENERATOR_CONFIG) \
+		--minimalKueue=$(MINIMALKUEUE_RUNNER) \
+		--timeout=30m $(SCALABILITY_EXTRA_ARGS) $(SCALABILITY_SCRAPE_ARGS)
+
+.PHONY: test-large-scale-performance-scheduler-once
+test-large-scale-performance-scheduler-once: gotestsum run-large-scale-performance-scheduler
+	$(GOTESTSUM) --junitfile $(ARTIFACTS)/junit.xml -- $(GO_TEST_FLAGS) ./test/performance/scheduler/checker  \
+		--summary=$(ARTIFACTS)/run-large-scale-performance-scheduler/summary.yaml \
+		--cmdStats=$(ARTIFACTS)/run-large-scale-performance-scheduler/minimalkueue.stats.yaml \
+		--range=$(SCALABILITY_LARGE_SCALE_RANGE_FILE)
+
+.PHONY: test-large-scale-performance-scheduler
+test-large-scale-performance-scheduler:
+	ARTIFACTS="$(ARTIFACTS)/$@" ./hack/testing/performance-test.sh $(PERFORMANCE_RETRY_COUNT) test-large-scale-performance-scheduler-once
+
+.PHONY: run-large-scale-performance-scheduler-in-cluster
+run-large-scale-performance-scheduler-in-cluster: envtest performance-scheduler-runner
+	mkdir -p "$(ARTIFACTS)/$@"
+	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" \
+	$(SCALABILITY_RUNNER) \
+		--o "$(ARTIFACTS)/$@" \
+		--generatorConfig=$(SCALABILITY_LARGE_SCALE_GENERATOR_CONFIG) \
+		--qps=1000 --burst=2000 --timeout=30m $(SCALABILITY_SCRAPE_ARGS)
 
 .PHONY: ginkgo-top
 ginkgo-top:

--- a/site/content/en/docs/contribution_guidelines/testing.md
+++ b/site/content/en/docs/contribution_guidelines/testing.md
@@ -56,19 +56,21 @@ For running a subset of tests, see [Running subset of tests](#running-subset-of-
 ## Running e2e tests using custom build
 ```shell
 make kind-image-build
-make test-e2e
 make test-tas-e2e-baseline
 make test-tas-e2e-extended
+make test-e2e-baseline
+make test-e2e-extended
 make test-e2e-sequential-extended
 make test-e2e-sequential-baseline
 make test-e2e-certmanager
 make test-e2e-kueueviz
-make test-multikueue-e2e
+make test-multikueue-e2e-main
+make test-multikueue-e2e-sequential
 ```
 
 You can specify the Kubernetes version used for running the e2e tests by setting the `E2E_K8S_FULL_VERSION` variable:
 ```shell
-E2E_K8S_FULL_VERSION=1.35.0 make test-e2e
+E2E_K8S_FULL_VERSION=1.35.0 make test-e2e-baseline
 ```
 
 For running a subset of tests, see [Running subset of tests](#running-subset-of-integration-or-e2e-tests).
@@ -127,21 +129,40 @@ Use `E2E_MODE=dev` to create-or-reuse a kind cluster, rebuild/redeploy Kueue, ru
 
 ```shell
 # Create if missing, otherwise reuse cluster. Rebuild image, run tests, keep the cluster.
-E2E_MODE=dev make kind-image-build test-e2e
+E2E_MODE=dev make kind-image-build test-e2e-baseline
 
 # MultiKueue dev mode
-E2E_MODE=dev make kind-image-build test-multikueue-e2e
+E2E_MODE=dev make kind-image-build test-multikueue-e2e-main
 
 # Loop a suite (until it fails) while keeping the cluster
-E2E_MODE=dev GINKGO_ARGS="--until-it-fails" make kind-image-build  test-e2e
+E2E_MODE=dev GINKGO_ARGS="--until-it-fails" make kind-image-build  test-e2e-baseline
+
 
 # Skip reinstallation of kueue (works only in dev mode)
-E2E_MODE=dev E2E_SKIP_REINSTALL=true make kind-image-build test-e2e
-E2E_MODE=dev E2E_SKIP_REINSTALL=true make kind-image-build test-multikueue-e2e
+E2E_MODE=dev E2E_SKIP_REINSTALL=true make kind-image-build test-e2e-baseline
+E2E_MODE=dev E2E_SKIP_REINSTALL=true make kind-image-build test-multikueue-e2e-main
 
 # Skip re-pulling dependency images and re-importing them into kind when already present (dev mode only)
-E2E_MODE=dev E2E_SKIP_IMAGE_RELOAD=true make kind-image-build test-e2e
+E2E_MODE=dev E2E_SKIP_IMAGE_RELOAD=true make kind-image-build test-e2e-baseline
 ```
+
+To use a **released** or **staging** Kueue image instead of building from source (no `kind-image-build` needed), pass `IMAGE_TAG` with the desired image:
+
+```shell
+# Released version
+E2E_MODE=dev IMAGE_TAG=registry.k8s.io/kueue/kueue:v0.16.0 make test-e2e-baseline
+E2E_MODE=dev IMAGE_TAG=registry.k8s.io/kueue/kueue:v0.16.0 make test-multikueue-e2e-main
+
+# Staging image (e.g. from a PR or nightly)
+E2E_MODE=dev IMAGE_TAG=us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue:main make test-e2e-baseline
+```
+
+**Using a released version with matching manifests:** The e2e framework deploys CRDs and other resources from the repo's config and overrides only the controller image via `IMAGE_TAG`. To run e2e against a specific release with manifests that match that image:
+
+1. Check out that version's tag (e.g. `git checkout v0.16.0`). The CRD and deployment config in the repo are committed at each release, so no `make manifests` step is needed.
+2. Run the command above with the same image tag, e.g. `E2E_MODE=dev IMAGE_TAG=registry.k8s.io/kueue/kueue:v0.16.0 make test-e2e-baseline`.
+
+This is useful to reproduce issues on a specific released version (e.g. for on-call debugging). For installing a released version into a real cluster (not e2e), see [Install a released version](/docs/installation/#install-a-released-version).
 
 {{% alert title="Note" color="primary" %}}
 When reusing a kept cluster in `E2E_MODE=dev`, external operators (MPI, KubeRay, etc.) are installed only once.
@@ -167,13 +188,23 @@ To delete the kept cluster(s) afterwards:
     ```
 
 ### Legacy: interactive attach mode
-Run `E2E_RUN_ONLY_ENV=true make kind-image-build test-multikueue-e2e` and wait for the `Do you want to cleanup? [Y/n] ` to appear (CI-style behavior).
+Run `E2E_RUN_ONLY_ENV=true make kind-image-build test-multikueue-e2e-main` and wait for the `Do you want to cleanup? [Y/n] ` to appear (CI-style behavior).
 
 The cluster is ready, and now you can run tests from another terminal:
 ```shell
 <your_kueue_path>/bin/ginkgo --json-report ./ginkgo.report -focus "MultiKueue when Creating a multikueue admission check Should run a jobSet on worker if admitted" -r
 ```
 or from VSCode.
+
+## Debugging metrics with Prometheus
+
+To provision a Kind cluster with Prometheus pre-configured for metrics debugging:
+
+```shell
+E2E_MODE=dev GINKGO_ARGS="--label-filter=feature:prometheus" make kind-image-build test-e2e-baseline
+```
+
+For more details, see [Setup Dev Monitoring](/docs/tasks/dev/setup_dev_monitoring).
 
 ## Running subset of integration or e2e tests
 
@@ -182,7 +213,7 @@ Integration tests are labeled by controller, job type, feature, and area to enab
 
 **Label Taxonomy:**
 - Controllers: `controller:workload`, `controller:localqueue`, `controller:clusterqueue`, `controller:admissioncheck`, `controller:resourceflavor`, `controller:provisioning`
-- Job Types: `job:batch`, `job:pod`, `job:jobset`, `job:pytorch`, `job:tensorflow`, `job:mpi`, `job:paddle`, `job:xgboost`, `job:jax`, `job:train`, `job:ray`, `job:appwrapper`
+- Job Types: `job:batch`, `job:pod`, `job:jobset`, `job:pytorch`, `job:tensorflow`, `job:mpi`, `job:paddle`, `job:xgboost`, `job:jax`, `job:train`, `job:ray`, `job:appwrapper`, `job:sparkapplication`
 - Features: `feature:tas`, `feature:multikueue`, `feature:provisioning`, `feature:fairsharing`, `feature:admissionfairsharing`
 - Areas: `area:core`, `area:jobs`, `area:admissionchecks`, `area:multikueue`
 
@@ -219,37 +250,38 @@ SingleCluster tests are labeled by feature and area. You can use `GINKGO_ARGS` w
 **Examples:**
 ```shell
 # Run only appwrapper tests
-GINKGO_ARGS="--label-filter=feature:appwrapper" make test-e2e
+GINKGO_ARGS="--label-filter=feature:appwrapper" make test-e2e-extended
+
 
 # Run only deployment tests with helm
-GINKGO_ARGS="--label-filter=feature:deployment" make test-e2e-helm
+GINKGO_ARGS="--label-filter=feature:deployment" make test-e2e-baseline-helm
 
 # Run only jobset and trainjob tests with helm
-GINKGO_ARGS="--label-filter=feature:jobset,feature:trainjob" make test-e2e
+GINKGO_ARGS="--label-filter=feature:jobset,feature:trainjob" make test-e2e-extended
 ```
 
 ### Use label filters for e2e sequential tests
 Sequential tests (Baseline and Extended) are labeled by feature. You can use `GINKGO_ARGS` with `--label-filter` to run specific tests:
 
 **Label Taxonomy (Baseline):**
-- Features: `admissionfairsharing, certs, failurerecoverypolicy, objectretentionpolicies, podintegrationautoenablement, reconcile, visibility, waitforpodsready`
+- Features: `admissionfairsharing, certs, failurerecoverypolicy, localqueuemetrics, objectretentionpolicies, podintegrationautoenablement, reconcile, visibility, waitforpodsready`
 
 **Label Taxonomy (Extended):**
-- Features: `managejobswithoutqueuename`
+- Features: `managejobswithoutqueuename, spark`
 
 **Examples:**
 ```shell
 # Run only admissionfairsharing tests (Baseline)
 GINKGO_ARGS="--label-filter=feature:admissionfairsharing" make test-e2e-sequential-baseline
 
-# Run only suite tests (Extended)
-GINKGO_ARGS="--label-filter=feature:suite" make test-e2e-sequential-extended
+# Run only spark tests (Extended)
+GINKGO_ARGS="--label-filter=feature:spark" make test-e2e-sequential-extended
 ```
 
 ### Use Ginkgo --focus arg
 ```shell
 GINKGO_ARGS="--focus=Scheduler" make test-integration
-GINKGO_ARGS="--focus='Creating a Pod requesting TAS'" make test-e2e
+GINKGO_ARGS="--focus='Creating a Pod requesting TAS'" make test-e2e-baseline
 ```
 ### Use ginkgo.FIt
 If you want to focus on specific tests, you can change
@@ -281,7 +313,7 @@ INTEGRATION_TARGET='test/integration/singlecluster/scheduler' make test-integrat
 You can use --until-it-fails or --repeat=N arguments to Ginkgo to run tests repeatedly, such as:
 ```shell
 GINKGO_ARGS="--until-it-fails" make test-integration
-GINKGO_ARGS="--repeat=10" make test-e2e
+GINKGO_ARGS="--repeat=10" make test-e2e-baseline
 ```
 See more [here](https://onsi.github.io/ginkgo/#repeating-spec-runs-and-managing-flaky-specs)
 

--- a/site/content/zh-CN/docs/contribution_guidelines/testing.md
+++ b/site/content/zh-CN/docs/contribution_guidelines/testing.md
@@ -56,19 +56,21 @@ make test-integration
 ## 使用自定义构建运行 e2e 测试 {#running-e2e-tests-using-custom-build}
 ```shell
 make kind-image-build
-make test-e2e
 make test-tas-e2e-baseline
 make test-tas-e2e-extended
+make test-e2e-baseline
+make test-e2e-extended
 make test-e2e-sequential-extended
 make test-e2e-sequential-baseline
 make test-e2e-certmanager
 make test-e2e-kueueviz
-make test-multikueue-e2e
+make test-multikueue-e2e-main
+make test-multikueue-e2e-sequential
 ```
 
 你可以通过设置 `E2E_K8S_FULL_VERSION` 变量来指定用于运行 e2e 测试的 Kubernetes 版本：
 ```shell
-E2E_K8S_FULL_VERSION=1.34.1 make test-e2e
+E2E_K8S_FULL_VERSION=1.34.1 make test-e2e-baseline
 ```
 
 关于运行测试子集，请参阅 [运行测试子集](#running-subset-of-integration-or-e2e-tests)。
@@ -127,26 +129,50 @@ func TestValidateClusterQueue(t *testing.T) {
 
 ```shell
 # 若不存在则创建；若已存在则复用。构建镜像、运行测试，并保留集群。
-E2E_MODE=dev make test-e2e
+E2E_MODE=dev make kind-image-build test-e2e-baseline
 
 # MultiKueue 的 dev 模式
-E2E_MODE=dev make test-multikueue-e2e
+E2E_MODE=dev make kind-image-build test-multikueue-e2e-main
 
 # 循环运行（直到失败），同时保留集群
-E2E_MODE=dev GINKGO_ARGS="--until-it-fails" make test-e2e
+E2E_MODE=dev GINKGO_ARGS="--until-it-fails" make kind-image-build  test-e2e-baseline
 ```
 
-当在 `E2E_MODE=dev` 下复用保留的集群时，外部算子（MPI、KubeRay 等）只会安装一次。
-如需在每次运行时强制重新安装它们，请设置 `E2E_ENFORCE_OPERATOR_UPDATE=true`。
-
-测试结束后如需删除保留的集群：
+若希望使用**已发布**或**预发布（staging）**的 Kueue 镜像而非从源码构建（无需执行 `kind-image-build`），可传入 `IMAGE_TAG` 并指定所需镜像：
 
 ```shell
-kind delete clusters kind kind-manager kind-worker1 kind-worker2
+# 已发布版本
+E2E_MODE=dev IMAGE_TAG=registry.k8s.io/kueue/kueue:v0.16.0 make test-e2e-baseline
+E2E_MODE=dev IMAGE_TAG=registry.k8s.io/kueue/kueue:v0.16.0 make test-multikueue-e2e-main
+
+# 预发布镜像（例如来自 PR 或每日构建）
+E2E_MODE=dev IMAGE_TAG=us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue:main make test-e2e-baseline
 ```
 
+**使用与 manifest 匹配的已发布版本：** e2e 框架从仓库的 config 部署 CRD 等资源，仅通过 `IMAGE_TAG` 覆盖控制器镜像。若要对某一发布版本运行 e2e 且使用与该镜像匹配的 manifest：
+
+1. 检出该版本的 tag（例如 `git checkout v0.16.0`）。仓库中的 CRD 与部署配置在每个版本中均已提交，无需执行 `make manifests`。
+2. 使用相同镜像 tag 运行上述命令，例如 `E2E_MODE=dev IMAGE_TAG=registry.k8s.io/kueue/kueue:v0.16.0 make test-e2e-baseline`。
+
+适用于在特定已发布版本上复现问题（例如值班排查）。若要在真实集群（非 e2e）中安装已发布版本，请参阅[安装已发布版本](/zh-CN/docs/installation/#install-a-released-version)。
+
+{{% alert title="Note" color="primary" %}}
+当在 `E2E_MODE=dev` 下复用保留的集群时，外部算子（MPI、KubeRay 等）只会安装一次。
+如需在每次运行时强制重新安装它们，请设置 `E2E_ENFORCE_OPERATOR_UPDATE=true`。
+{{% /alert %}}
+
+测试结束后如需删除保留的集群：
+- 常规 e2e 测试，请运行：
+    ```shell
+    kind delete clusters kind
+    ```
+- MultiKueue 测试，请运行：
+    ```shell
+    kind delete clusters kind kind-manager kind-worker1 kind-worker2
+    ```
+
 ### 旧方式：交互式附加模式
-运行 `E2E_RUN_ONLY_ENV=true make kind-image-build test-multikueue-e2e` 并等待 `Do you want to cleanup? [Y/n] ` 出现（CI 风格行为）。
+运行 `E2E_RUN_ONLY_ENV=true make kind-image-build test-multikueue-e2e-main` 并等待 `Do you want to cleanup? [Y/n] ` 出现（CI 风格行为）。
 
 集群已准备就绪，现在你可以从另一个终端运行测试：
 ```shell
@@ -158,7 +184,7 @@ kind delete clusters kind kind-manager kind-worker1 kind-worker2
 ### 使用 Ginkgo --focus 参数 {#use-ginkgo-focus-arg}
 ```shell
 GINKGO_ARGS="--focus=Scheduler" make test-integration
-GINKGO_ARGS="--focus='Creating a Pod requesting TAS'" make test-e2e
+GINKGO_ARGS="--focus='Creating a Pod requesting TAS'" make test-e2e-baseline
 ```
 ### 使用 ginkgo.FIt {#use-ginkgo-fit}
 如果你想专注于特定测试，可以将这些测试的
@@ -190,7 +216,7 @@ INTEGRATION_TARGET='test/integration/singlecluster/scheduler' make test-integrat
 你可以使用 --until-it-fails 或 --repeat=N 参数来让 Ginkgo 重复运行测试，例如：
 ```shell
 GINKGO_ARGS="--until-it-fails" make test-integration
-GINKGO_ARGS="--repeat=10" make test-e2e
+GINKGO_ARGS="--repeat=10" make test-e2e-baseline
 ```
 更多信息请参阅[这里](https://onsi.github.io/ginkgo/#repeating-spec-runs-and-managing-flaky-specs)
 

--- a/test/e2e/singlecluster/baseline/aggregated_openapi_test.go
+++ b/test/e2e/singlecluster/baseline/aggregated_openapi_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package baseline
 
 import (
 	"github.com/onsi/ginkgo/v2"

--- a/test/e2e/singlecluster/baseline/deployment_test.go
+++ b/test/e2e/singlecluster/baseline/deployment_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package baseline
 
 import (
 	"github.com/onsi/ginkgo/v2"

--- a/test/e2e/singlecluster/baseline/e2e_v1beta1_test.go
+++ b/test/e2e/singlecluster/baseline/e2e_v1beta1_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package baseline
 
 import (
 	"fmt"

--- a/test/e2e/singlecluster/baseline/fair_sharing_test.go
+++ b/test/e2e/singlecluster/baseline/fair_sharing_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package baseline
 
 import (
 	"fmt"

--- a/test/e2e/singlecluster/baseline/job_test.go
+++ b/test/e2e/singlecluster/baseline/job_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package baseline
 
 import (
 	"fmt"
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	kueueconstants "sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
@@ -179,7 +180,7 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cronJob), cronJob)).To(gomega.Succeed())
 					nextSchedule := cronJob.CreationTimestamp.Add(-2 * time.Minute)
-					cronJob.Status.LastScheduleTime = ptr.To(metav1.Time{Time: nextSchedule})
+					cronJob.Status.LastScheduleTime = new(metav1.Time{Time: nextSchedule})
 					g.Expect(k8sClient.Status().Update(ctx, cronJob)).Should(gomega.Succeed())
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -270,6 +271,20 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 					g.Expect(k8sClient.Get(ctx, jobKey, &job)).To(gomega.Succeed())
 					g.Expect(job.Status.Active).To(gomega.BeEquivalentTo(1))
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Verify pods have queue labels assigned", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					var pods corev1.PodList
+					g.Expect(k8sClient.List(ctx, &pods, client.InNamespace(ns.Name), client.MatchingLabels{
+						"job-name": sampleJob.Name,
+					})).To(gomega.Succeed())
+					g.Expect(pods.Items).ToNot(gomega.BeEmpty())
+					for _, pod := range pods.Items {
+						g.Expect(pod.Labels[kueueconstants.ClusterQueueLabel]).To(gomega.Equal(clusterQueue.Name))
+						g.Expect(pod.Labels[kueueconstants.LocalQueueLabel]).To(gomega.Equal(localQueue.Name))
+					}
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Delete all pods", func() {
@@ -427,6 +442,20 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 				util.ExpectJobUnsuspendedWithNodeSelectors(ctx, k8sClient, jobKey, map[string]string{
 					"instance-type": "on-demand",
 				})
+			})
+
+			ginkgo.By("Verify pods have queue labels assigned", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					var pods corev1.PodList
+					g.Expect(k8sClient.List(ctx, &pods, client.InNamespace(ns.Name), client.MatchingLabels{
+						"job-name": sampleJob.Name,
+					})).To(gomega.Succeed())
+					g.Expect(pods.Items).ToNot(gomega.BeEmpty())
+					for _, pod := range pods.Items {
+						g.Expect(pod.Labels[kueueconstants.ClusterQueueLabel]).To(gomega.Equal(clusterQueue.Name))
+						g.Expect(pod.Labels[kueueconstants.LocalQueueLabel]).To(gomega.Equal(localQueue.Name))
+					}
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Verify priority label is immutable when running", func() {
@@ -722,7 +751,7 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 				jobKey := client.ObjectKeyFromObject(sampleJob)
 				gomega.Consistently(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, jobKey, createdJob)).Should(gomega.Succeed())
-					g.Expect(createdJob.Spec.Suspend).Should(gomega.Equal(ptr.To(true)))
+					g.Expect(createdJob.Spec.Suspend).Should(gomega.Equal(new(true)))
 				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 			})
 
@@ -783,7 +812,7 @@ func expectJobUnsuspended(key types.NamespacedName) {
 	job := &batchv1.Job{}
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
 		g.Expect(k8sClient.Get(ctx, key, job)).To(gomega.Succeed())
-		g.Expect(job.Spec.Suspend).Should(gomega.Equal(ptr.To(false)))
+		g.Expect(job.Spec.Suspend).Should(gomega.Equal(new(false)))
 	}, util.Timeout, util.Interval).Should(gomega.Succeed())
 }
 

--- a/test/e2e/singlecluster/baseline/kueuectl_test.go
+++ b/test/e2e/singlecluster/baseline/kueuectl_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package baseline
 
 import (
 	"os/exec"

--- a/test/e2e/singlecluster/baseline/metrics_test.go
+++ b/test/e2e/singlecluster/baseline/metrics_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package baseline
 
 import (
 	"github.com/onsi/ginkgo/v2"
@@ -25,7 +25,6 @@ import (
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
@@ -153,6 +152,7 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Label("area:singlecluster", "feature:m
 				{"kueue_cluster_queue_resource_usage", clusterQueue.Name},
 				{"kueue_cluster_queue_status", clusterQueue.Name},
 				{"kueue_cluster_queue_resource_reservation", clusterQueue.Name},
+				{"kueue_cluster_queue_resource_pending", clusterQueue.Name},
 				{"kueue_cluster_queue_nominal_quota", clusterQueue.Name},
 				{"kueue_cluster_queue_borrowing_limit", clusterQueue.Name},
 				{"kueue_cluster_queue_lending_limit", clusterQueue.Name},
@@ -189,6 +189,7 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Label("area:singlecluster", "feature:m
 				{"kueue_cluster_queue_resource_usage", clusterQueue.Name},
 				{"kueue_cluster_queue_status", clusterQueue.Name},
 				{"kueue_cluster_queue_resource_reservation", clusterQueue.Name},
+				{"kueue_cluster_queue_resource_pending", clusterQueue.Name},
 				{"kueue_cluster_queue_nominal_quota", clusterQueue.Name},
 				{"kueue_cluster_queue_borrowing_limit", clusterQueue.Name},
 				{"kueue_cluster_queue_lending_limit", clusterQueue.Name},
@@ -501,7 +502,7 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Label("area:singlecluster", "feature:m
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, blockerWorkloadKey, blockerWorkload)).To(gomega.Succeed())
 
-					blockerWorkload.Spec.Active = ptr.To(false)
+					blockerWorkload.Spec.Active = new(false)
 
 					g.Expect(k8sClient.Update(ctx, blockerWorkload)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())

--- a/test/e2e/singlecluster/baseline/prometheus_test.go
+++ b/test/e2e/singlecluster/baseline/prometheus_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package baseline
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	corev1 "k8s.io/api/core/v1"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+const (
+	kueueBuildInfoMetric         = "kueue_build_info"
+	admittedWorkloadsTotalMetric = "kueue_admitted_workloads_total"
+)
+
+var _ = ginkgo.Describe("Prometheus", ginkgo.Label("area:prometheus", "feature:prometheus"), func() {
+	ginkgo.It("should discover Kueue target and report it as up", func() {
+		gomega.Eventually(func(g gomega.Gomega) {
+			result, err := prometheusClient.Targets(ctx)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+
+			hasKueueTarget := false
+			for _, t := range result.Active {
+				if t.Labels["job"] == model.LabelValue(util.DefaultMetricsServiceName) &&
+					t.Labels["namespace"] == model.LabelValue(util.GetKueueNamespace()) {
+					hasKueueTarget = true
+					g.Expect(t.Health).To(gomega.Equal(prometheusv1.HealthGood))
+					break
+				}
+			}
+			g.Expect(hasKueueTarget).To(gomega.BeTrue(), "Kueue target not found. Active targets: %v", result.Active)
+		}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("should scrape kueue_build_info metric via PromQL", func() {
+		gomega.Eventually(func(g gomega.Gomega) {
+			result, _, err := prometheusClient.Query(ctx, kueueBuildInfoMetric, time.Now())
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+
+			vector, ok := result.(model.Vector)
+			g.Expect(ok).To(gomega.BeTrue())
+			g.Expect(vector).NotTo(gomega.BeEmpty())
+			g.Expect(string(vector[0].Metric[model.MetricNameLabel])).To(gomega.Equal(kueueBuildInfoMetric))
+		}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("should report workload admission metrics via PromQL", func() {
+		ns := util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-prom-")
+		ginkgo.DeferCleanup(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		})
+
+		resourceFlavor := utiltestingapi.MakeResourceFlavor("prom-test-flavor-" + ns.Name).Obj()
+		util.MustCreate(ctx, k8sClient, resourceFlavor)
+		ginkgo.DeferCleanup(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, resourceFlavor, true)
+		})
+
+		clusterQueue := utiltestingapi.MakeClusterQueue("").
+			GeneratedName("prom-test-cq-").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).
+					Resource(corev1.ResourceCPU, "1").
+					Resource(corev1.ResourceMemory, "1Gi").
+					Obj(),
+			).
+			Obj()
+		util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+		ginkgo.DeferCleanup(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		})
+
+		localQueue := utiltestingapi.MakeLocalQueue("", ns.Name).
+			GeneratedName("prom-test-lq-").
+			ClusterQueue(clusterQueue.Name).
+			Obj()
+		util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+
+		ginkgo.By("Creating and admitting a workload")
+		workload := utiltestingapi.MakeWorkload("prom-test-workload", ns.Name).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			PodSets(
+				*utiltestingapi.MakePodSet("ps1", 1).Obj(),
+			).
+			RequestAndLimit(corev1.ResourceCPU, "1").
+			Obj()
+		util.MustCreate(ctx, k8sClient, workload)
+		ginkgo.DeferCleanup(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, workload, true)
+		})
+		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, workload)
+
+		ginkgo.By("Verifying the admission metric is reported")
+		gomega.Eventually(func(g gomega.Gomega) {
+			result, _, err := prometheusClient.Query(ctx,
+				fmt.Sprintf(`%s{cluster_queue="%s"}`, admittedWorkloadsTotalMetric, clusterQueue.Name),
+				time.Now())
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+
+			vector, ok := result.(model.Vector)
+			g.Expect(ok).To(gomega.BeTrue())
+			g.Expect(vector).NotTo(gomega.BeEmpty())
+		}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+	})
+})

--- a/test/e2e/singlecluster/baseline/statefulset_test.go
+++ b/test/e2e/singlecluster/baseline/statefulset_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package baseline
 
 import (
 	"fmt"
@@ -671,7 +671,7 @@ var _ = ginkgo.Describe("StatefulSet integration", ginkgo.Label("area:singleclus
 			ginkgo.By("Deactivate the workload", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
-					createdWorkload.Spec.Active = ptr.To(false)
+					createdWorkload.Spec.Active = new(false)
 					g.Expect(k8sClient.Update(ctx, createdWorkload)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -680,7 +680,7 @@ var _ = ginkgo.Describe("StatefulSet integration", ginkgo.Label("area:singleclus
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 					g.Expect(createdWorkload.UID).Should(gomega.Equal(createdWorkloadUID))
-					g.Expect(createdWorkload.Spec.Active).Should(gomega.Equal(ptr.To(false)))
+					g.Expect(createdWorkload.Spec.Active).Should(gomega.Equal(new(false)))
 					g.Expect(createdWorkload.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadEvicted))
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -696,7 +696,7 @@ var _ = ginkgo.Describe("StatefulSet integration", ginkgo.Label("area:singleclus
 			ginkgo.By("Re-activate the workload", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
-					createdWorkload.Spec.Active = ptr.To(true)
+					createdWorkload.Spec.Active = new(true)
 					g.Expect(k8sClient.Update(ctx, createdWorkload)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})

--- a/test/e2e/singlecluster/baseline/suite_test.go
+++ b/test/e2e/singlecluster/baseline/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package baseline
 
 import (
 	"context"
@@ -25,6 +25,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -34,18 +35,19 @@ import (
 )
 
 var (
-	kueuectlPath                 = filepath.Join("..", "..", "..", "bin", "kubectl-kueue")
+	kueuectlPath                 = filepath.Join("..", "..", "..", "..", "bin", "kubectl-kueue")
 	k8sClient                    client.WithWatch
 	cfg                          *rest.Config
 	restClient                   *rest.RESTClient
 	ctx                          context.Context
 	kueueClientset               kueueclientset.Interface
 	impersonatedVisibilityClient visibility.VisibilityV1beta2Interface
+	prometheusClient             prometheusv1.API
 	kueueNS                      = util.GetKueueNamespace()
 )
 
 func TestAPIs(t *testing.T) {
-	util.RunE2ESuite(t, "End To End Suite")
+	util.RunE2ESuite(t, "End To End Baseline Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -64,23 +66,9 @@ var _ = ginkgo.BeforeSuite(func() {
 	waitForAvailableStart := time.Now()
 	util.WaitForKueueAvailability(ctx, k8sClient)
 	labelFilter := ginkgo.GinkgoLabelFilter()
-	if ginkgo.Label("feature:jobset", "feature:tas", "feature:trainjob").MatchesLabelFilter(labelFilter) {
-		util.WaitForJobSetAvailability(ctx, k8sClient)
-	}
-	if ginkgo.Label("feature:leaderworkerset").MatchesLabelFilter(labelFilter) {
-		util.WaitForLeaderWorkerSetAvailability(ctx, k8sClient)
-	}
-	if ginkgo.Label("feature:appwrapper").MatchesLabelFilter(labelFilter) {
-		util.WaitForAppWrapperAvailability(ctx, k8sClient)
-	}
-	if ginkgo.Label("feature:jaxjob", "feature:pytorchjob").MatchesLabelFilter(labelFilter) {
-		util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sClient)
-	}
-	if ginkgo.Label("feature:kuberay").MatchesLabelFilter(labelFilter) {
-		util.WaitForKubeRayOperatorAvailability(ctx, k8sClient)
-	}
-	if ginkgo.Label("feature:tas", "feature:trainjob").MatchesLabelFilter(labelFilter) {
-		util.WaitForKubeFlowTrainnerControllerManagerAvailability(ctx, k8sClient)
+	if ginkgo.Label("feature:prometheus").MatchesLabelFilter(labelFilter) {
+		prometheusClient = util.CreatePrometheusClient(cfg)
+		util.WaitForPrometheusAvailability(ctx, k8sClient)
 	}
 	ginkgo.GinkgoLogr.Info(
 		"Kueue and all required operators are available in the cluster",

--- a/test/e2e/singlecluster/baseline/visibility_test.go
+++ b/test/e2e/singlecluster/baseline/visibility_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package baseline
 
 import (
 	"github.com/google/go-cmp/cmp"

--- a/test/e2e/singlecluster/extended/appwrapper_test.go
+++ b/test/e2e/singlecluster/extended/appwrapper_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package extended
 
 import (
 	"github.com/onsi/ginkgo/v2"

--- a/test/e2e/singlecluster/extended/jaxjob_test.go
+++ b/test/e2e/singlecluster/extended/jaxjob_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package extended
 
 import (
 	"github.com/google/go-cmp/cmp/cmpopts"

--- a/test/e2e/singlecluster/extended/jobset_test.go
+++ b/test/e2e/singlecluster/extended/jobset_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package extended
 
 import (
 	"github.com/onsi/ginkgo/v2"
@@ -177,7 +177,7 @@ var _ = ginkgo.Describe("JobSet", ginkgo.Label("area:singlecluster", "feature:jo
 				jobKey := client.ObjectKeyFromObject(jobSet)
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, jobKey, jobSet)).To(gomega.Succeed())
-					g.Expect(jobSet.Spec.Suspend).Should(gomega.BeEquivalentTo(ptr.To(false)))
+					g.Expect(jobSet.Spec.Suspend).Should(gomega.BeEquivalentTo(new(false)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -200,7 +200,7 @@ var _ = ginkgo.Describe("JobSet", ginkgo.Label("area:singlecluster", "feature:jo
 				jobKey := client.ObjectKeyFromObject(jobSet)
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, jobKey, jobSet)).To(gomega.Succeed())
-					g.Expect(jobSet.Spec.Suspend).Should(gomega.BeEquivalentTo(ptr.To(true)))
+					g.Expect(jobSet.Spec.Suspend).Should(gomega.BeEquivalentTo(new(true)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})

--- a/test/e2e/singlecluster/extended/kuberay_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package extended
 
 import (
 	"encoding/json"
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -31,12 +32,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/constants"
 	workloadraycluster "sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
 	workloadrayjob "sigs.k8s.io/kueue/pkg/controller/jobs/rayjob"
+	workloadrayservice "sigs.k8s.io/kueue/pkg/controller/jobs/rayservice"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
 	testingrayjob "sigs.k8s.io/kueue/pkg/util/testingjobs/rayjob"
@@ -75,15 +77,33 @@ var _ = ginkgo.Describe("Kuberay", ginkgo.Label("area:singlecluster", "feature:k
 		localQueueName     string
 	)
 
-	// getRunningWorkerPodNames returns the names of running pods that have "workers" in their name
-	getRunningWorkerPodNames := func(podList *corev1.PodList) []string {
+	getRunningRayWorkerPodNames := func(g gomega.Gomega) []string {
+		pods := &corev1.PodList{}
+		g.Expect(k8sClient.List(ctx, pods,
+			client.InNamespace(ns.Name),
+			client.MatchingLabels{
+				"ray.io/node-type": "worker",
+			},
+		)).To(gomega.Succeed())
 		var podNames []string
-		for _, pod := range podList.Items {
+		for _, pod := range pods.Items {
 			if strings.Contains(pod.Name, "workers") && pod.Status.Phase == corev1.PodRunning {
 				podNames = append(podNames, pod.Name)
 			}
 		}
 		return podNames
+	}
+
+	getRayHeadPod := func(g gomega.Gomega) corev1.Pod {
+		pods := &corev1.PodList{}
+		g.Expect(k8sClient.List(ctx, pods,
+			client.InNamespace(ns.Name),
+			client.MatchingLabels{
+				"ray.io/node-type": "head",
+			},
+		)).To(gomega.Succeed())
+		g.Expect(pods.Items).NotTo(gomega.BeEmpty())
+		return pods.Items[0]
 	}
 
 	ginkgo.BeforeEach(func() {
@@ -170,6 +190,18 @@ var _ = ginkgo.Describe("Kuberay", ginkgo.Label("area:singlecluster", "feature:k
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("RayJob cluster did not become ready", createdRayJob))
 		})
 
+		ginkgo.By("Verify ray job worker pods have queue labels assigned", func() {
+			pods := &corev1.PodList{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
+				g.Expect(pods.Items).ToNot(gomega.BeEmpty())
+				for _, pod := range pods.Items {
+					g.Expect(pod.Labels[constants.ClusterQueueLabel]).To(gomega.Equal(clusterQueueName))
+					g.Expect(pod.Labels[constants.LocalQueueLabel]).To(gomega.Equal(localQueueName))
+				}
+			}, util.Timeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Worker pods missing expected queue labels", pods))
+		})
+
 		ginkgo.By("Waiting for the RayJob to finish", func() {
 			createdRayJob := &rayv1.RayJob{}
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -208,6 +240,25 @@ print(ray.get([my_task.remote(i, 60) for i in range(3)]))`,
 			},
 		}
 
+		volumes := []corev1.Volume{
+			{
+				Name: "script-volume",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "rayjob-autoscaling",
+						},
+					},
+				},
+			},
+		}
+		volumeMounts := []corev1.VolumeMount{
+			{
+				Name:      "script-volume",
+				MountPath: "/home/ray/samples",
+			},
+		}
+
 		rayJob := testingrayjob.MakeJob("rayjob-autoscaling", ns.Name).
 			Queue(localQueueName).
 			Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
@@ -237,31 +288,11 @@ print(ray.get([my_task.remote(i, 60) for i in range(3)]))`,
 				},
 			}).
 			Image(rayv1.HeadNode, kuberayTestImage).
-			Image(rayv1.WorkerNode, kuberayTestImage).Obj()
-
-		// Add volume and volumeMount to head node for the ConfigMap
-		rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Volumes = []corev1.Volume{
-			{
-				Name: "script-volume",
-				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "rayjob-autoscaling",
-						},
-					},
-				},
-			},
-		}
-		rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
-			{
-				Name:      "script-volume",
-				MountPath: "/home/ray/samples",
-			},
-		}
-		rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.TerminationGracePeriodSeconds = ptr.To(int64(5))
-		for i := range len(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs) {
-			rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.TerminationGracePeriodSeconds = ptr.To(int64(5))
-		}
+			Image(rayv1.WorkerNode, kuberayTestImage).
+			Volumes(rayv1.HeadNode, volumes).
+			VolumeMounts(rayv1.HeadNode, volumeMounts).
+			TerminationGracePeriodSeconds(int64(5)).
+			Obj()
 
 		ginkgo.By("Creating the ConfigMap", func() {
 			gomega.Expect(k8sClient.Create(ctx, configMap)).Should(gomega.Succeed())
@@ -308,8 +339,7 @@ print(ray.get([my_task.remote(i, 60) for i in range(3)]))`,
 		ginkgo.By("Waiting for exactly 1 worker pod", func() {
 			podList := &corev1.PodList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
-				workerPodNames := getRunningWorkerPodNames(podList)
+				workerPodNames := getRunningRayWorkerPodNames(g)
 				g.Expect(workerPodNames).To(gomega.HaveLen(1), "Expected exactly 1 pod with 'workers' in the name")
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Expected exactly 1 worker pod", podList))
 		})
@@ -327,17 +357,14 @@ print(ray.get([my_task.remote(i, 60) for i in range(3)]))`,
 		ginkgo.By("Waiting for all 2 worker pods to be running", func() {
 			podList := &corev1.PodList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
-				runningWorkers := getRunningWorkerPodNames(podList)
+				runningWorkers := getRunningRayWorkerPodNames(g)
 				g.Expect(runningWorkers).To(gomega.HaveLen(2), "Expected 2 running worker pods")
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Did not observe 2 running worker pods", podList))
 		})
 
 		var deletedPodName string
 		ginkgo.By("Deleting one worker pod", func() {
-			podList := &corev1.PodList{}
-			gomega.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
-			runningWorkers := getRunningWorkerPodNames(podList)
+			runningWorkers := getRunningRayWorkerPodNames(gomega.Default)
 			gomega.Expect(runningWorkers).NotTo(gomega.BeEmpty())
 			deletedPodName = runningWorkers[0]
 			pod := &corev1.Pod{
@@ -352,8 +379,7 @@ print(ray.get([my_task.remote(i, 60) for i in range(3)]))`,
 		ginkgo.By("Waiting for a new worker pod to replace the deleted one", func() {
 			podList := &corev1.PodList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
-				runningWorkers := getRunningWorkerPodNames(podList)
+				runningWorkers := getRunningRayWorkerPodNames(g)
 				g.Expect(runningWorkers).To(gomega.HaveLen(2), "Expected 2 running worker pods after replacement")
 				g.Expect(runningWorkers).NotTo(gomega.ContainElement(deletedPodName),
 					"Deleted pod should not be present among running workers")
@@ -509,8 +535,7 @@ print([ray.get(my_task.remote(i, 1)) for i in range(32)])`,
 		ginkgo.By("Waiting for exactly 1 worker pod", func() {
 			podList := &corev1.PodList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
-				workerPodNames := getRunningWorkerPodNames(podList)
+				workerPodNames := getRunningRayWorkerPodNames(g)
 				g.Expect(workerPodNames).To(gomega.HaveLen(1), "Expected exactly 1 pod with 'workers' in the name")
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Expected exactly 1 worker pod", podList))
 		})
@@ -528,9 +553,7 @@ print([ray.get(my_task.remote(i, 1)) for i in range(32)])`,
 		ginkgo.By("Waiting for second scale-up to 5 workers due to high parallelism tasks", func() {
 			podList := &corev1.PodList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.List(ctx, podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
-				// Get worker pod names and check count
-				currentPodNames := getRunningWorkerPodNames(podList)
+				currentPodNames := getRunningRayWorkerPodNames(g)
 				g.Expect(currentPodNames).To(gomega.HaveLen(5), "Expected exactly 5 pods with 'workers' in the name after second scale-up")
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Did not scale up to 5 worker pods", podList))
 		})
@@ -700,11 +723,6 @@ app = HelloWorld.bind()`,
 			VolumeMounts(rayv1.WorkerNode, volumeMounts).
 			Obj()
 
-		// Configure worker group with minReplicas and maxReplicas
-		rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName = "small-group"
-		rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].MinReplicas = ptr.To[int32](1)
-		rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].MaxReplicas = ptr.To[int32](2)
-
 		ginkgo.By("Creating the ConfigMap", func() {
 			gomega.Expect(k8sClient.Create(ctx, configMap)).Should(gomega.Succeed())
 		})
@@ -713,22 +731,7 @@ app = HelloWorld.bind()`,
 			gomega.Expect(k8sClient.Create(ctx, rayService)).Should(gomega.Succeed())
 		})
 
-		// Kueue manages RayService through the child RayCluster created by KubeRay.
-		// Get the child RayCluster name from RayService status, then look up its workload.
-		var childRayCluster rayv1.RayCluster
-		ginkgo.By("Waiting for the child RayCluster to be created", func() {
-			gomega.Eventually(func(g gomega.Gomega) {
-				createdRayService := &rayv1.RayService{}
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayService), createdRayService)).To(gomega.Succeed())
-				g.Expect(createdRayService.Status.ActiveServiceStatus.RayClusterName).NotTo(gomega.BeEmpty())
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
-					Name:      createdRayService.Status.ActiveServiceStatus.RayClusterName,
-					Namespace: ns.Name,
-				}, &childRayCluster)).To(gomega.Succeed())
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
-		})
-
-		wlLookupKey := types.NamespacedName{Name: workloadraycluster.GetWorkloadNameForRayCluster(childRayCluster.Name, childRayCluster.UID), Namespace: ns.Name}
+		wlLookupKey := types.NamespacedName{Name: workloadrayservice.GetWorkloadNameForRayService(rayService.Name, rayService.UID), Namespace: ns.Name}
 		createdWorkload := &kueue.Workload{}
 		ginkgo.By("Checking workload is created", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -744,23 +747,14 @@ app = HelloWorld.bind()`,
 			createdRayService := &rayv1.RayService{}
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayService), createdRayService)).To(gomega.Succeed())
+				g.Expect(createdRayService.Spec.RayClusterSpec.Suspend).To(gomega.Equal(new(false)))
 				g.Expect(apimeta.IsStatusConditionTrue(createdRayService.Status.Conditions, string(rayv1.RayServiceReady))).To(gomega.BeTrue())
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("RayService did not become ready", createdRayService))
 		})
 
 		ginkgo.By("Verifying the RayService responds to HTTP requests via port-forward", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
-				// Find the head pod in this namespace
-				pods := &corev1.PodList{}
-				g.Expect(k8sClient.List(ctx, pods,
-					client.InNamespace(ns.Name),
-					client.MatchingLabels{
-						"ray.io/node-type": "head",
-					},
-				)).To(gomega.Succeed())
-				g.Expect(pods.Items).NotTo(gomega.BeEmpty())
-
-				headPodName := pods.Items[0].Name
+				headPodName := getRayHeadPod(g).Name
 
 				// Port-forward to the head pod on port 8000 (Ray Serve default)
 				localPort, stopChan, err := util.KPortForward(cfg, restClient, ns.Name, headPodName, 8000)
@@ -777,6 +771,181 @@ app = HelloWorld.bind()`,
 				body, err := io.ReadAll(resp.Body)
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(strings.TrimSpace(string(body))).To(gomega.ContainSubstring("Hello, World!"))
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.It("Should run a rayservice with InTreeAutoscaling", func() {
+		kuberayTestImage := util.GetKuberayTestImage()
+
+		// Create ConfigMap with a Ray Serve application that supports a delay parameter
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "rayservice-autoscale",
+				Namespace: ns.Name,
+			},
+			Data: map[string]string{
+				"hello_serve.py": `import asyncio
+from ray import serve
+
+@serve.deployment
+class HelloWorld:
+    async def __call__(self, request):
+        delay = request.query_params.get("delay", "0")
+        if float(delay) > 0:
+            await asyncio.sleep(float(delay))
+        return "Hello, World!"
+
+app = HelloWorld.bind()`,
+			},
+		}
+
+		// serveConfigV2 configuration for the simple serve app
+		serveConfigV2 := `applications:
+  - name: hello_app
+    import_path: hello_serve:app
+    route_prefix: /
+    deployments:
+      - name: HelloWorld
+        autoscaling_config:
+          min_replicas: 0
+          max_replicas: 5
+          target_ongoing_requests: 1
+          upscaling_factor: 1.0
+          upscale_delay_s: 2
+          downscale_delay_s: 2
+        max_replicas_per_node: 1
+        ray_actor_options:
+          num_cpus: 0.2`
+
+		volumes := []corev1.Volume{
+			{
+				Name: "code-sample",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "rayservice-autoscale",
+						},
+						Items: []corev1.KeyToPath{
+							{
+								Key:  "hello_serve.py",
+								Path: "hello_serve.py",
+							},
+						},
+					},
+				},
+			},
+		}
+		volumeMounts := []corev1.VolumeMount{
+			{
+				Name:      "code-sample",
+				MountPath: "/home/ray/samples",
+			},
+		}
+		env := []corev1.EnvVar{
+			{
+				Name:  "PYTHONPATH",
+				Value: "/home/ray/samples:$PYTHONPATH",
+			},
+		}
+
+		rayService := testingrayservice.MakeService("rayservice-autoscale", ns.Name).
+			Suspend(true).
+			Queue(localQueueName).
+			RequestAndLimit(rayv1.HeadNode, corev1.ResourceCPU, "1").
+			RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "400m").
+			Image(rayv1.HeadNode, kuberayTestImage).
+			Image(rayv1.WorkerNode, kuberayTestImage).
+			RayStartParam(rayv1.HeadNode, "object-store-memory", "100000000").
+			WithServeConfigV2(serveConfigV2).
+			Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			EnableInTreeAutoscaling().
+			Env(rayv1.HeadNode, env).
+			Env(rayv1.WorkerNode, env).
+			Volumes(rayv1.HeadNode, volumes).
+			Volumes(rayv1.WorkerNode, volumes).
+			VolumeMounts(rayv1.HeadNode, volumeMounts).
+			VolumeMounts(rayv1.WorkerNode, volumeMounts).
+			Obj()
+
+		ginkgo.By("Creating the ConfigMap", func() {
+			gomega.Expect(k8sClient.Create(ctx, configMap)).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Creating the RayService", func() {
+			gomega.Expect(k8sClient.Create(ctx, rayService)).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Checking one workload is created and admitted", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				workloadList := &kueue.WorkloadList{}
+				g.Expect(k8sClient.List(ctx, workloadList, client.InNamespace(ns.Name))).To(gomega.Succeed())
+				g.Expect(workloadList.Items).To(gomega.HaveLen(1), "Expected one workload in namespace")
+				wl := workloadList.Items[0]
+				g.Expect(workload.IsAdmitted(&wl)).Should(gomega.BeTrue(), "Expected admitted workload")
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Checking the RayService is running", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdRayService := &rayv1.RayService{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayService), createdRayService)).To(gomega.Succeed())
+				g.Expect(createdRayService.Spec.RayClusterSpec.Suspend).To(gomega.Equal(new(false)))
+				g.Expect(apimeta.IsStatusConditionTrue(createdRayService.Status.Conditions, string(rayv1.RayServiceReady))).To(gomega.BeTrue())
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		// Set up port-forwarding to the head pod for sending HTTP requests
+		var localPort int
+		var stopChan chan struct{}
+		gomega.Eventually(func(g gomega.Gomega) {
+			headPodName := getRayHeadPod(g).Name
+			var err error
+			localPort, stopChan, err = util.KPortForward(cfg, restClient, ns.Name, headPodName, 8000)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+		}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+		defer close(stopChan)
+
+		ginkgo.By("Verifying the RayService responds to HTTP requests via port-forward", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				resp, err := http.Get(fmt.Sprintf("http://localhost:%d/", localPort))
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				defer resp.Body.Close()
+				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
+				body, err := io.ReadAll(resp.Body)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(strings.TrimSpace(string(body))).To(gomega.ContainSubstring("Hello, World!"))
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Waiting for worker count to be zero due to autoscaling", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				runningWorkers := getRunningRayWorkerPodNames(g)
+				g.Expect(runningWorkers).To(gomega.BeEmpty(), "Expected 0 running worker pod before sending load")
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Sending concurrent requests to trigger autoscaling", func() {
+			// Send many concurrent slow requests so ongoing request count exceeds
+			// the target_ongoing_requests=1 threshold, triggering Ray Serve autoscaling.
+			// With max_replicas_per_node=1, new serve replicas require new Ray worker
+			// nodes, which triggers the RayCluster autoscaler to add workers.
+			for range 10 {
+				go func() {
+					reqClient := &http.Client{Timeout: 60 * time.Second}
+					resp, err := reqClient.Get(fmt.Sprintf("http://localhost:%d/?delay=10", localPort))
+					if err == nil && resp != nil {
+						resp.Body.Close()
+					}
+				}()
+			}
+		})
+
+		ginkgo.By("Waiting for worker count to increase due to autoscaling", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				runningWorkers := getRunningRayWorkerPodNames(g)
+				g.Expect(len(runningWorkers)).To(gomega.BeNumerically(">", 1),
+					fmt.Sprintf("Expected more than %d running worker pods after autoscaling", 1))
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
 		})
 	})

--- a/test/e2e/singlecluster/extended/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/extended/leaderworkerset_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package extended
 
 import (
 	"fmt"
@@ -23,7 +23,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -112,7 +111,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 			})
 
 			createdWorkload := &kueue.Workload{}
-			ginkgo.By("Check workload is created", func() {
+			ginkgo.By("Check workload is created and has JobUID label", func() {
 				gomega.Expect(k8sClient.Get(ctx, util.WorkloadKeyForLeaderWorkerSet(lws, "0"), createdWorkload)).To(gomega.Succeed())
 				gomega.Expect(createdWorkload.Labels[ctrlconstants.JobUIDLabel]).To(gomega.Equal(string(lws.UID)))
 			})
@@ -786,13 +785,9 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 			})
 
 			ginkgo.By(fmt.Sprintf("Verify workloads exist for initial %d groups", lwsReplicas), func() {
+				wl := &kueue.Workload{}
 				for i := range lwsReplicas {
-					wl := &kueue.Workload{}
-					wlKey := types.NamespacedName{
-						Name:      leaderworkerset.GetWorkloadName(lws.UID, lws.Name, strconv.Itoa(i)),
-						Namespace: ns.Name,
-					}
-					gomega.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
+					gomega.Expect(k8sClient.Get(ctx, util.WorkloadKeyForLeaderWorkerSet(lws, strconv.Itoa(i)), wl)).To(gomega.Succeed())
 				}
 			})
 
@@ -805,14 +800,10 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 			})
 
 			ginkgo.By(fmt.Sprintf("Wait for the surge workloads to be created with maxSurge=%d", maxSurge), func() {
+				wl := &kueue.Workload{}
 				gomega.Eventually(func(g gomega.Gomega) {
 					for i := lwsReplicas; i < lwsReplicas+maxSurge; i++ {
-						wl := &kueue.Workload{}
-						wlKey := types.NamespacedName{
-							Name:      leaderworkerset.GetWorkloadName(lws.UID, lws.Name, strconv.Itoa(i)),
-							Namespace: ns.Name,
-						}
-						g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed(),
+						g.Expect(k8sClient.Get(ctx, util.WorkloadKeyForLeaderWorkerSet(lws, strconv.Itoa(i)), wl)).To(gomega.Succeed(),
 							"workload for surge group %d should exist", i)
 					}
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
@@ -837,21 +828,142 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 
 			ginkgo.By(fmt.Sprintf("Verify surge workloads are cleaned up with maxSurge=%d", maxSurge), func() {
 				for i := lwsReplicas; i < lwsReplicas+maxSurge; i++ {
-					wlKey := types.NamespacedName{
-						Name:      leaderworkerset.GetWorkloadName(lws.UID, lws.Name, strconv.Itoa(i)),
-						Namespace: ns.Name,
-					}
-					gomega.Eventually(func() bool {
-						wl := &kueue.Workload{}
-						err := k8sClient.Get(ctx, wlKey, wl)
-						return apierrors.IsNotFound(err)
-					}, util.Timeout, util.Interval).Should(gomega.BeTrue(),
+					wl := &kueue.Workload{}
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, util.WorkloadKeyForLeaderWorkerSet(lws, strconv.Itoa(i)), wl)).
+							To(utiltesting.BeNotFoundError())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed(),
 						"surge workload for group %d should be deleted after rollout completes", i)
 				}
 			})
 
 			ginkgo.By("Delete the LeaderWorkerSet", func() {
 				util.ExpectObjectToBeDeleted(ctx, k8sClient, lws, true)
+			})
+		})
+
+		ginkgo.It("should admit and evict correctly when queue-name is set on pod templates", func() {
+			lws := leaderworkersettesting.MakeLeaderWorkerSet("lws", ns.Name).
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				Size(3).
+				Replicas(1).
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				TerminationGracePeriod(1).
+				Queue(lq.Name).
+				WorkerTemplateSpecLabel(ctrlconstants.QueueLabel, "user-queue").
+				Obj()
+
+			ginkgo.By("Create a LeaderWorkerSet with queue-name on worker template", func() {
+				util.MustCreate(ctx, k8sClient, lws)
+			})
+
+			wlLookupKey := util.WorkloadKeyForLeaderWorkerSet(lws, "0")
+
+			ginkgo.By("Checking that the workload is admitted", func() {
+				util.ExpectWorkloadsToBeAdmittedByKeys(ctx, k8sClient, wlLookupKey)
+			})
+
+			ginkgo.By("Waiting for replicas to be ready", func() {
+				createdLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
+					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
+					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(utiltesting.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			createdWorkload := &kueue.Workload{}
+			ginkgo.By("Deactivate the workload to simulate eviction", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+					createdWorkload.Spec.Active = new(false)
+					g.Expect(k8sClient.Update(ctx, createdWorkload)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking that pods are gated after eviction", func() {
+				pods := &corev1.PodList{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.List(ctx, pods, client.MatchingLabels{
+						leaderworkersetv1.SetNameLabelKey: lws.Name,
+					}, client.InNamespace(lws.Namespace))).Should(gomega.Succeed())
+					g.Expect(pods.Items).To(gomega.HaveLen(3))
+					for _, pod := range pods.Items {
+						g.Expect(pod.Spec.SchedulingGates).To(gomega.ContainElement(corev1.PodSchedulingGate{
+							Name: podconstants.SchedulingGateName,
+						}))
+					}
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Delete the LeaderWorkerSet", func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, lws, true)
+			})
+
+			ginkgo.By("Check pods are deleted", func() {
+				pods := &corev1.PodList{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.List(ctx, pods, client.MatchingLabels{
+						leaderworkersetv1.SetNameLabelKey: lws.Name,
+					}, client.InNamespace(lws.Namespace))).Should(gomega.Succeed())
+					g.Expect(pods.Items).To(gomega.BeEmpty())
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Check workload is deleted", func() {
+				util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, createdWorkload, false, util.MediumTimeout)
+			})
+		})
+
+		ginkgo.It("should allow to change queue-name if ReadyReplicas=0", func() {
+			lws := leaderworkersettesting.MakeLeaderWorkerSet("lws", ns.Name).
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				Size(1).
+				Replicas(1).
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				TerminationGracePeriod(1).
+				Queue(fmt.Sprintf("%s-invalid", lq.Name)).
+				Obj()
+
+			ginkgo.By("Creating a LeaderWorkerSet", func() {
+				util.MustCreate(ctx, k8sClient, lws)
+			})
+
+			wlLookupKey := types.NamespacedName{
+				Name:      leaderworkerset.GetWorkloadName(lws.UID, lws.Name, "0"),
+				Namespace: ns.Name,
+			}
+
+			ginkgo.By("Checking that workload is created and inadmissible", func() {
+				util.ExpectWorkloadsToBeInadmissibleByKeys(ctx, k8sClient, wlLookupKey)
+			})
+
+			createdLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
+
+			ginkgo.By("Checking that the replicas is not ready", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
+					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(0)))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Updating queue-name label", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
+					createdLeaderWorkerSet.Labels[ctrlconstants.QueueLabel] = lq.Name
+					g.Expect(k8sClient.Update(ctx, createdLeaderWorkerSet)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking that the workload is created and admitted", func() {
+				util.ExpectWorkloadsToBeAdmittedByKeys(ctx, k8sClient, wlLookupKey)
+			})
+
+			ginkgo.By("Waiting for replicas is ready", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
+					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
 	})
@@ -1310,7 +1422,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 			ginkgo.By("Deactivate workload", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
-					createdWorkload.Spec.Active = ptr.To(false)
+					createdWorkload.Spec.Active = new(false)
 					g.Expect(k8sClient.Update(ctx, createdWorkload)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -1344,14 +1456,14 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 				gomega.Consistently(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 					g.Expect(createdWorkload.UID).Should(gomega.Equal(createdWorkloadUID))
-					g.Expect(createdWorkload.Spec.Active).Should(gomega.Equal(ptr.To(false)))
+					g.Expect(createdWorkload.Spec.Active).Should(gomega.Equal(new(false)))
 				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Activate workload", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
-					createdWorkload.Spec.Active = ptr.To(true)
+					createdWorkload.Spec.Active = new(true)
 					g.Expect(k8sClient.Update(ctx, createdWorkload)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})

--- a/test/e2e/singlecluster/extended/pod_test.go
+++ b/test/e2e/singlecluster/extended/pod_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package extended
 
 import (
 	"fmt"
@@ -603,6 +603,16 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&p), &podWithHash)).To(gomega.Succeed())
 				initialRoleHash := podWithHash.Annotations[podconstants.RoleHashAnnotation]
 				gomega.Expect(initialRoleHash).NotTo(gomega.BeEmpty())
+			})
+
+			ginkgo.By("Verify pod has queue labels assigned", func() {
+				pKey := client.ObjectKey{Namespace: ns.Name, Name: "pod-0"}
+				gomega.Eventually(func(g gomega.Gomega) {
+					var runningPod corev1.Pod
+					g.Expect(k8sClient.Get(ctx, pKey, &runningPod)).To(gomega.Succeed())
+					g.Expect(runningPod.Labels[constants.ClusterQueueLabel]).To(gomega.Equal(cq.Name))
+					g.Expect(runningPod.Labels[constants.LocalQueueLabel]).To(gomega.Equal(lq.Name))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Verify the pod is scheduled and runs", func() {

--- a/test/e2e/singlecluster/extended/pytorchjob_test.go
+++ b/test/e2e/singlecluster/extended/pytorchjob_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package extended
 
 import (
 	"github.com/google/go-cmp/cmp/cmpopts"

--- a/test/e2e/singlecluster/extended/suite_test.go
+++ b/test/e2e/singlecluster/extended/suite_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extended
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var (
+	k8sClient  client.WithWatch
+	cfg        *rest.Config
+	restClient *rest.RESTClient
+	ctx        context.Context
+)
+
+func TestAPIs(t *testing.T) {
+	util.RunE2ESuite(t, "End To End Extended Suite")
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	util.SetupLogger()
+
+	var err error
+	k8sClient, cfg, err = util.CreateClientUsingCluster("")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	restClient = util.CreateRestClient(cfg)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	ctx = ginkgo.GinkgoT().Context()
+
+	waitForAvailableStart := time.Now()
+	util.WaitForKueueAvailability(ctx, k8sClient)
+	labelFilter := ginkgo.GinkgoLabelFilter()
+	if ginkgo.Label("feature:jobset", "feature:tas", "feature:trainjob").MatchesLabelFilter(labelFilter) {
+		util.WaitForJobSetAvailability(ctx, k8sClient)
+	}
+	if ginkgo.Label("feature:leaderworkerset").MatchesLabelFilter(labelFilter) {
+		util.WaitForLeaderWorkerSetAvailability(ctx, k8sClient)
+	}
+	if ginkgo.Label("feature:appwrapper").MatchesLabelFilter(labelFilter) {
+		util.WaitForAppWrapperAvailability(ctx, k8sClient)
+	}
+	if ginkgo.Label("feature:jaxjob", "feature:pytorchjob").MatchesLabelFilter(labelFilter) {
+		util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sClient)
+	}
+	if ginkgo.Label("feature:kuberay").MatchesLabelFilter(labelFilter) {
+		util.WaitForKubeRayOperatorAvailability(ctx, k8sClient)
+	}
+	if ginkgo.Label("feature:tas", "feature:trainjob").MatchesLabelFilter(labelFilter) {
+		util.WaitForKubeFlowTrainnerControllerManagerAvailability(ctx, k8sClient)
+	}
+	ginkgo.GinkgoLogr.Info(
+		"Kueue and all required operators are available in the cluster",
+		"waitingTime", time.Since(waitForAvailableStart),
+	)
+})

--- a/test/e2e/singlecluster/extended/tas_test.go
+++ b/test/e2e/singlecluster/extended/tas_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package extended
 
 import (
 	"fmt"
@@ -23,9 +23,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -223,7 +221,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", ginkgo.Label("area:singleclus
 				jobSetKey := client.ObjectKeyFromObject(jobSet)
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, jobSetKey, jobSet)).To(gomega.Succeed())
-					g.Expect(jobSet.Spec.Suspend).Should(gomega.Equal(ptr.To(false)))
+					g.Expect(jobSet.Spec.Suspend).Should(gomega.Equal(new(false)))
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -475,15 +473,14 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", ginkgo.Label("area:singleclus
 				TrainerImage(util.GetAgnHostImage(), []string{"/agnhost"}, util.BehaviorExitFast).
 				TrainerRequest(corev1.ResourceCPU, "500m").
 				TrainerRequest(corev1.ResourceMemory, "200Mi").
-				PodTemplateOverrides([]kftrainerapi.PodTemplateOverride{
-					{
-						TargetJobs: []kftrainerapi.PodTemplateOverrideTargetJob{
-							{Name: "node"},
-						},
-						Metadata: &metav1.ObjectMeta{
-							Annotations: map[string]string{kueue.PodSetRequiredTopologyAnnotation: corev1.LabelHostname},
-						},
-					},
+				RuntimePatches([]kftrainerapi.RuntimePatch{
+					testingtrainjob.MakeRuntimePatch("test-e2e/tas").
+						ReplicatedJobs(
+							testingtrainjob.MakeReplicatedJobPatch("node").
+								PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, corev1.LabelHostname).
+								Obj(),
+						).
+						Obj(),
 				}).
 				Obj()
 
@@ -495,13 +492,16 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", ginkgo.Label("area:singleclus
 				trainjobKey := client.ObjectKeyFromObject(trainjob)
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, trainjobKey, trainjob)).To(gomega.Succeed())
-					g.Expect(trainjob.Spec.Suspend).Should(gomega.Equal(ptr.To(false)))
+					g.Expect(trainjob.Spec.Suspend).Should(gomega.Equal(new(false)))
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			ginkgo.By("verify the TrainJob has nodeSelector set", func() {
-				gomega.Expect(trainjob.Spec.PodTemplateOverrides).To(gomega.HaveLen(2))
-				gomega.Expect(trainjob.Spec.PodTemplateOverrides[1].Spec.NodeSelector).To(gomega.Equal(
+			ginkgo.By("Verify that the trainjob has a runtime patch from kueue", func() {
+				kueueRuntimePatch := testingtrainjob.KueueRuntimePatch(trainjob)
+				gomega.Expect(kueueRuntimePatch).ToNot(gomega.BeNil())
+				rJobs := kueueRuntimePatch.TrainingRuntimeSpec.Template.Spec.ReplicatedJobs
+				gomega.Expect(rJobs).To(gomega.HaveLen(1))
+				gomega.Expect(rJobs[0].Template.Spec.Template.Spec.NodeSelector).To(gomega.Equal(
 					map[string]string{
 						"instance-type": "on-demand",
 					},
@@ -531,6 +531,114 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", ginkgo.Label("area:singleclus
 
 			ginkgo.By(fmt.Sprintf("verify the workload %q gets finished", wlLookupKey), func() {
 				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
+			})
+		})
+	})
+
+	ginkgo.When("Scaling a Job requesting TAS via workload slices", func() {
+		var (
+			topology     *kueue.Topology
+			onDemandRF   *kueue.ResourceFlavor
+			localQueue   *kueue.LocalQueue
+			clusterQueue *kueue.ClusterQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			topology = utiltestingapi.MakeDefaultOneLevelTopology("hostname-" + ns.Name)
+			util.MustCreate(ctx, k8sClient, topology)
+
+			onDemandRF = utiltestingapi.MakeResourceFlavor("on-demand-"+ns.Name).
+				NodeLabel("instance-type", "on-demand").TopologyName(topology.Name).Obj()
+			util.MustCreate(ctx, k8sClient, onDemandRF)
+			clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue-" + ns.Name).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(onDemandRF.Name).
+						Resource(corev1.ResourceCPU, "4").
+						Resource(corev1.ResourceMemory, "4Gi").
+						Obj(),
+				).
+				Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+
+			localQueue = utiltestingapi.MakeLocalQueue("main", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteAllJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			// Force remove workloads to be sure that cluster queue can be removed.
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandRF, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+		})
+
+		ginkgo.It("should preserve topology assignment during scale-up", func() {
+			sampleJob := testingjob.MakeJob("test-job", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				SetAnnotation("kueue.x-k8s.io/elastic-job", "true").
+				Parallelism(1).
+				Completions(10).
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				RequestAndLimit(corev1.ResourceMemory, "20Mi").
+				PodAnnotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				Obj()
+			util.MustCreate(ctx, k8sClient, sampleJob)
+
+			var createdWorkload *kueue.Workload
+			var originalNodeName string
+			ginkgo.By("await for admission of workload and record topology", func() {
+				// Use ExpectWorkloadsInNamespace instead of computing workload name
+				// because with workload slicing enabled, the name includes generation
+				workloads := util.ExpectWorkloadsInNamespace(ctx, k8sClient, ns.Name, 1)
+				createdWorkload = &workloads[0]
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(createdWorkload), createdWorkload)).Should(gomega.Succeed())
+					g.Expect(createdWorkload.Status.Admission).ShouldNot(gomega.BeNil())
+					g.Expect(createdWorkload.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(1))
+					g.Expect(createdWorkload.Status.Admission.PodSetAssignments[0].TopologyAssignment).ShouldNot(gomega.BeNil())
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+
+				ta := tas.InternalFrom(createdWorkload.Status.Admission.PodSetAssignments[0].TopologyAssignment)
+				gomega.Expect(ta.Domains).ShouldNot(gomega.BeEmpty())
+				originalNodeName = ta.Domains[0].Values[0]
+			})
+
+			scaledParallelism := int32(2)
+			ginkgo.By("scale up the job parallelism", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sampleJob), sampleJob)).To(gomega.Succeed())
+					sampleJob.Spec.Parallelism = new(scaledParallelism)
+					g.Expect(k8sClient.Update(ctx, sampleJob)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verify scaled workload preserves original topology assignment", func() {
+				scaledWorkload := util.ExpectNewWorkloadSlice(ctx, k8sClient, createdWorkload)
+				gomega.Expect(scaledWorkload).ShouldNot(gomega.BeNil())
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(scaledWorkload), scaledWorkload)).To(gomega.Succeed())
+					g.Expect(scaledWorkload.Status.Admission).ShouldNot(gomega.BeNil())
+					g.Expect(scaledWorkload.Spec.PodSets).Should(gomega.HaveLen(1))
+					g.Expect(scaledWorkload.Spec.PodSets[0].Count).Should(gomega.Equal(scaledParallelism))
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+
+				ta := tas.InternalFrom(scaledWorkload.Status.Admission.PodSetAssignments[0].TopologyAssignment)
+				gomega.Expect(ta).ShouldNot(gomega.BeNil())
+
+				foundOriginal := false
+				for _, domain := range ta.Domains {
+					if len(domain.Values) > 0 && domain.Values[0] == originalNodeName {
+						foundOriginal = true
+						break
+					}
+				}
+				gomega.Expect(foundOriginal).To(gomega.BeTrue(),
+					"original node %s should be preserved in scaled assignment", originalNodeName)
 			})
 		})
 	})

--- a/test/e2e/singlecluster/extended/trainjob_test.go
+++ b/test/e2e/singlecluster/extended/trainjob_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package extended
 
 import (
 	"github.com/onsi/ginkgo/v2"
@@ -97,7 +97,7 @@ var _ = ginkgo.Describe("TrainJob", ginkgo.Label("area:singlecluster", "feature:
 			ginkgo.By("Waiting for the trainjob to be unsuspended", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainjob), trainjob)).To(gomega.Succeed())
-					g.Expect(trainjob.Spec.Suspend).Should(gomega.BeEquivalentTo(ptr.To(false)))
+					g.Expect(trainjob.Spec.Suspend).Should(gomega.BeEquivalentTo(new(false)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -177,12 +177,18 @@ var _ = ginkgo.Describe("TrainJob", ginkgo.Label("area:singlecluster", "feature:
 			ginkgo.By("Waiting for the trainjob to be unsuspended", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainjob), trainjob)).To(gomega.Succeed())
-					g.Expect(trainjob.Spec.Suspend).Should(gomega.BeEquivalentTo(ptr.To(false)))
+					g.Expect(trainjob.Spec.Suspend).Should(gomega.BeEquivalentTo(new(false)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
+			ginkgo.By("Verify that the trainjob has a runtime patch from kueue", func() {
+				gomega.Expect(testingtrainjob.KueueRuntimePatch(trainjob)).ToNot(gomega.BeNil())
+			})
+
 			ginkgo.By("Verify the trainjob has nodeSelector set", func() {
-				gomega.Expect(trainjob.Spec.PodTemplateOverrides[0].Spec.NodeSelector).To(gomega.Equal(
+				rJobs := testingtrainjob.KueueRuntimePatch(trainjob).TrainingRuntimeSpec.Template.Spec.ReplicatedJobs
+				gomega.Expect(rJobs).To(gomega.HaveLen(1))
+				gomega.Expect(rJobs[0].Template.Spec.Template.Spec.NodeSelector).To(gomega.Equal(
 					map[string]string{
 						"instance-type": "on-demand",
 					},
@@ -199,7 +205,7 @@ var _ = ginkgo.Describe("TrainJob", ginkgo.Label("area:singlecluster", "feature:
 			ginkgo.By("Waiting for the TrainJob to be suspended", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainjob), trainjob)).To(gomega.Succeed())
-					g.Expect(trainjob.Spec.Suspend).Should(gomega.BeEquivalentTo(ptr.To(true)))
+					g.Expect(trainjob.Spec.Suspend).Should(gomega.BeEquivalentTo(new(true)))
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 		})


### PR DESCRIPTION
What type of PR is this?
/kind cleanup
/area testing

What this PR does / why we need it:
Splits the e2e singlecluster tests into two separate suites:

- baseline: contains core tests (job, deployment, metrics, visibility, 
  kueuectl, statefulset, fairsharing, etc.)
  
- extended: contains tests for external integrations (appwrapper, 
  jaxjob, jobset, kuberay, leaderworkerset, pytorchjob, tas, trainjob)

This separation allows baseline tests to run independently without 
needing external operators (Ray, Kubeflow, etc.), making CI faster 
and more reliable.
Which issue this fixes:
Part of #11138

Special notes for reviewer:
This is a cherry-pick of the singlecluster split from main onto 
release-0.16. The Makefile targets test-e2e-baseline and 
test-e2e-extended replace the old test-e2e target.

Release note:
```release-note
NONE
```
