### PR TITLE
visibility: follow-up cleanup for bind port defaulting

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -370,7 +370,7 @@ func main() {
 
 	if features.Enabled(features.VisibilityOnDemand) {
 		go func() {
-			if err := visibility.CreateAndStartVisibilityServer(ctx, queues, &cfg, kubeConfig, configapi.DefaultVisibilityBindPort, parsedTLSConfig); err != nil {
+			if err := visibility.CreateAndStartVisibilityServer(ctx, queues, &cfg, kubeConfig, parsedTLSConfig); err != nil {
 				setupLog.Error(err, "Unable to create and start visibility server")
 				os.Exit(1)
 			}

--- a/pkg/visibility/server.go
+++ b/pkg/visibility/server.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/component-base/compatibility"
 	"k8s.io/component-base/version"
+	"k8s.io/utils/ptr"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	generatedopenapi "sigs.k8s.io/kueue/apis/visibility/openapi"
@@ -76,9 +77,9 @@ func init() {
 // +kubebuilder:rbac:groups=flowcontrol.apiserver.k8s.io,resources=flowschemas/status,verbs=patch
 
 // CreateAndStartVisibilityServer creates a visibility server injecting KueueManager and starts it
-func CreateAndStartVisibilityServer(ctx context.Context, kueueMgr *qcache.Manager, cfg *configapi.Configuration, kubeConfig *rest.Config, port int, tlsOpts *tlsconfig.TLS) error {
+func CreateAndStartVisibilityServer(ctx context.Context, kueueMgr *qcache.Manager, cfg *configapi.Configuration, kubeConfig *rest.Config, tlsOpts *tlsconfig.TLS) error {
 	config := newVisibilityServerConfig(kubeConfig)
-	if err := applyVisibilityServerOptions(config, cfg, port, tlsOpts); err != nil {
+	if err := applyVisibilityServerOptions(config, cfg, tlsOpts); err != nil {
 		return fmt.Errorf("unable to apply VisibilityServerOptions: %w", err)
 	}
 
@@ -98,7 +99,7 @@ func CreateAndStartVisibilityServer(ctx context.Context, kueueMgr *qcache.Manage
 	return nil
 }
 
-func applyVisibilityServerOptions(config *genericapiserver.RecommendedConfig, cfg *configapi.Configuration, port int, tlsOpts *tlsconfig.TLS) error {
+func applyVisibilityServerOptions(config *genericapiserver.RecommendedConfig, cfg *configapi.Configuration, tlsOpts *tlsconfig.TLS) error {
 	o := genericoptions.NewRecommendedOptions("", codecs.LegacyCodec(
 		visibilityv1beta2.SchemeGroupVersion,
 		visibilityv1beta1.SchemeGroupVersion,
@@ -112,16 +113,13 @@ func applyVisibilityServerOptions(config *genericapiserver.RecommendedConfig, cf
 		o.SecureServing.ServerCert.CertKey.KeyFile = certDir + "/tls.key"
 	}
 
-	// Apply visibility overrides from Configuration API if present and non-default.
-	// If the API value is non-default, it takes precedence.
-	// Otherwise, use the flag.
-	if cfg.VisibilityServer != nil && cfg.VisibilityServer.BindPort != nil && *cfg.VisibilityServer.BindPort != configapi.DefaultVisibilityBindPort {
-		o.SecureServing.BindPort = int(*cfg.VisibilityServer.BindPort)
-	} else {
-		o.SecureServing.BindPort = port
-	}
-	if cfg.VisibilityServer != nil && cfg.VisibilityServer.BindAddress != nil {
-		o.SecureServing.BindAddress = net.ParseIP(*cfg.VisibilityServer.BindAddress)
+	o.SecureServing.BindPort = int(configapi.DefaultVisibilityBindPort)
+
+	if cfg.VisibilityServer != nil {
+		o.SecureServing.BindPort = int(ptr.Deref(
+			cfg.VisibilityServer.BindPort,
+			configapi.DefaultVisibilityBindPort,
+		))
 	}
 
 	if f := flag.Lookup("kubeconfig"); f != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Follow-up cleanup for #11309, which removed the deprecated --visibility-server-port flag in favor of visibilityServer.bindPort.

This PR centralises the visibility server bind port defaulting logic inside pkg/visibility/server.go instead of passing the default value from cmd/kueue/main.go.

The visibility server now internally defaults the bind port using ptr.Deref() with configapi.DefaultVisibilityBindPort.

#### Which issue(s) this PR fixes:
Follow up for #11309
Part of  #11274

#### Special notes for your reviewer:
Removed the port parameter from:
1) CreateAndStartVisibilityServer
2) applyVisibilityServerOptions
3) Added bind port defaulting directly in server.go
4) Updated visibility server startup call sites

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
