### PR TITLE
Automated cherry pick of #11214: Revert "[LeaderWorkerSet] Relax PodSpec validation. (#10275)"

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1221,8 +1221,7 @@ func EquivalentToWorkload(ctx context.Context, c client.Client, job GenericJob, 
 	}
 	jobPodSets := clearMinCountsIfFeatureDisabled(getPodSets)
 
-	opts := make([]equality.ComparePodSetsOption, 0, 2)
-	opts = append(opts, equality.WithIgnoreNodeSelector())
+	opts := make([]equality.ComparePodSetsOption, 0, 1)
 	if workload.IsAdmitted(wl) {
 		opts = append(opts, equality.WithIgnoreTolerations())
 	}

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -207,11 +207,7 @@ func validateUpdateForMaxExecTime(oldJob, newJob GenericJob) field.ErrorList {
 // ValidateImmutablePodGroupPodSpec function is used for serving workloads to ensure no changes are allowed
 // to the PodSpec except fields that required for role-hash generation.
 func ValidateImmutablePodGroupPodSpec(newPodSpec *corev1.PodSpec, oldPodSpec *corev1.PodSpec, fieldPath *field.Path) field.ErrorList {
-	return validateImmutablePodGroupPodSpecPath(
-		ignoreNodeSelector(utilpod.SpecShape(newPodSpec)),
-		ignoreNodeSelector(utilpod.SpecShape(oldPodSpec)),
-		fieldPath,
-	)
+	return validateImmutablePodGroupPodSpecPath(utilpod.SpecShape(newPodSpec), utilpod.SpecShape(oldPodSpec), fieldPath)
 }
 
 func validateImmutablePodGroupPodSpecPath(newShape, oldShape map[string]any, fieldPath *field.Path) field.ErrorList {
@@ -245,11 +241,6 @@ func validateImmutablePodGroupPodSpecPath(newShape, oldShape map[string]any, fie
 	}
 
 	return allErrs
-}
-
-func ignoreNodeSelector(shape map[string]any) map[string]any {
-	shape["nodeSelector"] = nil
-	return shape
 }
 
 func IsWorkloadPriorityClassNameEmpty(obj client.Object) bool {

--- a/pkg/controller/jobframework/validation_test.go
+++ b/pkg/controller/jobframework/validation_test.go
@@ -149,10 +149,16 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 				},
 			},
 		},
-		"change nodeSelector": {
+		"change nodeTemplate": {
 			oldPodSpec: &corev1.PodSpec{},
 			newPodSpec: &corev1.PodSpec{
 				NodeSelector: map[string]string{"key": "value"},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("nodeSelector").String(),
+				},
 			},
 		},
 		"add toleration": {

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -56,7 +56,6 @@ import (
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
-	"sigs.k8s.io/kueue/pkg/util/equality"
 	"sigs.k8s.io/kueue/pkg/util/parallelize"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
@@ -420,14 +419,6 @@ func (r *Reconciler) updateWorkload(ctx context.Context, lws *leaderworkersetv1.
 	log := ctrl.LoggerFrom(ctx).WithValues("workload", klog.KObj(wl))
 	log.V(3).Info("Update LeaderWorkerSet Workload")
 
-	podSets, err := podSets(lws)
-	if err != nil {
-		log.Error(err, "Failed to get pod sets")
-		return err
-	}
-	if !equality.ComparePodSetSlices(podSets, wl.Spec.PodSets) {
-		return r.deleteWorkload(ctx, wl)
-	}
 	if features.Enabled(features.AdmissionGatedBy) {
 		if err := jobframework.UpdateAdmissionGatedBy(ctx, r.client, r.record, lws, wl); err != nil {
 			log.Error(err, "Failed to update AdmissionGatedBy")
@@ -435,7 +426,7 @@ func (r *Reconciler) updateWorkload(ctx context.Context, lws *leaderworkersetv1.
 		}
 	}
 
-	err = jobframework.UpdateWorkloadPriority(ctx, r.client, r.record, lws, wl, nil)
+	err := jobframework.UpdateWorkloadPriority(ctx, r.client, r.record, lws, wl, nil)
 	if err != nil {
 		log.Error(err, "Failed to update workload priority")
 		return err

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
@@ -1261,38 +1261,6 @@ func TestValidateUpdate(t *testing.T) {
 				},
 			}.ToAggregate(),
 		},
-		"change nodeSelector": {
-			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
-				LeaderTemplate(corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						NodeSelector: map[string]string{},
-					},
-				}).
-				WorkerTemplate(corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						NodeSelector: map[string]string{},
-					},
-				}).
-				Queue("test-queue").
-				LeaderTemplateSpecAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
-				WorkerTemplateSpecAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
-				Obj(),
-			newObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
-				LeaderTemplate(corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						NodeSelector: map[string]string{"test": "test"},
-					},
-				}).
-				WorkerTemplate(corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						NodeSelector: map[string]string{"test": "test"},
-					},
-				}).
-				Queue("test-queue").
-				LeaderTemplateSpecAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
-				WorkerTemplateSpecAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
-				Obj(),
-		},
 		"set valid topology request": {
 			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				LeaderTemplate(corev1.PodTemplateSpec{}).

--- a/pkg/util/equality/podset.go
+++ b/pkg/util/equality/podset.go
@@ -25,8 +25,7 @@ import (
 )
 
 type ComparePodSetsOptions struct {
-	ignoreTolerations  bool
-	ignoreNodeSelector bool
+	ignoreTolerations bool
 }
 
 type ComparePodSetsOption func(*ComparePodSetsOptions)
@@ -34,12 +33,6 @@ type ComparePodSetsOption func(*ComparePodSetsOptions)
 func WithIgnoreTolerations() ComparePodSetsOption {
 	return func(options *ComparePodSetsOptions) {
 		options.ignoreTolerations = true
-	}
-}
-
-func WithIgnoreNodeSelector() ComparePodSetsOption {
-	return func(options *ComparePodSetsOptions) {
-		options.ignoreNodeSelector = true
 	}
 }
 
@@ -51,9 +44,6 @@ func comparePodTemplate(a, b *corev1.PodSpec, options ...ComparePodSetsOption) b
 		opt(opts)
 	}
 	if !opts.ignoreTolerations && !equality.Semantic.DeepEqual(a.Tolerations, b.Tolerations) {
-		return false
-	}
-	if !opts.ignoreNodeSelector && !equality.Semantic.DeepEqual(a.NodeSelector, b.NodeSelector) {
 		return false
 	}
 	if !equality.Semantic.DeepEqual(a.InitContainers, b.InitContainers) {

--- a/pkg/util/equality/podset_test.go
+++ b/pkg/util/equality/podset_test.go
@@ -28,11 +28,10 @@ import (
 
 func TestComparePodSetSlices(t *testing.T) {
 	cases := map[string]struct {
-		a                  []kueue.PodSet
-		b                  []kueue.PodSet
-		ignoreTolerations  bool
-		ignoreNodeSelector bool
-		wantEquivalent     bool
+		a                 []kueue.PodSet
+		b                 []kueue.PodSet
+		ignoreTolerations bool
+		wantEquivalent    bool
 	}{
 		"different name": {
 			a:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
@@ -47,13 +46,7 @@ func TestComparePodSetSlices(t *testing.T) {
 		"different node selector": {
 			a:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
 			b:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(5).NodeSelector(map[string]string{"key": "val"}).Obj()},
-			wantEquivalent: false,
-		},
-		"different node selector with ignoreNodeSelector": {
-			a:                  []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
-			b:                  []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(5).NodeSelector(map[string]string{"key": "val"}).Obj()},
-			ignoreNodeSelector: true,
-			wantEquivalent:     true,
+			wantEquivalent: true,
 		},
 		"different requests": {
 			a:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(5).Request("res", "1").Obj()},
@@ -141,23 +134,7 @@ func TestComparePodSetSlices(t *testing.T) {
 					NodeSelector(map[string]string{"key": "val2"}).
 					Obj(),
 			},
-			wantEquivalent: false,
-		},
-		"different requests in node selector with ignoreNodeSelector": {
-			a: []kueue.PodSet{
-				*utiltestingapi.MakePodSet("ps", 10).
-					SetMinimumCount(5).
-					NodeSelector(map[string]string{"key": "val"}).
-					Obj(),
-			},
-			b: []kueue.PodSet{
-				*utiltestingapi.MakePodSet("ps", 10).
-					SetMinimumCount(5).
-					NodeSelector(map[string]string{"key": "val2"}).
-					Obj(),
-			},
-			ignoreNodeSelector: true,
-			wantEquivalent:     true,
+			wantEquivalent: true,
 		},
 	}
 	for name, tc := range cases {
@@ -165,9 +142,6 @@ func TestComparePodSetSlices(t *testing.T) {
 			options := make([]ComparePodSetsOption, 0, 1)
 			if tc.ignoreTolerations {
 				options = append(options, WithIgnoreTolerations())
-			}
-			if tc.ignoreNodeSelector {
-				options = append(options, WithIgnoreNodeSelector())
 			}
 			got := ComparePodSetSlices(tc.a, tc.b, options...)
 			if got != tc.wantEquivalent {

--- a/test/e2e/singlecluster/extended/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/extended/leaderworkerset_test.go
@@ -135,69 +135,6 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 			})
 		})
 
-		ginkgo.It("should allow to mutate nodeSelector", func() {
-			lws := leaderworkersettesting.MakeLeaderWorkerSet("lws", ns.Name).
-				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
-				Size(1).
-				Replicas(1).
-				RequestAndLimit(corev1.ResourceCPU, "200m").
-				TerminationGracePeriod(1).
-				Queue(lq.Name).
-				Obj()
-
-			ginkgo.By("Create a LeaderWorkerSet", func() {
-				util.MustCreate(ctx, k8sClient, lws)
-			})
-
-			wlKey := util.WorkloadKeyForLeaderWorkerSet(lws, "0")
-
-			ginkgo.By("Waiting for replicas to be ready", func() {
-				createdLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
-					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
-					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(utiltesting.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			createdWorkload := &kueue.Workload{}
-			ginkgo.By("Check workload is created and has JobUID label", func() {
-				gomega.Expect(k8sClient.Get(ctx, wlKey, createdWorkload)).To(gomega.Succeed())
-				gomega.Expect(createdWorkload.Labels[ctrlconstants.JobUIDLabel]).To(gomega.Equal(string(lws.UID)))
-			})
-
-			oldUID := createdWorkload.UID
-
-			ginkgo.By("Updating nodeSelector", func() {
-				createdLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
-					createdLeaderWorkerSet.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.NodeSelector = map[string]string{"instance-type": "on-demand"}
-					g.Expect(k8sClient.Update(ctx, createdLeaderWorkerSet)).To(gomega.Succeed())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("Checking that workload recreated", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, wlKey, createdWorkload)).To(gomega.Succeed())
-					g.Expect(createdWorkload.UID).ToNot(gomega.Equal(oldUID))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("Checking that workload is admitted", func() {
-				util.ExpectWorkloadsToBeAdmittedByKeys(ctx, k8sClient, wlKey)
-			})
-
-			ginkgo.By("Waiting for replicas to be ready", func() {
-				createdLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
-					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
-					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(utiltesting.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
-			})
-		})
-
 		ginkgo.It("should admit group with leader and workers", func() {
 			lws := leaderworkersettesting.MakeLeaderWorkerSet("lws", ns.Name).
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).


### PR DESCRIPTION
Cherry pick of #11214 on release-0.17.

#11214: Revert "[LeaderWorkerSet] Relax PodSpec validation. (#10275)"

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind regression


```release-note
NONE
```