### PR TITLE
Automated cherry pick of #11165: Improve FairSharing logging and lower the logs verbosity

### DIFF
--- a/pkg/scheduler/fair_sharing_iterator.go
+++ b/pkg/scheduler/fair_sharing_iterator.go
@@ -253,7 +253,7 @@ type drsLogEntry struct {
 }
 
 func (e *entryComparer) logDrsValuesWhenVerbose(log logr.Logger) {
-	if logV := log.V(5); logV.Enabled() {
+	if logV := log.V(4); logV.Enabled() {
 		entries := make([]drsLogEntry, 0, len(e.drsValues))
 		for k, v := range e.drsValues {
 			entries = append(entries, drsLogEntry{

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -428,18 +428,19 @@ func runSecondFsStrategy(retryCandidates []*workload.Info, preemptionCtx *preemp
 	for candCQ := range ordering.Iter() {
 		preemptorNewShare, targetOldShare := candCQ.ComputeShares()
 		passed := fairsharing.LessThanInitialShare(preemptorNewShare, targetOldShare, fairsharing.TargetNewShare{})
+		// The criteria doesn't depend on the preempted workload, so just preempt the first candidate.
+		candWl := candCQ.PopWorkload()
 		if logV := preemptionCtx.log.V(4); logV.Enabled() {
 			logV.Info("Evaluating FairSharing strategy",
 				"preemptorNewShare", schdcache.DRS(preemptorNewShare).PreciseWeightedShare(),
 				"targetClusterQueue", klog.KRef("", string(candCQ.GetTargetCq().Name)),
+				"targetWorkload", klog.KObj(candWl.Obj),
 				"targetOldShare", schdcache.DRS(targetOldShare).PreciseWeightedShare(),
 				"strategyPassed", passed)
 		}
 		// Due to API validation, we can only reach here if the second strategy is LessThanInitialShare,
 		// in which case the last parameter for the strategy function is irrelevant.
 		if passed {
-			// The criteria doesn't depend on the preempted workload, so just preempt the first candidate.
-			candWl := candCQ.PopWorkload()
 			preemptionCtx.snapshot.RemoveWorkload(candWl)
 			targets = append(targets, &Target{
 				WorkloadInfo: candWl,

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -391,7 +391,17 @@ func runFirstFsStrategy(preemptionCtx *preemptionCtx, candidates []*workload.Inf
 		for candCQ.HasWorkload() {
 			candWl := candCQ.PopWorkload()
 			targetNewShare := candCQ.ComputeTargetShareAfterRemoval(candWl)
-			if strategy(preemptorNewShare, targetOldShare, targetNewShare) {
+			passed := strategy(preemptorNewShare, targetOldShare, targetNewShare)
+			if logV := preemptionCtx.log.V(4); logV.Enabled() {
+				logV.Info("Evaluating FairSharing strategy",
+					"preemptorNewShare", schdcache.DRS(preemptorNewShare).PreciseWeightedShare(),
+					"targetCQ", klog.KRef("", string(candCQ.GetTargetCq().Name)),
+					"targetWl", klog.KObj(candWl.Obj),
+					"targetOldShare", schdcache.DRS(targetOldShare).PreciseWeightedShare(),
+					"targetNewShare", schdcache.DRS(targetNewShare).PreciseWeightedShare(),
+					"strategyPassed", passed)
+			}
+			if passed {
 				preemptionCtx.snapshot.RemoveWorkload(candWl)
 				targets = append(targets, &Target{
 					WorkloadInfo: candWl,
@@ -417,9 +427,17 @@ func runSecondFsStrategy(retryCandidates []*workload.Info, preemptionCtx *preemp
 	ordering := fairsharing.MakeClusterQueueOrdering(preemptionCtx.preemptorCQ, retryCandidates, preemptionCtx.log, preemptionCtx.clock)
 	for candCQ := range ordering.Iter() {
 		preemptorNewShare, targetOldShare := candCQ.ComputeShares()
+		passed := fairsharing.LessThanInitialShare(preemptorNewShare, targetOldShare, fairsharing.TargetNewShare{})
+		if logV := preemptionCtx.log.V(4); logV.Enabled() {
+			logV.Info("Evaluating FairSharing strategy",
+				"preemptorNewShare", schdcache.DRS(preemptorNewShare).PreciseWeightedShare(),
+				"targetCQ", klog.KRef("", string(candCQ.GetTargetCq().Name)),
+				"targetOldShare", schdcache.DRS(targetOldShare).PreciseWeightedShare(),
+				"strategyPassed", passed)
+		}
 		// Due to API validation, we can only reach here if the second strategy is LessThanInitialShare,
 		// in which case the last parameter for the strategy function is irrelevant.
-		if fairsharing.LessThanInitialShare(preemptorNewShare, targetOldShare, fairsharing.TargetNewShare{}) {
+		if passed {
 			// The criteria doesn't depend on the preempted workload, so just preempt the first candidate.
 			candWl := candCQ.PopWorkload()
 			preemptionCtx.snapshot.RemoveWorkload(candWl)

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -395,8 +395,8 @@ func runFirstFsStrategy(preemptionCtx *preemptionCtx, candidates []*workload.Inf
 			if logV := preemptionCtx.log.V(4); logV.Enabled() {
 				logV.Info("Evaluating FairSharing strategy",
 					"preemptorNewShare", schdcache.DRS(preemptorNewShare).PreciseWeightedShare(),
-					"targetCQ", klog.KRef("", string(candCQ.GetTargetCq().Name)),
-					"targetWl", klog.KObj(candWl.Obj),
+					"targetClusterQueue", klog.KRef("", string(candCQ.GetTargetCq().Name)),
+					"targetWorkload", klog.KObj(candWl.Obj),
 					"targetOldShare", schdcache.DRS(targetOldShare).PreciseWeightedShare(),
 					"targetNewShare", schdcache.DRS(targetNewShare).PreciseWeightedShare(),
 					"strategyPassed", passed)
@@ -431,7 +431,7 @@ func runSecondFsStrategy(retryCandidates []*workload.Info, preemptionCtx *preemp
 		if logV := preemptionCtx.log.V(4); logV.Enabled() {
 			logV.Info("Evaluating FairSharing strategy",
 				"preemptorNewShare", schdcache.DRS(preemptorNewShare).PreciseWeightedShare(),
-				"targetCQ", klog.KRef("", string(candCQ.GetTargetCq().Name)),
+				"targetClusterQueue", klog.KRef("", string(candCQ.GetTargetCq().Name)),
 				"targetOldShare", schdcache.DRS(targetOldShare).PreciseWeightedShare(),
 				"strategyPassed", passed)
 		}


### PR DESCRIPTION
Cherry pick of #11165 on release-0.16.

#11165: Improve FairSharing logging and lower the logs verbosity

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind feature


```release-note
Observability: Improved FairSharing strategy-evaluation logs by including DRS share values and emitting them at verbosity level V(4).
```