### PR TITLE
Fix bindAddress regression

### DIFF
--- a/pkg/visibility/server.go
+++ b/pkg/visibility/server.go
@@ -113,14 +113,7 @@ func applyVisibilityServerOptions(config *genericapiserver.RecommendedConfig, cf
 		o.SecureServing.ServerCert.CertKey.KeyFile = certDir + "/tls.key"
 	}
 
-	o.SecureServing.BindPort = int(configapi.DefaultVisibilityBindPort)
-
-	if cfg.VisibilityServer != nil {
-		o.SecureServing.BindPort = int(ptr.Deref(
-			cfg.VisibilityServer.BindPort,
-			configapi.DefaultVisibilityBindPort,
-		))
-	}
+	applyVisibilityServerSecureServingOptions(o.SecureServing, cfg)
 
 	if f := flag.Lookup("kubeconfig"); f != nil {
 		kubeConfigPath := f.Value.String()
@@ -145,6 +138,20 @@ func applyVisibilityServerOptions(config *genericapiserver.RecommendedConfig, cf
 	}
 
 	return nil
+}
+
+func applyVisibilityServerSecureServingOptions(o *genericoptions.SecureServingOptionsWithLoopback, cfg *configapi.Configuration) {
+	o.BindPort = int(configapi.DefaultVisibilityBindPort)
+
+	if cfg.VisibilityServer != nil {
+		o.BindPort = int(ptr.Deref(
+			cfg.VisibilityServer.BindPort,
+			configapi.DefaultVisibilityBindPort,
+		))
+		if cfg.VisibilityServer.BindAddress != nil {
+			o.BindAddress = net.ParseIP(*cfg.VisibilityServer.BindAddress)
+		}
+	}
 }
 
 func newVisibilityServerConfig(kubeConfig *rest.Config) *genericapiserver.RecommendedConfig {

--- a/pkg/visibility/server_test.go
+++ b/pkg/visibility/server_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package visibility
+
+import (
+	"net"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	genericoptions "k8s.io/apiserver/pkg/server/options"
+
+	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
+)
+
+func TestApplyVisibilityServerSecureServingOptions(t *testing.T) {
+	bindAddress := "127.0.0.1"
+	bindPort := int32(9444)
+
+	tests := map[string]struct {
+		cfg         *configapi.Configuration
+		wantOptions *genericoptions.SecureServingOptionsWithLoopback
+	}{
+		"default visibility server config": {
+			cfg:         &configapi.Configuration{},
+			wantOptions: wantSecureServingOptions("", int(configapi.DefaultVisibilityBindPort)),
+		},
+		"custom bind port": {
+			cfg: &configapi.Configuration{
+				VisibilityServer: &configapi.VisibilityServerConfiguration{
+					BindPort: &bindPort,
+				},
+			},
+			wantOptions: wantSecureServingOptions("", 9444),
+		},
+		"custom bind address": {
+			cfg: &configapi.Configuration{
+				VisibilityServer: &configapi.VisibilityServerConfiguration{
+					BindAddress: &bindAddress,
+				},
+			},
+			wantOptions: wantSecureServingOptions("127.0.0.1", int(configapi.DefaultVisibilityBindPort)),
+		},
+		"custom bind address and port": {
+			cfg: &configapi.Configuration{
+				VisibilityServer: &configapi.VisibilityServerConfiguration{
+					BindAddress: &bindAddress,
+					BindPort:    &bindPort,
+				},
+			},
+			wantOptions: wantSecureServingOptions("127.0.0.1", 9444),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			options := genericoptions.NewSecureServingOptions().WithLoopback()
+
+			applyVisibilityServerSecureServingOptions(options, tc.cfg)
+
+			if diff := cmp.Diff(tc.wantOptions, options); diff != "" {
+				t.Errorf("Unexpected options (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func wantSecureServingOptions(bindAddress string, bindPort int) *genericoptions.SecureServingOptionsWithLoopback {
+	options := genericoptions.NewSecureServingOptions().WithLoopback()
+	options.BindPort = bindPort
+
+	if bindAddress != "" {
+		options.BindAddress = net.ParseIP(bindAddress)
+	}
+	return options
+}


### PR DESCRIPTION

#### What type of PR is this?

 
/kind bug
 

#### What this PR does / why we need it:

 Trigger Scenario

  A user configures the visibility server with a custom bind address:
  visibilityServer:
    bindAddress: 127.0.0.1  <--- example
    bindPort: 8082

  This happens when users want the embedded visibility API server to listen only on a specific interface, such as loopback, an internal network IP, or a  restricted node interface.

  The configuration is accepted and passes validation, but the visibility server ignores visibilityServer.bindAddress.
  Instead of listening on the configured IP, it keeps the default bind address:  0.0.0.0




  Root Cause
  PR #11323 refactored visibility server port defaulting and moved bindPort handling into pkg/visibility/server.go.
  During that refactor, the existing BindAddress assignment was accidentally removed:

  o.SecureServing.BindAddress = net.ParseIP(*cfg.VisibilityServer.BindAddress)

btw, if the user does not config  visibilityServer. bindPort,   the problem does not appeaer


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
