### PR TITLE
Automated cherry pick of #10311: Adds GroupNameAnnotation and PrebuiltWorkloadAnnotation

### DIFF
--- a/cmd/importer/pod/import.go
+++ b/cmd/importer/pod/import.go
@@ -115,6 +115,9 @@ func checkError(err error) (retry, reload bool, timeout time.Duration) {
 }
 
 func addLabels(ctx context.Context, c client.Client, p *corev1.Pod, queue string, addLabels map[string]string) error {
+	if p.Labels == nil {
+		p.Labels = make(map[string]string)
+	}
 	p.Labels[controllerconstants.QueueLabel] = queue
 	p.Labels[constants.ManagedByKueueLabelKey] = constants.ManagedByKueueLabelValue
 	maps.Copy(p.Labels, addLabels)

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -169,7 +169,7 @@ if [[ -n ${KUBERAY_VERSION:-} && ("$GINKGO_ARGS" =~ feature:kuberay || ! "$GINKG
     export KUBERAY_IMAGE=quay.io/kuberay/operator:${KUBERAY_VERSION}
 fi
 
-if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
     export LEADERWORKERSET_MANIFEST="https://github.com/kubernetes-sigs/lws/releases/download/${LEADERWORKERSET_VERSION}/manifests.yaml"
     export LEADERWORKERSET_IMAGE=registry.k8s.io/lws/lws:${LEADERWORKERSET_VERSION}
 fi
@@ -437,7 +437,7 @@ function prepare_docker_images {
             e2e_docker_pull_if_needed "${KUBERAY_RAY_IMAGE}"
         fi
     fi
-    if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${LEADERWORKERSET_IMAGE}"
     fi
     if [[ -n ${KUEUE_UPGRADE_FROM_VERSION:-} ]]; then
@@ -497,7 +497,7 @@ function kind_load {
     if [[ -n ${KUBEFLOW_MPI_VERSION:-} ]]; then
         install_mpi "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
-    if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         install_lws "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
     if [[ -n ${KUBERAY_VERSION:-} && ("$GINKGO_ARGS" =~ feature:kuberay || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then

--- a/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter.go
+++ b/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 )
@@ -216,11 +215,10 @@ func (a *Adapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedName, err
 		return nil, fmt.Errorf("unexpected GVK: expected %s, got %s for object %s", a.gvk, objGVK, klog.KObj(unstructuredObj))
 	}
 
-	labels := unstructuredObj.GetLabels()
-	prebuiltWl, hasPrebuiltWorkload := labels[constants.PrebuiltWorkloadLabel]
-	if !hasPrebuiltWorkload {
+	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(unstructuredObj)
+	if prebuiltWorkload == "" {
 		return nil, fmt.Errorf("no prebuilt workload found for %s: %s", a.gvk.Kind, klog.KObj(unstructuredObj))
 	}
 
-	return []types.NamespacedName{{Name: prebuiltWl, Namespace: unstructuredObj.GetNamespace()}}, nil
+	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: unstructuredObj.GetNamespace()}}, nil
 }

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -108,6 +108,7 @@ func TestWlReconcile(t *testing.T) {
 		wantWorker2Jobs      []batchv1.Job
 	}{
 		"deleted regular workload is removed from the cache": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersJobs: []batchv1.Job{*baseJobBuilder.DeepCopy()},
 			managersDeletedWorkloads: []*kueue.Workload{
@@ -120,6 +121,7 @@ func TestWlReconcile(t *testing.T) {
 			wantManagersJobs: []batchv1.Job{*baseJobBuilder.DeepCopy()},
 		},
 		"deleted MultiKueue workload is deleted from cache - the worker will be deleted by GC": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
 			managersDeletedWorkloads: []*kueue.Workload{
@@ -143,9 +145,11 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"missing workload": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "missing workload",
 		},
 		"missing workload (in deleted workload cache)": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersDeletedWorkloads: []*kueue.Workload{
 				baseWorkloadBuilder.Clone().
@@ -168,6 +172,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"missing workload (in deleted workload cache), no remote objects": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersDeletedWorkloads: []*kueue.Workload{
 				baseWorkloadBuilder.Clone().
@@ -178,6 +183,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"unmanaged wl (no ac) is ignored": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersWorkloads: []kueue.Workload{
 				*baseWorkloadBuilder.DeepCopy(),
@@ -187,6 +193,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"unmanaged wl (no parent) is rejected": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersWorkloads: []kueue.Workload{
 				*baseWorkloadBuilder.Clone().
@@ -200,6 +207,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"unmanaged wl (owned by pod) is rejected": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersWorkloads: []kueue.Workload{
 				*baseWorkloadBuilder.Clone().
@@ -215,6 +223,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"unmanaged wl (job not managed by multikueue) is rejected": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersJobs: []batchv1.Job{
 				*baseJobBuilder.DeepCopy(),
@@ -236,6 +245,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"failing to read from a worker": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
 			managersWorkloads: []kueue.Workload{
@@ -257,6 +267,7 @@ func TestWlReconcile(t *testing.T) {
 			wantError: errFake,
 		},
 		"reconnecting clients are skipped": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
 			managersWorkloads: []kueue.Workload{
@@ -279,6 +290,7 @@ func TestWlReconcile(t *testing.T) {
 			wantError: nil,
 		},
 		"wl without reservation, clears the workload objects": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
 			managersWorkloads: []kueue.Workload{
@@ -301,6 +313,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"wl with reservation, creates remote workloads, worker2 fails": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
 			managersWorkloads: []kueue.Workload{
@@ -330,6 +343,7 @@ func TestWlReconcile(t *testing.T) {
 			wantError: errFake,
 		},
 		"wl with reservation, creates missing workloads": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
 			managersWorkloads: []kueue.Workload{
@@ -368,7 +382,10 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"remote wl with reservation, unable to delete the second worker's workload": {
-			featureGates: map[featuregate.Feature]bool{features.MultiKueueWaitForWorkloadAdmitted: false},
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueueWaitForWorkloadAdmitted: false,
+				features.WorkloadIdentifierAnnotations:     false,
+			},
 			reconcileFor: "wl1",
 			managersWorkloads: []kueue.Workload{
 				*baseWorkloadBuilder.Clone().
@@ -419,6 +436,7 @@ func TestWlReconcile(t *testing.T) {
 		"remote wl with reservation": {
 			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueWaitForWorkloadAdmitted: false,
+				features.WorkloadIdentifierAnnotations:     false,
 			},
 			reconcileFor: "wl1",
 			managersWorkloads: []kueue.Workload{
@@ -486,6 +504,7 @@ func TestWlReconcile(t *testing.T) {
 		"remote wl with reservation but not admitted, feature gate enabled - other workers not deleted": {
 			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueWaitForWorkloadAdmitted: true,
+				features.WorkloadIdentifierAnnotations:     false,
 			},
 			reconcileFor: "wl1",
 			managersWorkloads: []kueue.Workload{
@@ -536,6 +555,7 @@ func TestWlReconcile(t *testing.T) {
 		"remote wl admitted, feature gate enabled - other workers deleted": {
 			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueWaitForWorkloadAdmitted: true,
+				features.WorkloadIdentifierAnnotations:     false,
 			},
 			reconcileFor: "wl1",
 			managersWorkloads: []kueue.Workload{
@@ -609,6 +629,7 @@ func TestWlReconcile(t *testing.T) {
 		"remote wl evicted due to eviction on manager cluster": {
 			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueWaitForWorkloadAdmitted: false,
+				features.WorkloadIdentifierAnnotations:     false,
 			},
 			reconcileFor: "wl1",
 			managersWorkloads: []kueue.Workload{
@@ -679,6 +700,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"handle workload evicted on manager cluster": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersWorkloads: []kueue.Workload{
 				*baseWorkloadBuilder.Clone().
@@ -758,6 +780,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"handle workload evicted on worker cluster": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersWorkloads: []kueue.Workload{
 				*baseWorkloadBuilder.Clone().
@@ -847,6 +870,7 @@ func TestWlReconcile(t *testing.T) {
 		"remote job is changing status the local Job is updated ": {
 			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueWaitForWorkloadAdmitted: false,
+				features.WorkloadIdentifierAnnotations:     false,
 			},
 			reconcileFor: "wl1",
 			managersWorkloads: []kueue.Workload{
@@ -919,6 +943,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"remote wl is finished, the local workload and Job are marked completed ": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersWorkloads: []kueue.Workload{
 				*baseWorkloadBuilder.Clone().
@@ -983,6 +1008,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"the local Job is marked finished, the remote objects are removed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersWorkloads: []kueue.Workload{
 				*baseWorkloadBuilder.Clone().
@@ -1036,6 +1062,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"the local workload admission check Ready if the remote WorkerLostTimeout is not exceeded": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
 			managersWorkloads: []kueue.Workload{
@@ -1064,6 +1091,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"the local workload's admission check is set to Retry if the WorkerLostTimeout is exceeded": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
 			managersWorkloads: []kueue.Workload{
@@ -1092,6 +1120,7 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"worker reconnects after the local workload is requeued, remote objects are deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
 			managersWorkloads: []kueue.Workload{
@@ -1132,6 +1161,7 @@ func TestWlReconcile(t *testing.T) {
 		"worker reconnects after the local workload is requeued and got reservation on a second worker": {
 			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueWaitForWorkloadAdmitted: false,
+				features.WorkloadIdentifierAnnotations:     false,
 			},
 			// the worker with the oldest reservation is kept
 			reconcileFor: "wl1",
@@ -1454,6 +1484,7 @@ func TestWlReconcile(t *testing.T) {
 			featureGates: map[featuregate.Feature]bool{
 				features.ElasticJobsViaWorkloadSlices:      true,
 				features.MultiKueueWaitForWorkloadAdmitted: false,
+				features.WorkloadIdentifierAnnotations:     false,
 			},
 			reconcileFor: "wl1",
 

--- a/pkg/controller/constants/constants.go
+++ b/pkg/controller/constants/constants.go
@@ -26,8 +26,17 @@ const (
 	// if QueueLabel is not specified.
 	DefaultLocalQueueName kueue.LocalQueueName = "default"
 
-	// PrebuiltWorkloadLabel is the label key of the job holding the name of the pre-built workload to use.
+	// PrebuiltWorkloadLabel is the label key on jobs that stores the name of the pre-built workload.
+	// This label is always allowed, including when the WorkloadIdentifierAnnotations feature is enabled.
+	// When the feature is enabled, we use the annotation value by default;
+	// if the annotation is absent, we fall back to this label.
 	PrebuiltWorkloadLabel = "kueue.x-k8s.io/prebuilt-workload-name"
+
+	// PrebuiltWorkloadAnnotation is the annotation key on jobs that stores the name of the pre-built workload.
+	// This annotation is allowed only when the WorkloadIdentifierAnnotations feature is enabled.
+	// When enabled, we use the value of pre-built workload from the annotation by default;
+	// if it is not present, we fall back to the label.
+	PrebuiltWorkloadAnnotation = "kueue.x-k8s.io/prebuilt-workload-name"
 
 	// JobUIDLabel is the label key in the workload resource, that holds the UID of
 	// the owner job.

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -854,9 +854,9 @@ func FindAncestorJobManagedByKueue(ctx context.Context, c client.Client, jobObj 
 func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, object client.Object) (*kueue.Workload, error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	if prebuiltWorkloadName, usePrebuiltWorkload := PrebuiltWorkloadFor(job); usePrebuiltWorkload {
+	if prebuiltWorkload := PrebuiltWorkloadNameFor(job.Object()); prebuiltWorkload != "" {
 		wl := &kueue.Workload{}
-		err := r.client.Get(ctx, types.NamespacedName{Name: prebuiltWorkloadName, Namespace: object.GetNamespace()}, wl)
+		err := r.client.Get(ctx, types.NamespacedName{Name: prebuiltWorkload, Namespace: object.GetNamespace()}, wl)
 		if err != nil {
 			return nil, client.IgnoreNotFound(err)
 		}
@@ -1572,8 +1572,8 @@ func assignQueueLabels(ctx context.Context, labels map[string]string, wl *kueue.
 func (r *JobReconciler) handleJobWithNoWorkload(ctx context.Context, job GenericJob, object client.Object) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	_, usePrebuiltWorkload := PrebuiltWorkloadFor(job)
-	if usePrebuiltWorkload {
+	prebuiltWorkload := PrebuiltWorkloadNameFor(job.Object())
+	if prebuiltWorkload != "" {
 		// Stop the job if not already suspended
 		if stopErr := r.stopJob(ctx, job, nil, StopReasonNoMatchingWorkload, "missing workload"); stopErr != nil {
 			return stopErr
@@ -1588,7 +1588,7 @@ func (r *JobReconciler) handleJobWithNoWorkload(ctx context.Context, job Generic
 		return nil
 	}
 
-	if usePrebuiltWorkload {
+	if prebuiltWorkload != "" {
 		return ErrPrebuiltWorkloadNotFound
 	}
 

--- a/pkg/controller/jobframework/utils.go
+++ b/pkg/controller/jobframework/utils.go
@@ -24,6 +24,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/orderedgroups"
 )
 
@@ -77,13 +78,41 @@ func sanitizeContainer(container *corev1.Container) {
 	}
 }
 
+func PrebuiltWorkloadNameFor(obj client.Object) string {
+	if features.Enabled(features.WorkloadIdentifierAnnotations) {
+		if name := obj.GetAnnotations()[controllerconstants.PrebuiltWorkloadAnnotation]; name != "" {
+			return name
+		}
+	}
+	return obj.GetLabels()[controllerconstants.PrebuiltWorkloadLabel]
+}
+
+func SetPrebuiltWorkloadName(obj client.Object, workloadName string) {
+	if features.Enabled(features.WorkloadIdentifierAnnotations) {
+		annotations := obj.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string, 1)
+		}
+		annotations[controllerconstants.PrebuiltWorkloadAnnotation] = workloadName
+		obj.SetAnnotations(annotations)
+	} else {
+		objLabels := obj.GetLabels()
+		if objLabels == nil {
+			objLabels = make(map[string]string, 1)
+		}
+		objLabels[controllerconstants.PrebuiltWorkloadLabel] = workloadName
+		obj.SetLabels(objLabels)
+	}
+}
+
 // SetMultiKueueMeta sets the MultiKueue origin label and the prebuilt workload label on the given object.
 func SetMultiKueueMeta(obj client.Object, workloadName, origin string) {
 	objLabels := obj.GetLabels()
 	if objLabels == nil {
-		objLabels = make(map[string]string, 2)
+		objLabels = make(map[string]string, 1)
 	}
 	objLabels[kueue.MultiKueueOriginLabel] = origin
-	objLabels[controllerconstants.PrebuiltWorkloadLabel] = workloadName
 	obj.SetLabels(objLabels)
+
+	SetPrebuiltWorkloadName(obj, workloadName)
 }

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -45,11 +45,15 @@ import (
 )
 
 var (
-	labelsPath                    = field.NewPath("metadata", "labels")
-	queueNameLabelPath            = labelsPath.Key(constants.QueueLabel)
-	maxExecTimeLabelPath          = labelsPath.Key(constants.MaxExecTimeSecondsLabel)
-	workloadPriorityClassNamePath = labelsPath.Key(constants.WorkloadPriorityClassLabel)
-	supportedPrebuiltWlJobGVKs    = sets.New(
+	metaPath                       = field.NewPath("metadata")
+	labelsPath                     = metaPath.Child("labels")
+	annotationsPath                = metaPath.Child("annotations")
+	queueNameLabelPath             = labelsPath.Key(constants.QueueLabel)
+	maxExecTimeLabelPath           = labelsPath.Key(constants.MaxExecTimeSecondsLabel)
+	workloadPriorityClassNamePath  = labelsPath.Key(constants.WorkloadPriorityClassLabel)
+	prebuiltWorkloadLabelPath      = labelsPath.Key(constants.PrebuiltWorkloadLabel)
+	prebuiltWorkloadAnnotationPath = annotationsPath.Key(constants.PrebuiltWorkloadAnnotation)
+	supportedPrebuiltWlJobGVKs     = sets.New(
 		batchv1.SchemeGroupVersion.WithKind("Job").String(),
 		jobset.SchemeGroupVersion.WithKind("JobSet").String(),
 		kftraining.SchemeGroupVersion.WithKind(kftraining.TFJobKind).String(),
@@ -96,13 +100,13 @@ func ValidateJobOnUpdate(oldJob, newJob GenericJob, defaultQueueExist func(strin
 
 func validateCreateForPrebuiltWorkload(job GenericJob) field.ErrorList {
 	var allErrs field.ErrorList
-	allErrs = append(allErrs, ValidateLabelAsCRDName(job.Object(), constants.PrebuiltWorkloadLabel)...)
+	allErrs = append(allErrs, ValidatePrebuiltWorkloadName(job.Object())...)
 
 	// this rule should be relaxed when its confirmed that running with a prebuilt wl is fully supported by each integration
-	if _, hasPrebuilt := job.Object().GetLabels()[constants.PrebuiltWorkloadLabel]; hasPrebuilt {
+	if PrebuiltWorkloadNameFor(job.Object()) != "" {
 		gvk := job.GVK().String()
 		if !supportedPrebuiltWlJobGVKs.Has(gvk) {
-			allErrs = append(allErrs, field.Forbidden(labelsPath.Key(constants.PrebuiltWorkloadLabel), fmt.Sprintf("Is not supported for %q", gvk)))
+			allErrs = append(allErrs, field.Forbidden(GetPrebuiltWorkloadPath(job.Object()), fmt.Sprintf("Is not supported for %q", gvk)))
 		}
 	}
 	return allErrs
@@ -116,6 +120,24 @@ func ValidateLabelAsCRDName(obj client.Object, crdNameLabel string) field.ErrorL
 		}
 	}
 	return allErrs
+}
+
+func ValidateAnnotationAsCRDName(obj client.Object, crdNameAnnotation string) field.ErrorList {
+	var allErrs field.ErrorList
+	if value, exists := obj.GetAnnotations()[crdNameAnnotation]; exists {
+		if errs := validation.IsDNS1123Subdomain(value); len(errs) > 0 {
+			allErrs = append(allErrs, field.Invalid(annotationsPath.Key(crdNameAnnotation), value, strings.Join(errs, ",")))
+		}
+	}
+	return allErrs
+}
+
+func ValidatePrebuiltWorkloadName(obj client.Object) field.ErrorList {
+	prebuiltAnnotation := obj.GetAnnotations()[constants.PrebuiltWorkloadAnnotation]
+	if features.Enabled(features.WorkloadIdentifierAnnotations) && prebuiltAnnotation != "" {
+		return ValidateAnnotationAsCRDName(obj, constants.PrebuiltWorkloadAnnotation)
+	}
+	return ValidateLabelAsCRDName(obj, constants.PrebuiltWorkloadLabel)
 }
 
 func ValidateQueueName(obj client.Object) field.ErrorList {
@@ -141,9 +163,9 @@ func validateUpdateForPrebuiltWorkload(oldJob, newJob GenericJob) field.ErrorLis
 		return validateCreateForPrebuiltWorkload(newJob)
 	}
 
-	oldWlName, _ := PrebuiltWorkloadFor(oldJob)
-	newWlName, _ := PrebuiltWorkloadFor(newJob)
-	return apivalidation.ValidateImmutableField(newWlName, oldWlName, labelsPath.Key(constants.PrebuiltWorkloadLabel))
+	oldWlName := PrebuiltWorkloadNameFor(oldJob.Object())
+	newWlName := PrebuiltWorkloadNameFor(newJob.Object())
+	return apivalidation.ValidateImmutableField(newWlName, oldWlName, GetPrebuiltWorkloadPath(newJob.Object()))
 }
 
 func validateJobUpdateForWorkloadPriorityClassName(oldJob, newJob GenericJob) field.ErrorList {
@@ -245,4 +267,12 @@ func validateImmutablePodGroupPodSpecPath(newShape, oldShape map[string]any, fie
 
 func IsWorkloadPriorityClassNameEmpty(obj client.Object) bool {
 	return WorkloadPriorityClassName(obj) == ""
+}
+
+func GetPrebuiltWorkloadPath(obj client.Object) *field.Path {
+	prebuiltWorkloadAnnotation := obj.GetAnnotations()[constants.PrebuiltWorkloadAnnotation]
+	if features.Enabled(features.WorkloadIdentifierAnnotations) && prebuiltWorkloadAnnotation != "" {
+		return prebuiltWorkloadAnnotationPath
+	}
+	return prebuiltWorkloadLabelPath
 }

--- a/pkg/controller/jobframework/validation_test.go
+++ b/pkg/controller/jobframework/validation_test.go
@@ -262,8 +262,9 @@ func TestValidateJobOnUpdate(t *testing.T) {
 		wantErr           field.ErrorList
 	}{
 		"local queue cannot be changed if job is not suspended": {
-			oldJob: utiltestingjob.MakeJob("test-job", "ns1").Queue("lq1").Suspend(false).Obj(),
-			newJob: utiltestingjob.MakeJob("test-job", "ns1").Queue("lq2").Suspend(false).Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			oldJob:       utiltestingjob.MakeJob("test-job", "ns1").Queue("lq1").Suspend(false).Obj(),
+			newJob:       utiltestingjob.MakeJob("test-job", "ns1").Queue("lq2").Suspend(false).Obj(),
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
@@ -272,16 +273,19 @@ func TestValidateJobOnUpdate(t *testing.T) {
 			},
 		},
 		"local queue can be changed": {
+			featureGates:      map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			oldJob:            utiltestingjob.MakeJob("test-job", "ns1").Queue("lq1").Suspend(true).Obj(),
 			newJob:            utiltestingjob.MakeJob("test-job", "ns1").Queue("lq2").Suspend(true).Obj(),
 			nsHasDefaultQueue: true,
 		},
 		"local queue can be changed from default": {
+			featureGates:      map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			oldJob:            utiltestingjob.MakeJob("test-job", "ns1").Queue("default").Suspend(true).Obj(),
 			newJob:            utiltestingjob.MakeJob("test-job", "ns1").Queue("lq2").Suspend(true).Obj(),
 			nsHasDefaultQueue: true,
 		},
 		"local queue cannot be removed if default queue exists and feature is enabled": {
+			featureGates:      map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			oldJob:            utiltestingjob.MakeJob("test-job", "ns1").Suspend(true).Queue("lq1").Obj(),
 			newJob:            utiltestingjob.MakeJob("test-job", "ns1").Suspend(true).Queue("").Obj(),
 			nsHasDefaultQueue: true,
@@ -293,6 +297,7 @@ func TestValidateJobOnUpdate(t *testing.T) {
 			},
 		},
 		"local queue can be removed if default queue does not exists and feature is enabled": {
+			featureGates:      map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			oldJob:            utiltestingjob.MakeJob("test-job", "ns1").Suspend(true).Queue("lq1").Obj(),
 			newJob:            utiltestingjob.MakeJob("test-job", "ns1").Suspend(true).Queue("").Obj(),
 			nsHasDefaultQueue: false,
@@ -317,6 +322,78 @@ func TestValidateJobOnUpdate(t *testing.T) {
 				field.Invalid(field.NewPath("metadata.labels["+workloadslicing.EnabledAnnotationKey+"]"), "false", "field is immutable"),
 			},
 		},
+		"prebuilt workload label valid on update": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			oldJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadLabel("workload-name").Suspend(true).Obj(),
+			newJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadLabel("workload-name").Suspend(true).Obj(),
+		},
+		"prebuilt workload annotation valid on update, WorkloadIdentifierAnnotations enabled": {
+			oldJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadAnnotation("workload-name").Suspend(true).Obj(),
+			newJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadAnnotation("workload-name").Suspend(true).Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		"prebuilt workload label fallback valid on update, WorkloadIdentifierAnnotations enabled": {
+			oldJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadLabel("workload-name").Suspend(true).Obj(),
+			newJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadLabel("workload-name").Suspend(true).Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		"prebuilt workload same label and annotation on update, WorkloadIdentifierAnnotations enabled": {
+			oldJob: utiltestingjob.MakeJob("test-job", "ns1").
+				PrebuiltWorkloadLabel("workload-name").
+				PrebuiltWorkloadAnnotation("workload-name").Suspend(true).Obj(),
+			newJob: utiltestingjob.MakeJob("test-job", "ns1").
+				PrebuiltWorkloadLabel("workload-name").
+				PrebuiltWorkloadAnnotation("workload-name").Suspend(true).Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		"prebuilt workload invalid label format with fallback on update, WorkloadIdentifierAnnotations enabled": {
+			oldJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadLabel("workload name").Suspend(true).Obj(),
+			newJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadLabel("workload name").Suspend(true).Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.labels[kueue.x-k8s.io/prebuilt-workload-name]",
+				},
+			},
+		},
+		"prebuilt workload invalid annotation format, WorkloadIdentifierAnnotations enabled": {
+			oldJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadAnnotation("workload name").Suspend(true).Obj(),
+			newJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadAnnotation("workload name").Suspend(true).Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.annotations[kueue.x-k8s.io/prebuilt-workload-name]",
+				},
+			},
+		},
+		"prebuilt workload annotation update, WorkloadIdentifierAnnotations enabled": {
+			oldJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadAnnotation("workload-name").Suspend(true).Obj(),
+			newJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadAnnotation("workload-name-new").Suspend(true).Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		"prebuilt workload annotation update not suspended, WorkloadIdentifierAnnotations enabled": {
+			oldJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadAnnotation("workload-name").Suspend(false).Obj(),
+			newJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadAnnotation("workload-name-new").Suspend(false).Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.annotations[kueue.x-k8s.io/prebuilt-workload-name]",
+				},
+			},
+		},
+		"prebuilt workload label to annotation update, WorkloadIdentifierAnnotations enabled": {
+			oldJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadLabel("workload-name").Suspend(true).Obj(),
+			newJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadAnnotation("workload-name-new").Suspend(true).Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		"prebuilt workload annotation to label update, WorkloadIdentifierAnnotations enabled": {
+			oldJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadAnnotation("workload-name").Suspend(true).Obj(),
+			newJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadLabel("workload-name-new").Suspend(true).Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
 	}
 
 	for tcName, tc := range testCases {
@@ -329,6 +406,7 @@ func TestValidateJobOnUpdate(t *testing.T) {
 				mj := mocks.NewMockGenericJob(mockctrl)
 				mj.EXPECT().Object().Return(job).AnyTimes()
 				mj.EXPECT().IsSuspended().Return(ptr.Deref(job.Spec.Suspend, false)).AnyTimes()
+				mj.EXPECT().GVK().Return(batchv1.SchemeGroupVersion.WithKind("Job")).AnyTimes()
 				return mj
 			}
 

--- a/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/util/api"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
@@ -112,10 +111,10 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 		return nil, errors.New("not an appwrapper")
 	}
 
-	prebuiltWl, hasPrebuiltWorkload := aw.Labels[constants.PrebuiltWorkloadLabel]
-	if !hasPrebuiltWorkload {
+	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(aw)
+	if prebuiltWorkload == "" {
 		return nil, fmt.Errorf("no prebuilt workload found for appwrapper: %s", klog.KObj(aw))
 	}
 
-	return []types.NamespacedName{{Name: prebuiltWl, Namespace: aw.Namespace}}, nil
+	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: aw.Namespace}}, nil
 }

--- a/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter_test.go
@@ -26,10 +26,12 @@ import (
 	awv1beta2 "github.com/project-codeflare/appwrapper/api/v1beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingaw "sigs.k8s.io/kueue/pkg/util/testingjobs/appwrapper"
@@ -62,9 +64,11 @@ func TestMultiKueueAdapter(t *testing.T) {
 		wantError               error
 		wantManagersAppWrappers []awv1beta2.AppWrapper
 		wantWorkerAppWrappers   []awv1beta2.AppWrapper
+		featureGates            map[featuregate.Feature]bool
 	}{
 
 		"sync creates missing remote appwrapper": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersAppWrappers: []awv1beta2.AppWrapper{
 				*baseAppWrapperManagedByKueueBuilder.DeepCopy(),
 			},
@@ -83,6 +87,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote appwrapper": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersAppWrappers: []awv1beta2.AppWrapper{
 				*baseAppWrapperManagedByKueueBuilder.Clone().Suspend(false).Obj(),
 			},
@@ -112,6 +117,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote while local appwrapper is suspended": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersAppWrappers: []awv1beta2.AppWrapper{
 				*baseAppWrapperManagedByKueueBuilder.Clone().Suspend(true).Obj(),
 			},
@@ -141,6 +147,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"remote appwrapper is deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			workerAppWrappers: []awv1beta2.AppWrapper{
 				*baseAppWrapperBuilder.Clone().
 					PrebuiltWorkloadLabel("wl1").
@@ -152,6 +159,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"missing appwrapper is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
 				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "aw1", Namespace: TestNamespace}); isManged {
 					return errors.New("expecting false")
@@ -160,6 +168,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"job with wrong managedBy is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersAppWrappers: []awv1beta2.AppWrapper{
 				*baseAppWrapperBuilder.DeepCopy(),
 			},
@@ -175,6 +184,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		},
 
 		"job managedBy multikueue": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersAppWrappers: []awv1beta2.AppWrapper{
 				*baseAppWrapperManagedByKueueBuilder.DeepCopy(),
 			},
@@ -188,9 +198,28 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*baseAppWrapperManagedByKueueBuilder.DeepCopy(),
 			},
 		},
+		"sync creates missing remote appwrapper, WorkloadIdentifierAnnotations enabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			managersAppWrappers: []awv1beta2.AppWrapper{
+				*baseAppWrapperManagedByKueueBuilder.DeepCopy(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "aw1", Namespace: TestNamespace}, "wl1", "origin1")
+			},
+			wantManagersAppWrappers: []awv1beta2.AppWrapper{
+				*baseAppWrapperManagedByKueueBuilder.DeepCopy(),
+			},
+			wantWorkerAppWrappers: []awv1beta2.AppWrapper{
+				*baseAppWrapperBuilder.Clone().
+					PrebuiltWorkloadAnnotation("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			managerBuilder := utiltesting.NewClientBuilder(awv1beta2.AddToScheme).WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 			managerBuilder = managerBuilder.WithLists(&awv1beta2.AppWrapperList{Items: tc.managersAppWrappers})
 			managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersAppWrappers, func(w *awv1beta2.AppWrapper) client.Object { return w })...)

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -3676,12 +3676,12 @@ func TestReconciler(t *testing.T) {
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
-				Label(controllerconsts.PrebuiltWorkloadLabel, "missing-workload").
+				PrebuiltWorkloadLabel("missing-workload").
 				UID("test-uid").
 				Obj(),
 			wantJob: *baseJobWrapper.
 				Clone().
-				Label(controllerconsts.PrebuiltWorkloadLabel, "missing-workload").
+				PrebuiltWorkloadLabel("missing-workload").
 				UID("test-uid").
 				Obj(),
 			wantEvents: []utiltesting.EventRecord{
@@ -3703,12 +3703,12 @@ func TestReconciler(t *testing.T) {
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
-				Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
+				PrebuiltWorkloadLabel("prebuilt-workload").
 				UID("test-uid").
 				Obj(),
 			wantJob: *baseJobWrapper.
 				Clone().
-				Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
+				PrebuiltWorkloadLabel("prebuilt-workload").
 				UID("test-uid").
 				Obj(),
 			workloads: []kueue.Workload{
@@ -3751,12 +3751,12 @@ func TestReconciler(t *testing.T) {
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
-				Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
+				PrebuiltWorkloadLabel("prebuilt-workload").
 				UID("test-uid").
 				Obj(),
 			wantJob: *baseJobWrapper.
 				Clone().
-				Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
+				PrebuiltWorkloadLabel("prebuilt-workload").
 				UID("test-uid").
 				Obj(),
 			workloads: []kueue.Workload{
@@ -3798,12 +3798,12 @@ func TestReconciler(t *testing.T) {
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
-				Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
+				PrebuiltWorkloadLabel("prebuilt-workload").
 				UID("test-uid").
 				Obj(),
 			wantJob: *baseJobWrapper.
 				Clone().
-				Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
+				PrebuiltWorkloadLabel("prebuilt-workload").
 				UID("test-uid").
 				Obj(),
 			workloads: []kueue.Workload{
@@ -4344,12 +4344,12 @@ func TestReconciler(t *testing.T) {
 
 				// For prebuilt workloads we are skipping the ownership setup in the test body and
 				// expect the reconciler to do it.
-				_, useesPrebuiltWorkload := tc.job.Labels[controllerconsts.PrebuiltWorkloadLabel]
+				prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(&tc.job)
 
 				kClient := kcBuilder.Build()
 				for _, testWl := range tc.workloads {
 					controller := metav1.GetControllerOfNoCopy(&testWl)
-					if !useesPrebuiltWorkload && controller == nil {
+					if prebuiltWorkload == "" && controller == nil {
 						if err := ctrl.SetControllerReference(&tc.job, &testWl, kClient.Scheme()); err != nil {
 							t.Fatalf("Could not setup owner reference in Workloads: %v", err)
 						}
@@ -4386,7 +4386,7 @@ func TestReconciler(t *testing.T) {
 				}
 
 				wlCheckOpts := workloadCmpOpts
-				if useesPrebuiltWorkload {
+				if prebuiltWorkload != "" {
 					wlCheckOpts = workloadCmpOptsWithOwner
 				}
 

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/api"
@@ -140,12 +139,12 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 		return nil, errors.New("not a job")
 	}
 
-	prebuiltWl, hasPrebuiltWorkload := job.Labels[constants.PrebuiltWorkloadLabel]
-	if !hasPrebuiltWorkload {
+	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(job)
+	if prebuiltWorkload == "" {
 		return nil, fmt.Errorf("no prebuilt workload found for job: %s", klog.KObj(job))
 	}
 
-	return []types.NamespacedName{{Name: prebuiltWl, Namespace: job.Namespace}}, nil
+	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: job.Namespace}}, nil
 }
 
 // needElasticJobSync determines if a remote Job requires synchronization due to elastic job features.
@@ -178,7 +177,8 @@ func needElasticJobSync(log logr.Logger, workloadName string, localJob, remoteJo
 			"newWorkloadName", newWorkloadName)
 		return false
 	}
-	return oldParallelism != newParallelism || remoteJob.Labels == nil || remoteJob.Labels[constants.PrebuiltWorkloadLabel] != workloadName
+
+	return oldParallelism != newParallelism || remoteJob.Labels == nil || jobframework.PrebuiltWorkloadNameFor(remoteJob) != workloadName
 }
 
 // syncElasticJob updates the remote job's workload label and parallelism to match the local job configuration.
@@ -192,21 +192,17 @@ func syncElasticJob(ctx context.Context, remoteClient client.Client, log logr.Lo
 
 	// Update a remote job's workload slice name and parallelism if needed.
 	if err := clientutil.Patch(ctx, remoteClient, remoteJob, func() (bool, error) {
-		// Update the workload name label.
-		labelsChanged := false
-		if remoteJob.Labels == nil {
-			remoteJob.Labels = map[string]string{constants.PrebuiltWorkloadLabel: workloadName}
-			labelsChanged = true
-		} else {
-			if cur, ok := remoteJob.Labels[constants.PrebuiltWorkloadLabel]; !ok || cur != workloadName {
-				remoteJob.Labels[constants.PrebuiltWorkloadLabel] = workloadName
-				labelsChanged = true
-			}
-		}
-
 		// Update parallelism.
 		remoteJob.Spec.Parallelism = localJob.Spec.Parallelism
-		return oldParallelism != newParallelism || labelsChanged, nil
+		changed := oldParallelism != newParallelism
+
+		// Update the workload name value.
+		if cur := jobframework.PrebuiltWorkloadNameFor(remoteJob); cur == "" || cur != workloadName {
+			jobframework.SetPrebuiltWorkloadName(remoteJob, workloadName)
+			changed = true
+		}
+
+		return changed, nil
 	}); err != nil {
 		return fmt.Errorf("failed to patch remote job: %w", err)
 	}

--- a/pkg/controller/jobs/job/job_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter_test.go
@@ -65,8 +65,10 @@ func TestMultiKueueAdapter(t *testing.T) {
 		wantError        error
 		wantManagersJobs []batchv1.Job
 		wantWorkerJobs   []batchv1.Job
+		featureGates     map[featuregate.Feature]bool
 	}{
 		"sync creates missing remote job": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersJobs: []batchv1.Job{
 				*baseJobManagedByKueueBuilder.DeepCopy(),
 			},
@@ -85,6 +87,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync intermediate status from remote job": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersJobs: []batchv1.Job{
 				*baseJobManagedByKueueBuilder.DeepCopy(),
 			},
@@ -111,6 +114,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"skip to sync intermediate status from remote suspended job": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersJobs: []batchv1.Job{
 				*baseJobManagedByKueueBuilder.Clone().
 					Suspend(true).
@@ -142,6 +146,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync final status from remote job": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersJobs: []batchv1.Job{
 				*baseJobManagedByKueueBuilder.DeepCopy(),
 			},
@@ -170,6 +175,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"remote job is deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			workerJobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
 					PrebuiltWorkloadLabel("wl1").
@@ -182,6 +188,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"missing job is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
 				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}); isManged {
 					return errors.New("expecting false")
@@ -190,6 +197,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"job with wrong managedBy is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersJobs: []batchv1.Job{
 				*baseJobBuilder.DeepCopy(),
 			},
@@ -204,6 +212,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"job managedBy multikueue": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersJobs: []batchv1.Job{
 				*baseJobManagedByKueueBuilder.DeepCopy(),
 			},
@@ -217,9 +226,28 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*baseJobManagedByKueueBuilder.DeepCopy(),
 			},
 		},
+		"sync creates missing remote job, WorkloadIdentifierAnnotations enabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			managersJobs: []batchv1.Job{
+				*baseJobManagedByKueueBuilder.DeepCopy(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, "wl1", "origin1")
+			},
+			wantManagersJobs: []batchv1.Job{
+				*baseJobManagedByKueueBuilder.DeepCopy(),
+			},
+			wantWorkerJobs: []batchv1.Job{
+				*baseJobBuilder.Clone().
+					PrebuiltWorkloadAnnotation("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			managerBuilder := utiltesting.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 			managerBuilder = managerBuilder.WithLists(&batchv1.JobList{Items: tc.managersJobs})
 			managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersJobs, func(w *batchv1.Job) client.Object { return w })...)
@@ -319,6 +347,9 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 			},
 		},
 		"RemoteJobNotFound": {
+			fields: fields{
+				featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
 					ManagedBy("parent").Obj()).Build(),

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -58,6 +58,7 @@ var (
 	labelsPath                     = field.NewPath("metadata", "labels")
 	annotationsPath                = field.NewPath("metadata", "annotations")
 	admissionGatedByAnnotationPath = annotationsPath.Key(kueueconstants.AdmissionGatedByAnnotation)
+	prebuiltWorkloadAnnotationPath = annotationsPath.Key(constants.PrebuiltWorkloadAnnotation)
 	prebuiltWorkloadLabelPath      = labelsPath.Key(constants.PrebuiltWorkloadLabel)
 	queueNameLabelPath             = labelsPath.Key(constants.QueueLabel)
 	maxExecTimeLabelPath           = labelsPath.Key(constants.MaxExecTimeSecondsLabel)
@@ -195,6 +196,37 @@ func TestValidateCreate(t *testing.T) {
 				Indexed(true).
 				Obj(),
 			wantValidationErrs: nil,
+		},
+		{
+			name: "invalid prebuilt workload annotation, WorkloadIdentifierAnnotations enabled",
+			job: testingutil.MakeJob("job", "default").
+				Parallelism(4).
+				Completions(4).
+				PrebuiltWorkloadAnnotation("workload name").
+				Indexed(true).
+				Obj(),
+			wantValidationErrs: field.ErrorList{
+				field.Invalid(prebuiltWorkloadAnnotationPath, "workload name", testutil.InvalidRFC1123Message),
+			},
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		{
+			name: "valid prebuilt workload annotation, WorkloadIdentifierAnnotations enabled",
+			job: testingutil.MakeJob("job", "default").
+				Parallelism(4).
+				Completions(4).
+				PrebuiltWorkloadAnnotation("workload-name").
+				Indexed(true).
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		{
+			name: "different prebuilt workload label and annotation, label ignored, WorkloadIdentifierAnnotations enabled",
+			job: testingutil.MakeJob("job", "default").
+				PrebuiltWorkloadLabel("workload-label").
+				PrebuiltWorkloadAnnotation("workload-annotation").
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
 		},
 		{
 			name: "invalid maximum execution time",
@@ -753,6 +785,32 @@ func TestValidateUpdate(t *testing.T) {
 				PrebuiltWorkloadLabel("new-workload").
 				Obj(),
 			wantValidationErrs: apivalidation.ValidateImmutableField("new-workload", "old-workload", prebuiltWorkloadLabelPath),
+		},
+		{
+			name: "immutable prebuilt workload annotation, WorkloadIdentifierAnnotations enabled",
+			oldJob: testingutil.MakeJob("job", "default").
+				Suspend(true).
+				SetAnnotation(constants.PrebuiltWorkloadAnnotation, "old-workload").
+				Obj(),
+			newJob: testingutil.MakeJob("job", "default").
+				Suspend(false).
+				SetAnnotation(constants.PrebuiltWorkloadAnnotation, "new-workload").
+				Obj(),
+			wantValidationErrs: apivalidation.ValidateImmutableField("new-workload", "old-workload", prebuiltWorkloadAnnotationPath),
+			featureGates:       map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		{
+			name: "migrate from label to annotation, WorkloadIdentifierAnnotations enabled",
+			oldJob: testingutil.MakeJob("job", "default").
+				Suspend(true).
+				PrebuiltWorkloadLabel("workload-name").
+				Obj(),
+			newJob: testingutil.MakeJob("job", "default").
+				Suspend(false).
+				PrebuiltWorkloadAnnotation("workload-name").
+				Obj(),
+			wantValidationErrs: nil,
+			featureGates:       map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
 		},
 		{
 			name: "immutable queue name not suspend",

--- a/pkg/controller/jobs/jobset/jobset_multikueue_adapter.go
+++ b/pkg/controller/jobs/jobset/jobset_multikueue_adapter.go
@@ -30,7 +30,6 @@ import (
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/util/api"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
@@ -111,10 +110,10 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 		return nil, errors.New("not a jobset")
 	}
 
-	prebuiltWl, hasPrebuiltWorkload := jobSet.Labels[constants.PrebuiltWorkloadLabel]
-	if !hasPrebuiltWorkload {
+	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(jobSet)
+	if prebuiltWorkload == "" {
 		return nil, fmt.Errorf("no prebuilt workload found for jobset: %s", klog.KObj(jobSet))
 	}
 
-	return []types.NamespacedName{{Name: prebuiltWl, Namespace: jobSet.Namespace}}, nil
+	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: jobSet.Namespace}}, nil
 }

--- a/pkg/controller/jobs/jobset/jobset_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/jobset/jobset_multikueue_adapter_test.go
@@ -25,11 +25,13 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	jobsetapi "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingjobset "sigs.k8s.io/kueue/pkg/util/testingjobs/jobset"
@@ -57,9 +59,11 @@ func TestMultiKueueAdapter(t *testing.T) {
 		wantError           error
 		wantManagersJobSets []jobsetapi.JobSet
 		wantWorkerJobSets   []jobsetapi.JobSet
+		featureGates        map[featuregate.Feature]bool
 	}{
 
 		"sync creates missing remote jobset": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersJobSets: []jobsetapi.JobSet{
 				*baseJobSetManagedByKueueBuilder.DeepCopy(),
 			},
@@ -78,6 +82,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote jobset": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersJobSets: []jobsetapi.JobSet{
 				*baseJobSetManagedByKueueBuilder.DeepCopy(),
 			},
@@ -139,6 +144,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote while local jobset is suspended": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersJobSets: []jobsetapi.JobSet{
 				*baseJobSetManagedByKueueBuilder.Clone().
 					Suspend(true).
@@ -205,6 +211,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"remote jobset is deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			workerJobSets: []jobsetapi.JobSet{
 				*baseJobSetBuilder.Clone().
 					PrebuiltWorkloadLabel("wl1").
@@ -228,6 +235,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"missing jobset is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
 				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "jobset1", Namespace: TestNamespace}); isManged {
 					return errors.New("expecting false")
@@ -236,6 +244,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"job with wrong managedBy is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersJobSets: []jobsetapi.JobSet{
 				*baseJobSetBuilder.DeepCopy(),
 			},
@@ -251,6 +260,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		},
 
 		"job managedBy multikueue": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersJobSets: []jobsetapi.JobSet{
 				*baseJobSetManagedByKueueBuilder.DeepCopy(),
 			},
@@ -264,9 +274,28 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*baseJobSetManagedByKueueBuilder.DeepCopy(),
 			},
 		},
+		"sync creates missing remote jobset, WorkloadIdentifierAnnotations enabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			managersJobSets: []jobsetapi.JobSet{
+				*baseJobSetManagedByKueueBuilder.DeepCopy(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "jobset1", Namespace: TestNamespace}, "wl1", "origin1")
+			},
+			wantManagersJobSets: []jobsetapi.JobSet{
+				*baseJobSetManagedByKueueBuilder.DeepCopy(),
+			},
+			wantWorkerJobSets: []jobsetapi.JobSet{
+				*baseJobSetBuilder.Clone().
+					PrebuiltWorkloadAnnotation("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			managerBuilder := utiltesting.NewClientBuilder(jobsetapi.AddToScheme).WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 			managerBuilder = managerBuilder.WithLists(&jobsetapi.JobSetList{Items: tc.managersJobSets})
 			managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersJobSets, func(w *jobsetapi.JobSet) client.Object { return w })...)

--- a/pkg/controller/jobs/jobset/jobset_webhook_test.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook_test.go
@@ -68,6 +68,19 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name:         "valid prebuilt workload annotation, WorkloadIdentifierAnnotations enabled",
+			job:          testingutil.MakeJobSet("job", "default").Queue("queue").PrebuiltWorkloadAnnotation("prebuilt-workload").Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			wantErr:      nil,
+		},
+		{
+			name: "different prebuilt workload label and annotation, label ignored, WorkloadIdentifierAnnotations enabled",
+			job: testingutil.MakeJobSet("job", "default").Queue("queue").
+				PrebuiltWorkloadLabel("prebuilt-workload-label").
+				PrebuiltWorkloadAnnotation("prebuilt-workload-annotation").Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		{
 			name: "valid topology request",
 			job: testingutil.MakeJobSet("job", "default").ReplicatedJobs(testingutil.ReplicatedJobRequirements{
 				Name: "launcher",

--- a/pkg/controller/jobs/kubeflow/jobs/jaxjob/jaxjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/jaxjob/jaxjob_multikueue_adapter_test.go
@@ -27,12 +27,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/kubeflowjob"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	kfutiltesting "sigs.k8s.io/kueue/pkg/util/testingjobs/jaxjob"
@@ -60,8 +62,10 @@ func TestMultiKueueAdapter(t *testing.T) {
 		wantError           error
 		wantManagersJAXJobs []kftraining.JAXJob
 		wantWorkerJAXJobs   []kftraining.JAXJob
+		featureGates        map[featuregate.Feature]bool
 	}{
 		"sync creates missing remote jaxjob": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersJAXJobs: []kftraining.JAXJob{
 				*jaxJobBuilder.DeepCopy(),
 			},
@@ -80,6 +84,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote jaxjob": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersJAXJobs: []kftraining.JAXJob{
 				*jaxJobBuilder.DeepCopy(),
 			},
@@ -108,6 +113,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote while local jaxjob is suspended": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersJAXJobs: []kftraining.JAXJob{
 				*jaxJobBuilder.Clone().
 					Suspend(true).
@@ -140,6 +146,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"remote jaxjob is deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			workerJAXJobs: []kftraining.JAXJob{
 				*jaxJobBuilder.Clone().
 					PrebuiltWorkloadLabel("wl1").
@@ -151,6 +158,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"missing job is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "jaxjob1", Namespace: TestNamespace}); isManged {
 					return errors.New("expecting false")
@@ -159,6 +167,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"job with wrong managedBy is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersJAXJobs: []kftraining.JAXJob{
 				*jaxJobBuilder.DeepCopy(),
 			},
@@ -173,6 +182,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"job managedBy multikueue": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersJAXJobs: []kftraining.JAXJob{
 				*jaxJobManagedByKueueBuilder.DeepCopy(),
 			},
@@ -186,9 +196,28 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*jaxJobManagedByKueueBuilder.DeepCopy(),
 			},
 		},
+		"sync creates missing remote jaxjob, WorkloadIdentifierAnnotations enabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			managersJAXJobs: []kftraining.JAXJob{
+				*jaxJobBuilder.DeepCopy(),
+			},
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
+				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "jaxjob1", Namespace: TestNamespace}, "wl1", "origin1")
+			},
+			wantManagersJAXJobs: []kftraining.JAXJob{
+				*jaxJobBuilder.DeepCopy(),
+			},
+			wantWorkerJAXJobs: []kftraining.JAXJob{
+				*jaxJobBuilder.Clone().
+					PrebuiltWorkloadAnnotation("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			managerBuilder := utiltesting.NewClientBuilder(kftraining.AddToScheme).WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 			managerBuilder = managerBuilder.WithLists(&kftraining.JAXJobList{Items: tc.managersJAXJobs})
 			managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersJAXJobs, func(w *kftraining.JAXJob) client.Object { return w })...)

--- a/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_multikueue_adapter_test.go
@@ -27,12 +27,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/kubeflowjob"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	kfutiltesting "sigs.k8s.io/kueue/pkg/util/testingjobs/paddlejob"
@@ -60,8 +62,10 @@ func TestMultiKueueAdapter(t *testing.T) {
 		wantError              error
 		wantManagersPaddleJobs []kftraining.PaddleJob
 		wantWorkerPaddleJobs   []kftraining.PaddleJob
+		featureGates           map[featuregate.Feature]bool
 	}{
 		"sync creates missing remote PaddleJob": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersPaddleJobs: []kftraining.PaddleJob{
 				*paddleJobBuilder.DeepCopy(),
 			},
@@ -81,6 +85,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote PaddleJob": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersPaddleJobs: []kftraining.PaddleJob{
 				*paddleJobBuilder.DeepCopy(),
 			},
@@ -109,6 +114,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote while local PaddleJob is suspended": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersPaddleJobs: []kftraining.PaddleJob{
 				*paddleJobBuilder.Clone().
 					Suspend(true).
@@ -141,6 +147,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"remote PaddleJob is deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			workerPaddleJobs: []kftraining.PaddleJob{
 				*paddleJobBuilder.Clone().
 					PrebuiltWorkloadLabel("wl1").
@@ -152,6 +159,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"missing job is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "paddlejob1", Namespace: TestNamespace}); isManged {
 					return errors.New("expecting false")
@@ -160,6 +168,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"job with wrong managedBy is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersPaddleJobs: []kftraining.PaddleJob{
 				*paddleJobBuilder.DeepCopy(),
 			},
@@ -174,6 +183,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"job managedBy multikueue": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersPaddleJobs: []kftraining.PaddleJob{
 				*paddleJobManagedByKueueBuilder.DeepCopy(),
 			},
@@ -187,9 +197,28 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*paddleJobManagedByKueueBuilder.DeepCopy(),
 			},
 		},
+		"sync creates missing remote paddlejob, WorkloadIdentifierAnnotations enabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			managersPaddleJobs: []kftraining.PaddleJob{
+				*paddleJobBuilder.DeepCopy(),
+			},
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
+				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "paddlejob1", Namespace: TestNamespace}, "wl1", "origin1")
+			},
+			wantManagersPaddleJobs: []kftraining.PaddleJob{
+				*paddleJobBuilder.DeepCopy(),
+			},
+			wantWorkerPaddleJobs: []kftraining.PaddleJob{
+				*paddleJobBuilder.Clone().
+					PrebuiltWorkloadAnnotation("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			managerBuilder := utiltesting.NewClientBuilder(kftraining.AddToScheme).WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 			managerBuilder = managerBuilder.WithLists(&kftraining.PaddleJobList{Items: tc.managersPaddleJobs})
 			managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersPaddleJobs, func(w *kftraining.PaddleJob) client.Object { return w })...)

--- a/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorch_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorch_multikueue_adapter_test.go
@@ -27,12 +27,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/kubeflowjob"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	kfutiltesting "sigs.k8s.io/kueue/pkg/util/testingjobs/pytorchjob"
@@ -60,8 +62,10 @@ func TestMultiKueueAdapter(t *testing.T) {
 		wantError               error
 		wantManagersPyTorchJobs []kftraining.PyTorchJob
 		wantWorkerPyTorchJobs   []kftraining.PyTorchJob
+		featureGates            map[featuregate.Feature]bool
 	}{
 		"sync creates missing remote pytorchjob": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersPyTorchJobs: []kftraining.PyTorchJob{
 				*pyTorchJobBuilder.DeepCopy(),
 			},
@@ -80,6 +84,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote pytorchjob": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersPyTorchJobs: []kftraining.PyTorchJob{
 				*pyTorchJobBuilder.DeepCopy(),
 			},
@@ -108,6 +113,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote while local pytorchjob is suspended": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersPyTorchJobs: []kftraining.PyTorchJob{
 				*pyTorchJobBuilder.Clone().
 					Suspend(true).
@@ -140,6 +146,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"remote pytorchjob is deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			workerPyTorchJobs: []kftraining.PyTorchJob{
 				*pyTorchJobBuilder.Clone().
 					PrebuiltWorkloadLabel("wl1").
@@ -151,6 +158,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"missing job is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "pytorchjob1", Namespace: TestNamespace}); isManged {
 					return errors.New("expecting false")
@@ -159,6 +167,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"job with wrong managedBy is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersPyTorchJobs: []kftraining.PyTorchJob{
 				*pyTorchJobBuilder.DeepCopy(),
 			},
@@ -173,6 +182,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"job managedBy multikueue": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersPyTorchJobs: []kftraining.PyTorchJob{
 				*pyTorchJobManagedByKueueBuilder.DeepCopy(),
 			},
@@ -186,9 +196,28 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*pyTorchJobManagedByKueueBuilder.DeepCopy(),
 			},
 		},
+		"sync creates missing remote pytorchjob, WorkloadIdentifierAnnotations enabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			managersPyTorchJobs: []kftraining.PyTorchJob{
+				*pyTorchJobBuilder.DeepCopy(),
+			},
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
+				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "pytorchjob1", Namespace: TestNamespace}, "wl1", "origin1")
+			},
+			wantManagersPyTorchJobs: []kftraining.PyTorchJob{
+				*pyTorchJobBuilder.DeepCopy(),
+			},
+			wantWorkerPyTorchJobs: []kftraining.PyTorchJob{
+				*pyTorchJobBuilder.Clone().
+					PrebuiltWorkloadAnnotation("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			managerBuilder := utiltesting.NewClientBuilder(kftraining.AddToScheme).WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 			managerBuilder = managerBuilder.WithLists(&kftraining.PyTorchJobList{Items: tc.managersPyTorchJobs})
 			managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersPyTorchJobs, func(w *kftraining.PyTorchJob) client.Object { return w })...)

--- a/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_multikueue_adapter_test.go
@@ -27,12 +27,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/kubeflowjob"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	kfutiltesting "sigs.k8s.io/kueue/pkg/util/testingjobs/tfjob"
@@ -60,8 +62,10 @@ func TestMultiKueueAdapter(t *testing.T) {
 		wantError          error
 		wantManagersTFJobs []kftraining.TFJob
 		wantWorkerTFJobs   []kftraining.TFJob
+		featureGates       map[featuregate.Feature]bool
 	}{
 		"sync creates missing remote tfjob": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersTFJobs: []kftraining.TFJob{
 				*tfJobBuilder.DeepCopy(),
 			},
@@ -80,6 +84,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote tfjob": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersTFJobs: []kftraining.TFJob{
 				*tfJobBuilder.DeepCopy(),
 			},
@@ -108,6 +113,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote while local tfjob is suspended": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersTFJobs: []kftraining.TFJob{
 				*tfJobBuilder.Clone().
 					Suspend(true).
@@ -140,6 +146,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"remote tfjob is deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			workerTFJobs: []kftraining.TFJob{
 				*tfJobBuilder.Clone().
 					PrebuiltWorkloadLabel("wl1").
@@ -151,6 +158,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"missing job is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "tfjob1", Namespace: TestNamespace}); isManged {
 					return errors.New("expecting false")
@@ -159,6 +167,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"job with wrong managedBy is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersTFJobs: []kftraining.TFJob{
 				*tfJobBuilder.DeepCopy(),
 			},
@@ -173,6 +182,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"job managedBy multikueue": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersTFJobs: []kftraining.TFJob{
 				*tfJobManagedByKueueBuilder.DeepCopy(),
 			},
@@ -186,9 +196,28 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*tfJobManagedByKueueBuilder.DeepCopy(),
 			},
 		},
+		"sync creates missing remote tfjob, WorkloadIdentifierAnnotations enabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			managersTFJobs: []kftraining.TFJob{
+				*tfJobBuilder.DeepCopy(),
+			},
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
+				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "tfjob1", Namespace: TestNamespace}, "wl1", "origin1")
+			},
+			wantManagersTFJobs: []kftraining.TFJob{
+				*tfJobBuilder.DeepCopy(),
+			},
+			wantWorkerTFJobs: []kftraining.TFJob{
+				*tfJobBuilder.Clone().
+					PrebuiltWorkloadAnnotation("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			managerBuilder := utiltesting.NewClientBuilder(kftraining.AddToScheme).WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 			managerBuilder = managerBuilder.WithLists(&kftraining.TFJobList{Items: tc.managersTFJobs})
 			managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersTFJobs, func(w *kftraining.TFJob) client.Object { return w })...)

--- a/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_multikueue_adapter_test.go
@@ -27,12 +27,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/kubeflowjob"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	kfutiltesting "sigs.k8s.io/kueue/pkg/util/testingjobs/xgboostjob"
@@ -60,8 +62,10 @@ func TestMultiKueueAdapter(t *testing.T) {
 		wantError               error
 		wantManagersXGBoostJobs []kftraining.XGBoostJob
 		wantWorkerXGBoostJobs   []kftraining.XGBoostJob
+		featureGates            map[featuregate.Feature]bool
 	}{
 		"sync creates missing remote xgboostjob": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersXGBoostJobs: []kftraining.XGBoostJob{
 				*xgboostJobBuilder.DeepCopy(),
 			},
@@ -80,6 +84,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote XgBoostJob": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersXGBoostJobs: []kftraining.XGBoostJob{
 				*xgboostJobBuilder.DeepCopy(),
 			},
@@ -108,6 +113,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote while local XgBoostJob is suspended": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersXGBoostJobs: []kftraining.XGBoostJob{
 				*xgboostJobBuilder.Clone().
 					Suspend(true).
@@ -141,6 +147,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"remote XgBoostJob is deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			workerXGBoostJobs: []kftraining.XGBoostJob{
 				*xgboostJobBuilder.Clone().
 					PrebuiltWorkloadLabel("wl1").
@@ -152,6 +159,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"missing job is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "xgboostjob1", Namespace: TestNamespace}); isManged {
 					return errors.New("expecting false")
@@ -160,6 +168,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"job with wrong managedBy is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersXGBoostJobs: []kftraining.XGBoostJob{
 				*xgboostJobBuilder.DeepCopy(),
 			},
@@ -174,6 +183,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"job managedBy multikueue": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersXGBoostJobs: []kftraining.XGBoostJob{
 				*xgboostJobManagedByKueueBuilder.DeepCopy(),
 			},
@@ -187,9 +197,28 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*xgboostJobManagedByKueueBuilder.DeepCopy(),
 			},
 		},
+		"sync creates missing remote xgboostjob, WorkloadIdentifierAnnotations enabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			managersXGBoostJobs: []kftraining.XGBoostJob{
+				*xgboostJobBuilder.DeepCopy(),
+			},
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
+				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "xgboostjob1", Namespace: TestNamespace}, "wl1", "origin1")
+			},
+			wantManagersXGBoostJobs: []kftraining.XGBoostJob{
+				*xgboostJobBuilder.DeepCopy(),
+			},
+			wantWorkerXGBoostJobs: []kftraining.XGBoostJob{
+				*xgboostJobBuilder.Clone().
+					PrebuiltWorkloadAnnotation("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			managerBuilder := utiltesting.NewClientBuilder(kftraining.AddToScheme).WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 			managerBuilder = managerBuilder.WithLists(&kftraining.XGBoostJobList{Items: tc.managersXGBoostJobs})
 			managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersXGBoostJobs, func(w *kftraining.XGBoostJob) client.Object { return w })...)

--- a/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_multikueue_adapter.go
+++ b/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_multikueue_adapter.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
 )
@@ -144,10 +143,10 @@ func (a adapter[PtrT, T]) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 		return nil, fmt.Errorf("not a %s", a.gvk.Kind)
 	}
 
-	prebuiltWl, hasPrebuiltWorkload := job.GetLabels()[constants.PrebuiltWorkloadLabel]
-	if !hasPrebuiltWorkload {
+	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(job)
+	if prebuiltWorkload == "" {
 		return nil, fmt.Errorf("no prebuilt workload found for %s: %s", a.gvk.Kind, klog.KObj(job))
 	}
 
-	return []types.NamespacedName{{Name: prebuiltWl, Namespace: job.GetNamespace()}}, nil
+	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: job.GetNamespace()}}, nil
 }

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_multikueue_adapter_test.go
@@ -24,12 +24,14 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingleaderworkerset "sigs.k8s.io/kueue/pkg/util/testingjobs/leaderworkerset"
@@ -52,8 +54,10 @@ func TestMultiKueueAdapter(t *testing.T) {
 		wantError                    error
 		wantManagersLeaderWorkerSets []leaderworkersetv1.LeaderWorkerSet
 		wantWorkerLeaderWorkerSets   []leaderworkersetv1.LeaderWorkerSet
+		featureGates                 map[featuregate.Feature]bool
 	}{
 		"sync creates missing remote leaderworkerset with origin UID annotation": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
 				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).UID("manager-uid-123").Obj(),
 			},
@@ -71,6 +75,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync does not overwrite existing remote leaderworkerset": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
 				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).UID("manager-uid-123").Obj(),
 			},
@@ -98,6 +103,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"remote leaderworkerset is deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			workerLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
 				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).
 					Label(kueue.MultiKueueOriginLabel, "origin1").
@@ -110,6 +116,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"IsJobManagedByKueue returns true": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
 				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).Obj(),
 			},
@@ -128,6 +135,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"GetExpectedWorkloadCount returns replicas count": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
 				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).Replicas(4).Obj(),
 			},
@@ -146,6 +154,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"GetExpectedWorkloadCount returns 1 for nil replicas": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
 				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).Obj(),
 			},
@@ -163,9 +172,28 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).Obj(),
 			},
 		},
+		"sync creates missing remote leaderworkerset, WorkloadIdentifierAnnotations enabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			managersLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
+				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).UID("manager-uid-123").Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "lws1", Namespace: TestNamespace}, "wl1", "origin1")
+			},
+			wantManagersLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
+				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).UID("manager-uid-123").Obj(),
+			},
+			wantWorkerLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
+				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-uid-123").
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			managerBuilder := utiltesting.NewClientBuilder(leaderworkersetv1.AddToScheme).WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 			managerBuilder = managerBuilder.WithLists(&leaderworkersetv1.LeaderWorkerSetList{Items: tc.managersLeaderWorkerSets})
 			managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersLeaderWorkerSets, func(w *leaderworkersetv1.LeaderWorkerSet) client.Object { return w })...)

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -464,7 +464,7 @@ func (r *Reconciler) reconcilePod(ctx context.Context, lws *leaderworkersetv1.Le
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"pod", klog.KObj(pod),
 		"podRevision", pod.Labels[appsv1.ControllerRevisionHashLabelKey],
-		"group", pod.Labels[podconstants.GroupNameLabel])
+		"group", podcontroller.GetPodGroupName(pod))
 	if sts != nil {
 		log = log.WithValues(
 			"statefulset", klog.KObj(sts),
@@ -523,10 +523,14 @@ func (r *Reconciler) setDefault(lws *leaderworkersetv1.LeaderWorkerSet, pod *cor
 
 	wlName := GetWorkloadName(GetOwnerUID(lws), lws.Name, pod.Labels[leaderworkersetv1.GroupIndexLabelKey])
 
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+
 	pod.Labels[constants.ManagedByKueueLabelKey] = constants.ManagedByKueueLabelValue
 	pod.Labels[controllerconstants.QueueLabel] = string(queueName)
-	pod.Labels[podconstants.GroupNameLabel] = wlName
-	pod.Labels[controllerconstants.PrebuiltWorkloadLabel] = wlName
+	podcontroller.SetPodGroupName(pod, wlName)
+	jobframework.SetPrebuiltWorkloadName(pod, wlName)
 	pod.Annotations[podconstants.GroupTotalCountAnnotation] = fmt.Sprint(ptr.Deref(lws.Spec.LeaderWorkerTemplate.Size, 1))
 	pod.Annotations[podconstants.RoleHashAnnotation] = string(kueue.DefaultPodSetName)
 

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -403,6 +403,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should create prebuilt workload with required topology annotation": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
 				UID(testLWS).
 				Size(3).
@@ -995,6 +996,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should finalize pods if leaderworkerset is deleted": {
+			featureGates:    map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			leaderWorkerSet: nil,
 			statefulSets: []appsv1.StatefulSet{
 				*statefulset.MakeStatefulSet(testSTS, testNS).
@@ -1025,6 +1027,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should finalize pods if statefulSet is deleted": {
+			featureGates:    map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testLWS).Obj(),
 			statefulSets:    nil,
 			workloads: []kueue.Workload{
@@ -1085,6 +1088,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should finalize succeeded pod": {
+			featureGates:    map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testLWS).Obj(),
 			statefulSets: []appsv1.StatefulSet{
 				*statefulset.MakeStatefulSet(testSTS, testNS).
@@ -1151,6 +1155,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should finalize failed pod": {
+			featureGates:    map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testLWS).Obj(),
 			statefulSets: []appsv1.StatefulSet{
 				*statefulset.MakeStatefulSet(testSTS, testNS).
@@ -1227,6 +1232,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should finalize deleted pod": {
+			featureGates:    map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testLWS).Obj(),
 			statefulSets: []appsv1.StatefulSet{
 				*statefulset.MakeStatefulSet(testSTS, testNS).
@@ -1289,6 +1295,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: nil,
 		},
 		"shouldn't set default values without queue-name": {
+			featureGates:    map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testLWS).Obj(),
 			statefulSets: []appsv1.StatefulSet{
 				*statefulset.MakeStatefulSet(testSTS, testNS).
@@ -1352,6 +1359,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"shouldn't set default values with managed-by-kueue label": {
+			featureGates:    map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testLWS).Obj(),
 			statefulSets: []appsv1.StatefulSet{
 				*statefulset.MakeStatefulSet(testSTS, testNS).
@@ -1417,6 +1425,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"shouldn't set default values without group index label": {
+			featureGates:    map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testLWS).Obj(),
 			statefulSets: []appsv1.StatefulSet{
 				*statefulset.MakeStatefulSet(testSTS, testNS).
@@ -1481,6 +1490,7 @@ func TestReconciler(t *testing.T) {
 		},
 		// Leader pod doesn't have a leaderworkerset.sigs.k8s.io/leader-name annotation.
 		"should set default values (worker template, leader pod)": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testLWS).
 				Queue("queue").
 				Obj(),
@@ -1555,6 +1565,7 @@ func TestReconciler(t *testing.T) {
 		},
 		// Worker pod has a leaderworkerset.sigs.k8s.io/leader-name annotation.
 		"should set default values (worker template, worker pod)": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testLWS).
 				Queue("queue").
 				Obj(),
@@ -1630,6 +1641,7 @@ func TestReconciler(t *testing.T) {
 		},
 		// Leader pod doesn't have a leaderworkerset.sigs.k8s.io/leader-name annotation.
 		"should set default values (leader+worker template, leader pod)": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testLWS).
 				Queue("queue").
 				LeaderTemplate(corev1.PodTemplateSpec{
@@ -1736,6 +1748,7 @@ func TestReconciler(t *testing.T) {
 		},
 		// Worker pod has a leaderworkerset.sigs.k8s.io/leader-name annotation.
 		"should set default values (leader+worker template, worker pod)": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testLWS).
 				Queue("queue").
 				LeaderTemplate(corev1.PodTemplateSpec{
@@ -1843,6 +1856,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should set default values using origin UID in MultiKueue scenario": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testLWS).
 				Queue("queue").
 				Label(kueue.MultiKueueOriginLabel, "origin1").

--- a/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter.go
+++ b/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/util/api"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
@@ -111,10 +110,10 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 		return nil, errors.New("not a mpijob")
 	}
 
-	prebuiltWl, hasPrebuiltWorkload := job.Labels[constants.PrebuiltWorkloadLabel]
-	if !hasPrebuiltWorkload {
+	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(job)
+	if prebuiltWorkload == "" {
 		return nil, fmt.Errorf("no prebuilt workload found for mpijob: %s", klog.KObj(job))
 	}
 
-	return []types.NamespacedName{{Name: prebuiltWl, Namespace: job.Namespace}}, nil
+	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: job.Namespace}}, nil
 }

--- a/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter_test.go
@@ -27,10 +27,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingmpijob "sigs.k8s.io/kueue/pkg/util/testingjobs/mpijob"
@@ -57,8 +59,10 @@ func TestMultiKueueAdapter(t *testing.T) {
 		wantError           error
 		wantManagersMpiJobs []kfmpi.MPIJob
 		wantWorkerMpiJobs   []kfmpi.MPIJob
+		featureGates        map[featuregate.Feature]bool
 	}{
 		"sync creates missing remote mpijob": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.DeepCopy(),
 			},
@@ -77,6 +81,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote mpijob": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.DeepCopy(),
 			},
@@ -105,6 +110,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote while local mpijob is suspended": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.Clone().
 					Suspend(true).
@@ -137,6 +143,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"remote mpijob is deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			workerMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.Clone().
 					PrebuiltWorkloadLabel("wl1").
@@ -148,6 +155,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"job with wrong managedBy is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.Clone().
 					ManagedBy("some-other-controller").
@@ -167,6 +175,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		},
 
 		"job managedBy multikueue": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.Clone().
 					ManagedBy(kueue.MultiKueueControllerName).
@@ -185,6 +194,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"missing job is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
 				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "mpijob1", Namespace: TestNamespace}); isManged {
 					return errors.New("expecting false")
@@ -192,9 +202,28 @@ func TestMultiKueueAdapter(t *testing.T) {
 				return nil
 			},
 		},
+		"sync creates missing remote mpijob, WorkloadIdentifierAnnotations enabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			managersMpiJobs: []kfmpi.MPIJob{
+				*mpiJobBuilder.DeepCopy(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "mpijob1", Namespace: TestNamespace}, "wl1", "origin1")
+			},
+			wantManagersMpiJobs: []kfmpi.MPIJob{
+				*mpiJobBuilder.DeepCopy(),
+			},
+			wantWorkerMpiJobs: []kfmpi.MPIJob{
+				*mpiJobBuilder.Clone().
+					PrebuiltWorkloadAnnotation("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			managerBuilder := utiltesting.NewClientBuilder(kfmpi.AddToScheme).WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 			managerBuilder = managerBuilder.WithLists(&kfmpi.MPIJobList{Items: tc.managersMpiJobs})
 			managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersMpiJobs, func(w *kfmpi.MPIJob) client.Object { return w })...)

--- a/pkg/controller/jobs/pod/constants/constants.go
+++ b/pkg/controller/jobs/pod/constants/constants.go
@@ -25,6 +25,7 @@ const (
 
 	SuspendedByParentAnnotation       = "kueue.x-k8s.io/pod-suspending-parent"
 	GroupNameLabel                    = "kueue.x-k8s.io/pod-group-name"
+	GroupNameAnnotation               = "kueue.x-k8s.io/pod-group-name"
 	GroupTotalCountAnnotation         = "kueue.x-k8s.io/pod-group-total-count"
 	GroupFastAdmissionAnnotationKey   = "kueue.x-k8s.io/pod-group-fast-admission"
 	GroupFastAdmissionAnnotationValue = "true"

--- a/pkg/controller/jobs/pod/event_handlers.go
+++ b/pkg/controller/jobs/pod/event_handlers.go
@@ -43,7 +43,7 @@ var (
 )
 
 func reconcileRequestForPod(p *corev1.Pod) reconcile.Request {
-	groupName := p.GetLabels()[podconstants.GroupNameLabel]
+	groupName := GetPodGroupName(p)
 
 	if groupName == "" {
 		return reconcile.Request{
@@ -83,10 +83,10 @@ func (h *podEventHandler) Delete(ctx context.Context, e event.DeleteEvent, q wor
 
 	log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(p))
 
-	if g, isGroup := p.Labels[podconstants.GroupNameLabel]; isGroup {
+	if groupName := GetPodGroupName(p); groupName != "" {
 		// If the watch was temporarily unavailable, it is possible that the object reported in the event still
 		// has a finalizer, but we can consider this Pod cleaned up, as it is being deleted.
-		h.cleanedUpPodsExpectations.ObservedUID(log, types.NamespacedName{Namespace: p.Namespace, Name: g}, p.UID)
+		h.cleanedUpPodsExpectations.ObservedUID(log, types.NamespacedName{Namespace: p.Namespace, Name: groupName}, p.UID)
 	}
 
 	log.V(5).Info("Queueing reconcile for pod")
@@ -105,9 +105,9 @@ func (h *podEventHandler) queueReconcileForPod(ctx context.Context, object clien
 
 	log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(p))
 
-	if g, isGroup := p.Labels[podconstants.GroupNameLabel]; isGroup {
+	if groupName := GetPodGroupName(p); groupName != "" {
 		if !slices.Contains(p.Finalizers, podconstants.PodFinalizer) {
-			h.cleanedUpPodsExpectations.ObservedUID(log, types.NamespacedName{Namespace: p.Namespace, Name: g}, p.UID)
+			h.cleanedUpPodsExpectations.ObservedUID(log, types.NamespacedName{Namespace: p.Namespace, Name: groupName}, p.UID)
 		}
 	}
 

--- a/pkg/controller/jobs/pod/indexer.go
+++ b/pkg/controller/jobs/pod/indexer.go
@@ -19,8 +19,6 @@ package pod
 import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 )
 
 const (
@@ -33,8 +31,8 @@ func IndexPodGroupName(o client.Object) []string {
 		return nil
 	}
 
-	if labelValue, exists := pod.GetLabels()[podconstants.GroupNameLabel]; exists {
-		return []string{labelValue}
+	if groupName := GetPodGroupName(pod); groupName != "" {
+		return []string{groupName}
 	}
 	return nil
 }

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -563,7 +563,7 @@ func SetupIndexes(ctx context.Context, indexer client.FieldIndexer) error {
 }
 
 func (p *Pod) Finalize(ctx context.Context, c client.Client) error {
-	groupName := podGroupName(p.pod)
+	groupName := GetPodGroupName(&p.pod)
 
 	var podsInGroup corev1.PodList
 	if groupName == "" {
@@ -597,16 +597,42 @@ func (p *Pod) Skip(ctx context.Context) bool {
 	return false
 }
 
-// podGroupName returns a value of GroupNameLabel for the pod object.
-// Returns an empty string if there's no such label.
-func podGroupName(p corev1.Pod) string {
-	return p.GetLabels()[podconstants.GroupNameLabel]
+// GetPodGroupName returns the pod group name for the given pod. It reads the
+// GroupNameLabel, or when the WorkloadIdentifierAnnotations feature gate is
+// enabled it first reads the GroupNameAnnotation and then falls back to the label.
+func GetPodGroupName(p *corev1.Pod) string {
+	if features.Enabled(features.WorkloadIdentifierAnnotations) {
+		if name := p.Annotations[podconstants.GroupNameAnnotation]; name != "" {
+			return name
+		}
+	}
+	return p.Labels[podconstants.GroupNameLabel]
+}
+
+// SetPodGroupName stores the pod group name on the given pod.
+// When the WorkloadIdentifierAnnotations feature gate is enabled the name is
+// written to the GroupNameAnnotation. Otherwise, it is written to the GroupNameLabel.
+func SetPodGroupName(p *corev1.Pod, groupName string) {
+	if features.Enabled(features.WorkloadIdentifierAnnotations) {
+		if p.Annotations == nil {
+			p.Annotations = make(map[string]string, 1)
+		}
+		p.Annotations[podconstants.GroupNameAnnotation] = groupName
+	} else {
+		if p.Labels == nil {
+			p.Labels = make(map[string]string, 1)
+		}
+		p.Labels[podconstants.GroupNameLabel] = groupName
+	}
 }
 
 // groupTotalCount returns the value of GroupTotalCountAnnotation for the pod being reconciled at the moment.
 // It doesn't check if the whole group has the same total group count annotation value.
 func (p *Pod) groupTotalCount() (int, error) {
-	if podGroupName(p.pod) == "" {
+	if groupName := GetPodGroupName(&p.pod); groupName == "" {
+		if features.Enabled(features.WorkloadIdentifierAnnotations) {
+			return 0, fmt.Errorf("pod doesn't have a '%s' annotation/label", podconstants.GroupNameAnnotation)
+		}
 		return 0, fmt.Errorf("pod doesn't have a '%s' label", podconstants.GroupNameLabel)
 	}
 
@@ -650,7 +676,7 @@ func (p *Pod) Load(ctx context.Context, c client.Client, key *types.NamespacedNa
 
 		// If the key.Namespace doesn't contain a "group/" prefix, even though
 		// the pod has a group name, there's something wrong with the event handler.
-		if podGroupName(p.pod) != "" {
+		if groupName := GetPodGroupName(&p.pod); groupName != "" {
 			return false, errIncorrectReconcileRequest
 		}
 
@@ -801,7 +827,7 @@ func (p *Pod) validatePodGroupMetadata(r record.EventRecorder, activePods []core
 	_, useFastAdmission := p.pod.GetAnnotations()[podconstants.GroupFastAdmissionAnnotationKey]
 
 	if !useFastAdmission && len(activePods) < groupTotalCount {
-		errMsg := fmt.Sprintf("'%s' group has fewer runnable pods than expected", podGroupName(p.pod))
+		errMsg := fmt.Sprintf("'%s' group has fewer runnable pods than expected", GetPodGroupName(&p.pod))
 		r.Eventf(p.Object(), corev1.EventTypeWarning, jobframework.ReasonErrWorkloadCompose, errMsg)
 		return jobframework.UnretryableError(errMsg)
 	}
@@ -1124,7 +1150,7 @@ func (p *Pod) ConstructComposableWorkload(ctx context.Context, c client.Client, 
 }
 
 func (p *Pod) workloadName() string {
-	if prebuiltWorkloadName, usePrebuiltWorkload := jobframework.PrebuiltWorkloadFor(p); usePrebuiltWorkload {
+	if prebuiltWorkloadName := jobframework.PrebuiltWorkloadNameFor(p.Object()); prebuiltWorkloadName != "" {
 		return prebuiltWorkloadName
 	}
 
@@ -1132,7 +1158,7 @@ func (p *Pod) workloadName() string {
 		return GetWorkloadNameForPod(p.pod.GetName(), p.pod.GetUID())
 	}
 
-	return podGroupName(p.pod)
+	return GetPodGroupName(&p.pod)
 }
 
 func (p *Pod) ListChildWorkloads(ctx context.Context, c client.Client, key types.NamespacedName) (*kueue.WorkloadList, error) {
@@ -1168,7 +1194,7 @@ func (p *Pod) ListChildWorkloads(ctx context.Context, c client.Client, key types
 func (p *Pod) FindMatchingWorkloads(ctx context.Context, c client.Client, r record.EventRecorder) (*kueue.Workload, []*kueue.Workload, error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	groupName := podGroupName(p.pod)
+	groupName := GetPodGroupName(&p.pod)
 	if groupName == "" {
 		return jobframework.FindMatchingWorkloads(ctx, c, p)
 	}

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -285,8 +285,10 @@ func TestReconciler(t *testing.T) {
 
 		wantEvents        []utiltesting.EventRecord
 		reconcilerOptions []jobframework.Option
+		featureGates      map[featuregate.Feature]bool
 	}{
 		"scheduling gate is removed and node selector is added if workload is admitted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			initObjects: []client.Object{
 				utiltestingapi.MakeResourceFlavor("unit-test-flavor").NodeLabel(corev1.LabelArchStable, "arm64").Obj(),
 			},
@@ -349,6 +351,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"non-matching admitted workload is deleted and pod is finalized": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
 				ManagedByKueueLabel().
@@ -381,6 +384,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the workload is created when queue name is set": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
 				ManagedByKueueLabel().
@@ -423,6 +427,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when the queue-name changed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -478,6 +483,7 @@ func TestReconciler(t *testing.T) {
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
 		"when the queue-name changed in pod-groupr": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -559,6 +565,7 @@ func TestReconciler(t *testing.T) {
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
 		"when the queue-name changed in serving pod-groupr": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -644,6 +651,7 @@ func TestReconciler(t *testing.T) {
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
 		"the pod reconciliation is skipped when 'kueue.x-k8s.io/managed' label is not set": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
 				Obj()},
@@ -654,6 +662,7 @@ func TestReconciler(t *testing.T) {
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
 		"pod is stopped when workload is evicted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
 				ManagedByKueueLabel().
@@ -711,6 +720,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"pod is finalized when it's succeeded": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
 				ManagedByKueueLabel().
@@ -766,6 +776,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"workload status condition is added even if the pod is finalized": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
 				ManagedByKueueLabel().
@@ -811,6 +822,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"pod without scheduling gate is terminated if workload is not admitted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
 				ManagedByKueueLabel().
@@ -850,6 +862,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when a workload is created for the pod it has its ProvReq annotations copied": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -899,6 +912,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"workload is composed and created for the pod group": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -973,7 +987,76 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		},
+		"workload is composed and created for the pod group, WorkloadIdentifierAnnotations enabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			pods: []corev1.Pod{
+				*basePodWrapper.
+					Clone().
+					ManagedByKueueLabel().
+					KueueFinalizer().
+					KueueSchedulingGate().
+					GroupNameAnnotation("test-group").
+					GroupTotalCount("2").
+					Obj(),
+				*basePodWrapper.
+					Clone().
+					Name("pod2").
+					ManagedByKueueLabel().
+					KueueFinalizer().
+					KueueSchedulingGate().
+					GroupNameAnnotation("test-group").
+					GroupTotalCount("2").
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*basePodWrapper.
+					Clone().
+					ManagedByKueueLabel().
+					KueueFinalizer().
+					KueueSchedulingGate().
+					GroupNameAnnotation("test-group").
+					GroupTotalCount("2").
+					Obj(),
+				*basePodWrapper.
+					Clone().
+					Name("pod2").
+					ManagedByKueueLabel().
+					KueueFinalizer().
+					KueueSchedulingGate().
+					GroupNameAnnotation("test-group").
+					GroupTotalCount("2").
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.NewPodSetReference(podUID), 2).
+							Request(corev1.ResourceCPU, "1").
+							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
+							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							Obj(),
+					).
+					Queue(localUserQueueName).
+					Priority(0).
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
+					Annotations(map[string]string{
+						podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue,
+					}).
+					Obj(),
+			},
+			workloadCmpOpts: defaultWorkloadCmpOpts,
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "pod", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "CreatedWorkload",
+					Message:   "Created Workload: ns/test-group",
+				},
+			},
+		},
 		"workload is composed and created for the pod group with fast admission": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -1029,6 +1112,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"workload is composed and created for the pod group with max exec time": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -1101,6 +1185,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"workload is recreated when max exec time changes": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -1187,6 +1272,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"workload is found for the pod group": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -1256,6 +1342,7 @@ func TestReconciler(t *testing.T) {
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
 		"scheduling gate is removed for all pods in the group if workload is admitted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			initObjects: []client.Object{
 				utiltestingapi.MakeResourceFlavor("unit-test-flavor").NodeLabel(corev1.LabelArchStable, "arm64").Obj(),
 			},
@@ -1362,6 +1449,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"workload is not finished if the pod in the group is running": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -1431,6 +1519,7 @@ func TestReconciler(t *testing.T) {
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
 		"workload is finished if all pods in the group has finished": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -1512,6 +1601,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"workload is not deleted if the pod in group has been deleted after admission": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
 				ManagedByKueueLabel().
@@ -1567,6 +1657,7 @@ func TestReconciler(t *testing.T) {
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
 		"pod group remains stopped when workload is evicted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -1642,6 +1733,7 @@ func TestReconciler(t *testing.T) {
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
 		"Pods are finalized even if one of the pods in the finished group is absent": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -1723,6 +1815,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"workload for pod group with different queue names shouldn't be created": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -1771,6 +1864,7 @@ func TestReconciler(t *testing.T) {
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
 		"all pods in group should be removed if workload is deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -1828,6 +1922,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"replacement pod should be started for pod group of size 1": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -1920,6 +2015,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"replacement pod should be started for set of Running, Failed, Succeeded pods": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -2056,6 +2152,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"pod group of size 2 is finished when 2 pods has succeeded and 1 pod has failed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -2156,6 +2253,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"wl should not get the quota reservation cleared for a running pod group of size 1": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -2235,6 +2333,7 @@ func TestReconciler(t *testing.T) {
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
 		"wl should get the quota reservation cleared for a failed pod group of size 1": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -2335,6 +2434,7 @@ func TestReconciler(t *testing.T) {
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
 		"deleted pods in group should not be finalized if the workload doesn't match": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -2424,6 +2524,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"workload is not deleted if all of the pods in the group are deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -2505,6 +2606,7 @@ func TestReconciler(t *testing.T) {
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
 		"workload is not deleted if one pod role is absent from the cluster": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -2572,6 +2674,7 @@ func TestReconciler(t *testing.T) {
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
 		"if pod group is finished and wl is deleted, new workload shouldn't be created": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -2613,6 +2716,7 @@ func TestReconciler(t *testing.T) {
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
 		"if pod in group is scheduling gated and wl is deleted, workload should be recreated": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -2679,6 +2783,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"if there's not enough non-failed pods in the group, workload should not be created": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -2729,6 +2834,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"pod group is considered finished if there is an unretriable pod and no running pods": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -2853,6 +2959,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"reclaimable pods updated for pod group": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -2965,6 +3072,7 @@ func TestReconciler(t *testing.T) {
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
 		"reclaimablePods field is not updated for a serving pod group": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -3082,6 +3190,7 @@ func TestReconciler(t *testing.T) {
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
 		"excess pods before wl creation, youngest pods are deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -3147,6 +3256,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"excess pods before admission, youngest pods are deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -3238,6 +3348,7 @@ func TestReconciler(t *testing.T) {
 		// In this case, group-total-count is equal to the number of pods in the cluster.
 		// But one of the roles is missing, and another role has an excess pod.
 		"excess pods in pod set after admission, youngest pods are deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -3327,6 +3438,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"waiting to observe previous deletion of excess pod, no pods are deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -3420,6 +3532,7 @@ func TestReconciler(t *testing.T) {
 			}},
 		},
 		"delete excess pod that is gated": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -3513,6 +3626,7 @@ func TestReconciler(t *testing.T) {
 		// If an excess pod is already deleted and finalized, but an external finalizer blocks
 		// pod deletion, kueue should ignore such a pod, when creating a workload.
 		"deletion of excess pod is blocked by another controller": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -3585,6 +3699,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"deleted pods in incomplete group are finalized": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -3620,6 +3735,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"finalize workload for non existent pod": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileKey: &types.NamespacedName{Namespace: "ns", Name: "deleted_pod"},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("test-group", "ns").
@@ -3635,6 +3751,7 @@ func TestReconciler(t *testing.T) {
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
 		"replacement pods are owning the workload": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -3741,6 +3858,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"all pods in a group should receive the event about preemption, unless already terminating": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -3878,6 +3996,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"preemption reason should be propagated to termination target": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -3963,6 +4082,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"the failed pods are finalized in order": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -4147,6 +4267,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"no failed pods are finalized while waiting for expectations": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -4248,6 +4369,7 @@ func TestReconciler(t *testing.T) {
 			}},
 		},
 		"no unnecessary additional failed pods are finalized": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -4378,6 +4500,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"workload is created with correct labels for a single pod": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
 				ManagedByKueueLabel().
@@ -4420,6 +4543,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"workload is created with correct labels for pod group": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -4482,6 +4606,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"reconciler returns error in case pod group pod index is bigger or equal pod group total count": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
 				ManagedByKueueLabel().
@@ -4496,6 +4621,7 @@ func TestReconciler(t *testing.T) {
 			wantErr:         utilpod.ErrValidation,
 		},
 		"reconciler returns error in case pod group pod index is less than 0": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
 				ManagedByKueueLabel().
@@ -4510,6 +4636,7 @@ func TestReconciler(t *testing.T) {
 			wantErr:         utilpod.ErrInvalidUInt,
 		},
 		"reconciler returns error in case of label mismatch in pod group": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -4543,6 +4670,7 @@ func TestReconciler(t *testing.T) {
 			wantErr:         errPodGroupLabelsMismatch,
 		},
 		"admission check message is recorded as event for a single pod": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
 				ManagedByKueueLabel().
@@ -4621,6 +4749,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"admission check message is recorded as event for each pod in the group": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -4711,6 +4840,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"deleted unschedulable pods are finalized": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -4825,6 +4955,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"shouldn't set waiting for pods ready condition to true when all pods pending": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -4900,6 +5031,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should set waiting for pods ready condition to true when at least one pod failed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -4981,6 +5113,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should set waiting for pods ready condition to true when at least one pod deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -5064,6 +5197,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should set waiting for pods ready condition to true when workload was evicted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -5161,6 +5295,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should update reason and message on waiting for pods ready condition when workload was evicted again": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -5261,6 +5396,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"shouldn't change waiting for pods ready condition when it's true and workload was readmitted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -5364,6 +5500,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"should set waiting for pods ready condition to false when pods was replaced": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -5451,12 +5588,13 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when the prebuilt workload exists its owner info is updated": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
 					ManagedByKueueLabel().
-					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
+					PrebuiltWorkloadLabel("prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					GroupNameLabel("test-group").
@@ -5466,7 +5604,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod2").
 					ManagedByKueueLabel().
-					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
+					PrebuiltWorkloadLabel("prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					GroupNameLabel("test-group").
@@ -5485,7 +5623,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod1").
 					ManagedByKueueLabel().
-					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
+					PrebuiltWorkloadLabel("prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					GroupNameLabel("test-group").
@@ -5501,7 +5639,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod2").
 					ManagedByKueueLabel().
-					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
+					PrebuiltWorkloadLabel("prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					GroupNameLabel("test-group").
@@ -5546,12 +5684,13 @@ func TestReconciler(t *testing.T) {
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
 		"when the prebuilt workload is partially owned": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
 					ManagedByKueueLabel().
-					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
+					PrebuiltWorkloadLabel("prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					GroupNameLabel("test-group").
@@ -5561,7 +5700,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod2").
 					ManagedByKueueLabel().
-					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
+					PrebuiltWorkloadLabel("prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					GroupNameLabel("test-group").
@@ -5581,7 +5720,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod1").
 					ManagedByKueueLabel().
-					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
+					PrebuiltWorkloadLabel("prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					GroupNameLabel("test-group").
@@ -5597,7 +5736,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod2").
 					ManagedByKueueLabel().
-					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
+					PrebuiltWorkloadLabel("prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					GroupNameLabel("test-group").
@@ -5642,12 +5781,13 @@ func TestReconciler(t *testing.T) {
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
 		"when the prebuilt workload is not equivalent to the job": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
 					ManagedByKueueLabel().
-					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
+					PrebuiltWorkloadLabel("prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					GroupNameLabel("test-group").
@@ -5657,7 +5797,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod2").
 					ManagedByKueueLabel().
-					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
+					PrebuiltWorkloadLabel("prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					GroupNameLabel("test-group").
@@ -5678,7 +5818,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod1").
 					ManagedByKueueLabel().
-					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
+					PrebuiltWorkloadLabel("prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					GroupNameLabel("test-group").
@@ -5694,7 +5834,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod2").
 					ManagedByKueueLabel().
-					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
+					PrebuiltWorkloadLabel("prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					GroupNameLabel("test-group").
@@ -5740,6 +5880,7 @@ func TestReconciler(t *testing.T) {
 			wantErr:         jobframework.ErrPrebuiltWorkloadNotFound,
 		},
 		"when workload is deactivated by kueue; objectRetentionPolicies.workloads.afterDeactivatedByKueue=0; should delete the job": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithObjectRetentionPolicies(&configapi.ObjectRetentionPolicies{
 					Workloads: &configapi.WorkloadRetentionPolicy{
@@ -5837,6 +5978,7 @@ func TestReconciler(t *testing.T) {
 		for _, enabled := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", name, enabled), func(t *testing.T) {
 				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, enabled)
+				features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 				ctx, log := utiltesting.ContextWithLog(t)
 				clientBuilder := utiltesting.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter.go
@@ -30,7 +30,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/util/api"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
@@ -49,11 +48,11 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		return err
 	}
 
-	if !isPodAPartOfGroup(localPod) {
+	groupName := GetPodGroupName(&localPod)
+	if groupName == "" {
 		return syncLocalPodWithRemote(ctx, localClient, remoteClient, &localPod, workloadName, origin, &log)
 	}
 
-	groupName := podGroupName(localPod)
 	return syncPodGroup(ctx, localClient, remoteClient, key, workloadName, origin, groupName)
 }
 
@@ -64,11 +63,11 @@ func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, localClient 
 		return client.IgnoreNotFound(err)
 	}
 
-	if !isPodAPartOfGroup(pod) {
+	groupName := GetPodGroupName(&pod)
+	if groupName == "" {
 		return client.IgnoreNotFound(remoteClient.Delete(ctx, &pod))
 	}
 
-	groupName := podGroupName(pod)
 	localPodGroup, err := listLocalPods(ctx, localClient, key.Namespace, groupName)
 	if err != nil {
 		return err
@@ -103,17 +102,12 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 		return nil, errors.New("not a pod")
 	}
 
-	prebuiltWl, hasPrebuiltWorkload := pod.Labels[constants.PrebuiltWorkloadLabel]
-	if !hasPrebuiltWorkload {
+	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(pod)
+	if prebuiltWorkload == "" {
 		return nil, fmt.Errorf("no prebuilt workload found for pod: %s", klog.KObj(pod))
 	}
 
-	return []types.NamespacedName{{Name: prebuiltWl, Namespace: pod.Namespace}}, nil
-}
-
-// isPodAPartOfGroup checks if a pod belongs to a group by verifying the presence of a group name label.
-func isPodAPartOfGroup(p corev1.Pod) bool {
-	return podGroupName(p) != ""
+	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: pod.Namespace}}, nil
 }
 
 func syncPodGroup(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin, groupName string) error {

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter_test.go
@@ -26,10 +26,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
@@ -59,6 +61,16 @@ func TestMultiKueueAdapter(t *testing.T) {
 		Label(kueue.MultiKueueOriginLabel, "origin1").
 		MakePodGroupWrappers(groupSize)
 
+	podGroupWithWlAnnotations := basePodBuilder.
+		Clone().
+		MakePodGroupWrappersWithWorkloadAnnotations(groupSize)
+
+	workerPodGroupWithAnnotations := basePodBuilder.
+		Clone().
+		PrebuiltWorkloadAnnotation("wl1").
+		Label(kueue.MultiKueueOriginLabel, "origin1").
+		MakePodGroupWrappersWithWorkloadAnnotations(groupSize)
+
 	cases := map[string]struct {
 		managersPods []corev1.Pod
 		workerPods   []corev1.Pod
@@ -68,8 +80,10 @@ func TestMultiKueueAdapter(t *testing.T) {
 		wantError        error
 		wantManagersPods []corev1.Pod
 		wantWorkerPods   []corev1.Pod
+		featureGates     map[featuregate.Feature]bool
 	}{
 		"sync creates missing remote pod": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersPods: []corev1.Pod{
 				*basePodBuilder.DeepCopy(),
 			},
@@ -88,6 +102,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote pod": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersPods: []corev1.Pod{
 				*basePodBuilder.DeepCopy(),
 			},
@@ -119,6 +134,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"remote pod is deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			workerPods: []corev1.Pod{
 				*basePodBuilder.Clone().
 					PrebuiltWorkloadLabel("wl1").
@@ -130,6 +146,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"pod managedBy multikueue": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersPods: []corev1.Pod{
 				*basePodBuilder.DeepCopy(),
 			},
@@ -144,6 +161,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync creates missing remote pods of the group": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersPods: []corev1.Pod{
 				*podGroup[0].DeepCopy(),
 				*podGroup[1].DeepCopy(),
@@ -164,6 +182,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote pod group": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersPods: []corev1.Pod{
 				*podGroup[0].DeepCopy(),
 				*podGroup[1].DeepCopy(),
@@ -198,15 +217,16 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"remote pod group is deleted": {
-			workerPods: []corev1.Pod{
-				*podGroupWithWl[0].DeepCopy(),
-				*podGroupWithWl[1].DeepCopy(),
-				*podGroupWithWl[2].DeepCopy(),
-			},
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersPods: []corev1.Pod{
 				*podGroup[0].DeepCopy(),
 				*podGroup[1].DeepCopy(),
 				*podGroup[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
 				return adapter.DeleteRemoteObject(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace})
@@ -217,9 +237,49 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*podGroup[2].DeepCopy(),
 			},
 		},
+		"sync creates missing remote pod, WorkloadIdentifierAnnotations enabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			managersPods: []corev1.Pod{
+				*basePodBuilder.DeepCopy(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: basePodName, Namespace: TestNamespace}, "wl1", "origin1")
+			},
+			wantManagersPods: []corev1.Pod{
+				*basePodBuilder.DeepCopy(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*basePodBuilder.Clone().
+					PrebuiltWorkloadAnnotation("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Obj(),
+			},
+		},
+		"sync creates missing remote pods of the group, WorkloadIdentifierAnnotations enabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			managersPods: []corev1.Pod{
+				*podGroupWithWlAnnotations[0].DeepCopy(),
+				*podGroupWithWlAnnotations[1].DeepCopy(),
+				*podGroupWithWlAnnotations[2].DeepCopy(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+			},
+			wantManagersPods: []corev1.Pod{
+				*podGroupWithWlAnnotations[0].DeepCopy(),
+				*podGroupWithWlAnnotations[1].DeepCopy(),
+				*podGroupWithWlAnnotations[2].DeepCopy(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*workerPodGroupWithAnnotations[0].DeepCopy(),
+				*workerPodGroupWithAnnotations[1].DeepCopy(),
+				*workerPodGroupWithAnnotations[2].DeepCopy(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			managerBuilder := utiltesting.NewClientBuilder().
 				WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).
 				WithIndex(&corev1.Pod{}, PodGroupNameCacheKey, IndexPodGroupName)

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -47,7 +47,7 @@ var (
 	annotationsPath                = metaPath.Child("annotations")
 	managedLabelPath               = labelsPath.Key(constants.ManagedByKueueLabelKey)
 	groupNameLabelPath             = labelsPath.Key(podconstants.GroupNameLabel)
-	prebuiltWorkloadLabelPath      = labelsPath.Key(ctrlconstants.PrebuiltWorkloadLabel)
+	groupNameAnnotationPath        = annotationsPath.Key(podconstants.GroupNameAnnotation)
 	groupTotalCountAnnotationPath  = annotationsPath.Key(podconstants.GroupTotalCountAnnotation)
 	retriableInGroupAnnotationPath = annotationsPath.Key(podconstants.RetriableInGroupAnnotationKey)
 )
@@ -225,8 +225,9 @@ func (w *PodWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj *corev1.
 	allErrs = append(allErrs, validateCommon(newPod)...)
 	allErrs = append(allErrs, validateUpdateForRetriableInGroupAnnotation(oldPod, newPod)...)
 
-	if podGroupName(oldPod.pod) != "" {
-		allErrs = append(allErrs, validation.ValidateImmutableField(podGroupName(newPod.pod), podGroupName(oldPod.pod), groupNameLabelPath)...)
+	if oldGroupName := GetPodGroupName(&oldPod.pod); oldGroupName != "" {
+		newGroupName := GetPodGroupName(&newPod.pod)
+		allErrs = append(allErrs, validation.ValidateImmutableField(newGroupName, oldGroupName, getGroupNamePath(&newPod.pod))...)
 	}
 
 	if _, suspendByParent := newPod.pod.Annotations[podconstants.SuspendedByParentAnnotation]; !suspendByParent {
@@ -276,30 +277,26 @@ func validatePodGroupMetadata(p *Pod) field.ErrorList {
 
 	gtc, gtcExists := p.pod.GetAnnotations()[podconstants.GroupTotalCountAnnotation]
 
-	if podGroupName(p.pod) == "" {
+	errorDetail := fmt.Sprintf("both the '%s' annotation and the '%s' label should be set", podconstants.GroupTotalCountAnnotation, podconstants.GroupNameLabel)
+	groupNameAnnotation := p.pod.Annotations[podconstants.GroupNameAnnotation]
+	if features.Enabled(features.WorkloadIdentifierAnnotations) && groupNameAnnotation != "" {
+		errorDetail = fmt.Sprintf("both the '%s' annotation and the '%s' annotation should be set", podconstants.GroupTotalCountAnnotation, podconstants.GroupNameAnnotation)
+	}
+
+	if groupName := GetPodGroupName(&p.pod); groupName == "" {
 		if gtcExists {
-			return append(allErrs, field.Required(
-				groupNameLabelPath,
-				fmt.Sprintf("both the '%s' annotation and the '%s' label should be set", podconstants.GroupTotalCountAnnotation, podconstants.GroupNameLabel),
-			))
+			return append(allErrs, field.Required(getGroupNamePath(&p.pod), errorDetail))
 		}
 	} else {
-		allErrs = append(allErrs, jobframework.ValidateLabelAsCRDName(p.Object(), podconstants.GroupNameLabel)...)
+		allErrs = append(allErrs, validatePodGroupName(p.Object())...)
 
 		if !gtcExists {
-			return append(allErrs, field.Required(
-				groupTotalCountAnnotationPath,
-				fmt.Sprintf("both the '%s' annotation and the '%s' label should be set", podconstants.GroupTotalCountAnnotation, podconstants.GroupNameLabel),
-			))
+			return append(allErrs, field.Required(groupTotalCountAnnotationPath, errorDetail))
 		}
 	}
 
 	if _, err := p.groupTotalCount(); gtcExists && err != nil {
-		return append(allErrs, field.Invalid(
-			groupTotalCountAnnotationPath,
-			gtc,
-			err.Error(),
-		))
+		return append(allErrs, field.Invalid(groupTotalCountAnnotationPath, gtc, err.Error()))
 	}
 
 	return allErrs
@@ -310,7 +307,7 @@ func validateTopologyRequest(pod *Pod) field.ErrorList {
 }
 
 func validateUpdateForRetriableInGroupAnnotation(oldPod, newPod *Pod) field.ErrorList {
-	if podGroupName(newPod.pod) != "" && isUnretriablePod(oldPod.pod) && !isUnretriablePod(newPod.pod) {
+	if groupName := GetPodGroupName(&newPod.pod); groupName != "" && isUnretriablePod(oldPod.pod) && !isUnretriablePod(newPod.pod) {
 		return field.ErrorList{
 			field.Forbidden(retriableInGroupAnnotationPath, "unretriable pod group can't be converted to retriable"),
 		}
@@ -321,10 +318,26 @@ func validateUpdateForRetriableInGroupAnnotation(oldPod, newPod *Pod) field.Erro
 
 func validatePrebuiltWorkloadName(pod *Pod) field.ErrorList {
 	var allErrs field.ErrorList
-	prebuiltWorkloadName, hasPrebuiltWorkload := jobframework.PrebuiltWorkloadFor(pod)
-	groupName := podGroupName(pod.pod)
-	if hasPrebuiltWorkload && groupName != "" && prebuiltWorkloadName != groupName {
-		allErrs = append(allErrs, field.Invalid(prebuiltWorkloadLabelPath, prebuiltWorkloadLabelPath, "prebuilt workload and pod group should be equal"))
+
+	groupName := GetPodGroupName(&pod.pod)
+	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(&pod.pod)
+	if groupName != "" && prebuiltWorkload != "" && prebuiltWorkload != groupName {
+		allErrs = append(allErrs, field.Invalid(jobframework.GetPrebuiltWorkloadPath(&pod.pod), prebuiltWorkload, "prebuilt workload and pod group should be equal"))
 	}
 	return allErrs
+}
+func validatePodGroupName(obj client.Object) field.ErrorList {
+	groupName := obj.GetAnnotations()[podconstants.GroupNameAnnotation]
+	if features.Enabled(features.WorkloadIdentifierAnnotations) && groupName != "" {
+		return jobframework.ValidateAnnotationAsCRDName(obj, podconstants.GroupNameAnnotation)
+	}
+	return jobframework.ValidateLabelAsCRDName(obj, podconstants.GroupNameLabel)
+}
+
+func getGroupNamePath(obj client.Object) *field.Path {
+	groupNameAnnotation := obj.GetAnnotations()[podconstants.GroupNameAnnotation]
+	if features.Enabled(features.WorkloadIdentifierAnnotations) && groupNameAnnotation != "" {
+		return groupNameAnnotationPath
+	}
+	return groupNameLabelPath
 }

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -705,11 +705,13 @@ func TestGetRoleHash(t *testing.T) {
 func TestValidateCreate(t *testing.T) {
 	t.Cleanup(jobframework.EnableIntegrationsForTest(t, "batch/job"))
 	testCases := map[string]struct {
-		pod       *corev1.Pod
-		wantErr   error
-		wantWarns admission.Warnings
+		pod          *corev1.Pod
+		wantErr      error
+		wantWarns    admission.Warnings
+		featureGates map[featuregate.Feature]bool
 	}{
 		"pod owner is managed by kueue": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
 				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
@@ -719,6 +721,7 @@ func TestValidateCreate(t *testing.T) {
 			},
 		},
 		"pod with group name and no group total count": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
 				GroupNameLabel("test-group").
@@ -731,6 +734,7 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"pod with group total count and no group name": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
 				GroupTotalCount("3").
@@ -743,6 +747,7 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"pod with 0 group total count": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
 				GroupNameLabel("test-group").
@@ -756,6 +761,7 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"pod with empty group total count": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
 				GroupNameLabel("test-group").
@@ -769,6 +775,7 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"pod with incorrect group name": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
 				GroupNameLabel("notAdns1123Subdomain*").
@@ -782,12 +789,14 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"valid topology request": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
 				Annotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				Obj(),
 		},
 		"invalid topology request": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
 				Annotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
@@ -801,11 +810,13 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"prebuilt workload for pod": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pod: testingpod.MakePod("test-pod", "test-ns").
 				PrebuiltWorkloadLabel("workload-name").
 				Obj(),
 		},
 		"prebuilt workload for pod group valid": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pod: testingpod.MakePod("test-pod", "test-ns").
 				PrebuiltWorkloadLabel("group-name").
 				GroupNameLabel("group-name").
@@ -813,6 +824,7 @@ func TestValidateCreate(t *testing.T) {
 				Obj(),
 		},
 		"prebuilt workload for pod group invalid": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pod: testingpod.MakePod("test-pod", "test-ns").
 				PrebuiltWorkloadLabel("workload-name").
 				GroupNameLabel("group-name").
@@ -825,10 +837,128 @@ func TestValidateCreate(t *testing.T) {
 				},
 			}.ToAggregate(),
 		},
+		"prebuilt workload annotation for pod, WorkloadIdentifierAnnotations enabled": {
+			pod: testingpod.MakePod("test-pod", "test-ns").
+				PrebuiltWorkloadAnnotation("workload-name").
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		"prebuilt workload label fallback for pod, WorkloadIdentifierAnnotations enabled": {
+			pod: testingpod.MakePod("test-pod", "test-ns").
+				PrebuiltWorkloadLabel("workload-name").
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		"prebuilt workload different label and annotation, label ignored, WorkloadIdentifierAnnotations enabled": {
+			pod: testingpod.MakePod("test-pod", "test-ns").
+				PrebuiltWorkloadLabel("workload-a").
+				PrebuiltWorkloadAnnotation("workload-b").
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		"prebuilt workload annotation matches group name annotation, WorkloadIdentifierAnnotations enabled": {
+			pod: testingpod.MakePod("test-pod", "test-ns").
+				PrebuiltWorkloadAnnotation("group-name").
+				GroupNameAnnotation("group-name").
+				GroupTotalCount("3").
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		"prebuilt workload annotation mismatches group name annotation, WorkloadIdentifierAnnotations enabled": {
+			pod: testingpod.MakePod("test-pod", "test-ns").
+				PrebuiltWorkloadAnnotation("workload-name").
+				GroupNameAnnotation("group-name").
+				GroupTotalCount("3").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.annotations[kueue.x-k8s.io/prebuilt-workload-name]",
+				},
+			}.ToAggregate(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		"prebuilt workload label mismatches group name annotation, WorkloadIdentifierAnnotations enabled": {
+			pod: testingpod.MakePod("test-pod", "test-ns").
+				PrebuiltWorkloadLabel("workload-name").
+				GroupNameAnnotation("group-name").
+				GroupTotalCount("3").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.labels[kueue.x-k8s.io/prebuilt-workload-name]",
+				},
+			}.ToAggregate(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		"prebuilt workload annotation mismatches group name label, WorkloadIdentifierAnnotations enabled": {
+			pod: testingpod.MakePod("test-pod", "test-ns").
+				PrebuiltWorkloadAnnotation("workload-name").
+				GroupNameLabel("group-name").
+				GroupTotalCount("3").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.annotations[kueue.x-k8s.io/prebuilt-workload-name]",
+				},
+			}.ToAggregate(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		"invalid group name": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			pod: testingpod.MakePod("test-pod", "test-ns").
+				GroupNameLabel("group name").
+				GroupTotalCount("3").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.labels[kueue.x-k8s.io/pod-group-name]",
+				},
+			}.ToAggregate(),
+		},
+		"invalid group name label, WorkloadIdentifierAnnotations enabled": {
+			pod: testingpod.MakePod("test-pod", "test-ns").
+				GroupNameLabel("group name").
+				GroupTotalCount("3").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.labels[kueue.x-k8s.io/pod-group-name]",
+				},
+			}.ToAggregate(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		"invalid group name annotation, WorkloadIdentifierAnnotations enabled": {
+			pod: testingpod.MakePod("test-pod", "test-ns").
+				GroupNameAnnotation("group name").
+				GroupTotalCount("3").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.annotations[kueue.x-k8s.io/pod-group-name]",
+				},
+			}.ToAggregate(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		"different group name label and annotation, label ignored, WorkloadIdentifierAnnotations enabled": {
+			pod: testingpod.MakePod("test-pod", "test-ns").
+				GroupNameLabel("group-name-a").
+				GroupNameAnnotation("group-name-b").
+				GroupTotalCount("3").
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+
 			builder := utiltesting.NewClientBuilder()
 			cli := builder.Build()
 
@@ -852,12 +982,14 @@ func TestValidateCreate(t *testing.T) {
 func TestValidateUpdate(t *testing.T) {
 	t.Cleanup(jobframework.EnableIntegrationsForTest(t, "batch/job"))
 	testCases := map[string]struct {
-		oldPod    *corev1.Pod
-		newPod    *corev1.Pod
-		wantErr   error
-		wantWarns admission.Warnings
+		oldPod       *corev1.Pod
+		newPod       *corev1.Pod
+		wantErr      error
+		wantWarns    admission.Warnings
+		featureGates map[featuregate.Feature]bool
 	}{
 		"pods owner is managed by kueue, managed label is set for both pods": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			oldPod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
 				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
@@ -871,6 +1003,7 @@ func TestValidateUpdate(t *testing.T) {
 			},
 		},
 		"pod owner is managed by kueue, managed label is set for new pod": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			oldPod: testingpod.MakePod("test-pod", "test-ns").
 				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Obj(),
@@ -883,6 +1016,7 @@ func TestValidateUpdate(t *testing.T) {
 			},
 		},
 		"pod owner is managed by kueue, managed label is set for new pod with suspend by parent annotation": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			oldPod: testingpod.MakePod("test-pod", "test-ns").
 				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Obj(),
@@ -893,7 +1027,8 @@ func TestValidateUpdate(t *testing.T) {
 				Obj(),
 		},
 		"pod with group name and no group total count": {
-			oldPod: testingpod.MakePod("test-pod", "test-ns").GroupNameLabel("test-group").Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			oldPod:       testingpod.MakePod("test-pod", "test-ns").GroupNameLabel("test-group").Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
 				GroupNameLabel("test-group").
@@ -906,7 +1041,8 @@ func TestValidateUpdate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"pod with 0 group total count": {
-			oldPod: testingpod.MakePod("test-pod", "test-ns").GroupNameLabel("test-group").Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			oldPod:       testingpod.MakePod("test-pod", "test-ns").GroupNameLabel("test-group").Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
 				GroupNameLabel("test-group").
@@ -920,7 +1056,8 @@ func TestValidateUpdate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"pod with empty group total count": {
-			oldPod: testingpod.MakePod("test-pod", "test-ns").GroupNameLabel("test-group").Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			oldPod:       testingpod.MakePod("test-pod", "test-ns").GroupNameLabel("test-group").Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
 				ManagedByKueueLabel().
 				GroupNameLabel("test-group").
@@ -934,6 +1071,7 @@ func TestValidateUpdate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"pod group name is changed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			oldPod: testingpod.MakePod("test-pod", "test-ns").
 				GroupNameLabel("test-group").
 				GroupTotalCount("2").
@@ -949,7 +1087,87 @@ func TestValidateUpdate(t *testing.T) {
 				},
 			}.ToAggregate(),
 		},
+		"pod group name is changed, labels, WorkloadIdentifierAnnotations enabled": {
+			oldPod: testingpod.MakePod("test-pod", "test-ns").
+				GroupNameLabel("test-group").
+				GroupTotalCount("2").
+				Obj(),
+			newPod: testingpod.MakePod("test-pod", "test-ns").
+				GroupNameLabel("test-group-new").
+				GroupTotalCount("2").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.labels[kueue.x-k8s.io/pod-group-name]",
+				},
+			}.ToAggregate(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		"pod group name is changed, annotations, WorkloadIdentifierAnnotations enabled": {
+			oldPod: testingpod.MakePod("test-pod", "test-ns").
+				GroupNameAnnotation("test-group").
+				GroupTotalCount("2").
+				Obj(),
+			newPod: testingpod.MakePod("test-pod", "test-ns").
+				GroupNameAnnotation("test-group-new").
+				GroupTotalCount("2").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.annotations[kueue.x-k8s.io/pod-group-name]",
+				},
+			}.ToAggregate(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		"pod group name is changed, label to annotation, WorkloadIdentifierAnnotations enabled": {
+			oldPod: testingpod.MakePod("test-pod", "test-ns").
+				GroupNameLabel("test-group").
+				GroupTotalCount("2").
+				Obj(),
+			newPod: testingpod.MakePod("test-pod", "test-ns").
+				GroupNameAnnotation("test-group-new").
+				GroupTotalCount("2").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.annotations[kueue.x-k8s.io/pod-group-name]",
+				},
+			}.ToAggregate(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		"pod group name is changed, annotation to label, WorkloadIdentifierAnnotations enabled": {
+			oldPod: testingpod.MakePod("test-pod", "test-ns").
+				GroupNameAnnotation("test-group").
+				GroupTotalCount("2").
+				Obj(),
+			newPod: testingpod.MakePod("test-pod", "test-ns").
+				GroupNameLabel("test-group-new").
+				GroupTotalCount("2").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.labels[kueue.x-k8s.io/pod-group-name]",
+				},
+			}.ToAggregate(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		"pod group name label replaced with annotation, WorkloadIdentifierAnnotations enabled": {
+			oldPod: testingpod.MakePod("test-pod", "test-ns").
+				GroupNameLabel("test-group").
+				GroupTotalCount("2").
+				Obj(),
+			newPod: testingpod.MakePod("test-pod", "test-ns").
+				GroupNameAnnotation("test-group").
+				GroupTotalCount("2").
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
 		"assign pod group name": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			oldPod: testingpod.MakePod("test-pod", "test-ns").
 				Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
@@ -958,6 +1176,7 @@ func TestValidateUpdate(t *testing.T) {
 				Obj(),
 		},
 		"retriable in group annotation is removed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			oldPod: testingpod.MakePod("test-pod", "test-ns").
 				GroupNameLabel("test-group").
 				GroupTotalCount("2").
@@ -975,6 +1194,7 @@ func TestValidateUpdate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"retriable in group annotation is changed from false to true": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			oldPod: testingpod.MakePod("test-pod", "test-ns").
 				GroupNameLabel("test-group").
 				GroupTotalCount("2").
@@ -993,6 +1213,7 @@ func TestValidateUpdate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"prebuilt workload for pod group invalid": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			oldPod: testingpod.MakePod("test-pod", "test-ns").
 				PrebuiltWorkloadLabel("group-name").
 				GroupNameLabel("group-name").
@@ -1012,10 +1233,48 @@ func TestValidateUpdate(t *testing.T) {
 				},
 			}.ToAggregate(),
 		},
+		"prebuilt workload annotation unchanged on update, WorkloadIdentifierAnnotations enabled": {
+			oldPod: testingpod.MakePod("test-pod", "test-ns").
+				PrebuiltWorkloadAnnotation("group-name").
+				GroupNameAnnotation("group-name").
+				GroupTotalCount("3").
+				KueueSchedulingGate().
+				Obj(),
+			newPod: testingpod.MakePod("test-pod", "test-ns").
+				PrebuiltWorkloadAnnotation("group-name").
+				GroupNameAnnotation("group-name").
+				GroupTotalCount("3").
+				KueueSchedulingGate().
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		"prebuilt workload annotation mismatches group name on update, WorkloadIdentifierAnnotations enabled": {
+			oldPod: testingpod.MakePod("test-pod", "test-ns").
+				PrebuiltWorkloadAnnotation("group-name").
+				GroupNameAnnotation("group-name").
+				GroupTotalCount("3").
+				KueueSchedulingGate().
+				Obj(),
+			newPod: testingpod.MakePod("test-pod", "test-ns").
+				PrebuiltWorkloadAnnotation("workload-name").
+				GroupNameAnnotation("group-name").
+				GroupTotalCount("3").
+				KueueSchedulingGate().
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.annotations[kueue.x-k8s.io/prebuilt-workload-name]",
+				},
+			}.ToAggregate(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+
 			builder := utiltesting.NewClientBuilder()
 			cli := builder.Build()
 

--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
 )
@@ -150,10 +149,10 @@ func (a *adapter[PtrT, T]) WorkloadKeysFor(o runtime.Object) ([]types.Namespaced
 		return nil, fmt.Errorf("not a %s", a.gvk.Kind)
 	}
 
-	prebuiltWl, hasPrebuiltWorkload := job.GetLabels()[constants.PrebuiltWorkloadLabel]
-	if !hasPrebuiltWorkload {
+	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(job)
+	if prebuiltWorkload == "" {
 		return nil, fmt.Errorf("no prebuilt workload found for %s: %s", a.gvk.Kind, klog.KObj(job))
 	}
 
-	return []types.NamespacedName{{Name: prebuiltWl, Namespace: job.GetNamespace()}}, nil
+	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: job.GetNamespace()}}, nil
 }

--- a/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
@@ -27,12 +27,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/ray"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
@@ -59,8 +61,10 @@ func TestMultiKueueAdapter(t *testing.T) {
 		wantError               error
 		wantManagersRayClusters []rayv1.RayCluster
 		wantWorkerRayClusters   []rayv1.RayCluster
+		featureGates            map[featuregate.Feature]bool
 	}{
 		"sync creates missing remote raycluster": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersRayClusters: []rayv1.RayCluster{
 				*rayClusterBuilder.DeepCopy(),
 			},
@@ -79,6 +83,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote raycluster": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersRayClusters: []rayv1.RayCluster{
 				*rayClusterBuilder.DeepCopy(),
 			},
@@ -107,6 +112,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote while local raycluster is suspended": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersRayClusters: []rayv1.RayCluster{
 				*rayClusterBuilder.Clone().
 					Suspend(true).
@@ -139,6 +145,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"remote raycluster is deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			workerRayClusters: []rayv1.RayCluster{
 				*rayClusterBuilder.Clone().
 					PrebuiltWorkloadLabel("wl1").
@@ -150,6 +157,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"raycluster with wrong managedBy is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersRayClusters: []rayv1.RayCluster{
 				*rayClusterBuilder.Clone().
 					ManagedBy("some-other-controller").
@@ -169,6 +177,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		},
 
 		"raycluster managedBy multikueue": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersRayClusters: []rayv1.RayCluster{
 				*rayClusterBuilder.Clone().
 					ManagedBy(kueue.MultiKueueControllerName).
@@ -187,6 +196,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"missing raycluster is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}); isManged {
 					return errors.New("expecting false")
@@ -194,9 +204,28 @@ func TestMultiKueueAdapter(t *testing.T) {
 				return nil
 			},
 		},
+		"sync creates missing remote raycluster, WorkloadIdentifierAnnotations enabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			managersRayClusters: []rayv1.RayCluster{
+				*rayClusterBuilder.DeepCopy(),
+			},
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
+				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}, "wl1", "origin1")
+			},
+			wantManagersRayClusters: []rayv1.RayCluster{
+				*rayClusterBuilder.DeepCopy(),
+			},
+			wantWorkerRayClusters: []rayv1.RayCluster{
+				*rayClusterBuilder.Clone().
+					PrebuiltWorkloadAnnotation("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			managerBuilder := utiltesting.NewClientBuilder(rayv1.AddToScheme).WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 			managerBuilder = managerBuilder.WithLists(&rayv1.RayClusterList{Items: tc.managersRayClusters})
 			managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersRayClusters, func(w *rayv1.RayCluster) client.Object { return w })...)

--- a/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
@@ -136,11 +136,13 @@ func TestValidateCreate(t *testing.T) {
 		featureGates map[featuregate.Feature]bool
 	}{
 		"invalid unmanaged": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			job: testingrayutil.MakeCluster("job", "ns").
 				Obj(),
 			wantErr: nil,
 		},
 		"invalid managed - has auto scaler": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			job: testingrayutil.MakeCluster("job", "ns").Queue("queue").
 				WithEnableAutoscaling(ptr.To(true)).
 				Obj(),
@@ -153,6 +155,7 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"invalid managed - too many worker groups": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			job: testingrayutil.MakeCluster("job", "ns").Queue("queue").
 				WithWorkerGroups(bigWorkerGroup...).
 				Obj(),
@@ -161,6 +164,7 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"worker group uses head name": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			job: testingrayutil.MakeCluster("job", "ns").Queue("queue").
 				WithWorkerGroups(rayv1.WorkerGroupSpec{
 					GroupName: headGroupPodSetName,
@@ -549,6 +553,13 @@ func TestValidateCreate(t *testing.T) {
 				),
 			}.ToAggregate(),
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+		},
+		"valid with prebuilt workload annotation, WorkloadIdentifierAnnotations enabled": {
+			job: testingrayutil.MakeCluster("raycluster", "ns").
+				Queue("queue").
+				PrebuiltWorkloadAnnotation("wl1").
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
 		},
 	}
 

--- a/pkg/controller/jobs/rayjob/rayjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_multikueue_adapter_test.go
@@ -26,12 +26,14 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/ray"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingrayjob "sigs.k8s.io/kueue/pkg/util/testingjobs/rayjob"
@@ -58,8 +60,10 @@ func TestMultiKueueAdapter(t *testing.T) {
 		wantError           error
 		wantManagersRayJobs []rayv1.RayJob
 		wantWorkerRayJobs   []rayv1.RayJob
+		featureGates        map[featuregate.Feature]bool
 	}{
 		"sync creates missing remote rayjob": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersRayJobs: []rayv1.RayJob{
 				*rayJobBuilder.DeepCopy(),
 			},
@@ -78,6 +82,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote rayjob": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersRayJobs: []rayv1.RayJob{
 				*rayJobBuilder.DeepCopy(),
 			},
@@ -106,6 +111,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote while local rayjob is suspended": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersRayJobs: []rayv1.RayJob{
 				*rayJobBuilder.Clone().
 					Suspend(true).
@@ -138,6 +144,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"remote rayjob is deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			workerRayJobs: []rayv1.RayJob{
 				*rayJobBuilder.Clone().
 					PrebuiltWorkloadLabel("wl1").
@@ -149,6 +156,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"job with wrong managedBy is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersRayJobs: []rayv1.RayJob{
 				*rayJobBuilder.Clone().
 					ManagedBy("some-other-controller").
@@ -168,6 +176,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		},
 
 		"job managedBy multikueue": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersRayJobs: []rayv1.RayJob{
 				*rayJobBuilder.Clone().
 					ManagedBy(kueue.MultiKueueControllerName).
@@ -186,6 +195,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"missing job is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "rayjob1", Namespace: TestNamespace}); isManged {
 					return errors.New("expecting false")
@@ -193,9 +203,28 @@ func TestMultiKueueAdapter(t *testing.T) {
 				return nil
 			},
 		},
+		"sync creates missing remote rayjob, WorkloadIdentifierAnnotations enabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			managersRayJobs: []rayv1.RayJob{
+				*rayJobBuilder.DeepCopy(),
+			},
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
+				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayjob1", Namespace: TestNamespace}, "wl1", "origin1")
+			},
+			wantManagersRayJobs: []rayv1.RayJob{
+				*rayJobBuilder.DeepCopy(),
+			},
+			wantWorkerRayJobs: []rayv1.RayJob{
+				*rayJobBuilder.Clone().
+					PrebuiltWorkloadAnnotation("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			managerBuilder := utiltesting.NewClientBuilder(rayv1.AddToScheme).WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 			managerBuilder = managerBuilder.WithLists(&rayv1.RayJobList{Items: tc.managersRayJobs})
 			managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersRayJobs, func(w *rayv1.RayJob) client.Object { return w })...)

--- a/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
@@ -136,6 +136,7 @@ func TestValidateCreate(t *testing.T) {
 		featureGates map[featuregate.Feature]bool
 	}{
 		"invalid unmanaged": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			job: testingrayutil.MakeJob("job", "ns").
 				ShutdownAfterJobFinishes(false).
 				Obj(),
@@ -143,6 +144,7 @@ func TestValidateCreate(t *testing.T) {
 		},
 
 		"invalid managed - no cluster selector and no RayClusterSpec": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			job: testingrayutil.MakeJob("job", "ns").Queue("queue").
 				RayClusterSpec(nil).
 				Obj(),
@@ -151,12 +153,14 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"invalid unmanaged - local queue default": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			job: testingrayutil.MakeJob("job", "ns").
 				ShutdownAfterJobFinishes(false).
 				Obj(),
 			wantErr: nil,
 		},
 		"invalid managed - by config": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			job: testingrayutil.MakeJob("job", "ns").
 				ShutdownAfterJobFinishes(false).
 				Obj(),
@@ -166,6 +170,7 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"invalid managed - by queue": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			job: testingrayutil.MakeJob("job", "ns").Queue("queue").
 				ShutdownAfterJobFinishes(false).
 				Obj(),
@@ -174,6 +179,7 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"invalid managed - has cluster selector and RayClusterSpec": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			job: testingrayutil.MakeJob("job", "ns").Queue("queue").
 				ClusterSelector(map[string]string{
 					"k1": "v1",
@@ -192,6 +198,7 @@ func TestValidateCreate(t *testing.T) {
 			wantErr:      nil,
 		},
 		"invalid managed - too many worker groups": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			job: testingrayutil.MakeJob("job", "ns").Queue("queue").
 				WithWorkerGroups(bigWorkerGroup...).
 				Obj(),
@@ -200,6 +207,7 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"worker group uses head name": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			job: testingrayutil.MakeJob("job", "ns").Queue("queue").
 				WithWorkerGroups(rayv1.WorkerGroupSpec{
 					GroupName: headGroupPodSetName,
@@ -587,6 +595,13 @@ func TestValidateCreate(t *testing.T) {
 				),
 			}.ToAggregate(),
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+		},
+		"valid with prebuilt workload annotation, WorkloadIdentifierAnnotations enabled": {
+			job: testingrayutil.MakeJob("rayjob", "ns").
+				Queue("queue").
+				PrebuiltWorkloadAnnotation("wl1").
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
 		},
 	}
 

--- a/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter_test.go
@@ -26,12 +26,14 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/ray"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingrayservice "sigs.k8s.io/kueue/pkg/util/testingjobs/rayservice"
@@ -58,8 +60,10 @@ func TestMultiKueueAdapter(t *testing.T) {
 		wantError               error
 		wantManagersRayServices []rayv1.RayService
 		wantWorkerRayServices   []rayv1.RayService
+		featureGates            map[featuregate.Feature]bool
 	}{
 		"sync creates missing remote rayservice": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersRayServices: []rayv1.RayService{
 				*rayServiceBuilder.DeepCopy(),
 			},
@@ -78,6 +82,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote rayservice": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersRayServices: []rayv1.RayService{
 				*rayServiceBuilder.DeepCopy(),
 			},
@@ -118,6 +123,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote while local rayservice is suspended": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersRayServices: []rayv1.RayService{
 				*rayServiceBuilder.Clone().
 					Suspend(true).
@@ -162,6 +168,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"remote rayservice is deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			workerRayServices: []rayv1.RayService{
 				*rayServiceBuilder.Clone().
 					PrebuiltWorkloadLabel("wl1").
@@ -173,6 +180,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"job with wrong managedBy is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersRayServices: []rayv1.RayService{
 				*rayServiceBuilder.Clone().
 					ManagedBy("some-other-controller").
@@ -192,6 +200,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		},
 
 		"job managedBy multikueue": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersRayServices: []rayv1.RayService{
 				*rayServiceBuilder.Clone().
 					ManagedBy(kueue.MultiKueueControllerName).
@@ -210,6 +219,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"missing job is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
 				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "rayservice1", Namespace: TestNamespace}); isManged {
 					return errors.New("expecting false")
@@ -217,9 +227,28 @@ func TestMultiKueueAdapter(t *testing.T) {
 				return nil
 			},
 		},
+		"sync creates missing remote rayservice, WorkloadIdentifierAnnotations enabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			managersRayServices: []rayv1.RayService{
+				*rayServiceBuilder.DeepCopy(),
+			},
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
+				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayservice1", Namespace: TestNamespace}, "wl1", "origin1")
+			},
+			wantManagersRayServices: []rayv1.RayService{
+				*rayServiceBuilder.DeepCopy(),
+			},
+			wantWorkerRayServices: []rayv1.RayService{
+				*rayServiceBuilder.Clone().
+					PrebuiltWorkloadAnnotation("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			managerBuilder := utiltesting.NewClientBuilder(rayv1.AddToScheme).WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 			managerBuilder = managerBuilder.WithLists(&rayv1.RayServiceList{Items: tc.managersRayServices})
 			managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersRayServices, func(w *rayv1.RayService) client.Object { return w })...)

--- a/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter.go
+++ b/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/util/api"
 )
@@ -101,10 +100,10 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 		return nil, errors.New("not a statefulset")
 	}
 
-	prebuiltWl, hasPrebuiltWorkload := statefulSet.Labels[constants.PrebuiltWorkloadLabel]
-	if !hasPrebuiltWorkload {
+	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(statefulSet)
+	if prebuiltWorkload == "" {
 		return nil, fmt.Errorf("no prebuilt workload found for statefulset: %s", klog.KObj(statefulSet))
 	}
 
-	return []types.NamespacedName{{Name: prebuiltWl, Namespace: statefulSet.Namespace}}, nil
+	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: statefulSet.Namespace}}, nil
 }

--- a/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter_test.go
@@ -25,10 +25,12 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingstatefulset "sigs.k8s.io/kueue/pkg/util/testingjobs/statefulset"
@@ -51,8 +53,10 @@ func TestMultiKueueAdapter(t *testing.T) {
 		wantError                error
 		wantManagersStatefulSets []appsv1.StatefulSet
 		wantWorkerStatefulSets   []appsv1.StatefulSet
+		featureGates             map[featuregate.Feature]bool
 	}{
 		"sync creates missing remote statefulset": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersStatefulSets: []appsv1.StatefulSet{
 				*utiltestingstatefulset.MakeStatefulSet("statefulset1", TestNamespace).
 					UID("manager-uid").
@@ -75,6 +79,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote statefulset": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersStatefulSets: []appsv1.StatefulSet{
 				*utiltestingstatefulset.MakeStatefulSet("statefulset1", TestNamespace).Obj(),
 			},
@@ -103,6 +108,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"remote statefulset is deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			workerStatefulSets: []appsv1.StatefulSet{
 				*utiltestingstatefulset.MakeStatefulSet("statefulset1", TestNamespace).
 					PrebuiltWorkloadLabel("wl1").
@@ -116,6 +122,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"IsJobManagedByKueue returns true": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersStatefulSets: []appsv1.StatefulSet{
 				*utiltestingstatefulset.MakeStatefulSet("statefulset1", TestNamespace).Obj(),
 			},
@@ -133,9 +140,33 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*utiltestingstatefulset.MakeStatefulSet("statefulset1", TestNamespace).Obj(),
 			},
 		},
+		"sync creates missing remote statefulset, WorkloadIdentifierAnnotations enabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			managersStatefulSets: []appsv1.StatefulSet{
+				*utiltestingstatefulset.MakeStatefulSet("statefulset1", TestNamespace).
+					UID("manager-uid").
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "statefulset1", Namespace: TestNamespace}, "wl1", "origin1")
+			},
+			wantManagersStatefulSets: []appsv1.StatefulSet{
+				*utiltestingstatefulset.MakeStatefulSet("statefulset1", TestNamespace).
+					UID("manager-uid").
+					Obj(),
+			},
+			wantWorkerStatefulSets: []appsv1.StatefulSet{
+				*utiltestingstatefulset.MakeStatefulSet("statefulset1", TestNamespace).
+					PrebuiltWorkloadAnnotation("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-uid").
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			managerBuilder := utiltesting.NewClientBuilder(appsv1.AddToScheme).WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 			managerBuilder = managerBuilder.WithLists(&appsv1.StatefulSetList{Items: tc.managersStatefulSets})
 			managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersStatefulSets, func(w *appsv1.StatefulSet) client.Object { return w })...)

--- a/pkg/controller/jobs/statefulset/statefulset_pod_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_pod_reconciler.go
@@ -36,8 +36,9 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/constants"
-	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
+	ctrlconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	podcontroller "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
@@ -89,11 +90,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		err = client.IgnoreNotFound(clientutil.Patch(ctx, r.client, pod, func() (bool, error) {
 			removed := controllerutil.RemoveFinalizer(pod, podconstants.PodFinalizer)
 			if removed {
-				log.V(3).Info(
-					"Finalizing statefulset pod in group",
-					"pod", klog.KObj(pod),
-					"group", pod.Labels[podconstants.GroupNameLabel],
-				)
+				log.V(3).Info("Finalizing statefulset pod in group", "pod", klog.KObj(pod), "group", podcontroller.GetPodGroupName(pod))
 			}
 			return removed, nil
 		}))
@@ -104,7 +101,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 				return false, err
 			}
 			if updated {
-				log.V(3).Info("Updating pod in group", "pod", klog.KObj(pod), "group", pod.Labels[podconstants.GroupNameLabel])
+				log.V(3).Info("Updating pod in group", "pod", klog.KObj(pod), "group", podcontroller.GetPodGroupName(pod))
 			}
 			return updated, nil
 		}))
@@ -134,9 +131,16 @@ func (r *PodReconciler) setDefault(ctx context.Context, pod *corev1.Pod) (bool, 
 		return false, err
 	}
 
-	if pod.Labels[podconstants.GroupNameLabel] == wlName {
-		if queueName != "" && pod.Labels[controllerconstants.QueueLabel] != string(queueName) {
-			pod.Labels[controllerconstants.QueueLabel] = string(queueName)
+	if pod.Labels == nil {
+		pod.Labels = make(map[string]string)
+	}
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+
+	if groupName := podcontroller.GetPodGroupName(pod); groupName == wlName {
+		if queueName != "" && pod.Labels[ctrlconstants.QueueLabel] != string(queueName) {
+			pod.Labels[ctrlconstants.QueueLabel] = string(queueName)
 			return true, nil
 		}
 		return false, nil
@@ -146,20 +150,17 @@ func (r *PodReconciler) setDefault(ctx context.Context, pod *corev1.Pod) (bool, 
 		return false, nil
 	}
 
-	if pod.Labels == nil {
-		pod.Labels = make(map[string]string)
-	}
 	pod.Labels[constants.ManagedByKueueLabelKey] = constants.ManagedByKueueLabelValue
-	pod.Labels[podconstants.GroupNameLabel] = wlName
-	pod.Labels[controllerconstants.PrebuiltWorkloadLabel] = wlName
 	if queueName != "" {
-		pod.Labels[controllerconstants.QueueLabel] = string(queueName)
+		pod.Labels[ctrlconstants.QueueLabel] = string(queueName)
 	}
 
 	if priorityClass := jobframework.WorkloadPriorityClassName(sts); priorityClass != "" {
-		pod.Labels[controllerconstants.WorkloadPriorityClassLabel] = priorityClass
+		pod.Labels[ctrlconstants.WorkloadPriorityClassLabel] = priorityClass
 	}
 
+	jobframework.SetPrebuiltWorkloadName(pod, wlName)
+	podcontroller.SetPodGroupName(pod, wlName)
 	pod.Annotations[podconstants.GroupTotalCountAnnotation] = fmt.Sprint(ptr.Deref(sts.Spec.Replicas, 1))
 	pod.Annotations[podconstants.GroupFastAdmissionAnnotationKey] = podconstants.GroupFastAdmissionAnnotationValue
 	pod.Annotations[podconstants.GroupServingAnnotationKey] = podconstants.GroupServingAnnotationValue

--- a/pkg/controller/jobs/statefulset/statefulset_pod_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_pod_reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -31,6 +32,7 @@ import (
 	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
+	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingjobspod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
@@ -46,9 +48,11 @@ func TestPodReconciler(t *testing.T) {
 		workloads                  []kueue.Workload
 		wantPods                   []corev1.Pod
 		wantErr                    error
+		featureGates               map[featuregate.Feature]bool
 	}{
 		"should finalize succeeded pod": {
-			sts: statefulsettesting.MakeStatefulSet("sts", "ns").Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			sts:          statefulsettesting.MakeStatefulSet("sts", "ns").Obj(),
 			pod: testingjobspod.MakePod("pod", "ns").
 				OwnerReference("sts", gvk).
 				StatusPhase(corev1.PodSucceeded).
@@ -62,7 +66,8 @@ func TestPodReconciler(t *testing.T) {
 			},
 		},
 		"should finalize failed pod": {
-			sts: statefulsettesting.MakeStatefulSet("sts", "ns").Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			sts:          statefulsettesting.MakeStatefulSet("sts", "ns").Obj(),
 			pod: testingjobspod.MakePod("pod", "ns").
 				OwnerReference("sts", gvk).
 				StatusPhase(corev1.PodFailed).
@@ -76,7 +81,8 @@ func TestPodReconciler(t *testing.T) {
 			},
 		},
 		"should finalize deleted pod": {
-			sts: statefulsettesting.MakeStatefulSet("sts", "ns").Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			sts:          statefulsettesting.MakeStatefulSet("sts", "ns").Obj(),
 			pod: testingjobspod.MakePod("pod", "ns").
 				OwnerReference("sts", gvk).
 				DeletionTimestamp(now).
@@ -84,7 +90,8 @@ func TestPodReconciler(t *testing.T) {
 				Obj(),
 		},
 		"shouldn't set default values without controller reference": {
-			sts: statefulsettesting.MakeStatefulSet("sts", "ns").Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			sts:          statefulsettesting.MakeStatefulSet("sts", "ns").Obj(),
 			pod: testingjobspod.MakePod("pod", "ns").
 				Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 				Obj(),
@@ -95,7 +102,8 @@ func TestPodReconciler(t *testing.T) {
 			},
 		},
 		"shouldn't set default values without queue name": {
-			sts: statefulsettesting.MakeStatefulSet("sts", "ns").UID("sts-uid").Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			sts:          statefulsettesting.MakeStatefulSet("sts", "ns").UID("sts-uid").Obj(),
 			pod: testingjobspod.MakePod("pod", "ns").
 				OwnerReference("sts", gvk).
 				Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
@@ -108,6 +116,7 @@ func TestPodReconciler(t *testing.T) {
 			},
 		},
 		"should set default values": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			sts: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("queue").
@@ -134,6 +143,7 @@ func TestPodReconciler(t *testing.T) {
 			},
 		},
 		"should set default values with priority class": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			sts: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("queue").
@@ -162,6 +172,7 @@ func TestPodReconciler(t *testing.T) {
 			},
 		},
 		"shouldn't update pod if already labeled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			sts: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("queue").
@@ -187,6 +198,7 @@ func TestPodReconciler(t *testing.T) {
 			},
 		},
 		"should sync queue label on already labeled pod": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			sts: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("new-queue").
@@ -212,6 +224,7 @@ func TestPodReconciler(t *testing.T) {
 			},
 		},
 		"shouldn't relabel pod with legacy workload name when legacy workload exists": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			sts: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("queue").
@@ -240,6 +253,7 @@ func TestPodReconciler(t *testing.T) {
 			},
 		},
 		"should label new pod with legacy name when legacy workload exists": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			sts: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
 				Queue("queue").
@@ -269,6 +283,7 @@ func TestPodReconciler(t *testing.T) {
 			},
 		},
 		"should set default values without queue name when manageJobsWithoutQueueName": {
+			featureGates:               map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			manageJobsWithoutQueueName: true,
 			sts: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").
@@ -296,6 +311,7 @@ func TestPodReconciler(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			clientBuilder := utiltesting.NewClientBuilder()
 

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -90,8 +90,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	podList := &corev1.PodList{}
-	if err := r.client.List(ctx, podList, client.InNamespace(req.Namespace), client.MatchingLabels{
-		podconstants.GroupNameLabel: wlName,
+	if err := r.client.List(ctx, podList, client.InNamespace(req.Namespace), client.MatchingFields{
+		podcontroller.PodGroupNameCacheKey: wlName,
 	}); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -126,7 +126,7 @@ func (r *Reconciler) finalizePod(ctx context.Context, sts *appsv1.StatefulSet, p
 			log.V(3).Info(
 				"Finalizing pod in group",
 				"pod", klog.KObj(pod),
-				"group", pod.Labels[podconstants.GroupNameLabel],
+				"group", podcontroller.GetPodGroupName(pod),
 			)
 			return true, nil
 		}
@@ -149,6 +149,9 @@ func (r *Reconciler) syncQueueLabel(ctx context.Context, sts *appsv1.StatefulSet
 			return nil
 		}
 		return client.IgnoreNotFound(clientutil.Patch(ctx, r.client, pod, func() (bool, error) {
+			if pod.Labels == nil {
+				pod.Labels = make(map[string]string, 1)
+			}
 			pod.Labels[controllerconstants.QueueLabel] = queueName
 			return true, nil
 		}))

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -35,6 +35,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	kueueconstants "sigs.k8s.io/kueue/pkg/constants"
 	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
+	podcontroller "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -527,6 +528,10 @@ func TestReconciler(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
 			clientBuilder := utiltesting.NewClientBuilder()
 			indexer := utiltesting.AsIndexer(clientBuilder)
+			err := indexer.IndexField(ctx, &corev1.Pod{}, podcontroller.PodGroupNameCacheKey, podcontroller.IndexPodGroupName)
+			if err != nil {
+				t.Fatalf("Could not add index for %s field name", podcontroller.PodGroupNameCacheKey)
+			}
 
 			objs := make([]client.Object, 0, len(tc.pods)+len(tc.workloads)+1)
 			if tc.statefulSet != nil {

--- a/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter.go
+++ b/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/util/api"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
@@ -117,10 +116,10 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 		return nil, errors.New("not a trainjob")
 	}
 
-	prebuiltWl, hasPrebuiltWorkload := trainJob.Labels[constants.PrebuiltWorkloadLabel]
-	if !hasPrebuiltWorkload {
+	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(trainJob)
+	if prebuiltWorkload == "" {
 		return nil, fmt.Errorf("no prebuilt workload found for trainjob: %s", klog.KObj(trainJob))
 	}
 
-	return []types.NamespacedName{{Name: prebuiltWl, Namespace: trainJob.Namespace}}, nil
+	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: trainJob.Namespace}}, nil
 }

--- a/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter_test.go
@@ -26,10 +26,12 @@ import (
 	kftrainerapi "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingtrainjob "sigs.k8s.io/kueue/pkg/util/testingjobs/trainjob"
@@ -57,9 +59,11 @@ func TestMultiKueueAdapter(t *testing.T) {
 		wantError             error
 		wantManagersTrainJobs []kftrainerapi.TrainJob
 		wantWorkerTrainJobs   []kftrainerapi.TrainJob
+		featureGates          map[featuregate.Feature]bool
 	}{
 
 		"sync creates missing remote TrainJob": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersTrainJobs: []kftrainerapi.TrainJob{
 				*baseTrainJobManagedByKueueBuilder.DeepCopy(),
 			},
@@ -78,6 +82,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync creates remote TrainJob stripping kueue runtime patch": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersTrainJobs: []kftrainerapi.TrainJob{
 				*baseTrainJobManagedByKueueBuilder.Clone().
 					RuntimePatches([]kftrainerapi.RuntimePatch{
@@ -104,6 +109,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote trainjob": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersTrainJobs: []kftrainerapi.TrainJob{
 				*baseTrainJobManagedByKueueBuilder.DeepCopy(),
 			},
@@ -159,6 +165,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote while local trainjob is suspended": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersTrainJobs: []kftrainerapi.TrainJob{
 				*baseTrainJobManagedByKueueBuilder.Clone().
 					Suspend(true).
@@ -219,6 +226,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"remote trainjob is deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			workerTrainJobs: []kftrainerapi.TrainJob{
 				*baseTrainJobBuilder.Clone().
 					PrebuiltWorkloadLabel("wl1").
@@ -240,6 +248,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"missing trainjob is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
 				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "trainjob1", Namespace: TestNamespace}); isManged {
 					return errors.New("expecting false")
@@ -248,6 +257,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"job with wrong managedBy is not considered managed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersTrainJobs: []kftrainerapi.TrainJob{
 				*baseTrainJobBuilder.DeepCopy(),
 			},
@@ -263,6 +273,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		},
 
 		"job managedBy multikueue": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersTrainJobs: []kftrainerapi.TrainJob{
 				*baseTrainJobManagedByKueueBuilder.DeepCopy(),
 			},
@@ -276,9 +287,28 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*baseTrainJobManagedByKueueBuilder.DeepCopy(),
 			},
 		},
+		"sync creates missing remote trainjob, WorkloadIdentifierAnnotations enabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			managersTrainJobs: []kftrainerapi.TrainJob{
+				*baseTrainJobManagedByKueueBuilder.DeepCopy(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "trainjob1", Namespace: TestNamespace}, "wl1", "origin1")
+			},
+			wantManagersTrainJobs: []kftrainerapi.TrainJob{
+				*baseTrainJobManagedByKueueBuilder.DeepCopy(),
+			},
+			wantWorkerTrainJobs: []kftrainerapi.TrainJob{
+				*baseTrainJobBuilder.Clone().
+					PrebuiltWorkloadAnnotation("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			managerBuilder := utiltesting.NewClientBuilder(kftrainerapi.AddToScheme).WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 			managerBuilder = managerBuilder.WithLists(&kftrainerapi.TrainJobList{Items: tc.managersTrainJobs})
 			managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersTrainJobs, func(w *kftrainerapi.TrainJob) client.Object { return w })...)

--- a/pkg/controller/jobs/trainjob/trainjob_webhook_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_webhook_test.go
@@ -78,7 +78,7 @@ func TestValidateCreate(t *testing.T) {
 		},
 		"with prebuilt workload": {
 			clusterTrainingRuntime: testCtr,
-			trainJob:               testTrainJob.Clone().Queue("local-queue").Label(controllerconstants.PrebuiltWorkloadLabel, "prebuilt-workload").Obj(),
+			trainJob:               testTrainJob.Clone().Queue("local-queue").PrebuiltWorkloadLabel("prebuilt-workload").Obj(),
 			wantErr:                nil,
 		},
 		"valid topology request in RuntimePatch": {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -367,6 +367,14 @@ const (
 	// stale workload accumulation (e.g., after PodsReady timeout eviction
 	// deletes a Deployment-owned pod).
 	FinishOrphanedWorkloads featuregate.Feature = "FinishOrphanedWorkloads"
+
+	// owner: @ivnovakov
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/10032
+	//
+	// WorkloadIdentifierAnnotations makes Kueue read and write the workload identifiers
+	// (pod-group-name and prebuilt-workload-name) via annotations. When the gate is
+	// disabled, the label-based identifiers are used instead.
+	WorkloadIdentifierAnnotations featuregate.Feature = "WorkloadIdentifierAnnotations"
 )
 
 func init() {
@@ -563,6 +571,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	FinishOrphanedWorkloads: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	WorkloadIdentifierAnnotations: {
+		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
 	},
 }
 

--- a/pkg/util/testingjobs/appwrapper/wrappers.go
+++ b/pkg/util/testingjobs/appwrapper/wrappers.go
@@ -73,6 +73,15 @@ func (aw *AppWrapperWrapper) Label(k, v string) *AppWrapperWrapper {
 	return aw
 }
 
+// Annotation sets an annotation of the AppWrapper
+func (aw *AppWrapperWrapper) Annotation(k, v string) *AppWrapperWrapper {
+	if aw.ObjectMeta.Annotations == nil {
+		aw.ObjectMeta.Annotations = make(map[string]string, 1)
+	}
+	aw.ObjectMeta.Annotations[k] = v
+	return aw
+}
+
 // Annotations updates annotations of the AppWrapper.
 func (aw *AppWrapperWrapper) Annotations(annotations map[string]string) *AppWrapperWrapper {
 	aw.ObjectMeta.Annotations = annotations
@@ -87,6 +96,11 @@ func (aw *AppWrapperWrapper) Queue(q string) *AppWrapperWrapper {
 // PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the AppWrapperWrapper
 func (aw *AppWrapperWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *AppWrapperWrapper {
 	return aw.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
+// PrebuiltWorkloadAnnotation updates PrebuiltWorkloadAnnotation of the AppWrapperWrapper
+func (aw *AppWrapperWrapper) PrebuiltWorkloadAnnotation(prebuiltWorkload string) *AppWrapperWrapper {
+	return aw.Annotation(constants.PrebuiltWorkloadAnnotation, prebuiltWorkload)
 }
 
 // Name updates the name of the AppWrapper

--- a/pkg/util/testingjobs/jaxjob/wrappers.go
+++ b/pkg/util/testingjobs/jaxjob/wrappers.go
@@ -115,6 +115,15 @@ func (j *JAXJobWrapper) Label(key, value string) *JAXJobWrapper {
 	return j
 }
 
+// Annotation sets the annotation key and value
+func (j *JAXJobWrapper) Annotation(k, v string) *JAXJobWrapper {
+	if j.Annotations == nil {
+		j.Annotations = make(map[string]string, 1)
+	}
+	j.Annotations[k] = v
+	return j
+}
+
 // PriorityClass updates job priorityclass.
 func (j *JAXJobWrapper) PriorityClass(pc string) *JAXJobWrapper {
 	if j.Spec.RunPolicy.SchedulingPolicy == nil {
@@ -150,6 +159,11 @@ func (j *JAXJobWrapper) Queue(queue string) *JAXJobWrapper {
 // PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the job
 func (j *JAXJobWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *JAXJobWrapper {
 	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
+// PrebuiltWorkloadAnnotation updates PrebuiltWorkloadAnnotation of the job
+func (j *JAXJobWrapper) PrebuiltWorkloadAnnotation(prebuiltWorkload string) *JAXJobWrapper {
+	return j.Annotation(constants.PrebuiltWorkloadAnnotation, prebuiltWorkload)
 }
 
 // Request adds a resource request to the default container.

--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -156,6 +156,11 @@ func (j *JobWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *JobWrapper 
 	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
 }
 
+// PrebuiltWorkloadAnnotation updates PrebuiltWorkloadAnnotation of the job
+func (j *JobWrapper) PrebuiltWorkloadAnnotation(prebuiltWorkload string) *JobWrapper {
+	return j.SetAnnotation(constants.PrebuiltWorkloadAnnotation, prebuiltWorkload)
+}
+
 // Label sets the label key and value
 func (j *JobWrapper) Label(key, value string) *JobWrapper {
 	if j.Labels == nil {
@@ -166,6 +171,9 @@ func (j *JobWrapper) Label(key, value string) *JobWrapper {
 }
 
 func (j *JobWrapper) SetAnnotation(key, content string) *JobWrapper {
+	if j.Annotations == nil {
+		j.Annotations = make(map[string]string, 1)
+	}
 	j.Annotations[key] = content
 	return j
 }

--- a/pkg/util/testingjobs/jobset/wrappers.go
+++ b/pkg/util/testingjobs/jobset/wrappers.go
@@ -121,6 +121,15 @@ func (j *JobSetWrapper) Label(k, v string) *JobSetWrapper {
 	return j
 }
 
+// Annotation sets an annotation to the JobSet.
+func (j *JobSetWrapper) Annotation(k, v string) *JobSetWrapper {
+	if j.ObjectMeta.Annotations == nil {
+		j.ObjectMeta.Annotations = make(map[string]string, 1)
+	}
+	j.ObjectMeta.Annotations[k] = v
+	return j
+}
+
 // Annotations sets annotations to the JobSet.
 func (j *JobSetWrapper) Annotations(annotations map[string]string) *JobSetWrapper {
 	j.ObjectMeta.Annotations = annotations
@@ -141,6 +150,11 @@ func (j *JobSetWrapper) Queue(queue string) *JobSetWrapper {
 // PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the JobSet.
 func (j *JobSetWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *JobSetWrapper {
 	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
+// PrebuiltWorkloadAnnotation updates PrebuiltWorkloadAnnotation of the JobSet.
+func (j *JobSetWrapper) PrebuiltWorkloadAnnotation(prebuiltWorkload string) *JobSetWrapper {
+	return j.Annotation(constants.PrebuiltWorkloadAnnotation, prebuiltWorkload)
 }
 
 // Request adds a resource request to the first container of the target replicatedJob.

--- a/pkg/util/testingjobs/leaderworkerset/wrappers.go
+++ b/pkg/util/testingjobs/leaderworkerset/wrappers.go
@@ -84,7 +84,7 @@ func (w *LeaderWorkerSetWrapper) Label(k, v string) *LeaderWorkerSetWrapper {
 // Annotation sets an annotation on the LeaderWorkerSet
 func (w *LeaderWorkerSetWrapper) Annotation(k, v string) *LeaderWorkerSetWrapper {
 	if w.Annotations == nil {
-		w.Annotations = make(map[string]string)
+		w.Annotations = make(map[string]string, 1)
 	}
 	w.Annotations[k] = v
 	return w
@@ -98,6 +98,11 @@ func (w *LeaderWorkerSetWrapper) Queue(q string) *LeaderWorkerSetWrapper {
 // PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the LeaderWorkerSet.
 func (w *LeaderWorkerSetWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *LeaderWorkerSetWrapper {
 	return w.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
+// PrebuiltWorkloadAnnotation updates PrebuiltWorkloadAnnotation of the LeaderWorkerSet.
+func (w *LeaderWorkerSetWrapper) PrebuiltWorkloadAnnotation(prebuiltWorkload string) *LeaderWorkerSetWrapper {
+	return w.Annotation(constants.PrebuiltWorkloadAnnotation, prebuiltWorkload)
 }
 
 // Name updated the name of the LeaderWorkerSet

--- a/pkg/util/testingjobs/mpijob/wrappers_mpijob.go
+++ b/pkg/util/testingjobs/mpijob/wrappers_mpijob.go
@@ -140,6 +140,15 @@ func (j *MPIJobWrapper) Label(key, value string) *MPIJobWrapper {
 	return j
 }
 
+// Annotation sets the annotation key and value
+func (j *MPIJobWrapper) Annotation(k, v string) *MPIJobWrapper {
+	if j.Annotations == nil {
+		j.Annotations = make(map[string]string, 1)
+	}
+	j.Annotations[k] = v
+	return j
+}
+
 // PriorityClass updates job priorityclass.
 func (j *MPIJobWrapper) PriorityClass(pc string) *MPIJobWrapper {
 	if j.Spec.RunPolicy.SchedulingPolicy == nil {
@@ -175,6 +184,11 @@ func (j *MPIJobWrapper) Queue(queue string) *MPIJobWrapper {
 // PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the job
 func (j *MPIJobWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *MPIJobWrapper {
 	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
+// PrebuiltWorkloadAnnotation updates PrebuiltWorkloadAnnotation of the job
+func (j *MPIJobWrapper) PrebuiltWorkloadAnnotation(prebuiltWorkload string) *MPIJobWrapper {
+	return j.Annotation(constants.PrebuiltWorkloadAnnotation, prebuiltWorkload)
 }
 
 // Request adds a resource request to the default container.

--- a/pkg/util/testingjobs/node/wrappers.go
+++ b/pkg/util/testingjobs/node/wrappers.go
@@ -66,7 +66,7 @@ func (n *NodeWrapper) Label(k, v string) *NodeWrapper {
 // Annotation adds an annotation to the Node
 func (n *NodeWrapper) Annotation(k, v string) *NodeWrapper {
 	if n.Annotations == nil {
-		n.Annotations = make(map[string]string)
+		n.Annotations = make(map[string]string, 1)
 	}
 	n.Annotations[k] = v
 	return n

--- a/pkg/util/testingjobs/paddlejob/wrappers.go
+++ b/pkg/util/testingjobs/paddlejob/wrappers.go
@@ -126,6 +126,15 @@ func (j *PaddleJobWrapper) Label(key, value string) *PaddleJobWrapper {
 	return j
 }
 
+// Annotation sets the annotation key and value
+func (j *PaddleJobWrapper) Annotation(k, v string) *PaddleJobWrapper {
+	if j.Annotations == nil {
+		j.Annotations = make(map[string]string, 1)
+	}
+	j.Annotations[k] = v
+	return j
+}
+
 // PriorityClass updates job priorityclass.
 func (j *PaddleJobWrapper) PriorityClass(pc string) *PaddleJobWrapper {
 	if j.Spec.RunPolicy.SchedulingPolicy == nil {
@@ -152,6 +161,11 @@ func (j *PaddleJobWrapper) Queue(queue string) *PaddleJobWrapper {
 // PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the job.
 func (j *PaddleJobWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *PaddleJobWrapper {
 	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
+// PrebuiltWorkloadAnnotation updates PrebuiltWorkloadAnnotation of the job.
+func (j *PaddleJobWrapper) PrebuiltWorkloadAnnotation(prebuiltWorkload string) *PaddleJobWrapper {
+	return j.Annotation(constants.PrebuiltWorkloadAnnotation, prebuiltWorkload)
 }
 
 // Request adds a resource request to the default container.

--- a/pkg/util/testingjobs/pod/wrappers.go
+++ b/pkg/util/testingjobs/pod/wrappers.go
@@ -89,6 +89,16 @@ func (p *PodWrapper) MakePodGroupWrappers(count int) []*PodWrapper {
 	return pods
 }
 
+func (p *PodWrapper) MakePodGroupWrappersWithWorkloadAnnotations(count int) []*PodWrapper {
+	var pods []*PodWrapper
+	for i := range count {
+		pod := p.Clone().GroupNameAnnotation(p.Pod.Name).GroupTotalCount(strconv.Itoa(count))
+		pod.Pod.Name += fmt.Sprintf("-%d", i)
+		pods = append(pods, pod)
+	}
+	return pods
+}
+
 // MakeIndexedGroup returns multiple indexed pods that form a pod group, based on the original wrapper.
 func (p *PodWrapper) MakeIndexedGroup(count int) []*corev1.Pod {
 	var pods []*corev1.Pod
@@ -121,6 +131,10 @@ func (p *PodWrapper) PrebuiltWorkloadLabel(name string) *PodWrapper {
 	return p.Label(controllerconsts.PrebuiltWorkloadLabel, name)
 }
 
+func (p *PodWrapper) PrebuiltWorkloadAnnotation(name string) *PodWrapper {
+	return p.Annotation(controllerconsts.PrebuiltWorkloadAnnotation, name)
+}
+
 // PriorityClass updates the priority class name of the Pod
 func (p *PodWrapper) PriorityClass(pc string) *PodWrapper {
 	p.Spec.PriorityClassName = pc
@@ -144,6 +158,11 @@ func (p *PodWrapper) GroupNameLabel(g string) *PodWrapper {
 	return p.Label(podconstants.GroupNameLabel, g)
 }
 
+// GroupNameAnnotation updates GroupNameAnnotation of the Pod
+func (p *PodWrapper) GroupNameAnnotation(g string) *PodWrapper {
+	return p.Annotation(podconstants.GroupNameAnnotation, g)
+}
+
 // GroupTotalCount updates the pod.GroupTotalCountAnnotation of the Pod
 func (p *PodWrapper) GroupTotalCount(gtc string) *PodWrapper {
 	return p.Annotation(podconstants.GroupTotalCountAnnotation, gtc)
@@ -164,6 +183,9 @@ func (p *PodWrapper) Label(k, v string) *PodWrapper {
 }
 
 func (p *PodWrapper) Annotation(key, content string) *PodWrapper {
+	if p.Annotations == nil {
+		p.Annotations = make(map[string]string, 1)
+	}
 	p.Annotations[key] = content
 	return p
 }

--- a/pkg/util/testingjobs/pytorchjob/wrappers_pytorchjob.go
+++ b/pkg/util/testingjobs/pytorchjob/wrappers_pytorchjob.go
@@ -181,6 +181,11 @@ func (j *PyTorchJobWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *PyTo
 	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
 }
 
+// PrebuiltWorkloadAnnotation updates PrebuiltWorkloadAnnotation of the job
+func (j *PyTorchJobWrapper) PrebuiltWorkloadAnnotation(prebuiltWorkload string) *PyTorchJobWrapper {
+	return j.SetAnnotation(constants.PrebuiltWorkloadAnnotation, prebuiltWorkload)
+}
+
 // Request adds a resource request to the default container.
 func (j *PyTorchJobWrapper) Request(replicaType kftraining.ReplicaType, r corev1.ResourceName, v string) *PyTorchJobWrapper {
 	j.Spec.PyTorchReplicaSpecs[replicaType].Template.Spec.Containers[0].Resources.Requests[r] = resource.MustParse(v)
@@ -254,6 +259,9 @@ func (j *PyTorchJobWrapper) SetTypeMeta() *PyTorchJobWrapper {
 
 // SetAnnotation sets an annotation on the job.
 func (j *PyTorchJobWrapper) SetAnnotation(key, content string) *PyTorchJobWrapper {
+	if j.Annotations == nil {
+		j.Annotations = make(map[string]string, 1)
+	}
 	j.Annotations[key] = content
 	return j
 }

--- a/pkg/util/testingjobs/raycluster/wrappers.go
+++ b/pkg/util/testingjobs/raycluster/wrappers.go
@@ -138,7 +138,15 @@ func (j *ClusterWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *Cluster
 	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
 }
 
+// PrebuiltWorkloadAnnotation updates PrebuiltWorkloadAnnotation of the job
+func (j *ClusterWrapper) PrebuiltWorkloadAnnotation(prebuiltWorkload string) *ClusterWrapper {
+	return j.SetAnnotation(constants.PrebuiltWorkloadAnnotation, prebuiltWorkload)
+}
+
 func (j *ClusterWrapper) SetAnnotation(key, content string) *ClusterWrapper {
+	if j.Annotations == nil {
+		j.Annotations = make(map[string]string, 1)
+	}
 	j.Annotations[key] = content
 	return j
 }

--- a/pkg/util/testingjobs/rayjob/wrappers.go
+++ b/pkg/util/testingjobs/rayjob/wrappers.go
@@ -117,6 +117,11 @@ func (j *JobWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *JobWrapper 
 	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
 }
 
+// PrebuiltWorkloadAnnotation updates PrebuiltWorkloadAnnotation of the job
+func (j *JobWrapper) PrebuiltWorkloadAnnotation(prebuiltWorkload string) *JobWrapper {
+	return j.Annotation(constants.PrebuiltWorkloadAnnotation, prebuiltWorkload)
+}
+
 func (j *JobWrapper) RequestWorkerGroup(name corev1.ResourceName, quantity string) *JobWrapper {
 	c := &j.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0]
 	if c.Resources.Requests == nil {
@@ -335,7 +340,7 @@ func (j *JobWrapper) ManagedBy(c string) *JobWrapper {
 
 func (j *JobWrapper) Annotation(key string, value string) *JobWrapper {
 	if j.Annotations == nil {
-		j.Annotations = make(map[string]string)
+		j.Annotations = make(map[string]string, 1)
 	}
 	j.Annotations[key] = value
 	return j

--- a/pkg/util/testingjobs/rayservice/wrappers.go
+++ b/pkg/util/testingjobs/rayservice/wrappers.go
@@ -114,6 +114,11 @@ func (j *ServiceWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *Service
 	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
 }
 
+// PrebuiltWorkloadAnnotation updates PrebuiltWorkloadAnnotation of the job
+func (j *ServiceWrapper) PrebuiltWorkloadAnnotation(prebuiltWorkload string) *ServiceWrapper {
+	return j.Annotation(constants.PrebuiltWorkloadAnnotation, prebuiltWorkload)
+}
+
 // Request adds a resource request to the default container.
 func (j *ServiceWrapper) Request(rayType rayv1.RayNodeType, r corev1.ResourceName, v string) *ServiceWrapper {
 	switch rayType {
@@ -221,7 +226,7 @@ func (j *ServiceWrapper) Label(key, value string) *ServiceWrapper {
 // Annotation sets the annotation key and value
 func (j *ServiceWrapper) Annotation(key, value string) *ServiceWrapper {
 	if j.Annotations == nil {
-		j.Annotations = make(map[string]string)
+		j.Annotations = make(map[string]string, 1)
 	}
 	j.Annotations[key] = value
 	return j

--- a/pkg/util/testingjobs/sparkapplication/wrappers_sparkapplication.go
+++ b/pkg/util/testingjobs/sparkapplication/wrappers_sparkapplication.go
@@ -87,7 +87,7 @@ func (w *SparkApplicationWrapper) Label(key, value string) *SparkApplicationWrap
 // Annotation sets the annotation of the SparkApplication.
 func (w *SparkApplicationWrapper) Annotation(key, value string) *SparkApplicationWrapper {
 	if w.Annotations == nil {
-		w.Annotations = make(map[string]string)
+		w.Annotations = make(map[string]string, 1)
 	}
 	w.Annotations[key] = value
 	return w

--- a/pkg/util/testingjobs/statefulset/wrappers.go
+++ b/pkg/util/testingjobs/statefulset/wrappers.go
@@ -88,7 +88,7 @@ func (ss *StatefulSetWrapper) Obj() *appsv1.StatefulSet {
 // Annotation sets the annotation of the StatefulSet
 func (ss *StatefulSetWrapper) Annotation(k, v string) *StatefulSetWrapper {
 	if ss.Annotations == nil {
-		ss.Annotations = make(map[string]string)
+		ss.Annotations = make(map[string]string, 1)
 	}
 	ss.Annotations[k] = v
 	return ss
@@ -111,6 +111,11 @@ func (ss *StatefulSetWrapper) Queue(q string) *StatefulSetWrapper {
 // PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the StatefulSet
 func (ss *StatefulSetWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *StatefulSetWrapper {
 	return ss.Label(controllerconstants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
+// PrebuiltWorkloadAnnotation updates PrebuiltWorkloadAnnotation of the StatefulSet
+func (ss *StatefulSetWrapper) PrebuiltWorkloadAnnotation(prebuiltWorkload string) *StatefulSetWrapper {
+	return ss.Annotation(controllerconstants.PrebuiltWorkloadAnnotation, prebuiltWorkload)
 }
 
 // Name updated the name of the StatefulSet

--- a/pkg/util/testingjobs/tfjob/wrappers_tfjob.go
+++ b/pkg/util/testingjobs/tfjob/wrappers_tfjob.go
@@ -167,6 +167,15 @@ func (j *TFJobWrapper) Label(key, value string) *TFJobWrapper {
 	return j
 }
 
+// Annotation sets the annotation key and value
+func (j *TFJobWrapper) Annotation(k, v string) *TFJobWrapper {
+	if j.Annotations == nil {
+		j.Annotations = make(map[string]string, 1)
+	}
+	j.Annotations[k] = v
+	return j
+}
+
 // Queue updates the queue name of the job.
 func (j *TFJobWrapper) Queue(queue string) *TFJobWrapper {
 	if j.Labels == nil {
@@ -179,6 +188,11 @@ func (j *TFJobWrapper) Queue(queue string) *TFJobWrapper {
 // PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the job
 func (j *TFJobWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *TFJobWrapper {
 	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
+// PrebuiltWorkloadAnnotation updates PrebuiltWorkloadAnnotation of the job
+func (j *TFJobWrapper) PrebuiltWorkloadAnnotation(prebuiltWorkload string) *TFJobWrapper {
+	return j.Annotation(constants.PrebuiltWorkloadAnnotation, prebuiltWorkload)
 }
 
 // Request adds a resource request to the default container.

--- a/pkg/util/testingjobs/trainjob/wrappers.go
+++ b/pkg/util/testingjobs/trainjob/wrappers.go
@@ -91,7 +91,7 @@ func (t *TrainJobWrapper) TrainerNumNodes(numNodes int32) *TrainJobWrapper {
 // Label sets a Trainjob annotation key and value
 func (t *TrainJobWrapper) Annotation(key, value string) *TrainJobWrapper {
 	if t.Annotations == nil {
-		t.Annotations = make(map[string]string)
+		t.Annotations = make(map[string]string, 1)
 	}
 	t.Annotations[key] = value
 	return t
@@ -142,6 +142,11 @@ func (t *TrainJobWrapper) Queue(queue string) *TrainJobWrapper {
 // PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the TrainJob.
 func (t *TrainJobWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *TrainJobWrapper {
 	return t.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
+// PrebuiltWorkloadAnnotation updates PrebuiltWorkloadAnnotation of the job
+func (j *TrainJobWrapper) PrebuiltWorkloadAnnotation(prebuiltWorkload string) *TrainJobWrapper {
+	return j.Annotation(constants.PrebuiltWorkloadAnnotation, prebuiltWorkload)
 }
 
 // ManagedBy sets the managedby field of the TrainJob.

--- a/pkg/util/testingjobs/xgboostjob/wrappers.go
+++ b/pkg/util/testingjobs/xgboostjob/wrappers.go
@@ -126,6 +126,15 @@ func (j *XGBoostJobWrapper) Label(key, value string) *XGBoostJobWrapper {
 	return j
 }
 
+// Annotation sets the annotation key and value
+func (j *XGBoostJobWrapper) Annotation(k, v string) *XGBoostJobWrapper {
+	if j.Annotations == nil {
+		j.Annotations = make(map[string]string, 1)
+	}
+	j.Annotations[k] = v
+	return j
+}
+
 // PriorityClass updates job priorityclass.
 func (j *XGBoostJobWrapper) PriorityClass(pc string) *XGBoostJobWrapper {
 	if j.Spec.RunPolicy.SchedulingPolicy == nil {
@@ -152,6 +161,11 @@ func (j *XGBoostJobWrapper) Queue(queue string) *XGBoostJobWrapper {
 // PrebuiltWorkloadLabel updates PrebuiltWorkloadLabel of the job
 func (j *XGBoostJobWrapper) PrebuiltWorkloadLabel(prebuiltWorkload string) *XGBoostJobWrapper {
 	return j.Label(constants.PrebuiltWorkloadLabel, prebuiltWorkload)
+}
+
+// PrebuiltWorkloadAnnotation updates PrebuiltWorkloadAnnotation of the job
+func (j *XGBoostJobWrapper) PrebuiltWorkloadAnnotation(prebuiltWorkload string) *XGBoostJobWrapper {
+	return j.Annotation(constants.PrebuiltWorkloadAnnotation, prebuiltWorkload)
 }
 
 // Request updates a resource request to the default container.

--- a/site/content/en/docs/tasks/run/leaderworkerset.md
+++ b/site/content/en/docs/tasks/run/leaderworkerset.md
@@ -115,3 +115,22 @@ When `replicas` is greater than 1 (as in the example above where `replicas: 2`),
 
 ## Multikueue
 Check [MultiKueue](/docs/tasks/run/multikueue/leaderworkerset) for details on running LeaderWorkerSets in MultiKueue environment.
+
+## Troubleshooting
+
+For general troubleshooting guidance, see the [Kueue troubleshooting guide](/docs/tasks/troubleshooting).
+
+### Long LeaderWorkerSet names
+
+By default, Kueue stores the pod-group identifier in the
+`kueue.x-k8s.io/pod-group-name` label, which inherits Kubernetes'
+63-character label value limit. Because Kueue derives this value by appending
+a group suffix to the LeaderWorkerSet name, the effective LWS name limit is
+**39 characters**.
+
+Enable the alpha
+[`WorkloadIdentifierAnnotations`](/docs/getting-started/installation/#feature-gates-for-alpha-and-beta-features)
+feature gate to store the identifier in an annotation instead, removing
+Kueue's label-length constraint. With the feature gate enabled, the effective
+limit shifts to the upstream LWS constraint of **51 characters**
+(see [Unable to Create LWS Object with a Name Exceeding 51 Characters](https://lws.sigs.k8s.io/docs/troubleshooting/#3-unable-to-create-lws-object-with-a-name-exceeding-51-characters) in the LWS troubleshooting guide).

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -409,6 +409,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.9"
+- name: WorkloadIdentifierAnnotations
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.18"
 - name: WorkloadRequestUseMergePatch
   versionedSpecs:
   - default: false

--- a/site/data/labels_and_annotations.yaml
+++ b/site/data/labels_and_annotations.yaml
@@ -169,6 +169,22 @@
     [Plain Pods](/docs/tasks/run/plain_pods/).
   description: |
     The label key indicates the name of the group of Pods that should be admitted together.
+  note: |
+    This label is always allowed, including when the WorkloadIdentifierAnnotations feature is enabled.
+    When the feature is enabled, we use the annotation value by default;
+    if the annotation is absent, we fall back to this label.
+
+- key: kueue.x-k8s.io/pod-group-name
+  type: Annotation
+  example: '`kueue.x-k8s.io/pod-group-name: "my-pod-group-name"`'
+  used_on: |
+    [Plain Pods](/docs/tasks/run/plain_pods/).
+  description: |
+    The annotation key indicates the name of the group of Pods that should be admitted together.
+  note: |
+    This annotation is allowed only when the WorkloadIdentifierAnnotations feature is enabled.
+    When enabled, we use the value of Pod group name from the annotation by default;
+    if it is not present, we fall back to the label.
 
 - key: kueue.x-k8s.io/pod-group-pod-index
   type: Label
@@ -337,11 +353,31 @@
     Kueue-managed Jobs.
   description: |
     The label key of the job holds the name of the pre-built workload to be used.
-    The intended use of prebuilt workload is to create the Job once the workload
-    is created. In other scenarios the behavior is undefined.
+    The intended use of prebuilt workload is to create the Job once the workload is created.
+    In other scenarios the behavior is undefined.
   note: |
     When using `kueue.x-k8s.io/pod-group-name`, the prebuilt workload name
     and the Pod group name should be the same.
+
+    This label is always allowed, including when the WorkloadIdentifierAnnotations feature is enabled.
+    When the feature is enabled, we use the annotation value by default;
+    if the annotation is absent, we fall back to this label.
+
+- key: kueue.x-k8s.io/prebuilt-workload-name
+  type: Annotation
+  example: '`kueue.x-k8s.io/prebuilt-workload-name: "my-prebuilt-workload-name"`'
+  used_on: |
+    Kueue-managed Jobs.
+  description: |
+    The annotation key of the job holds the name of the pre-built workload to be used.
+    The intended use of prebuilt workload is to create the Job once the workload is created.
+    In other scenarios the behavior is undefined.
+  note: |
+    When using `kueue.x-k8s.io/pod-group-name`, the prebuilt workload name and the Pod group name should be the same.
+    
+    This annotation is allowed only when the WorkloadIdentifierAnnotations feature is enabled.
+    When enabled, we use the value of pre-built workload from the annotation by default;
+    if it is not present, we fall back to the label.
 
 - key: kueue.x-k8s.io/priority-boost
   type: Annotation

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -409,6 +409,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.9"
+- name: WorkloadIdentifierAnnotations
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.18"
 - name: WorkloadRequestUseMergePatch
   versionedSpecs:
   - default: false

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -506,9 +506,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			ginkgo.By("Verifying pods on management cluster remain gated", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					pods := &corev1.PodList{}
-					g.Expect(k8sManagerClient.List(ctx, pods, client.InNamespace(managerNs.Name), client.MatchingLabels{
-						podconstants.GroupNameLabel: workloadstatefulset.GetWorkloadName(statefulset.UID, statefulset.Name),
-					})).To(gomega.Succeed())
+					g.Expect(k8sManagerClient.List(ctx, pods, client.InNamespace(managerNs.Name),
+						client.MatchingLabels(statefulset.Spec.Selector.MatchLabels))).To(gomega.Succeed())
 					g.Expect(pods.Items).ToNot(gomega.BeEmpty())
 					for _, pod := range pods.Items {
 						g.Expect(utilpod.HasGate(&pod, podconstants.SchedulingGateName)).To(gomega.BeTrue())

--- a/test/e2e/sequential/extended/suite_test.go
+++ b/test/e2e/sequential/extended/suite_test.go
@@ -51,6 +51,9 @@ var _ = ginkgo.BeforeSuite(func() {
 
 	waitForAvailableStart := time.Now()
 	util.WaitForKueueAvailability(ctx, k8sClient)
+	if ginkgo.Label("feature:workloadidentifierannotations").MatchesLabelFilter(ginkgo.GinkgoLabelFilter()) {
+		util.WaitForLeaderWorkerSetAvailability(ctx, k8sClient)
+	}
 	if ginkgo.Label("feature:managejobswithoutqueuename").MatchesLabelFilter(ginkgo.GinkgoLabelFilter()) {
 		util.WaitForJobSetAvailability(ctx, k8sClient)
 		util.WaitForAppWrapperAvailability(ctx, k8sClient)

--- a/test/e2e/sequential/extended/workloadidentifierannotations_test.go
+++ b/test/e2e/sequential/extended/workloadidentifierannotations_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extended
+
+import (
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
+
+	config "sigs.k8s.io/kueue/apis/config/v1beta2"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	leaderworkersettesting "sigs.k8s.io/kueue/pkg/util/testingjobs/leaderworkerset"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("WorkloadIdentifierAnnotations", ginkgo.Ordered, ginkgo.ContinueOnFailure, ginkgo.Label("feature:workloadidentifierannotations"), func() {
+	var (
+		ns *corev1.Namespace
+		rf *kueue.ResourceFlavor
+		cq *kueue.ClusterQueue
+		lq *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "lws-e2e-")
+
+		rf = utiltestingapi.MakeResourceFlavor("rf-"+ns.Name).NodeLabel("instance-type", "on-demand").Obj()
+		util.MustCreate(ctx, k8sClient, rf)
+
+		cq = utiltestingapi.MakeClusterQueue("cq-" + ns.Name).
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas(rf.Name).
+					Resource(corev1.ResourceCPU, "5").
+					Obj(),
+			).
+			Obj()
+		util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+		lq = utiltestingapi.MakeLocalQueue("lq-"+ns.Name, ns.Name).ClusterQueue(cq.Name).Obj()
+		util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteAllLeaderWorkerSetsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, rf, true)
+		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
+	})
+
+	ginkgo.Context("with WorkloadIdentifierAnnotations enabled", func() {
+		ginkgo.BeforeAll(func() {
+			util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
+				if cfg.FeatureGates == nil {
+					cfg.FeatureGates = make(map[string]bool, 1)
+				}
+				cfg.FeatureGates[string(features.WorkloadIdentifierAnnotations)] = true
+			})
+		})
+
+		ginkgo.It("should admit group with 50-character lws name", func() {
+			lwsName := strings.Repeat("a", 50)
+			lws := leaderworkersettesting.MakeLeaderWorkerSet(lwsName, ns.Name).
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				Size(3).Replicas(1).
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				TerminationGracePeriod(1).
+				Queue(lq.Name).Obj()
+
+			ginkgo.By("create a LeaderWorkerSet", func() {
+				util.MustCreate(ctx, k8sClient, lws)
+			})
+
+			ginkgo.By("waiting for replicas to be ready", func() {
+				createdLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
+					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
+					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(utiltesting.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("checking pods have group name as annotation, not label", func() {
+				pods := &corev1.PodList{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.List(ctx, pods, client.MatchingLabels{
+						leaderworkersetv1.SetNameLabelKey: lws.Name,
+					}, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					g.Expect(pods.Items).ToNot(gomega.BeEmpty())
+					for _, pod := range pods.Items {
+						g.Expect(pod.Annotations).To(gomega.HaveKey(podconstants.GroupNameAnnotation))
+						g.Expect(pod.Labels).ToNot(gomega.HaveKey(podconstants.GroupNameLabel))
+					}
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("should fail to admit group with 52-character lws name, sts controller-revision-hash label exceeds 63 chars", func() {
+			lwsName := strings.Repeat("a", 52)
+			lws := leaderworkersettesting.MakeLeaderWorkerSet(lwsName, ns.Name).
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				Size(3).Replicas(1).Queue(lq.Name).Obj()
+
+			ginkgo.By("create a LeaderWorkerSet", func() {
+				util.MustCreate(ctx, k8sClient, lws)
+			})
+
+			ginkgo.By("waiting for FailedCreate event", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					eventList := &corev1.EventList{}
+					g.Expect(k8sClient.List(ctx, eventList, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					var found bool
+					for _, e := range eventList.Items {
+						if e.Reason == "FailedCreate" && strings.Contains(e.Message, "must be no more than 63") {
+							found = true
+						}
+					}
+					g.Expect(found).To(gomega.BeTrue())
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("confirming no replicas become ready", func() {
+				createdLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
+					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(0)))
+				}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	})
+})

--- a/test/e2e/singlecluster/extended/pod_test.go
+++ b/test/e2e/singlecluster/extended/pod_test.go
@@ -536,8 +536,10 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 			})
 
 			ginkgo.By("Call high priority group pods to complete", func() {
-				listOpts := util.GetListOptsFromLabel("kueue.x-k8s.io/pod-group-name=high-priority-group")
-				util.WaitForActivePodsAndTerminate(ctx, k8sClient, restClient, cfg, ns.Name, 2, 0, listOpts)
+				for _, p := range highPriorityGroup {
+					listOpts := client.MatchingFields{metav1.ObjectNameField: p.Name}
+					util.WaitForActivePodsAndTerminate(ctx, k8sClient, restClient, cfg, ns.Name, 1, 0, listOpts)
+				}
 			})
 
 			ginkgo.By("Verify the high priority group completes", func() {
@@ -592,7 +594,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 				pKey := client.ObjectKey{Namespace: ns.Name, Name: "pod-0"}
 				gomega.Expect(k8sClient.Get(ctx, pKey, &p)).To(gomega.Succeed())
 
-				p.Labels[podconstants.GroupNameLabel] = "test-group"
+				pod.SetPodGroupName(&p, "test-group")
 				p.Annotations[podconstants.GroupTotalCountAnnotation] = "1"
 				p.Annotations[podconstants.SuspendedByParentAnnotation] = "OtherController"
 				p.Labels[controllerconsts.QueueLabel] = lq.Name

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -598,6 +598,107 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:batch", "area:jobs")
 		})
 	})
 
+	ginkgo.When("WorkloadIdentifierAnnotations feature gate is enabled", func() {
+		ginkgo.BeforeEach(func() {
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.WorkloadIdentifierAnnotations, true)
+		})
+
+		ginkgo.It("should adopt prebuilt workload via PrebuiltWorkloadLabel fallback", func() {
+			job := testingjob.MakeJob(jobName, ns.Name).
+				Queue("main").
+				PrebuiltWorkloadLabel("wl").
+				Obj()
+			util.MustCreate(ctx, k8sClient, job)
+
+			wl := utiltestingapi.MakeWorkload("wl", ns.Name).
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					Containers(job.Spec.Template.Spec.Containers[0]).
+					Obj()).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+
+			ginkgo.By("admitting the workload, the job should unsuspend", func() {
+				admission := utiltestingapi.MakeAdmission("cq", kueue.NewPodSetReference(job.Spec.Template.Spec.Containers[0].Name)).Obj()
+				util.SetQuotaReservation(ctx, k8sClient, client.ObjectKeyFromObject(wl), admission)
+				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, wl)
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					createdJob := batchv1.Job{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
+					g.Expect(ptr.Deref(createdJob.Spec.Suspend, true)).To(gomega.BeFalse())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("should adopt prebuilt workload via PrebuiltWorkloadAnnotation", framework.SlowSpec, func() {
+			job := testingjob.MakeJob(jobName, ns.Name).
+				Queue("main").
+				PrebuiltWorkloadAnnotation("wl").
+				Obj()
+			util.MustCreate(ctx, k8sClient, job)
+
+			wl := utiltestingapi.MakeWorkload("wl", ns.Name).
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					Containers(job.Spec.Template.Spec.Containers[0]).
+					Obj()).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+
+			ginkgo.By("checking no second workload was created", func() {
+				gomega.Consistently(func(g gomega.Gomega) {
+					wlList := &kueue.WorkloadList{}
+					g.Expect(k8sClient.List(ctx, wlList, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					g.Expect(wlList.Items).To(gomega.HaveLen(1))
+				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("admitting the workload, the job should unsuspend", func() {
+				admission := utiltestingapi.MakeAdmission("cq", kueue.NewPodSetReference(job.Spec.Template.Spec.Containers[0].Name)).Obj()
+				util.SetQuotaReservation(ctx, k8sClient, client.ObjectKeyFromObject(wl), admission)
+				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, wl)
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					createdJob := batchv1.Job{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
+					g.Expect(ptr.Deref(createdJob.Spec.Suspend, true)).To(gomega.BeFalse())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	})
+
+	ginkgo.When("WorkloadIdentifierAnnotations feature gate is disabled", func() {
+		ginkgo.BeforeEach(func() {
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.WorkloadIdentifierAnnotations, false)
+		})
+
+		ginkgo.It("should ignore PrebuiltWorkloadAnnotation and create a new workload", func() {
+			wl := utiltestingapi.MakeWorkload("wl", ns.Name).Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+
+			job := testingjob.MakeJob(jobName, ns.Name).
+				Queue("main").
+				PrebuiltWorkloadAnnotation(wl.Name).
+				Obj()
+			util.MustCreate(ctx, k8sClient, job)
+
+			ginkgo.By("checking a new workload is created for the job", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					wlList := &kueue.WorkloadList{}
+					g.Expect(k8sClient.List(ctx, wlList, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					g.Expect(wlList.Items).To(gomega.HaveLen(2))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("checking the prebuilt workload has no owner", func() {
+				gomega.Consistently(func(g gomega.Gomega) {
+					createdWl := kueue.Workload{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &createdWl)).To(gomega.Succeed())
+					g.Expect(createdWl.OwnerReferences).To(gomega.BeEmpty())
+				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+			})
+		})
+	})
+
 	ginkgo.It("Should finish the preemption when the job becomes inactive", framework.SlowSpec, func() {
 		job := testingjob.MakeJob(jobName, ns.Name).Queue("q").Obj()
 		wl := &kueue.Workload{}

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -1752,6 +1752,254 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 				})
 			})
 		})
+
+		ginkgo.When("WorkloadIdentifierAnnotations feature gate is enabled", func() {
+			ginkgo.BeforeEach(func() {
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.WorkloadIdentifierAnnotations, true)
+			})
+
+			ginkgo.It("should create workload and ungate pod group using GroupNameAnnotation", framework.SlowSpec, func() {
+				pod1 := testingpod.MakePod("test-pod-annotation-1", ns.Name).
+					GroupNameAnnotation("test-group-annotation").
+					GroupTotalCount("2").
+					Queue(lq.Name).
+					Obj()
+				pod2 := testingpod.MakePod("test-pod-annotation-2", ns.Name).
+					GroupNameAnnotation("test-group-annotation").
+					GroupTotalCount("2").
+					Request(corev1.ResourceCPU, "1").
+					Queue(lq.Name).
+					Obj()
+
+				util.MustCreate(ctx, k8sClient, pod1)
+				util.MustCreate(ctx, k8sClient, pod2)
+
+				wlLookupKey := types.NamespacedName{Name: "test-group-annotation", Namespace: ns.Name}
+				createdWorkload := &kueue.Workload{}
+
+				ginkgo.By("checking workload is created for the pod group from annotation", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+					gomega.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(2))
+					gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal(kueue.LocalQueueName(lq.Name)))
+				})
+
+				ginkgo.By("admitting the workload", func() {
+					admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueue.Name)).PodSets(
+						utiltestingapi.MakePodSetAssignment(createdWorkload.Spec.PodSets[0].Name).
+							Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(defaultFlavor.Name)).
+							Count(createdWorkload.Spec.PodSets[0].Count).
+							Obj(),
+						utiltestingapi.MakePodSetAssignment(createdWorkload.Spec.PodSets[1].Name).
+							Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(defaultFlavor.Name)).
+							Count(createdWorkload.Spec.PodSets[1].Count).
+							Obj(),
+					).Obj()
+					util.SetQuotaReservation(ctx, k8sClient, wlLookupKey, admission)
+					util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+				})
+
+				ginkgo.By("checking pods are ungated after admission", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						createdPod1 := &corev1.Pod{}
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod1), createdPod1)).To(gomega.Succeed())
+						g.Expect(createdPod1.Spec.SchedulingGates).Should(gomega.BeEmpty())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+					gomega.Eventually(func(g gomega.Gomega) {
+						createdPod2 := &corev1.Pod{}
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod2), createdPod2)).To(gomega.Succeed())
+						g.Expect(createdPod2.Spec.SchedulingGates).Should(gomega.BeEmpty())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+			})
+
+			ginkgo.It("should fall back to GroupNameLabel when GroupNameAnnotation is absent", framework.SlowSpec, func() {
+				pod1 := testingpod.MakePod("test-pod-label-1", ns.Name).
+					GroupNameLabel("test-group-label").
+					GroupTotalCount("2").
+					Queue(lq.Name).
+					Obj()
+				pod2 := testingpod.MakePod("test-pod-label-2", ns.Name).
+					GroupNameLabel("test-group-label").
+					GroupTotalCount("2").
+					Request(corev1.ResourceCPU, "1").
+					Queue(lq.Name).
+					Obj()
+
+				util.MustCreate(ctx, k8sClient, pod1)
+				util.MustCreate(ctx, k8sClient, pod2)
+
+				wlLookupKey := types.NamespacedName{Name: "test-group-label", Namespace: ns.Name}
+				createdWorkload := &kueue.Workload{}
+
+				ginkgo.By("checking workload is created from label fallback", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+					gomega.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(2))
+					gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal(kueue.LocalQueueName(lq.Name)))
+				})
+
+				ginkgo.By("admitting the workload", func() {
+					admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueue.Name)).PodSets(
+						utiltestingapi.MakePodSetAssignment(createdWorkload.Spec.PodSets[0].Name).
+							Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(defaultFlavor.Name)).
+							Count(createdWorkload.Spec.PodSets[0].Count).
+							Obj(),
+						utiltestingapi.MakePodSetAssignment(createdWorkload.Spec.PodSets[1].Name).
+							Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(defaultFlavor.Name)).
+							Count(createdWorkload.Spec.PodSets[1].Count).
+							Obj(),
+					).Obj()
+					util.SetQuotaReservation(ctx, k8sClient, wlLookupKey, admission)
+					util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+				})
+
+				ginkgo.By("checking pods are ungated after admission", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						createdPod1 := &corev1.Pod{}
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod1), createdPod1)).To(gomega.Succeed())
+						g.Expect(createdPod1.Spec.SchedulingGates).Should(gomega.BeEmpty())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+					gomega.Eventually(func(g gomega.Gomega) {
+						createdPod2 := &corev1.Pod{}
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod2), createdPod2)).To(gomega.Succeed())
+						g.Expect(createdPod2.Spec.SchedulingGates).Should(gomega.BeEmpty())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+			})
+
+			ginkgo.It("should adopt prebuilt workload via PrebuiltWorkloadAnnotation", framework.SlowSpec, func() {
+				const workloadName = "test-prebuilt-ann"
+
+				pod1 := testingpod.MakePod("test-pod-pb-ann-1", ns.Name).
+					GroupNameAnnotation(workloadName).
+					GroupTotalCount("2").
+					Request(corev1.ResourceCPU, "1").
+					Queue(lq.Name).
+					PrebuiltWorkloadAnnotation(workloadName).
+					RoleHash("leader").
+					Obj()
+				pod2 := testingpod.MakePod("test-pod-pb-ann-2", ns.Name).
+					GroupNameAnnotation(workloadName).
+					GroupTotalCount("2").
+					Request(corev1.ResourceCPU, "2").
+					Queue(lq.Name).
+					PrebuiltWorkloadAnnotation(workloadName).
+					RoleHash("worker").
+					Obj()
+
+				pod1LookupKey := client.ObjectKeyFromObject(pod1)
+				pod2LookupKey := client.ObjectKeyFromObject(pod2)
+
+				wl := utiltestingapi.MakeWorkload(workloadName, ns.Name).
+					Queue(kueue.LocalQueueName(lq.Name)).
+					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
+					PodSets(
+						*utiltestingapi.MakePodSet("leader", 1).PodSpec(pod1.Spec).Obj(),
+						*utiltestingapi.MakePodSet("worker", 1).PodSpec(pod2.Spec).Obj(),
+					).
+					Obj()
+				wlLookupKey := types.NamespacedName{Name: workloadName, Namespace: ns.Name}
+
+				ginkgo.By("creating prebuilt workload", func() {
+					util.MustCreate(ctx, k8sClient, wl)
+				})
+
+				ginkgo.By("creating first pod", func() {
+					util.MustCreate(ctx, k8sClient, pod1)
+				})
+
+				ginkgo.By("admitting the workload", func() {
+					admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueue.Name)).PodSets(
+						utiltestingapi.MakePodSetAssignment("leader").
+							Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(defaultFlavor.Name)).
+							Count(wl.Spec.PodSets[0].Count).
+							Obj(),
+						utiltestingapi.MakePodSetAssignment("worker").
+							Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(defaultFlavor.Name)).
+							Count(wl.Spec.PodSets[1].Count).
+							Obj(),
+					).Obj()
+					util.SetQuotaReservation(ctx, k8sClient, wlLookupKey, admission)
+					util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, wl)
+				})
+
+				ginkgo.By("checking no second workload was created", func() {
+					gomega.Consistently(func(g gomega.Gomega) {
+						wlList := &kueue.WorkloadList{}
+						g.Expect(k8sClient.List(ctx, wlList, client.InNamespace(ns.Name))).To(gomega.Succeed())
+						g.Expect(wlList.Items).To(gomega.HaveLen(1))
+					}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("checking first pod is ungated", func() {
+					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, pod1LookupKey, map[string]string{corev1.LabelArchStable: "arm64"})
+				})
+
+				ginkgo.By("creating second pod", func() {
+					util.MustCreate(ctx, k8sClient, pod2)
+				})
+
+				ginkgo.By("checking workload is owned by both pods", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, wlLookupKey, wl)).Should(gomega.Succeed())
+						g.Expect(wl.OwnerReferences).Should(gomega.HaveLen(2))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("checking second pod is ungated", func() {
+					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, pod2LookupKey, map[string]string{corev1.LabelArchStable: "arm64"})
+				})
+
+				ginkgo.By("finishing pods", func() {
+					util.SetPodsPhase(ctx, k8sClient, corev1.PodSucceeded, pod1)
+					util.SetPodsPhase(ctx, k8sClient, corev1.PodSucceeded, pod2)
+				})
+
+				ginkgo.By("checking the workload is finished", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, wlLookupKey, wl)).Should(gomega.Succeed())
+						g.Expect(wl.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("checking pod and workload finalizers are removed", func() {
+					util.ExpectPodsFinalizedOrGone(ctx, k8sClient, pod1LookupKey, pod2LookupKey)
+					util.ExpectWorkloadsFinalizedOrGone(ctx, k8sClient, wlLookupKey)
+				})
+			})
+
+			ginkgo.It("should reject pod with different GroupNameAnnotation and PrebuiltWorkloadAnnotation", func() {
+				pod := testingpod.MakePod("test-pod-mismatch", ns.Name).
+					GroupNameAnnotation("group-a").
+					GroupTotalCount("1").
+					Queue(lq.Name).
+					PrebuiltWorkloadAnnotation("group-b").
+					Obj()
+
+				err := k8sClient.Create(ctx, pod)
+				gomega.Expect(err).Should(gomega.And(
+					utiltesting.BeForbiddenError(),
+					gomega.MatchError(gomega.ContainSubstring("metadata.annotations")),
+				))
+			})
+
+			ginkgo.It("should reject pod with GroupNameAnnotation but missing GroupTotalCountAnnotation", func() {
+				pod := testingpod.MakePod("test-pod-no-gtc", ns.Name).
+					GroupNameAnnotation("some-group").
+					Queue(lq.Name).
+					Obj()
+
+				err := k8sClient.Create(ctx, pod)
+				gomega.Expect(err).Should(gomega.And(
+					utiltesting.BeForbiddenError(),
+					gomega.MatchError(gomega.ContainSubstring(podconstants.GroupTotalCountAnnotation)),
+					gomega.MatchError(gomega.ContainSubstring(podconstants.GroupNameAnnotation)),
+				))
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
Cherry pick of #10311 on release-0.17.

#10311: Adds GroupNameAnnotation and PrebuiltWorkloadAnnotation

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
LeaderWorkerSet & Pods: Fixed a bug where LeaderWorkerSets with names longer than 39 characters failed to create pods with a `metadata.labels: Invalid value` error. This happened when the `kueue.x-k8s.io/pod-group-name` and
`kueue.x-k8s.io/prebuilt-workload-name` labels, set by the LWS integration, exceeded 63 characters. 

The `WorkloadIdentifierAnnotations` feature gate (disabled by default) resolves this by supporting these identifiers
as both labels and annotations. LeaderWorkerSet now utilizes the annotation counterparts to support names up to
52 characters. Labels, now along with annotations, remain the user-facing API for manually defining PodGroups.
```