### PR TITLE
[integration] Drop ginkgo.Ordered from jobframework setup singlecluster tests

### DIFF
--- a/test/integration/singlecluster/controller/jobframework/setup/setup_controllers_test.go
+++ b/test/integration/singlecluster/controller/jobframework/setup/setup_controllers_test.go
@@ -39,7 +39,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("Setup Controllers", ginkgo.Label("controller:jobframework", "area:jobs"), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("Setup Controllers", ginkgo.Label("controller:jobframework", "area:jobs"), func() {
 	var (
 		ns           *corev1.Namespace
 		flavor       *kueue.ResourceFlavor


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it:
Removes `ginkgo.Ordered` and `ginkgo.ContinueOnFailure` from the jobframework setup integration Describe under `test/integration/singlecluster/controller/jobframework/setup`.
The suite already uses `BeforeEach`/`AfterEach` for manager lifecycle and resource cleanup, so it does not rely on ordered execution or `BeforeAll`. Dropping `Ordered` lets Ginkgo schedule its specs in parallel with other singlecluster packages.
Follow-up split after #11384, part of the work previously in #9972.

#### Which issue(s) this PR fixes:
Part of #9880

#### Special notes for your reviewer:
- One file, one-line change (Describe declaration only).
- No changes to `suite_test.go` or `test/integration/framework`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
