### PR TITLE
Improve FairSharing logging and lower the logs verbosity

### DIFF
--- a/pkg/scheduler/fair_sharing_iterator.go
+++ b/pkg/scheduler/fair_sharing_iterator.go
@@ -258,7 +258,7 @@ type drsLogEntry struct {
 }
 
 func (e *entryComparer) logDrsValuesWhenVerbose(log logr.Logger) {
-	if logV := log.V(5); logV.Enabled() {
+	if logV := log.V(4); logV.Enabled() {
 		entries := make([]drsLogEntry, 0, len(e.drsValues))
 		for k, v := range e.drsValues {
 			entries = append(entries, drsLogEntry{

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -416,11 +416,13 @@ func runFirstFsStrategy(preemptionCtx *preemptionCtx, candidates []*workload.Inf
 			candWl := candCQ.PopWorkload()
 			targetNewShare := candCQ.ComputeTargetShareAfterRemoval(candWl)
 			passed := strategy(preemptorNewShare, targetOldShare, targetNewShare)
-			if logV := preemptionCtx.log.V(6); logV.Enabled() {
+			if logV := preemptionCtx.log.V(4); logV.Enabled() {
 				logV.Info("Evaluating FairSharing strategy",
-					"preemptorNewShare", preemptorNewShare,
-					"targetOldShare", targetOldShare,
-					"targetNewShare", targetNewShare,
+					"preemptorNewShare", schdcache.DRS(preemptorNewShare).PreciseWeightedShare(),
+					"targetCQ", klog.KRef("", string(candCQ.GetTargetCq().Name)),
+					"targetWl", klog.KObj(candWl.Obj),
+					"targetOldShare", schdcache.DRS(targetOldShare).PreciseWeightedShare(),
+					"targetNewShare", schdcache.DRS(targetNewShare).PreciseWeightedShare(),
 					"strategyPassed", passed)
 			}
 			if passed {
@@ -450,10 +452,11 @@ func runSecondFsStrategy(retryCandidates []*workload.Info, preemptionCtx *preemp
 	for candCQ := range ordering.Iter() {
 		preemptorNewShare, targetOldShare := candCQ.ComputeShares()
 		passed := fairsharing.LessThanInitialShare(preemptorNewShare, targetOldShare, fairsharing.TargetNewShare{})
-		if logV := preemptionCtx.log.V(6); logV.Enabled() {
+		if logV := preemptionCtx.log.V(4); logV.Enabled() {
 			logV.Info("Evaluating FairSharing strategy",
-				"preemptorNewShare", preemptorNewShare,
-				"targetOldShare", targetOldShare,
+				"preemptorNewShare", schdcache.DRS(preemptorNewShare).PreciseWeightedShare(),
+				"targetCQ", klog.KRef("", string(candCQ.GetTargetCq().Name)),
+				"targetOldShare", schdcache.DRS(targetOldShare).PreciseWeightedShare(),
 				"strategyPassed", passed)
 		}
 		// Due to API validation, we can only reach here if the second strategy is LessThanInitialShare,

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -419,8 +419,8 @@ func runFirstFsStrategy(preemptionCtx *preemptionCtx, candidates []*workload.Inf
 			if logV := preemptionCtx.log.V(4); logV.Enabled() {
 				logV.Info("Evaluating FairSharing strategy",
 					"preemptorNewShare", schdcache.DRS(preemptorNewShare).PreciseWeightedShare(),
-					"targetCQ", klog.KRef("", string(candCQ.GetTargetCq().Name)),
-					"targetWl", klog.KObj(candWl.Obj),
+					"targetClusterQueue", klog.KRef("", string(candCQ.GetTargetCq().Name)),
+					"targetWorkload", klog.KObj(candWl.Obj),
 					"targetOldShare", schdcache.DRS(targetOldShare).PreciseWeightedShare(),
 					"targetNewShare", schdcache.DRS(targetNewShare).PreciseWeightedShare(),
 					"strategyPassed", passed)
@@ -455,7 +455,7 @@ func runSecondFsStrategy(retryCandidates []*workload.Info, preemptionCtx *preemp
 		if logV := preemptionCtx.log.V(4); logV.Enabled() {
 			logV.Info("Evaluating FairSharing strategy",
 				"preemptorNewShare", schdcache.DRS(preemptorNewShare).PreciseWeightedShare(),
-				"targetCQ", klog.KRef("", string(candCQ.GetTargetCq().Name)),
+				"targetClusterQueue", klog.KRef("", string(candCQ.GetTargetCq().Name)),
 				"targetOldShare", schdcache.DRS(targetOldShare).PreciseWeightedShare(),
 				"strategyPassed", passed)
 		}

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -452,18 +452,19 @@ func runSecondFsStrategy(retryCandidates []*workload.Info, preemptionCtx *preemp
 	for candCQ := range ordering.Iter() {
 		preemptorNewShare, targetOldShare := candCQ.ComputeShares()
 		passed := fairsharing.LessThanInitialShare(preemptorNewShare, targetOldShare, fairsharing.TargetNewShare{})
+		// The criteria doesn't depend on the preempted workload, so just preempt the first candidate.
+		candWl := candCQ.PopWorkload()
 		if logV := preemptionCtx.log.V(4); logV.Enabled() {
 			logV.Info("Evaluating FairSharing strategy",
 				"preemptorNewShare", schdcache.DRS(preemptorNewShare).PreciseWeightedShare(),
 				"targetClusterQueue", klog.KRef("", string(candCQ.GetTargetCq().Name)),
+				"targetWorkload", klog.KObj(candWl.Obj),
 				"targetOldShare", schdcache.DRS(targetOldShare).PreciseWeightedShare(),
 				"strategyPassed", passed)
 		}
 		// Due to API validation, we can only reach here if the second strategy is LessThanInitialShare,
 		// in which case the last parameter for the strategy function is irrelevant.
 		if passed {
-			// The criteria doesn't depend on the preempted workload, so just preempt the first candidate.
-			candWl := candCQ.PopWorkload()
 			preemptionCtx.snapshot.RemoveWorkload(candWl)
 			targets = append(targets, &Target{
 				WorkloadInfo: candWl,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
- Decreased verbosity level of some FairSharing logs to 4 instead 5/6
- Added `targetWorkload` and `targetClusterQueue` fields to some logs
- Used DRS float64 representation instead of struct in logs

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Tested it e2e manually, this is how an example log line looks like:
```
{"level":"Level(-4)","ts":"2026-05-13T14:12:04.749932681Z","logger":"scheduler","caller":"preemption/preemption.go:420","msg":"Evaluating FairSharing strategy","replica-role":"leader","schedulingCycle":26,"workload":{"name":"job-sample-job-2-tqrj6-1a98d","namespace":"default"},"clusterQueue":{"name":"cluster-queue-2"},"preemptorNewShare":222.22222222222223,"targetCQ":{"name":"cluster-queue"},"targetWl":{"name":"job-sample-job-cdwx5-5cd80","namespace":"default"},"targetOldShare":222.22222222222223,"targetNewShare":111.11111111111111,"strategyPassed":false}
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Observability: Improved FairSharing strategy-evaluation logs by including DRS share values and emitting them at verbosity level V(4).
```
