### PR TITLE
Add RetainFirstAdmission migration mode for concurrent admissions

### DIFF
--- a/apis/kueue/v1beta2/clusterqueue_types.go
+++ b/apis/kueue/v1beta2/clusterqueue_types.go
@@ -218,6 +218,7 @@ type ConcurrentAdmissionMigration struct {
 	// mode defines the mode of Workload's migration.
 	// The possible values are:
 	// - `TryPreferredFlavors` (default): a Workload will try to migrate to the preferred flavor after it's admitted and running.
+	// - `RetainFirstAdmission`: a Workload, once admitted to a flavor, will stick to a flavor and will not be migrated.
 	//
 	// +required
 	Mode ConcurrentAdmissionMigrationMode `json:"mode,omitempty"`
@@ -240,12 +241,14 @@ type ConcurrentAdmissionConstraints struct {
 }
 
 // +kubebuilder:validation:MaxLength=253
-// +kubebuilder:validation:Enum=TryPreferredFlavors
+// +kubebuilder:validation:Enum=TryPreferredFlavors;RetainFirstAdmission
 type ConcurrentAdmissionMigrationMode string
 
 const (
 	// TryPreferredFlavors means that a Workload will try to migrate to the preferred flavor after it's admitted and running.
 	ConcurrentAdmissionTryPreferredFlavors ConcurrentAdmissionMigrationMode = "TryPreferredFlavors"
+	// RetainFirstAdmission means that a Workload, once admitted to a flavor, will not try to migrate to another flavor.
+	ConcurrentAdmissionRetainFirstAdmission ConcurrentAdmissionMigrationMode = "RetainFirstAdmission"
 )
 
 // +kubebuilder:validation:XValidation:rule="self.flavors.all(x, size(x.resources) == size(self.coveredResources))", message="flavors must have the same number of resources as the coveredResources"

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -966,8 +966,10 @@ spec:
                             mode defines the mode of Workload's migration.
                             The possible values are:
                             - `TryPreferredFlavors` (default): a Workload will try to migrate to the preferred flavor after it's admitted and running.
+                            - `RetainFirstAdmission`: a Workload, once admitted to a flavor, will stick to a flavor and will not be migrated.
                           enum:
                             - TryPreferredFlavors
+                            - RetainFirstAdmission
                           maxLength: 253
                           type: string
                       required:

--- a/client-go/applyconfiguration/kueue/v1beta2/concurrentadmissionmigration.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/concurrentadmissionmigration.go
@@ -28,6 +28,7 @@ type ConcurrentAdmissionMigrationApplyConfiguration struct {
 	// mode defines the mode of Workload's migration.
 	// The possible values are:
 	// - `TryPreferredFlavors` (default): a Workload will try to migrate to the preferred flavor after it's admitted and running.
+	// - `RetainFirstAdmission`: a Workload, once admitted to a flavor, will stick to a flavor and will not be migrated.
 	Mode *kueuev1beta2.ConcurrentAdmissionMigrationMode `json:"mode,omitempty"`
 	// constraints defines the constraints of Workload's migration.
 	Constraints *ConcurrentAdmissionConstraintsApplyConfiguration `json:"constraints,omitempty"`

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -958,8 +958,10 @@ spec:
                           mode defines the mode of Workload's migration.
                           The possible values are:
                           - `TryPreferredFlavors` (default): a Workload will try to migrate to the preferred flavor after it's admitted and running.
+                          - `RetainFirstAdmission`: a Workload, once admitted to a flavor, will stick to a flavor and will not be migrated.
                         enum:
                         - TryPreferredFlavors
+                        - RetainFirstAdmission
                         maxLength: 253
                         type: string
                     required:

--- a/keps/8691-concurrent-admission/README.md
+++ b/keps/8691-concurrent-admission/README.md
@@ -266,7 +266,7 @@ spec:
 #### Story 4: Homogenous Flavors only
 As an admin, I have three homogeneous resource flavors (1a, 1b, 1c). I want my workloads to start as soon as possible on any flavor and stop pursuing other variants once the job is accommodated.
 
-To achieve that, I use the `HoldFirstAdmission` mode.
+To achieve that, I use the `RetainFirstAdmission` mode.
 
 ```yaml
 kind: ClusterQueue
@@ -276,7 +276,7 @@ spec:
   ...
   concurrentAdmissionPolicy:
     migration:
-      mode: HoldFirstAdmission
+      mode: RetainFirstAdmission
 ```
 
 #### Story 5: Delaying Variant creation
@@ -425,7 +425,7 @@ type ConcurrentAdmissionMigrationMode string
 
 const (
     // Do not allow any kind of migration
-    HoldFirstAdmission ConcurrentAdmissionMigrationMode = "HoldFirstAdmission"
+    RetainFirstAdmission ConcurrentAdmissionMigrationMode = "RetainFirstAdmission"
 
     // Allow upgrades
     TryPreferredFlavors ConcurrentAdmissionMigrationMode = "TryPreferredFlavors"
@@ -698,7 +698,7 @@ After the implementation PR is merged, add the names of the tests here.
 
 #### Beta
 
-- Support for `migration.constraints.mode=HoldFirstAdmission` and `migration.constraints.MinTargetExplicitVariant`.
+- Support for `migration.constraints.mode=RetainFirstAdmission` and `migration.constraints.MinTargetExplicitVariant`.
 - Introduction of `AdmissionConstraints` field.
 - Introduction of `ExplicitVariants` functionality.
 - Revisit extending `ExplicitVariants` API with some additional fields.

--- a/pkg/controller/concurrentadmission/controller.go
+++ b/pkg/controller/concurrentadmission/controller.go
@@ -357,6 +357,22 @@ func (r *variantReconciler) deactivateVariant(ctx context.Context, v *kueue.Work
 	return nil
 }
 
+func (r *variantReconciler) deactivateMatchingVariants(ctx context.Context, variants []kueue.Workload, reason string, match func(*kueue.Workload) bool, logArgs ...any) error {
+	log := ctrl.LoggerFrom(ctx)
+	for i := range variants {
+		v := &variants[i]
+		if match != nil && !match(v) {
+			continue
+		}
+		logFields := append([]any{"variant", klog.KObj(v), "flavor", concurrentadmission.GetVariantFlavor(v), "reason", reason}, logArgs...)
+		log.V(2).Info("Deactivating variant", logFields...)
+		if err := r.deactivateVariant(ctx, v, reason); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (r *variantReconciler) deactivateVariants(
 	ctx context.Context,
 	parent *kueue.Workload,
@@ -367,13 +383,12 @@ func (r *variantReconciler) deactivateVariants(
 	log := ctrl.LoggerFrom(ctx)
 	if !workload.IsActive(parent) {
 		log.V(2).Info("Parent is not active, deactivating all variants", "parent", klog.KObj(parent))
-		for i := range variants {
-			v := &variants[i]
-			if err := r.deactivateVariant(ctx, v, fmt.Sprintf("Parent Workload %q not active", klog.KObj(parent))); err != nil {
-				return err
-			}
-		}
-		return nil
+		return r.deactivateMatchingVariants(
+			ctx,
+			variants,
+			fmt.Sprintf("Parent Workload %q not active", klog.KObj(parent)),
+			nil,
+		)
 	}
 
 	admittedWl := getAdmittedVariant(variants)
@@ -381,40 +396,51 @@ func (r *variantReconciler) deactivateVariants(
 		log.V(3).Info("No admitted variant, no need to deactivate any variant")
 		return nil
 	}
-	// deactivate Variants below lastAcceptableFlavor if specified
-	var lastAcceptableFlavor *kueue.ResourceFlavorReference
-	if cq.Spec.ConcurrentAdmissionPolicy != nil && cq.Spec.ConcurrentAdmissionPolicy.Migration.Constraints != nil {
-		lastAcceptableFlavor = cq.Spec.ConcurrentAdmissionPolicy.Migration.Constraints.LastAcceptableFlavorName
-	}
-	if lastAcceptableFlavor != nil {
-		log.V(3).Info("Deactivating variants below lastAcceptableFlavor", "lastAcceptableFlavor", *lastAcceptableFlavor)
-		for i := range variants {
-			v := &variants[i]
-			if v.Name == admittedWl.Name {
-				continue
-			}
-			if flavorOrder[concurrentadmission.GetVariantFlavor(v)] > flavorOrder[*lastAcceptableFlavor] {
-				log.V(2).
-					Info("Deactivating variant because it is below the lastAcceptableFlavor", "variant", klog.KObj(v), "flavor", concurrentadmission.GetVariantFlavor(v), "lastAcceptableFlavor", *lastAcceptableFlavor)
-				if err := r.deactivateVariant(ctx, v, fmt.Sprintf("being below lastAcceptableFlavor: %q and another Variant admitted %q", *lastAcceptableFlavor, klog.KObj(admittedWl))); err != nil {
-					return err
-				}
-			}
+	switch migrationMode(cq) {
+	case kueue.ConcurrentAdmissionRetainFirstAdmission:
+		log.V(3).Info("RetainFirstAdmission mode, deactivating all variants except the admitted one", "admittedVariant", klog.KObj(admittedWl))
+		return r.deactivateMatchingVariants(
+			ctx,
+			variants,
+			fmt.Sprintf("RetainFirstAdmission: another Variant %q is admitted", klog.KObj(admittedWl)),
+			func(v *kueue.Workload) bool { return v.Name != admittedWl.Name },
+		)
+	case kueue.ConcurrentAdmissionTryPreferredFlavors:
+		// deactivate Variants below lastAcceptableFlavor if specified
+		var lastAcceptableFlavor *kueue.ResourceFlavorReference
+		if cq.Spec.ConcurrentAdmissionPolicy != nil && cq.Spec.ConcurrentAdmissionPolicy.Migration.Constraints != nil {
+			lastAcceptableFlavor = cq.Spec.ConcurrentAdmissionPolicy.Migration.Constraints.LastAcceptableFlavorName
 		}
-	}
-	// also deactivate Variants below the admitted variant regardless of lastAcceptableFlavorName
-	log.V(3).Info("Deactivating variants below the admitted variant", "admittedVariant", klog.KObj(admittedWl), "admittedFlavor", concurrentadmission.GetVariantFlavor(admittedWl))
-	for i := range variants {
-		v := &variants[i]
-		if flavorOrder[concurrentadmission.GetVariantFlavor(v)] > flavorOrder[concurrentadmission.GetVariantFlavor(admittedWl)] {
-			log.V(2).
-				Info("Deactivating variant because it is below the admitted variant", "variant", klog.KObj(v), "flavor", concurrentadmission.GetVariantFlavor(v), "admittedFlavor", concurrentadmission.GetVariantFlavor(admittedWl))
-			if err := r.deactivateVariant(ctx, v, fmt.Sprintf("being lower priority than admitted Variant %q", klog.KObj(admittedWl))); err != nil {
+		if lastAcceptableFlavor != nil {
+			log.V(3).Info("Deactivating variants below lastAcceptableFlavor", "lastAcceptableFlavor", *lastAcceptableFlavor)
+			err := r.deactivateMatchingVariants(
+				ctx,
+				variants,
+				fmt.Sprintf("being below lastAcceptableFlavor: %q and another Variant admitted %q", *lastAcceptableFlavor, klog.KObj(admittedWl)),
+				func(v *kueue.Workload) bool {
+					return v.Name != admittedWl.Name &&
+						flavorOrder[concurrentadmission.GetVariantFlavor(v)] > flavorOrder[*lastAcceptableFlavor]
+				},
+				"lastAcceptableFlavor", *lastAcceptableFlavor,
+			)
+			if err != nil {
 				return err
 			}
 		}
+		// also deactivate Variants below the admitted variant regardless of lastAcceptableFlavorName
+		log.V(3).Info("Deactivating variants below the admitted variant", "admittedVariant", klog.KObj(admittedWl), "admittedFlavor", concurrentadmission.GetVariantFlavor(admittedWl))
+		return r.deactivateMatchingVariants(
+			ctx,
+			variants,
+			fmt.Sprintf("being lower priority than admitted Variant %q", klog.KObj(admittedWl)),
+			func(v *kueue.Workload) bool {
+				return flavorOrder[concurrentadmission.GetVariantFlavor(v)] > flavorOrder[concurrentadmission.GetVariantFlavor(admittedWl)]
+			},
+			"admittedFlavor", concurrentadmission.GetVariantFlavor(admittedWl),
+		)
+	default:
+		return fmt.Errorf("unknown migration mode %q", migrationMode(cq))
 	}
-	return nil
 }
 
 func (r *variantReconciler) activateVariants(ctx context.Context, parent *kueue.Workload, variants []kueue.Workload, cq *kueue.ClusterQueue, flavorOrder map[kueue.ResourceFlavorReference]int) error {
@@ -435,36 +461,44 @@ func (r *variantReconciler) activateVariants(ctx context.Context, parent *kueue.
 		}
 		return nil
 	}
-	// activate all variants that are at least at the lastAcceptableFlavorName if specificed
-	var lastAcceptableFlavor *kueue.ResourceFlavorReference
-	if cq.Spec.ConcurrentAdmissionPolicy != nil && cq.Spec.ConcurrentAdmissionPolicy.Migration.Constraints != nil {
-		lastAcceptableFlavor = cq.Spec.ConcurrentAdmissionPolicy.Migration.Constraints.LastAcceptableFlavorName
-	}
-	if lastAcceptableFlavor != nil {
+	switch migrationMode(cq) {
+	case kueue.ConcurrentAdmissionRetainFirstAdmission:
+		log.V(3).Info("RetainFirstAdmission mode and a Variant is admitted, not activating any other variant", "admittedVariant", klog.KObj(admittedVariant))
+		return nil
+	case kueue.ConcurrentAdmissionTryPreferredFlavors:
+		// activate all variants that are at least at the lastAcceptableFlavorName if specificed
+		var lastAcceptableFlavor *kueue.ResourceFlavorReference
+		if cq.Spec.ConcurrentAdmissionPolicy != nil && cq.Spec.ConcurrentAdmissionPolicy.Migration.Constraints != nil {
+			lastAcceptableFlavor = cq.Spec.ConcurrentAdmissionPolicy.Migration.Constraints.LastAcceptableFlavorName
+		}
+		if lastAcceptableFlavor != nil {
+			for i := range variants {
+				v := &variants[i]
+				if flavorOrder[concurrentadmission.GetVariantFlavor(v)] <= flavorOrder[*lastAcceptableFlavor] &&
+					flavorOrder[concurrentadmission.GetVariantFlavor(v)] < flavorOrder[concurrentadmission.GetVariantFlavor(admittedVariant)] {
+					// activate the variant, the smaller or equal the flavor order is to the lastAcceptableFlavor, the higher the priority is
+					if err := r.activateWl(ctx, v, fmt.Sprintf("being at least lastAcceptableFlavor: %q and higher priority than admitted Variant %q",
+						*lastAcceptableFlavor, klog.KObj(admittedVariant))); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		}
+		// no lastAcceptableFlavorName specified, so activate all variants that are below the admitted variant in the flavor order
 		for i := range variants {
 			v := &variants[i]
-			if flavorOrder[concurrentadmission.GetVariantFlavor(v)] <= flavorOrder[*lastAcceptableFlavor] &&
-				flavorOrder[concurrentadmission.GetVariantFlavor(v)] < flavorOrder[concurrentadmission.GetVariantFlavor(admittedVariant)] {
-				// activate the variant, the smaller or equal the flavor order is to the lastAcceptableFlavor, the higher the priority is
-				if err := r.activateWl(ctx, v, fmt.Sprintf("being at least lastAcceptableFlavor: %q and higher priority than admitted Variant %q",
-					*lastAcceptableFlavor, klog.KObj(admittedVariant))); err != nil {
+			if flavorOrder[concurrentadmission.GetVariantFlavor(v)] < flavorOrder[concurrentadmission.GetVariantFlavor(admittedVariant)] {
+				// activate the variant, the smaller the flavor order is to the admitted variant, the higher the priority is
+				if err := r.activateWl(ctx, v, fmt.Sprintf("being higher priority than admitted Variant %q", klog.KObj(admittedVariant))); err != nil {
 					return err
 				}
 			}
 		}
 		return nil
+	default:
+		return fmt.Errorf("unknown migration mode %q", migrationMode(cq))
 	}
-	// no lastAcceptableFlavorName specified, so activate all variants that are below the admitted variant in the flavor order
-	for i := range variants {
-		v := &variants[i]
-		if flavorOrder[concurrentadmission.GetVariantFlavor(v)] < flavorOrder[concurrentadmission.GetVariantFlavor(admittedVariant)] {
-			// activate the variant, the smaller the flavor order is to the admitted variant, the higher the priority is
-			if err := r.activateWl(ctx, v, fmt.Sprintf("being higher priority than admitted Variant %q", klog.KObj(admittedVariant))); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 func (r *variantReconciler) activateWl(ctx context.Context, wl *kueue.Workload, message string) error {
@@ -605,4 +639,12 @@ func getAdmittedVariant(variants []kueue.Workload) *kueue.Workload {
 		}
 	}
 	return nil
+}
+
+func migrationMode(cq *kueue.ClusterQueue) kueue.ConcurrentAdmissionMigrationMode {
+	if cq.Spec.ConcurrentAdmissionPolicy == nil ||
+		cq.Spec.ConcurrentAdmissionPolicy.Migration.Mode == "" {
+		return kueue.ConcurrentAdmissionTryPreferredFlavors
+	}
+	return cq.Spec.ConcurrentAdmissionPolicy.Migration.Mode
 }

--- a/pkg/controller/concurrentadmission/controller_test.go
+++ b/pkg/controller/concurrentadmission/controller_test.go
@@ -85,6 +85,16 @@ func TestReconcile(t *testing.T) {
 		Obj()
 	migrationLQNoConstraint := utiltestingapi.MakeLocalQueue("lq-migration-no-constraint", "default").ClusterQueue("cq-migration-no-constraint").Obj()
 
+	retainFirstAdmissionCQ := utiltestingapi.MakeClusterQueue("cq-hold").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("reservation").Obj(),
+			*utiltestingapi.MakeFlavorQuotas("on-demand").Obj(),
+			*utiltestingapi.MakeFlavorQuotas("spot").Obj(),
+		).
+		ConcurrentAdmissionPolicy(kueue.ConcurrentAdmissionRetainFirstAdmission).
+		Obj()
+	retainFirstAdmissionLQ := utiltestingapi.MakeLocalQueue("lq-hold", "default").ClusterQueue("cq-hold").Obj()
+
 	testCases := map[string]struct {
 		parentWorkload       *kueue.Workload
 		variantWorkloads     []kueue.Workload
@@ -966,6 +976,99 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		},
+		"RetainFirstAdmission, variant admitted on spot, deactivate reservation and on-demand": {
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
+				Queue("lq-hold").
+				Request(corev1.ResourceCPU, "1").
+				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+				Obj(),
+			variantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-variant-reservation", "default").
+					Queue("lq-hold").
+					AllowedFlavors("reservation").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
+					Queue("lq-hold").
+					AllowedFlavors("on-demand").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq-hold").
+					AllowedFlavors("spot").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
+					SimpleReserveQuota("cq-hold", "spot", metav1.Now().Time).
+					AdmittedAt(true, metav1.Now().Time).
+					Obj(),
+			},
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
+				Queue("lq-hold").
+				Request(corev1.ResourceCPU, "1").
+				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+				Admission(utiltestingapi.MakeAdmission("cq-hold", "main").
+					PodSets(kueue.PodSetAssignment{
+						Name: "main",
+						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+							corev1.ResourceCPU: "spot",
+						},
+						Count:         ptr.To[int32](1),
+						ResourceUsage: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+					}).Obj()).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionTrue,
+					Reason:  "Admitted",
+					Message: "The variant wl-variant-spot is admitted",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionTrue,
+					Reason:  "QuotaReserved",
+					Message: "Quota reserved in ClusterQueue cq-hold",
+				}).
+				Obj(),
+			wantVariantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-variant-reservation", "default").
+					Queue("lq-hold").
+					AllowedFlavors("reservation").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
+					Active(false).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
+					Queue("lq-hold").
+					AllowedFlavors("on-demand").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
+					Active(false).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq-hold").
+					AllowedFlavors("spot").
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Request(corev1.ResourceCPU, "1").
+					SimpleReserveQuota("cq-hold", "spot", metav1.Now().Time).
+					AdmittedAt(true, metav1.Now().Time).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Namespace: "default", Name: "wl-variant-reservation"},
+					EventType: corev1.EventTypeNormal,
+					Reason:    ReasonDeactivatedVariant,
+					Message:   "Variant Workload deactivated due to RetainFirstAdmission: another Variant \"default/wl-variant-spot\" is admitted",
+				},
+				{
+					Key:       types.NamespacedName{Namespace: "default", Name: "wl-variant-on-demand"},
+					EventType: corev1.EventTypeNormal,
+					Reason:    ReasonDeactivatedVariant,
+					Message:   "Variant Workload deactivated due to RetainFirstAdmission: another Variant \"default/wl-variant-spot\" is admitted",
+				},
+			},
+		},
 		"parent marked finished, mark all variants finished": {
 			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
@@ -1341,8 +1444,8 @@ func TestReconcile(t *testing.T) {
 			qManager := qcache.NewManagerForUnitTests(cl, nil, qcache.WithPreemptionExpectations(preemptionExpectations))
 			roleTracker := roletracker.NewFakeRoleTracker(roletracker.RoleLeader)
 
-			cqs := []*kueue.ClusterQueue{defaultCQ.DeepCopy(), migrationCQ.DeepCopy(), migrationCQNoConstraint.DeepCopy()}
-			lqs := []*kueue.LocalQueue{defaultLQ.DeepCopy(), migrationLQ.DeepCopy(), migrationLQNoConstraint.DeepCopy()}
+			cqs := []*kueue.ClusterQueue{defaultCQ.DeepCopy(), migrationCQ.DeepCopy(), migrationCQNoConstraint.DeepCopy(), retainFirstAdmissionCQ.DeepCopy()}
+			lqs := []*kueue.LocalQueue{defaultLQ.DeepCopy(), migrationLQ.DeepCopy(), migrationLQNoConstraint.DeepCopy(), retainFirstAdmissionLQ.DeepCopy()}
 
 			for _, cq := range cqs {
 				if err := cl.Create(t.Context(), cq); err != nil {

--- a/pkg/webhooks/clusterqueue_webhook.go
+++ b/pkg/webhooks/clusterqueue_webhook.go
@@ -247,15 +247,23 @@ func validateConcurrentAdmissionPolicy(cq *kueue.ClusterQueue, path *field.Path)
 			"cannot have more than 16 resource flavors in the ResourceGroup when ConcurrentAdmissionPolicy is defined"))
 	}
 
-	if cq.Spec.ConcurrentAdmissionPolicy.Migration.Constraints != nil && cq.Spec.ConcurrentAdmissionPolicy.Migration.Constraints.LastAcceptableFlavorName != nil {
-		lastAcceptableFlavor := *cq.Spec.ConcurrentAdmissionPolicy.Migration.Constraints.LastAcceptableFlavorName
-		validFlavors := utilqueue.AllFlavors(cq.Spec.ResourceGroups)
-		if !validFlavors.Has(lastAcceptableFlavor) {
-			allowedFlavors := utilslices.Map(validFlavors.UnsortedList(), func(f *kueue.ResourceFlavorReference) string { return string(*f) })
-			allErrs = append(allErrs, field.Invalid(
-				path.Child("concurrentAdmissionPolicy").Child("migration").Child("constraints").Child("lastAcceptableFlavorName"),
-				lastAcceptableFlavor,
-				fmt.Sprintf("must be one of the flavors defined in the ClusterQueue: %v", allowedFlavors)))
+	if cq.Spec.ConcurrentAdmissionPolicy.Migration.Constraints != nil {
+		mode := cq.Spec.ConcurrentAdmissionPolicy.Migration.Mode
+		if mode != "" && mode != kueue.ConcurrentAdmissionTryPreferredFlavors {
+			allErrs = append(allErrs, field.Forbidden(
+				path.Child("concurrentAdmissionPolicy").Child("migration").Child("constraints"),
+				fmt.Sprintf("may only be set when migration.mode is %q (got %q)",
+					kueue.ConcurrentAdmissionTryPreferredFlavors, mode)))
+		} else if cq.Spec.ConcurrentAdmissionPolicy.Migration.Constraints.LastAcceptableFlavorName != nil {
+			lastAcceptableFlavor := *cq.Spec.ConcurrentAdmissionPolicy.Migration.Constraints.LastAcceptableFlavorName
+			validFlavors := utilqueue.AllFlavors(cq.Spec.ResourceGroups)
+			if !validFlavors.Has(lastAcceptableFlavor) {
+				allowedFlavors := utilslices.Map(validFlavors.UnsortedList(), func(f *kueue.ResourceFlavorReference) string { return string(*f) })
+				allErrs = append(allErrs, field.Invalid(
+					path.Child("concurrentAdmissionPolicy").Child("migration").Child("constraints").Child("lastAcceptableFlavorName"),
+					lastAcceptableFlavor,
+					fmt.Sprintf("must be one of the flavors defined in the ClusterQueue: %v", allowedFlavors)))
+			}
 		}
 	}
 

--- a/pkg/webhooks/clusterqueue_webhook_test.go
+++ b/pkg/webhooks/clusterqueue_webhook_test.go
@@ -451,6 +451,26 @@ func TestValidateClusterQueue(t *testing.T) {
 				Obj(),
 		},
 		{
+			name: "ConcurrentAdmissionPolicy constraints with RetainFirstAdmission mode is forbidden",
+			clusterQueue: utiltestingapi.MakeClusterQueue("cluster-queue").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("flavor1").Resource("cpu", "1").Obj()).
+				ConcurrentAdmissionPolicy(kueue.ConcurrentAdmissionRetainFirstAdmission).
+				LastAcceptableFlavorName("flavor1").
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Forbidden(specPath.Child("concurrentAdmissionPolicy").Child("migration").Child("constraints"), ""),
+			},
+			wantDetail: `may only be set when migration.mode is "TryPreferredFlavors" (got "RetainFirstAdmission")`,
+		},
+		{
+			name: "ConcurrentAdmissionPolicy constraints with empty migration mode is allowed",
+			clusterQueue: utiltestingapi.MakeClusterQueue("cluster-queue").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("flavor1").Resource("cpu", "1").Obj()).
+				ConcurrentAdmissionPolicy("").
+				LastAcceptableFlavorName("flavor1").
+				Obj(),
+		},
+		{
 			name: "ConcurrentAdmissionPolicy with invalid LastAcceptableFlavorName",
 			clusterQueue: utiltestingapi.MakeClusterQueue("cluster-queue").
 				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("flavor1").Resource("cpu", "1").Obj()).

--- a/site/content/en/docs/reference/kueue.v1beta2.md
+++ b/site/content/en/docs/reference/kueue.v1beta2.md
@@ -1317,6 +1317,7 @@ Workload can migrate to any flavor that is more preferable than the one it was a
 The possible values are:</p>
 <ul>
 <li><code>TryPreferredFlavors</code> (default): a Workload will try to migrate to the preferred flavor after it's admitted and running.</li>
+<li><code>RetainFirstAdmission</code>: a Workload, once admitted to a flavor, will stick to a flavor and will not be migrated.</li>
 </ul>
 </td>
 </tr>

--- a/test/integration/singlecluster/controller/concurrentadmission/concurrent_admission_test.go
+++ b/test/integration/singlecluster/controller/concurrentadmission/concurrent_admission_test.go
@@ -316,6 +316,93 @@ var _ = ginkgo.Describe("Concurrent Admission", ginkgo.Ordered, ginkgo.ContinueO
 		})
 	})
 
+	ginkgo.When("ClusterQueue uses RetainFirstAdmission mode", func() {
+		var cq *kueue.ClusterQueue
+		var lq *kueue.LocalQueue
+		var flavorReservation *kueue.ResourceFlavor
+		var flavorSpot *kueue.ResourceFlavor
+
+		ginkgo.BeforeEach(func() {
+			flavorReservation = utiltestingapi.MakeResourceFlavor("reservation").Obj()
+			util.MustCreate(ctx, k8sClient, flavorReservation)
+
+			flavorSpot = utiltestingapi.MakeResourceFlavor("spot").Obj()
+			util.MustCreate(ctx, k8sClient, flavorSpot)
+
+			cq = utiltestingapi.MakeClusterQueue("cq-hold").
+				ConcurrentAdmissionPolicy(kueue.ConcurrentAdmissionRetainFirstAdmission).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(flavorReservation.Name).Resource(corev1.ResourceCPU, "0").Obj(),
+					*utiltestingapi.MakeFlavorQuotas(flavorSpot.Name).Resource(corev1.ResourceCPU, "5").Obj(),
+				).Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+			lq = utiltestingapi.MakeLocalQueue("lq", ns.Name).ClusterQueue(cq.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, lq, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, flavorSpot, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, flavorReservation, true)
+		})
+
+		ginkgo.It("should not migrate to a preferred flavor when it becomes available", func() {
+			parentWl := utiltestingapi.MakeWorkload("parent-wl-hold", ns.Name).
+				Request(corev1.ResourceCPU, "1").
+				Queue(kueue.LocalQueueName(lq.Name)).
+				ParentVariant().
+				Obj()
+
+			ginkgo.By("Creating the parent workload", func() {
+				util.MustCreate(ctx, k8sClient, parentWl)
+			})
+
+			ginkgo.By("Verifying workload is admitted on spot", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(parentWl), parentWl)).To(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(parentWl)).To(gomega.BeTrue())
+					g.Expect(parentWl.Status.Admission.PodSetAssignments[0].Flavors[corev1.ResourceCPU]).To(gomega.Equal(kueue.ResourceFlavorReference(flavorSpot.Name)))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Verifying reservation variant is deactivated", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					list := &kueue.WorkloadList{}
+					g.Expect(k8sClient.List(ctx, list, client.InNamespace(ns.Name))).To(gomega.Succeed())
+
+					variantReservation := getVariantByFlavor(list, parentWl.Name, flavorReservation.Name)
+					g.Expect(variantReservation).ToNot(gomega.BeNil(), "Variant for reservation not found")
+					g.Expect(ptr.Deref(variantReservation.Spec.Active, true)).To(gomega.BeFalse(), "Variant for reservation should be inactive")
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Releasing quota on reservation", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					var updatedCq kueue.ClusterQueue
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: cq.Name}, &updatedCq)).To(gomega.Succeed())
+					updatedCq.Spec.ResourceGroups[0].Flavors[0].Resources[0].NominalQuota = resource.MustParse("5")
+					g.Expect(k8sClient.Update(ctx, &updatedCq)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Verifying workload does not migrate and reservation variant stays deactivated", func() {
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(parentWl), parentWl)).To(gomega.Succeed())
+					g.Expect(parentWl.Status.Admission.PodSetAssignments[0].Flavors[corev1.ResourceCPU]).To(gomega.Equal(kueue.ResourceFlavorReference(flavorSpot.Name)))
+
+					list := &kueue.WorkloadList{}
+					g.Expect(k8sClient.List(ctx, list, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					variantReservation := getVariantByFlavor(list, parentWl.Name, flavorReservation.Name)
+					g.Expect(variantReservation).ToNot(gomega.BeNil(), "Variant for reservation not found")
+					g.Expect(ptr.Deref(variantReservation.Spec.Active, true)).To(gomega.BeFalse(), "Variant for reservation should remain inactive")
+				}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	})
+
 	ginkgo.When("ClusterQueue has admission checks", func() {
 		var cq *kueue.ClusterQueue
 		var lq *kueue.LocalQueue


### PR DESCRIPTION
…n a Workload to its first admitted flavor

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Add HoldFirstAdmission migration mode for concurrent admissions to pin a Workload to its first admitted flavor
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10911 

#### Special notes for your reviewer:
Unit Test code coverage
```
sigs.k8s.io/kueue/pkg/controller/concurrentadmission/controller.go:360: deactivateMatchingVariants      90.0%
sigs.k8s.io/kueue/pkg/controller/concurrentadmission/controller.go:376: deactivateVariants              92.0%
sigs.k8s.io/kueue/pkg/controller/concurrentadmission/controller.go:446: activateVariants                87.5%
sigs.k8s.io/kueue/pkg/controller/concurrentadmission/controller.go:644: migrationMode                   66.7%
```
[concurrentadmission.html](https://github.com/user-attachments/files/28144491/concurrentadmission.html)

Unit test code coverage Web hook
```
sigs.k8s.io/kueue/pkg/webhooks/clusterqueue_webhook.go (89.8%)
```
[cq_webhook_cover.html](https://github.com/user-attachments/files/28144594/cq_webhook_cover.html)


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
