### PR TITLE
Add copyright preamble to agent skill files and bump skillsaw to 0.9.2

### DIFF
--- a/.skillsaw.yaml
+++ b/.skillsaw.yaml
@@ -1,0 +1,193 @@
+# skillsaw configuration
+# https://github.com/stbenjam/skillsaw
+version: "0.9.2"
+rules:
+  # Skill just have valid name, description and kubernetes additionally
+  # enforces `license` and `copyright`.
+  agentskill-valid:
+    enabled: auto
+    severity: error
+    required-fields:
+      - license
+    required-metadata:
+      - copyright
+
+  # Skill name must be lowercase with hyphens and match directory name
+  agentskill-name:
+    enabled: auto
+    severity: error
+
+  # Skill description should be meaningful and within length limits
+  agentskill-description:
+    enabled: auto
+    severity: warning
+
+  # Skill directories should only contain recognized subdirectories (stricter than spec)
+  agentskill-structure:
+    enabled: false
+    severity: warning
+    # allowed_dirs:
+    #   - assets
+    #   - evals
+    #   - references
+    #   - scripts
+
+  # Require evals/evals.json for each skill (opt-in)
+  agentskill-evals-required:
+    enabled: false
+    severity: warning
+
+  # Validate evals/evals.json format when present
+  agentskill-evals:
+    enabled: auto
+    severity: warning
+
+  # Instruction files (AGENTS.md, CLAUDE.md, GEMINI.md) must be valid and non-empty
+  instruction-file-valid:
+    enabled: auto
+    severity: warning
+
+  # Import references (@path) in CLAUDE.md and GEMINI.md must point to existing files
+  instruction-imports-valid:
+    enabled: auto
+    severity: warning
+
+  # Warn when instruction or config files exceed recommended token limits
+  context-budget:
+    enabled: auto
+    severity: warning
+    # limits:
+    #   agents-md:
+    #     warn: 6000
+    #     error: 12000
+    #   claude-md:
+    #     warn: 6000
+    #     error: 12000
+    #   gemini-md:
+    #     warn: 6000
+    #     error: 12000
+    #   instruction:
+    #     warn: 4000
+    #     error: 8000
+    #   skill:
+    #     warn: 3000
+    #     error: 6000
+    #   command:
+    #     warn: 2000
+    #     error: 4000
+    #   agent:
+    #     warn: 2000
+    #     error: 4000
+    #   rule:
+    #     warn: 2000
+    #     error: 4000
+    #   skill-description:
+    #     warn: 200
+    #     error: 500
+    #   command-description:
+    #     warn: 200
+    #     error: 500
+
+  # Detect hedging, vague, and non-actionable language in instruction files
+  content-weak-language:
+    enabled: auto
+    severity: warning
+
+  # Detect tautological instructions that the model already follows by default
+  content-tautological:
+    enabled: auto
+    severity: warning
+
+  # Detect critical instructions in the middle of files where LLM attention is lowest
+  content-critical-position:
+    enabled: auto
+    severity: warning
+    min-lines: 50
+
+  # Detect instructions that duplicate .editorconfig, ESLint, Prettier, or tsconfig settings
+  content-redundant-with-tooling:
+    enabled: auto
+    severity: warning
+
+  # Check if instruction count in a file exceeds LLM instruction budget (~150)
+  content-instruction-budget:
+    enabled: auto
+    severity: warning
+
+  # Detect prohibitions without a positive alternative (agent has no path forward)
+  content-negative-only:
+    enabled: auto
+    severity: warning
+
+  # Warn about markdown sections longer than ~500 tokens
+  content-section-length:
+    enabled: auto
+    severity: info
+    # max-tokens: 500
+
+  # Detect likely contradictions within instruction files using keyword-pair heuristics
+  content-contradiction:
+    enabled: auto
+    severity: warning
+
+  # Score instruction files on actionability (verb density, commands, file references)
+  content-actionability-score:
+    enabled: auto
+    severity: info
+
+  # Check that instruction files are organized into cognitive chunks with headings
+  content-cognitive-chunks:
+    enabled: auto
+    severity: info
+
+  # Detect potential API keys, tokens, and passwords in instruction files
+  content-embedded-secrets:
+    enabled: auto
+    severity: error
+
+  # Detect banned or deprecated model names, APIs, and custom patterns
+  content-banned-references:
+    enabled: auto
+    severity: warning
+    # banned: []
+    # skip-builtins: false
+
+  # Detect inconsistent terminology across instruction files (e.g., mixing 'directory' and 'folder')
+  content-inconsistent-terminology:
+    enabled: auto
+    severity: info
+
+  # Detect markdown links where the target file does not exist
+  content-broken-internal-reference:
+    enabled: auto
+    severity: warning
+
+  # Detect bare path-like strings not wrapped in markdown link syntax
+  content-unlinked-internal-reference:
+    enabled: auto
+    severity: info
+    # patterns:
+    #   - "./**/*.*"
+    #   - "references/**/*.md"
+
+  # Detect TODO markers, bracket placeholders, and unfilled template text
+  content-placeholder-text:
+    enabled: auto
+    severity: warning
+
+# Load custom rules from these files
+custom-rules: []
+
+# Exclude patterns (glob format)
+# Use exclude: [] to disable all excludes including defaults
+exclude:
+    # - "**/template/**"
+    # - "**/templates/**"
+    # - "**/_template/**"
+
+# Additional markdown files to run content rules on (glob format)
+content-paths:
+  - cmd/experimental/agent/skills/**
+
+# Treat warnings as errors
+strict: true

--- a/Makefile-verify.mk
+++ b/Makefile-verify.mk
@@ -16,7 +16,7 @@
 
 GO_FMT ?= gofmt
 CONTAINER_ENGINE ?= $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
-SKILLSAW_IMAGE ?= ghcr.io/stbenjam/skillsaw:0.6.0
+SKILLSAW_IMAGE ?= ghcr.io/stbenjam/skillsaw:0.9.2
 VERIFY_NPROCS ?= 8
 # Output sync mode for parallel verification. Set to empty to disable.
 # Requires GNU Make 4.0+. Values: target, line, recurse, or empty.
@@ -158,7 +158,8 @@ endef
 
 # Validates skills against https://agentskills.io/specification
 define _skills_lint_recipe
-$(CONTAINER_ENGINE) run --rm -v $(PROJECT_DIR):/workspace:Z $(SKILLSAW_IMAGE) --strict cmd/experimental/agent/skills/
+mkdir -p $(ARTIFACTS)
+$(CONTAINER_ENGINE) run --rm -v $(PROJECT_DIR):/workspace:Z -v $(ARTIFACTS):/out:Z $(SKILLSAW_IMAGE) --output /out/skillsaw-summary.html
 endef
 
 

--- a/cmd/experimental/agent/skills/kueue-flake-debugger/SKILL.md
+++ b/cmd/experimental/agent/skills/kueue-flake-debugger/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: kueue-flake-debugger
 description: Debug Kueue CI flakes. Use when a user asks to debug a flake, investigate a test failure, a test timeout, or a CI flake. Analyzes Prow build logs, kube-scheduler logs, kubelet logs, and test code to identify root causes.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
 ---
 
 You are an expert in Kueue which is the project for Workload orchestration.

--- a/cmd/experimental/agent/skills/kueue-lineage/SKILL.md
+++ b/cmd/experimental/agent/skills/kueue-lineage/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: kueue-lineage
 description: Trace workload lineage to pods. Use when a user wants to trace lineage across any tier such as workload to pods, pod to workload, or job to workload. The user may provide a resource at any level (Workload, Job, Pod, JobSet, etc.) and this skill produces the full tree from Workload down to Pods.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
 ---
 
 Use this when a user wants to trace lineage across any tier: workload → pods, pod → workload, job → workload, etc. The user may provide a resource at **any level** (Workload, Job, Pod, JobSet, etc.) — always produce the full tree from Workload down to Pods.

--- a/cmd/experimental/agent/skills/kueue-who-preempted/SKILL.md
+++ b/cmd/experimental/agent/skills/kueue-who-preempted/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: kueue-who-preempted
 description: Identify what preempted a workload. Use when a user asks why their workload was evicted or preempted, or wants to identify what preempted it. Investigates Kubernetes events, workload status conditions, and controller logs to trace preemption.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
 ---
 
 Use this when a user asks why their workload was evicted or preempted, or wants to identify what preempted it.
@@ -70,7 +73,7 @@ Extract:
 
 Since LocalQueues in different namespaces can feed the same ClusterQueue, the preemptor workload may live in a namespace different from the victim's.
 
-`kubectl get kueueworkload -A` requires cluster-scoped `list` permission — it does **not** gracefully show only accessible namespaces; it returns `403 Forbidden` if you lack that permission. Use the access check below to pick the right path:
+`kubectl get kueueworkload -A` requires cluster-scoped `list` permission — it does **not** filter to accessible namespaces; it returns `403 Forbidden` if you lack that permission. Use the access check below to pick the right path:
 
 ```bash
 kubectl auth can-i list kueueworkloads --all-namespaces
@@ -95,7 +98,7 @@ Proceed to Step 5 with the returned workload.
 
 #### Path B: Limited namespace access
 
-`-A` will be forbidden. Try to enumerate the namespaces you can see; note that namespace listing may also be forbidden — always include the victim's namespace as a fallback:
+`-A` will be forbidden. Enumerate the namespaces you can see; namespace listing may also be forbidden — always include the victim's namespace as a fallback:
 
 ```bash
 # Attempt to list visible namespaces; this may itself be forbidden


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area agents

#### What this PR does / why we need it:

Enable the new required-fields and required-metadata options in skillsaw 0.9.2 to enforce license and copyright in skill frontmatter. Also output an HTML report to CI artifacts.

Resolved weak-language violations caught by skillsaw 0.9.2 --strict:
- kueue-who-preempted/SKILL.md: 'gracefully' (vagueness)
- kueue-who-preempted/SKILL.md: 'Try to' (hedging)
- kueue-who-preempted/SKILL.md: 'note that' (non-actionable)

#### Which issue(s) this PR fixes:

Fixes #11129

#### Special notes for your reviewer:

N/A


#### Does this PR introduce a user-facing change?

```release-note
NONE
```
