### PR TITLE
fix race in TestHeadsCancelled

### DIFF
--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -1563,23 +1563,23 @@ func TestHeadsAsync(t *testing.T) {
 	}
 	cases := map[string]struct {
 		initialObjs []client.Object
-		op          func(context.Context, *Manager)
+		op          func(context.Context, *Manager, *sync.WaitGroup)
 		wantHeads   []workload.Info
 	}{
 		"AddClusterQueue": {
 			initialObjs: []client.Object{&wl, &queues[0]},
-			op: func(ctx context.Context, mgr *Manager) {
+			op: func(ctx context.Context, mgr *Manager, wg *sync.WaitGroup) {
 				if err := mgr.AddClusterQueue(ctx, clusterQueues[0]); err != nil {
 					t.Errorf("Failed adding clusterQueue: %v", err)
 				}
 				if err := mgr.AddLocalQueue(ctx, &queues[0]); err != nil {
 					t.Errorf("Failed adding queue: %s", err)
 				}
-				go func() {
+				wg.Go(func() {
 					if err := mgr.AddOrUpdateWorkload(logr.FromContextOrDiscard(ctx), &wl); err != nil {
 						t.Errorf("Failed to add or update workload: %v", err)
 					}
-				}()
+				})
 			},
 			wantHeads: []workload.Info{
 				{
@@ -1590,15 +1590,15 @@ func TestHeadsAsync(t *testing.T) {
 		},
 		"AddLocalQueue": {
 			initialObjs: []client.Object{&wl},
-			op: func(ctx context.Context, mgr *Manager) {
+			op: func(ctx context.Context, mgr *Manager, wg *sync.WaitGroup) {
 				if err := mgr.AddClusterQueue(ctx, clusterQueues[0]); err != nil {
 					t.Errorf("Failed adding clusterQueue: %v", err)
 				}
-				go func() {
+				wg.Go(func() {
 					if err := mgr.AddLocalQueue(ctx, &queues[0]); err != nil {
 						t.Errorf("Failed adding queue: %s", err)
 					}
-				}()
+				})
 			},
 			wantHeads: []workload.Info{
 				{
@@ -1608,18 +1608,18 @@ func TestHeadsAsync(t *testing.T) {
 			},
 		},
 		"AddWorkload": {
-			op: func(ctx context.Context, mgr *Manager) {
+			op: func(ctx context.Context, mgr *Manager, wg *sync.WaitGroup) {
 				if err := mgr.AddClusterQueue(ctx, clusterQueues[0]); err != nil {
 					t.Errorf("Failed adding clusterQueue: %v", err)
 				}
 				if err := mgr.AddLocalQueue(ctx, &queues[0]); err != nil {
 					t.Errorf("Failed adding queue: %s", err)
 				}
-				go func() {
+				wg.Go(func() {
 					if err := mgr.AddOrUpdateWorkload(logr.FromContextOrDiscard(ctx), &wl); err != nil {
 						t.Errorf("Failed to add or update workload: %v", err)
 					}
-				}()
+				})
 			},
 			wantHeads: []workload.Info{
 				{
@@ -1629,19 +1629,19 @@ func TestHeadsAsync(t *testing.T) {
 			},
 		},
 		"UpdateWorkload": {
-			op: func(ctx context.Context, mgr *Manager) {
+			op: func(ctx context.Context, mgr *Manager, wg *sync.WaitGroup) {
 				if err := mgr.AddClusterQueue(ctx, clusterQueues[0]); err != nil {
 					t.Errorf("Failed adding clusterQueue: %v", err)
 				}
 				if err := mgr.AddLocalQueue(ctx, &queues[0]); err != nil {
 					t.Errorf("Failed adding queue: %s", err)
 				}
-				go func() {
+				wg.Go(func() {
 					log := logr.FromContextOrDiscard(ctx)
 					if err := mgr.AddOrUpdateWorkload(log, &wl); err != nil {
 						t.Errorf("Failed to add or update workload: %v", err)
 					}
-				}()
+				})
 			},
 			wantHeads: []workload.Info{
 				{
@@ -1652,7 +1652,7 @@ func TestHeadsAsync(t *testing.T) {
 		},
 		"RequeueWorkload": {
 			initialObjs: []client.Object{&wl},
-			op: func(ctx context.Context, mgr *Manager) {
+			op: func(ctx context.Context, mgr *Manager, wg *sync.WaitGroup) {
 				if err := mgr.AddClusterQueue(ctx, clusterQueues[0]); err != nil {
 					t.Errorf("Failed adding clusterQueue: %v", err)
 				}
@@ -1661,9 +1661,9 @@ func TestHeadsAsync(t *testing.T) {
 				}
 				// Remove the initial workload from the manager.
 				mgr.Heads(ctx)
-				go func() {
+				wg.Go(func() {
 					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), RequeueReasonFailedAfterNomination)
-				}()
+				})
 			},
 			wantHeads: []workload.Info{
 				{
@@ -1674,7 +1674,7 @@ func TestHeadsAsync(t *testing.T) {
 		},
 		"RequeueWithOutOfDateWorkload": {
 			initialObjs: []client.Object{&wl},
-			op: func(ctx context.Context, mgr *Manager) {
+			op: func(ctx context.Context, mgr *Manager, wg *sync.WaitGroup) {
 				if err := mgr.AddClusterQueue(ctx, clusterQueues[0]); err != nil {
 					t.Errorf("Failed adding clusterQueue: %v", err)
 				}
@@ -1689,9 +1689,9 @@ func TestHeadsAsync(t *testing.T) {
 				}
 				// Remove the initial workload from the manager.
 				mgr.Heads(ctx)
-				go func() {
+				wg.Go(func() {
 					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), RequeueReasonFailedAfterNomination)
-				}()
+				})
 			},
 			wantHeads: []workload.Info{
 				{
@@ -1702,7 +1702,7 @@ func TestHeadsAsync(t *testing.T) {
 		},
 		"RequeueWithQueueChangedWorkload": {
 			initialObjs: []client.Object{&wl},
-			op: func(ctx context.Context, mgr *Manager) {
+			op: func(ctx context.Context, mgr *Manager, wg *sync.WaitGroup) {
 				for _, cq := range clusterQueues {
 					if err := mgr.AddClusterQueue(ctx, cq); err != nil {
 						t.Errorf("Failed adding clusterQueue: %v", err)
@@ -1721,9 +1721,9 @@ func TestHeadsAsync(t *testing.T) {
 				}
 				// Remove the initial workload from the manager.
 				mgr.Heads(ctx)
-				go func() {
+				wg.Go(func() {
 					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), RequeueReasonFailedAfterNomination)
-				}()
+				})
 			},
 			wantHeads: []workload.Info{
 				{
@@ -1737,13 +1737,17 @@ func TestHeadsAsync(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
 			ctx, cancel := context.WithTimeout(ctx, headsTimeout)
-			defer cancel()
+			var wg sync.WaitGroup
+			t.Cleanup(func() {
+				cancel()
+				wg.Wait()
+			})
 			client := utiltesting.NewFakeClient(tc.initialObjs...)
 			queueOptions := []Option{WithPreemptionExpectations(preemptexpectations.New())}
 			manager := NewManagerForUnitTests(client, nil, queueOptions...)
 
 			go manager.CleanUpOnContext(ctx)
-			tc.op(ctx, manager)
+			tc.op(ctx, manager, &wg)
 			heads := manager.Heads(ctx)
 			if diff := cmp.Diff(tc.wantHeads, heads, ignoreTypeMeta, ignoreSchedulingHash); diff != "" {
 				t.Errorf("GetHeads returned wrong heads (-want,+got):\n%s", diff)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind failing-test
/kind flake
/area testing

/cc @kannon92 

#### What this PR does / why we need it:

In `TestHeadsAsync`, each subtest creates a logger bound to the subtest's `*testing.T` via `utiltesting.ContextWithLog(t)`. The `tc.op(ctx, manager)` call then spawns goroutines that pass that context's logger deep into production code (`AddOrUpdateWorkload` → `AddOrUpdateWorkloadWithoutLock` → `expectations.Store.ObservedUID()`), where it calls `log.V(3).Info(...)` → `t.Log()`.

The race: after `manager.Heads(ctx)` returns (meaning the workload was added and the goroutine's work is logically done), the subtest goroutine can exit and finalize the subtest's `t`—but the spawned goroutine may still be executing the trailing `log.Info` call, which reads `t`'s internal state concurrently with `t`'s finalization write.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11189

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
