### PR TITLE
[integration] Drop ginkgo.Ordered from StatefulSet webhook singlecluster tests

### DIFF
--- a/test/integration/singlecluster/webhook/jobs/statefulset_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/statefulset_webhook_test.go
@@ -36,8 +36,8 @@ import (
 var _ = ginkgo.Describe("StatefulSet Webhook", func() {
 	var ns *corev1.Namespace
 
-	ginkgo.When("with pod integration enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-		ginkgo.BeforeAll(func() {
+	ginkgo.When("with pod integration enabled", func() {
+		ginkgo.BeforeEach(func() {
 			discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			serverVersionFetcher = kubeversion.NewServerVersionFetcher(discoveryClient)
@@ -49,15 +49,11 @@ var _ = ginkgo.Describe("StatefulSet Webhook", func() {
 				jobframework.WithManageJobsWithoutQueueName(false),
 				jobframework.WithKubeServerVersion(serverVersionFetcher),
 			))
-		})
-		ginkgo.AfterAll(func() {
-			fwk.StopManager(ctx)
-		})
-		ginkgo.BeforeEach(func() {
 			ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "statefulset-")
 		})
 		ginkgo.AfterEach(func() {
 			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			fwk.StopManager(ctx)
 		})
 
 		ginkgo.When("The queue-name label is set", func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it:
Updates the StatefulSet webhook integration tests under `test/integration/singlecluster/webhook/jobs`.
- Removes `ginkgo.Ordered` and `ginkgo.ContinueOnFailure` from the When block.
- Moves discovery setup, manager `StartManager`/`StopManager`, and namespace creation from `BeforeAll`/`AfterAll` into `BeforeEach`/`AfterEach` (see #8726).
Continues the split from #9880.

#### Which issue(s) this PR fixes:
Part of #9880

#### Special notes for your reviewer:
- One file only; nested When blocks for specs are unchanged.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
