### PR TITLE
Automated cherry pick of #11358: Create new hugo-approvers role.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -28,6 +28,10 @@ filters:
     approvers:
       - dependency-approvers
 
+  "^site/hugo\\.toml$":
+    approvers:
+      - hugo-approvers
+
   # Vendor directory
   "^vendor/.*$":
     approvers:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,3 +20,5 @@ aliases:
   test-approvers:
     - mbobrovskyi
     - pbundyra
+  hugo-approvers:
+    - mbobrovskyi


### PR DESCRIPTION
Cherry pick of #11358 on release-0.17.

#11358: Create new hugo-approvers role.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind documentation


```release-note
NONE
```