### PR TITLE
Exclude kube-system from webhooks targeting common resources

### DIFF
--- a/charts/kueue/templates/webhook/manifests.yaml
+++ b/charts/kueue/templates/webhook/manifests.yaml
@@ -39,10 +39,17 @@ webhooks:
         path: /mutate-workload-codeflare-dev-v1beta2-appwrapper
     failurePolicy: Fail
     name: mappwrapper.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - workload.codeflare.dev
@@ -119,10 +126,17 @@ webhooks:
         path: /mutate-kubeflow-org-v1-jaxjob
     failurePolicy: Fail
     name: mjaxjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -143,10 +157,17 @@ webhooks:
         path: /mutate-batch-v1-job
     failurePolicy: Fail
     name: mjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - batch
@@ -167,10 +188,17 @@ webhooks:
         path: /mutate-jobset-x-k8s-io-v1alpha2-jobset
     failurePolicy: Fail
     name: mjobset.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - jobset.x-k8s.io
@@ -191,10 +219,17 @@ webhooks:
         path: /mutate-leaderworkerset-x-k8s-io-v1-leaderworkerset
     failurePolicy: Fail
     name: mleaderworkerset.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - leaderworkerset.x-k8s.io
@@ -216,10 +251,17 @@ webhooks:
         path: /mutate-kubeflow-org-v2beta1-mpijob
     failurePolicy: Fail
     name: mmpijob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -240,10 +282,17 @@ webhooks:
         path: /mutate-kubeflow-org-v1-paddlejob
     failurePolicy: Fail
     name: mpaddlejob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -299,10 +348,17 @@ webhooks:
         path: /mutate-kubeflow-org-v1-pytorchjob
     failurePolicy: Fail
     name: mpytorchjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -323,10 +379,17 @@ webhooks:
         path: /mutate-ray-io-v1-raycluster
     failurePolicy: Fail
     name: mraycluster.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - ray.io
@@ -347,10 +410,17 @@ webhooks:
         path: /mutate-ray-io-v1-rayjob
     failurePolicy: Fail
     name: mrayjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - ray.io
@@ -371,10 +441,17 @@ webhooks:
         path: /mutate-ray-io-v1-rayservice
     failurePolicy: Fail
     name: mrayservice.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - ray.io
@@ -471,10 +548,17 @@ webhooks:
         path: /mutate-kubeflow-org-v1-tfjob
     failurePolicy: Fail
     name: mtfjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -535,10 +619,17 @@ webhooks:
         path: /mutate-kubeflow-org-v1-xgboostjob
     failurePolicy: Fail
     name: mxgboostjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -572,10 +663,17 @@ webhooks:
         path: /validate-workload-codeflare-dev-v1beta2-appwrapper
     failurePolicy: Fail
     name: vappwrapper.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - workload.codeflare.dev
@@ -671,10 +769,17 @@ webhooks:
         path: /validate-kubeflow-org-v1-jaxjob
     failurePolicy: Fail
     name: vjaxjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -695,10 +800,17 @@ webhooks:
         path: /validate-batch-v1-job
     failurePolicy: Fail
     name: vjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - batch
@@ -719,10 +831,17 @@ webhooks:
         path: /validate-jobset-x-k8s-io-v1alpha2-jobset
     failurePolicy: Fail
     name: vjobset.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - jobset.x-k8s.io
@@ -743,10 +862,17 @@ webhooks:
         path: /validate-leaderworkerset-x-k8s-io-v1-leaderworkerset
     failurePolicy: Fail
     name: vleaderworkerset.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - leaderworkerset.x-k8s.io
@@ -767,10 +893,17 @@ webhooks:
         path: /validate-kubeflow-org-v2beta1-mpijob
     failurePolicy: Fail
     name: vmpijob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -791,10 +924,17 @@ webhooks:
         path: /validate-kubeflow-org-v1-paddlejob
     failurePolicy: Fail
     name: vpaddlejob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -850,10 +990,17 @@ webhooks:
         path: /validate-kubeflow-org-v1-pytorchjob
     failurePolicy: Fail
     name: vpytorchjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -874,10 +1021,17 @@ webhooks:
         path: /validate-ray-io-v1-raycluster
     failurePolicy: Fail
     name: vraycluster.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - ray.io
@@ -898,10 +1052,17 @@ webhooks:
         path: /validate-ray-io-v1-rayjob
     failurePolicy: Fail
     name: vrayjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - ray.io
@@ -922,10 +1083,17 @@ webhooks:
         path: /validate-ray-io-v1-rayservice
     failurePolicy: Fail
     name: vrayservice.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - ray.io
@@ -1021,10 +1189,17 @@ webhooks:
         path: /validate-kubeflow-org-v1-tfjob
     failurePolicy: Fail
     name: vtfjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -1086,10 +1261,17 @@ webhooks:
         path: /validate-kubeflow-org-v1-xgboostjob
     failurePolicy: Fail
     name: vxgboostjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-    {{- end }}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org

--- a/charts/kueue/templates/webhook/manifests.yaml
+++ b/charts/kueue/templates/webhook/manifests.yaml
@@ -89,11 +89,6 @@ webhooks:
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-apps-v1-deployment
     name: mdeployment.kb.io
-    {{- if has "deployment" $integrationsConfig.frameworks }}
-    failurePolicy: Fail
-    {{- else }}
-    failurePolicy: Ignore
-    {{- end }}
     namespaceSelector:
       {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
         {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
@@ -105,6 +100,11 @@ webhooks:
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
+    {{- if has "deployment" $integrationsConfig.frameworks }}
+    failurePolicy: Fail
+    {{- else }}
+    failurePolicy: Ignore
+    {{- end }}
     rules:
       - apiGroups:
           - apps
@@ -312,11 +312,6 @@ webhooks:
         namespace: '{{ .Release.Namespace }}'
         path: /mutate--v1-pod
     name: mpod.kb.io
-    {{- if has "pod" $integrationsConfig.frameworks }}
-    failurePolicy: Fail
-    {{- else }}
-    failurePolicy: Ignore
-    {{- end }}
     namespaceSelector:
       {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
         {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
@@ -328,6 +323,11 @@ webhooks:
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
+    {{- if has "pod" $integrationsConfig.frameworks }}
+    failurePolicy: Fail
+    {{- else }}
+    failurePolicy: Ignore
+    {{- end }}
     rules:
       - apiGroups:
           - ""
@@ -492,6 +492,17 @@ webhooks:
         path: /mutate-sparkoperator-k8s-io-v1beta2-sparkapplication
     failurePolicy: Fail
     name: msparkapplication.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - sparkoperator.k8s.io
@@ -511,11 +522,6 @@ webhooks:
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-apps-v1-statefulset
     name: mstatefulset.kb.io
-    {{- if has "statefulset" $integrationsConfig.frameworks }}
-    failurePolicy: Fail
-    {{- else }}
-    failurePolicy: Ignore
-    {{- end }}
     namespaceSelector:
       {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
         {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
@@ -527,6 +533,11 @@ webhooks:
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
+    {{- if has "statefulset" $integrationsConfig.frameworks }}
+    failurePolicy: Fail
+    {{- else }}
+    failurePolicy: Ignore
+    {{- end }}
     rules:
       - apiGroups:
           - apps
@@ -579,6 +590,17 @@ webhooks:
         path: /mutate-trainer-kubeflow-org-v1alpha1-trainjob
     failurePolicy: Fail
     name: mtrainjob.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - trainer.kubeflow.org
@@ -733,11 +755,6 @@ webhooks:
         namespace: '{{ .Release.Namespace }}'
         path: /validate-apps-v1-deployment
     name: vdeployment.kb.io
-    {{- if has "deployment" $integrationsConfig.frameworks }}
-    failurePolicy: Fail
-    {{- else }}
-    failurePolicy: Ignore
-    {{- end }}
     namespaceSelector:
       {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
         {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
@@ -749,6 +766,11 @@ webhooks:
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
+    {{- if has "deployment" $integrationsConfig.frameworks }}
+    failurePolicy: Fail
+    {{- else }}
+    failurePolicy: Ignore
+    {{- end }}
     rules:
       - apiGroups:
           - apps
@@ -954,11 +976,6 @@ webhooks:
         namespace: '{{ .Release.Namespace }}'
         path: /validate--v1-pod
     name: vpod.kb.io
-    {{- if has "pod" $integrationsConfig.frameworks }}
-    failurePolicy: Fail
-    {{- else }}
-    failurePolicy: Ignore
-    {{- end }}
     namespaceSelector:
       {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
         {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
@@ -970,6 +987,11 @@ webhooks:
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
+    {{- if has "pod" $integrationsConfig.frameworks }}
+    failurePolicy: Fail
+    {{- else }}
+    failurePolicy: Ignore
+    {{- end }}
     rules:
       - apiGroups:
           - ""
@@ -1134,6 +1156,17 @@ webhooks:
         path: /validate-sparkoperator-k8s-io-v1beta2-sparkapplication
     failurePolicy: Fail
     name: vsparkapplication.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - sparkoperator.k8s.io
@@ -1153,11 +1186,6 @@ webhooks:
         namespace: '{{ .Release.Namespace }}'
         path: /validate-apps-v1-statefulset
     name: vstatefulset.kb.io
-    {{- if has "statefulset" $integrationsConfig.frameworks }}
-    failurePolicy: Fail
-    {{- else }}
-    failurePolicy: Ignore
-    {{- end }}
     namespaceSelector:
       {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
         {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
@@ -1169,6 +1197,11 @@ webhooks:
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
+    {{- if has "statefulset" $integrationsConfig.frameworks }}
+    failurePolicy: Fail
+    {{- else }}
+    failurePolicy: Ignore
+    {{- end }}
     rules:
       - apiGroups:
           - apps
@@ -1220,6 +1253,17 @@ webhooks:
         path: /validate-trainer-kubeflow-org-v1alpha1-trainjob
     failurePolicy: Fail
     name: vtrainjob.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - trainer.kubeflow.org

--- a/charts/kueue/templates/webhook/manifests.yaml
+++ b/charts/kueue/templates/webhook/manifests.yaml
@@ -95,8 +95,8 @@ webhooks:
     failurePolicy: Ignore
     {{- end }}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
       {{- else }}
       matchExpressions:
         - key: kubernetes.io/metadata.name
@@ -318,8 +318,8 @@ webhooks:
     failurePolicy: Ignore
     {{- end }}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
       {{- else }}
       matchExpressions:
         - key: kubernetes.io/metadata.name
@@ -517,8 +517,8 @@ webhooks:
     failurePolicy: Ignore
     {{- end }}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
       {{- else }}
       matchExpressions:
         - key: kubernetes.io/metadata.name
@@ -739,8 +739,8 @@ webhooks:
     failurePolicy: Ignore
     {{- end }}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
       {{- else }}
       matchExpressions:
         - key: kubernetes.io/metadata.name
@@ -960,8 +960,8 @@ webhooks:
     failurePolicy: Ignore
     {{- end }}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
       {{- else }}
       matchExpressions:
         - key: kubernetes.io/metadata.name
@@ -1159,8 +1159,8 @@ webhooks:
     failurePolicy: Ignore
     {{- end }}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
       {{- else }}
       matchExpressions:
         - key: kubernetes.io/metadata.name

--- a/charts/kueue/templates/webhook/manifests.yaml
+++ b/charts/kueue/templates/webhook/manifests.yaml
@@ -89,6 +89,11 @@ webhooks:
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-apps-v1-deployment
     name: mdeployment.kb.io
+    {{- if has "deployment" $integrationsConfig.frameworks }}
+    failurePolicy: Fail
+    {{- else }}
+    failurePolicy: Ignore
+    {{- end }}
     namespaceSelector:
       {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
         {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
@@ -100,11 +105,6 @@ webhooks:
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
-    {{- if has "deployment" $integrationsConfig.frameworks }}
-    failurePolicy: Fail
-    {{- else }}
-    failurePolicy: Ignore
-    {{- end }}
     rules:
       - apiGroups:
           - apps
@@ -312,6 +312,11 @@ webhooks:
         namespace: '{{ .Release.Namespace }}'
         path: /mutate--v1-pod
     name: mpod.kb.io
+    {{- if has "pod" $integrationsConfig.frameworks }}
+    failurePolicy: Fail
+    {{- else }}
+    failurePolicy: Ignore
+    {{- end }}
     namespaceSelector:
       {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
         {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
@@ -323,11 +328,6 @@ webhooks:
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
-    {{- if has "pod" $integrationsConfig.frameworks }}
-    failurePolicy: Fail
-    {{- else }}
-    failurePolicy: Ignore
-    {{- end }}
     rules:
       - apiGroups:
           - ""
@@ -522,6 +522,11 @@ webhooks:
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-apps-v1-statefulset
     name: mstatefulset.kb.io
+    {{- if has "statefulset" $integrationsConfig.frameworks }}
+    failurePolicy: Fail
+    {{- else }}
+    failurePolicy: Ignore
+    {{- end }}
     namespaceSelector:
       {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
         {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
@@ -533,11 +538,6 @@ webhooks:
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
-    {{- if has "statefulset" $integrationsConfig.frameworks }}
-    failurePolicy: Fail
-    {{- else }}
-    failurePolicy: Ignore
-    {{- end }}
     rules:
       - apiGroups:
           - apps
@@ -755,6 +755,11 @@ webhooks:
         namespace: '{{ .Release.Namespace }}'
         path: /validate-apps-v1-deployment
     name: vdeployment.kb.io
+    {{- if has "deployment" $integrationsConfig.frameworks }}
+    failurePolicy: Fail
+    {{- else }}
+    failurePolicy: Ignore
+    {{- end }}
     namespaceSelector:
       {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
         {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
@@ -766,11 +771,6 @@ webhooks:
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
-    {{- if has "deployment" $integrationsConfig.frameworks }}
-    failurePolicy: Fail
-    {{- else }}
-    failurePolicy: Ignore
-    {{- end }}
     rules:
       - apiGroups:
           - apps
@@ -976,6 +976,11 @@ webhooks:
         namespace: '{{ .Release.Namespace }}'
         path: /validate--v1-pod
     name: vpod.kb.io
+    {{- if has "pod" $integrationsConfig.frameworks }}
+    failurePolicy: Fail
+    {{- else }}
+    failurePolicy: Ignore
+    {{- end }}
     namespaceSelector:
       {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
         {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
@@ -987,11 +992,6 @@ webhooks:
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
-    {{- if has "pod" $integrationsConfig.frameworks }}
-    failurePolicy: Fail
-    {{- else }}
-    failurePolicy: Ignore
-    {{- end }}
     rules:
       - apiGroups:
           - ""
@@ -1186,6 +1186,11 @@ webhooks:
         namespace: '{{ .Release.Namespace }}'
         path: /validate-apps-v1-statefulset
     name: vstatefulset.kb.io
+    {{- if has "statefulset" $integrationsConfig.frameworks }}
+    failurePolicy: Fail
+    {{- else }}
+    failurePolicy: Ignore
+    {{- end }}
     namespaceSelector:
       {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
         {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
@@ -1197,11 +1202,6 @@ webhooks:
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
-    {{- if has "statefulset" $integrationsConfig.frameworks }}
-    failurePolicy: Fail
-    {{- else }}
-    failurePolicy: Ignore
-    {{- end }}
     rules:
       - apiGroups:
           - apps

--- a/config/components/webhook/kustomization.yaml
+++ b/config/components/webhook/kustomization.yaml
@@ -21,8 +21,6 @@ patches:
           - kube-system
           - kueue-system
 
-# as kustomize does not allow * targeting in path, we use replacements
-# to apply the same namespaceSelector to all webhooks
 replacements:
 - source:
     kind: ValidatingWebhookConfiguration

--- a/config/components/webhook/kustomization.yaml
+++ b/config/components/webhook/kustomization.yaml
@@ -6,7 +6,7 @@ configurations:
 - kustomizeconfig.yaml
 
 patches:
- - patch: |-
+- patch: |-
     apiVersion: admissionregistration.k8s.io/v1
     kind: ValidatingWebhookConfiguration
     metadata:

--- a/config/components/webhook/kustomization.yaml
+++ b/config/components/webhook/kustomization.yaml
@@ -6,40 +6,74 @@ configurations:
 - kustomizeconfig.yaml
 
 patches:
-- target:
-    kind: MutatingWebhookConfiguration
-    name: mutating-webhook-configuration
-  patch: |-
-    - op: add
-      path: /webhooks/0/namespaceSelector
-      value:
+ - patch: |-
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: validating-webhook-configuration
+    webhooks:
+    - name: vpod.kb.io
+      namespaceSelector:
         matchExpressions:
-          - key: kubernetes.io/metadata.name
-            operator: NotIn
-            values:
-            - kube-system
-            - kueue-system
-
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - kueue-system
 
 # as kustomize does not allow * targeting in path, we use replacements
 # to apply the same namespaceSelector to all webhooks
 replacements:
 - source:
-    kind: MutatingWebhookConfiguration
-    name: mutating-webhook-configuration
-    fieldPath: webhooks.0.namespaceSelector
+    kind: ValidatingWebhookConfiguration
+    name: validating-webhook-configuration
+    fieldPath: webhooks.[name=vpod.kb.io].namespaceSelector
   targets:
     - select:
         kind: MutatingWebhookConfiguration
         name: mutating-webhook-configuration
       fieldPaths:
-        - webhooks.*.namespaceSelector
+        - webhooks.[name=mappwrapper.kb.io].namespaceSelector
+        - webhooks.[name=mdeployment.kb.io].namespaceSelector
+        - webhooks.[name=mjaxjob.kb.io].namespaceSelector
+        - webhooks.[name=mjob.kb.io].namespaceSelector
+        - webhooks.[name=mjobset.kb.io].namespaceSelector
+        - webhooks.[name=mleaderworkerset.kb.io].namespaceSelector
+        - webhooks.[name=mmpijob.kb.io].namespaceSelector
+        - webhooks.[name=mpaddlejob.kb.io].namespaceSelector
+        - webhooks.[name=mpod.kb.io].namespaceSelector
+        - webhooks.[name=mpytorchjob.kb.io].namespaceSelector
+        - webhooks.[name=mraycluster.kb.io].namespaceSelector
+        - webhooks.[name=mrayjob.kb.io].namespaceSelector
+        - webhooks.[name=mrayservice.kb.io].namespaceSelector
+        - webhooks.[name=msparkapplication.kb.io].namespaceSelector
+        - webhooks.[name=mstatefulset.kb.io].namespaceSelector
+        - webhooks.[name=mtfjob.kb.io].namespaceSelector
+        - webhooks.[name=mtrainjob.kb.io].namespaceSelector
+        - webhooks.[name=mxgboostjob.kb.io].namespaceSelector
       options:
         create: true
     - select:
         kind: ValidatingWebhookConfiguration
         name: validating-webhook-configuration
       fieldPaths:
-        - webhooks.*.namespaceSelector
+        - webhooks.[name=vappwrapper.kb.io].namespaceSelector
+        - webhooks.[name=vdeployment.kb.io].namespaceSelector
+        - webhooks.[name=vjaxjob.kb.io].namespaceSelector
+        - webhooks.[name=vjob.kb.io].namespaceSelector
+        - webhooks.[name=vjobset.kb.io].namespaceSelector
+        - webhooks.[name=vleaderworkerset.kb.io].namespaceSelector
+        - webhooks.[name=vmpijob.kb.io].namespaceSelector
+        - webhooks.[name=vpaddlejob.kb.io].namespaceSelector
+        - webhooks.[name=vpod.kb.io].namespaceSelector
+        - webhooks.[name=vpytorchjob.kb.io].namespaceSelector
+        - webhooks.[name=vraycluster.kb.io].namespaceSelector
+        - webhooks.[name=vrayjob.kb.io].namespaceSelector
+        - webhooks.[name=vrayservice.kb.io].namespaceSelector
+        - webhooks.[name=vsparkapplication.kb.io].namespaceSelector
+        - webhooks.[name=vstatefulset.kb.io].namespaceSelector
+        - webhooks.[name=vtfjob.kb.io].namespaceSelector
+        - webhooks.[name=vtrainjob.kb.io].namespaceSelector
+        - webhooks.[name=vxgboostjob.kb.io].namespaceSelector
       options:
         create: true

--- a/config/components/webhook/kustomization.yaml
+++ b/config/components/webhook/kustomization.yaml
@@ -6,63 +6,40 @@ configurations:
 - kustomizeconfig.yaml
 
 patches:
-- patch: |-
-    apiVersion: admissionregistration.k8s.io/v1
+- target:
     kind: MutatingWebhookConfiguration
-    metadata:
-      name: mutating-webhook-configuration
-    webhooks:
-    - name: mpod.kb.io
-      namespaceSelector:
+    name: mutating-webhook-configuration
+  patch: |-
+    - op: add
+      path: /webhooks/0/namespaceSelector
+      value:
         matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
+          - key: kubernetes.io/metadata.name
+            operator: NotIn
+            values:
             - kube-system
             - kueue-system
-    - name: mdeployment.kb.io
-      namespaceSelector:
-        matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - kueue-system
-    - name: mstatefulset.kb.io
-      namespaceSelector:
-        matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - kueue-system
-- patch: |-
-    apiVersion: admissionregistration.k8s.io/v1
-    kind: ValidatingWebhookConfiguration
-    metadata:
-      name: validating-webhook-configuration
-    webhooks:
-    - name: vpod.kb.io
-      namespaceSelector:
-        matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-          - kube-system
-          - kueue-system
-    - name: vdeployment.kb.io
-      namespaceSelector:
-        matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-          - kube-system
-          - kueue-system
-    - name: vstatefulset.kb.io
-      namespaceSelector:
-        matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - kueue-system
+
+
+# as kustomize does not allow * targeting in path, we use replacements
+# to apply the same namespaceSelector to all webhooks
+replacements:
+- source:
+    kind: MutatingWebhookConfiguration
+    name: mutating-webhook-configuration
+    fieldPath: webhooks.0.namespaceSelector
+  targets:
+    - select:
+        kind: MutatingWebhookConfiguration
+        name: mutating-webhook-configuration
+      fieldPaths:
+        - webhooks.*.namespaceSelector
+      options:
+        create: true
+    - select:
+        kind: ValidatingWebhookConfiguration
+        name: validating-webhook-configuration
+      fieldPaths:
+        - webhooks.*.namespaceSelector
+      options:
+        create: true

--- a/hack/processing-plan.yaml
+++ b/hack/processing-plan.yaml
@@ -271,6 +271,38 @@ files:
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].rules[0].apiGroups[0] != "kueue.x-k8s.io"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].rules[0].apiGroups[0] != "kueue.x-k8s.io"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
           {{- if has "pod" $integrationsConfig.frameworks }}
           failurePolicy: Fail
           {{- else }}
@@ -328,38 +360,6 @@ files:
           {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-apps-v1-statefulset"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].rules[0].apiGroups[0] != "kueue.x-k8s.io"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].rules[0].apiGroups[0] != "kueue.x-k8s.io"'
   - path: ./config/components/kueueviz/*.yaml
     outputDir: ./charts/kueue/templates/kueueviz
     removeComments: true

--- a/hack/processing-plan.yaml
+++ b/hack/processing-plan.yaml
@@ -63,14 +63,14 @@ files:
         key: .metadata.labels
         value: |
           {{- include "kueue.labels" . | nindent 4 }}
-        onFileCondition: '.metadata.labels != null'
+        onFileCondition: ".metadata.labels != null"
       - type: INSERT_TEXT
         key: .metadata
         value: |
           labels:
           {{- include "kueue.labels" . | nindent 4 }}
         indentation: 2
-        onFileCondition: '.metadata.labels == null'
+        onFileCondition: ".metadata.labels == null"
   - path: ./config/components/visibility/*.yaml
     outputDir: ./charts/kueue/templates/visibility
     removeComments: true
@@ -397,234 +397,416 @@ files:
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-batch-v1-job"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-jobset-x-k8s-io-v1alpha2-jobset"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-jaxjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-paddlejob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-pytorchjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-tfjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-xgboostjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-leaderworkerset-x-k8s-io-v1-leaderworkerset"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v2beta1-mpijob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-ray-io-v1-raycluster"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-ray-io-v1-rayjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-workload-codeflare-dev-v1beta2-appwrapper"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-batch-v1-job"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-jobset-x-k8s-io-v1alpha2-jobset"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-jaxjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-paddlejob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-pytorchjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-tfjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-xgboostjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-leaderworkerset-x-k8s-io-v1-leaderworkerset"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v2beta1-mpijob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-ray-io-v1-raycluster"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-ray-io-v1-rayjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-ray-io-v1-rayservice"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-ray-io-v1-rayservice"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
+          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-workload-codeflare-dev-v1beta2-appwrapper"'
@@ -848,7 +1030,7 @@ files:
           {{- toYaml . | nindent 8 }}
           {{- end }}
         indentation: 2
-        onFileCondition: '.kind == "Deployment" and  .metadata.name | contains("backend")' 
+        onFileCondition: '.kind == "Deployment" and  .metadata.name | contains("backend")'
       - type: INSERT_TEXT
         position: END
         value: |

--- a/hack/processing-plan.yaml
+++ b/hack/processing-plan.yaml
@@ -63,14 +63,14 @@ files:
         key: .metadata.labels
         value: |
           {{- include "kueue.labels" . | nindent 4 }}
-        onFileCondition: ".metadata.labels != null"
+        onFileCondition: '.metadata.labels != null'
       - type: INSERT_TEXT
         key: .metadata
         value: |
           labels:
           {{- include "kueue.labels" . | nindent 4 }}
         indentation: 2
-        onFileCondition: ".metadata.labels == null"
+        onFileCondition: '.metadata.labels == null'
   - path: ./config/components/visibility/*.yaml
     outputDir: ./charts/kueue/templates/visibility
     removeComments: true

--- a/hack/processing-plan.yaml
+++ b/hack/processing-plan.yaml
@@ -276,17 +276,6 @@ files:
           {{- else }}
           failurePolicy: Ignore
           {{- end }}
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate--v1-pod"'
       - type: INSERT_TEXT
@@ -297,17 +286,6 @@ files:
           {{- else }}
           failurePolicy: Ignore
           {{- end }}
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate--v1-pod"'
       - type: INSERT_TEXT
@@ -318,17 +296,6 @@ files:
           {{- else }}
           failurePolicy: Ignore
           {{- end }}
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-apps-v1-deployment"'
       - type: INSERT_TEXT
@@ -339,17 +306,6 @@ files:
           {{- else }}
           failurePolicy: Ignore
           {{- end }}
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-apps-v1-deployment"'
       - type: INSERT_TEXT
@@ -360,17 +316,6 @@ files:
           {{- else }}
           failurePolicy: Ignore
           {{- end }}
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-apps-v1-statefulset"'
       - type: INSERT_TEXT
@@ -381,17 +326,6 @@ files:
           {{- else }}
           failurePolicy: Ignore
           {{- end }}
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-apps-v1-statefulset"'
       - type: INSERT_TEXT
@@ -409,167 +343,7 @@ files:
                   - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-batch-v1-job"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-jobset-x-k8s-io-v1alpha2-jobset"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-jaxjob"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-paddlejob"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-pytorchjob"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-tfjob"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-xgboostjob"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-leaderworkerset-x-k8s-io-v1-leaderworkerset"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v2beta1-mpijob"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-ray-io-v1-raycluster"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-ray-io-v1-rayjob"'
+        onItemCondition: '.webhooks.[].rules[0].apiGroups[0] != "kueue.x-k8s.io"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
@@ -585,231 +359,7 @@ files:
                   - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-workload-codeflare-dev-v1beta2-appwrapper"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-batch-v1-job"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-jobset-x-k8s-io-v1alpha2-jobset"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-jaxjob"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-paddlejob"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-pytorchjob"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-tfjob"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-xgboostjob"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-leaderworkerset-x-k8s-io-v1-leaderworkerset"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v2beta1-mpijob"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-ray-io-v1-raycluster"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-ray-io-v1-rayjob"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-ray-io-v1-rayservice"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-ray-io-v1-rayservice"'
-      - type: INSERT_TEXT
-        key: .webhooks.[].name
-        value: |
-          namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
-            {{- end }}
-        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
-        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-workload-codeflare-dev-v1beta2-appwrapper"'
+        onItemCondition: '.webhooks.[].rules[0].apiGroups[0] != "kueue.x-k8s.io"'
   - path: ./config/components/kueueviz/*.yaml
     outputDir: ./charts/kueue/templates/kueueviz
     removeComments: true
@@ -1030,7 +580,7 @@ files:
           {{- toYaml . | nindent 8 }}
           {{- end }}
         indentation: 2
-        onFileCondition: '.kind == "Deployment" and  .metadata.name | contains("backend")'
+        onFileCondition: '.kind == "Deployment" and  .metadata.name | contains("backend")' 
       - type: INSERT_TEXT
         position: END
         value: |

--- a/hack/processing-plan.yaml
+++ b/hack/processing-plan.yaml
@@ -277,8 +277,8 @@ files:
           failurePolicy: Ignore
           {{- end }}
           namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- else }}
             matchExpressions:
               - key: kubernetes.io/metadata.name
@@ -298,8 +298,8 @@ files:
           failurePolicy: Ignore
           {{- end }}
           namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- else }}
             matchExpressions:
               - key: kubernetes.io/metadata.name
@@ -319,8 +319,8 @@ files:
           failurePolicy: Ignore
           {{- end }}
           namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- else }}
             matchExpressions:
               - key: kubernetes.io/metadata.name
@@ -340,8 +340,8 @@ files:
           failurePolicy: Ignore
           {{- end }}
           namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- else }}
             matchExpressions:
               - key: kubernetes.io/metadata.name
@@ -361,8 +361,8 @@ files:
           failurePolicy: Ignore
           {{- end }}
           namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- else }}
             matchExpressions:
               - key: kubernetes.io/metadata.name
@@ -382,8 +382,8 @@ files:
           failurePolicy: Ignore
           {{- end }}
           namespaceSelector:
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- else }}
             matchExpressions:
               - key: kubernetes.io/metadata.name

--- a/hack/tools/yaml-processor/yamlproc/processor_test.go
+++ b/hack/tools/yaml-processor/yamlproc/processor_test.go
@@ -215,10 +215,10 @@ root:
   - child:
       name: child3
 `,
-			opType:      InsertText,
-			key:         ".root.[].child.name",
-			value:       "plain text\nsecond line\nthird line\n",
-			indentation: 0,
+			opType:          InsertText,
+			key:             ".root.[].child.name",
+			value:           "plain text\nsecond line\nthird line\n",
+			indentation:     0,
 			onItemCondition: `.root.[].child.name != "child2"`,
 			want: `
 root:

--- a/hack/tools/yaml-processor/yamlproc/processor_test.go
+++ b/hack/tools/yaml-processor/yamlproc/processor_test.go
@@ -36,6 +36,7 @@ func TestApplyOperations(t *testing.T) {
 		value           string
 		addKeyIfMissing bool
 		onCondition     string
+		onItemCondition string
 		indentation     int
 		want            string
 		wantErr         []string
@@ -204,6 +205,37 @@ root:
     name: child1
 `,
 		},
+		"InsertText_onItemConditionMet_With_Multiple_Matching_Keys": {
+			data: `
+root:
+  - child:
+      name: child1
+  - child:
+      name: child2
+  - child:
+      name: child3
+`,
+			opType:      InsertText,
+			key:         ".root.[].child.name",
+			value:       "plain text\nsecond line\nthird line\n",
+			indentation: 0,
+			onItemCondition: `.root.[].child.name != "child2"`,
+			want: `
+root:
+  - child:
+      name: child1
+      plain text
+      second line
+      third line
+  - child:
+      name: child2
+  - child:
+      name: child3
+      plain text
+      second line
+      third line
+`,
+		},
 		"InsertText_OnConditionNotMet": {
 			data: `
 root:
@@ -234,6 +266,7 @@ root:
 				Value:           tt.value,
 				AddKeyIfMissing: tt.addKeyIfMissing,
 				OnFileCondition: tt.onCondition,
+				OnItemCondition: tt.onItemCondition,
 				Indentation:     tt.indentation,
 			}
 			fileOps := FileOperations{}

--- a/hack/tools/yaml-processor/yamlproc/txtinserter.go
+++ b/hack/tools/yaml-processor/yamlproc/txtinserter.go
@@ -60,7 +60,6 @@ func (ti *TextInserter) Insert(yamlData []byte, opts InsertOptions) ([]byte, err
 
 func (ti *TextInserter) insertBelowKey(yamlData []byte, opts InsertOptions) ([]byte, error) {
 	var buffer bytes.Buffer
-	var offset int
 
 	sanitizedYaml := Sanitize(yamlData)
 	keyLines, err := ti.yq.FindKeyLines(sanitizedYaml, opts.Key, opts.OnItemCondition)
@@ -73,7 +72,7 @@ func (ti *TextInserter) insertBelowKey(yamlData []byte, opts InsertOptions) ([]b
 		trimmedLine := strings.TrimSpace(line)
 		buffer.WriteString(line + "\n")
 
-		if slices.Contains(keyLines, i+offset) {
+		if slices.Contains(keyLines, i) {
 			before, _, ok := strings.Cut(line, trimmedLine)
 			if !ok {
 				return nil, fmt.Errorf("unable to calculate indentation for %q in line %q (line number: %d)", trimmedLine, line, i)
@@ -81,7 +80,6 @@ func (ti *TextInserter) insertBelowKey(yamlData []byte, opts InsertOptions) ([]b
 			baseIndent := before
 			indentedContent := ti.indentContent(opts.Value, baseIndent+strings.Repeat(" ", opts.Indentation))
 			buffer.WriteString(indentedContent)
-			offset += len(strings.Split(indentedContent, "\n"))
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area integrations

#### What this PR does / why we need it:
Adds `kube-system` and `kueue-system` (or other release namespace in case of helm installation) namespace excludes to webhooks targeting common resource types.
(Custom resources that are not added by Kueue)

This makes sure Kueue deployment does not suspend crucial system components, e.g. jobs run by `kubeadm`.

#### Which issue(s) this PR fixes:
Fixes #11006

#### Special notes for your reviewer:
I haven't modified webhook selectors for Kueue's own resources as those shouldn't be run by other crucial system components. But if you think it is worth to also exclude those, just let me know.

Prepared with Antigravity, but carefully reviewed to not miss any resource.

#### Does this PR introduce a user-facing change?
```release-note
Kueue integration webhooks now consistently exclude `kube-system` and the Kueue
installation namespace. For manifest-based installs this is `kueue-system`; for Helm
installs this is the Helm release namespace.

Previously, Pod, Deployment, and StatefulSet integrations already excluded these
namespaces, while other workload integrations did not.

ACTION REQUIRED: If you run Kueue-managed workloads in `kube-system` or in the namespace
where Kueue is installed, move them to another namespace before upgrading.

If this is not possible, update `managedJobsNamespaceSelector` and the relevant webhook
`namespaceSelector`s to include those namespaces. This setup is discouraged, as it may
affect system workloads and disrupt cluster upgrades.
```
