### PR TITLE
test : Removed the deprecated --visibility-server-port in favour of visibilityServer.bindPort

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -132,9 +132,6 @@ func main() {
 	var featureGates string
 	flag.StringVar(&featureGates, "feature-gates", "", "A set of key=value pairs that describe feature gates for alpha/experimental features.")
 
-	var visibilityServerPort int
-	flag.IntVar(&visibilityServerPort, "visibility-server-port", configapi.DefaultVisibilityBindPort, "The port the visibility server binds to.")
-
 	customLogProcessor := zaplog.WrapCore(utillogging.NewCustomLogProcessor)
 
 	zapOptions := zap.Options{
@@ -373,7 +370,7 @@ func main() {
 
 	if features.Enabled(features.VisibilityOnDemand) {
 		go func() {
-			if err := visibility.CreateAndStartVisibilityServer(ctx, queues, &cfg, kubeConfig, visibilityServerPort, parsedTLSConfig); err != nil {
+			if err := visibility.CreateAndStartVisibilityServer(ctx, queues, &cfg, kubeConfig, parsedTLSConfig); err != nil {
 				setupLog.Error(err, "Unable to create and start visibility server")
 				os.Exit(1)
 			}

--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -370,7 +370,7 @@ func main() {
 
 	if features.Enabled(features.VisibilityOnDemand) {
 		go func() {
-			if err := visibility.CreateAndStartVisibilityServer(ctx, queues, &cfg, kubeConfig, parsedTLSConfig); err != nil {
+			if err := visibility.CreateAndStartVisibilityServer(ctx, queues, &cfg, kubeConfig, configapi.DefaultVisibilityBindPort, parsedTLSConfig); err != nil {
 				setupLog.Error(err, "Unable to create and start visibility server")
 				os.Exit(1)
 			}

--- a/site/content/en/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand.md
+++ b/site/content/en/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand.md
@@ -76,8 +76,6 @@ If you disable the feature, you also need to remove the associated `APIService` 
 
 If you need the embedded visibility server to run on a different port, you can use the Configuration API `visibilityServer.bindPort`.
 
-(Deprecated as of 0.17, to be removed in the future) Alternatively, you can use the `--visibility-server-port` flag when running the Kueue controller manager. For example: `--visibility-server-port=8443`.
-
 {{% /alert %}}
 
 To install a simple setup of ClusterQueue

--- a/test/e2e/sequential/baseline/visibility_server_test.go
+++ b/test/e2e/sequential/baseline/visibility_server_test.go
@@ -18,7 +18,6 @@ package baseline
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -237,42 +236,6 @@ var _ = ginkgo.Describe("Visibility Server", ginkgo.Label("feature:visibility"),
 		}
 		util.MustCreate(ctx, k8sClient, authDelegatorBinding)
 
-		gomega.Eventually(func(g gomega.Gomega) {
-			visClient := util.CreateVisibilityClient("")
-			pw, err := visClient.ClusterQueues().GetPendingWorkloadsSummary(ctx, cqName, metav1.GetOptions{})
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-			g.Expect(pw).NotTo(gomega.BeNil())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-	})
-
-	ginkgo.It("Should use the custom port from the --visibility-server-port flag", func() {
-		ginkgo.By("Updating the visibility-server service's targetPort")
-		gomega.Eventually(func(g gomega.Gomega) {
-			patchedService := &corev1.Service{}
-			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: kueueVisibilityServerName, Namespace: kueueNS}, patchedService)).To(gomega.Succeed())
-			for i, p := range patchedService.Spec.Ports {
-				if p.Name == "https" {
-					patchedService.Spec.Ports[i].TargetPort = intstr.FromInt32(customVisibilityPort)
-				}
-			}
-			g.Expect(k8sClient.Update(ctx, patchedService)).To(gomega.Succeed())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-		ginkgo.By("Updating the visibility-server deployment's port")
-		gomega.Eventually(func(g gomega.Gomega) {
-			patchedDeployment := &appsv1.Deployment{}
-			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: kueueManagerName, Namespace: kueueNS}, patchedDeployment)).To(gomega.Succeed())
-			for i, c := range patchedDeployment.Spec.Template.Spec.Containers {
-				if c.Name == "manager" {
-					container := &patchedDeployment.Spec.Template.Spec.Containers[i]
-					container.Args = append(c.Args, fmt.Sprintf("--visibility-server-port=%d", customVisibilityPort))
-				}
-			}
-			g.Expect(k8sClient.Update(ctx, patchedDeployment)).To(gomega.Succeed())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		util.WaitForKueueAvailabilityNoRestartCountCheck(ctx, k8sClient)
-
-		ginkgo.By("Verifying requests succeed on the custom port")
 		gomega.Eventually(func(g gomega.Gomega) {
 			visClient := util.CreateVisibilityClient("")
 			pw, err := visClient.ClusterQueues().GetPendingWorkloadsSummary(ctx, cqName, metav1.GetOptions{})


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it:
This PR helps to reduce the CI clock time by approximately 30 seconds.
This PR removes the deprecated --visibility-server-port in favour of visibilityServer.bindPort

#### Which issue(s) this PR fixes:
Fixes #11274
Part of #11274

#### Special notes for your reviewer:
I have removed the --visibility-server-port from visibility_server_test.go file in baseline folder of sequential tests 

#### Does this PR introduce a user-facing change?

```release-note
Removed the deprecated `--visibility-server-port` flag from the Kueue controller manager.

ACTION REQUIRED: If your installation passes `--visibility-server-port` to the
controller manager, remove the flag before upgrading and set the same port via 
Kueue Configuration API in `visibilityServer.bindPort` instead.
```
