### PR TITLE
fix: make navbar responsive on mobile

### DIFF
--- a/cmd/kueueviz/frontend/src/Navbar.jsx
+++ b/cmd/kueueviz/frontend/src/Navbar.jsx
@@ -14,28 +14,111 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { AppBar, Toolbar, Button, Box } from '@mui/material';
+import { AppBar, Toolbar, Button, Box, IconButton, Menu, MenuItem } from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
 import { useAuth } from './AuthContext';
 import './App.css';
 
 const Navbar = () => {
   const { token, logout, authMode } = useAuth();
+  const [anchorEl, setAnchorEl] = useState(null);
+
+  const handleOpenMenu = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleCloseMenu = () => {
+    setAnchorEl(null);
+  };
+
+  const navItems = [
+    { label: 'Dashboard', to: '/' },
+    { label: 'Workloads', to: '/workloads' },
+    { label: 'Local Queues', to: '/local-queues' },
+    { label: 'Cluster Queues', to: '/cluster-queues' },
+    { label: 'Cohorts', to: '/cohorts' },
+    { label: 'Resource Flavors', to: '/resource-flavors' },
+  ];
 
   return (
     <AppBar position="static">
       <Toolbar>
-        <Link to="/" className="navbar-link"><img src="/kueueviz.png" className="navbar-logo"/></Link>
-        <Button color="inherit" component={Link} to="/">Dashboard</Button>
-        <Button color="inherit" component={Link} to="/workloads">Workloads</Button>
-        <Button color="inherit" component={Link} to="/local-queues">Local Queues</Button>
-        <Button color="inherit" component={Link} to="/cluster-queues">Cluster Queues</Button>
-        <Button color="inherit" component={Link} to="/cohorts">Cohorts</Button>
-        <Button color="inherit" component={Link} to="/resource-flavors">Resource Flavors</Button>
+        <Link to="/" className="navbar-link">
+          <img src="/kueueviz.png" className="navbar-logo" alt="KueueViz Logo" />
+        </Link>
+
+        {/* Mobile Navigation Menu */}
+        <Box sx={{ display: { xs: 'flex', md: 'none' }, ml: 'auto' }}>
+          <IconButton
+            size="large"
+            aria-label="menu"
+            aria-controls="menu-appbar"
+            aria-haspopup="true"
+            onClick={handleOpenMenu}
+            color="inherit"
+          >
+            <MenuIcon />
+          </IconButton>
+          <Menu
+            id="menu-appbar"
+            anchorEl={anchorEl}
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'right',
+            }}
+            keepMounted
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'right',
+            }}
+            open={Boolean(anchorEl)}
+            onClose={handleCloseMenu}
+          >
+            {navItems.map((item) => (
+              <MenuItem
+                key={item.label}
+                component={Link}
+                to={item.to}
+                onClick={handleCloseMenu}
+              >
+                {item.label}
+              </MenuItem>
+            ))}
+            {authMode !== 'Disabled' && token && (
+              <MenuItem
+                onClick={() => {
+                  handleCloseMenu();
+                  logout();
+                }}
+              >
+                Logout
+              </MenuItem>
+            )}
+          </Menu>
+        </Box>
+
+        {/* Desktop Navigation Buttons */}
+        <Box sx={{ display: { xs: 'none', md: 'flex' }, gap: 1, ml: 2 }}>
+          {navItems.map((item) => (
+            <Button
+              key={item.label}
+              color="inherit"
+              component={Link}
+              to={item.to}
+            >
+              {item.label}
+            </Button>
+          ))}
+        </Box>
+
+        {/* Desktop Logout Button */}
         {authMode !== 'Disabled' && token && (
-          <Box sx={{ ml: 'auto' }}>
-            <Button color="inherit" onClick={logout}>Logout</Button>
+          <Box sx={{ display: { xs: 'none', md: 'flex' }, ml: 'auto' }}>
+            <Button color="inherit" onClick={logout}>
+              Logout
+            </Button>
           </Box>
         )}
       </Toolbar>

--- a/test/e2e/kueueviz/cypress/e2e/app.cy.js
+++ b/test/e2e/kueueviz/cypress/e2e/app.cy.js
@@ -10,7 +10,7 @@ describe('Kueue Dashboard', () => {
 
   it('should navigate to resource-flavors and verify table content', () => {
     // Check for the link to resource-flavors
-    cy.get('a[href="/resource-flavors"]').should('exist')
+    cy.get('a[href="/resource-flavors"]:visible').should('exist')
       .click()
 
     // Verify the table structure and content
@@ -61,7 +61,7 @@ describe('Kueue Dashboard', () => {
     cy.get('a[href="/cohort/ai-for-humanity-foundation"]').should('exist')
 
     // Navigate to /cohorts
-    cy.get('a[href="/cohorts"]').should('exist')
+    cy.get('a[href="/cohorts"]:visible').should('exist')
       .click()
 
     // Verify the table and its content
@@ -108,7 +108,7 @@ describe('Kueue Dashboard', () => {
     ];
 
     links.forEach(link => {
-      cy.get(`a[href="${link}"]`).should('exist').click();
+      cy.get(`a[href="${link}"]:visible`).should('exist').click();
     });
   })
 


### PR DESCRIPTION
Closes #11321

Refactors `Navbar.jsx` to be responsive using Material UI display breakpoints:
- Collapses navigation items into a hamburger menu icon with a dropdown (`Menu`/`MenuItem`) on small screens (`xs` up to `md`).
- Retains the standard horizontal row of buttons on larger viewports (`md` and up).
- Avoids layout breakage and overlap with the logo on mobile/narrow windows.
<img width="622" height="101" alt="kue2" src="https://github.com/user-attachments/assets/bd653065-e03c-4be3-a9d7-55bca6b1a1b9" />
<img width="1917" height="102" alt="kue1" src="https://github.com/user-attachments/assets/2ae8061a-6969-482e-bd93-54173ad939d9" />
<img width="617" height="960" alt="Screenshot 2026-05-19 170414" src="https://github.com/user-attachments/assets/7310e262-596c-4518-81be-4ed64a18ebc9" />

```release-note
KueueViz: Fixed the navigation bar to avoid layout breakage on narrow mobile screens.
```
