### PR TITLE
MultiKueue: detect a hung remote in 1 minute, not 10

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -64,6 +64,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
+	utilwait "sigs.k8s.io/kueue/pkg/util/wait"
 )
 
 const (
@@ -78,13 +79,14 @@ const (
 	// covers the apiserver cold cache + conversion warmup path documented in
 	// kubernetes/kubernetes#136950 (~8 min at 50k Workloads). v1beta2 does
 	// not exercise that path today; the cap is a guard. See #11206.
-	initialEstablishTimeout  = 1 * time.Minute
-	maxEstablishTimeout      = 10 * time.Minute
-	establishTimeoutMaxSteps = 4
+	initialEstablishTimeout = 1 * time.Minute
+	maxEstablishTimeout     = 10 * time.Minute
 )
 
 var (
 	errWatchEstablishTimeout = errors.New("watch establishment timed out")
+
+	establishBackoff = utilwait.NewBackoff(initialEstablishTimeout, maxEstablishTimeout, 2, 0)
 )
 
 // retryAfter returns an exponentially increasing interval between
@@ -94,16 +96,6 @@ func retryAfter(failedAttempts uint) time.Duration {
 		return 0
 	}
 	return (1 << (min(failedAttempts, retryMaxSteps) - 1)) * retryIncrement
-}
-
-// establishTimeoutFor doubles initialEstablishTimeout per failure, capped at
-// maxEstablishTimeout. Schedule: 1m, 2m, 4m, 8m, 10m, 10m, ...
-func establishTimeoutFor(failedAttempts uint) time.Duration {
-	t := initialEstablishTimeout << min(failedAttempts, establishTimeoutMaxSteps)
-	if t > maxEstablishTimeout {
-		return maxEstablishTimeout
-	}
-	return t
 }
 
 type clientWithWatchBuilder func(config *clientConfig, options client.Options) (client.WithWatch, error)
@@ -300,7 +292,7 @@ func establishWatch(ctx context.Context, c client.WithWatch, obj client.ObjectLi
 
 func (rc *remoteClient) startWatcher(ctx context.Context, kind string, w jobframework.MultiKueueWatcher) error {
 	log := ctrl.LoggerFrom(ctx).WithValues("watchKind", kind)
-	newWatcher, err := establishWatch(ctx, rc.client, w.GetEmptyList(), rc.origin, establishTimeoutFor(rc.failedConnAttempts))
+	newWatcher, err := establishWatch(ctx, rc.client, w.GetEmptyList(), rc.origin, establishBackoff.WaitTime(int(rc.failedConnAttempts)+1))
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -73,26 +73,17 @@ const (
 	retryIncrement = 5 * time.Second
 	retryMaxSteps  = 7
 
-	// Bounds how long startWatcher waits for client.Watch() to return,
-	// so a hung remote cannot head-of-line block the reconciler. See #11206.
-	//
-	// The bound has to cover the slowest legitimate case, not just the common
-	// one. client.Watch() returns as soon as the apiserver sends HTTP 200
-	// headers, but the apiserver can delay sending those headers while it
-	// warms its watch cache. When the served version differs from the storage
-	// version and a conversion webhook is in play, that warmup serializes a
-	// per-object conversion and has been observed to take ~8 min at ~50k
-	// Workloads (kubernetes/kubernetes#136950). 10 min leaves headroom above
-	// the documented worst case while still ringing the alarm on a remote
-	// that is truly hung. Today Kueue's served and storage versions match
-	// (v1beta2), so the warmup path is not exercised, but we keep the
-	// generous bound as a guard against future version skew and unknown
-	// apiserver behavior.
-	defaultWatchEstablishTimeout = 10 * time.Minute
+	// Bounds how long startWatcher waits for client.Watch(). The schedule
+	// (1m, 2m, 4m, 8m, 10m, ...) catches hung remotes quickly while the cap
+	// covers the apiserver cold cache + conversion warmup path documented in
+	// kubernetes/kubernetes#136950 (~8 min at 50k Workloads). v1beta2 does
+	// not exercise that path today; the cap is a guard. See #11206.
+	initialEstablishTimeout  = 1 * time.Minute
+	maxEstablishTimeout      = 10 * time.Minute
+	establishTimeoutMaxSteps = 4
 )
 
 var (
-	watchEstablishTimeout    = defaultWatchEstablishTimeout
 	errWatchEstablishTimeout = errors.New("watch establishment timed out")
 )
 
@@ -103,6 +94,16 @@ func retryAfter(failedAttempts uint) time.Duration {
 		return 0
 	}
 	return (1 << (min(failedAttempts, retryMaxSteps) - 1)) * retryIncrement
+}
+
+// establishTimeoutFor doubles initialEstablishTimeout per failure, capped at
+// maxEstablishTimeout. Schedule: 1m, 2m, 4m, 8m, 10m, 10m, ...
+func establishTimeoutFor(failedAttempts uint) time.Duration {
+	t := initialEstablishTimeout << min(failedAttempts, establishTimeoutMaxSteps)
+	if t > maxEstablishTimeout {
+		return maxEstablishTimeout
+	}
+	return t
 }
 
 type clientWithWatchBuilder func(config *clientConfig, options client.Options) (client.WithWatch, error)
@@ -261,11 +262,11 @@ func (cw *cancelOnStopWatcher) Stop() {
 	cw.cancel()
 }
 
-// establishWatch opens a MultiKueue remote watch, bounded by
-// watchEstablishTimeout. On timeout the in-flight Watch is canceled and
+// establishWatch opens a MultiKueue remote watch, bounded by the given
+// timeout. On timeout the in-flight Watch is canceled and
 // errWatchEstablishTimeout is returned so the caller falls back to the
 // standard failedConnAttempts / retryAfter backoff in setConfig.
-func establishWatch(ctx context.Context, c client.WithWatch, obj client.ObjectList, origin string) (watch.Interface, error) {
+func establishWatch(ctx context.Context, c client.WithWatch, obj client.ObjectList, origin string, timeout time.Duration) (watch.Interface, error) {
 	type result struct {
 		w   watch.Interface
 		err error
@@ -288,7 +289,7 @@ func establishWatch(ctx context.Context, c client.WithWatch, obj client.ObjectLi
 			return nil, r.err
 		}
 		return &cancelOnStopWatcher{Interface: r.w, cancel: cancel}, nil
-	case <-time.After(watchEstablishTimeout):
+	case <-time.After(timeout):
 		cancel()
 		if r := <-resultCh; r.w != nil {
 			r.w.Stop()
@@ -299,7 +300,7 @@ func establishWatch(ctx context.Context, c client.WithWatch, obj client.ObjectLi
 
 func (rc *remoteClient) startWatcher(ctx context.Context, kind string, w jobframework.MultiKueueWatcher) error {
 	log := ctrl.LoggerFrom(ctx).WithValues("watchKind", kind)
-	newWatcher, err := establishWatch(ctx, rc.client, w.GetEmptyList(), rc.origin)
+	newWatcher, err := establishWatch(ctx, rc.client, w.GetEmptyList(), rc.origin, establishTimeoutFor(rc.failedConnAttempts))
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -1164,10 +1164,7 @@ func TestClustersReconcilerEventFilters(t *testing.T) {
 func TestEstablishWatch(t *testing.T) {
 	ctx, _ := utiltesting.ContextWithLog(t)
 
-	prev := watchEstablishTimeout
-	watchEstablishTimeout = 100 * time.Millisecond
-	t.Cleanup(func() { watchEstablishTimeout = prev })
-
+	const testTimeout = 100 * time.Millisecond
 	errBoom := errors.New("boom")
 
 	cases := map[string]struct {
@@ -1183,7 +1180,7 @@ func TestEstablishWatch(t *testing.T) {
 				},
 			},
 			wantErr:    errWatchEstablishTimeout,
-			maxElapsed: 10 * watchEstablishTimeout,
+			maxElapsed: 10 * testTimeout,
 		},
 		"Watch error propagates": {
 			interceptor: interceptor.Funcs{
@@ -1194,7 +1191,7 @@ func TestEstablishWatch(t *testing.T) {
 			wantErr: errBoom,
 		},
 		"success returns without waiting": {
-			maxElapsed: watchEstablishTimeout,
+			maxElapsed: testTimeout,
 		},
 	}
 
@@ -1203,7 +1200,7 @@ func TestEstablishWatch(t *testing.T) {
 			c := getClientBuilder(ctx).WithInterceptorFuncs(tc.interceptor).Build()
 
 			start := time.Now()
-			w, err := establishWatch(ctx, c, &kueue.WorkloadList{}, "test-origin")
+			w, err := establishWatch(ctx, c, &kueue.WorkloadList{}, "test-origin", testTimeout)
 			elapsed := time.Since(start)
 
 			if !errors.Is(err, tc.wantErr) {
@@ -1227,12 +1224,12 @@ func TestEstablishWatch(t *testing.T) {
 		fw := watch.NewFake()
 		c := getClientBuilder(ctx).WithInterceptorFuncs(interceptor.Funcs{
 			Watch: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) (watch.Interface, error) {
-				time.Sleep(2 * watchEstablishTimeout)
+				time.Sleep(2 * testTimeout)
 				return fw, nil
 			},
 		}).Build()
 
-		w, err := establishWatch(ctx, c, &kueue.WorkloadList{}, "test-origin")
+		w, err := establishWatch(ctx, c, &kueue.WorkloadList{}, "test-origin", testTimeout)
 		if !errors.Is(err, errWatchEstablishTimeout) {
 			t.Fatalf("want errWatchEstablishTimeout, got: %v", err)
 		}
@@ -1243,4 +1240,28 @@ func TestEstablishWatch(t *testing.T) {
 			t.Fatal("racing watcher was not Stop()ed; would leak")
 		}
 	})
+}
+
+func TestEstablishTimeoutFor(t *testing.T) {
+	cases := map[string]struct {
+		failedAttempts uint
+		want           time.Duration
+	}{
+		"first attempt is initial":  {failedAttempts: 0, want: 1 * time.Minute},
+		"one failure doubles":       {failedAttempts: 1, want: 2 * time.Minute},
+		"two failures":              {failedAttempts: 2, want: 4 * time.Minute},
+		"three failures":            {failedAttempts: 3, want: 8 * time.Minute},
+		"four failures hits cap":    {failedAttempts: 4, want: maxEstablishTimeout},
+		"many failures stay at cap": {failedAttempts: 20, want: maxEstablishTimeout},
+		"huge value does not panic": {failedAttempts: 1000, want: maxEstablishTimeout},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := establishTimeoutFor(tc.failedAttempts)
+			if got != tc.want {
+				t.Fatalf("establishTimeoutFor(%d) = %v, want %v", tc.failedAttempts, got, tc.want)
+			}
+		})
+	}
 }

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -1242,7 +1242,10 @@ func TestEstablishWatch(t *testing.T) {
 	})
 }
 
-func TestEstablishTimeoutFor(t *testing.T) {
+// Pins the schedule produced by establishBackoff: 1m, 2m, 4m, 8m, 10m, 10m, ...
+// The helper itself is tested in pkg/util/wait; this is a guard against
+// accidental changes to the initial/cap/factor wiring.
+func TestEstablishBackoffSchedule(t *testing.T) {
 	cases := map[string]struct {
 		failedAttempts uint
 		want           time.Duration
@@ -1253,14 +1256,13 @@ func TestEstablishTimeoutFor(t *testing.T) {
 		"three failures":            {failedAttempts: 3, want: 8 * time.Minute},
 		"four failures hits cap":    {failedAttempts: 4, want: maxEstablishTimeout},
 		"many failures stay at cap": {failedAttempts: 20, want: maxEstablishTimeout},
-		"huge value does not panic": {failedAttempts: 1000, want: maxEstablishTimeout},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := establishTimeoutFor(tc.failedAttempts)
+			got := establishBackoff.WaitTime(int(tc.failedAttempts) + 1)
 			if got != tc.want {
-				t.Fatalf("establishTimeoutFor(%d) = %v, want %v", tc.failedAttempts, got, tc.want)
+				t.Fatalf("WaitTime(%d) = %v, want %v", tc.failedAttempts+1, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area multikueue

#### What this PR does / why we need it:

Follow up to #11207. Replaces the static 10 min `watchEstablishTimeout` with a schedule that starts at 1 min and doubles on each consecutive `failedConnAttempts`, capped at the existing 10 min.

Schedule: 1m, 2m, 4m, 8m, 10m, 10m, ...

`failedConnAttempts` already resets to zero on a successful establishment and on config change, so there is no new state. The new schedule also stacks naturally with the `retryAfter(rc.failedConnAttempts)` reconnect backoff from #10990: both grow together when the same remote keeps failing.

Why bother: under the static 10 min, a truly hung remote keeps a reconciler worker parked for 10 full minutes before the timeout fires. With the new schedule, the first attempt fails fast (1 min), so hung remotes get caught quickly while slow but recovering remotes still get the time they need.

Today Kueue's served and storage versions match (v1beta2), so the apiserver cold cache path that motivated the generous 10 min cap is not exercised. The cap stays as a guard against future version skew and unknown apiserver behavior (kubernetes/kubernetes#136950).

#### Which issue(s) this PR fixes:

Fixes #11303

#### Special notes for your reviewer:

- Refactors `establishWatch` to take an explicit `timeout` parameter instead of reading from a package var. Tests now pass `testTimeout` directly, which is cleaner than the previous var mutation pattern.
- The schedule comes from `pkg/util/wait.NewBackoff` (the kueue-wide helper) rather than a hand rolled function, per review feedback.
- New `TestEstablishBackoffSchedule` pins the 1m/2m/4m/8m/10m schedule produced by our configured `establishBackoff`. The helper itself is tested upstream.
- No behavior change for the success path or for already healthy clusters. Only the worst case (hung remote, no prior failures) changes: was 10 min, now 1 min.

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: Fixed a bug where a hung watch connection to one remote cluster could block
reconciliation of other MultiKueueClusters, leaving them inactive and preventing workload
admission. Kueue now applies a circuit-breaking timeout while establishing remote-cluster
watches: the timeout starts at 1 minute and backs off exponentially on consecutive failures,
up to 10 minutes.
```
