### PR TITLE
Automated cherry pick of #10990: Add reconnect backoff guardrail to suppress redundant cluster reconciles

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	inventoryv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
 	"sigs.k8s.io/cluster-inventory-api/pkg/credentials"
@@ -100,8 +101,11 @@ type remoteClient struct {
 	origin       string
 	adapters     map[string]jobframework.MultiKueueAdapter
 
-	connecting         atomic.Bool
-	failedConnAttempts uint
+	connecting           atomic.Bool
+	failedConnAttempts   uint
+	retryConnNextAttempt metav1.Time
+
+	clock clock.Clock
 
 	// For unit testing only. There is now need of creating fully functional remote clients in the unit tests
 	// and creating valid kubeconfig content is not trivial.
@@ -117,6 +121,7 @@ func newRemoteClient(localClient client.Client, wlUpdateCh, watchEndedCh chan<- 
 		localClient:  localClient,
 		origin:       origin,
 		adapters:     adapters,
+		clock:        clock.RealClock{},
 	}
 	rc.connecting.Store(true)
 	return rc
@@ -149,19 +154,39 @@ func (*workloadKueueWatcher) WorkloadKeyFor(o runtime.Object) (types.NamespacedN
 	return client.ObjectKeyFromObject(wl), nil
 }
 
+func (rc *remoteClient) resetFailedConnAttempt() {
+	rc.failedConnAttempts = 0
+	rc.retryConnNextAttempt = metav1.Time{}
+}
+
+func (rc *remoteClient) increaseFailedConnAttempt() *time.Duration {
+	rc.failedConnAttempts++
+	d := retryAfter(rc.failedConnAttempts)
+	rc.retryConnNextAttempt = metav1.NewTime(rc.clock.Now().Add(d))
+	return &d
+}
+
 // setConfig - will try to recreate the k8s client and restart watching if the new config is different than
 // the one currently used or a reconnect was requested.
 // If the encountered error is not permanent the duration after which a retry should be done is returned.
 func (rc *remoteClient) setConfig(watchCtx context.Context, config *clientConfig) (*time.Duration, error) {
 	configChanged := !equality.Semantic.DeepEqual(config, rc.config)
-	if !configChanged && !rc.connecting.Load() {
+	connecting := rc.connecting.Load()
+	if !configChanged && !connecting {
 		return nil, nil
 	}
 
 	rc.StopWatchers()
+
 	if configChanged {
 		rc.config = config
-		rc.failedConnAttempts = 0
+		rc.resetFailedConnAttempt()
+	}
+
+	if connecting {
+		if untilNextAttempt := rc.retryConnNextAttempt.Sub(rc.clock.Now()); untilNextAttempt > 0 {
+			return &untilNextAttempt, nil
+		}
 	}
 
 	builder := newClientWithWatch
@@ -178,8 +203,7 @@ func (rc *remoteClient) setConfig(watchCtx context.Context, config *clientConfig
 	watchCtx, rc.watchCancel = context.WithCancel(watchCtx)
 	err = rc.startWatcher(watchCtx, kueue.GroupVersion.WithKind("Workload").GroupKind().String(), &workloadKueueWatcher{})
 	if err != nil {
-		rc.failedConnAttempts++
-		return ptr.To(retryAfter(rc.failedConnAttempts)), err
+		return rc.increaseFailedConnAttempt(), err
 	}
 
 	// add a watch for all the adapters implementing multiKueueWatcher
@@ -193,13 +217,12 @@ func (rc *remoteClient) setConfig(watchCtx context.Context, config *clientConfig
 			// not being able to setup a watcher is not ideal but we can function with only the wl watcher.
 			ctrl.LoggerFrom(watchCtx).Error(err, "Unable to start the watcher", "kind", kind)
 			// however let's not accept this for now.
-			rc.failedConnAttempts++
-			return ptr.To(retryAfter(rc.failedConnAttempts)), err
+			return rc.increaseFailedConnAttempt(), err
 		}
 	}
 
 	rc.connecting.Store(false)
-	rc.failedConnAttempts = 0
+	rc.resetFailedConnAttempt()
 	return nil, nil
 }
 
@@ -421,6 +444,9 @@ func (c *clustersReconciler) setRemoteClientConfig(ctx context.Context, clusterN
 	if retryAfter, err := client.setConfig(clientCtx, config); err != nil {
 		ctrl.LoggerFrom(ctx).Error(err, "failed to set kubeConfig in the remote client")
 		return retryAfter, err
+	} else if retryAfter != nil {
+		ctrl.LoggerFrom(ctx).V(2).Info("reconnect deferred, backoff not elapsed", "retryAfter", retryAfter, "failedAttempts", client.failedConnAttempts)
+		return retryAfter, nil
 	}
 	return nil, nil
 }
@@ -471,6 +497,8 @@ func (c *clustersReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 		} else {
 			return reconcile.Result{RequeueAfter: ptr.Deref(retryAfter, 0)}, nil
 		}
+	} else if retryAfter != nil {
+		return reconcile.Result{RequeueAfter: ptr.Deref(retryAfter, 0)}, nil
 	}
 
 	return reconcile.Result{}, client.IgnoreNotFound(c.updateStatus(ctx, cluster, true, "Active", "Connected"))

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -38,6 +38,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/component-base/featuregate"
+	"k8s.io/utils/clock"
+	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	inventoryv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -88,6 +90,7 @@ func newTestClient(ctx context.Context, kubeconfig []byte, restConfig *rest.Conf
 		config:      &clientConfig{Kubeconfig: kubeconfig, RestConfig: restConfig},
 		localClient: localClient,
 		watchCancel: watchCancel,
+		clock:       clock.RealClock{},
 
 		builderOverride: fakeClientBuilder(ctx),
 	}
@@ -738,6 +741,116 @@ func TestUpdateConfig(t *testing.T) {
 					return true
 				})); diff != "" {
 				t.Errorf("unexpected controllers (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestReconnectBackoff(t *testing.T) {
+	now := time.Now()
+
+	type step struct {
+		advance            time.Duration
+		wantBuildCalls     int
+		wantFailedAttempts uint
+		wantRequeueAfter   time.Duration
+	}
+
+	cases := map[string]struct {
+		kubeconfig string
+		steps      []step
+	}{
+		"double reconcile within backoff window does not advance attempts": {
+			kubeconfig: testKubeconfig("nowatch"),
+			steps: []step{
+				{advance: 0, wantBuildCalls: 1, wantFailedAttempts: 1, wantRequeueAfter: 5 * time.Second},
+				{advance: 0, wantBuildCalls: 0, wantFailedAttempts: 1, wantRequeueAfter: 5 * time.Second},
+				{advance: 2 * time.Second, wantBuildCalls: 0, wantFailedAttempts: 1, wantRequeueAfter: 3 * time.Second},
+			},
+		},
+		"backoff progresses once window elapses": {
+			kubeconfig: testKubeconfig("nowatch"),
+			steps: []step{
+				{advance: 0, wantBuildCalls: 1, wantFailedAttempts: 1, wantRequeueAfter: 5 * time.Second},
+				{advance: 5 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 2, wantRequeueAfter: 10 * time.Second},
+				{advance: 10 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 3, wantRequeueAfter: 20 * time.Second},
+			},
+		},
+		"deferred reconciles between failures do not consume backoff slots": {
+			kubeconfig: testKubeconfig("nowatch"),
+			steps: []step{
+				{advance: 0, wantBuildCalls: 1, wantFailedAttempts: 1, wantRequeueAfter: 5 * time.Second},
+				{advance: 0, wantBuildCalls: 0, wantFailedAttempts: 1, wantRequeueAfter: 5 * time.Second},
+				{advance: 5 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 2, wantRequeueAfter: 10 * time.Second},
+				{advance: 0, wantBuildCalls: 0, wantFailedAttempts: 2, wantRequeueAfter: 10 * time.Second},
+				{advance: 10 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 3, wantRequeueAfter: 20 * time.Second},
+			},
+		},
+		"backoff saturates at retryMaxSteps": {
+			kubeconfig: testKubeconfig("nowatch"),
+			steps: []step{
+				{advance: 0, wantBuildCalls: 1, wantFailedAttempts: 1, wantRequeueAfter: 5 * time.Second},
+				{advance: 5 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 2, wantRequeueAfter: 10 * time.Second},
+				{advance: 10 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 3, wantRequeueAfter: 20 * time.Second},
+				{advance: 20 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 4, wantRequeueAfter: 40 * time.Second},
+				{advance: 40 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 5, wantRequeueAfter: 80 * time.Second},
+				{advance: 80 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 6, wantRequeueAfter: 160 * time.Second},
+				{advance: 160 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 7, wantRequeueAfter: 320 * time.Second},
+				{advance: 320 * time.Second, wantBuildCalls: 1, wantFailedAttempts: 8, wantRequeueAfter: 320 * time.Second},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			fc := testingclock.NewFakeClock(now)
+
+			cluster := utiltestingapi.MakeMultiKueueCluster("worker1").
+				KubeConfig(kueue.SecretLocationType, "worker1").
+				Generation(1).
+				Obj()
+			secret := makeTestSecret("worker1", tc.kubeconfig)
+
+			builder := getClientBuilder(ctx)
+			builder = builder.WithObjects(cluster, &secret)
+			builder = builder.WithStatusSubresource(&kueue.MultiKueueCluster{})
+			c := builder.Build()
+
+			adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
+			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileCreds{}, nil)
+			reconciler.rootContext = ctx
+
+			var buildCalls int
+			inner := fakeClientBuilder(ctx)
+			reconciler.builderOverride = func(cfg *clientConfig, opts client.Options) (client.WithWatch, error) {
+				buildCalls++
+				return inner(cfg, opts)
+			}
+
+			rc := newRemoteClient(c, reconciler.wlUpdateCh, reconciler.watchEndedCh, defaultOrigin, "worker1", adapters)
+			rc.clock = fc
+			rc.builderOverride = reconciler.builderOverride
+			reconciler.remoteClients["worker1"] = rc
+
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "worker1"}}
+
+			for i, s := range tc.steps {
+				fc.Step(s.advance)
+				before := buildCalls
+				res, err := reconciler.Reconcile(ctx, req)
+				if err != nil {
+					t.Fatalf("step %d: unexpected reconcile error: %v", i, err)
+				}
+				if got := buildCalls - before; got != s.wantBuildCalls {
+					t.Errorf("step %d: builder invocations: want %d, got %d", i, s.wantBuildCalls, got)
+				}
+				if rc.failedConnAttempts != s.wantFailedAttempts {
+					t.Errorf("step %d: failedConnAttempts: want %d, got %d", i, s.wantFailedAttempts, rc.failedConnAttempts)
+				}
+				if res.RequeueAfter != s.wantRequeueAfter {
+					t.Errorf("step %d: RequeueAfter: want %v, got %v", i, s.wantRequeueAfter, res.RequeueAfter)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Cherry pick of #10990 on release-0.16.

#10990: Add reconnect backoff guardrail to suppress redundant cluster reconciles

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
MultiKueue: Add reconnect backoff guardrail to suppress redundant cluster reconciles for the MultiKueueCluster reconciler.
```