### PR TITLE
test: remove unused test-e2e Makefile target

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -145,9 +145,6 @@ test-multikueue-integration: compile-crd-manifests envtest ginkgo dep-crds ginkg
 	$(GINKGO) $(INTEGRATION_FILTERS) $(GINKGO_ARGS) $(GOFLAGS) -procs=$(INTEGRATION_NPROCS_MULTIKUEUE) --race --junit-report=multikueue-junit.xml --json-report=multikueue-integration.json --output-interceptor-mode=none --output-dir=$(ARTIFACTS) -v $(INTEGRATION_TARGET_MULTIKUEUE)
 	$(BIN_DIR)/ginkgo-top -i $(ARTIFACTS)/multikueue-integration.json > $(ARTIFACTS)/multikueue-integration-top.yaml
 
-.PHONY: test-e2e
-test-e2e: test-e2e-baseline test-e2e-extended
-
 .PHONY: test-e2e-baseline-helm
 test-e2e-baseline-helm: E2E_USE_HELM=true
 test-e2e-baseline-helm: test-e2e-baseline


### PR DESCRIPTION
What type of PR is this:
/kind cleanup
/area testing

What this PR does / why we need it:

Removes the now-unused test-e2e Makefile target since test-e2e-baseline 
and test-e2e-extended are the only targets used after the singlecluster 
e2e split in #11138.

Which issue(s) this PR fixes:

Part of #10995

Special notes for your reviewer:

Follow-up cleanup after #11138 which split the singlecluster e2e tests 
into baseline and extended.

Does this PR introduce a user-facing change:

```release-note
NONE
```
