### PR TITLE
Skip DeviceClass index if DRA API is not available

### DIFF
--- a/pkg/controller/core/indexer/indexer.go
+++ b/pkg/controller/core/indexer/indexer.go
@@ -268,8 +268,9 @@ func Setup(ctx context.Context, indexer client.FieldIndexer) error {
 		}
 	}
 	// Index DeviceClasses by extendedResourceName for fast lookup during extended resource translation.
+	// The index is skipped if the DeviceClass API is not available on the cluster.
 	if features.Enabled(features.KueueDRAIntegrationExtendedResource) {
-		if err := indexer.IndexField(ctx, &resourceapi.DeviceClass{}, DeviceClassExtendedResourceNameIndex, IndexDeviceClassExtendedResourceName); err != nil {
+		if err := indexer.IndexField(ctx, &resourceapi.DeviceClass{}, DeviceClassExtendedResourceNameIndex, IndexDeviceClassExtendedResourceName); err != nil && !apimeta.IsNoMatchError(err) {
 			return fmt.Errorf("setting index on extendedResourceName for DeviceClass: %w", err)
 		}
 	}

--- a/pkg/controller/core/indexer/indexer_test.go
+++ b/pkg/controller/core/indexer/indexer_test.go
@@ -17,17 +17,20 @@ limitations under the License.
 package indexer
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 )
 
 // helpers to build test objects without importing any package that transitively
@@ -644,6 +647,52 @@ func TestIndexDeviceClassExtendedResourceName(t *testing.T) {
 			got := IndexDeviceClassExtendedResourceName(tc.obj)
 			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// fakeFieldIndexer implements client.FieldIndexer for testing Setup().
+// It returns noMatchErr for DeviceClass objects when set, simulating a cluster
+// where the DeviceClass API is not available.
+type fakeFieldIndexer struct {
+	noMatchErr error
+}
+
+func (f *fakeFieldIndexer) IndexField(_ context.Context, obj client.Object, _ string, _ client.IndexerFunc) error {
+	if _, ok := obj.(*resourceapi.DeviceClass); ok && f.noMatchErr != nil {
+		return f.noMatchErr
+	}
+	return nil
+}
+
+func TestSetupToleratesNoMatchErrorForDeviceClass(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.KueueDRAIntegrationExtendedResource, true)
+
+	noMatchErr := &apimeta.NoKindMatchError{
+		GroupKind:        schema.GroupKind{Group: "resource.k8s.io", Kind: "DeviceClass"},
+		SearchedVersions: []string{"v1"},
+	}
+
+	cases := map[string]struct {
+		indexer *fakeFieldIndexer
+		wantErr bool
+	}{
+		"DeviceClass API available": {
+			indexer: &fakeFieldIndexer{},
+			wantErr: false,
+		},
+		"DeviceClass API not available (NoKindMatchError)": {
+			indexer: &fakeFieldIndexer{noMatchErr: noMatchErr},
+			wantErr: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := Setup(t.Context(), tc.indexer)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Setup() error = %v, wantErr %v", err, tc.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Pannaga Rao Bhoja Ramamanohara

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes the issue raised in https://github.com/kubernetes-sigs/kueue/pull/10973

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
DRA: Fixed a bug where the kueue-controller-manager startup fails when DRA v1 APIs are not available
```
