### PR TITLE
Fix Label Path Reuse in Elastic Job Annotation Update Validation

### DIFF
--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -175,11 +175,11 @@ func validateJobUpdateForWorkloadPriorityClassName(oldJob, newJob GenericJob) fi
 //
 // It compares the boolean returned by workloadslicing.Enabled for the old and new Job objects.
 // If the value changed, it returns a field.ErrorList with a single field.Invalid pointing at
-// labels[workloadslicing.EnabledAnnotationKey] and using apivalidation.FieldImmutableErrorMsg.
+// annotations[workloadslicing.EnabledAnnotationKey] and using apivalidation.FieldImmutableErrorMsg.
 // If the value did not change, // it returns nil.
 func validatedUpdateForEnabledWorkloadSlice(oldJob, newJob GenericJob) field.ErrorList {
 	if oldEnabled, newEnabled := workloadslicing.Enabled(oldJob.Object()), workloadslicing.Enabled(newJob.Object()); oldEnabled != newEnabled {
-		return field.ErrorList{field.Invalid(labelsPath.Key(workloadslicing.EnabledAnnotationKey), newEnabled, apivalidation.FieldImmutableErrorMsg)}
+		return field.ErrorList{field.Invalid(elasticJobAnnotationPath, newEnabled, apivalidation.FieldImmutableErrorMsg)}
 	}
 	return nil
 }

--- a/pkg/controller/jobframework/validation_test.go
+++ b/pkg/controller/jobframework/validation_test.go
@@ -305,7 +305,7 @@ func TestValidateJobOnUpdate(t *testing.T) {
 				features.ElasticJobsViaWorkloadSlices: true,
 			},
 			wantErr: field.ErrorList{
-				field.Invalid(field.NewPath("metadata.labels["+workloadslicing.EnabledAnnotationKey+"]"), "false", "field is immutable"),
+				field.Invalid(field.NewPath("metadata.annotations["+workloadslicing.EnabledAnnotationKey+"]"), "false", "field is immutable"),
 			},
 		},
 		"elastic job enabled annotation cannot be added on update": {
@@ -315,7 +315,7 @@ func TestValidateJobOnUpdate(t *testing.T) {
 				features.ElasticJobsViaWorkloadSlices: true,
 			},
 			wantErr: field.ErrorList{
-				field.Invalid(field.NewPath("metadata.labels["+workloadslicing.EnabledAnnotationKey+"]"), "false", "field is immutable"),
+				field.Invalid(field.NewPath("metadata.annotations["+workloadslicing.EnabledAnnotationKey+"]"), "false", "field is immutable"),
 			},
 		},
 	}


### PR DESCRIPTION


#### What type of PR is this?


/kind bug



#### What this PR does / why we need it:

  Trigger scenario: 
A user updates a Kueue-managed job and changes the kueue.x-k8s.io/elastic-job annotation, either adding it or removing it after creation.
 The webhook correctly rejects the update as immutable, but the validation error points to metadata.labels[kueue.x-k8s.io/elastic-job].

  Expected behavior: 
The validation error should point to metadata.annotations[kueue.x-k8s.io/elastic-job], because elastic job enablement is configured through an annotation.

There are many codes showing that the config should exist in the annotation , rather than  label
  // EnabledAnnotationKey refers to the annotation key present on Job's that support
  // workload slicing.
  EnabledAnnotationKey = "kueue.x-k8s.io/elastic-job"

 


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
ElasticJobsViaWorkloadSlices: Fixed a bug where updating the `kueue.x-k8s.io/elastic-job` annotation on a Job resulted in a validation error pointing to the incorrect path `metadata.labels` instead of `metadata.annotations`.
```
