### PR TITLE
Reorganize drop finalizers logic.

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -287,12 +287,9 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 		err = r.ignoreUnretryableError(log, err)
 	}()
 
-	dropFinalizers := false
-	if cJob, isComposable := job.(ComposableJob); isComposable {
-		dropFinalizers, err = cJob.Load(ctx, r.client, &req.NamespacedName)
-	} else {
-		err = r.client.Get(ctx, req.NamespacedName, object)
-		dropFinalizers = apierrors.IsNotFound(err) || !object.GetDeletionTimestamp().IsZero()
+	shouldFinalize, err := r.loadJob(ctx, &req.NamespacedName, job)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	if jws, implements := job.(JobWithSkip); implements {
@@ -301,42 +298,11 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	if dropFinalizers {
-		// Remove workload finalizer
-		workloads := &kueue.WorkloadList{}
-
-		if cJob, isComposable := job.(ComposableJob); isComposable {
-			var err error
-			workloads, err = cJob.ListChildWorkloads(ctx, r.client, req.NamespacedName)
-			if err != nil {
-				log.Error(err, "Removing finalizer")
-				return ctrl.Result{}, err
-			}
-		} else {
-			if err := r.client.List(ctx, workloads, client.InNamespace(req.Namespace), OwnerReferenceIndexFieldMatcher(job.GVK(), req.Name)); err != nil {
-				log.Error(err, "Unable to list child workloads")
-				return ctrl.Result{}, err
-			}
-		}
-		for i := range workloads.Items {
-			err := workload.RemoveFinalizer(ctx, r.client, &workloads.Items[i])
-			if client.IgnoreNotFound(err) != nil {
-				log.Error(err, "Removing finalizer")
-				return ctrl.Result{}, err
-			}
-		}
-
-		// Remove job finalizer
-		if !object.GetDeletionTimestamp().IsZero() {
-			if err = r.finalizeJob(ctx, job); err != nil {
-				return ctrl.Result{}, err
-			}
+	if shouldFinalize {
+		if err := r.finalize(ctx, req.NamespacedName, job); err != nil {
+			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
-	}
-
-	if err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	if features.Enabled(features.ManagedJobsNamespaceSelectorAlwaysRespected) {
@@ -655,6 +621,79 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 	// For elastic jobs, pod ungating is handled by the ElasticJobUngater controller.
 	log.V(3).Info("Job running with admitted workload, nothing to do")
 	return ctrl.Result{}, nil
+}
+
+// loadJob retrieves and loads the specified job resource into memory.
+// Returns true if the job should be finalized and an error if loading fails.
+func (r *JobReconciler) loadJob(ctx context.Context, key *types.NamespacedName, job GenericJob) (bool, error) {
+	if cJob, isComposable := job.(ComposableJob); isComposable {
+		return cJob.Load(ctx, r.client, key)
+	}
+	obj := job.Object()
+	if err := r.client.Get(ctx, *key, obj); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	return !obj.GetDeletionTimestamp().IsZero(), nil
+}
+
+// finalize removes finalizers from workloads and the job itself,
+// ensuring proper cleanup during object deletion.
+func (r *JobReconciler) finalize(ctx context.Context, key types.NamespacedName, job GenericJob) error {
+	// Remove workloads finalizer
+	if err := r.finalizeWorkloads(ctx, key, job); client.IgnoreNotFound(err) != nil {
+		return err
+	}
+
+	// Remove job finalizer
+	if !job.Object().GetDeletionTimestamp().IsZero() {
+		if err := r.finalizeJob(ctx, job); client.IgnoreNotFound(err) != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// getWorkloads retrieves a list of workloads associated with the specified job.
+func (r *JobReconciler) getWorkloads(ctx context.Context, key types.NamespacedName, job GenericJob) ([]kueue.Workload, error) {
+	log := ctrl.LoggerFrom(ctx)
+	workloads := &kueue.WorkloadList{}
+
+	var err error
+	if cJob, isComposable := job.(ComposableJob); isComposable {
+		workloads, err = cJob.ListChildWorkloads(ctx, r.client, key)
+	} else {
+		err = r.client.List(ctx, workloads,
+			client.InNamespace(key.Namespace),
+			OwnerReferenceIndexFieldMatcher(job.GVK(), key.Name),
+		)
+	}
+	if err != nil {
+		log.Error(err, "Unable to list child workloads")
+		return nil, err
+	}
+
+	return workloads.Items, nil
+}
+
+// finalizeWorkloads removes finalizers from workloads associated with the specified job.
+func (r *JobReconciler) finalizeWorkloads(ctx context.Context, key types.NamespacedName, job GenericJob) error {
+	log := ctrl.LoggerFrom(ctx)
+	workloads, err := r.getWorkloads(ctx, key, job)
+	if err != nil {
+		return err
+	}
+	for i := range workloads {
+		wl := &workloads[i]
+		if err := workload.RemoveFinalizer(ctx, r.client, wl); client.IgnoreNotFound(err) != nil {
+			log.Error(err, "Removing finalizer")
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *JobReconciler) handleQueueNameChange(ctx context.Context, job GenericJob, wl *kueue.Workload) error {

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -599,7 +599,8 @@ func TestReconciler(t *testing.T) {
 		featureGates map[featuregate.Feature]bool
 
 		reconcilerOptions []jobframework.Option
-		job               batchv1.Job
+		reconcileKey      *types.NamespacedName
+		job               *batchv1.Job
 		workloads         []kueue.Workload
 		otherJobs         []batchv1.Job
 		priorityClasses   []client.Object
@@ -608,6 +609,42 @@ func TestReconciler(t *testing.T) {
 		wantEvents        []utiltesting.EventRecord
 		wantErr           error
 	}{
+		"job is not found": {
+			reconcileKey: &types.NamespacedName{Namespace: "ns", Name: "deleted_job"},
+			job:          nil,
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					ControllerReference(gvk, "deleted_job", "deleted_job").
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					ControllerReference(gvk, "deleted_job", "deleted_job").
+					Obj(),
+			},
+		},
+		"job is deleted": {
+			job: baseJobWrapper.Clone().
+				DeletionTimestamp(now).
+				Finalizers(kueue.ResourceInUseFinalizerName).
+				Obj(),
+			wantJob: *baseJobWrapper.Clone().
+				DeletionTimestamp(now).
+				Finalizers(kueue.ResourceInUseFinalizerName).
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					ControllerReference(gvk, baseJobWrapper.GetName(), string(baseJobWrapper.GetUID())).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					ControllerReference(gvk, baseJobWrapper.GetName(), string(baseJobWrapper.GetUID())).
+					Obj(),
+			},
+		},
 		"PodsReady is set to False before Workload is Admitted": {
 			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:                     false,
@@ -617,7 +654,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job:     *baseJobWrapper.DeepCopy(),
+			job:     baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.DeepCopy(),
 			workloads: []kueue.Workload{*baseWorkloadWrapper.Clone().
 				AdmittedAt(false, now).
@@ -643,7 +680,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job:     *baseJobWrapper.DeepCopy(),
+			job:     baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.DeepCopy(),
 			workloads: []kueue.Workload{*baseWorkloadWrapper.Clone().
 				AdmittedAt(true, now).
@@ -669,7 +706,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Ready(9).
 				Active(10).
@@ -709,7 +746,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Ready(10).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -745,7 +782,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Ready(10).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -775,7 +812,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Ready(9).
 				Failed(1).
 				Obj(),
@@ -813,7 +850,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Ready(9).
 				Failed(1).
@@ -853,7 +890,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Ready(10).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -889,7 +926,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job:     *baseJobWrapper.DeepCopy(),
+			job:     baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.DeepCopy(),
 			workloads: []kueue.Workload{*baseWorkloadWrapper.Clone().
 				AdmittedAt(true, now).
@@ -921,7 +958,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Ready(10).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -957,7 +994,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job:     *baseJobWrapper.DeepCopy(),
+			job:     baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.DeepCopy(),
 			workloads: []kueue.Workload{*baseWorkloadWrapper.Clone().
 				AdmittedAt(true, now).
@@ -990,7 +1027,7 @@ func TestReconciler(t *testing.T) {
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
 			},
-			job: *baseJobWrapper.DeepCopy(),
+			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(false).
 				PodLabel(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
@@ -1023,7 +1060,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    false,
 			},
-			job: *baseJobWrapper.DeepCopy(),
+			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(false).
 				PodLabel(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
@@ -1053,7 +1090,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.DeepCopy(),
+			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(false).
 				PodLabel(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
@@ -1092,7 +1129,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				SetAnnotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
 				SetAnnotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
 				UID("test-uid").
@@ -1129,7 +1166,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Label("toCopyKey", "toCopyValue").
 				Label("dontCopyKey", "dontCopyValue").
 				UID("test-uid").
@@ -1169,7 +1206,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.DeepCopy(),
+			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(false).
 				PodLabel("ac-key", "ac-value").
@@ -1226,7 +1263,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -1320,7 +1357,7 @@ func TestReconciler(t *testing.T) {
 					},
 				}),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -1415,7 +1452,7 @@ func TestReconciler(t *testing.T) {
 					},
 				}),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -1510,7 +1547,7 @@ func TestReconciler(t *testing.T) {
 					},
 				}),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			workloads: []kueue.Workload{
@@ -1608,7 +1645,7 @@ func TestReconciler(t *testing.T) {
 					},
 				}),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -1703,7 +1740,7 @@ func TestReconciler(t *testing.T) {
 					},
 				}),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			workloads: []kueue.Workload{
@@ -1794,7 +1831,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -1855,7 +1892,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -1940,7 +1977,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2025,7 +2062,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2110,7 +2147,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2196,7 +2233,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(true).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2271,7 +2308,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.DeepCopy(),
+			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(true).
 				Obj(),
@@ -2346,7 +2383,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.DeepCopy(),
+			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(true).
 				Obj(),
@@ -2421,7 +2458,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.DeepCopy(),
+			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(true).
 				Obj(),
@@ -2496,7 +2533,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				NodeSelector("provisioning", "spot").
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2550,7 +2587,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.DeepCopy(),
+			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(false).
 				PodAnnotation("annotation-key1", "common-value").
@@ -2667,7 +2704,7 @@ func TestReconciler(t *testing.T) {
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
 			},
-			job: *baseJobWrapper.DeepCopy(),
+			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(false).
 				PodLabel(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
@@ -2703,7 +2740,7 @@ func TestReconciler(t *testing.T) {
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
 			},
-			job:     *baseJobWrapper.DeepCopy(),
+			job:     baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.DeepCopy(),
 			workloads: []kueue.Workload{
 				*baseWorkloadWrapper.Clone().
@@ -2731,7 +2768,7 @@ func TestReconciler(t *testing.T) {
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
 			},
-			job:     *baseJobWrapper.DeepCopy(),
+			job:     baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.DeepCopy(),
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("a", "ns").
@@ -2767,7 +2804,7 @@ func TestReconciler(t *testing.T) {
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				SetAnnotation(JobMinParallelismAnnotation, "5").
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2820,7 +2857,7 @@ func TestReconciler(t *testing.T) {
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				SetAnnotation(JobMinParallelismAnnotation, "5").
 				Suspend(false).
 				Obj(),
@@ -2862,7 +2899,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				Queue("test-queue").
@@ -2905,7 +2942,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(true).
 				Queue("test-queue-new").
@@ -2945,7 +2982,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(true).
 				WorkloadPriorityClass(highWPCWrapper.Name).
@@ -2998,7 +3035,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(true).
 				PriorityClass(basePCWrapper.Name).
@@ -3043,7 +3080,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				Queue("test-queue").
@@ -3084,7 +3121,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *utiltestingjob.MakeJob("job", "ns").
+			job: utiltestingjob.MakeJob("job", "ns").
 				Suspend(false).
 				Obj(),
 			wantJob: *utiltestingjob.MakeJob("job", "ns").
@@ -3097,7 +3134,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				OwnerReference("parent", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Suspend(false).
@@ -3131,7 +3168,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				OwnerReference("parent", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Suspend(false).
@@ -3174,7 +3211,7 @@ func TestReconciler(t *testing.T) {
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				OwnerReference("parent", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Suspend(false).
@@ -3218,7 +3255,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				OwnerReference("parent", batchv1.SchemeGroupVersion.WithKind("Job")).
@@ -3265,7 +3302,7 @@ func TestReconciler(t *testing.T) {
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				Parallelism(5).
@@ -3306,7 +3343,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is evicted, suspend, reset startTime and restore node affinity": {
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				StartTime(now).
 				NodeSelector("provisioning", "spot").
@@ -3348,7 +3385,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(true).
 				StartTime(now).
 				NodeSelector("provisioning", "spot").
@@ -3383,7 +3420,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(true).
 				NodeSelector("provisioning", "spot").
 				Active(10).
@@ -3417,7 +3454,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Condition(batchv1.JobCondition{
 					Type:    batchv1.JobComplete,
 					Status:  corev1.ConditionTrue,
@@ -3465,7 +3502,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.DeepCopy(),
+			job: baseJobWrapper.DeepCopy(),
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("a", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
@@ -3509,7 +3546,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				Queue("test-queue").
@@ -3558,7 +3595,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				Queue("test-queue").
@@ -3607,7 +3644,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				Queue("test-queue").
@@ -3658,7 +3695,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
 				Obj(),
 			workloads: []kueue.Workload{},
@@ -3673,7 +3710,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				Label(controllerconsts.PrebuiltWorkloadLabel, "missing-workload").
@@ -3700,7 +3737,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
@@ -3748,7 +3785,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
@@ -3795,7 +3832,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
@@ -3850,7 +3887,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().Toleration(corev1.Toleration{
+			job: baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
 				Operator: corev1.TolerationOpExists,
 				Effect:   corev1.TaintEffectNoSchedule,
@@ -3919,7 +3956,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().Toleration(corev1.Toleration{
+			job: baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
 				Operator: corev1.TolerationOpExists,
 				Effect:   corev1.TaintEffectNoSchedule,
@@ -3998,7 +4035,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().Toleration(corev1.Toleration{
+			job: baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
 				Operator: corev1.TolerationOpExists,
 				Effect:   corev1.TaintEffectNoSchedule,
@@ -4053,7 +4090,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(true).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -4108,7 +4145,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(true).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -4173,7 +4210,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -4204,7 +4241,7 @@ func TestReconciler(t *testing.T) {
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 				features.AssignQueueLabelsForPods:                    true,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -4250,7 +4287,7 @@ func TestReconciler(t *testing.T) {
 					"managed-by-kueue": "true",
 				})),
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Queue("test-queue").
 				Suspend(false).
@@ -4274,7 +4311,7 @@ func TestReconciler(t *testing.T) {
 				})),
 				jobframework.WithManageJobsWithoutQueueName(true),
 			},
-			job: *utiltestingjob.MakeJob("job", "labelled-ns").
+			job: utiltestingjob.MakeJob("job", "labelled-ns").
 				Queue("test-queue").
 				Suspend(true).
 				UID("test-uid").
@@ -4330,27 +4367,28 @@ func TestReconciler(t *testing.T) {
 					Label("managed-by-kueue", "true").
 					Obj()
 
-				objs := append(tc.priorityClasses, &tc.job, utiltestingapi.MakeResourceFlavor("default").Obj(), testNamespace, labelledNamespace)
-				kcBuilder := clientBuilder.
-					WithObjects(objs...)
-
-				if len(tc.otherJobs) > 0 {
-					kcBuilder = kcBuilder.WithLists(&batchv1.JobList{Items: tc.otherJobs})
+				objs := append(tc.priorityClasses, utiltestingapi.MakeResourceFlavor("default").Obj(), testNamespace, labelledNamespace)
+				if tc.job != nil {
+					objs = append(objs, tc.job)
 				}
 
-				for i := range tc.workloads {
-					kcBuilder = kcBuilder.WithStatusSubresource(&tc.workloads[i])
+				kClient := clientBuilder.
+					WithObjects(objs...).
+					WithLists(&batchv1.JobList{Items: tc.otherJobs}).
+					WithStatusSubresource(&kueue.Workload{}).
+					Build()
+
+				useesPrebuiltWorkload := false
+				if tc.job != nil {
+					// For prebuilt workloads we are skipping the ownership setup in the test body and
+					// expect the reconciler to do it.
+					_, useesPrebuiltWorkload = tc.job.Labels[controllerconsts.PrebuiltWorkloadLabel]
 				}
 
-				// For prebuilt workloads we are skipping the ownership setup in the test body and
-				// expect the reconciler to do it.
-				_, useesPrebuiltWorkload := tc.job.Labels[controllerconsts.PrebuiltWorkloadLabel]
-
-				kClient := kcBuilder.Build()
 				for _, testWl := range tc.workloads {
 					controller := metav1.GetControllerOfNoCopy(&testWl)
 					if !useesPrebuiltWorkload && controller == nil {
-						if err := ctrl.SetControllerReference(&tc.job, &testWl, kClient.Scheme()); err != nil {
+						if err := ctrl.SetControllerReference(tc.job, &testWl, kClient.Scheme()); err != nil {
 							t.Fatalf("Could not setup owner reference in Workloads: %v", err)
 						}
 					}
@@ -4365,16 +4403,19 @@ func TestReconciler(t *testing.T) {
 					t.Errorf("Error creating the reconciler: %v", err)
 				}
 
-				jobKey := client.ObjectKeyFromObject(&tc.job)
-				_, err = reconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: jobKey,
-				})
+				var reconcileRequest reconcile.Request
+				if tc.reconcileKey != nil {
+					reconcileRequest.NamespacedName = *tc.reconcileKey
+				} else {
+					reconcileRequest.NamespacedName = client.ObjectKeyFromObject(tc.job)
+				}
+				_, err = reconciler.Reconcile(ctx, reconcileRequest)
 				if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
 					t.Errorf("Reconcile returned error (-want,+got):\n%s", diff)
 				}
 
 				var gotJob batchv1.Job
-				if err := kClient.Get(ctx, jobKey, &gotJob); client.IgnoreNotFound(err) != nil {
+				if err := kClient.Get(ctx, reconcileRequest.NamespacedName, &gotJob); client.IgnoreNotFound(err) != nil {
 					t.Fatalf("Could not get Job after reconcile: %v", err)
 				}
 				if diff := cmp.Diff(tc.wantJob, gotJob, jobCmpOpts...); diff != "" {

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -640,7 +640,10 @@ func (p *Pod) Load(ctx context.Context, c client.Client, key *types.NamespacedNa
 
 	if len(nsKey) == 1 {
 		if err := c.Get(ctx, *key, &p.pod); err != nil {
-			return apierrors.IsNotFound(err), err
+			if client.IgnoreNotFound(err) != nil {
+				return false, err
+			}
+			return true, nil
 		}
 		p.isFound = true
 

--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -87,6 +87,18 @@ func (j *JobWrapper) GeneratedName(name string) *JobWrapper {
 	return j
 }
 
+// DeletionTimestamp sets the deletionTimestamp.
+func (j *JobWrapper) DeletionTimestamp(t time.Time) *JobWrapper {
+	j.ObjectMeta.DeletionTimestamp = new(metav1.NewTime(t))
+	return j
+}
+
+// Finalizers sets the finalizers.
+func (j *JobWrapper) Finalizers(finalizers ...string) *JobWrapper {
+	j.ObjectMeta.Finalizers = finalizers
+	return j
+}
+
 func (j *JobWrapper) BackoffLimit(limit int32) *JobWrapper {
 	j.Spec.BackoffLimit = new(limit)
 	return j


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Reorganize drop finalizers logic.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
