### PR TITLE
[integration] Drop ginkgo.Ordered from kueuectl and conversion singlecluster tests

### DIFF
--- a/test/integration/singlecluster/conversion/conversions_v1beta1_test.go
+++ b/test/integration/singlecluster/conversion/conversions_v1beta1_test.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("v1beta2 conversions", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("v1beta2 conversions", func() {
 	const (
 		flavorModelC = "model-c"
 		flavorModelD = "model-d"

--- a/test/integration/singlecluster/kueuectl/create_test.go
+++ b/test/integration/singlecluster/kueuectl/create_test.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("Kueuectl Create", func() {
 	var (
 		ns *corev1.Namespace
 		cq *kueue.ClusterQueue

--- a/test/integration/singlecluster/kueuectl/list_test.go
+++ b/test/integration/singlecluster/kueuectl/list_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("Kueuectl List", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("Kueuectl List", func() {
 	var ns *corev1.Namespace
 
 	ginkgo.BeforeEach(func() {

--- a/test/integration/singlecluster/kueuectl/passthrough_test.go
+++ b/test/integration/singlecluster/kueuectl/passthrough_test.go
@@ -63,7 +63,7 @@ func setupEnv(c *exec.Cmd, kassetsPath string, kubeconfigPath string) {
 	c.Env = append(c.Env, "KUBECONFIG="+kubeconfigPath)
 }
 
-var _ = ginkgo.Describe("Kueuectl Pass-through", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("Kueuectl Pass-through", func() {
 	var (
 		ns *corev1.Namespace
 	)

--- a/test/integration/singlecluster/kueuectl/resume_test.go
+++ b/test/integration/singlecluster/kueuectl/resume_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("Kueuectl Resume", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("Kueuectl Resume", func() {
 	var (
 		ns *corev1.Namespace
 	)

--- a/test/integration/singlecluster/kueuectl/stop_test.go
+++ b/test/integration/singlecluster/kueuectl/stop_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("Kueuectl Stop", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("Kueuectl Stop", func() {
 	var (
 		ns *corev1.Namespace
 	)


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup
/area testing

#### What this PR does / why we need it:

Removes `ginkgo.Ordered` and `ginkgo.ContinueOnFailure` from the kueuectl and conversion integration Describes under `test/integration/singlecluster`.
These suites already use `BeforeEach`/`AfterEach` for setup and teardown, so they do not rely on ordered execution or `BeforeAll`. Dropping `Ordered` lets Ginkgo schedule their specs in parallel with other singlecluster packages.
This is a small, self-contained slice of the work in #9972, split per reviewer feedback to reduce review and flake risk.

#### Which issue(s) this PR fixes:
Part of #9880

#### Special notes for your reviewer:
- No changes to `test/integration/framework` or controller/webhook suites.
- Six files, one-line change per file (Describe declaration only).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
