### PR TITLE
Fix flaky tests which create trainjob just after trainingruntime

### DIFF
--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -1625,7 +1625,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			Obj()
 
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, testCtr)
-		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, trainJob)
+		util.MustCreateWithRetry(managerTestCluster.ctx, managerTestCluster.client, trainJob)
 		wlLookupKey := types.NamespacedName{Name: workloadtrainjob.GetWorkloadNameForTrainJob(trainJob.Name, trainJob.UID), Namespace: managerNs.Name}
 		gomega.Eventually(func(g gomega.Gomega) {
 			createdWorkload := &kueue.Workload{}

--- a/test/integration/singlecluster/controller/jobs/trainjob/trainjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/trainjob/trainjob_controller_test.go
@@ -353,7 +353,7 @@ var _ = ginkgo.Describe("TrainJob controller for workloads when only jobs with q
 			Obj()
 
 		util.MustCreate(ctx, k8sClient, testTr)
-		util.MustCreate(ctx, k8sClient, trainJob)
+		util.MustCreateWithRetry(ctx, k8sClient, trainJob)
 		createdTrainJob := &kftrainerapi.TrainJob{}
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: trainJob.Name, Namespace: ns.Name}, createdTrainJob)).Should(gomega.Succeed())
@@ -452,7 +452,7 @@ var _ = ginkgo.Describe("TrainJob controller interacting with scheduler", ginkgo
 			Obj()
 
 		util.MustCreate(ctx, k8sClient, testTr)
-		util.MustCreate(ctx, k8sClient, trainJob)
+		util.MustCreateWithRetry(ctx, k8sClient, trainJob)
 		createdTrainJob := &kftrainerapi.TrainJob{}
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: trainJob.Name, Namespace: ns.Name}, createdTrainJob)).Should(gomega.Succeed())
@@ -504,7 +504,7 @@ var _ = ginkgo.Describe("TrainJob controller interacting with scheduler", ginkgo
 			Obj()
 
 		util.MustCreate(ctx, k8sClient, testTr1)
-		util.MustCreate(ctx, k8sClient, trainJob1)
+		util.MustCreateWithRetry(ctx, k8sClient, trainJob1)
 		ginkgo.By("checking the first trainjob starts", func() {
 			createdTrainJob1 := &kftrainerapi.TrainJob{}
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -543,7 +543,7 @@ var _ = ginkgo.Describe("TrainJob controller interacting with scheduler", ginkgo
 			Obj()
 
 		util.MustCreate(ctx, k8sClient, testTr2)
-		util.MustCreate(ctx, k8sClient, trainJob2)
+		util.MustCreateWithRetry(ctx, k8sClient, trainJob2)
 		ginkgo.By("checking a second no-fit trainjob does not start", func() {
 			createdTrainJob2 := &kftrainerapi.TrainJob{}
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -693,7 +693,7 @@ var _ = ginkgo.Describe("TrainJob controller with TopologyAwareScheduling", gink
 
 		ginkgo.By("creating a TrainJob", func() {
 			util.MustCreate(ctx, k8sClient, testTr)
-			util.MustCreate(ctx, k8sClient, trainJob)
+			util.MustCreateWithRetry(ctx, k8sClient, trainJob)
 		})
 
 		wl := &kueue.Workload{}

--- a/test/integration/singlecluster/webhook/jobs/trainjob_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/trainjob_webhook_test.go
@@ -80,7 +80,7 @@ var _ = ginkgo.Describe("Trainjob Webhook", func() {
 
 			ginkgo.By("by creating the TrainJob", func() {
 				util.MustCreate(ctx, k8sClient, testTr)
-				util.MustCreate(ctx, k8sClient, trainJob)
+				util.MustCreateWithRetry(ctx, k8sClient, trainJob)
 			})
 
 			ginkgo.By("suspending it", func() {
@@ -112,7 +112,7 @@ var _ = ginkgo.Describe("Trainjob Webhook", func() {
 
 			ginkgo.By("by creating the TrainJob", func() {
 				util.MustCreate(ctx, k8sClient, testTr)
-				util.MustCreate(ctx, k8sClient, trainJob)
+				util.MustCreateWithRetry(ctx, k8sClient, trainJob)
 			})
 
 			ginkgo.By("and not suspending it", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind flake
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/11072

#### Special notes for your reviewer:

This can be considered a bug that TrainJob creation fails if it follows TrainingRuntime creation, but the fix would not be trivial, and also the priority isn't that clear.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
