### PR TITLE
[integration] Drop ginkgo.Ordered from AppWrapper webhook singlecluster tests

### DIFF
--- a/test/integration/singlecluster/webhook/jobs/appwrapper_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/appwrapper_webhook_test.go
@@ -30,18 +30,14 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("AppWrapper Webhook", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("AppWrapper Webhook", func() {
 	var ns *corev1.Namespace
-	ginkgo.BeforeAll(func() {
-		fwk.StartManager(ctx, cfg, managerSetup(appwrapper.SetupAppWrapperWebhook, jobframework.WithManageJobsWithoutQueueName(false)))
-	})
 	ginkgo.BeforeEach(func() {
+		fwk.StartManager(ctx, cfg, managerSetup(appwrapper.SetupAppWrapperWebhook, jobframework.WithManageJobsWithoutQueueName(false)))
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "aw-")
 	})
 	ginkgo.AfterEach(func() {
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
-	})
-	ginkgo.AfterAll(func() {
 		fwk.StopManager(ctx)
 	})
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it:
Updates the AppWrapper webhook integration tests under `test/integration/singlecluster/webhook/jobs`.
- Removes `ginkgo.Ordered` from the Describe.
- Moves manager `StartManager`/`StopManager` from `BeforeAll`/`AfterAll` into `BeforeEach`/`AfterEach` so specs do not depend on ordered execution (see #8726).
Follow-up split after #11384 and #11389, part of the work previously in #9972.


#### Which issue(s) this PR fixes:
Part of #9880

#### Special notes for your reviewer:
- One file only; no changes to `suite_test.go` or `test/integration/framework`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
