### PR TITLE
Added retry for docker pull in e2e-common.sh

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -57,7 +57,33 @@ function e2e_docker_pull_if_needed {
         echo "Image '$image' already cached locally; skipping pull (E2E_MODE=dev, E2E_SKIP_IMAGE_RELOAD=true)"
         return 0
     fi
-    docker pull "$image"
+
+    local max_retries=5
+    local retry_delay=1
+    local attempt output
+    for attempt in $(seq 1 "$max_retries"); do
+        if output=$(docker pull "$image" 2>&1); then
+            echo "$output"
+            return 0
+        fi
+        echo "$output"
+
+        if echo "$output" | grep -qiE 'manifest (unknown|for .* not found)|repository does not exist|not found|pull access denied|unauthorized|denied: requested access|no space left on device'; then
+            echo "ERROR: docker pull '$image' failed with a non-retriable error."
+            return 1
+        fi
+
+        if [ "$attempt" -eq "$max_retries" ]; then
+            break
+        fi
+
+        echo "WARNING: docker pull '$image' failed (attempt $attempt/$max_retries). Retrying in ${retry_delay}s..."
+        sleep "$retry_delay"
+        retry_delay=$((retry_delay * 2))
+    done
+
+    echo "ERROR: Failed to pull '$image' after $max_retries attempts."
+    return 1
 }
 
 function e2e_deployment_exists {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->
/kind flake
/area testing
#### What this PR does / why we need it:

E2E runs occasionally fail due to transient `docker pull` errors (e.g. layer verification failures). 
This PR adds exponential backoff retry for `docker pull` in `e2e-common.sh`.

`docker pull` exits with status 1 for every failure regardless of cause, so a regex match against the error output detects non-retriable cases (missing manifest, auth denied, disk full) and skips retries for them.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:
Example of non-retriable error.
```bash
Error response from daemon: failed to resolve reference "quay.io/kuberay/operator:does-not-exist": quay.io/kuberay/operator:does-not-exist: not found
ERROR: docker pull 'quay.io/kuberay/operator:does-not-exist' failed with a non-retriable error.
```

Example for failed retry.
```bash
Error response from daemon: failed to resolve reference "intentionally.invalid.example.com/kuberay/operator:v1.6.1": failed to do request: Head "https://intentionally.invalid.example.com/v2/kuberay/operator/manifests/v1.6.1": dial tcp: lookup intentionally.invalid.example.com on 192.168.5.1:53: no such host
WARNING: docker pull 'intentionally.invalid.example.com/kuberay/operator:v1.6.1' failed (attempt 1/5). Retrying in 1s...
...
Error response from daemon: failed to resolve reference "intentionally.invalid.example.com/kuberay/operator:v1.6.1": failed to do request: Head "https://intentionally.invalid.example.com/v2/kuberay/operator/manifests/v1.6.1": dial tcp: lookup intentionally.invalid.example.com on 192.168.5.1:53: no such host
WARNING: docker pull 'intentionally.invalid.example.com/kuberay/operator:v1.6.1' failed (attempt 4/5). Retrying in 8s...
Error response from daemon: failed to resolve reference "intentionally.invalid.example.com/kuberay/operator:v1.6.1": failed to do request: Head "https://intentionally.invalid.example.com/v2/kuberay/operator/manifests/v1.6.1": dial tcp: lookup intentionally.invalid.example.com on 192.168.5.1:53: no such host
ERROR: Failed to pull 'intentionally.invalid.example.com/kuberay/operator:v1.6.1' after 5 attempts.
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```