### PR TITLE
Automated cherry pick of #10931: Ensure featureGates passed by the user are validated

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	autoscaling "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"k8s.io/client-go/discovery"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -153,21 +152,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := config.ValidateFeatureGates(featureGates, cfg.FeatureGates).ToAggregate(); err != nil {
+	if err := config.LoadAndValidateFeatureGates(featureGates, cfg.FeatureGates).ToAggregate(); err != nil {
 		setupLog.Error(err, "conflicting feature gates detected")
 		os.Exit(1)
-	}
-
-	if featureGates != "" {
-		if err := utilfeature.DefaultMutableFeatureGate.Set(featureGates); err != nil {
-			setupLog.Error(err, "Unable to set flag gates for known features")
-			os.Exit(1)
-		}
-	} else {
-		if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(cfg.FeatureGates); err != nil {
-			setupLog.Error(err, "Unable to set flag gates for known features")
-			os.Exit(1)
-		}
 	}
 
 	setupLog.Info("Initializing", "gitVersion", version.GitVersion, "gitCommit", version.GitCommit, "buildDate", version.BuildDate)

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	apimachineryutilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -500,7 +501,16 @@ func validateManagedJobsNamespaceSelector(c *configapi.Configuration) field.Erro
 	return allErrs
 }
 
-func ValidateFeatureGates(featureGateCLI string, featureGateMap map[string]bool) field.ErrorList {
+func LoadAndValidateFeatureGates(featureGateCLI string, featureGateMap map[string]bool) field.ErrorList {
+	if featureGateCLI != "" {
+		if err := utilfeature.DefaultMutableFeatureGate.Set(featureGateCLI); err != nil {
+			return field.ErrorList{field.Invalid(featureGatesPath, featureGateCLI, err.Error())}
+		}
+	} else {
+		if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(featureGateMap); err != nil {
+			return field.ErrorList{field.Invalid(featureGatesPath, featureGateMap, err.Error())}
+		}
+	}
 	var allErrs field.ErrorList
 	if featureGateCLI != "" && featureGateMap != nil {
 		allErrs = append(allErrs, field.Invalid(featureGatesPath, featureGateMap, "feature gates for CLI and configuration cannot both specified"))

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1016,22 +1016,30 @@ func TestValidate(t *testing.T) {
 	}
 }
 
-func TestValidateFeatureGates(t *testing.T) {
+func TestLoadAndValidateFeatureGates(t *testing.T) {
 	cases := map[string]struct {
 		featureGatesCLI string
 		featureGateMap  map[string]bool
-		featureGates    map[featuregate.Feature]bool
+		gatesToRestore  map[featuregate.Feature]bool
 		wantErr         field.ErrorList
 	}{
 		"no feature gates is null": {
 			featureGatesCLI: "",
 		},
 		"feature gate cli": {
-			featureGatesCLI: "test:true",
+			featureGatesCLI: string(features.DynamicResourceAllocation) + "=false",
+			gatesToRestore: map[featuregate.Feature]bool{
+				features.DynamicResourceAllocation: false,
+			},
 		},
 		"cannot specify both feature gates": {
-			featureGatesCLI: "test:true",
-			featureGateMap:  map[string]bool{"test": true},
+			featureGatesCLI: string(features.DynamicResourceAllocation) + "=false",
+			featureGateMap: map[string]bool{
+				string(features.DynamicResourceAllocation): false,
+			},
+			gatesToRestore: map[featuregate.Feature]bool{
+				features.DynamicResourceAllocation: false,
+			},
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:   field.ErrorTypeInvalid,
@@ -1041,9 +1049,13 @@ func TestValidateFeatureGates(t *testing.T) {
 			},
 		},
 		"cannot set TAS profile with TAS disabled": {
-			featureGates: map[featuregate.Feature]bool{
-				features.TASProfileMixed:         true,
-				features.TopologyAwareScheduling: false,
+			featureGateMap: map[string]bool{
+				string(features.TASProfileMixed):         true,
+				string(features.TopologyAwareScheduling): false,
+			},
+			gatesToRestore: map[featuregate.Feature]bool{
+				features.TASProfileMixed:         false,
+				features.TopologyAwareScheduling: true,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1054,11 +1066,17 @@ func TestValidateFeatureGates(t *testing.T) {
 			},
 		},
 		"ElasticJobsViaWorkloadSlicesWithTAS requires ElasticJobsViaWorkloadSlices": {
-			featureGates: map[featuregate.Feature]bool{
-				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
-				features.TopologyAwareScheduling:             true,
-				features.ElasticJobsViaWorkloadSlices:        false,
-				features.TASProfileMixed:                     false,
+			featureGateMap: map[string]bool{
+				string(features.ElasticJobsViaWorkloadSlicesWithTAS): true,
+				string(features.TopologyAwareScheduling):             true,
+				string(features.ElasticJobsViaWorkloadSlices):        false,
+				string(features.TASProfileMixed):                     false,
+			},
+			gatesToRestore: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlicesWithTAS: false,
+				features.TopologyAwareScheduling:             false,
+				features.ElasticJobsViaWorkloadSlices:        true,
+				features.TASProfileMixed:                     true,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1069,11 +1087,17 @@ func TestValidateFeatureGates(t *testing.T) {
 			},
 		},
 		"ElasticJobsViaWorkloadSlicesWithTAS requires TopologyAwareScheduling": {
-			featureGates: map[featuregate.Feature]bool{
-				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
-				features.ElasticJobsViaWorkloadSlices:        true,
-				features.TopologyAwareScheduling:             false,
-				features.TASProfileMixed:                     false,
+			featureGateMap: map[string]bool{
+				string(features.ElasticJobsViaWorkloadSlicesWithTAS): true,
+				string(features.ElasticJobsViaWorkloadSlices):        true,
+				string(features.TopologyAwareScheduling):             false,
+				string(features.TASProfileMixed):                     false,
+			},
+			gatesToRestore: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlicesWithTAS: false,
+				features.ElasticJobsViaWorkloadSlices:        false,
+				features.TopologyAwareScheduling:             true,
+				features.TASProfileMixed:                     true,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1084,19 +1108,31 @@ func TestValidateFeatureGates(t *testing.T) {
 			},
 		},
 		"ElasticJobsViaWorkloadSlicesWithTAS valid when all dependencies enabled": {
-			featureGates: map[featuregate.Feature]bool{
-				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
-				features.ElasticJobsViaWorkloadSlices:        true,
-				features.TopologyAwareScheduling:             true,
-				features.TASProfileMixed:                     false,
+			featureGateMap: map[string]bool{
+				string(features.ElasticJobsViaWorkloadSlicesWithTAS): true,
+				string(features.ElasticJobsViaWorkloadSlices):        true,
+				string(features.TopologyAwareScheduling):             true,
+				string(features.TASProfileMixed):                     false,
+			},
+			gatesToRestore: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlicesWithTAS: false,
+				features.ElasticJobsViaWorkloadSlices:        false,
+				features.TopologyAwareScheduling:             false,
+				features.TASProfileMixed:                     true,
 			},
 		},
 		"multiple FG validation errors at once": {
-			featureGates: map[featuregate.Feature]bool{
-				features.TASProfileMixed:                     true,
-				features.TopologyAwareScheduling:             false,
-				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
-				features.ElasticJobsViaWorkloadSlices:        false,
+			featureGateMap: map[string]bool{
+				string(features.TASProfileMixed):                     true,
+				string(features.TopologyAwareScheduling):             false,
+				string(features.ElasticJobsViaWorkloadSlicesWithTAS): true,
+				string(features.ElasticJobsViaWorkloadSlices):        false,
+			},
+			gatesToRestore: map[featuregate.Feature]bool{
+				features.TASProfileMixed:                     false,
+				features.TopologyAwareScheduling:             true,
+				features.ElasticJobsViaWorkloadSlicesWithTAS: false,
+				features.ElasticJobsViaWorkloadSlices:        true,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1117,9 +1153,13 @@ func TestValidateFeatureGates(t *testing.T) {
 			},
 		},
 		"DRAExtendedResources requires DynamicResourceAllocation": {
-			featureGates: map[featuregate.Feature]bool{
-				features.DRAExtendedResources:      true,
-				features.DynamicResourceAllocation: false,
+			featureGateMap: map[string]bool{
+				string(features.DRAExtendedResources):      true,
+				string(features.DynamicResourceAllocation): false,
+			},
+			gatesToRestore: map[featuregate.Feature]bool{
+				features.DRAExtendedResources:      false,
+				features.DynamicResourceAllocation: true,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1132,11 +1172,11 @@ func TestValidateFeatureGates(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			// Set up feature gates for this test
-			features.SetFeatureGatesDuringTest(t, tc.featureGates)
-			got := ValidateFeatureGates(tc.featureGatesCLI, tc.featureGateMap)
+			// Ensure clean up is registered for the feature gates to their default values
+			features.SetFeatureGatesDuringTest(t, tc.gatesToRestore)
+			got := LoadAndValidateFeatureGates(tc.featureGatesCLI, tc.featureGateMap)
 			if diff := cmp.Diff(tc.wantErr, got, cmpopts.IgnoreFields(field.Error{}, "BadValue")); diff != "" {
-				t.Errorf("Unexpected result from ValidateFeatureGates (-want,+got):\n%s", diff)
+				t.Errorf("Unexpected result from LoadAndValidateFeatureGates (-want,+got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Cherry pick of #10931 on release-0.17.

#10931: Ensure featureGates passed by the user are validated

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note
FeatureGates: Fixed a bug that user-specified feature gate parameters are not verified.
```