### PR TITLE
Make the read-only contract on Snapshot explicit

### DIFF
--- a/pkg/cache/scheduler/snapshot.go
+++ b/pkg/cache/scheduler/snapshot.go
@@ -38,6 +38,14 @@ import (
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
+type inactiveCQReason string
+
+const (
+	inactiveCQReasonNotActive         inactiveCQReason = "NotActive"
+	inactiveCQReasonHasCycle          inactiveCQReason = "HasCycle"
+	inactiveCQReasonTASUsageNotSynced inactiveCQReason = "TASUsageNotSynced"
+)
+
 type Snapshot struct {
 	hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]
 	ResourceFlavors          map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor
@@ -176,12 +184,11 @@ func (c *Cache) Snapshot(ctx context.Context, options ...SnapshotOption) (*Snaps
 	log := ctrl.LoggerFrom(ctx)
 	cqNames := c.hm.ClusterQueues()
 	for _, cq := range cqNames {
-		if !cq.Active() || (cq.HasParent() && hierarchy.HasCycle(cq.Parent())) {
+		if reason := skipInactiveCQReason(cq); reason != "" {
+			log.V(3).Info("Skipping ClusterQueue", "clusterQueue", cq.Name, "reason", reason)
 			snap.InactiveClusterQueueSets.Insert(cq.Name)
 			continue
 		}
-		// ensure all workloads are accounted for TAS before building TAS snapshots
-		cq.ensureTASIsSynced(log)
 	}
 	tasSnapshots := make(map[kueue.ResourceFlavorReference]*TASFlavorSnapshot)
 	if features.Enabled(features.TopologyAwareScheduling) {
@@ -212,6 +219,23 @@ func (c *Cache) Snapshot(ctx context.Context, options ...SnapshotOption) (*Snaps
 	// Shallow copy is enough
 	maps.Copy(snap.ResourceFlavors, c.resourceFlavors)
 	return &snap, nil
+}
+
+// skipInactiveCQReason reports why the CQ should not be considered for
+// admitting workloads in this scheduler snapshot. If the CQ can be considered,
+// an empty reason is returned.
+func skipInactiveCQReason(cq *clusterQueue) inactiveCQReason {
+	if !cq.Active() {
+		return inactiveCQReasonNotActive
+	}
+	if cq.HasParent() && hierarchy.HasCycle(cq.Parent()) {
+		return inactiveCQReasonHasCycle
+	}
+	if features.Enabled(features.TopologyAwareScheduling) && len(cq.tasFlavors) > 0 && !cq.isTASSynced {
+		// The CQ uses a TAS flavor, but TAS usage is not synced yet.
+		return inactiveCQReasonTASUsageNotSynced
+	}
+	return ""
 }
 
 // snapshotClusterQueue creates a copy of ClusterQueue that includes

--- a/pkg/cache/scheduler/snapshot_test.go
+++ b/pkg/cache/scheduler/snapshot_test.go
@@ -51,6 +51,7 @@ func TestSnapshot(t *testing.T) {
 		cqs          []*kueue.ClusterQueue
 		cohorts      []*kueue.Cohort
 		rfs          []*kueue.ResourceFlavor
+		topologies   []*kueue.Topology
 		wls          []*kueue.Workload
 		wantSnapshot Snapshot
 	}{
@@ -768,6 +769,90 @@ func TestSnapshot(t *testing.T) {
 				),
 			},
 		},
+		"clusterQueue with unsynced TAS usage (due to missing topology) is excluded from snapshot": {
+			cqs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("tas-cq").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("tas-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj(),
+			},
+			rfs: []*kueue.ResourceFlavor{
+				utiltestingapi.MakeResourceFlavor("tas-flavor").
+					TopologyName("missing-topology").
+					Obj(),
+			},
+			wantSnapshot: Snapshot{
+				Manager: hierarchy.NewManagerForTest(
+					map[kueue.CohortReference]*CohortSnapshot{},
+					map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{},
+				),
+				InactiveClusterQueueSets: sets.New[kueue.ClusterQueueReference]("tas-cq"),
+				ResourceFlavors: map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
+					"tas-flavor": utiltestingapi.MakeResourceFlavor("tas-flavor").
+						TopologyName("missing-topology").
+						Obj(),
+				},
+			},
+		},
+		"clusterQueue with synced TAS usage is included in snapshot": {
+			cqs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("tas-cq").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("tas-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj(),
+			},
+			rfs: []*kueue.ResourceFlavor{
+				utiltestingapi.MakeResourceFlavor("tas-flavor").
+					TopologyName("topology").
+					Obj(),
+			},
+			topologies: []*kueue.Topology{
+				utiltestingapi.MakeDefaultOneLevelTopology("topology"),
+			},
+			wantSnapshot: Snapshot{
+				Manager: hierarchy.NewManagerForTest(
+					map[kueue.CohortReference]*CohortSnapshot{},
+					map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
+						"tas-cq": {
+							Name:                          "tas-cq",
+							AllocatableResourceGeneration: 2,
+							ResourceGroups: []ResourceGroup{
+								{
+									CoveredResources: sets.New(corev1.ResourceCPU),
+									Flavors:          []kueue.ResourceFlavorReference{"tas-flavor"},
+								},
+							},
+							ResourceNode: resourceNode{
+								Quotas: map[resources.FlavorResource]ResourceQuota{
+									{Flavor: "tas-flavor", Resource: corev1.ResourceCPU}: {
+										Nominal: 100_000,
+									},
+								},
+								SubtreeQuota: resources.FlavorResourceQuantities{
+									{Flavor: "tas-flavor", Resource: corev1.ResourceCPU}: 100_000,
+								},
+							},
+							FlavorFungibility: defaultFlavorFungibility,
+							Preemption:        defaultPreemption,
+							FairWeight:        defaultWeight,
+							NamespaceSelector: labels.Everything(),
+							Status:            active,
+						},
+					},
+				),
+				ResourceFlavors: map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
+					"tas-flavor": utiltestingapi.MakeResourceFlavor("tas-flavor").
+						TopologyName("topology").
+						Obj(),
+				},
+			},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -786,6 +871,9 @@ func TestSnapshot(t *testing.T) {
 			}
 			for _, rf := range tc.rfs {
 				cache.AddOrUpdateResourceFlavor(log, rf)
+			}
+			for _, topology := range tc.topologies {
+				cache.AddOrUpdateTopology(log, topology)
 			}
 			for _, wl := range tc.wls {
 				cache.AddOrUpdateWorkload(log, wl)


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Snapshot() is conceptually a read-only operation, but the current implementation calls a mutating helper, which makes the locking correctness very hard to reason about. To make the intended contract explicit, I am proposing this PR: Snapshot() no longer tries to repair TAS usage; instead, it skips TAS ClusterQueues whose TAS usage is not synced yet. The cache update paths remain responsible for performing TAS sync under the cache write lock.




#### Special notes for your reviewer:

I’ve analyzed this case, and I think this is a false-positive bug detection from the system-level perspective.

The concern is valid locally: `Snapshot()` currently calls `ensureTASIsSynced()` while holding only the cache read lock, and `ensureTASIsSynced()` is a mutating helper. 

However, due to the interaction between the scheduler cache update paths and the controllers, `ensureTASIsSynced()` called from Scheduler does not perform the mutating repair.

The problematic state would be:

```
cq.isTASInitialized() == true
cq.isTASSynced == false
```

This is the only state where `ensureTASIsSynced()` would perform the mutating repair path and re-account existing workloads for TAS usage.

When a Topology is added or updated, the scheduler cache handles it under the cache write lock:
```
Cache.AddOrUpdateTopology
  -> Cache.Lock()
  -> tasCache.AddTopology(...)
  -> updateClusterQueues(...)
      -> cq.UpdateWithFlavors(...)
          -> cq.updateQueueStatus(...)
              -> cq.ensureTASIsSynced(...)
  -> Cache.Unlock()
```

The same applies when a ResourceFlavor is added or updated:
```
Cache.AddOrUpdateResourceFlavor
  -> Cache.Lock()
  -> tasCache.AddResourceFlavor(...)
  -> updateClusterQueues(...)
      -> cq.UpdateWithFlavors(...)
          -> cq.updateQueueStatus(...)
              -> cq.ensureTASIsSynced(...)
  -> Cache.Unlock()
```

So if adding or updating the Topology or ResourceFlavor makes TAS usage sync performed under the cache write lock, blocking `Snapshot()` which needs to take the read lock.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: ensure that `Snapshot()` does not perform update the list of workloads under the read-lock.
```
