### PR TITLE
Fix TAS node taint checks to use admitted tolerations

### DIFF
--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -422,17 +422,7 @@ func (r *nodeReconciler) podSetsWithEffectiveTolerationsOnNode(ctx context.Conte
 	var result []kueue.PodSet
 	for i := range wl.Status.Admission.PodSetAssignments {
 		psa := &wl.Status.Admission.PodSetAssignments[i]
-		if psa.TopologyAssignment == nil || !utiltas.IsLowestLevelHostname(psa.TopologyAssignment.Levels) {
-			continue
-		}
-		assigned := false
-		for val := range utiltas.LowestLevelValues(psa.TopologyAssignment) {
-			if val == nodeName {
-				assigned = true
-				break
-			}
-		}
-		if !assigned {
+		if !utiltas.HasNodeInPodSetAssignment(psa, nodeName) {
 			continue
 		}
 
@@ -446,15 +436,19 @@ func (r *nodeReconciler) podSetsWithEffectiveTolerationsOnNode(ctx context.Conte
 		if err != nil {
 			return nil, err
 		}
-		effective.Template.Spec.Tolerations = append(effective.Template.Spec.Tolerations, info.Tolerations...)
 
 		for _, admissionCheck := range wl.Status.AdmissionChecks {
 			for _, podSetUpdate := range admissionCheck.PodSetUpdates {
 				if podSetUpdate.Name == psa.Name {
-					effective.Template.Spec.Tolerations = append(effective.Template.Spec.Tolerations, podSetUpdate.Tolerations...)
+					if err := info.Merge(podsetinfo.FromUpdate(&podSetUpdate)); err != nil {
+						return nil, fmt.Errorf("in admission check %q: %w", admissionCheck.Name, err)
+					}
 					break
 				}
 			}
+		}
+		if err := podsetinfo.Merge(&effective.Template.ObjectMeta, &effective.Template.Spec, info); err != nil {
+			return nil, err
 		}
 		result = append(result, *effective)
 	}

--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -52,8 +52,10 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
+	podsetinfo "sigs.k8s.io/kueue/pkg/podset"
 	utilclient "sigs.k8s.io/kueue/pkg/util/client"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
+	utilpodset "sigs.k8s.io/kueue/pkg/util/podset"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -236,6 +238,7 @@ func (r *nodeReconciler) Delete(e event.TypedDeleteEvent[*corev1.Node]) bool {
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=pods/status,verbs=patch
+//+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=resourceflavors,verbs=get;list;watch
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads,verbs=get;list;watch;patch
 
 func newNodeReconciler(
@@ -383,8 +386,14 @@ func (r *nodeReconciler) getWorkloadStatus(
 		return r.checkPodsOnNode(ctx, nodeName, wl, false, hasTASAssignment, nodeSelectorAssignedPods)
 	case !features.Enabled(features.TASReplaceNodeOnNodeTaints):
 		return workloadHealthCheck{status: workloadHealthy}, nil
+	case !hasSchedulingTaints(node.Spec.Taints):
+		return workloadHealthCheck{status: workloadHealthy}, nil
 	default:
-		untolerated, temporarilyTolerated := classifyTaints(ctx, node.Spec.Taints, workload.PodSetsOnNode(wl, nodeName))
+		podSets, err := r.podSetsWithEffectiveTolerationsOnNode(ctx, wl, nodeName)
+		if err != nil {
+			return workloadHealthCheck{status: workloadHealthUnknown}, err
+		}
+		untolerated, temporarilyTolerated := classifyTaints(ctx, node.Spec.Taints, podSets)
 
 		if len(untolerated) > 0 {
 			if !features.Enabled(features.TASReplaceNodeOnPodTermination) {
@@ -397,6 +406,59 @@ func (r *nodeReconciler) getWorkloadStatus(
 		}
 		return workloadHealthCheck{status: workloadHealthy}, nil
 	}
+}
+
+func hasSchedulingTaints(taints []corev1.Taint) bool {
+	return slices.ContainsFunc(taints, func(taint corev1.Taint) bool {
+		return taint.Effect == corev1.TaintEffectNoExecute || taint.Effect == corev1.TaintEffectNoSchedule
+	})
+}
+
+func (r *nodeReconciler) podSetsWithEffectiveTolerationsOnNode(ctx context.Context, wl *kueue.Workload, nodeName string) ([]kueue.PodSet, error) {
+	if wl.Status.Admission == nil {
+		return nil, nil
+	}
+
+	var result []kueue.PodSet
+	for i := range wl.Status.Admission.PodSetAssignments {
+		psa := &wl.Status.Admission.PodSetAssignments[i]
+		if psa.TopologyAssignment == nil || !utiltas.IsLowestLevelHostname(psa.TopologyAssignment.Levels) {
+			continue
+		}
+		assigned := false
+		for val := range utiltas.LowestLevelValues(psa.TopologyAssignment) {
+			if val == nodeName {
+				assigned = true
+				break
+			}
+		}
+		if !assigned {
+			continue
+		}
+
+		ps := utilpodset.FindPodSetByName(wl.Spec.PodSets, psa.Name)
+		if ps == nil {
+			continue
+		}
+
+		effective := ps.DeepCopy()
+		info, err := podsetinfo.FromAssignment(ctx, r.client, psa, ps)
+		if err != nil {
+			return nil, err
+		}
+		effective.Template.Spec.Tolerations = append(effective.Template.Spec.Tolerations, info.Tolerations...)
+
+		for _, admissionCheck := range wl.Status.AdmissionChecks {
+			for _, podSetUpdate := range admissionCheck.PodSetUpdates {
+				if podSetUpdate.Name == psa.Name {
+					effective.Template.Spec.Tolerations = append(effective.Template.Spec.Tolerations, podSetUpdate.Tolerations...)
+					break
+				}
+			}
+		}
+		result = append(result, *effective)
+	}
+	return result, nil
 }
 
 func (r *nodeReconciler) checkPodsOnNode(

--- a/pkg/controller/tas/node_controller_test.go
+++ b/pkg/controller/tas/node_controller_test.go
@@ -77,6 +77,8 @@ func TestNodeFailureReconciler(t *testing.T) {
 		AdmittedAt(true, testStartTime).
 		Obj()
 
+	baseResourceFlavor := utiltestingapi.MakeResourceFlavor("unit-test-flavor").Obj()
+
 	workloadReassigned := utiltestingapi.MakeWorkload(wlName, nsName).
 		Finalizers(kueue.ResourceInUseFinalizerName).
 		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
@@ -738,6 +740,87 @@ func TestNodeFailureReconciler(t *testing.T) {
 			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
 			wantUnhealthyNodes: nil,
 		},
+		"Node has NoSchedule taint tolerated by assigned ResourceFlavor -> Healthy": {
+			initObjs: []client.Object{
+				baseNode.Clone().StatusConditions(corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: now}).
+					Taints(corev1.Taint{Key: "foo", Effect: corev1.TaintEffectNoSchedule}).Obj(),
+				utiltestingapi.MakeResourceFlavor("rf-toleration-flavor").
+					Toleration(corev1.Toleration{
+						Key:      "foo",
+						Effect:   corev1.TaintEffectNoSchedule,
+						Operator: corev1.TolerationOpExists,
+					}).
+					Obj(),
+				utiltestingapi.MakeWorkload(wlName, nsName).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "rf-toleration-flavor", "1").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+									Domains(utiltestingapi.MakeTopologyDomainAssignment([]string{nodeName}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(), testStartTime,
+					).
+					AdmittedAt(true, testStartTime).
+					Obj(),
+			},
+			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
+			wantUnhealthyNodes: nil,
+			featureGates: map[featuregate.Feature]bool{
+				features.TASReplaceNodeOnNodeTaints: true,
+			},
+		},
+		"Assigned node gets NoSchedule taint tolerated by AdmissionCheck PodSetUpdate -> Healthy": {
+			initObjs: []client.Object{
+				baseNode.Clone().StatusConditions(corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: now}).
+					Taints(corev1.Taint{Key: "foo", Effect: corev1.TaintEffectNoSchedule}).Obj(),
+				utiltestingapi.MakeWorkload(wlName, nsName).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+									Domains(utiltestingapi.MakeTopologyDomainAssignment([]string{nodeName}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(), testStartTime,
+					).
+					AdmittedAt(true, testStartTime).
+					AdmissionChecks(kueue.AdmissionCheckState{
+						Name:  "check",
+						State: kueue.CheckStateReady,
+						PodSetUpdates: []kueue.PodSetUpdate{
+							{
+								Name: kueue.DefaultPodSetName,
+								Tolerations: []corev1.Toleration{
+									{
+										Key:      "foo",
+										Effect:   corev1.TaintEffectNoSchedule,
+										Operator: corev1.TolerationOpExists,
+									},
+								},
+							},
+						},
+					}).
+					Obj(),
+			},
+			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
+			wantUnhealthyNodes: nil,
+			featureGates: map[featuregate.Feature]bool{
+				features.TASReplaceNodeOnNodeTaints: true,
+			},
+		},
 		"Node NotReady, pod pending (assigned via nodeSelector) -> Unhealthy": {
 			initObjs: []client.Object{
 				baseNode.Clone().StatusConditions(corev1.NodeCondition{
@@ -987,8 +1070,9 @@ func TestNodeFailureReconciler(t *testing.T) {
 			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			fakeClock.SetTime(testStartTime)
 
+			initObjs := append([]client.Object{baseResourceFlavor.DeepCopy()}, tc.initObjs...)
 			clientBuilder := utiltesting.NewClientBuilder().
-				WithObjects(tc.initObjs...).
+				WithObjects(initObjs...).
 				WithStatusSubresource(tc.initObjs...).
 				WithInterceptorFuncs(interceptor.Funcs{
 					SubResourcePatch: func(ctx context.Context, client client.Client, subResource string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {

--- a/pkg/util/tas/tas_assignment.go
+++ b/pkg/util/tas/tas_assignment.go
@@ -317,14 +317,22 @@ func HasTASAssignmentOnNode(admission *kueue.Admission, nodeName string) bool {
 	if admission == nil {
 		return false
 	}
-	for _, psa := range admission.PodSetAssignments {
-		if psa.TopologyAssignment == nil || !IsLowestLevelHostname(psa.TopologyAssignment.Levels) {
-			continue
+	for i := range admission.PodSetAssignments {
+		if HasNodeInPodSetAssignment(&admission.PodSetAssignments[i], nodeName) {
+			return true
 		}
-		for domain := range InternalSeqFrom(psa.TopologyAssignment) {
-			if len(domain.Values) > 0 && domain.Values[len(domain.Values)-1] == nodeName && domain.Count > 0 {
-				return true
-			}
+	}
+	return false
+}
+
+// HasNodeInPodSetAssignment reports whether the PodSetAssignment has pods assigned to nodeName.
+func HasNodeInPodSetAssignment(psa *kueue.PodSetAssignment, nodeName string) bool {
+	if psa == nil || psa.TopologyAssignment == nil || !IsLowestLevelHostname(psa.TopologyAssignment.Levels) {
+		return false
+	}
+	for domain := range InternalSeqFrom(psa.TopologyAssignment) {
+		if len(domain.Values) > 0 && domain.Values[len(domain.Values)-1] == nodeName && domain.Count > 0 {
+			return true
 		}
 	}
 	return false

--- a/pkg/util/tas/tas_assignment_test.go
+++ b/pkg/util/tas/tas_assignment_test.go
@@ -791,6 +791,79 @@ func TestLowestLevelValues_iteratorStops(t *testing.T) {
 	}
 }
 
+func TestHasNodeInPodSetAssignment(t *testing.T) {
+	testCases := []struct {
+		name     string
+		psa      *kueue.PodSetAssignment
+		nodeName string
+		want     bool
+	}{
+		{
+			name:     "nil assignment",
+			psa:      nil,
+			nodeName: "node1",
+			want:     false,
+		},
+		{
+			name:     "no topology assignment",
+			psa:      &kueue.PodSetAssignment{Name: "ps1"},
+			nodeName: "node1",
+			want:     false,
+		},
+		{
+			name: "topology level is not hostname",
+			psa: &kueue.PodSetAssignment{
+				Name: "ps1",
+				TopologyAssignment: V1Beta2From(&TopologyAssignment{
+					Levels: []string{"example.com/rack"},
+					Domains: []TopologyDomainAssignment{
+						{Values: []string{"rack1"}, Count: 1},
+					},
+				}),
+			},
+			nodeName: "node1",
+			want:     false,
+		},
+		{
+			name: "pod on target node",
+			psa: &kueue.PodSetAssignment{
+				Name: "ps1",
+				TopologyAssignment: V1Beta2From(&TopologyAssignment{
+					Levels: []string{corev1.LabelHostname},
+					Domains: []TopologyDomainAssignment{
+						{Values: []string{"node1"}, Count: 1},
+					},
+				}),
+			},
+			nodeName: "node1",
+			want:     true,
+		},
+		{
+			name: "target node with zero pods",
+			psa: &kueue.PodSetAssignment{
+				Name: "ps1",
+				TopologyAssignment: V1Beta2From(&TopologyAssignment{
+					Levels: []string{corev1.LabelHostname},
+					Domains: []TopologyDomainAssignment{
+						{Values: []string{"node1"}, Count: 0},
+					},
+				}),
+			},
+			nodeName: "node1",
+			want:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := HasNodeInPodSetAssignment(tc.psa, tc.nodeName)
+			if got != tc.want {
+				t.Errorf("HasNodeInPodSetAssignment() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestHasTASAssignmentOnNode(t *testing.T) {
 	testCases := []struct {
 		name      string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->
/kind bug
/area tas

#### What this PR does / why we need it:

This PR updates TAS node taint checks to use the effective PodSet tolerations for admitted Workloads, including tolerations both from assigned ResourceFlavor and AdmissionCheck `PodSetUpdates`.

TAS NodeHotSwap currently classifies node taints based on `Workload.Spec.PodSets[*].Template.Spec.Tolerations`.
However, the Pod created after admission can also receive tolerations from the assigned ResourceFlavor and AdmissionCheck. In that case, TAS can incorrectly treat a healthy tainted node as unhealthy for the Workload, and eventually evict the Workload with `NodeFailures` even though the effective PodSpec tolerates the taint.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11152

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Fixed NodeHotSwap with TASReplaceNodeOnNodeTaints enabled to evaluate node taints using effective Workload tolerations, including tolerations from AdmissionCheck PodSetUpdates.
```
