### PR TITLE
Fix: FindNotFinishedWorkloads sort comparator antisymmetry violation

### DIFF
--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -125,7 +125,10 @@ func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject
 				if b.Annotations[WorkloadSliceReplacementFor] == string(workload.Key(&a)) {
 					return -1
 				}
-				return 1
+				if a.Annotations[WorkloadSliceReplacementFor] == string(workload.Key(&b)) {
+					return 1
+				}
+				return 0
 			},
 		)
 	})

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -283,6 +283,41 @@ func TestFindNotFinishedWorkloads(t *testing.T) {
 					Obj(),
 			},
 		},
+		// Regression test for https://github.com/kubernetes-sigs/kueue/issues/11166:
+		// When two workloads have identical timestamps and neither's ReplacementFor
+		// annotation points to the other (e.g., v1 and v3 from a v1→v2→v3 chain where
+		// v2 was finished), the comparator must return 0 rather than 1 in both
+		// directions, which would violate the antisymmetry required by slices.SortFunc.
+		"TwoActiveWorkloads_TimestampCollision_NeitherReplacesOther": {
+			args: args{
+				clnt: testWorkloadClientBuilder().WithLists(&kueue.WorkloadList{
+					Items: []kueue.Workload{
+						// test-23 (v3) has ReplacementFor pointing to test-22 (v2), not test-21 (v1).
+						*testWorkload("test-23", testJobObject.Name, testJobObject.UID, now).
+							ResourceVersion("300").
+							Annotation(WorkloadSliceReplacementFor, string(workload.NewReference("default", "test-22"))).
+							Obj(),
+						// test-21 (v1) has no ReplacementFor annotation (it was the first slice).
+						*testWorkload("test-21", testJobObject.Name, testJobObject.UID, now).
+							ResourceVersion("100").
+							Obj(),
+					},
+				}).Build(),
+				jobObject:    testJobObject,
+				jobObjectGVK: testJobGVK,
+			},
+			// Both workloads should be returned without a panic.
+			// Since neither replaces the other, the comparator returns 0 (equal).
+			want: []kueue.Workload{
+				*testWorkload("test-21", testJobObject.Name, testJobObject.UID, now).
+					ResourceVersion("100").
+					Obj(),
+				*testWorkload("test-23", testJobObject.Name, testJobObject.UID, now).
+					ResourceVersion("300").
+					Annotation(WorkloadSliceReplacementFor, string(workload.NewReference("default", "test-22"))).
+					Obj(),
+			},
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
fixes : #11166 

## What changed

The tiebreaker in the `slices.SortFunc` comparator inside `FindNotFinishedWorkloads()` now checks **both** directions of the `WorkloadSliceReplacementFor` annotation and returns `0` when neither workload replaces the other.

## Why

The previous comparator only checked whether `b` replaces `a` (returning `-1`), then fell through to unconditional `return 1`. When two workloads had identical `CreationTimestamp` values and neither's `WorkloadSliceReplacementFor` annotation pointed to the other, both `cmp(a,b)` and `cmp(b,a)` returned `1` — violating the [antisymmetry requirement](https://pkg.go.dev/slices#SortFunc) of strict weak ordering.

This could cause `EnsureWorkloadSlices` `case 2:` to swap old/new workloads, finishing the wrong slice and leaking quota.

### Reproduction scenario

A `v1→v2→v3` workload chain where `v2` gets finished but `v1` does not (e.g., transient `Finish` failure). `FindNotFinishedWorkloads` returns `[v1, v3]` where `v1` has no replacement annotation and `v3` points to `v2` (not `v1`) — the tiebreaker returns `1` in both directions.

## Changes

- Add symmetric reverse check (`a` replaces `b` → `return 1`)
- Return `0` when neither workload replaces the other
- Add regression test `TwoActiveWorkloads_TimestampCollision_NeitherReplacesOther`

```diff
 		func() int {
 			if b.Annotations[WorkloadSliceReplacementFor] == string(workload.Key(&a)) {
 				return -1
 			}
-			return 1
+			if a.Annotations[WorkloadSliceReplacementFor] == string(workload.Key(&b)) {
+				return 1
+			}
+			return 0
 		},
```

```release-note
ElasticJobsViaWorkloadSlices: Fixed a bug where workload slices with identical creation timestamps could be incorrectly sorted, potentially leading to quota leaks during scale-up.
```
