### PR TITLE
fix: Return on error in e2e cluster_create instead of continuing execution

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -230,13 +230,23 @@ function cluster_collect_artifacts {
     local name=$1
     local kubeconfig=${2:-}
 
+    if ! kind_cluster_exists "$name"; then
+        echo "Skipping artifact collection for '$name': cluster does not exist."
+        return 0
+    fi
+
+    $KIND export logs "$ARTIFACTS" --name "$name" || true
+
     local -a kubectl_args=()
     if [[ -n "${kubeconfig}" ]]; then
         kubectl_args=(--kubeconfig="${kubeconfig}")
     fi
 
-    kubectl config ${kubectl_args[@]+"${kubectl_args[@]}"} use-context "kind-${name}" || true
-    $KIND export logs "$ARTIFACTS" --name "$name" || true
+    if ! kubectl ${kubectl_args[@]+"${kubectl_args[@]}"} version --request-timeout=30s >/dev/null 2>&1; then
+        echo "Skipping pod descriptions for '$name': API server is not reachable."
+        return 0
+    fi
+
     kubectl describe pods ${kubectl_args[@]+"${kubectl_args[@]}"} -n kueue-system > "$ARTIFACTS/${name}-kueue-system-pods.log" || true
     kubectl describe pods ${kubectl_args[@]+"${kubectl_args[@]}"} > "$ARTIFACTS/${name}-default-pods.log" || true
 }
@@ -368,12 +378,17 @@ function cluster_create {
         cat "$kind_config"
     fi
 
-    $KIND create cluster --name "$cluster" --image "$E2E_KIND_VERSION" --config "$kind_config" --kubeconfig="$kubeconfig" --wait 1m -v 5  > "$ARTIFACTS/$cluster-create.log" 2>&1 \
-    ||  { echo "unable to start the $cluster cluster "; cat "$ARTIFACTS/$cluster-create.log" ; }
+    if ! $KIND create cluster --name "$cluster" --image "$E2E_KIND_VERSION" \
+            --config "$kind_config" --kubeconfig="$kubeconfig" --wait 5m -v 5 \
+            > "$ARTIFACTS/$cluster-create.log" 2>&1; then
+        echo "ERROR: Unable to create kind cluster '$cluster'." >&2
+        cat "$ARTIFACTS/$cluster-create.log" >&2
+        return 1
+    fi
 
     kubectl config --kubeconfig="$kubeconfig" use-context "kind-$cluster"
     # wait for nodes to become ready before loading images or deploying components
-    kubectl wait --kubeconfig="$kubeconfig" --for=condition=Ready node --all --timeout=300s
+    kubectl wait --kubeconfig="$kubeconfig" --for=condition=Ready node --all --timeout=5m
     kubectl get nodes --kubeconfig="$kubeconfig" > "$ARTIFACTS/$cluster-nodes.log" || true
     kubectl describe pods --kubeconfig="$kubeconfig" -n kube-system > "$ARTIFACTS/$cluster-system-pods.log" || true
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind flake
/area testing

#### What this PR does / why we need it:

After looking into flaky e2e logs, the issue with `cluster_create` in `hack/testing/e2e-common.sh` was found.

`cluster_create` previously masked failures with `|| { echo "unable to start the $cluster cluster"; cat "$ARTIFACTS/$cluster-create.log"; }`, which returns 0 to the shell.
So, when `kind create cluster` failed, the function kept going to `kubectl config use-context`, which then errored with a misleading `error: no context exists with the name: "kind-kind"`.
Meanwhile, the EXIT-trap cleanup ran kubectl/kind commands against the non-existent or half-built cluster, producing a cascade of `error: no context exists`, `unknown cluster`, and `connection refused` errors.

This PR adds following changes in:
- **`cluster_collect_artifacts`** — prevents errors in case there is no cluster or apiserver.
    - `kind_cluster_exists` is false, skip everything; prints
      `Skipping artifact collection for '<name>': cluster does not exist.`
    - apiserver unreachable (containers exist, but `kubeadm init` never finished),
      skip `kubectl describe pods`; prints
      `Skipping pod descriptions for '<name>': API server is not reachable.`
- **`cluster_create`** — `kind create cluster` failure now returns 1 immediately.
  This replaces the vague `unable to start the kind cluster `
  prefix with `ERROR: Unable to create kind cluster '<name>'.`, and stops
  the function from continuing into `kubectl config use-context`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

Verified locally on macOS/colima against two reproducers; in each case the main script output ends with a clear single cause failure block and the EXIT-trap cleanup is quiet.

- **`kind create` returns non-zero**
  (`E2E_KIND_VERSION=kindest/node:v0.0.0-bogus make test-e2e`):
  output ends with `ERROR: Unable to create kind cluster 'kind'.` + dumped kind log, followed by
  `Skipping artifact collection for 'kind': cluster does not exist.`
- **Compound failure matching the CI run** — foreground `docker pull` fails while background `kind create` is still running
  (`KUBERAY_VERSION=does-not-exist make test-e2e`):
  main script ends with the pull-failure message, then
  `Skipping pod descriptions for 'kind': API server is not reachable.`
  (the API-reachability guard, since kind got far enough to create containers). The background subshell's deferred kind log dump appears after
  `make: *** Error 1` but is now prefixed by `ERROR: Unable to create kind cluster 'kind'.`
  instead of the misleading `unable to start the kind cluster `.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
