### PR TITLE
Prevent integer overflow in TotalRequests

### DIFF
--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	resourcehelpers "k8s.io/component-helpers/resource"
 	"k8s.io/utils/ptr"
+
+	utilmath "sigs.k8s.io/kueue/pkg/util/math"
 )
 
 // The following resources calculations are inspired on
@@ -75,7 +77,7 @@ func (r Requests) Divide(f int64) {
 
 func (r Requests) Mul(f int64) {
 	for k := range r {
-		r[k] *= f
+		r[k] = utilmath.SaturatingMul(r[k], f)
 	}
 }
 

--- a/pkg/util/math/math.go
+++ b/pkg/util/math/math.go
@@ -56,6 +56,11 @@ func SaturatingMul(a, b int64) int64 {
 	if a == 0 || b == 0 {
 		return 0
 	}
+	// Explicitly catch the MinInt64 * -1 edge case.
+	// In two's complement, the absolute value of MinInt64 is 1 greater than MaxInt64.
+	// If we multiply it by -1, it overflows to MinInt64. Go safely handles MinInt64 / -1
+	// by evaluating it back to MinInt64. Because of this, our division check
+	// (res/b != a) evaluates to false and fails to detect the overflow.
 	if (a == -1 && b == stdmath.MinInt64) || (b == -1 && a == stdmath.MinInt64) {
 		return stdmath.MaxInt64
 	}

--- a/pkg/util/math/math.go
+++ b/pkg/util/math/math.go
@@ -29,3 +29,22 @@ func SaturatingAdd(a, b int64) int64 {
 	}
 	return a + b
 }
+
+// SaturatingMul multiplies two int64s, returning math.MaxInt64 or math.MinInt64 if the
+// result would overflow or underflow.
+func SaturatingMul(a, b int64) int64 {
+	if a == 0 || b == 0 {
+		return 0
+	}
+	if (a == -1 && b == stdmath.MinInt64) || (b == -1 && a == stdmath.MinInt64) {
+		return stdmath.MaxInt64
+	}
+	res := a * b
+	if res/b != a {
+		if (a < 0) == (b < 0) {
+			return stdmath.MaxInt64
+		}
+		return stdmath.MinInt64
+	}
+	return res
+}

--- a/pkg/util/math/math_test.go
+++ b/pkg/util/math/math_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package math
+
+import (
+	stdmath "math"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestSaturatingAdd(t *testing.T) {
+	cases := map[string]struct {
+		a    int64
+		b    int64
+		want int64
+	}{
+		"zero":                  {a: 0, b: 0, want: 0},
+		"positive":              {a: 2, b: 3, want: 5},
+		"negative":              {a: -2, b: 3, want: 1},
+		"overflow positive":     {a: stdmath.MaxInt64, b: 1, want: stdmath.MaxInt64},
+		"overflow negative":     {a: stdmath.MinInt64, b: -1, want: stdmath.MinInt64},
+		"max int64 + max int64": {a: stdmath.MaxInt64, b: stdmath.MaxInt64, want: stdmath.MaxInt64},
+		"min int64 + min int64": {a: stdmath.MinInt64, b: stdmath.MinInt64, want: stdmath.MinInt64},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := SaturatingAdd(tc.a, tc.b); got != tc.want {
+				t.Errorf("SaturatingAdd(%d, %d) = %d, want %d", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSafeMilliValue(t *testing.T) {
+	cases := map[string]struct {
+		q    resource.Quantity
+		want int64
+	}{
+		"zero":      {q: resource.MustParse("0"), want: 0},
+		"positive":  {q: resource.MustParse("1"), want: 1000},
+		"negative":  {q: resource.MustParse("-1"), want: -1000},
+		"max int64": {q: *resource.NewMilliQuantity(stdmath.MaxInt64, resource.DecimalSI), want: stdmath.MaxInt64},
+		"min int64": {q: *resource.NewMilliQuantity(stdmath.MinInt64, resource.DecimalSI), want: stdmath.MinInt64},
+		"overflow":  {q: resource.MustParse("10P"), want: stdmath.MaxInt64},
+		"underflow": {q: resource.MustParse("-10P"), want: stdmath.MinInt64},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := SafeMilliValue(tc.q); got != tc.want {
+				t.Errorf("SafeMilliValue(%v) = %d, want %d", tc.q, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSaturatingMul(t *testing.T) {
+	cases := map[string]struct {
+		a    int64
+		b    int64
+		want int64
+	}{
+		"zero a":             {a: 0, b: stdmath.MaxInt64, want: 0},
+		"zero b":             {a: stdmath.MinInt64, b: 0, want: 0},
+		"positive":           {a: 2, b: 3, want: 6},
+		"negative":           {a: -2, b: 3, want: -6},
+		"both negative":      {a: -2, b: -3, want: 6},
+		"max int64":          {a: stdmath.MaxInt64, b: 1, want: stdmath.MaxInt64},
+		"min int64":          {a: stdmath.MinInt64, b: 1, want: stdmath.MinInt64},
+		"overflow positive":  {a: stdmath.MaxInt64, b: 2, want: stdmath.MaxInt64},
+		"overflow negative":  {a: stdmath.MaxInt64, b: -2, want: stdmath.MinInt64},
+		"underflow positive": {a: stdmath.MinInt64, b: 2, want: stdmath.MinInt64},
+		"underflow negative": {a: stdmath.MinInt64, b: -2, want: stdmath.MaxInt64},
+		"min int * -1":       {a: stdmath.MinInt64, b: -1, want: stdmath.MaxInt64},
+		"-1 * min int":       {a: -1, b: stdmath.MinInt64, want: stdmath.MaxInt64},
+		"large overflow":     {a: 3000000000, b: 4000000000, want: stdmath.MaxInt64},
+		"large underflow":    {a: 3000000000, b: -4000000000, want: stdmath.MinInt64},
+		"max int * max int":  {a: stdmath.MaxInt64, b: stdmath.MaxInt64, want: stdmath.MaxInt64},
+		"min int * min int":  {a: stdmath.MinInt64, b: stdmath.MinInt64, want: stdmath.MaxInt64},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := SaturatingMul(tc.a, tc.b); got != tc.want {
+				t.Errorf("SaturatingMul(%d, %d) = %d, want %d", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/util/math/math_test.go
+++ b/pkg/util/math/math_test.go
@@ -19,54 +19,7 @@ package math
 import (
 	stdmath "math"
 	"testing"
-
-	"k8s.io/apimachinery/pkg/api/resource"
 )
-
-func TestSaturatingAdd(t *testing.T) {
-	cases := map[string]struct {
-		a    int64
-		b    int64
-		want int64
-	}{
-		"zero":                  {a: 0, b: 0, want: 0},
-		"positive":              {a: 2, b: 3, want: 5},
-		"negative":              {a: -2, b: 3, want: 1},
-		"overflow positive":     {a: stdmath.MaxInt64, b: 1, want: stdmath.MaxInt64},
-		"overflow negative":     {a: stdmath.MinInt64, b: -1, want: stdmath.MinInt64},
-		"max int64 + max int64": {a: stdmath.MaxInt64, b: stdmath.MaxInt64, want: stdmath.MaxInt64},
-		"min int64 + min int64": {a: stdmath.MinInt64, b: stdmath.MinInt64, want: stdmath.MinInt64},
-	}
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			if got := SaturatingAdd(tc.a, tc.b); got != tc.want {
-				t.Errorf("SaturatingAdd(%d, %d) = %d, want %d", tc.a, tc.b, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestSafeMilliValue(t *testing.T) {
-	cases := map[string]struct {
-		q    resource.Quantity
-		want int64
-	}{
-		"zero":      {q: resource.MustParse("0"), want: 0},
-		"positive":  {q: resource.MustParse("1"), want: 1000},
-		"negative":  {q: resource.MustParse("-1"), want: -1000},
-		"max int64": {q: *resource.NewMilliQuantity(stdmath.MaxInt64, resource.DecimalSI), want: stdmath.MaxInt64},
-		"min int64": {q: *resource.NewMilliQuantity(stdmath.MinInt64, resource.DecimalSI), want: stdmath.MinInt64},
-		"overflow":  {q: resource.MustParse("10P"), want: stdmath.MaxInt64},
-		"underflow": {q: resource.MustParse("-10P"), want: stdmath.MinInt64},
-	}
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			if got := SafeMilliValue(tc.q); got != tc.want {
-				t.Errorf("SafeMilliValue(%v) = %d, want %d", tc.q, got, tc.want)
-			}
-		})
-	}
-}
 
 func TestSaturatingMul(t *testing.T) {
 	cases := map[string]struct {

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -177,6 +177,24 @@ func TestNewInfo(t *testing.T) {
 				features.ReclaimablePods: false,
 			},
 		},
+		"prevent int overflow in total requests": {
+			workload: *utiltestingapi.MakeWorkload("test-wl", "default").
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2147483647).
+					Request(corev1.ResourceCPU, "4300000").
+					Obj()).
+				Obj(),
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{
+					{
+						Name:  kueue.DefaultPodSetName,
+						Count: 2147483647,
+						Requests: resources.Requests{
+							corev1.ResourceCPU: 9223372036854775807,
+						},
+					},
+				},
+			},
+		},
 		"admitted": {
 			workload: *utiltestingapi.MakeWorkload("", "").
 				PodSets(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Automatic vulnerability scanner flagged that this multiplication could result in int64 overflow.

I confirmed in unit test, that when setting very high requests and a very large number of pods, a total requests would overflow to negative.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed vulnerability where workload with a large number of pods and with CPU requests close to max int64 would lead to integer overflow when calculating total requests and break quota limits
```
