### PR TITLE
Add hack/retry.sh script that is used for KUBEBUILDER_ASSETS to imple…

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -21,20 +21,11 @@ GO_TEST_FLAGS ?= -race
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION ?= 1.35
 
-# setup-envtest occasionally fails to download binaries due to network errors in CI.
-# Retry up to ENVTEST_RETRY_ATTEMPTS times with an ENVTEST_RETRY_DELAY second delay before giving up.
 ENVTEST_RETRY_ATTEMPTS ?= 4
 ENVTEST_RETRY_DELAY ?= 5
-define _envtest_with_retry
-attempts=$(ENVTEST_RETRY_ATTEMPTS); delay=$(ENVTEST_RETRY_DELAY);
-for i in $$(seq 1 $$attempts); do
-	echo "setup-envtest attempt $$i/$$attempts" 1>&2;
-	$(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path && exit 0;
-	echo "setup-envtest attempt $$i/$$attempts failed" 1>&2;
-	[ "$$i" -lt "$$attempts" ] && sleep "$$delay";
-done
-endef
-KUBEBUILDER_ASSETS = $(or $(shell $(_envtest_with_retry)),$(error setup-envtest failed to download binaries. KUBEBUILDER_ASSETS is empty))
+KUBEBUILDER_ASSETS = $(or \
+	$(shell $(PROJECT_DIR)/hack/retry.sh --attempts $(ENVTEST_RETRY_ATTEMPTS) --delay $(ENVTEST_RETRY_DELAY) -- $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path), \
+	$(error setup-envtest failed to download binaries. KUBEBUILDER_ASSETS is empty))
 
 TEST_LOG_LEVEL ?= -3
 

--- a/cmd/experimental/kueue-populator/Makefile
+++ b/cmd/experimental/kueue-populator/Makefile
@@ -20,7 +20,11 @@ GINKGO := $(BIN_DIR)/ginkgo
 GOTESTSUM := $(BIN_DIR)/gotestsum
 ARTIFACTS ?= $(ROOT_DIR)/artifacts
 ENVTEST_K8S_VERSION ?= 1.35
-KUBEBUILDER_ASSETS = $(or $(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path),$(error setup-envtest failed to download binaries. KUBEBUILDER_ASSETS is empty))
+ENVTEST_RETRY_ATTEMPTS ?= 4
+ENVTEST_RETRY_DELAY ?= 5
+KUBEBUILDER_ASSETS = $(or \
+	$(shell $(ROOT_DIR)/hack/retry.sh --attempts $(ENVTEST_RETRY_ATTEMPTS) --delay $(ENVTEST_RETRY_DELAY) -- $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path), \
+	$(error setup-envtest failed to download binaries. KUBEBUILDER_ASSETS is empty))
 INTEGRATION_NPROCS ?= 4
 CONTROLLER_GEN := $(BIN_DIR)/controller-gen
 YAML_PROCESSOR = $(BIN_DIR)/yaml-processor

--- a/hack/retry.sh
+++ b/hack/retry.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Retry a command on failure. Captures the command's stdout on success and
+# echoes it; stderr passes through. Designed to be invoked from Make $(shell ...)
+# where the captured stdout becomes the variable value.
+#
+# Usage:
+#   retry.sh [--attempts N] [--delay SECONDS] -- <command> [args...]
+#
+# Defaults: --attempts 4, --delay 5
+# Exit:     0 on first success, 1 if all attempts fail, 2 on usage error.
+
+set -u
+
+attempts=4
+delay=5
+
+while [ $# -gt 0 ]; do
+    case $1 in
+        --attempts) attempts=$2; shift 2 ;;
+        --delay)    delay=$2;    shift 2 ;;
+        --)         shift; break ;;
+        -*)         echo "retry: unknown flag: $1" 1>&2; exit 2 ;;
+        *)          break ;;
+    esac
+done
+
+if [ $# -eq 0 ]; then
+    echo "retry: no command given" 1>&2
+    exit 2
+fi
+
+for i in $(seq 1 "$attempts"); do
+    echo "retry [$i/$attempts]: $*" 1>&2
+    if out=$("$@"); then
+        printf '%s' "$out"
+        exit 0
+    fi
+    echo "retry [$i/$attempts] failed" 1>&2
+    [ "$i" -lt "$attempts" ] && sleep "$delay"
+done
+exit 1


### PR DESCRIPTION
…ment inline retry functionality

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Add hack/retry.sh script that is used for KUBEBUILDER_ASSETS to implement inline retry functionality
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11369 

#### Special notes for your reviewer:
```
$ make test-integration-run ENVTEST_K8S_VERSION=99.99 ENVTEST_RETRY_DELAY=1
retry [1/4]: /home/user/Projects/kueue/bin/setup-envtest use 99.99 -p path
unable to find a version that was supported for platform linux/amd64
retry [1/4] failed
retry [2/4]: /home/user/Projects/kueue/bin/setup-envtest use 99.99 -p path
unable to find a version that was supported for platform linux/amd64
retry [2/4] failed
retry [3/4]: /home/user/Projects/kueue/bin/setup-envtest use 99.99 -p path
unable to find a version that was supported for platform linux/amd64
retry [3/4] failed
retry [4/4]: /home/user/Projects/kueue/bin/setup-envtest use 99.99 -p path
unable to find a version that was supported for platform linux/amd64
retry [4/4] failed
Makefile-test.mk:110: *** setup-envtest failed to download binaries. KUBEBUILDER_ASSETS is empty.  Stop.
```

```
$ make -C cmd/experimental/kueue-populator test-integration ENVTEST_K8S_VERSION=99.99 ENVTEST_RETRY_DELAY=1
/home/user1/Projects/kueue/bin/kustomize build config/components/crd > config/components/crd/_output/crds-with-webhooks.yaml
make[1]: Leaving directory '/home/user/Projects/kueue'
retry [1/4]: /home/user/Projects/kueue/cmd/experimental/kueue-populator/../../../bin/setup-envtest use 99.99 -p path
unable to find a version that was supported for platform linux/amd64
retry [1/4] failed
retry [2/4]: /home/user/Projects/kueue/cmd/experimental/kueue-populator/../../../bin/setup-envtest use 99.99 -p path
unable to find a version that was supported for platform linux/amd64
retry [2/4] failed
retry [3/4]: /home/user/Projects/kueue/cmd/experimental/kueue-populator/../../../bin/setup-envtest use 99.99 -p path
unable to find a version that was supported for platform linux/amd64
retry [3/4] failed
retry [4/4]: /home/user/Projects/kueue/cmd/experimental/kueue-populator/../../../bin/setup-envtest use 99.99 -p path
unable to find a version that was supported for platform linux/amd64
retry [4/4] failed
Makefile:117: *** setup-envtest failed to download binaries. KUBEBUILDER_ASSETS is empty.  Stop.
make: Leaving directory '/home/user/Projects/kueue/cmd/experimental/kueue-populator'
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
