### PR TITLE
[integration] Drop ginkgo.Ordered from XGBoostJob webhook singlecluster tests

### DIFF
--- a/test/integration/singlecluster/webhook/jobs/xgboostjob_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/xgboostjob_webhook_test.go
@@ -29,21 +29,16 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("XGBoostJob Webhook", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("XGBoostJob Webhook", func() {
 	var ns *corev1.Namespace
-	ginkgo.BeforeAll(func() {
-		fwk.StartManager(ctx, cfg, managerSetup(xgboostjob.SetupXGBoostJobWebhook))
-	})
-	ginkgo.AfterAll(func() {
-		fwk.StopManager(ctx)
-	})
-
 	ginkgo.BeforeEach(func() {
+		fwk.StartManager(ctx, cfg, managerSetup(xgboostjob.SetupXGBoostJobWebhook))
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "xgboost-")
 	})
 
 	ginkgo.AfterEach(func() {
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		fwk.StopManager(ctx)
 	})
 
 	ginkgo.When("with TopologyAwareScheduling", func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it:
Updates the XGBoostJob webhook integration tests under `test/integration/singlecluster/webhook/jobs`.
- Removes `ginkgo.Ordered` from the Describe.
- Moves manager `StartManager`/`StopManager` from `BeforeAll`/`AfterAll` into `BeforeEach`/`AfterEach` (see #8726).
Follow-up split after #11384–#11395, part of the work previously in #9972.

#### Which issue(s) this PR fixes:
Part of #9880

#### Special notes for your reviewer:
- One file only; no changes to `suite_test.go` or `test/integration/framework`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
