### PR TITLE
Unblock ray version update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ TESTING_DIR := $(HACK_DIR)/testing
 MOCKS_DIR := internal/mocks
 
 RAY_VERSION := $(shell grep '^FROM' "${TESTING_DIR}/ray/Dockerfile" | cut -d: -f2)
-RAYMINI_VERSION ?= 0.0.2
+RAYMINI_VERSION ?= 0.0.3
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/hack/testing/ray-mini/Dockerfile
+++ b/hack/testing/ray-mini/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 # Set environment variable to avoid interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive

--- a/hack/testing/ray/Dockerfile
+++ b/hack/testing/ray/Dockerfile
@@ -1,1 +1,1 @@
-FROM rayproject/ray:2.53.0
+FROM rayproject/ray:2.55.1

--- a/pkg/util/testing/defaults.go
+++ b/pkg/util/testing/defaults.go
@@ -38,10 +38,10 @@ func MakeNamespaceWithGenerateName(prefix string) *corev1.Namespace {
 }
 
 // TestRayVersion retrieves the Ray version from the "RAY_VERSION" environment variable.
-// If the environment variable is not set, it returns the default Ray version ("2.53.0").
+// If the environment variable is not set, it returns the default Ray version ("2.55.1").
 // Keep in sync with RAY_VERSION in Makefile.
 func TestRayVersion() string {
-	const defaultVersion = "2.53.0" // Default Ray version
+	const defaultVersion = "2.55.1" // Default Ray version
 	ver, found := os.LookupEnv("RAY_VERSION")
 	if found {
 		return ver

--- a/pkg/util/testingjobs/raycluster/wrappers.go
+++ b/pkg/util/testingjobs/raycluster/wrappers.go
@@ -17,6 +17,8 @@ limitations under the License.
 package raycluster
 
 import (
+	"fmt"
+
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -292,5 +294,18 @@ func (j *ClusterWrapper) Image(rayType rayv1.RayNodeType, image string, args []s
 
 func (j *ClusterWrapper) RayVersion(rv string) *ClusterWrapper {
 	j.Spec.RayVersion = rv
+	return j
+}
+
+// RayStartParam sets a Ray start param for the specified ray node type.
+func (j *ClusterWrapper) RayStartParam(rayType rayv1.RayNodeType, key, value string) *ClusterWrapper {
+	switch rayType {
+	case rayv1.HeadNode:
+		j.Spec.HeadGroupSpec.RayStartParams[key] = value
+	case rayv1.WorkerNode:
+		j.Spec.WorkerGroupSpecs[0].RayStartParams[key] = value
+	default:
+		panic(fmt.Sprintf("unsupported RayNodeType: %v", rayType))
+	}
 	return j
 }

--- a/pkg/util/testingjobs/rayjob/wrappers.go
+++ b/pkg/util/testingjobs/rayjob/wrappers.go
@@ -17,6 +17,8 @@ limitations under the License.
 package rayjob
 
 import (
+	"fmt"
+
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -357,5 +359,18 @@ func (j *JobWrapper) EnableInTreeAutoscaling() *JobWrapper {
 
 func (j *JobWrapper) MaxWorkerReplicas(count int32) *JobWrapper {
 	j.Spec.RayClusterSpec.WorkerGroupSpecs[0].MaxReplicas = new(count)
+	return j
+}
+
+// RayStartParam sets a Ray start param for the specified ray node type.
+func (j *JobWrapper) RayStartParam(rayType rayv1.RayNodeType, key, value string) *JobWrapper {
+	switch rayType {
+	case rayv1.HeadNode:
+		j.Spec.RayClusterSpec.HeadGroupSpec.RayStartParams[key] = value
+	case rayv1.WorkerNode:
+		j.Spec.RayClusterSpec.WorkerGroupSpecs[0].RayStartParams[key] = value
+	default:
+		panic(fmt.Sprintf("unsupported RayNodeType: %v", rayType))
+	}
 	return j
 }

--- a/test/e2e/singlecluster/extended/kuberay_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_test.go
@@ -66,6 +66,12 @@ func parsePodSetReplicaCount(annotationValue, groupName string) (int32, error) {
 	return 0, fmt.Errorf("group %q not found in annotation", groupName)
 }
 
+const (
+	// objectStoreMemory is the Ray object store memory (bytes) set on each node
+	// to avoid Ray auto-sizing it too large for the constrained test environment.
+	objectStoreMemory = "100000000"
+)
+
 var _ = ginkgo.Describe("Kuberay", ginkgo.Label("area:singlecluster", "feature:kuberay"), func() {
 	var (
 		ns                 *corev1.Namespace
@@ -142,7 +148,9 @@ var _ = ginkgo.Describe("Kuberay", ginkgo.Label("area:singlecluster", "feature:k
 			WithSubmissionMode(rayv1.K8sJobMode).
 			Entrypoint("python -c \"import ray; ray.init(); print(ray.cluster_resources())\"").
 			RequestAndLimit(rayv1.HeadNode, corev1.ResourceCPU, "1").
-			RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "300m").
+			RayStartParam(rayv1.HeadNode, "object-store-memory", objectStoreMemory).
+			RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "400m").
+			RayStartParam(rayv1.WorkerNode, "object-store-memory", objectStoreMemory).
 			WithSubmitterPodTemplate(corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -267,7 +275,9 @@ print(ray.get([my_task.remote(i, 60) for i in range(3)]))`,
 			WithSubmissionMode(rayv1.K8sJobMode).
 			Entrypoint("python /home/ray/samples/sample_code.py").
 			RequestAndLimit(rayv1.HeadNode, corev1.ResourceCPU, "1").
-			RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "200m").
+			RayStartParam(rayv1.HeadNode, "object-store-memory", objectStoreMemory).
+			RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "400m").
+			RayStartParam(rayv1.WorkerNode, "object-store-memory", objectStoreMemory).
 			WithSubmitterPodTemplate(corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -276,10 +286,10 @@ print(ray.get([my_task.remote(i, 60) for i in range(3)]))`,
 							Image: kuberayTestImage,
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("200m"),
+									corev1.ResourceCPU: resource.MustParse("400m"),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("200m"),
+									corev1.ResourceCPU: resource.MustParse("400m"),
 								},
 							},
 						},
@@ -463,7 +473,9 @@ print([ray.get(my_task.remote(i, 1)) for i in range(32)])`,
 			WithSubmissionMode(rayv1.K8sJobMode).
 			Entrypoint("python /home/ray/samples/sample_code.py").
 			RequestAndLimit(rayv1.HeadNode, corev1.ResourceCPU, "1").
-			RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "200m").
+			RayStartParam(rayv1.HeadNode, "object-store-memory", objectStoreMemory).
+			RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "400m").
+			RayStartParam(rayv1.WorkerNode, "object-store-memory", objectStoreMemory).
 			WithSubmitterPodTemplate(corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -472,10 +484,10 @@ print([ray.get(my_task.remote(i, 1)) for i in range(32)])`,
 							Image: kuberayTestImage,
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("200m"),
+									corev1.ResourceCPU: resource.MustParse("400m"),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("200m"),
+									corev1.ResourceCPU: resource.MustParse("400m"),
 								},
 							},
 						},
@@ -610,7 +622,9 @@ print([ray.get(my_task.remote(i, 1)) for i in range(32)])`,
 			Suspend(true).
 			Queue(localQueueName).
 			RequestAndLimit(rayv1.HeadNode, corev1.ResourceCPU, "1").
-			RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "300m").
+			RayStartParam(rayv1.HeadNode, "object-store-memory", objectStoreMemory).
+			RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "400m").
+			RayStartParam(rayv1.WorkerNode, "object-store-memory", objectStoreMemory).
 			Image(rayv1.HeadNode, kuberayTestImage, []string{}).
 			Image(rayv1.WorkerNode, kuberayTestImage, []string{}).
 			Obj()
@@ -713,7 +727,7 @@ app = HelloWorld.bind()`,
 			RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "600m").
 			Image(rayv1.HeadNode, kuberayTestImage).
 			Image(rayv1.WorkerNode, kuberayTestImage).
-			RayStartParam(rayv1.HeadNode, "object-store-memory", "100000000").
+			RayStartParam(rayv1.HeadNode, "object-store-memory", objectStoreMemory).
 			WithServeConfigV2(serveConfigV2).
 			Env(rayv1.HeadNode, env).
 			Env(rayv1.WorkerNode, env).
@@ -856,7 +870,7 @@ app = HelloWorld.bind()`,
 			RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "400m").
 			Image(rayv1.HeadNode, kuberayTestImage).
 			Image(rayv1.WorkerNode, kuberayTestImage).
-			RayStartParam(rayv1.HeadNode, "object-store-memory", "100000000").
+			RayStartParam(rayv1.HeadNode, "object-store-memory", objectStoreMemory).
 			WithServeConfigV2(serveConfigV2).
 			Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 			EnableInTreeAutoscaling().


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area integrations
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

Update the ray-project version to 2.55.1.
Added .RayStartParam(rayv1.HeadNode, "object-store-memory", "100000000") to both failing InTreeAutoscaling RayJob tests. This limits GCS object store memory to 100MB, reducing GCS load so worker raylets can register within the 30-second timeout — matching the fix already present in the passing RayService InTreeAutoscaling test.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11114 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
