### PR TITLE
[integration] Drop ginkgo.Ordered from Deployment webhook singlecluster tests

### DIFF
--- a/test/integration/singlecluster/webhook/jobs/deployment_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/deployment_webhook_test.go
@@ -33,13 +33,13 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("Deployment Webhook", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("Deployment Webhook", func() {
 	var (
 		ns         *corev1.Namespace
 		deployment *appsv1.Deployment
 	)
 
-	ginkgo.BeforeAll(func() {
+	ginkgo.BeforeEach(func() {
 		discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		serverVersionFetcher = kubeversion.NewServerVersionFetcher(discoveryClient)
@@ -50,16 +50,11 @@ var _ = ginkgo.Describe("Deployment Webhook", ginkgo.Ordered, ginkgo.ContinueOnF
 			deploymentcontroller.SetupWebhook,
 			jobframework.WithKubeServerVersion(serverVersionFetcher),
 		))
-	})
-	ginkgo.AfterAll(func() {
-		fwk.StopManager(ctx)
-	})
-
-	ginkgo.BeforeEach(func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "deployment-")
 	})
 	ginkgo.AfterEach(func() {
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		fwk.StopManager(ctx)
 	})
 
 	ginkgo.When("the queue-name label is set", func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it:
Updates the Deployment webhook integration tests under `test/integration/singlecluster/webhook/jobs`.
- Removes `ginkgo.Ordered` and `ginkgo.ContinueOnFailure` from the Describe.
- Moves discovery setup, manager `StartManager`/`StopManager`, and namespace creation from `BeforeAll`/`AfterAll` into `BeforeEach`/`AfterEach` (see #8726).
Continues the split from #9880.

#### Which issue(s) this PR fixes:
Part of #9880

#### Special notes for your reviewer:
- One file only; inner `When` blocks and specs are unchanged.
- No changes to `suite_test.go` or `test/integration/framework`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
