### PR TITLE
Fix stale skillsaw path so moved skills stay linted

### DIFF
--- a/.skillsaw.yaml
+++ b/.skillsaw.yaml
@@ -187,7 +187,7 @@ exclude:
 
 # Additional markdown files to run content rules on (glob format)
 content-paths:
-  - cmd/experimental/agent/skills/**
+  - cmd/experimental/skills/**
 
 # Treat warnings as errors
 strict: true


### PR DESCRIPTION

#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:

issue
 the skills was moved from cmd/experimental/agent/skills/ to cmd/experimental/skills/, any skillsaw lint run that relies  on .skillsaw.yaml still used the old glob in content-paths.
 
The skills files were no longer matched by the lint config, so make verify-skills-lint or make skills-lint could silently miss problems in the moved  skills directory.
  

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
