### PR TITLE
[release-0.16] fix: account assumed pod usage in TAS multi-podset placement

### DIFF
--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -2075,6 +2075,51 @@ func TestFindTopologyAssignments(t *testing.T) {
 				wantReason: `topology "default" doesn't allow to fit any of 1 pod(s). Total nodes: 1; excluded: resource "pods": 1`,
 			}},
 		},
+		"multiple PodSets account assumed pod usage against allocatable pods; BestFit": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("1"),
+					}).
+					Ready().
+					Obj(),
+			},
+			levels: defaultOneLevel,
+			podSets: []PodSetTestCase{
+				{
+					podSetName: "one",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required: ptr.To(corev1.LabelHostname),
+					},
+					requests: resources.Requests{
+						corev1.ResourceCPU: 1000,
+					},
+					count: 1,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: defaultOneLevel,
+						Domains: []tas.TopologyDomainAssignment{
+							{
+								Values: []string{"x1"},
+								Count:  1,
+							},
+						},
+					},
+				},
+				{
+					podSetName: "two",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required: ptr.To(corev1.LabelHostname),
+					},
+					requests: resources.Requests{
+						corev1.ResourceCPU: 1000,
+					},
+					count:      1,
+					wantReason: `topology "default" doesn't allow to fit any of 1 pod(s). Total nodes: 1; excluded: resource "pods": 1`,
+				},
+			},
+		},
 		"skip node which doesn't match node selector, missing label; BestFit": {
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("x3").

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -621,12 +621,15 @@ func (s *TASFlavorSnapshot) findReplacementAssignment(
 }
 
 func addAssumedUsage(assumedUsage map[utiltas.TopologyDomainID]resources.Requests, ta *utiltas.TopologyAssignment, tr *TASPodSetRequests) {
-	for _, domain := range ta.Domains {
-		domainID := utiltas.DomainID(domain.Values)
+	addUsagePerDomain(assumedUsage, utiltas.ComputeUsagePerDomain(ta, tr.SinglePodRequests))
+}
+
+func addUsagePerDomain(assumedUsage map[utiltas.TopologyDomainID]resources.Requests, usagePerDomain map[utiltas.TopologyDomainID]resources.Requests) {
+	for domainID, usage := range usagePerDomain {
 		if assumedUsage[domainID] == nil {
 			assumedUsage[domainID] = resources.Requests{}
 		}
-		assumedUsage[domainID].Add(tr.SinglePodRequests.ScaledUp(int64(domain.Count)))
+		assumedUsage[domainID].Add(usage)
 	}
 }
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -516,42 +516,76 @@ func TestSortedDomainsWithLeader(t *testing.T) {
 		})
 	}
 }
-func TestAddAssumedUsageIncludesPodCount(t *testing.T) {
-	assumedUsage := map[tas.TopologyDomainID]resources.Requests{
-		"node-a": {
-			corev1.ResourceCPU:  1000,
-			corev1.ResourcePods: 1,
+func TestAddAssumedUsage(t *testing.T) {
+	cases := map[string]struct {
+		assumedUsage map[tas.TopologyDomainID]resources.Requests
+		assignment   *tas.TopologyAssignment
+		tasRequests  *TASPodSetRequests
+		want         map[tas.TopologyDomainID]resources.Requests
+	}{
+		"includes pod count for existing and new domains": {
+			assumedUsage: map[tas.TopologyDomainID]resources.Requests{
+				"node-a": {
+					corev1.ResourceCPU:  1000,
+					corev1.ResourcePods: 1,
+				},
+			},
+			assignment: &tas.TopologyAssignment{
+				Levels: []string{"hostname"},
+				Domains: []tas.TopologyDomainAssignment{
+					{Values: []string{"node-a"}, Count: 1},
+					{Values: []string{"node-b"}, Count: 2},
+				},
+			},
+			tasRequests: &TASPodSetRequests{
+				SinglePodRequests: resources.Requests{
+					corev1.ResourceCPU:    500,
+					corev1.ResourceMemory: 2048,
+				},
+			},
+			want: map[tas.TopologyDomainID]resources.Requests{
+				"node-a": {
+					corev1.ResourceCPU:    1500,
+					corev1.ResourceMemory: 2048,
+					corev1.ResourcePods:   2,
+				},
+				"node-b": {
+					corev1.ResourceCPU:    1000,
+					corev1.ResourceMemory: 4096,
+					corev1.ResourcePods:   2,
+				},
+			},
 		},
-	}
-	assignment := &tas.TopologyAssignment{
-		Levels: []string{"hostname"},
-		Domains: []tas.TopologyDomainAssignment{
-			{Values: []string{"node-a"}, Count: 1},
-			{Values: []string{"node-b"}, Count: 2},
-		},
-	}
-	tasRequests := &TASPodSetRequests{
-		SinglePodRequests: resources.Requests{
-			corev1.ResourceCPU:    500,
-			corev1.ResourceMemory: 2048,
+		"includes pod count starting from empty assumed usage": {
+			assumedUsage: map[tas.TopologyDomainID]resources.Requests{},
+			assignment: &tas.TopologyAssignment{
+				Levels: []string{"hostname"},
+				Domains: []tas.TopologyDomainAssignment{
+					{Values: []string{"node-a"}, Count: 3},
+				},
+			},
+			tasRequests: &TASPodSetRequests{
+				SinglePodRequests: resources.Requests{
+					corev1.ResourceCPU:    250,
+					corev1.ResourceMemory: 512,
+				},
+			},
+			want: map[tas.TopologyDomainID]resources.Requests{
+				"node-a": {
+					corev1.ResourceCPU:    750,
+					corev1.ResourceMemory: 1536,
+					corev1.ResourcePods:   3,
+				},
+			},
 		},
 	}
 
-	addAssumedUsage(assumedUsage, assignment, tasRequests)
-
-	want := map[tas.TopologyDomainID]resources.Requests{
-		"node-a": {
-			corev1.ResourceCPU:    1500,
-			corev1.ResourceMemory: 2048,
-			corev1.ResourcePods:   2,
-		},
-		"node-b": {
-			corev1.ResourceCPU:    1000,
-			corev1.ResourceMemory: 4096,
-			corev1.ResourcePods:   2,
-		},
-	}
-	if diff := cmp.Diff(want, assumedUsage); diff != "" {
-		t.Errorf("addAssumedUsage() mismatch (-want +got):\n%s", diff)
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			addAssumedUsage(tc.assumedUsage, tc.assignment, tc.tasRequests)
+			if diff := cmp.Diff(tc.want, tc.assumedUsage); diff != "" {
+				t.Errorf("addAssumedUsage() mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -516,3 +516,42 @@ func TestSortedDomainsWithLeader(t *testing.T) {
 		})
 	}
 }
+func TestAddAssumedUsageIncludesPodCount(t *testing.T) {
+	assumedUsage := map[tas.TopologyDomainID]resources.Requests{
+		"node-a": {
+			corev1.ResourceCPU:  1000,
+			corev1.ResourcePods: 1,
+		},
+	}
+	assignment := &tas.TopologyAssignment{
+		Levels: []string{"hostname"},
+		Domains: []tas.TopologyDomainAssignment{
+			{Values: []string{"node-a"}, Count: 1},
+			{Values: []string{"node-b"}, Count: 2},
+		},
+	}
+	tasRequests := &TASPodSetRequests{
+		SinglePodRequests: resources.Requests{
+			corev1.ResourceCPU:    500,
+			corev1.ResourceMemory: 2048,
+		},
+	}
+
+	addAssumedUsage(assumedUsage, assignment, tasRequests)
+
+	want := map[tas.TopologyDomainID]resources.Requests{
+		"node-a": {
+			corev1.ResourceCPU:    1500,
+			corev1.ResourceMemory: 2048,
+			corev1.ResourcePods:   2,
+		},
+		"node-b": {
+			corev1.ResourceCPU:    1000,
+			corev1.ResourceMemory: 4096,
+			corev1.ResourcePods:   2,
+		},
+	}
+	if diff := cmp.Diff(want, assumedUsage); diff != "" {
+		t.Errorf("addAssumedUsage() mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -4403,6 +4403,77 @@ func TestScheduleForTASCohorts(t *testing.T) {
 		// eventCmpOpts are the comparison options for the events
 		eventCmpOpts cmp.Options
 	}{
+		"workload with two PodSets exceeds node pods capacity": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label("tas-node", "true").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("1"),
+					}).
+					Ready().
+					Obj(),
+			},
+			topologies:      []kueue.Topology{defaultSingleLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{defaultTASFlavor},
+			clusterQueues:   []kueue.ClusterQueue{defaultClusterQueueA},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("foo", "default").
+					Queue("tas-lq-a").
+					PodSets(
+						*utiltestingapi.MakePodSet("one", 1).
+							RequiredTopologyRequest(corev1.LabelHostname).
+							Request(corev1.ResourceCPU, "1").
+							Obj(),
+						*utiltestingapi.MakePodSet("two", 1).
+							RequiredTopologyRequest(corev1.LabelHostname).
+							Request(corev1.ResourceCPU, "1").
+							Obj(),
+					).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("foo", "default").
+					Queue("tas-lq-a").
+					PodSets(
+						*utiltestingapi.MakePodSet("one", 1).
+							RequiredTopologyRequest(corev1.LabelHostname).
+							Request(corev1.ResourceCPU, "1").
+							Obj(),
+						*utiltestingapi.MakePodSet("two", 1).
+							RequiredTopologyRequest(corev1.LabelHostname).
+							Request(corev1.ResourceCPU, "1").
+							Obj(),
+					).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             "Pending",
+						Message:            `couldn't assign flavors to pod set two: topology "tas-single-level" doesn't allow to fit any of 1 pod(s). Total nodes: 1; excluded: resource "pods": 1`,
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "one",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+					}, kueue.PodSetRequest{
+						Name: "two",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+					}).
+					Obj(),
+			},
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"tas-cq-a": {"default/foo"},
+			},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "foo", "Pending", corev1.EventTypeWarning).Obj(),
+			},
+			eventCmpOpts: cmp.Options{eventIgnoreMessage},
+		},
 		"workload which requires borrowing gets scheduled": {
 			nodes:           defaultTwoNodes,
 			topologies:      []kueue.Topology{defaultSingleLevelTopology},

--- a/pkg/util/tas/tas_assignment.go
+++ b/pkg/util/tas/tas_assignment.go
@@ -20,9 +20,11 @@ import (
 	"iter"
 	"slices"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/resources"
 )
 
 type TopologyAssignment struct {
@@ -254,6 +256,18 @@ func V1Beta2From(ta *TopologyAssignment) *kueue.TopologyAssignment {
 		return nil
 	}
 	return singleCompactSliceEncoding(ta)
+}
+
+// ComputeUsagePerDomain calculates resource usage per topology domain from an assignment.
+func ComputeUsagePerDomain(ta *TopologyAssignment, singlePodRequests resources.Requests) map[TopologyDomainID]resources.Requests {
+	usage := make(map[TopologyDomainID]resources.Requests)
+	for _, domain := range ta.Domains {
+		domainID := DomainID(domain.Values)
+		domainUsage := singlePodRequests.ScaledUp(int64(domain.Count))
+		domainUsage.Add(resources.Requests{corev1.ResourcePods: int64(domain.Count)})
+		usage[domainID] = domainUsage
+	}
+	return usage
 }
 
 func HasTASAssignmentOnNode(admission *kueue.Admission, nodeName string) bool {


### PR DESCRIPTION
Cherry-pick of #11293 onto release-0.16.\n\nOriginal commits:\n- b3f97386e8d90685be63bb733d75eb2670c13bd5\n- 4578a39d5d2df4ecc3c0e0c1ee04aed52b0f35a6\n\nVerification:\n- go test ./pkg/cache/scheduler ./pkg/scheduler\n- go test ./pkg/util/tas

```release-note
TAS: Fixed a scheduling bug where a workload with multiple PodSets could be admitted even when the combined PodSets exceeded node pod capacity.
```