### PR TITLE
[MultiKueue] add RayService permissions to MultiKueue worker ClusterRole

### DIFF
--- a/site/static/examples/multikueue/create-multikueue-kubeconfig.sh
+++ b/site/static/examples/multikueue/create-multikueue-kubeconfig.sh
@@ -240,6 +240,22 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ray.io
+  resources:
+  - rayservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices/status
+  verbs:
+  - get
+- apiGroups:
   - workload.codeflare.dev
   resources:
   - appwrappers


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
/area multikueue

#### What this PR does / why we need it:

The MultiKueue worker ClusterRole generated by create-multikueue-kubeconfig.sh was missing rayservices/* rules even though Kueue supports RayService as a MultiKueue-managed integration (since v0.17.0) (https://github.com/kubernetes-sigs/kueue/blame/v0.17.0/charts/kueue/values.yaml#L155). Without these permissions, RayService workloads dispatched to worker clusters fail at the API level.

Add rayservices and rayservices/status rules alongside the existing rayjobs and rayclusters rules. The script is embedded into the MultiKueue setup docs via Hugo include, so the rendered doc picks up the change automatically.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
