### PR TITLE
Switch to using kind build node-image for e2e tests

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -43,6 +43,23 @@ export E2E_SKIP_IMAGE_RELOAD="${E2E_SKIP_IMAGE_RELOAD:-false}"
 
 export KIND_VERSION="${E2E_KIND_VERSION/"kindest/node:v"/}"
 
+function build_kind_node_image {
+    if [[ "$E2E_KIND_VERSION" != kindest/node:v* ]]; then
+        echo "Skipping kind node image build for non-standard image: $E2E_KIND_VERSION"
+        return 0
+    fi
+
+    E2E_KIND_VERSION="kueue/kind-node:v${KIND_VERSION}"
+
+    if [[ "${E2E_MODE}" == "dev" ]] && docker image inspect "$E2E_KIND_VERSION" &>/dev/null; then
+        echo "Reusing existing node image: $E2E_KIND_VERSION (E2E_MODE=dev)"
+        return 0
+    fi
+
+    echo "Building kind node image: $E2E_KIND_VERSION (K8s v$KIND_VERSION)"
+    $KIND build node-image "v$KIND_VERSION" --image "$E2E_KIND_VERSION"
+}
+
 function e2e_is_truthy {
     case "${1:-}" in
         1|true|TRUE|True|yes|YES|Yes|y|Y|on|ON|On) return 0 ;;

--- a/hack/testing/e2e-multikueue-test.sh
+++ b/hack/testing/e2e-multikueue-test.sh
@@ -90,7 +90,8 @@ function kueue_deploy {
 }
 
 trap cleanup EXIT
-startup 
+build_kind_node_image
+startup
 prepare_docker_images
 for job in $(jobs -p); do 
     wait "$job" || { echo "Cluster creation failed!"; exit 1; } 

--- a/hack/testing/e2e-test.sh
+++ b/hack/testing/e2e-test.sh
@@ -48,6 +48,7 @@ function startup {
 }
 
 trap cleanup EXIT
+build_kind_node_image
 startup &
 prepare_docker_images
 wait


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area testing

#### What this PR does / why we need it:

Switches e2e tests to build kind node images locally from K8s release
artifacts instead of pulling pre-built `kindest/node` images from
Docker Hub.

This adds a `build_kind_node_image` function in `e2e-common.sh` that
runs `kind build node-image v<version>` before cluster creation. The
command downloads release tarballs (does not compile K8s from source),
so the cost is comparable to pulling the pre-built image.

Behavior:
- Non-standard images (e.g. `k8s-main:latest`) are skipped since they
  have their own build targets
- In dev mode (`E2E_MODE=dev`), the build is skipped when the image
  already exists locally

#### Which issue(s) this PR fixes:

Fixes #11249

#### Special notes for your reviewer:

The existing `kind-k8s-main-image-build` Makefile target is unchanged
since it builds from CI artifacts, not releases.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

---
> **AI Assistance Disclosure**: This pull request was created with the assistance of AI (Claude Code by Anthropic).