### PR TITLE
add unique label per clusterrole

### DIFF
--- a/charts/kueue/templates/rbac/clusterqueue_editor_role.yaml
+++ b/charts/kueue/templates/rbac/clusterqueue_editor_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-clusterqueue-editor-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "clusterqueue-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
   - apiGroups:

--- a/charts/kueue/templates/rbac/clusterqueue_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/clusterqueue_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-clusterqueue-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "clusterqueue-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:

--- a/charts/kueue/templates/rbac/cohort_editor_role.yaml
+++ b/charts/kueue/templates/rbac/cohort_editor_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-cohort-editor-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "cohort-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
   - apiGroups:

--- a/charts/kueue/templates/rbac/cohort_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/cohort_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-cohort-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "cohort-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:

--- a/charts/kueue/templates/rbac/jaxjob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/jaxjob_editor_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-jaxjob-editor-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "jaxjob-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/jaxjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/jaxjob_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-jaxjob-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "jaxjob-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/charts/kueue/templates/rbac/job_editor_role.yaml
+++ b/charts/kueue/templates/rbac/job_editor_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-job-editor-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "job-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/job_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/job_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-job-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "job-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/charts/kueue/templates/rbac/jobset_editor_role.yaml
+++ b/charts/kueue/templates/rbac/jobset_editor_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-jobset-editor-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "jobset-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/jobset_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/jobset_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-jobset-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "jobset-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/charts/kueue/templates/rbac/leaderworkerset_editor_role.yaml
+++ b/charts/kueue/templates/rbac/leaderworkerset_editor_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-leaderworkerset-editor-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "leaderworkerset-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/leaderworkerset_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/leaderworkerset_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-leaderworkerset-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "leaderworkerset-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/charts/kueue/templates/rbac/localqueue_editor_role.yaml
+++ b/charts/kueue/templates/rbac/localqueue_editor_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-localqueue-editor-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "localqueue-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
   - apiGroups:

--- a/charts/kueue/templates/rbac/localqueue_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/localqueue_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-localqueue-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "localqueue-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/charts/kueue/templates/rbac/mpijob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/mpijob_editor_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-mpijob-editor-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "mpijob-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/mpijob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/mpijob_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-mpijob-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "mpijob-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/charts/kueue/templates/rbac/paddlejob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/paddlejob_editor_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-paddlejob-editor-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "paddlejob-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/paddlejob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/paddlejob_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-paddlejob-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "paddlejob-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/charts/kueue/templates/rbac/pending_workloads_cq_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/pending_workloads_cq_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-pending-workloads-cq-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "pending-workloads-cq-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"

--- a/charts/kueue/templates/rbac/pending_workloads_lq_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/pending_workloads_lq_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-pending-workloads-lq-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "pending-workloads-lq-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/charts/kueue/templates/rbac/pytorchjob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/pytorchjob_editor_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-pytorchjob-editor-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "pytorchjob-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/pytorchjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/pytorchjob_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-pytorchjob-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "pytorchjob-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/charts/kueue/templates/rbac/raycluster_editor_role.yaml
+++ b/charts/kueue/templates/rbac/raycluster_editor_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-raycluster-editor-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "raycluster-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/raycluster_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/raycluster_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-raycluster-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "raycluster-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"

--- a/charts/kueue/templates/rbac/rayjob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/rayjob_editor_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-rayjob-editor-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "rayjob-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/rayjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/rayjob_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-rayjob-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "rayjob-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/charts/kueue/templates/rbac/rayservice_editor_role.yaml
+++ b/charts/kueue/templates/rbac/rayservice_editor_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-rayservice-editor-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "rayservice-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/rayservice_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/rayservice_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-rayservice-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "rayservice-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"

--- a/charts/kueue/templates/rbac/resourceflavor_editor_role.yaml
+++ b/charts/kueue/templates/rbac/resourceflavor_editor_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-resourceflavor-editor-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "resourceflavor-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
   - apiGroups:

--- a/charts/kueue/templates/rbac/resourceflavor_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/resourceflavor_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-resourceflavor-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "resourceflavor-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:

--- a/charts/kueue/templates/rbac/sparkapplication_editor_role.yaml
+++ b/charts/kueue/templates/rbac/sparkapplication_editor_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-sparkapplication-editor-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "sparkapplication-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/sparkapplication_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/sparkapplication_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-sparkapplication-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "sparkapplication-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/charts/kueue/templates/rbac/tfjob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/tfjob_editor_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-tfjob-editor-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "tfjob-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/tfjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/tfjob_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-tfjob-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "tfjob-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/charts/kueue/templates/rbac/topology_editor_role.yaml
+++ b/charts/kueue/templates/rbac/topology_editor_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-topology-editor-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "topology-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
   - apiGroups:

--- a/charts/kueue/templates/rbac/topology_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/topology_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-topology-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "topology-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:

--- a/charts/kueue/templates/rbac/trainjob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/trainjob_editor_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-trainjob-editor-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "trainjob-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/trainjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/trainjob_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-trainjob-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "trainjob-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/charts/kueue/templates/rbac/workload_editor_role.yaml
+++ b/charts/kueue/templates/rbac/workload_editor_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-workload-editor-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "workload-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
   - apiGroups:

--- a/charts/kueue/templates/rbac/workload_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/workload_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-workload-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "workload-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/charts/kueue/templates/rbac/xgboostjob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/xgboostjob_editor_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-xgboostjob-editor-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "xgboostjob-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/xgboostjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/xgboostjob_viewer_role.yaml
@@ -22,6 +22,7 @@ metadata:
   name: '{{ include "kueue.fullname" . }}-xgboostjob-viewer-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/role: "xgboostjob-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/config/components/rbac/clusterqueue_editor_role.yaml
+++ b/config/components/rbac/clusterqueue_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: clusterqueue-editor-role
   labels:
+    rbac.kueue.x-k8s.io/role: "clusterqueue-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
 - apiGroups:

--- a/config/components/rbac/clusterqueue_viewer_role.yaml
+++ b/config/components/rbac/clusterqueue_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: clusterqueue-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "clusterqueue-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:

--- a/config/components/rbac/cohort_editor_role.yaml
+++ b/config/components/rbac/cohort_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: cohort-editor-role
   labels:
+    rbac.kueue.x-k8s.io/role: "cohort-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
 - apiGroups:

--- a/config/components/rbac/cohort_viewer_role.yaml
+++ b/config/components/rbac/cohort_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: cohort-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "cohort-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:

--- a/config/components/rbac/jaxjob_editor_role.yaml
+++ b/config/components/rbac/jaxjob_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: jaxjob-editor-role
   labels:
+    rbac.kueue.x-k8s.io/role: "jaxjob-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/config/components/rbac/jaxjob_viewer_role.yaml
+++ b/config/components/rbac/jaxjob_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: jaxjob-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "jaxjob-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/config/components/rbac/job_editor_role.yaml
+++ b/config/components/rbac/job_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: job-editor-role
   labels:
+    rbac.kueue.x-k8s.io/role: "job-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/config/components/rbac/job_viewer_role.yaml
+++ b/config/components/rbac/job_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: job-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "job-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/config/components/rbac/jobset_editor_role.yaml
+++ b/config/components/rbac/jobset_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: jobset-editor-role
   labels:
+    rbac.kueue.x-k8s.io/role: "jobset-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/config/components/rbac/jobset_viewer_role.yaml
+++ b/config/components/rbac/jobset_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: jobset-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "jobset-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/config/components/rbac/leaderworkerset_editor_role.yaml
+++ b/config/components/rbac/leaderworkerset_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: leaderworkerset-editor-role
   labels:
+    rbac.kueue.x-k8s.io/role: "leaderworkerset-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/config/components/rbac/leaderworkerset_viewer_role.yaml
+++ b/config/components/rbac/leaderworkerset_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: leaderworkerset-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "leaderworkerset-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/config/components/rbac/localqueue_editor_role.yaml
+++ b/config/components/rbac/localqueue_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: localqueue-editor-role
   labels:
+    rbac.kueue.x-k8s.io/role: "localqueue-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
 - apiGroups:

--- a/config/components/rbac/localqueue_viewer_role.yaml
+++ b/config/components/rbac/localqueue_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: localqueue-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "localqueue-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/config/components/rbac/mpijob_editor_role.yaml
+++ b/config/components/rbac/mpijob_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: mpijob-editor-role
   labels:
+    rbac.kueue.x-k8s.io/role: "mpijob-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/config/components/rbac/mpijob_viewer_role.yaml
+++ b/config/components/rbac/mpijob_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: mpijob-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "mpijob-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/config/components/rbac/paddlejob_editor_role.yaml
+++ b/config/components/rbac/paddlejob_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: paddlejob-editor-role
   labels:
+    rbac.kueue.x-k8s.io/role: "paddlejob-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/config/components/rbac/paddlejob_viewer_role.yaml
+++ b/config/components/rbac/paddlejob_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: paddlejob-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "paddlejob-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/config/components/rbac/pending_workloads_cq_viewer_role.yaml
+++ b/config/components/rbac/pending_workloads_cq_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: pending-workloads-cq-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "pending-workloads-cq-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"

--- a/config/components/rbac/pending_workloads_lq_viewer_role.yaml
+++ b/config/components/rbac/pending_workloads_lq_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: pending-workloads-lq-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "pending-workloads-lq-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/config/components/rbac/pytorchjob_editor_role.yaml
+++ b/config/components/rbac/pytorchjob_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: pytorchjob-editor-role
   labels:
+    rbac.kueue.x-k8s.io/role: "pytorchjob-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/config/components/rbac/pytorchjob_viewer_role.yaml
+++ b/config/components/rbac/pytorchjob_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: pytorchjob-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "pytorchjob-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/config/components/rbac/raycluster_editor_role.yaml
+++ b/config/components/rbac/raycluster_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: raycluster-editor-role
   labels:
+    rbac.kueue.x-k8s.io/role: "raycluster-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/config/components/rbac/raycluster_viewer_role.yaml
+++ b/config/components/rbac/raycluster_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: raycluster-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "raycluster-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"

--- a/config/components/rbac/rayjob_editor_role.yaml
+++ b/config/components/rbac/rayjob_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: rayjob-editor-role
   labels:
+    rbac.kueue.x-k8s.io/role: "rayjob-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/config/components/rbac/rayjob_viewer_role.yaml
+++ b/config/components/rbac/rayjob_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: rayjob-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "rayjob-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/config/components/rbac/rayservice_editor_role.yaml
+++ b/config/components/rbac/rayservice_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: rayservice-editor-role
   labels:
+    rbac.kueue.x-k8s.io/role: "rayservice-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/config/components/rbac/rayservice_viewer_role.yaml
+++ b/config/components/rbac/rayservice_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: rayservice-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "rayservice-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"

--- a/config/components/rbac/resourceflavor_editor_role.yaml
+++ b/config/components/rbac/resourceflavor_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: resourceflavor-editor-role
   labels:
+    rbac.kueue.x-k8s.io/role: "resourceflavor-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
 - apiGroups:

--- a/config/components/rbac/resourceflavor_viewer_role.yaml
+++ b/config/components/rbac/resourceflavor_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: resourceflavor-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "resourceflavor-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:

--- a/config/components/rbac/sparkapplication_editor_role.yaml
+++ b/config/components/rbac/sparkapplication_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: sparkapplication-editor-role
   labels:
+    rbac.kueue.x-k8s.io/role: "sparkapplication-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/config/components/rbac/sparkapplication_viewer_role.yaml
+++ b/config/components/rbac/sparkapplication_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: sparkapplication-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "sparkapplication-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/config/components/rbac/tfjob_editor_role.yaml
+++ b/config/components/rbac/tfjob_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: tfjob-editor-role
   labels:
+    rbac.kueue.x-k8s.io/role: "tfjob-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/config/components/rbac/tfjob_viewer_role.yaml
+++ b/config/components/rbac/tfjob_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: tfjob-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "tfjob-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/config/components/rbac/topology_editor_role.yaml
+++ b/config/components/rbac/topology_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: topology-editor-role
   labels:
+    rbac.kueue.x-k8s.io/role: "topology-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
 - apiGroups:

--- a/config/components/rbac/topology_viewer_role.yaml
+++ b/config/components/rbac/topology_viewer_role.yaml
@@ -3,6 +3,7 @@ kind: ClusterRole
 metadata:
   name: topology-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "topology-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:

--- a/config/components/rbac/trainjob_editor_role.yaml
+++ b/config/components/rbac/trainjob_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: trainjob-editor-role
   labels:
+    rbac.kueue.x-k8s.io/role: "trainjob-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/config/components/rbac/trainjob_viewer_role.yaml
+++ b/config/components/rbac/trainjob_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: trainjob-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "trainjob-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/config/components/rbac/workload_editor_role.yaml
+++ b/config/components/rbac/workload_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: workload-editor-role
   labels:
+    rbac.kueue.x-k8s.io/role: "workload-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
 - apiGroups:

--- a/config/components/rbac/workload_viewer_role.yaml
+++ b/config/components/rbac/workload_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: workload-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "workload-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/config/components/rbac/xgboostjob_editor_role.yaml
+++ b/config/components/rbac/xgboostjob_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: xgboostjob-editor-role
   labels:
+    rbac.kueue.x-k8s.io/role: "xgboostjob-editor"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/config/components/rbac/xgboostjob_viewer_role.yaml
+++ b/config/components/rbac/xgboostjob_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: xgboostjob-viewer-role
   labels:
+    rbac.kueue.x-k8s.io/role: "xgboostjob-viewer"
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/site/content/en/docs/tasks/manage/rbac.md
+++ b/site/content/en/docs/tasks/manage/rbac.md
@@ -31,6 +31,54 @@ two main personas that we assume will interact with Kueue:
 - `kueue-batch-user-role` includes the permissions to manage [Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/)
   and to view Queues and Workloads.
 
+In addition, Kueue creates a set of per-resource editor and viewer ClusterRoles
+(for example, `kueue-clusterqueue-viewer-role`, `kueue-workload-editor-role`).
+Each of these ClusterRoles is tagged with the `rbac.kueue.x-k8s.io/role` label
+whose value is the short role identifier (e.g. `clusterqueue-viewer`,
+`workload-editor`). You can use this label to discover or select the Kueue
+ClusterRole for a specific resource and access level:
+
+```shell
+# List all editor/viewer ClusterRoles managed by Kueue.
+kubectl get clusterroles -l rbac.kueue.x-k8s.io/role
+
+# Find the viewer ClusterRole for ClusterQueues.
+kubectl get clusterroles -l rbac.kueue.x-k8s.io/role=clusterqueue-viewer
+```
+
+### Building custom roles with ClusterRole aggregation
+
+The `rbac.kueue.x-k8s.io/role` label is intended as a selector for use
+with [Kubernetes ClusterRole aggregation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles).
+By writing an aggregation rule that matches on this label, you can compose
+custom ClusterRoles from any subset of the Kueue editor/viewer roles without
+having to copy or maintain the underlying rules.
+
+For example, the following ClusterRole grants read-only access to queueing
+state across ClusterQueues, LocalQueues, and Workloads:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kueue-queue-readonly
+aggregationRule:
+  clusterRoleSelectors:
+  - matchExpressions:
+    - key: rbac.kueue.x-k8s.io/role
+      operator: In
+      values:
+      - clusterqueue-viewer
+      - localqueue-viewer
+      - workload-viewer
+rules: [] # The control plane fills this in.
+```
+
+You can mix and match values from any of the editor/viewer ClusterRoles
+listed by `kubectl get clusterroles -l rbac.kueue.x-k8s.io/role` to build
+roles tailored to a specific persona (for example, a team lead who can
+edit LocalQueues and Workloads but only view ClusterQueues and Cohorts).
+
 ## Giving permissions to a batch administrator
 
 A batch administrator typically requires the `kueue-batch-admin-role` ClusterRole


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
--> /kind cleanup

#### What this PR does / why we need it:
Adding labels unique to each clusterrole. This allows for custom clusterrole aggregation combinations instead of depending on `rbac.authorization.k8s.io/aggregate-to-view` or `rbac.authorization.k8s.io/aggregate-to-admin`

As an example, I want a clusterrole that is granted view access to all CRDs. But this doesn't make sense to push upstream given security issues viewing cluster level objects. But it makes sense downstream for specific setups using custom clusterrole aggregations. 


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
RBAC: Each per-resource editor and viewer ClusterRoles carries the label `rbac.kueue.x-k8s.io/role=<resource>-<access>` (e.g., `clusterqueue-viewer`).
```
