### PR TITLE
Automated cherry pick of #11027: Self nominate amy as agent owner
#11174: nominate kannon92 for approver for agents
#11226: Self nominate @pbundyra as agent approver
#11358: Create new hugo-approvers role.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -47,3 +47,10 @@ filters:
   "^\\.golangci.*\\.ya?ml$":
     approvers:
       - test-approvers
+
+  # Agent instructions and experimental agent
+  "^AGENTS\\.md$":
+    approvers:
+      - agent-approvers
+    reviewers:
+      - agent-reviewers

--- a/OWNERS
+++ b/OWNERS
@@ -28,6 +28,10 @@ filters:
     approvers:
       - dependency-approvers
 
+  "^site/hugo\\.toml$":
+    approvers:
+      - hugo-approvers
+
   # Vendor directory
   "^vendor/.*$":
     approvers:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -26,3 +26,5 @@ aliases:
     - amy
     - kannon92
     - pbundyra
+  hugo-approvers:
+    - mbobrovskyi

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -21,6 +21,8 @@ aliases:
   agent-approvers:
     - amy
     - kannon92
+    - pbundyra
   agent-reviewers:
     - amy
     - kannon92
+    - pbundyra

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -18,3 +18,7 @@ aliases:
   test-approvers:
     - mbobrovskyi
     - pbundyra
+  agent-approvers:
+    - amy
+  agent-reviewers:
+    - amy

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,5 +20,7 @@ aliases:
     - pbundyra
   agent-approvers:
     - amy
+    - kannon92
   agent-reviewers:
     - amy
+    - kannon92

--- a/cmd/experimental/agent/OWNERS
+++ b/cmd/experimental/agent/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - agent-approvers
+reviewers:
+  - agent-reviewers


### PR DESCRIPTION
Cherry pick of #11027 #11174 #11226 #11358 on release-0.16.

#11027: Self nominate amy as agent owner
#11174: nominate kannon92 for approver for agents
#11226: Self nominate @pbundyra as agent approver
#11358: Create new hugo-approvers role.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup
/kind documentation


```release-note
NONE
```