### PR TITLE
Automated cherry pick of #10931: Ensure featureGates passed by the user are validated

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	autoscaling "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"k8s.io/client-go/discovery"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -146,21 +145,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := config.ValidateFeatureGates(featureGates, cfg.FeatureGates); err != nil {
+	if err := config.LoadAndValidateFeatureGates(featureGates, cfg.FeatureGates); err != nil {
 		setupLog.Error(err, "conflicting feature gates detected")
 		os.Exit(1)
-	}
-
-	if featureGates != "" {
-		if err := utilfeature.DefaultMutableFeatureGate.Set(featureGates); err != nil {
-			setupLog.Error(err, "Unable to set flag gates for known features")
-			os.Exit(1)
-		}
-	} else {
-		if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(cfg.FeatureGates); err != nil {
-			setupLog.Error(err, "Unable to set flag gates for known features")
-			os.Exit(1)
-		}
 	}
 
 	setupLog.Info("Initializing", "gitVersion", version.GitVersion, "gitCommit", version.GitCommit, "buildDate", version.BuildDate)

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	apimachineryutilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -492,7 +493,16 @@ func validateManagedJobsNamespaceSelector(c *configapi.Configuration) field.Erro
 	return allErrs
 }
 
-func ValidateFeatureGates(featureGateCLI string, featureGateMap map[string]bool) error {
+func LoadAndValidateFeatureGates(featureGateCLI string, featureGateMap map[string]bool) error {
+	if featureGateCLI != "" {
+		if err := utilfeature.DefaultMutableFeatureGate.Set(featureGateCLI); err != nil {
+			return err
+		}
+	} else {
+		if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(featureGateMap); err != nil {
+			return err
+		}
+	}
 	if featureGateCLI != "" && featureGateMap != nil {
 		return errors.New("feature gates for CLI and configuration cannot both specified")
 	}

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -30,9 +30,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 )
 
 func TestValidate(t *testing.T) {
@@ -970,10 +972,11 @@ func TestValidate(t *testing.T) {
 	}
 }
 
-func TestValidateFeatureGates(t *testing.T) {
+func TestLoadAndValidateFeatureGates(t *testing.T) {
 	cases := map[string]struct {
 		featureGatesCLI string
 		featureGateMap  map[string]bool
+		gatesToRestore  map[featuregate.Feature]bool
 		errorStr        string
 	}{
 		"no feature gates is null": {
@@ -982,33 +985,57 @@ func TestValidateFeatureGates(t *testing.T) {
 			errorStr:        "",
 		},
 		"feature gate cli": {
-			featureGatesCLI: "test:true",
-			featureGateMap:  nil,
-			errorStr:        "",
+			featureGatesCLI: string(features.DynamicResourceAllocation) + "=false",
+			gatesToRestore: map[featuregate.Feature]bool{
+				features.DynamicResourceAllocation: false,
+			},
 		},
 		"cannot specify both feature gates": {
-			featureGatesCLI: "test:true",
-			featureGateMap:  map[string]bool{"test": true},
-
+			featureGatesCLI: string(features.DynamicResourceAllocation) + "=false",
+			featureGateMap: map[string]bool{
+				string(features.DynamicResourceAllocation): false,
+			},
+			gatesToRestore: map[featuregate.Feature]bool{
+				features.DynamicResourceAllocation: false,
+			},
 			errorStr: "feature gates for CLI and configuration cannot both specified",
 		},
 		"cannot specify more than one TAS profile using GateMap": {
 			featureGateMap: map[string]bool{"TASProfileMixed": true,
 				"TASProfileLeastFreeCapacity": true},
-			errorStr: "Cannot use more than one TAS profiles",
+			gatesToRestore: map[featuregate.Feature]bool{
+				features.TASProfileMixed:             true,
+				features.TASProfileLeastFreeCapacity: false,
+			},
+			errorStr: "cannot use more than one TAS profiles",
 		},
 		"cannot specify more than one TAS profile using GatesCLI": {
-			featureGatesCLI: "TASProfileLeastFreeCapacity:true,TASProfileMixed:true",
-			errorStr:        "Cannot use more than one TAS profiles",
+			featureGatesCLI: "TASProfileLeastFreeCapacity=true,TASProfileMixed=true",
+			gatesToRestore: map[featuregate.Feature]bool{
+				features.TASProfileLeastFreeCapacity: false,
+				features.TASProfileMixed:             true,
+			},
+			errorStr: "cannot use more than one TAS profiles",
 		},
 		"cannot set TAS profile with TAS disabled": {
-			featureGateMap: map[string]bool{"TASProfileLeastFreeCapacity": true},
-			errorStr:       "Cannot use a TAS profile with TAS disabled",
+			featureGateMap: map[string]bool{
+				string(features.TASProfileLeastFreeCapacity): true,
+				string(features.TASProfileMixed):             false,
+				string(features.TopologyAwareScheduling):     false,
+			},
+			gatesToRestore: map[featuregate.Feature]bool{
+				features.TASProfileLeastFreeCapacity: false,
+				features.TASProfileMixed:             true,
+				features.TopologyAwareScheduling:     true,
+			},
+			errorStr: "cannot use a TAS profile with TAS disabled",
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := ValidateFeatureGates(tc.featureGatesCLI, tc.featureGateMap)
+			// Ensure clean up is registered for the feature gates to their default values
+			features.SetFeatureGatesDuringTest(t, tc.gatesToRestore)
+			got := LoadAndValidateFeatureGates(tc.featureGatesCLI, tc.featureGateMap)
 			if got != nil && tc.errorStr != got.Error() {
 				t.Errorf("Unexpected result from ValidateFeatureGates\nwant:\n%v\ngot:%v\n", tc.errorStr, got.Error())
 			}


### PR DESCRIPTION
Cherry pick of #10931 on release-0.16.

#10931: Ensure featureGates passed by the user are validated

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
FeatureGates: Fixed a bug that user-specified feature gate parameters are not verified.
```