### PR TITLE
WIP: Use GetOwnerObject() to fetch owner object.

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -55,6 +55,7 @@ import (
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/dra"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
@@ -1356,24 +1357,33 @@ func (r *WorkloadReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.Conf
 func (r *WorkloadReconciler) isControllerOwnerGone(ctx context.Context, wl *kueue.Workload) (bool, error) {
 	ref := metav1.GetControllerOf(wl)
 	if ref == nil {
+		ctrl.LoggerFrom(ctx).Info("Workload has no controller reference")
 		return false, nil
 	}
-	obj := &metav1.PartialObjectMetadata{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: ref.APIVersion,
-			Kind:       ref.Kind,
-		},
-	}
-	key := client.ObjectKey{Namespace: wl.Namespace, Name: ref.Name}
-	if err := r.client.Get(ctx, key, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return true, nil
-		}
+
+	log := ctrl.LoggerFrom(ctx).WithValues(
+		"ownerAPIVersion", ref.APIVersion,
+		"ownerKind", ref.Kind,
+		"ownerName", ref.Name,
+		"ownerUID", ref.UID,
+	)
+	ctx = ctrl.LoggerInto(ctx, log)
+
+	_, ownerObj, err := jobframework.GetOwnerObject(ctx, r.client, ref, wl.Namespace)
+	if err != nil {
+		log.Error(err, "Failed to get owner object")
 		return false, err
 	}
+
+	if ownerObj == nil {
+		// Owner object does not exist means the original owner was deleted.
+		log.Info("Owner object does not exist")
+		return true, nil
+	}
+
 	// A different UID means the original owner was deleted and a new object
 	// with the same name was created.
-	return obj.UID != ref.UID, nil
+	return ownerObj.GetUID() != ref.UID, nil
 }
 
 // admittedNotReadyWorkload returns the underlying cause and remaining time for

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -825,19 +825,15 @@ func FindAncestorJobManagedByKueue(ctx context.Context, c client.Client, jobObj 
 			)
 			return topLevelJob, nil
 		}
-		parentObj := GetEmptyOwnerObject(owner)
-		managed := parentObj != nil
+
+		managed, parentObj, err := GetOwnerObject(ctx, c, owner, jobObj.GetNamespace())
+		if err != nil {
+			return nil, err
+		}
 		if parentObj == nil {
-			parentObj = &metav1.PartialObjectMetadata{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: owner.APIVersion,
-					Kind:       owner.Kind,
-				},
-			}
+			return nil, ErrWorkloadOwnerNotFound
 		}
-		if err := c.Get(ctx, client.ObjectKey{Name: owner.Name, Namespace: jobObj.GetNamespace()}, parentObj); err != nil {
-			return nil, errors.Join(ErrWorkloadOwnerNotFound, err)
-		}
+
 		if managed && (manageJobsWithoutQueueName || QueueNameForObject(parentObj) != "") {
 			topLevelJob = parentObj
 		}

--- a/pkg/controller/jobframework/utils.go
+++ b/pkg/controller/jobframework/utils.go
@@ -203,3 +203,22 @@ func NewWorkload(name string, obj client.Object, podSets []kueue.PodSet, labelKe
 		},
 	}
 }
+
+func GetOwnerObject(ctx context.Context, c client.Client, owner *metav1.OwnerReference, namespace string) (bool, client.Object, error) {
+	ownerObj := GetEmptyOwnerObject(owner)
+	managed := ownerObj != nil
+	if ownerObj == nil {
+		ctrl.LoggerFrom(ctx).V(3).
+			Info("Owner object is not managed by Kueue; trying to fetch it using PartialObjectMetadata")
+		ownerObj = &metav1.PartialObjectMetadata{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: owner.APIVersion,
+				Kind:       owner.Kind,
+			},
+		}
+	}
+	if err := c.Get(ctx, client.ObjectKey{Name: owner.Name, Namespace: namespace}, ownerObj); err != nil {
+		return managed, nil, client.IgnoreNotFound(err)
+	}
+	return managed, ownerObj, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Use GetOwnerObject() to fetch owner object.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10901

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
