### PR TITLE
[integration] Drop ginkgo.Ordered from MPIJob webhook singlecluster tests

### DIFF
--- a/test/integration/singlecluster/webhook/jobs/mpijob_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/mpijob_webhook_test.go
@@ -27,29 +27,22 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("MPIJob Webhook", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("MPIJob Webhook", func() {
 	var ns *corev1.Namespace
-	ginkgo.BeforeAll(func() {
+
+	ginkgo.BeforeEach(func() {
 		fwk.StartManager(ctx, cfg, managerSetup(mpijob.SetupMPIJobWebhook))
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "mpi-")
 	})
-	ginkgo.AfterAll(func() {
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 		fwk.StopManager(ctx)
 	})
 
-	ginkgo.When("With manageJobsWithoutQueueName disabled", func() {
-		ginkgo.BeforeEach(func() {
-			ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "mpi-")
-		})
-
-		ginkgo.AfterEach(func() {
-			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
-		})
-
-		ginkgo.It("the creation doesn't succeed if the queue name is invalid", func() {
-			job := testingjob.MakeMPIJob("job", ns.Name).Queue("indexed_job").Obj()
-			err := k8sClient.Create(ctx, job)
-			gomega.Expect(err).Should(gomega.HaveOccurred())
-			gomega.Expect(err).Should(utiltesting.BeForbiddenError())
-		})
+	ginkgo.It("the creation doesn't succeed if the queue name is invalid", func() {
+		job := testingjob.MakeMPIJob("job", ns.Name).Queue("indexed_job").Obj()
+		err := k8sClient.Create(ctx, job)
+		gomega.Expect(err).Should(gomega.HaveOccurred())
+		gomega.Expect(err).Should(utiltesting.BeForbiddenError())
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it:
Updates the MPIJob webhook integration tests under `test/integration/singlecluster/webhook/jobs`.
- Removes `ginkgo.Ordered` from the Describe.
- Moves manager `StartManager`/`StopManager` from `BeforeAll`/`AfterAll` into `BeforeEach`/`AfterEach` (see #8726).
Continues the split from #9880 / #9972 after #11384–#11398.

#### Which issue(s) this PR fixes:
Part of #9880

#### Special notes for your reviewer:
- One file only; no changes to `suite_test.go` or `test/integration/framework`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
