### PR TITLE
Automated cherry pick of #11356: Introduce SetMultiKueueMeta helper and migrate all MultiKueue adapters to use it

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter.go
+++ b/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter.go
@@ -94,14 +94,8 @@ func (a *Adapter) createRemoteObject(ctx context.Context, remoteClient client.Cl
 	// Apply default transformation: remove the managedBy field
 	a.removeManagedByField(remoteObj)
 
-	// Add MultiKueue labels
-	labels := remoteObj.GetLabels()
-	if labels == nil {
-		labels = make(map[string]string)
-	}
-	labels[constants.PrebuiltWorkloadLabel] = workloadName
-	labels[kueue.MultiKueueOriginLabel] = origin
-	remoteObj.SetLabels(labels)
+	// Add prebuilt workload name and multikueue origin
+	jobframework.SetMultiKueueMeta(remoteObj, workloadName, origin)
 
 	// Create the object in the remote cluster
 	log.V(2).Info("Creating remote object", "gvk", a.gvk, "name", remoteObj.GetName(), "namespace", remoteObj.GetNamespace())

--- a/pkg/controller/jobframework/utils.go
+++ b/pkg/controller/jobframework/utils.go
@@ -20,8 +20,10 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/util/orderedgroups"
 )
 
@@ -73,4 +75,15 @@ func sanitizeContainer(container *corev1.Container) {
 	for _, envVars := range envVarGroups.InOrder {
 		container.Env = append(container.Env, envVars[len(envVars)-1])
 	}
+}
+
+// SetMultiKueueMeta sets the MultiKueue origin label and the prebuilt workload label on the given object.
+func SetMultiKueueMeta(obj client.Object, workloadName, origin string) {
+	objLabels := obj.GetLabels()
+	if objLabels == nil {
+		objLabels = make(map[string]string, 2)
+	}
+	objLabels[kueue.MultiKueueOriginLabel] = origin
+	objLabels[controllerconstants.PrebuiltWorkloadLabel] = workloadName
+	obj.SetLabels(objLabels)
 }

--- a/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter.go
@@ -67,12 +67,8 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		Spec:       *localAppWrapper.Spec.DeepCopy(),
 	}
 
-	// add the prebuilt workload
-	if remoteAppWrapper.Labels == nil {
-		remoteAppWrapper.Labels = map[string]string{}
-	}
-	remoteAppWrapper.Labels[constants.PrebuiltWorkloadLabel] = workloadName
-	remoteAppWrapper.Labels[kueue.MultiKueueOriginLabel] = origin
+	// Add prebuilt workload name and multikueue origin
+	jobframework.SetMultiKueueMeta(&remoteAppWrapper, workloadName, origin)
 
 	// clear the managedBy to enable the remote AppWrapper controller to take over
 	remoteAppWrapper.Spec.ManagedBy = nil

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -95,12 +95,8 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	// drop the templates cleanup labels
 	cleanLabels(&remoteJob.Spec.Template)
 
-	// add the prebuilt workload
-	if remoteJob.Labels == nil {
-		remoteJob.Labels = map[string]string{}
-	}
-	remoteJob.Labels[constants.PrebuiltWorkloadLabel] = workloadName
-	remoteJob.Labels[kueue.MultiKueueOriginLabel] = origin
+	// Add prebuilt workload name and multikueue origin
+	jobframework.SetMultiKueueMeta(&remoteJob, workloadName, origin)
 
 	// clear the managedBy enables the batch/Job controller to take over
 	remoteJob.Spec.ManagedBy = nil

--- a/pkg/controller/jobs/jobset/jobset_multikueue_adapter.go
+++ b/pkg/controller/jobs/jobset/jobset_multikueue_adapter.go
@@ -66,12 +66,8 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		Spec:       *localJob.Spec.DeepCopy(),
 	}
 
-	// add the prebuilt workload
-	if remoteJob.Labels == nil {
-		remoteJob.Labels = map[string]string{}
-	}
-	remoteJob.Labels[constants.PrebuiltWorkloadLabel] = workloadName
-	remoteJob.Labels[kueue.MultiKueueOriginLabel] = origin
+	// Add prebuilt workload name and multikueue origin
+	jobframework.SetMultiKueueMeta(&remoteJob, workloadName, origin)
 
 	// clear the managedBy enables the JobSet controller to take over
 	remoteJob.Spec.ManagedBy = nil

--- a/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_multikueue_adapter.go
+++ b/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_multikueue_adapter.go
@@ -118,14 +118,8 @@ func (a adapter[PtrT, T]) SyncJob(
 	remoteJob = PtrT(new(T))
 	a.copySpec(remoteJob, localJob)
 
-	// add the prebuilt workload
-	labels := remoteJob.GetLabels()
-	if remoteJob.GetLabels() == nil {
-		labels = make(map[string]string, 2)
-	}
-	labels[constants.PrebuiltWorkloadLabel] = workloadName
-	labels[kueue.MultiKueueOriginLabel] = origin
-	remoteJob.SetLabels(labels)
+	// Add prebuilt workload name and multikueue origin
+	jobframework.SetMultiKueueMeta(remoteJob, workloadName, origin)
 
 	// clearing the managedBy enables the controller to take over
 	a.fromObject(remoteJob).SetManagedBy(nil)

--- a/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter.go
+++ b/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter.go
@@ -66,12 +66,8 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		Spec:       *localJob.Spec.DeepCopy(),
 	}
 
-	// add the prebuilt workload
-	if remoteJob.Labels == nil {
-		remoteJob.Labels = make(map[string]string, 2)
-	}
-	remoteJob.Labels[constants.PrebuiltWorkloadLabel] = workloadName
-	remoteJob.Labels[kueue.MultiKueueOriginLabel] = origin
+	// Add prebuilt workload name and multikueue origin
+	jobframework.SetMultiKueueMeta(&remoteJob, workloadName, origin)
 
 	// clear the managedBy enables the controller to take over
 	remoteJob.Spec.RunPolicy.ManagedBy = nil

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter.go
@@ -30,7 +30,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
@@ -175,12 +174,8 @@ func syncLocalPodWithRemote(
 		Spec:       *localPod.Spec.DeepCopy(),
 	}
 
-	// add the prebuilt workload
-	if remotePod.Labels == nil {
-		remotePod.Labels = map[string]string{}
-	}
-	remotePod.Labels[constants.PrebuiltWorkloadLabel] = workloadName
-	remotePod.Labels[kueue.MultiKueueOriginLabel] = origin
+	// Add prebuilt workload name and multikueue origin
+	jobframework.SetMultiKueueMeta(&remotePod, workloadName, origin)
 
 	if err = remoteClient.Create(ctx, &remotePod); err != nil {
 		log.Error(err, "Failed to create remote pod", "podName", remotePod.Name)

--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -124,14 +124,8 @@ func (a *adapter[PtrT, T]) SyncJob(
 	remoteJob = PtrT(new(T))
 	a.copySpec(remoteJob, localJob)
 
-	// add the prebuilt workload
-	labels := remoteJob.GetLabels()
-	if labels == nil {
-		labels = make(map[string]string, 2)
-	}
-	labels[constants.PrebuiltWorkloadLabel] = workloadName
-	labels[kueue.MultiKueueOriginLabel] = origin
-	remoteJob.SetLabels(labels)
+	// Add prebuilt workload name and multikueue origin
+	jobframework.SetMultiKueueMeta(remoteJob, workloadName, origin)
 
 	// clearing the managedBy enables the controller to take over
 	a.setManagedBy(remoteJob, nil)

--- a/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter.go
+++ b/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter.go
@@ -63,12 +63,8 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		Spec:       *localStatefulSet.Spec.DeepCopy(),
 	}
 
-	// add the prebuilt workload
-	if remoteStatefulSet.Labels == nil {
-		remoteStatefulSet.Labels = map[string]string{}
-	}
-	remoteStatefulSet.Labels[constants.PrebuiltWorkloadLabel] = workloadName
-	remoteStatefulSet.Labels[kueue.MultiKueueOriginLabel] = origin
+	// Add prebuilt workload name and multikueue origin
+	jobframework.SetMultiKueueMeta(&remoteStatefulSet, workloadName, origin)
 
 	if remoteStatefulSet.Annotations == nil {
 		remoteStatefulSet.Annotations = make(map[string]string, 1)

--- a/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter.go
+++ b/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter.go
@@ -67,12 +67,8 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		Spec:       *localJob.Spec.DeepCopy(),
 	}
 
-	// add the prebuilt workload
-	if remoteJob.Labels == nil {
-		remoteJob.Labels = map[string]string{}
-	}
-	remoteJob.Labels[constants.PrebuiltWorkloadLabel] = workloadName
-	remoteJob.Labels[kueue.MultiKueueOriginLabel] = origin
+	// Add prebuilt workload name and multikueue origin
+	jobframework.SetMultiKueueMeta(&remoteJob, workloadName, origin)
 
 	// clear the managedBy enables the TrainJob controller to take over
 	remoteJob.Spec.ManagedBy = nil


### PR DESCRIPTION
Cherry pick of #11356 on release-0.17.

#11356: Introduce SetMultiKueueMeta helper and migrate all MultiKueue adapters to use it

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```