### PR TITLE
[integration] Drop ginkgo.Ordered from TrainJob webhook singlecluster tests

### DIFF
--- a/test/integration/singlecluster/webhook/jobs/trainjob_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/trainjob_webhook_test.go
@@ -36,8 +36,8 @@ import (
 var _ = ginkgo.Describe("Trainjob Webhook", func() {
 	var ns *corev1.Namespace
 
-	ginkgo.When("with manageJobsWithoutQueueName disabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-		ginkgo.BeforeAll(func() {
+	ginkgo.When("with manageJobsWithoutQueueName disabled", func() {
+		ginkgo.BeforeEach(func() {
 			fwk.StartManager(ctx, cfg, managerSetup(func(mgr ctrl.Manager, opts ...jobframework.Option) error {
 				// Necessary to initialize the runtimes
 				if _, err := workloadtrainjob.NewReconciler(
@@ -50,14 +50,10 @@ var _ = ginkgo.Describe("Trainjob Webhook", func() {
 				}
 				return workloadtrainjob.SetupTrainJobWebhook(mgr, opts...)
 			}))
-		})
-		ginkgo.BeforeEach(func() {
 			ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "trainjob-")
 		})
 		ginkgo.AfterEach(func() {
 			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
-		})
-		ginkgo.AfterAll(func() {
 			fwk.StopManager(ctx)
 		})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area testing

#### What this PR does / why we need it:

Updates the TrainJob webhook integration tests under `test/integration/singlecluster/webhook/jobs`.

- Removes `ginkgo.Ordered` and `ginkgo.ContinueOnFailure` from the When block.
- Moves manager `StartManager`/`StopManager` from `BeforeAll`/`AfterAll` into `BeforeEach`/`AfterEach` so specs do not depend on ordered execution (see #8726).

Follow-up split after #11384, #11389, #11390, and #11391, part of the work previously in #9972.

#### Which issue(s) this PR fixes:

Part of #9880

#### Special notes for your reviewer:

- One file only; no changes to `suite_test.go` or `test/integration/framework`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```