### PR TITLE
MultiKueue: one slow remote no longer stalls every other cluster

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -120,6 +120,10 @@ type remoteClient struct {
 	failedConnAttempts   uint
 	retryConnNextAttempt metav1.Time
 
+	// Held during setConfig. Without it, one stuck remote would stall every
+	// other cluster's reconcile via clustersReconciler.lock. See #11297.
+	setConfigLock sync.Mutex
+
 	clock clock.Clock
 
 	// For unit testing only. There is now need of creating fully functional remote clients in the unit tests
@@ -490,8 +494,6 @@ func (c *clustersReconciler) stopAndRemoveCluster(clusterName string) {
 
 func (c *clustersReconciler) setRemoteClientConfig(ctx context.Context, clusterName string, config *clientConfig, origin string) (*time.Duration, error) {
 	c.lock.Lock()
-	defer c.lock.Unlock()
-
 	client, found := c.remoteClients[clusterName]
 	if !found {
 		client = newRemoteClient(c.localClient, c.wlUpdateCh, c.watchEndedCh, origin, clusterName, c.adapters)
@@ -500,6 +502,10 @@ func (c *clustersReconciler) setRemoteClientConfig(ctx context.Context, clusterN
 		}
 		c.remoteClients[clusterName] = client
 	}
+	c.lock.Unlock()
+
+	client.setConfigLock.Lock()
+	defer client.setConfigLock.Unlock()
 
 	clientLog := ctrl.LoggerFrom(c.rootContext).WithValues("clusterName", clusterName)
 	clientCtx := ctrl.LoggerInto(c.rootContext, clientLog)

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -492,8 +492,12 @@ func (c *clustersReconciler) stopAndRemoveCluster(clusterName string) {
 	}
 }
 
-func (c *clustersReconciler) setRemoteClientConfig(ctx context.Context, clusterName string, config *clientConfig, origin string) (*time.Duration, error) {
+// findOrCreateRemoteClient returns the remoteClient for clusterName, creating
+// one if absent. Only the brief map operation runs under c.lock.
+func (c *clustersReconciler) findOrCreateRemoteClient(clusterName, origin string) *remoteClient {
 	c.lock.Lock()
+	defer c.lock.Unlock()
+
 	client, found := c.remoteClients[clusterName]
 	if !found {
 		client = newRemoteClient(c.localClient, c.wlUpdateCh, c.watchEndedCh, origin, clusterName, c.adapters)
@@ -502,7 +506,11 @@ func (c *clustersReconciler) setRemoteClientConfig(ctx context.Context, clusterN
 		}
 		c.remoteClients[clusterName] = client
 	}
-	c.lock.Unlock()
+	return client
+}
+
+func (c *clustersReconciler) setRemoteClientConfig(ctx context.Context, clusterName string, config *clientConfig, origin string) (*time.Duration, error) {
+	client := c.findOrCreateRemoteClient(clusterName, origin)
 
 	client.setConfigLock.Lock()
 	defer client.setConfigLock.Unlock()

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1265,5 +1266,78 @@ func TestEstablishBackoffSchedule(t *testing.T) {
 				t.Fatalf("WaitTime(%d) = %v, want %v", tc.failedAttempts+1, got, tc.want)
 			}
 		})
+	}
+}
+
+// Regression for #11297. A remote stuck inside Watch must not stop
+// reconciles of other clusters.
+func TestSetRemoteClientConfigDoesNotBlockOtherClusters(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	slowReached := make(chan struct{})
+	slowRelease := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseSlow := func() { releaseOnce.Do(func() { close(slowRelease) }) }
+	t.Cleanup(releaseSlow)
+
+	gatedBuilder := func(config *clientConfig, _ client.Options) (client.WithWatch, error) {
+		kubeconfig := string(config.Kubeconfig)
+		b := getClientBuilder(ctx).WithInterceptorFuncs(interceptor.Funcs{
+			Watch: func(watchCtx context.Context, c client.WithWatch, obj client.ObjectList, opts ...client.ListOption) (watch.Interface, error) {
+				if strings.Contains(kubeconfig, "slow-user") {
+					close(slowReached)
+					select {
+					case <-slowRelease:
+						return nil, errors.New("released")
+					case <-watchCtx.Done():
+						return nil, watchCtx.Err()
+					}
+				}
+				return c.Watch(watchCtx, obj, opts...)
+			},
+		})
+		return b.Build(), nil
+	}
+
+	localClient := getClientBuilder(ctx).Build()
+	reconciler := newClustersReconciler(localClient, TestNamespace, 0, defaultOrigin, nil, nil, &NoOpClusterProfileCreds{}, nil)
+	reconciler.rootContext = ctx
+	reconciler.builderOverride = gatedBuilder
+
+	slowConfig := &clientConfig{Kubeconfig: []byte(testKubeconfig("slow-user"))}
+	fastConfig := &clientConfig{Kubeconfig: []byte(testKubeconfig("fast-user"))}
+
+	slowDone := make(chan struct{})
+	go func() {
+		defer close(slowDone)
+		_, _ = reconciler.setRemoteClientConfig(ctx, "cluster-slow", slowConfig, defaultOrigin)
+	}()
+
+	select {
+	case <-slowReached:
+	case <-time.After(2 * time.Second):
+		t.Fatal("slow cluster's setConfig did not reach the Watch call in time")
+	}
+
+	fastDone := make(chan error, 1)
+	go func() {
+		_, err := reconciler.setRemoteClientConfig(ctx, "cluster-fast", fastConfig, defaultOrigin)
+		fastDone <- err
+	}()
+
+	select {
+	case err := <-fastDone:
+		if err != nil {
+			t.Fatalf("cluster-fast setRemoteClientConfig returned err: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("cluster-fast setRemoteClientConfig was blocked by cluster-slow (head-of-line)")
+	}
+
+	releaseSlow()
+	select {
+	case <-slowDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("slow goroutine did not exit after release")
 	}
 }

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -1272,6 +1272,12 @@ func TestEstablishBackoffSchedule(t *testing.T) {
 // Regression for #11297. A remote stuck inside Watch must not stop
 // reconciles of other clusters.
 func TestSetRemoteClientConfigDoesNotBlockOtherClusters(t *testing.T) {
+	// stuckWatchTimeout is the per-phase budget for the test: how long we
+	// wait for the slow watch to be reached, for the fast reconcile to
+	// finish, and for the slow goroutine to clean up after release. Generous
+	// enough to survive a loaded CI runner.
+	const stuckWatchTimeout = 5 * time.Second
+
 	ctx, _ := utiltesting.ContextWithLog(t)
 
 	slowReached := make(chan struct{})
@@ -1299,45 +1305,54 @@ func TestSetRemoteClientConfigDoesNotBlockOtherClusters(t *testing.T) {
 		return b.Build(), nil
 	}
 
-	localClient := getClientBuilder(ctx).Build()
+	slowCluster := utiltestingapi.MakeMultiKueueCluster("cluster-slow").
+		KubeConfig(kueue.SecretLocationType, "secret-slow").Generation(1).Obj()
+	fastCluster := utiltestingapi.MakeMultiKueueCluster("cluster-fast").
+		KubeConfig(kueue.SecretLocationType, "secret-fast").Generation(1).Obj()
+	slowSecret := makeTestSecret("secret-slow", testKubeconfig("slow-user"))
+	fastSecret := makeTestSecret("secret-fast", testKubeconfig("fast-user"))
+
+	localClient := getClientBuilder(ctx).
+		WithLists(&kueue.MultiKueueClusterList{Items: []kueue.MultiKueueCluster{*slowCluster, *fastCluster}}).
+		WithLists(&corev1.SecretList{Items: []corev1.Secret{slowSecret, fastSecret}}).
+		WithStatusSubresource(slowCluster, fastCluster).
+		Build()
+
 	reconciler := newClustersReconciler(localClient, TestNamespace, 0, defaultOrigin, nil, nil, &NoOpClusterProfileCreds{}, nil)
 	reconciler.rootContext = ctx
 	reconciler.builderOverride = gatedBuilder
 
-	slowConfig := &clientConfig{Kubeconfig: []byte(testKubeconfig("slow-user"))}
-	fastConfig := &clientConfig{Kubeconfig: []byte(testKubeconfig("fast-user"))}
-
 	slowDone := make(chan struct{})
 	go func() {
 		defer close(slowDone)
-		_, _ = reconciler.setRemoteClientConfig(ctx, "cluster-slow", slowConfig, defaultOrigin)
+		_, _ = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "cluster-slow"}})
 	}()
 
 	select {
 	case <-slowReached:
-	case <-time.After(2 * time.Second):
-		t.Fatal("slow cluster's setConfig did not reach the Watch call in time")
+	case <-time.After(stuckWatchTimeout):
+		t.Fatal("slow cluster's reconcile did not reach the Watch call in time")
 	}
 
 	fastDone := make(chan error, 1)
 	go func() {
-		_, err := reconciler.setRemoteClientConfig(ctx, "cluster-fast", fastConfig, defaultOrigin)
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "cluster-fast"}})
 		fastDone <- err
 	}()
 
 	select {
 	case err := <-fastDone:
 		if err != nil {
-			t.Fatalf("cluster-fast setRemoteClientConfig returned err: %v", err)
+			t.Fatalf("cluster-fast reconcile returned err: %v", err)
 		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("cluster-fast setRemoteClientConfig was blocked by cluster-slow (head-of-line)")
+	case <-time.After(stuckWatchTimeout):
+		t.Fatal("cluster-fast reconcile was blocked by cluster-slow (head-of-line)")
 	}
 
 	releaseSlow()
 	select {
 	case <-slowDone:
-	case <-time.After(2 * time.Second):
+	case <-time.After(stuckWatchTimeout):
 		t.Fatal("slow goroutine did not exit after release")
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area multikueue

#### What this PR does / why we need it:

Fixes #11297. One slow or unresponsive remote used to stall reconciles for every other MultiKueueCluster because `clustersReconciler.lock` was held across the synchronous remote watch establishment in `setConfig`. Bumping `GroupKindConcurrency` did not help, since every worker ended up waiting on that same lock.

This narrows `c.lock` to just the `remoteClients` map find or insert, and adds a per cluster `setConfigLock` on `remoteClient` for the slow path. Different clusters now reconcile in parallel under their own locks.

#### Which issue(s) this PR fixes:

Fixes #11297

#### Special notes for your reviewer:

Test driven. `TestSetRemoteClientConfigDoesNotBlockOtherClusters` was written first and failed on `main` (hits the 2 second timeout). After the fix it passes in about 40ms. Race detector clean on the full multikueue suite.

`stopAndRemoveCluster`, `controllerFor`, and `getRemoteClients` already only hold `c.lock` briefly, so they did not need to change. Same key reconciles still serialize through the workqueue dedup contract, so `setRemoteClientConfig` and `stopAndRemoveCluster` cannot race for the same cluster name. The per cluster lock is mostly defensive.

Pairs with #11304 (exponential watch establish timeout). Same head of line scenario, different angle.

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: Fixed a bug where one slow or unresponsive remote cluster could stall
reconciliation for other MultiKueueClusters, even when
`controller.groupKindConcurrency["MultiKueueCluster.kueue.x-k8s.io"]` was set above 1.
This could delay or block admission through other healthy clusters.
```
