### PR TITLE
TAS: Stop implicitly assuming ResrouceFlavor:Node = 1:N

### DIFF
--- a/keps/2724-topology-aware-scheduling/kep.yaml
+++ b/keps/2724-topology-aware-scheduling/kep.yaml
@@ -48,6 +48,7 @@ feature-gates:
   - name: TASReplaceNodeOnNodeTaints
   - name: TASMultiLayerTopology
   - name: TASRespectNodeAffinityPreferred
+  - name: TASHandleOverlappingFlavors
 disable-supported: true
 
 # The following PRR answers are required at beta release

--- a/pkg/cache/scheduler/clusterqueue_snapshot.go
+++ b/pkg/cache/scheduler/clusterqueue_snapshot.go
@@ -19,6 +19,7 @@ package scheduler
 import (
 	"iter"
 	"maps"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -198,13 +199,23 @@ func (c *ClusterQueueSnapshot) FindTopologyAssignmentsForWorkload(
 		option(opts)
 	}
 
+	var aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests
+	if features.Enabled(features.TASHandleOverlappingFlavors) {
+		aggregatedDomainUsages = make(map[utiltas.TopologyDomainID]resources.Requests)
+	}
+
 	result := make(TASAssignmentsResult)
-	for tasFlavor, flavorTASRequests := range tasRequestsByFlavor {
+	for _, tasFlavor := range slices.Sorted(maps.Keys(tasRequestsByFlavor)) {
+		flavorTASRequests := tasRequestsByFlavor[tasFlavor]
 		// We assume the `tasFlavor` is already in the snapshot as this was
 		// already checked earlier during flavor assignment, and the set of
 		// flavors is immutable in snapshot.
 		tasFlavorCache := c.TASFlavors[tasFlavor]
-		flvResult := tasFlavorCache.FindTopologyAssignmentsForFlavor(flavorTASRequests, options...)
+		flvOpts := options
+		if features.Enabled(features.TASHandleOverlappingFlavors) && tasFlavorCache.isLowestLevelNode {
+			flvOpts = append(slices.Clone(options), WithAggregatedDomainUsages(aggregatedDomainUsages))
+		}
+		flvResult := tasFlavorCache.FindTopologyAssignmentsForFlavor(flavorTASRequests, flvOpts...)
 		maps.Copy(result, flvResult)
 	}
 	return result

--- a/pkg/cache/scheduler/snapshot.go
+++ b/pkg/cache/scheduler/snapshot.go
@@ -33,8 +33,10 @@ import (
 	"sigs.k8s.io/kueue/pkg/cache/hierarchy"
 	queueafs "sigs.k8s.io/kueue/pkg/cache/queue/afs"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/resources"
 	afs "sigs.k8s.io/kueue/pkg/util/admissionfairsharing"
 	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
@@ -192,8 +194,27 @@ func (c *Cache) Snapshot(ctx context.Context, options ...SnapshotOption) (*Snaps
 	}
 	tasSnapshots := make(map[kueue.ResourceFlavorReference]*TASFlavorSnapshot)
 	if features.Enabled(features.TopologyAwareScheduling) {
-		for flavor, cache := range c.tasCache.Clone() {
-			tasSnapshots[flavor] = cache.snapshot(log, c.tasCache.nodesCache.find(cache.flavor.NodeLabels, cache.topology.Levels))
+		var aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests
+		flvTASCache := c.tasCache.Clone()
+
+		if features.Enabled(features.TASHandleOverlappingFlavors) {
+			aggregatedDomainUsages = make(map[utiltas.TopologyDomainID]resources.Requests)
+			for _, cache := range flvTASCache {
+				c.snapshotTopologyDomainUsages(cache, aggregatedDomainUsages)
+			}
+		}
+		for flavor, cache := range flvTASCache {
+			// Only when this flavor is aggregation targets,
+			// we should propagate aggregated domain usages to snapshot constructions.
+			var aggregatedDomainUsagesForFlavor map[utiltas.TopologyDomainID]resources.Requests
+			if features.Enabled(features.TASHandleOverlappingFlavors) && utiltas.IsLowestLevelHostname(cache.topology.Levels) {
+				aggregatedDomainUsagesForFlavor = aggregatedDomainUsages
+			}
+			tasSnapshots[flavor] = cache.snapshot(
+				log,
+				c.tasCache.nodesCache.find(cache.flavor.NodeLabels, cache.topology.Levels),
+				aggregatedDomainUsagesForFlavor,
+			)
 		}
 	}
 	for _, cq := range cqNames {
@@ -219,6 +240,24 @@ func (c *Cache) Snapshot(ctx context.Context, options ...SnapshotOption) (*Snaps
 	// Shallow copy is enough
 	maps.Copy(snap.ResourceFlavors, c.resourceFlavors)
 	return &snap, nil
+}
+
+func (c *Cache) snapshotTopologyDomainUsages(
+	tasFlvCache *TASFlavorCache, aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests,
+) {
+	tasFlvCache.RLock()
+	defer tasFlvCache.RUnlock()
+
+	if len(tasFlvCache.topology.Levels) == 0 || !utiltas.IsLowestLevelHostname(tasFlvCache.topology.Levels) {
+		return
+	}
+	for domainID, domainUsage := range tasFlvCache.usage {
+		if _, ok := aggregatedDomainUsages[domainID]; ok {
+			aggregatedDomainUsages[domainID].Add(domainUsage)
+		} else {
+			aggregatedDomainUsages[domainID] = domainUsage.Clone()
+		}
+	}
 }
 
 // skipInactiveCQReason reports why the CQ should not be considered for

--- a/pkg/cache/scheduler/snapshot.go
+++ b/pkg/cache/scheduler/snapshot.go
@@ -202,6 +202,7 @@ func (c *Cache) Snapshot(ctx context.Context, options ...SnapshotOption) (*Snaps
 			for _, cache := range flvTASCache {
 				c.snapshotTopologyDomainUsages(cache, aggregatedDomainUsages)
 			}
+			log.V(4).Info("Aggregated TAS usage across flavors")
 		}
 		for flavor, cache := range flvTASCache {
 			// Only when this flavor is aggregation targets,

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -18,6 +18,7 @@ package scheduler
 
 import (
 	"fmt"
+	"maps"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -36,6 +37,7 @@ import (
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 // PodSetTestCase defines a test case for a single podset in the consolidated test.
@@ -382,12 +384,15 @@ func TestFindTopologyAssignments(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		featureGates map[featuregate.Feature]bool
-		nodes        []corev1.Node
-		pods         []corev1.Pod
-		levels       []string
-		nodeLabels   map[string]string
-		podSets      []PodSetTestCase
+		featureGates           map[featuregate.Feature]bool
+		nodes                  []corev1.Node
+		pods                   []corev1.Pod
+		levels                 []string
+		nodeLabels             map[string]string
+		aggregatedDomainUsages map[tas.TopologyDomainID]resources.Requests
+		priorFlavorUsage       []workload.TopologyDomainRequests
+		priorOwnUsage          []workload.TopologyDomainRequests
+		podSets                []PodSetTestCase
 	}{
 		"minimize the number of used racks before optimizing the number of nodes; BestFit": {
 			// Solution by optimizing the number of racks then nodes: [r3]: [x1,x6,x2,x4]
@@ -7119,6 +7124,121 @@ func TestFindTopologyAssignments(t *testing.T) {
 				},
 			},
 		},
+		"sibling-flavor usage on the shared hostname reduces remaining capacity": {
+			levels: []string{tasBlockLabel, corev1.LabelHostname},
+			// Two nodes only, so the discrimination is unambiguous.
+			// The x1's effective capacity is 0, so x2 is the only
+			// candidate that can fit the request.
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("b1-x1").
+					Label(tasBlockLabel, "b1").Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-x2").
+					Label(tasBlockLabel, "b1").Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+			},
+			nodeLabels: map[string]string{},
+			priorFlavorUsage: []workload.TopologyDomainRequests{
+				{
+					Values:            []string{"x1"},
+					SinglePodRequests: resources.Requests{corev1.ResourceCPU: 1000},
+					Count:             1,
+				},
+			},
+			podSets: []PodSetTestCase{
+				{
+					podSetName: "main",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required: new(corev1.LabelHostname),
+					},
+					requests: resources.Requests{corev1.ResourceCPU: 1000},
+					count:    1,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels:  []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{{Count: 1, Values: []string{"x2"}}},
+					},
+				},
+			},
+		},
+		"non-hostname-leaf topology: nil aggregatedDomainUsages preserves per-flavor behavior": {
+			// Topology lowest level is rack (not hostname). In the new model
+			// topologyInformation.Usage is nil for such topologies, so
+			// NewTASFlavorCache gives each flavor a private map. The harness
+			// leaves tc.aggregatedDomainUsages nil. The snapshot() call then takes the
+			// per-flavor branch and iterates c.usage (empty here).
+			levels:     []string{tasBlockLabel, tasRackLabel},
+			nodes:      defaultNodes,
+			nodeLabels: map[string]string{},
+			podSets: []PodSetTestCase{
+				{
+					podSetName: "main",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasRackLabel),
+					},
+					requests: resources.Requests{corev1.ResourceCPU: 1000},
+					count:    1,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels:  []string{tasBlockLabel, tasRackLabel},
+						Domains: []tas.TopologyDomainAssignment{{Count: 1, Values: []string{"b1", "r1"}}},
+					},
+				},
+			},
+		},
+		"non-hostname-leaf topology: prior c.usage must be applied even when aggregatedDomainUsages is non-nil empty": {
+			// Reproduces the integration regression: with TASHandleOverlappingFlavors on,
+			// Cache.Snapshot allocates aggregatedDomainUsages as a non-nil empty map and
+			// snapshotTopologyDomainUsages returns early for non-hostname-leaf flavors,
+			// leaving the map empty. snapshot() must still apply c.usage in this case.
+			//
+			//      b1            b2
+			//     /  \          /  \
+			//   r1    r2      r1    r2
+			//   |     |       |     |
+			//  b1-r1 b1-r2   b2-r1 b2-r2   (each 1 CPU)
+			//
+			// b1/r1 and b1/r2 are fully consumed by prior workloads of this flavor.
+			// A 1-CPU, required-rack request must land on b2.
+			levels: []string{tasBlockLabel, tasRackLabel},
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("b1-r1").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r1").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-r2").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r2").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b2-r1").
+					Label(tasBlockLabel, "b2").Label(tasRackLabel, "r1").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b2-r2").
+					Label(tasBlockLabel, "b2").Label(tasRackLabel, "r2").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+			},
+			nodeLabels: map[string]string{},
+			priorOwnUsage: []workload.TopologyDomainRequests{
+				{Values: []string{"b1", "r1"}, SinglePodRequests: resources.Requests{corev1.ResourceCPU: 1000}, Count: 1},
+				{Values: []string{"b1", "r2"}, SinglePodRequests: resources.Requests{corev1.ResourceCPU: 1000}, Count: 1},
+			},
+			podSets: []PodSetTestCase{
+				{
+					podSetName: "main",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required: new(tasRackLabel),
+					},
+					requests: resources.Requests{corev1.ResourceCPU: 1000},
+					count:    1,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels:  []string{tasBlockLabel, tasRackLabel},
+						Domains: []tas.TopologyDomainAssignment{{Count: 1, Values: []string{"b2", "r1"}}},
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -7153,7 +7273,29 @@ func TestFindTopologyAssignments(t *testing.T) {
 				tasCache.Update(&pod, log)
 			}
 			tasFlavorCache := tasCache.NewTASFlavorCache(topologyInformation, flavorInformation)
-			snapshot := tasFlavorCache.snapshot(log, tasCache.nodesCache.find(tasFlavorCache.flavor.NodeLabels, tasFlavorCache.topology.Levels))
+			if len(tc.priorOwnUsage) > 0 {
+				tasFlavorCache.addUsage("prior-wl", tc.priorOwnUsage)
+			}
+
+			if features.Enabled(features.TASHandleOverlappingFlavors) {
+				tc.aggregatedDomainUsages = aggregatedDomainUsagesForPriorFlavorUsage(
+					topologyInformation,
+					flavorInformation,
+					tc.priorFlavorUsage,
+					&tasCache,
+					tc.aggregatedDomainUsages,
+				)
+			}
+
+			var aggregatedDomainUsage map[tas.TopologyDomainID]resources.Requests
+			if features.Enabled(features.TASHandleOverlappingFlavors) && tas.IsLowestLevelHostname(tasFlavorCache.topology.Levels) {
+				aggregatedDomainUsage = tc.aggregatedDomainUsages
+			}
+			snapshot := tasFlavorCache.snapshot(
+				log,
+				tasCache.nodesCache.find(tasFlavorCache.flavor.NodeLabels, tasFlavorCache.topology.Levels),
+				aggregatedDomainUsage,
+			)
 			flavorTASRequests := make([]TASPodSetRequests, 0, len(tc.podSets))
 			wantResult := make(TASAssignmentsResult)
 			for _, ps := range tc.podSets {
@@ -7213,16 +7355,19 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 	podSetName := kueue.PodSetReference("main")
 
 	cases := map[string]struct {
-		levels          []string
-		nodes           []corev1.Node
-		pods            []corev1.Pod
-		existingTA      *kueue.TopologyAssignment
-		admissionCount  int32
-		unhealthyNode   string
-		topologyRequest *kueue.PodSetTopologyRequest
-		count           int32
-		wantAssignment  *tas.TopologyAssignment
-		wantReason      string
+		featureGates           map[featuregate.Feature]bool
+		levels                 []string
+		nodes                  []corev1.Node
+		pods                   []corev1.Pod
+		existingTA             *kueue.TopologyAssignment
+		admissionCount         int32
+		unhealthyNode          string
+		topologyRequest        *kueue.PodSetTopologyRequest
+		count                  int32
+		aggregatedDomainUsages map[tas.TopologyDomainID]resources.Requests
+		priorFlavorUsage       []workload.TopologyDomainRequests
+		wantAssignment         *tas.TopologyAssignment
+		wantReason             string
 	}{
 		"replace unhealthy node in incomplete rack slice": {
 			//       b1
@@ -7486,10 +7631,67 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 			// Without fix: sliceSize=1, scatters x4(1)+x5(1) → wrongly succeeds.
 			wantReason: `topology "default" doesn't allow to fit any of 1 slice(s). Total nodes: 4; excluded: topologyDomain: 2`,
 		},
+		"sibling-flavor aggregatedDomainUsages on replacement candidate blocks the replacement": {
+			//       b1
+			//   /        \
+			//  r1        r2
+			//  /  \    /    \
+			// x1  x2  x3    x4
+			//          ^(NotReady)
+			//
+			// x4 has 1 CPU allocatable. priorFlavorUsage drives a sibling
+			// TASFlavorCache's addUsage that consumes 1 CPU on x4 through
+			// the real write path. The harness clones the resulting shared
+			// map into tc.aggregatedDomainUsages. x4 is the only candidate in r2 for
+			// replacing x3, and its effective capacity is 0 CPU, so
+			// replacement must fail with the no-capacity reason.
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("b1-r1-x1").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r1").Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-r1-x2").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r1").Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-r2-x3").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r2").Label(corev1.LabelHostname, "x3").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourcePods: resource.MustParse("10")}).
+					NotReady().Obj(),
+				*testingnode.MakeNode("b1-r2-x4").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r2").Label(corev1.LabelHostname, "x4").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+			},
+			existingTA: utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+				Domain(tas.TopologyDomainAssignment{Count: 1, Values: []string{"x1"}}).
+				Domain(tas.TopologyDomainAssignment{Count: 1, Values: []string{"x2"}}).
+				Domain(tas.TopologyDomainAssignment{Count: 1, Values: []string{"x3"}}).
+				Domain(tas.TopologyDomainAssignment{Count: 1, Values: []string{"x4"}}).
+				Obj(),
+			admissionCount: 4,
+			unhealthyNode:  "x3",
+			topologyRequest: &kueue.PodSetTopologyRequest{
+				Required: new(tasBlockLabel),
+				PodsetSliceRequiredTopologyConstraints: []kueue.PodsetSliceRequiredTopologyConstraint{
+					{Topology: tasRackLabel, Size: 2},
+				},
+			},
+			count: 4,
+			priorFlavorUsage: []workload.TopologyDomainRequests{
+				{
+					Values:            []string{"x4"},
+					SinglePodRequests: resources.Requests{corev1.ResourceCPU: 1000},
+					Count:             1,
+				},
+			},
+			wantReason: `topology "default" doesn't allow to fit any of 1 pod(s). Total nodes: 3; excluded: resource "cpu": 1, topologyDomain: 2`,
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.TASMultiLayerTopology, true)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, log := utiltesting.ContextWithLog(t)
 
 			wl := utiltestingapi.MakeWorkload("test-wl", "test-ns").
@@ -7535,12 +7737,31 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 			if tcLevels == nil {
 				tcLevels = defaultLevels
 			}
-			tasFlavorCache := tasCache.NewTASFlavorCache(
-				topologyInformation{Levels: tcLevels},
-				flavorInformation{TopologyName: "default"},
-			)
 
-			snapshot := tasFlavorCache.snapshot(log, tasCache.nodesCache.find(tasFlavorCache.flavor.NodeLabels, tasFlavorCache.topology.Levels))
+			topologyInfo := topologyInformation{Levels: tcLevels}
+			flvInfo := flavorInformation{TopologyName: "default"}
+
+			tasFlavorCache := tasCache.NewTASFlavorCache(topologyInfo, flvInfo)
+
+			if features.Enabled(features.TASHandleOverlappingFlavors) {
+				tc.aggregatedDomainUsages = aggregatedDomainUsagesForPriorFlavorUsage(
+					topologyInfo,
+					flvInfo,
+					tc.priorFlavorUsage,
+					&tasCache,
+					tc.aggregatedDomainUsages,
+				)
+			}
+
+			var aggregatedDomainUsages map[tas.TopologyDomainID]resources.Requests
+			if features.Enabled(features.TASHandleOverlappingFlavors) && tas.IsLowestLevelHostname(tasFlavorCache.topology.Levels) {
+				aggregatedDomainUsages = tc.aggregatedDomainUsages
+			}
+			snapshot := tasFlavorCache.snapshot(
+				log,
+				tasCache.nodesCache.find(tasFlavorCache.flavor.NodeLabels, tasFlavorCache.topology.Levels),
+				aggregatedDomainUsages,
+			)
 			result := snapshot.FindTopologyAssignmentsForFlavor(flavorTASRequests, WithWorkload(wl))
 
 			psResult, ok := result[podSetName]
@@ -7561,4 +7782,28 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TODO: Once we commonize "TestFindTopologyAssignments" and "TestFindTopologyAssignmentsMultiLayerReplacement" into one,
+// we should remove this helper function.
+func aggregatedDomainUsagesForPriorFlavorUsage(
+	topologyInfo topologyInformation,
+	flvInfo flavorInformation,
+	priorFlavorUsage []workload.TopologyDomainRequests,
+	cache *tasCache,
+	initialAggregatedDomainUsages map[tas.TopologyDomainID]resources.Requests,
+) map[tas.TopologyDomainID]resources.Requests {
+	siblingCache := cache.NewTASFlavorCache(topologyInfo, flvInfo)
+	if len(priorFlavorUsage) > 0 {
+		siblingCache.addUsage("prior-wl", priorFlavorUsage)
+	}
+
+	aggregatedDomainUsages := maps.Clone(initialAggregatedDomainUsages)
+	if aggregatedDomainUsages == nil {
+		aggregatedDomainUsages = make(map[tas.TopologyDomainID]resources.Requests, len(siblingCache.usage))
+	}
+	for domainID, usage := range siblingCache.usage {
+		aggregatedDomainUsages[domainID] = usage.Clone()
+	}
+	return aggregatedDomainUsages
 }

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -115,18 +116,34 @@ func (c *TASFlavorCache) TopologyLevels() []string {
 	return c.topology.Levels
 }
 
-func (c *TASFlavorCache) snapshot(log logr.Logger, nodes []*nodeInfo) *TASFlavorSnapshot {
+func (c *TASFlavorCache) snapshot(
+	log logr.Logger, nodes []*nodeInfo, aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests,
+) *TASFlavorSnapshot {
 	c.RLock()
 	defer c.RUnlock()
-	log.V(3).Info("Constructing TAS snapshot", "nodeLabels", c.flavor.NodeLabels,
-		"levels", c.topology.Levels, "nodeCount", len(nodes))
+
+	infoKV := []any{
+		"nodeLabels", c.flavor.NodeLabels,
+		"levels", c.topology.Levels,
+		"nodeCount", len(nodes),
+	}
+	if features.Enabled(features.TASHandleOverlappingFlavors) {
+		infoKV = append(infoKV, "crossFlavorAggregation", aggregatedDomainUsages != nil)
+	}
+	log.V(3).Info("Constructing TAS snapshot", infoKV...)
+
 	snapshot := newTASFlavorSnapshot(log, c.flavor.TopologyName, c.topology.Levels, c.flavor.Tolerations)
 	nodeToDomain := make(map[string]utiltas.TopologyDomainID)
 	for _, node := range nodes {
 		nodeToDomain[node.Name] = snapshot.addNode(node)
 	}
 	snapshot.initialize()
-	for domainID, usage := range c.usage {
+
+	tasDomainUsages := c.usage
+	if features.Enabled(features.TASHandleOverlappingFlavors) && aggregatedDomainUsages != nil {
+		tasDomainUsages = aggregatedDomainUsages
+	}
+	for domainID, usage := range tasDomainUsages {
 		snapshot.addTASUsage(domainID, usage)
 	}
 	for nodeName, usage := range c.nonTasUsageCache.usagePerNode() {

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -419,8 +419,9 @@ func (s *TASFlavorSnapshot) Fits(flavorUsage workload.TASFlavorUsage) bool {
 }
 
 type findTopologyAssignmentsOption struct {
-	simulateEmpty bool
-	workload      *kueue.Workload
+	simulateEmpty          bool
+	workload               *kueue.Workload
+	aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests
 }
 
 // ExclusionStats tracks why nodes were excluded during TAS scheduling.
@@ -519,6 +520,15 @@ func WithWorkload(wl *kueue.Workload) FindTopologyAssignmentsOption {
 	}
 }
 
+// WithAggregatedDomainUsages supplies a cross-flavor assumedUsage so that
+// per-PodSet TAS placements within a single workload account for reservations
+// already made in sibling flavors sharing the same Topology (hostname leaf).
+func WithAggregatedDomainUsages(m map[utiltas.TopologyDomainID]resources.Requests) FindTopologyAssignmentsOption {
+	return func(o *findTopologyAssignmentsOption) {
+		o.aggregatedDomainUsages = m
+	}
+}
+
 // FindTopologyAssignmentsForFlavor returns TAS assignment, if possible, for all
 // the TAS requests in the flavor handled by the snapshot.
 func (s *TASFlavorSnapshot) FindTopologyAssignmentsForFlavor(flavorTASRequests FlavorTASRequests, options ...FindTopologyAssignmentsOption) TASAssignmentsResult {
@@ -529,6 +539,9 @@ func (s *TASFlavorSnapshot) FindTopologyAssignmentsForFlavor(flavorTASRequests F
 
 	result := make(map[kueue.PodSetReference]tasPodSetAssignmentResult)
 	assumedUsage := make(map[utiltas.TopologyDomainID]resources.Requests)
+	if features.Enabled(features.TASHandleOverlappingFlavors) && opts.aggregatedDomainUsages != nil {
+		assumedUsage = opts.aggregatedDomainUsages
+	}
 
 	groupedTASRequests := make(map[string]FlavorTASRequests)
 	groupsOrder := make([]string, 0)

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -561,6 +561,10 @@ func LoadAndValidateFeatureGates(featureGateCLI string, featureGateMap map[strin
 	if !features.Enabled(features.TopologyAwareScheduling) && enabledProfilesCount > 0 {
 		allErrs = append(allErrs, field.Invalid(featureGatesPath, enabledProfilesCount, "cannot use a TAS profile with TAS disabled"))
 	}
+	if !features.Enabled(features.TopologyAwareScheduling) && features.Enabled(features.TASHandleOverlappingFlavors) {
+		allErrs = append(allErrs, field.Invalid(featureGatesPath, features.TASHandleOverlappingFlavors,
+			fmt.Sprintf("%s requires %s to be enabled", features.TASHandleOverlappingFlavors, features.TopologyAwareScheduling)))
+	}
 
 	if features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
 		if !features.Enabled(features.ElasticJobsViaWorkloadSlices) {

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1131,8 +1131,9 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 		},
 		"cannot set TAS profile with TAS disabled": {
 			featureGateMap: map[string]bool{
-				string(features.TASProfileMixed):         true,
-				string(features.TopologyAwareScheduling): false,
+				string(features.TASProfileMixed):             true,
+				string(features.TopologyAwareScheduling):     false,
+				string(features.TASHandleOverlappingFlavors): false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TASProfileMixed:         false,
@@ -1172,6 +1173,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.ElasticJobsViaWorkloadSlicesWithTAS): true,
 				string(features.ElasticJobsViaWorkloadSlices):        true,
 				string(features.TopologyAwareScheduling):             false,
+				string(features.TASHandleOverlappingFlavors):         false,
 				string(features.TASProfileMixed):                     false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
@@ -1206,12 +1208,14 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 			featureGateMap: map[string]bool{
 				string(features.TASProfileMixed):                     true,
 				string(features.TopologyAwareScheduling):             false,
+				string(features.TASHandleOverlappingFlavors):         true,
 				string(features.ElasticJobsViaWorkloadSlicesWithTAS): true,
 				string(features.ElasticJobsViaWorkloadSlices):        false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TASProfileMixed:                     false,
 				features.TopologyAwareScheduling:             true,
+				features.TASHandleOverlappingFlavors:         true,
 				features.ElasticJobsViaWorkloadSlicesWithTAS: false,
 				features.ElasticJobsViaWorkloadSlices:        true,
 			},
@@ -1220,6 +1224,11 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 					Type:   field.ErrorTypeInvalid,
 					Field:  "featureGates",
 					Detail: "cannot use a TAS profile with TAS disabled",
+				},
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "featureGates",
+					Detail: "TASHandleOverlappingFlavors requires TopologyAwareScheduling to be enabled",
 				},
 				&field.Error{
 					Type:   field.ErrorTypeInvalid,
@@ -1248,6 +1257,36 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 					Field:  "featureGates",
 					Detail: "KueueDRAIntegrationExtendedResource requires KueueDRAIntegration to be enabled",
 				},
+			},
+		},
+		"TASHandleOverlappingFlavors requires TopologyAwareScheduling": {
+			featureGateMap: map[string]bool{
+				string(features.TopologyAwareScheduling):     false,
+				string(features.TASProfileMixed):             false,
+				string(features.TASHandleOverlappingFlavors): true,
+			},
+			gatesToRestore: map[featuregate.Feature]bool{
+				features.TASHandleOverlappingFlavors: true,
+				features.TopologyAwareScheduling:     true,
+				features.TASProfileMixed:             true,
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "featureGates",
+					Detail: "TASHandleOverlappingFlavors requires TopologyAwareScheduling to be enabled",
+				},
+			},
+		},
+		"TASHandleOverlappingFlavors valid when all dependencies enabled": {
+			featureGateMap: map[string]bool{
+				string(features.TopologyAwareScheduling):     true,
+				string(features.TASHandleOverlappingFlavors): true,
+			},
+			gatesToRestore: map[featuregate.Feature]bool{
+				features.TASHandleOverlappingFlavors: true,
+				features.TopologyAwareScheduling:     true,
+				features.TASProfileMixed:             true,
 			},
 		},
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -428,6 +428,11 @@ const (
 	// issue: https://github.com/kubernetes-sigs/kueue/issues/7539
 	// Enable reporting of Cohort related metrics (also including ClusterQueueInfo metric).
 	MetricsForCohorts featuregate.Feature = "MetricsForCohorts"
+	// owner: @tenzen-y
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-scheduling
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/10659
+	// Enable accurately topology aware scheduling when multiple flavors cover the same Node.
+	TASHandleOverlappingFlavors featuregate.Feature = "TASHandleOverlappingFlavors"
 )
 
 func init() {
@@ -664,8 +669,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	WorkloadPriorityClassDefaulting: {
 		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},
 	},
-
 	MetricsForCohorts: {
+		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
+	},
+	TASHandleOverlappingFlavors: {
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
 	},
 }

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -2448,6 +2448,243 @@ func TestScheduleForTAS(t *testing.T) {
 				utiltesting.MakeEventRecord("default", "foo", "Admitted", corev1.EventTypeNormal).Obj(),
 			},
 		},
+		// Two TAS ResourceFlavors share the same physical nodes (same NodeLabel and
+		// Topology). tas-flavor-b has an extra NodeTaint that only the pending
+		// workload tolerates. Two already-admitted primary workloads have filled
+		// x1 (and tas-flavor-a's quota); the pending workload must land on
+		// tas-flavor-b on the free node x2.
+		"two ResourceFlavors share nodes: pending workload lands on the fallback flavor when the primary flavor is full": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label("tas-node", "true").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("400m"),
+						corev1.ResourceMemory: resource.MustParse("400Mi"),
+						corev1.ResourcePods:   resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x2").
+					Label("tas-node", "true").
+					Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("400m"),
+						corev1.ResourceMemory: resource.MustParse("400Mi"),
+						corev1.ResourcePods:   resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			topologies: []kueue.Topology{defaultSingleLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("tas-flavor-a").
+					NodeLabel("tas-node", "true").
+					TopologyName("tas-single-level").
+					Obj(),
+				*utiltestingapi.MakeResourceFlavor("tas-flavor-b").
+					NodeLabel("tas-node", "true").
+					Taint(corev1.Taint{
+						Key:    "tas-class",
+						Value:  "b",
+						Effect: corev1.TaintEffectNoSchedule,
+					}).
+					TopologyName("tas-single-level").
+					Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("tas-main").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("tas-flavor-a").
+							Resource(corev1.ResourceCPU, "400m").
+							Resource(corev1.ResourceMemory, "400Mi").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("tas-flavor-b").
+							Resource(corev1.ResourceCPU, "100m").
+							Resource(corev1.ResourceMemory, "100Mi").Obj(),
+					).
+					Preemption(kueue.ClusterQueuePreemption{
+						ReclaimWithinCohort: kueue.PreemptionPolicyNever,
+					}).
+					Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("primary-admitted-1", "default").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						PreferredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "200m").
+						Request(corev1.ResourceMemory, "200Mi").
+						Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "tas-flavor-a", "200m").
+								Assignment(corev1.ResourceMemory, "tas-flavor-a", "200Mi").
+								Count(1).
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(
+									[]string{corev1.LabelHostname}).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("primary-admitted-2", "default").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						PreferredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "200m").
+						Request(corev1.ResourceMemory, "200Mi").
+						Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "tas-flavor-a", "200m").
+								Assignment(corev1.ResourceMemory, "tas-flavor-a", "200Mi").
+								Count(1).
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(
+									[]string{corev1.LabelHostname}).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("pending-wl", "default").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						PreferredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "100m").
+						Request(corev1.ResourceMemory, "100Mi").
+						Toleration(corev1.Toleration{
+							Key:      "tas-class",
+							Operator: corev1.TolerationOpEqual,
+							Value:    "b",
+							Effect:   corev1.TaintEffectNoSchedule,
+						}).
+						Obj()).
+					Obj(),
+			},
+			wantNewAssignments: map[workload.Reference]kueue.Admission{
+				"default/pending-wl": *utiltestingapi.MakeAdmission("tas-main").
+					PodSets(utiltestingapi.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "tas-flavor-b", "100m").
+						Assignment(corev1.ResourceMemory, "tas-flavor-b", "100Mi").
+						Count(1).
+						TopologyAssignment(utiltestingapi.MakeTopologyAssignment(
+							[]string{corev1.LabelHostname}).
+							Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
+							Obj()).
+						Obj()).
+					Obj(),
+			},
+			eventCmpOpts: cmp.Options{eventIgnoreMessage},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "pending-wl", "QuotaReserved", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "pending-wl", "Admitted", corev1.EventTypeNormal).Obj(),
+			},
+		},
+		// Multi-PodSet workload across sibling flavors sharing the same nodes: ps-a is pinned
+		// to flavor-a (via a flavor-specific taint/toleration pair), ps-b to flavor-b. Each
+		// PodSet requests 300m CPU; combined 300+300m > 400m per node, so the two PodSets
+		// must land on distinct nodes.
+		"multi-PodSet workload across sibling flavors must not self-overlap on shared node": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label("tas-node", "true").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("400m"),
+						corev1.ResourceMemory: resource.MustParse("400Mi"),
+						corev1.ResourcePods:   resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x2").
+					Label("tas-node", "true").
+					Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("400m"),
+						corev1.ResourceMemory: resource.MustParse("400Mi"),
+						corev1.ResourcePods:   resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			topologies: []kueue.Topology{defaultSingleLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("flavor-a").
+					NodeLabel("tas-node", "true").
+					Taint(corev1.Taint{Key: "example.com/flavor", Value: "a", Effect: corev1.TaintEffectNoSchedule}).
+					TopologyName("tas-single-level").
+					Obj(),
+				*utiltestingapi.MakeResourceFlavor("flavor-b").
+					NodeLabel("tas-node", "true").
+					Taint(corev1.Taint{Key: "example.com/flavor", Value: "b", Effect: corev1.TaintEffectNoSchedule}).
+					TopologyName("tas-single-level").
+					Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("tas-main").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("flavor-a").
+							Resource(corev1.ResourceCPU, "400m").
+							Resource(corev1.ResourceMemory, "400Mi").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("flavor-b").
+							Resource(corev1.ResourceCPU, "400m").
+							Resource(corev1.ResourceMemory, "400Mi").Obj(),
+					).
+					Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("multi-podset-wl", "default").
+					Queue("tas-main").
+					PodSets(
+						*utiltestingapi.MakePodSet("ps-a", 1).
+							PreferredTopologyRequest(corev1.LabelHostname).
+							Request(corev1.ResourceCPU, "300m").
+							Request(corev1.ResourceMemory, "300Mi").
+							Toleration(corev1.Toleration{Key: "example.com/flavor", Operator: corev1.TolerationOpEqual, Value: "a", Effect: corev1.TaintEffectNoSchedule}).
+							Obj(),
+						*utiltestingapi.MakePodSet("ps-b", 1).
+							PreferredTopologyRequest(corev1.LabelHostname).
+							Request(corev1.ResourceCPU, "300m").
+							Request(corev1.ResourceMemory, "300Mi").
+							Toleration(corev1.Toleration{Key: "example.com/flavor", Operator: corev1.TolerationOpEqual, Value: "b", Effect: corev1.TaintEffectNoSchedule}).
+							Obj(),
+					).
+					Obj(),
+			},
+			wantNewAssignments: map[workload.Reference]kueue.Admission{
+				"default/multi-podset-wl": *utiltestingapi.MakeAdmission("tas-main").
+					PodSets(
+						utiltestingapi.MakePodSetAssignment("ps-a").
+							Assignment(corev1.ResourceCPU, "flavor-a", "300m").
+							Assignment(corev1.ResourceMemory, "flavor-a", "300Mi").
+							Count(1).
+							TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+								Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
+						utiltestingapi.MakePodSetAssignment("ps-b").
+							Assignment(corev1.ResourceCPU, "flavor-b", "300m").
+							Assignment(corev1.ResourceMemory, "flavor-b", "300Mi").
+							Count(1).
+							TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+								Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
+								Obj()).
+							Obj(),
+					).
+					Obj(),
+			},
+			eventCmpOpts: cmp.Options{eventIgnoreMessage},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "multi-podset-wl", "QuotaReserved", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "multi-podset-wl", "Admitted", corev1.EventTypeNormal).Obj(),
+			},
+		},
 		"TAS workload gets scheduled as trimmed by partial admission": {
 			nodes:           defaultSingleNode,
 			topologies:      []kueue.Topology{defaultSingleLevelTopology},
@@ -4533,6 +4770,212 @@ func TestScheduleForTASPreemption(t *testing.T) {
 			eventCmpOpts: cmp.Options{
 				eventIgnoreMessage,
 				cmpopts.SortSlices(utiltesting.SortEvents),
+			},
+		},
+		// Same-flavor preemption correctly accounts for sibling-flavor usage on the
+		// shared node. x1 has 5 CPU, admitted W1 in flavor-a (1 CPU) plus W2 in
+		// flavor-b (3 CPU) share x1 via the same hostname-leaf topology. Pending
+		// W3 in flavor-a wants 2 CPU. With the shared-usage aliasing, the
+		// preemptor's view of x1 correctly shows 4 CPU used so the admission path
+		// selects Preempt mode; classical preemption picks W1 as the same-flavor
+		// lower-priority candidate, simulated removal drops tasUsage by 1 CPU
+		// (W3 now fits), and W1 is preempted. Without the aliasing, flavor-a's
+		// local leaf would only show 1 CPU used, W3 would look immediately
+		// admissible, no preemption would fire, and the physical node would be
+		// oversubscribed (1 + 3 + 2 = 6 > 5).
+		"sibling-flavor usage on the shared node forces same-flavor preemption": {
+			nodes:      defaultSingleNode,
+			topologies: []kueue.Topology{defaultSingleLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("flavor-a").
+					NodeLabel("tas-node", "true").
+					Taint(corev1.Taint{Key: "example.com/flavor", Value: "a", Effect: corev1.TaintEffectNoSchedule}).
+					TopologyName("tas-single-level").
+					Obj(),
+				*utiltestingapi.MakeResourceFlavor("flavor-b").
+					NodeLabel("tas-node", "true").
+					Taint(corev1.Taint{Key: "example.com/flavor", Value: "b", Effect: corev1.TaintEffectNoSchedule}).
+					TopologyName("tas-single-level").
+					Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("tas-main").
+					Preemption(kueue.ClusterQueuePreemption{WithinClusterQueue: kueue.PreemptionPolicyLowerPriority}).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("flavor-a").
+							Resource(corev1.ResourceCPU, "5").
+							Resource(corev1.ResourceMemory, "5Gi").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("flavor-b").
+							Resource(corev1.ResourceCPU, "5").
+							Resource(corev1.ResourceMemory, "5Gi").Obj(),
+					).
+					Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("w3-pending", "default").
+					UID("wl-w3").
+					JobUID("job-w3").
+					Queue("tas-main").
+					Priority(5).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						PreferredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "2").
+						Request(corev1.ResourceMemory, "2Gi").
+						Toleration(corev1.Toleration{Key: "example.com/flavor", Operator: corev1.TolerationOpEqual, Value: "a", Effect: corev1.TaintEffectNoSchedule}).
+						Obj()).
+					Obj(),
+				*utiltestingapi.MakeWorkload("w1-low-prio-a", "default").
+					UID("wl-w1").
+					Queue("tas-main").
+					Priority(1).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "flavor-a", "1").
+								Assignment(corev1.ResourceMemory, "flavor-a", "1Gi").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						PreferredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "1").
+						Request(corev1.ResourceMemory, "1Gi").
+						Toleration(corev1.Toleration{Key: "example.com/flavor", Operator: corev1.TolerationOpEqual, Value: "a", Effect: corev1.TaintEffectNoSchedule}).
+						Obj()).
+					Obj(),
+				*utiltestingapi.MakeWorkload("w2-sibling-b", "default").
+					UID("wl-w2").
+					Queue("tas-main").
+					Priority(1).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "flavor-b", "3").
+								Assignment(corev1.ResourceMemory, "flavor-b", "3Gi").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						PreferredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "3").
+						Request(corev1.ResourceMemory, "3Gi").
+						Toleration(corev1.Toleration{Key: "example.com/flavor", Operator: corev1.TolerationOpEqual, Value: "b", Effect: corev1.TaintEffectNoSchedule}).
+						Obj()).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("w1-low-prio-a", "default").
+					UID("wl-w1").
+					Queue("tas-main").
+					Priority(1).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "flavor-a", "1").
+								Assignment(corev1.ResourceMemory, "flavor-a", "1Gi").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						PreferredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "1").
+						Request(corev1.ResourceMemory, "1Gi").
+						Toleration(corev1.Toleration{Key: "example.com/flavor", Operator: corev1.TolerationOpEqual, Value: "a", Effect: corev1.TaintEffectNoSchedule}).
+						Obj()).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-w3, JobUID: job-w3) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InClusterQueue",
+						Message:            "Preempted to accommodate a workload (UID: wl-w3, JobUID: job-w3) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("w2-sibling-b", "default").
+					UID("wl-w2").
+					Queue("tas-main").
+					Priority(1).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "flavor-b", "3").
+								Assignment(corev1.ResourceMemory, "flavor-b", "3Gi").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						PreferredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "3").
+						Request(corev1.ResourceMemory, "3Gi").
+						Toleration(corev1.Toleration{Key: "example.com/flavor", Operator: corev1.TolerationOpEqual, Value: "b", Effect: corev1.TaintEffectNoSchedule}).
+						Obj()).
+					Obj(),
+				*utiltestingapi.MakeWorkload("w3-pending", "default").
+					UID("wl-w3").
+					JobUID("job-w3").
+					Queue("tas-main").
+					Priority(5).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						PreferredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "2").
+						Request(corev1.ResourceMemory, "2Gi").
+						Toleration(corev1.Toleration{Key: "example.com/flavor", Operator: corev1.TolerationOpEqual, Value: "a", Effect: corev1.TaintEffectNoSchedule}).
+						Obj()).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             "Pending",
+						Message:            `couldn't assign flavors to pod set one: topology "tas-single-level" doesn't allow to fit any of 1 pod(s). Total nodes: 1; excluded: resource "cpu": 1. Pending the preemption of 1 workload(s)`,
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "one",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("2"),
+							corev1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+					}).
+					Obj(),
+			},
+			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"tas-main": {"default/w3-pending"},
+			},
+			eventCmpOpts: cmp.Options{
+				eventIgnoreMessage,
+				cmpopts.SortSlices(utiltesting.SortEvents),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "w1-low-prio-a", "EvictedDueToPreempted", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "w1-low-prio-a", "Preempted", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "w3-pending", "PreemptedWorkload", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "w3-pending", "Pending", corev1.EventTypeWarning).Obj(),
 			},
 		},
 	}

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -427,6 +427,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.14"
+- name: TASHandleOverlappingFlavors
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.18"
 - name: TASMultiLayerTopology
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -427,6 +427,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.14"
+- name: TASHandleOverlappingFlavors
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.18"
 - name: TASMultiLayerTopology
   versionedSpecs:
   - default: false

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -5186,6 +5186,334 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				})
 			})
 		})
+
+		// Two TAS ResourceFlavors share the same physical nodes (same NodeLabel)
+		// but are made mutually exclusive via flavor-only NodeTaints
+		// (tas-class=a on flavor-a, tas-class=b on flavor-b) so each workload
+		// targets exactly one flavor. It also blocks exercise the
+		// cross-flavor TAS usage aggregation on shared nodes in the following:
+		//   1. It verifies the add side (sibling-flavor placement skips a node already
+		//   occupied by the primary flavor)
+		//   2. the second It verifies the subtract side (the freed node becomes reusable
+		//   by the sibling flavor once the primary workload finishes).
+		ginkgo.When("Two TAS ResourceFlavors share nodes", func() {
+			var (
+				tasFlavorA   *kueue.ResourceFlavor
+				tasFlavorB   *kueue.ResourceFlavor
+				topology     *kueue.Topology
+				localQueue   *kueue.LocalQueue
+				clusterQueue *kueue.ClusterQueue
+				nodes        []corev1.Node
+			)
+
+			ginkgo.BeforeEach(func() {
+				nodes = []corev1.Node{
+					*testingnode.MakeNode("x1").
+						Label("node-group", "tas").
+						Label(corev1.LabelHostname, "x1").
+						StatusAllocatable(corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("400m"),
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
+							corev1.ResourcePods:   resource.MustParse("10"),
+						}).
+						Taints(corev1.Taint{
+							Key:    "node-group",
+							Value:  "tas",
+							Effect: corev1.TaintEffectNoSchedule,
+						}).
+						Ready().
+						Obj(),
+					*testingnode.MakeNode("x2").
+						Label("node-group", "tas").
+						Label(corev1.LabelHostname, "x2").
+						StatusAllocatable(corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("400m"),
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
+							corev1.ResourcePods:   resource.MustParse("10"),
+						}).
+						Taints(corev1.Taint{
+							Key:    "node-group",
+							Value:  "tas",
+							Effect: corev1.TaintEffectNoSchedule,
+						}).
+						Ready().
+						Obj(),
+				}
+				util.CreateNodesWithStatus(ctx, k8sClient, nodes)
+
+				topology = utiltestingapi.MakeDefaultOneLevelTopology("default")
+				util.MustCreate(ctx, k8sClient, topology)
+
+				tasFlavorA = utiltestingapi.MakeResourceFlavor("tas-flavor-a").
+					NodeLabel("node-group", "tas").
+					Taint(corev1.Taint{
+						Key:    "node-group",
+						Value:  "tas",
+						Effect: corev1.TaintEffectNoSchedule,
+					}).
+					Taint(corev1.Taint{
+						Key:    "tas-class",
+						Value:  "a",
+						Effect: corev1.TaintEffectNoSchedule,
+					}).
+					TopologyName("default").
+					Obj()
+				util.MustCreate(ctx, k8sClient, tasFlavorA)
+
+				tasFlavorB = utiltestingapi.MakeResourceFlavor("tas-flavor-b").
+					NodeLabel("node-group", "tas").
+					Taint(corev1.Taint{
+						Key:    "node-group",
+						Value:  "tas",
+						Effect: corev1.TaintEffectNoSchedule,
+					}).
+					Taint(corev1.Taint{
+						Key:    "tas-class",
+						Value:  "b",
+						Effect: corev1.TaintEffectNoSchedule,
+					}).
+					TopologyName("default").
+					Obj()
+				util.MustCreate(ctx, k8sClient, tasFlavorB)
+
+				clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(tasFlavorA.Name).
+							Resource(corev1.ResourceCPU, "400m").
+							Resource(corev1.ResourceMemory, "400Mi").Obj(),
+						*utiltestingapi.MakeFlavorQuotas(tasFlavorB.Name).
+							Resource(corev1.ResourceCPU, "100m").
+							Resource(corev1.ResourceMemory, "100Mi").Obj(),
+					).
+					Preemption(kueue.ClusterQueuePreemption{
+						ReclaimWithinCohort: kueue.PreemptionPolicyNever,
+					}).
+					Obj()
+				util.MustCreate(ctx, k8sClient, clusterQueue)
+
+				localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+				util.MustCreate(ctx, k8sClient, localQueue)
+			})
+
+			ginkgo.AfterEach(func() {
+				gomega.Expect(util.DeleteAllPodsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+				gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+				gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavorA, true)
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavorB, true)
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+				for _, node := range nodes {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, &node, true)
+				}
+			})
+
+			ginkgo.It("should admit the pending workload to tas-flavor-b on the free node when tas-flavor-a is full", func() {
+				var (
+					primaryWl1 *kueue.Workload
+					primaryWl2 *kueue.Workload
+					pendingWl  *kueue.Workload
+				)
+
+				ginkgo.By("creating the first tas-flavor-a workload pinned to x1", func() {
+					primaryWl1 = utiltestingapi.MakeWorkload("primary-wl1", ns.Name).
+						Queue(kueue.LocalQueueName(localQueue.Name)).
+						PodSets(*utiltestingapi.MakePodSet("one", 1).
+							NodeSelector(map[string]string{corev1.LabelHostname: "x1"}).
+							PreferredTopologyRequest(corev1.LabelHostname).
+							Request(corev1.ResourceCPU, "200m").
+							Request(corev1.ResourceMemory, "200Mi").
+							Toleration(corev1.Toleration{
+								Key:      "node-group",
+								Operator: corev1.TolerationOpEqual,
+								Value:    "tas",
+								Effect:   corev1.TaintEffectNoSchedule,
+							}).
+							Toleration(corev1.Toleration{
+								Key:      "tas-class",
+								Operator: corev1.TolerationOpEqual,
+								Value:    "a",
+								Effect:   corev1.TaintEffectNoSchedule,
+							}).
+							Obj()).Obj()
+					util.MustCreate(ctx, k8sClient, primaryWl1)
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, primaryWl1)
+					createPodsForWorkload(primaryWl1, ns.Name, false, true)
+				})
+
+				ginkgo.By("creating the second tas-flavor-a workload pinned to x1", func() {
+					primaryWl2 = utiltestingapi.MakeWorkload("primary-wl2", ns.Name).
+						Queue(kueue.LocalQueueName(localQueue.Name)).
+						PodSets(*utiltestingapi.MakePodSet("one", 1).
+							NodeSelector(map[string]string{corev1.LabelHostname: "x1"}).
+							PreferredTopologyRequest(corev1.LabelHostname).
+							Request(corev1.ResourceCPU, "200m").
+							Request(corev1.ResourceMemory, "200Mi").
+							Toleration(corev1.Toleration{
+								Key:      "node-group",
+								Operator: corev1.TolerationOpEqual,
+								Value:    "tas",
+								Effect:   corev1.TaintEffectNoSchedule,
+							}).
+							Toleration(corev1.Toleration{
+								Key:      "tas-class",
+								Operator: corev1.TolerationOpEqual,
+								Value:    "a",
+								Effect:   corev1.TaintEffectNoSchedule,
+							}).
+							Obj()).Obj()
+					util.MustCreate(ctx, k8sClient, primaryWl2)
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, primaryWl2)
+					createPodsForWorkload(primaryWl2, ns.Name, false, true)
+				})
+
+				ginkgo.By("verifying both primary workloads consumed tas-flavor-a and share node x1", func() {
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(primaryWl1), primaryWl1)).To(gomega.Succeed())
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(primaryWl2), primaryWl2)).To(gomega.Succeed())
+					for _, wl := range []*kueue.Workload{primaryWl1, primaryWl2} {
+						gomega.Expect(wl.Status.Admission.PodSetAssignments[0].Flavors[corev1.ResourceCPU]).To(
+							gomega.Equal(kueue.ResourceFlavorReference(tasFlavorA.Name)))
+						gomega.Expect(wl.Status.Admission.PodSetAssignments[0].Flavors[corev1.ResourceMemory]).To(
+							gomega.Equal(kueue.ResourceFlavorReference(tasFlavorA.Name)))
+						ta := utiltas.InternalFrom(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment)
+						gomega.Expect(ta.Domains).To(gomega.HaveLen(1))
+						gomega.Expect(ta.Domains[0].Values).To(gomega.Equal([]string{"x1"}))
+					}
+				})
+
+				ginkgo.By("creating the pending workload that tolerates both taints", func() {
+					pendingWl = utiltestingapi.MakeWorkload("pending-wl", ns.Name).
+						Queue(kueue.LocalQueueName(localQueue.Name)).
+						PodSets(*utiltestingapi.MakePodSet("one", 1).
+							PreferredTopologyRequest(corev1.LabelHostname).
+							Request(corev1.ResourceCPU, "100m").
+							Request(corev1.ResourceMemory, "100Mi").
+							Toleration(corev1.Toleration{
+								Key:      "node-group",
+								Operator: corev1.TolerationOpEqual,
+								Value:    "tas",
+								Effect:   corev1.TaintEffectNoSchedule,
+							}).
+							Toleration(corev1.Toleration{
+								Key:      "tas-class",
+								Operator: corev1.TolerationOpEqual,
+								Value:    "b",
+								Effect:   corev1.TaintEffectNoSchedule,
+							}).
+							Obj()).Obj()
+					util.MustCreate(ctx, k8sClient, pendingWl)
+				})
+
+				ginkgo.By("verifying the pending workload is admitted to tas-flavor-b on the free node x2", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, pendingWl)
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pendingWl), pendingWl)).To(gomega.Succeed())
+					gomega.Expect(pendingWl.Status.Admission.PodSetAssignments[0].Flavors[corev1.ResourceCPU]).To(
+						gomega.Equal(kueue.ResourceFlavorReference(tasFlavorB.Name)))
+					gomega.Expect(pendingWl.Status.Admission.PodSetAssignments[0].Flavors[corev1.ResourceMemory]).To(
+						gomega.Equal(kueue.ResourceFlavorReference(tasFlavorB.Name)))
+					gomega.Expect(pendingWl.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+						utiltas.V1Beta2From(&utiltas.TopologyAssignment{
+							Levels: []string{corev1.LabelHostname},
+							Domains: []utiltas.TopologyDomainAssignment{
+								{
+									Count:  1,
+									Values: []string{"x2"},
+								},
+							},
+						}),
+					))
+				})
+			})
+
+			ginkgo.It("should admit a sibling-flavor workload on the freed node once the primary workload finishes", func() {
+				var (
+					primaryWl *kueue.Workload
+					siblingWl *kueue.Workload
+				)
+
+				ginkgo.By("admitting a tas-flavor-a workload that fully consumes x1", func() {
+					primaryWl = utiltestingapi.MakeWorkload("primary-wl", ns.Name).
+						Queue(kueue.LocalQueueName(localQueue.Name)).
+						PodSets(*utiltestingapi.MakePodSet("one", 1).
+							NodeSelector(map[string]string{corev1.LabelHostname: "x1"}).
+							RequiredTopologyRequest(corev1.LabelHostname).
+							Request(corev1.ResourceCPU, "400m").
+							Request(corev1.ResourceMemory, "400Mi").
+							Toleration(corev1.Toleration{
+								Key:      "node-group",
+								Operator: corev1.TolerationOpEqual,
+								Value:    "tas",
+								Effect:   corev1.TaintEffectNoSchedule,
+							}).
+							Toleration(corev1.Toleration{
+								Key:      "tas-class",
+								Operator: corev1.TolerationOpEqual,
+								Value:    "a",
+								Effect:   corev1.TaintEffectNoSchedule,
+							}).
+							Obj()).Obj()
+					util.MustCreate(ctx, k8sClient, primaryWl)
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, primaryWl)
+					createPodsForWorkload(primaryWl, ns.Name, false, true)
+				})
+
+				ginkgo.By("creating a tas-flavor-b workload pinned to x1 that must stay pending while the sibling flavor occupies the node", func() {
+					siblingWl = utiltestingapi.MakeWorkload("sibling-wl", ns.Name).
+						Queue(kueue.LocalQueueName(localQueue.Name)).
+						PodSets(*utiltestingapi.MakePodSet("one", 1).
+							NodeSelector(map[string]string{corev1.LabelHostname: "x1"}).
+							RequiredTopologyRequest(corev1.LabelHostname).
+							Request(corev1.ResourceCPU, "100m").
+							Request(corev1.ResourceMemory, "100Mi").
+							Toleration(corev1.Toleration{
+								Key:      "node-group",
+								Operator: corev1.TolerationOpEqual,
+								Value:    "tas",
+								Effect:   corev1.TaintEffectNoSchedule,
+							}).
+							Toleration(corev1.Toleration{
+								Key:      "tas-class",
+								Operator: corev1.TolerationOpEqual,
+								Value:    "b",
+								Effect:   corev1.TaintEffectNoSchedule,
+							}).
+							Obj()).Obj()
+					util.MustCreate(ctx, k8sClient, siblingWl)
+					util.ExpectWorkloadsToBePending(ctx, k8sClient, siblingWl)
+				})
+
+				ginkgo.By("verifying the sibling workload stays pending while the primary workload still holds x1", func() {
+					gomega.Consistently(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(siblingWl), siblingWl)).To(gomega.Succeed())
+						g.Expect(workload.IsAdmitted(siblingWl)).To(gomega.BeFalse())
+					}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("finishing the tas-flavor-a workload to release x1 in the shared TAS usage", func() {
+					util.FinishWorkloads(ctx, k8sClient, primaryWl)
+				})
+
+				ginkgo.By("verifying the sibling tas-flavor-b workload is admitted on the freed node x1", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, siblingWl)
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(siblingWl), siblingWl)).To(gomega.Succeed())
+					gomega.Expect(siblingWl.Status.Admission.PodSetAssignments[0].Flavors[corev1.ResourceCPU]).To(
+						gomega.Equal(kueue.ResourceFlavorReference(tasFlavorB.Name)))
+					gomega.Expect(siblingWl.Status.Admission.PodSetAssignments[0].Flavors[corev1.ResourceMemory]).To(
+						gomega.Equal(kueue.ResourceFlavorReference(tasFlavorB.Name)))
+					gomega.Expect(siblingWl.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+						utiltas.V1Beta2From(&utiltas.TopologyAssignment{
+							Levels: []string{corev1.LabelHostname},
+							Domains: []utiltas.TopologyDomainAssignment{
+								{
+									Count:  1,
+									Values: []string{"x1"},
+								},
+							},
+						}),
+					))
+				})
+			})
+		})
 	})
 
 	// The purpose of this test is to demonstrate a TAS use case


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:
I fixed a TAS over-subscription bug where multiple `ResourceFlavor` referencing the same Topology and overlapping on physical nodes each independently track `usage`, so sibling flavors believe a shared node is only partially used.

This PR refined the TAS cache so that sibling flavors aggregate usage.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/10659

#### Special notes for your reviewer:

https://github.com/kubernetes-sigs/kueue/pull/10657 is problem reproduced PR.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: fix over-subscription of nodes that belong to multiple ResourceFlavors sharing the same hostname-leaf Topology.
```
