### PR TITLE
perf: calibrate large-scale scheduler thresholds from CI data

### DIFF
--- a/test/performance/scheduler/configs/large-scale/rangespec.yaml
+++ b/test/performance/scheduler/configs/large-scale/rangespec.yaml
@@ -1,8 +1,5 @@
 # Large-Scale Performance Test - Expected Performance Ranges
 #
-# NOTE: These thresholds are conservative placeholders and must be calibrated
-# from actual trial runs before being used to gate CI.
-#
 # Calibration procedure (mirrors baseline/rangespec.yaml):
 #   1. Run `make run-large-scale-performance-scheduler` at least 5 times
 #   2. Collect the cmdStats WallMs from artifacts/run-large-scale-performance-scheduler/minimalkueue.stats.yaml
@@ -10,20 +7,20 @@
 #   4. Set maxWallMs = mean × 1.20 (rounded up to nearest 1000ms)
 #   5. Set wlClassesMaxAvgTimeToAdmissionMs = mean × 1.20 (rounded up to nearest 1000ms)
 #   6. Set clusterQueueClassesMinUsage = mean − 7% (rounded down to 0.1%)
+#
+# Calibrated from 19 successful periodic runs of
+# periodic-kueue-test-large-scale-scheduling-perf-main.
 
 cmd:
-  # Target: 20 minutes. 50k workloads (1000 CQs × 50/queue), same runtimeMs as original config.
-  # Replace after calibration.
-  maxWallMs: 1_200_000
+  # mean=1179411ms, stdev=13280ms; mean×1.2 rounded up to nearest 1000ms
+  maxWallMs: 1_416_000
 
 clusterQueueClassesMinUsage:
-  # Placeholder: same as baseline. Replace after calibration.
-  cq: 33 #%
+  # mean=38.64%, mean-7% rounded down to 0.1%
+  cq: 31.6 #%
 
 wlClassesMaxAvgTimeToAdmissionMs:
-  # Placeholder values — scaled proportionally from original 60k config.
-  # Fewer CQs reduces scheduler complexity; more wl/queue increases local pressure.
-  # Replace after calibration.
-  large: 150_000
-  medium: 500_000
-  small: 1_500_000
+  # mean×1.2 rounded up to nearest 1000ms
+  large: 119_000   # mean=98803ms
+  medium: 308_000  # mean=256413ms
+  small: 841_000   # mean=700379ms


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->
/area testing
#### What this PR does / why we need it:
Replace placeholder thresholds in large-scale/rangespec.yaml with values calibrated from 19 successful runs of
periodic-kueue-test-large-scale-scheduling-perf-main.

Previous values were conservative placeholders; the new values are derived using the same procedure as baseline/rangespec.yaml:
  maxWallMs = mean × 1.20 (ceil to nearest 1000ms)
  wlClassesMaxAvgTimeToAdmissionMs = mean × 1.20 (ceil to nearest 1000ms)
  clusterQueueClassesMinUsage = mean − 7% (floor to 0.1%)

Observed stats across 19 runs:
  wallMs:  mean=1179411ms, stdev=13280ms  → maxWallMs: 1_416_000
  cq usage: mean=38.64%                  → minUsage:  31.6%
  large:   mean=98803ms                  → max:       119_000
  medium:  mean=256413ms                 → max:       308_000
  small:   mean=700379ms                 → max:       841_000

The previous maxWallMs of 1_200_000ms was also causing intermittent test failures (wall time 1205300ms > 1200000ms) since the scheduler consistently runs for ~19m40s on the periodic infrastructure.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes-sigs/kueue/issues/10773

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
