### PR TITLE
test: consolidate failure recovery scenarios under a single kubelet outage

### DIFF
--- a/test/e2e/sequential/baseline/failure_recovery_policy_test.go
+++ b/test/e2e/sequential/baseline/failure_recovery_policy_test.go
@@ -177,11 +177,7 @@ var _ = ginkgo.Describe("Failure Recovery Policy", ginkgo.Label("feature:failure
 			})
 		})
 
-		ginkgo.It("should delete pods running on an unreachable node", func() {
-			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, pod, false, nodeMonitorGracePeriod+unhealthyNodeforcefulTerminationCheckTimeout+util.MediumTimeout)
-		})
-
-		ginkgo.It("should unblock the stuck pod's parents that are being deleted with foreground propagation", func() {
+		ginkgo.It("should handle failure recovery scenarios during a single kubelet outage", func() {
 			ginkgo.By("waiting for pods to be marked for termination", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(gomega.Succeed())
@@ -189,12 +185,42 @@ var _ = ginkgo.Describe("Failure Recovery Policy", ginkgo.Label("feature:failure
 				}, nodeMonitorGracePeriod+util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
+			ginkgo.By("verifying the pod is forcefully deleted from the unreachable node", func() {
+				util.ExpectObjectToBeDeletedWithTimeout(
+					ctx,
+					k8sClient,
+					pod,
+					false,
+					nodeMonitorGracePeriod+unhealthyNodeforcefulTerminationCheckTimeout+util.MediumTimeout,
+				)
+			})
+
+			ginkgo.By("ensuring the job still exists before foreground deletion", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), job)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
 			ginkgo.By("deleting the job with foreground propagation", func() {
-				gomega.Expect(k8sClient.Delete(ctx, job, &client.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationForeground)})).To(gomega.Succeed())
+				gomega.Expect(
+					k8sClient.Delete(
+						ctx,
+						job,
+						&client.DeleteOptions{
+							PropagationPolicy: ptr.To(metav1.DeletePropagationForeground),
+						},
+					),
+				).To(gomega.Succeed())
 			})
 
 			ginkgo.By("ensuring the job is deleted", func() {
-				util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, job, false, unhealthyNodeforcefulTerminationCheckTimeout+util.Timeout)
+				util.ExpectObjectToBeDeletedWithTimeout(
+					ctx,
+					k8sClient,
+					job,
+					false,
+					unhealthyNodeforcefulTerminationCheckTimeout+util.Timeout,
+				)
 			})
 		})
 	})

--- a/test/e2e/sequential/baseline/failure_recovery_policy_test.go
+++ b/test/e2e/sequential/baseline/failure_recovery_policy_test.go
@@ -177,21 +177,11 @@ var _ = ginkgo.Describe("Failure Recovery Policy", ginkgo.Label("feature:failure
 			})
 		})
 
-		ginkgo.It("should handle failure recovery scenarios during a single kubelet outage", func() {
-			ginkgo.By("waiting for pods to be marked for termination", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(gomega.Succeed())
-					g.Expect(pod.DeletionTimestamp).ToNot(gomega.BeNil())
-				}, nodeMonitorGracePeriod+util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("verifying the pod is forcefully deleted from the unreachable node", func() {
-				util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, pod, false, nodeMonitorGracePeriod+unhealthyNodeforcefulTerminationCheckTimeout+util.MediumTimeout)
-			})
-
-			ginkgo.By("ensuring the job still exists before foreground deletion", func() {
+		ginkgo.It("should unblock foreground deletion during a kubelet outage", func() {
+			ginkgo.By("ensuring the job is active before foreground deletion", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), job)).To(gomega.Succeed())
+					g.Expect(job.Status.Active).To(gomega.Equal(int32(1)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 

--- a/test/e2e/sequential/baseline/failure_recovery_policy_test.go
+++ b/test/e2e/sequential/baseline/failure_recovery_policy_test.go
@@ -186,13 +186,7 @@ var _ = ginkgo.Describe("Failure Recovery Policy", ginkgo.Label("feature:failure
 			})
 
 			ginkgo.By("verifying the pod is forcefully deleted from the unreachable node", func() {
-				util.ExpectObjectToBeDeletedWithTimeout(
-					ctx,
-					k8sClient,
-					pod,
-					false,
-					nodeMonitorGracePeriod+unhealthyNodeforcefulTerminationCheckTimeout+util.MediumTimeout,
-				)
+				util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, pod, false, nodeMonitorGracePeriod+unhealthyNodeforcefulTerminationCheckTimeout+util.MediumTimeout)
 			})
 
 			ginkgo.By("ensuring the job still exists before foreground deletion", func() {
@@ -202,25 +196,11 @@ var _ = ginkgo.Describe("Failure Recovery Policy", ginkgo.Label("feature:failure
 			})
 
 			ginkgo.By("deleting the job with foreground propagation", func() {
-				gomega.Expect(
-					k8sClient.Delete(
-						ctx,
-						job,
-						&client.DeleteOptions{
-							PropagationPolicy: ptr.To(metav1.DeletePropagationForeground),
-						},
-					),
-				).To(gomega.Succeed())
+				gomega.Expect(k8sClient.Delete(ctx, job, &client.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationForeground)})).To(gomega.Succeed())
 			})
 
 			ginkgo.By("ensuring the job is deleted", func() {
-				util.ExpectObjectToBeDeletedWithTimeout(
-					ctx,
-					k8sClient,
-					job,
-					false,
-					unhealthyNodeforcefulTerminationCheckTimeout+util.Timeout,
-				)
+				util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, job, false, unhealthyNodeforcefulTerminationCheckTimeout+util.Timeout)
 			})
 		})
 	})

--- a/test/e2e/sequential/baseline/failure_recovery_policy_test.go
+++ b/test/e2e/sequential/baseline/failure_recovery_policy_test.go
@@ -61,8 +61,8 @@ var _ = ginkgo.Describe("Failure Recovery Policy", ginkgo.Label("feature:failure
 		job = testingjob.MakeJob("test-job", ns.Name).
 			Queue("lq").
 			Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
-			RequestAndLimit(corev1.ResourceCPU, "100m").
-			RequestAndLimit(corev1.ResourceMemory, "20Mi").
+			RequestAndLimit(corev1.ResourceCPU, "1").
+			RequestAndLimit(corev1.ResourceMemory, "40Mi").
 			Parallelism(1).
 			TerminationGracePeriod(podTerminationGracePeriodSeconds).
 			PodReplacementPolicy(ptr.To(batchv1.Failed)).
@@ -106,11 +106,7 @@ var _ = ginkgo.Describe("Failure Recovery Policy", ginkgo.Label("feature:failure
 		var (
 			cq       *kueue.ClusterQueue
 			lq       *kueue.LocalQueue
-			pod      *corev1.Pod
 			nodeName string
-
-			// Unresponsive node is marked as unreachable after the grace period.
-			nodeMonitorGracePeriod = 50 * time.Second
 
 			// `podToleration` + `deletionGracePeriodSeconds` + `forcefulTerminationGracePeriod`
 			unhealthyNodeforcefulTerminationCheckTimeout = (1 + podTerminationGracePeriodSeconds + 60) * time.Second
@@ -148,8 +144,7 @@ var _ = ginkgo.Describe("Failure Recovery Policy", ginkgo.Label("feature:failure
 					g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name), client.MatchingLabels(job.Spec.Selector.MatchLabels))).To(gomega.Succeed())
 					g.Expect(pods.Items).To(gomega.HaveLen(1))
 
-					pod = &pods.Items[0]
-					nodeName = pod.Spec.NodeName
+					nodeName = pods.Items[0].Spec.NodeName
 					g.Expect(nodeName).ToNot(gomega.BeEmpty())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing


#### What this PR does / why we need it:
This PR consolidates the Failure Recovery Policy e2e scenarios to share a single kubelet stop/start cycle instead of restarting kubelet independently for each spec.

#### Which issue(s) this PR fixes:
Part of #11274
Fixes #11274

#### Special notes for your reviewer:
Consolidate Failure Recovery tests to share one kubelet outage
The two Failure Recovery specs currently stop and restart kubelet independently. 
Refactored them so both scenarios use pods on the same worker node and share a single kubelet stop/start cycle.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
