### PR TITLE
Automated cherry pick of #11138: test: e2e split singlecluster into extended and baseline

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -130,20 +130,16 @@ test-multikueue-integration: compile-crd-manifests envtest ginkgo dep-crds ginkg
 	$(GINKGO) $(INTEGRATION_FILTERS) $(GINKGO_ARGS) $(GOFLAGS) -procs=$(INTEGRATION_NPROCS_MULTIKUEUE) --race --junit-report=multikueue-junit.xml --json-report=multikueue-integration.json --output-interceptor-mode=none --output-dir=$(ARTIFACTS) -v $(INTEGRATION_TARGET_MULTIKUEUE)
 	$(BIN_DIR)/ginkgo-top -i $(ARTIFACTS)/multikueue-integration.json > $(ARTIFACTS)/multikueue-integration-top.yaml
 
-## Label Taxonomy:
-##   Features: appwrapper,certs,deployment,job,fairsharing,jaxjob,jobset,kuberay,kueuectl,leaderworkerset,metrics,pod,pytorchjob,statefulset,tas,trainjob,visibility,e2e_v1beta1,ha
-##
-## Examples:
-##   Run only AppWrapper tests: GINKGO_ARGS="--label-filter=feature:appwrapper" make test-e2e
-##   Run only certs tests: GINKGO_ARGS="--label-filter=feature:certs" make test-e2e
-##   Run only jobset and trainjob tests: GINKGO_ARGS="--label-filter=feature:jobset,feature:trainjob" make test-e2e
-test-e2e: E2E_NPROCS := 4
 .PHONY: test-e2e
-test-e2e: setup-e2e-env kueuectl kind-ray-project-mini-image-build run-test-e2e-singlecluster-$(E2E_KIND_VERSION:kindest/node:v%=%)
+test-e2e: test-e2e-baseline test-e2e-extended
 
-.PHONY: test-e2e-helm
-test-e2e-helm: E2E_USE_HELM=true
-test-e2e-helm: test-e2e
+.PHONY: test-e2e-baseline-helm
+test-e2e-baseline-helm: E2E_USE_HELM=true
+test-e2e-baseline-helm: test-e2e-baseline
+
+.PHONY: test-e2e-extended-helm
+test-e2e-extended-helm: E2E_USE_HELM=true
+test-e2e-extended-helm: test-e2e-extended
 
 .PHONY: test-multikueue-e2e-parallel-builds
 test-multikueue-e2e-parallel-builds:
@@ -159,6 +155,24 @@ test-multikueue-e2e-sequential: setup-e2e-env test-multikueue-e2e-parallel-build
 .PHONY: test-multikueue-e2e-helm
 test-multikueue-e2e-helm: E2E_USE_HELM=true
 test-multikueue-e2e-helm: test-multikueue-e2e
+
+## Label Taxonomy:
+##   Features: appwrapper,jaxjob,jobset,kuberay,leaderworkerset,pytorchjob,tas,trainjob
+##
+## Examples:
+##   Run only AppWrapper tests: GINKGO_ARGS="--label-filter=feature:appwrapper" make test-e2e-extended
+.PHONY: test-e2e-extended
+test-e2e-extended: E2E_NPROCS := 4
+test-e2e-extended: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
+
+## Label Taxonomy:
+##   Features: certs,deployment,job,fairsharing,kueuectl,metrics,pod,statefulset,visibility,e2e_v1beta1,ha
+##
+## Examples:
+##   Run only job tests: GINKGO_ARGS="--label-filter=feature:job" make test-e2e-baseline
+.PHONY: test-e2e-baseline
+test-e2e-baseline: E2E_NPROCS := 4
+test-e2e-baseline: setup-e2e-env kueuectl run-test-e2e-baseline-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-tas-e2e-baseline
 test-tas-e2e-baseline: setup-e2e-env run-test-tas-e2e-baseline-$(E2E_KIND_VERSION:kindest/node:v%=%)
@@ -209,9 +223,33 @@ test-e2e-certmanager-upgrade: setup-e2e-env run-test-e2e-certmanager-upgrade-$(E
 .PHONY: test-e2e-dra
 test-e2e-dra: setup-e2e-env run-test-e2e-dra-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
+<<<<<<< HEAD
 run-test-e2e-singlecluster-%: K8S_VERSION = $(@:run-test-e2e-singlecluster-%=%)
 run-test-e2e-singlecluster-%:
 	@echo Running e2e for k8s ${K8S_VERSION}
+=======
+.PHONY: test-e2e-multikueue-dra
+test-e2e-multikueue-dra: setup-e2e-env run-test-e2e-multikueue-dra-$(E2E_KIND_VERSION:kindest/node:v%=%)
+
+run-test-e2e-baseline-%: K8S_VERSION = $(@:run-test-e2e-baseline-%=%)
+run-test-e2e-baseline-%:
+	@echo Running baseline e2e for k8s ${K8S_VERSION}
+	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
+		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
+		E2E_MODE=$(E2E_MODE) \
+		E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
+		E2E_ENFORCE_OPERATOR_UPDATE=$(E2E_ENFORCE_OPERATOR_UPDATE) \
+		PROMETHEUS_OPERATOR_VERSION=$(PROMETHEUS_OPERATOR_VERSION) \
+		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="singlecluster/baseline" \
+		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
+		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
+		E2E_USE_HELM=$(E2E_USE_HELM) \
+		./hack/testing/e2e-test.sh
+
+run-test-e2e-extended-%: K8S_VERSION = $(@:run-test-e2e-extended-%=%)
+run-test-e2e-extended-%:
+	@echo Running extended e2e for k8s ${K8S_VERSION}
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended
 	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
 		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
 		E2E_MODE=$(E2E_MODE) \
@@ -223,7 +261,11 @@ run-test-e2e-singlecluster-%:
 		KUBEFLOW_TRAINER_VERSION=$(KUBEFLOW_TRAINER_VERSION) \
 		LEADERWORKERSET_VERSION=$(LEADERWORKERSET_VERSION) \
 		KUBERAY_VERSION=$(KUBERAY_VERSION) RAY_VERSION=$(RAY_VERSION) RAYMINI_VERSION=$(RAYMINI_VERSION) USE_RAY_FOR_TESTS=$(USE_RAY_FOR_TESTS) \
+<<<<<<< HEAD
 		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="singlecluster" \
+=======
+		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="singlecluster/extended" \
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
 		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		E2E_USE_HELM=$(E2E_USE_HELM) \

--- a/site/content/en/docs/contribution_guidelines/testing.md
+++ b/site/content/en/docs/contribution_guidelines/testing.md
@@ -56,9 +56,10 @@ For running a subset of tests, see [Running subset of tests](#running-subset-of-
 ## Running e2e tests using custom build
 ```shell
 make kind-image-build
-make test-e2e
 make test-tas-e2e-baseline
 make test-tas-e2e-extended
+make test-e2e-baseline
+make test-e2e-extended
 make test-e2e-sequential-extended
 make test-e2e-sequential-baseline
 make test-e2e-certmanager
@@ -68,7 +69,7 @@ make test-multikueue-e2e
 
 You can specify the Kubernetes version used for running the e2e tests by setting the `E2E_K8S_FULL_VERSION` variable:
 ```shell
-E2E_K8S_FULL_VERSION=1.35.0 make test-e2e
+E2E_K8S_FULL_VERSION=1.35.0 make test-e2e-baseline
 ```
 
 For running a subset of tests, see [Running subset of tests](#running-subset-of-integration-or-e2e-tests).
@@ -127,22 +128,49 @@ Use `E2E_MODE=dev` to create-or-reuse a kind cluster, rebuild/redeploy Kueue, ru
 
 ```shell
 # Create if missing, otherwise reuse cluster. Rebuild image, run tests, keep the cluster.
-E2E_MODE=dev make kind-image-build test-e2e
+E2E_MODE=dev make kind-image-build test-e2e-baseline
 
 # MultiKueue dev mode
 E2E_MODE=dev make kind-image-build test-multikueue-e2e
 
 # Loop a suite (until it fails) while keeping the cluster
-E2E_MODE=dev GINKGO_ARGS="--until-it-fails" make kind-image-build  test-e2e
+E2E_MODE=dev GINKGO_ARGS="--until-it-fails" make kind-image-build  test-e2e-baseline
+
 
 # Skip reinstallation of kueue (works only in dev mode)
+<<<<<<< HEAD
 E2E_MODE=dev E2E_SKIP_REINSTALL=true make kind-image-build test-e2e
 E2E_MODE=dev E2E_SKIP_REINSTALL=true make kind-image-build test-multikueue-e2e
+=======
+E2E_MODE=dev E2E_SKIP_REINSTALL=true make kind-image-build test-e2e-baseline
+E2E_MODE=dev E2E_SKIP_REINSTALL=true make kind-image-build test-multikueue-e2e-main
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended
 
 # Skip re-pulling dependency images and re-importing them into kind when already present (dev mode only)
-E2E_MODE=dev E2E_SKIP_IMAGE_RELOAD=true make kind-image-build test-e2e
+E2E_MODE=dev E2E_SKIP_IMAGE_RELOAD=true make kind-image-build test-e2e-baseline
 ```
 
+<<<<<<< HEAD
+=======
+To use a **released** or **staging** Kueue image instead of building from source (no `kind-image-build` needed), pass `IMAGE_TAG` with the desired image:
+
+```shell
+# Released version
+E2E_MODE=dev IMAGE_TAG=registry.k8s.io/kueue/kueue:v0.16.0 make test-e2e-baseline
+E2E_MODE=dev IMAGE_TAG=registry.k8s.io/kueue/kueue:v0.16.0 make test-multikueue-e2e-main
+
+# Staging image (e.g. from a PR or nightly)
+E2E_MODE=dev IMAGE_TAG=us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue:main make test-e2e-baseline
+```
+
+**Using a released version with matching manifests:** The e2e framework deploys CRDs and other resources from the repo's config and overrides only the controller image via `IMAGE_TAG`. To run e2e against a specific release with manifests that match that image:
+
+1. Check out that version's tag (e.g. `git checkout v0.16.0`). The CRD and deployment config in the repo are committed at each release, so no `make manifests` step is needed.
+2. Run the command above with the same image tag, e.g. `E2E_MODE=dev IMAGE_TAG=registry.k8s.io/kueue/kueue:v0.16.0 make test-e2e-baseline`.
+
+This is useful to reproduce issues on a specific released version (e.g. for on-call debugging). For installing a released version into a real cluster (not e2e), see [Install a released version](/docs/installation/#install-a-released-version).
+
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended
 {{% alert title="Note" color="primary" %}}
 When reusing a kept cluster in `E2E_MODE=dev`, external operators (MPI, KubeRay, etc.) are installed only once.
 To force re-installing them on every run, set `E2E_ENFORCE_OPERATOR_UPDATE=true`.
@@ -175,6 +203,19 @@ The cluster is ready, and now you can run tests from another terminal:
 ```
 or from VSCode.
 
+<<<<<<< HEAD
+=======
+## Debugging metrics with Prometheus
+
+To provision a Kind cluster with Prometheus pre-configured for metrics debugging:
+
+```shell
+E2E_MODE=dev GINKGO_ARGS="--label-filter=feature:prometheus" make kind-image-build test-e2e-baseline
+```
+
+For more details, see [Setup Dev Monitoring](/docs/tasks/dev/setup_dev_monitoring).
+
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended
 ## Running subset of integration or e2e tests
 
 ### Use label filters for integration tests
@@ -219,13 +260,14 @@ SingleCluster tests are labeled by feature and area. You can use `GINKGO_ARGS` w
 **Examples:**
 ```shell
 # Run only appwrapper tests
-GINKGO_ARGS="--label-filter=feature:appwrapper" make test-e2e
+GINKGO_ARGS="--label-filter=feature:appwrapper" make test-e2e-extended
+
 
 # Run only deployment tests with helm
-GINKGO_ARGS="--label-filter=feature:deployment" make test-e2e-helm
+GINKGO_ARGS="--label-filter=feature:deployment" make test-e2e-baseline-helm
 
 # Run only jobset and trainjob tests with helm
-GINKGO_ARGS="--label-filter=feature:jobset,feature:trainjob" make test-e2e
+GINKGO_ARGS="--label-filter=feature:jobset,feature:trainjob" make test-e2e-extended
 ```
 
 ### Use label filters for e2e sequential tests
@@ -249,7 +291,7 @@ GINKGO_ARGS="--label-filter=feature:suite" make test-e2e-sequential-extended
 ### Use Ginkgo --focus arg
 ```shell
 GINKGO_ARGS="--focus=Scheduler" make test-integration
-GINKGO_ARGS="--focus='Creating a Pod requesting TAS'" make test-e2e
+GINKGO_ARGS="--focus='Creating a Pod requesting TAS'" make test-e2e-baseline
 ```
 ### Use ginkgo.FIt
 If you want to focus on specific tests, you can change
@@ -281,7 +323,7 @@ INTEGRATION_TARGET='test/integration/singlecluster/scheduler' make test-integrat
 You can use --until-it-fails or --repeat=N arguments to Ginkgo to run tests repeatedly, such as:
 ```shell
 GINKGO_ARGS="--until-it-fails" make test-integration
-GINKGO_ARGS="--repeat=10" make test-e2e
+GINKGO_ARGS="--repeat=10" make test-e2e-baseline
 ```
 See more [here](https://onsi.github.io/ginkgo/#repeating-spec-runs-and-managing-flaky-specs)
 

--- a/site/content/zh-CN/docs/contribution_guidelines/testing.md
+++ b/site/content/zh-CN/docs/contribution_guidelines/testing.md
@@ -56,9 +56,10 @@ make test-integration
 ## 使用自定义构建运行 e2e 测试 {#running-e2e-tests-using-custom-build}
 ```shell
 make kind-image-build
-make test-e2e
 make test-tas-e2e-baseline
 make test-tas-e2e-extended
+make test-e2e-baseline
+make test-e2e-extended
 make test-e2e-sequential-extended
 make test-e2e-sequential-baseline
 make test-e2e-certmanager
@@ -68,7 +69,7 @@ make test-multikueue-e2e
 
 你可以通过设置 `E2E_K8S_FULL_VERSION` 变量来指定用于运行 e2e 测试的 Kubernetes 版本：
 ```shell
-E2E_K8S_FULL_VERSION=1.34.1 make test-e2e
+E2E_K8S_FULL_VERSION=1.34.1 make test-e2e-baseline
 ```
 
 关于运行测试子集，请参阅 [运行测试子集](#running-subset-of-integration-or-e2e-tests)。
@@ -127,15 +128,44 @@ func TestValidateClusterQueue(t *testing.T) {
 
 ```shell
 # 若不存在则创建；若已存在则复用。构建镜像、运行测试，并保留集群。
+<<<<<<< HEAD
 E2E_MODE=dev make test-e2e
+=======
+E2E_MODE=dev make kind-image-build test-e2e-baseline
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended
 
 # MultiKueue 的 dev 模式
 E2E_MODE=dev make test-multikueue-e2e
 
 # 循环运行（直到失败），同时保留集群
+<<<<<<< HEAD
 E2E_MODE=dev GINKGO_ARGS="--until-it-fails" make test-e2e
 ```
 
+=======
+E2E_MODE=dev GINKGO_ARGS="--until-it-fails" make kind-image-build  test-e2e-baseline
+```
+
+若希望使用**已发布**或**预发布（staging）**的 Kueue 镜像而非从源码构建（无需执行 `kind-image-build`），可传入 `IMAGE_TAG` 并指定所需镜像：
+
+```shell
+# 已发布版本
+E2E_MODE=dev IMAGE_TAG=registry.k8s.io/kueue/kueue:v0.16.0 make test-e2e-baseline
+E2E_MODE=dev IMAGE_TAG=registry.k8s.io/kueue/kueue:v0.16.0 make test-multikueue-e2e-main
+
+# 预发布镜像（例如来自 PR 或每日构建）
+E2E_MODE=dev IMAGE_TAG=us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue:main make test-e2e-baseline
+```
+
+**使用与 manifest 匹配的已发布版本：** e2e 框架从仓库的 config 部署 CRD 等资源，仅通过 `IMAGE_TAG` 覆盖控制器镜像。若要对某一发布版本运行 e2e 且使用与该镜像匹配的 manifest：
+
+1. 检出该版本的 tag（例如 `git checkout v0.16.0`）。仓库中的 CRD 与部署配置在每个版本中均已提交，无需执行 `make manifests`。
+2. 使用相同镜像 tag 运行上述命令，例如 `E2E_MODE=dev IMAGE_TAG=registry.k8s.io/kueue/kueue:v0.16.0 make test-e2e-baseline`。
+
+适用于在特定已发布版本上复现问题（例如值班排查）。若要在真实集群（非 e2e）中安装已发布版本，请参阅[安装已发布版本](/zh-CN/docs/installation/#install-a-released-version)。
+
+{{% alert title="Note" color="primary" %}}
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended
 当在 `E2E_MODE=dev` 下复用保留的集群时，外部算子（MPI、KubeRay 等）只会安装一次。
 如需在每次运行时强制重新安装它们，请设置 `E2E_ENFORCE_OPERATOR_UPDATE=true`。
 
@@ -158,7 +188,7 @@ kind delete clusters kind kind-manager kind-worker1 kind-worker2
 ### 使用 Ginkgo --focus 参数 {#use-ginkgo-focus-arg}
 ```shell
 GINKGO_ARGS="--focus=Scheduler" make test-integration
-GINKGO_ARGS="--focus='Creating a Pod requesting TAS'" make test-e2e
+GINKGO_ARGS="--focus='Creating a Pod requesting TAS'" make test-e2e-baseline
 ```
 ### 使用 ginkgo.FIt {#use-ginkgo-fit}
 如果你想专注于特定测试，可以将这些测试的
@@ -190,7 +220,7 @@ INTEGRATION_TARGET='test/integration/singlecluster/scheduler' make test-integrat
 你可以使用 --until-it-fails 或 --repeat=N 参数来让 Ginkgo 重复运行测试，例如：
 ```shell
 GINKGO_ARGS="--until-it-fails" make test-integration
-GINKGO_ARGS="--repeat=10" make test-e2e
+GINKGO_ARGS="--repeat=10" make test-e2e-baseline
 ```
 更多信息请参阅[这里](https://onsi.github.io/ginkgo/#repeating-spec-runs-and-managing-flaky-specs)
 

--- a/test/e2e/singlecluster/baseline/aggregated_openapi_test.go
+++ b/test/e2e/singlecluster/baseline/aggregated_openapi_test.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+<<<<<<< HEAD:test/e2e/singlecluster/aggregated_openapi_test.go
 package e2e
+=======
+package baseline
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended:test/e2e/singlecluster/baseline/aggregated_openapi_test.go
 
 import (
 	"github.com/onsi/ginkgo/v2"

--- a/test/e2e/singlecluster/baseline/deployment_test.go
+++ b/test/e2e/singlecluster/baseline/deployment_test.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+<<<<<<< HEAD:test/e2e/singlecluster/deployment_test.go
 package e2e
+=======
+package baseline
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended:test/e2e/singlecluster/baseline/deployment_test.go
 
 import (
 	"github.com/onsi/ginkgo/v2"

--- a/test/e2e/singlecluster/baseline/e2e_v1beta1_test.go
+++ b/test/e2e/singlecluster/baseline/e2e_v1beta1_test.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+<<<<<<< HEAD:test/e2e/singlecluster/e2e_v1beta1_test.go
 package e2e
+=======
+package baseline
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended:test/e2e/singlecluster/baseline/e2e_v1beta1_test.go
 
 import (
 	"fmt"

--- a/test/e2e/singlecluster/baseline/fair_sharing_test.go
+++ b/test/e2e/singlecluster/baseline/fair_sharing_test.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+<<<<<<< HEAD:test/e2e/singlecluster/fair_sharing_test.go
 package e2e
+=======
+package baseline
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended:test/e2e/singlecluster/baseline/fair_sharing_test.go
 
 import (
 	"fmt"

--- a/test/e2e/singlecluster/baseline/job_test.go
+++ b/test/e2e/singlecluster/baseline/job_test.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+<<<<<<< HEAD:test/e2e/singlecluster/job_test.go
 package e2e
+=======
+package baseline
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended:test/e2e/singlecluster/baseline/job_test.go
 
 import (
 	"fmt"

--- a/test/e2e/singlecluster/baseline/kueuectl_test.go
+++ b/test/e2e/singlecluster/baseline/kueuectl_test.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+<<<<<<< HEAD:test/e2e/singlecluster/kueuectl_test.go
 package e2e
+=======
+package baseline
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended:test/e2e/singlecluster/baseline/kueuectl_test.go
 
 import (
 	"os/exec"

--- a/test/e2e/singlecluster/baseline/metrics_test.go
+++ b/test/e2e/singlecluster/baseline/metrics_test.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+<<<<<<< HEAD:test/e2e/singlecluster/metrics_test.go
 package e2e
+=======
+package baseline
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended:test/e2e/singlecluster/baseline/metrics_test.go
 
 import (
 	"github.com/onsi/ginkgo/v2"

--- a/test/e2e/singlecluster/baseline/prometheus_test.go
+++ b/test/e2e/singlecluster/baseline/prometheus_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package baseline
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	corev1 "k8s.io/api/core/v1"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+const (
+	kueueBuildInfoMetric         = "kueue_build_info"
+	admittedWorkloadsTotalMetric = "kueue_admitted_workloads_total"
+)
+
+var _ = ginkgo.Describe("Prometheus", ginkgo.Label("area:prometheus", "feature:prometheus"), func() {
+	ginkgo.It("should discover Kueue target and report it as up", func() {
+		gomega.Eventually(func(g gomega.Gomega) {
+			result, err := prometheusClient.Targets(ctx)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+
+			hasKueueTarget := false
+			for _, t := range result.Active {
+				if t.Labels["job"] == model.LabelValue(util.DefaultMetricsServiceName) &&
+					t.Labels["namespace"] == model.LabelValue(util.GetKueueNamespace()) {
+					hasKueueTarget = true
+					g.Expect(t.Health).To(gomega.Equal(prometheusv1.HealthGood))
+					break
+				}
+			}
+			g.Expect(hasKueueTarget).To(gomega.BeTrue(), "Kueue target not found. Active targets: %v", result.Active)
+		}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("should scrape kueue_build_info metric via PromQL", func() {
+		gomega.Eventually(func(g gomega.Gomega) {
+			result, _, err := prometheusClient.Query(ctx, kueueBuildInfoMetric, time.Now())
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+
+			vector, ok := result.(model.Vector)
+			g.Expect(ok).To(gomega.BeTrue())
+			g.Expect(vector).NotTo(gomega.BeEmpty())
+			g.Expect(string(vector[0].Metric[model.MetricNameLabel])).To(gomega.Equal(kueueBuildInfoMetric))
+		}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("should report workload admission metrics via PromQL", func() {
+		ns := util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-prom-")
+		ginkgo.DeferCleanup(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		})
+
+		resourceFlavor := utiltestingapi.MakeResourceFlavor("prom-test-flavor-" + ns.Name).Obj()
+		util.MustCreate(ctx, k8sClient, resourceFlavor)
+		ginkgo.DeferCleanup(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, resourceFlavor, true)
+		})
+
+		clusterQueue := utiltestingapi.MakeClusterQueue("").
+			GeneratedName("prom-test-cq-").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).
+					Resource(corev1.ResourceCPU, "1").
+					Resource(corev1.ResourceMemory, "1Gi").
+					Obj(),
+			).
+			Obj()
+		util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+		ginkgo.DeferCleanup(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		})
+
+		localQueue := utiltestingapi.MakeLocalQueue("", ns.Name).
+			GeneratedName("prom-test-lq-").
+			ClusterQueue(clusterQueue.Name).
+			Obj()
+		util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+
+		ginkgo.By("Creating and admitting a workload")
+		workload := utiltestingapi.MakeWorkload("prom-test-workload", ns.Name).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			PodSets(
+				*utiltestingapi.MakePodSet("ps1", 1).Obj(),
+			).
+			RequestAndLimit(corev1.ResourceCPU, "1").
+			Obj()
+		util.MustCreate(ctx, k8sClient, workload)
+		ginkgo.DeferCleanup(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, workload, true)
+		})
+		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, workload)
+
+		ginkgo.By("Verifying the admission metric is reported")
+		gomega.Eventually(func(g gomega.Gomega) {
+			result, _, err := prometheusClient.Query(ctx,
+				fmt.Sprintf(`%s{cluster_queue="%s"}`, admittedWorkloadsTotalMetric, clusterQueue.Name),
+				time.Now())
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+
+			vector, ok := result.(model.Vector)
+			g.Expect(ok).To(gomega.BeTrue())
+			g.Expect(vector).NotTo(gomega.BeEmpty())
+		}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+	})
+})

--- a/test/e2e/singlecluster/baseline/statefulset_test.go
+++ b/test/e2e/singlecluster/baseline/statefulset_test.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+<<<<<<< HEAD:test/e2e/singlecluster/statefulset_test.go
 package e2e
+=======
+package baseline
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended:test/e2e/singlecluster/baseline/statefulset_test.go
 
 import (
 	"fmt"

--- a/test/e2e/singlecluster/baseline/suite_test.go
+++ b/test/e2e/singlecluster/baseline/suite_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+<<<<<<< HEAD:test/e2e/singlecluster/suite_test.go
+package e2e
+=======
+package baseline
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended:test/e2e/singlecluster/baseline/suite_test.go
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueueclientset "sigs.k8s.io/kueue/client-go/clientset/versioned"
+	visibility "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/visibility/v1beta2"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var (
+	kueuectlPath                 = filepath.Join("..", "..", "..", "..", "bin", "kubectl-kueue")
+	k8sClient                    client.WithWatch
+	cfg                          *rest.Config
+	restClient                   *rest.RESTClient
+	ctx                          context.Context
+	kueueClientset               kueueclientset.Interface
+	impersonatedVisibilityClient visibility.VisibilityV1beta2Interface
+	kueueNS                      = util.GetKueueNamespace()
+)
+
+func TestAPIs(t *testing.T) {
+	util.RunE2ESuite(t, "End To End Baseline Suite")
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	util.SetupLogger()
+
+	var err error
+	k8sClient, cfg, err = util.CreateClientUsingCluster("")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	restClient = util.CreateRestClient(cfg)
+	kueueClientset = util.CreateKueueClientset("")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	impersonatedVisibilityClient = util.CreateVisibilityClient(fmt.Sprintf("system:serviceaccount:%s:default", kueueNS))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	ctx = ginkgo.GinkgoT().Context()
+
+	waitForAvailableStart := time.Now()
+	util.WaitForKueueAvailability(ctx, k8sClient)
+	labelFilter := ginkgo.GinkgoLabelFilter()
+<<<<<<< HEAD:test/e2e/singlecluster/suite_test.go
+	if ginkgo.Label("feature:jobset", "feature:tas", "feature:trainjob").MatchesLabelFilter(labelFilter) {
+		util.WaitForJobSetAvailability(ctx, k8sClient)
+	}
+	if ginkgo.Label("feature:leaderworkerset").MatchesLabelFilter(labelFilter) {
+		util.WaitForLeaderWorkerSetAvailability(ctx, k8sClient)
+	}
+	if ginkgo.Label("feature:appwrapper").MatchesLabelFilter(labelFilter) {
+		util.WaitForAppWrapperAvailability(ctx, k8sClient)
+	}
+	if ginkgo.Label("feature:jaxjob", "feature:pytorchjob").MatchesLabelFilter(labelFilter) {
+		util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sClient)
+	}
+	if ginkgo.Label("feature:kuberay").MatchesLabelFilter(labelFilter) {
+		util.WaitForKubeRayOperatorAvailability(ctx, k8sClient)
+	}
+	if ginkgo.Label("feature:tas", "feature:trainjob").MatchesLabelFilter(labelFilter) {
+		util.WaitForKubeFlowTrainnerControllerManagerAvailability(ctx, k8sClient)
+=======
+	if ginkgo.Label("feature:prometheus").MatchesLabelFilter(labelFilter) {
+		prometheusClient = util.CreatePrometheusClient(cfg)
+		util.WaitForPrometheusAvailability(ctx, k8sClient)
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended:test/e2e/singlecluster/baseline/suite_test.go
+	}
+	ginkgo.GinkgoLogr.Info(
+		"Kueue and all required operators are available in the cluster",
+		"waitingTime", time.Since(waitForAvailableStart),
+	)
+})

--- a/test/e2e/singlecluster/baseline/visibility_test.go
+++ b/test/e2e/singlecluster/baseline/visibility_test.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+<<<<<<< HEAD:test/e2e/singlecluster/visibility_test.go
 package e2e
+=======
+package baseline
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended:test/e2e/singlecluster/baseline/visibility_test.go
 
 import (
 	"github.com/google/go-cmp/cmp"

--- a/test/e2e/singlecluster/extended/appwrapper_test.go
+++ b/test/e2e/singlecluster/extended/appwrapper_test.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+<<<<<<< HEAD:test/e2e/singlecluster/appwrapper_test.go
 package e2e
+=======
+package extended
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended:test/e2e/singlecluster/extended/appwrapper_test.go
 
 import (
 	"github.com/onsi/ginkgo/v2"

--- a/test/e2e/singlecluster/extended/jaxjob_test.go
+++ b/test/e2e/singlecluster/extended/jaxjob_test.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+<<<<<<< HEAD:test/e2e/singlecluster/jaxjob_test.go
 package e2e
+=======
+package extended
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended:test/e2e/singlecluster/extended/jaxjob_test.go
 
 import (
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -26,13 +30,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs/pytorchjob"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs/jaxjob"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
-	pytorchjobtesting "sigs.k8s.io/kueue/pkg/util/testingjobs/pytorchjob"
+	jaxjobtesting "sigs.k8s.io/kueue/pkg/util/testingjobs/jaxjob"
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("PyTorch integration", ginkgo.Label("area:singlecluster", "feature:pytorchjob"), func() {
+var _ = ginkgo.Describe("JAX integration", ginkgo.Label("area:singlecluster", "feature:jaxjob"), func() {
 	var (
 		ns                 *corev1.Namespace
 		rf                 *kueue.ResourceFlavor
@@ -44,10 +48,10 @@ var _ = ginkgo.Describe("PyTorch integration", ginkgo.Label("area:singlecluster"
 	)
 
 	ginkgo.BeforeEach(func() {
-		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "pytorch-e2e-")
-		resourceFlavorName = "pytorch-rf-" + ns.Name
-		clusterQueueName = "pytorch-cq-" + ns.Name
-		localQueueName = "pytorch-lq-" + ns.Name
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "jax-e2e-")
+		resourceFlavorName = "jax-rf-" + ns.Name
+		clusterQueueName = "jax-cq-" + ns.Name
+		localQueueName = "jax-lq-" + ns.Name
 
 		rf = utiltestingapi.MakeResourceFlavor(resourceFlavorName).Obj()
 		util.MustCreate(ctx, k8sClient, rf)
@@ -69,46 +73,48 @@ var _ = ginkgo.Describe("PyTorch integration", ginkgo.Label("area:singlecluster"
 		util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
 	})
 	ginkgo.AfterEach(func() {
-		gomega.Expect(util.DeleteAllPyTorchJobsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		gomega.Expect(util.DeleteAllJAXJobsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, rf, true)
 		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
 	})
 
-	ginkgo.When("PyTorch created", func() {
+	ginkgo.When("JAX created", func() {
 		ginkgo.It("should admit group with leader only", func() {
-			pytorch := pytorchjobtesting.MakePyTorchJob("pytorch-simple", ns.Name).
-				Queue(localQueueName).
+			jax := jaxjobtesting.MakeJAXJob("jax-simple", ns.Name).
+				Label("kueue.x-k8s.io/queue-name", localQueueName).
 				Suspend(false).
 				SetTypeMeta().
-				PyTorchReplicaSpecsOnlyMasterDefault().
-				Image(kftraining.PyTorchJobReplicaTypeMaster, util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
-				Request(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceCPU, "1").
-				Request(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceMemory, "200Mi").
+				JAXReplicaSpecsDefault().
+				TerminationGracePeriod(kftraining.JAXJobReplicaTypeWorker, 1).
+				Parallelism(kftraining.JAXJobReplicaTypeWorker, 2).
+				Image(kftraining.JAXJobReplicaTypeWorker, util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				Request(kftraining.JAXJobReplicaTypeWorker, corev1.ResourceCPU, "1").
+				Request(kftraining.JAXJobReplicaTypeWorker, corev1.ResourceMemory, "200Mi").
 				Obj()
 
-			ginkgo.By("Create a PyTorch", func() {
-				util.MustCreate(ctx, k8sClient, pytorch)
+			ginkgo.By("Create a JAX", func() {
+				util.MustCreate(ctx, k8sClient, jax)
 			})
 
 			ginkgo.By("Waiting for replicas to be ready", func() {
-				createdPyTorch := &kftraining.PyTorchJob{}
+				createdJAX := &kftraining.JAXJob{}
 
 				gomega.Eventually(func(g gomega.Gomega) {
-					// Fetch the PyTorch object
-					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(pytorch), createdPyTorch)
-					g.Expect(err).ToNot(gomega.HaveOccurred(), "Failed to fetch PyTorch")
+					// Fetch the JAX object
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(jax), createdJAX)
+					g.Expect(err).ToNot(gomega.HaveOccurred(), "Failed to fetch JAX")
 
 					// Check the worker replica status exists
-					masterReplicaStatus, ok := createdPyTorch.Status.ReplicaStatuses[kftraining.PyTorchJobReplicaTypeMaster]
-					g.Expect(ok).To(gomega.BeTrue(), "Master replica status not found in PyTorch status")
+					workerReplicaStatus, ok := createdJAX.Status.ReplicaStatuses[kftraining.JAXJobReplicaTypeWorker]
+					g.Expect(ok).To(gomega.BeTrue(), "Worker replica status not found in JAX status")
 
-					// Check the number of active replicas
-					g.Expect(masterReplicaStatus.Active).To(gomega.Equal(int32(1)), "Unexpected number of active %s replicas", kftraining.PyTorchJobReplicaTypeMaster)
+					// Check the number of active worker replicas
+					g.Expect(workerReplicaStatus.Active).To(gomega.Equal(int32(2)), "Unexpected number of active worker replicas")
 
-					// Ensure PyTorch job has "Running" condition with status "True"
-					g.Expect(createdPyTorch.Status.Conditions).To(gomega.ContainElements(
+					// Ensure JAX job has "Running" condition with status "True"
+					g.Expect(createdJAX.Status.Conditions).To(gomega.ContainElements(
 						gomega.BeComparableTo(kftraining.JobCondition{
 							Type:   kftraining.JobRunning,
 							Status: corev1.ConditionTrue,
@@ -118,7 +124,7 @@ var _ = ginkgo.Describe("PyTorch integration", ginkgo.Label("area:singlecluster"
 			})
 
 			wlLookupKey := types.NamespacedName{
-				Name:      pytorchjob.GetWorkloadNameForPyTorchJob(pytorch.Name, pytorch.UID),
+				Name:      jaxjob.GetWorkloadNameForJAXJob(jax.Name, jax.UID),
 				Namespace: ns.Name,
 			}
 			createdWorkload := &kueue.Workload{}
@@ -132,13 +138,13 @@ var _ = ginkgo.Describe("PyTorch integration", ginkgo.Label("area:singlecluster"
 
 			ginkgo.By("Check workload is finished", func() {
 				// Wait for active pods and terminate them
-				util.WaitForActivePodsAndTerminate(ctx, k8sClient, restClient, cfg, ns.Name, 1, 0, client.InNamespace(ns.Name))
+				util.WaitForActivePodsAndTerminate(ctx, k8sClient, restClient, cfg, ns.Name, 2, 0, client.InNamespace(ns.Name))
 
 				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
 			})
 
-			ginkgo.By("Delete the PyTorch", func() {
-				util.ExpectObjectToBeDeleted(ctx, k8sClient, pytorch, true)
+			ginkgo.By("Delete the JAX", func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, jax, true)
 			})
 
 			ginkgo.By("Check workload is deleted", func() {

--- a/test/e2e/singlecluster/extended/jobset_test.go
+++ b/test/e2e/singlecluster/extended/jobset_test.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+<<<<<<< HEAD:test/e2e/singlecluster/jobset_test.go
 package e2e
+=======
+package extended
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended:test/e2e/singlecluster/extended/jobset_test.go
 
 import (
 	"github.com/onsi/ginkgo/v2"

--- a/test/e2e/singlecluster/extended/kuberay_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_test.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+<<<<<<< HEAD:test/e2e/singlecluster/kuberay_test.go
 package e2e
+=======
+package extended
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended:test/e2e/singlecluster/extended/kuberay_test.go
 
 import (
 	"encoding/json"

--- a/test/e2e/singlecluster/extended/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/extended/leaderworkerset_test.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+<<<<<<< HEAD:test/e2e/singlecluster/leaderworkerset_test.go
 package e2e
+=======
+package extended
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended:test/e2e/singlecluster/extended/leaderworkerset_test.go
 
 import (
 	"fmt"

--- a/test/e2e/singlecluster/extended/pod_test.go
+++ b/test/e2e/singlecluster/extended/pod_test.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+<<<<<<< HEAD:test/e2e/singlecluster/pod_test.go
 package e2e
+=======
+package extended
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended:test/e2e/singlecluster/extended/pod_test.go
 
 import (
 	"fmt"

--- a/test/e2e/singlecluster/extended/pytorchjob_test.go
+++ b/test/e2e/singlecluster/extended/pytorchjob_test.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+<<<<<<< HEAD:test/e2e/singlecluster/pytorchjob_test.go
 package e2e
+=======
+package extended
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended:test/e2e/singlecluster/extended/pytorchjob_test.go
 
 import (
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -26,13 +30,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs/jaxjob"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs/pytorchjob"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
-	jaxjobtesting "sigs.k8s.io/kueue/pkg/util/testingjobs/jaxjob"
+	pytorchjobtesting "sigs.k8s.io/kueue/pkg/util/testingjobs/pytorchjob"
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("JAX integration", ginkgo.Label("area:singlecluster", "feature:jaxjob"), func() {
+var _ = ginkgo.Describe("PyTorch integration", ginkgo.Label("area:singlecluster", "feature:pytorchjob"), func() {
 	var (
 		ns                 *corev1.Namespace
 		rf                 *kueue.ResourceFlavor
@@ -44,10 +48,10 @@ var _ = ginkgo.Describe("JAX integration", ginkgo.Label("area:singlecluster", "f
 	)
 
 	ginkgo.BeforeEach(func() {
-		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "jax-e2e-")
-		resourceFlavorName = "jax-rf-" + ns.Name
-		clusterQueueName = "jax-cq-" + ns.Name
-		localQueueName = "jax-lq-" + ns.Name
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "pytorch-e2e-")
+		resourceFlavorName = "pytorch-rf-" + ns.Name
+		clusterQueueName = "pytorch-cq-" + ns.Name
+		localQueueName = "pytorch-lq-" + ns.Name
 
 		rf = utiltestingapi.MakeResourceFlavor(resourceFlavorName).Obj()
 		util.MustCreate(ctx, k8sClient, rf)
@@ -69,48 +73,46 @@ var _ = ginkgo.Describe("JAX integration", ginkgo.Label("area:singlecluster", "f
 		util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
 	})
 	ginkgo.AfterEach(func() {
-		gomega.Expect(util.DeleteAllJAXJobsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		gomega.Expect(util.DeleteAllPyTorchJobsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, rf, true)
 		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
 	})
 
-	ginkgo.When("JAX created", func() {
+	ginkgo.When("PyTorch created", func() {
 		ginkgo.It("should admit group with leader only", func() {
-			jax := jaxjobtesting.MakeJAXJob("jax-simple", ns.Name).
-				Label("kueue.x-k8s.io/queue-name", localQueueName).
+			pytorch := pytorchjobtesting.MakePyTorchJob("pytorch-simple", ns.Name).
+				Queue(localQueueName).
 				Suspend(false).
 				SetTypeMeta().
-				JAXReplicaSpecsDefault().
-				TerminationGracePeriod(kftraining.JAXJobReplicaTypeWorker, 1).
-				Parallelism(kftraining.JAXJobReplicaTypeWorker, 2).
-				Image(kftraining.JAXJobReplicaTypeWorker, util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
-				Request(kftraining.JAXJobReplicaTypeWorker, corev1.ResourceCPU, "1").
-				Request(kftraining.JAXJobReplicaTypeWorker, corev1.ResourceMemory, "200Mi").
+				PyTorchReplicaSpecsOnlyMasterDefault().
+				Image(kftraining.PyTorchJobReplicaTypeMaster, util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				Request(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceCPU, "1").
+				Request(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceMemory, "200Mi").
 				Obj()
 
-			ginkgo.By("Create a JAX", func() {
-				util.MustCreate(ctx, k8sClient, jax)
+			ginkgo.By("Create a PyTorch", func() {
+				util.MustCreate(ctx, k8sClient, pytorch)
 			})
 
 			ginkgo.By("Waiting for replicas to be ready", func() {
-				createdJAX := &kftraining.JAXJob{}
+				createdPyTorch := &kftraining.PyTorchJob{}
 
 				gomega.Eventually(func(g gomega.Gomega) {
-					// Fetch the JAX object
-					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(jax), createdJAX)
-					g.Expect(err).ToNot(gomega.HaveOccurred(), "Failed to fetch JAX")
+					// Fetch the PyTorch object
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(pytorch), createdPyTorch)
+					g.Expect(err).ToNot(gomega.HaveOccurred(), "Failed to fetch PyTorch")
 
 					// Check the worker replica status exists
-					workerReplicaStatus, ok := createdJAX.Status.ReplicaStatuses[kftraining.JAXJobReplicaTypeWorker]
-					g.Expect(ok).To(gomega.BeTrue(), "Worker replica status not found in JAX status")
+					masterReplicaStatus, ok := createdPyTorch.Status.ReplicaStatuses[kftraining.PyTorchJobReplicaTypeMaster]
+					g.Expect(ok).To(gomega.BeTrue(), "Master replica status not found in PyTorch status")
 
-					// Check the number of active worker replicas
-					g.Expect(workerReplicaStatus.Active).To(gomega.Equal(int32(2)), "Unexpected number of active worker replicas")
+					// Check the number of active replicas
+					g.Expect(masterReplicaStatus.Active).To(gomega.Equal(int32(1)), "Unexpected number of active %s replicas", kftraining.PyTorchJobReplicaTypeMaster)
 
-					// Ensure JAX job has "Running" condition with status "True"
-					g.Expect(createdJAX.Status.Conditions).To(gomega.ContainElements(
+					// Ensure PyTorch job has "Running" condition with status "True"
+					g.Expect(createdPyTorch.Status.Conditions).To(gomega.ContainElements(
 						gomega.BeComparableTo(kftraining.JobCondition{
 							Type:   kftraining.JobRunning,
 							Status: corev1.ConditionTrue,
@@ -120,7 +122,7 @@ var _ = ginkgo.Describe("JAX integration", ginkgo.Label("area:singlecluster", "f
 			})
 
 			wlLookupKey := types.NamespacedName{
-				Name:      jaxjob.GetWorkloadNameForJAXJob(jax.Name, jax.UID),
+				Name:      pytorchjob.GetWorkloadNameForPyTorchJob(pytorch.Name, pytorch.UID),
 				Namespace: ns.Name,
 			}
 			createdWorkload := &kueue.Workload{}
@@ -134,13 +136,13 @@ var _ = ginkgo.Describe("JAX integration", ginkgo.Label("area:singlecluster", "f
 
 			ginkgo.By("Check workload is finished", func() {
 				// Wait for active pods and terminate them
-				util.WaitForActivePodsAndTerminate(ctx, k8sClient, restClient, cfg, ns.Name, 2, 0, client.InNamespace(ns.Name))
+				util.WaitForActivePodsAndTerminate(ctx, k8sClient, restClient, cfg, ns.Name, 1, 0, client.InNamespace(ns.Name))
 
 				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
 			})
 
-			ginkgo.By("Delete the JAX", func() {
-				util.ExpectObjectToBeDeleted(ctx, k8sClient, jax, true)
+			ginkgo.By("Delete the PyTorch", func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, pytorch, true)
 			})
 
 			ginkgo.By("Check workload is deleted", func() {

--- a/test/e2e/singlecluster/extended/suite_test.go
+++ b/test/e2e/singlecluster/extended/suite_test.go
@@ -14,12 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package extended
 
 import (
 	"context"
-	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -28,24 +26,18 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kueueclientset "sigs.k8s.io/kueue/client-go/clientset/versioned"
-	visibility "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/visibility/v1beta2"
 	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
-	kueuectlPath                 = filepath.Join("..", "..", "..", "bin", "kubectl-kueue")
-	k8sClient                    client.WithWatch
-	cfg                          *rest.Config
-	restClient                   *rest.RESTClient
-	ctx                          context.Context
-	kueueClientset               kueueclientset.Interface
-	impersonatedVisibilityClient visibility.VisibilityV1beta2Interface
-	kueueNS                      = util.GetKueueNamespace()
+	k8sClient  client.WithWatch
+	cfg        *rest.Config
+	restClient *rest.RESTClient
+	ctx        context.Context
 )
 
 func TestAPIs(t *testing.T) {
-	util.RunE2ESuite(t, "End To End Suite")
+	util.RunE2ESuite(t, "End To End Extended Suite")
 }
 
 var _ = ginkgo.BeforeSuite(func() {
@@ -55,9 +47,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	k8sClient, cfg, err = util.CreateClientUsingCluster("")
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	restClient = util.CreateRestClient(cfg)
-	kueueClientset = util.CreateKueueClientset("")
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	impersonatedVisibilityClient = util.CreateVisibilityClient(fmt.Sprintf("system:serviceaccount:%s:default", kueueNS))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	ctx = ginkgo.GinkgoT().Context()
 

--- a/test/e2e/singlecluster/extended/tas_test.go
+++ b/test/e2e/singlecluster/extended/tas_test.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+<<<<<<< HEAD:test/e2e/singlecluster/tas_test.go
 package e2e
+=======
+package extended
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended:test/e2e/singlecluster/extended/tas_test.go
 
 import (
 	"fmt"

--- a/test/e2e/singlecluster/extended/trainjob_test.go
+++ b/test/e2e/singlecluster/extended/trainjob_test.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+<<<<<<< HEAD:test/e2e/singlecluster/trainjob_test.go
 package e2e
+=======
+package extended
+>>>>>>> This is a squashed commit for test : split e2e singlecluster to baseline and extended:test/e2e/singlecluster/extended/trainjob_test.go
 
 import (
 	"github.com/onsi/ginkgo/v2"


### PR DESCRIPTION
Cherry pick of #11138 on release-0.16.

#11138: test: e2e split singlecluster into extended and baseline

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```