### PR TITLE
[integration] Drop ginkgo.Ordered from Pod webhook singlecluster tests

### DIFF
--- a/test/integration/singlecluster/webhook/jobs/pod_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/pod_webhook_test.go
@@ -36,13 +36,12 @@ import (
 var _ = ginkgo.Describe("Pod Webhook", func() {
 	var ns *corev1.Namespace
 
-	ginkgo.When("with manageJobsWithoutQueueName disabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-		ginkgo.BeforeAll(func() {
+	ginkgo.When("with manageJobsWithoutQueueName disabled", func() {
+		ginkgo.BeforeEach(func() {
 			discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			serverVersionFetcher = kubeversion.NewServerVersionFetcher(discoveryClient)
 			err = serverVersionFetcher.FetchServerVersion()
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			nsSelector := &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
@@ -62,15 +61,11 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 				jobframework.WithManagedJobsNamespaceSelector(mjnsSelector),
 				jobframework.WithKubeServerVersion(serverVersionFetcher),
 			))
-		})
-		ginkgo.BeforeEach(func() {
 			ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "pod-")
 		})
 
 		ginkgo.AfterEach(func() {
 			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
-		})
-		ginkgo.AfterAll(func() {
 			fwk.StopManager(ctx)
 		})
 
@@ -167,8 +162,8 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 		})
 	})
 
-	ginkgo.When("with manageJobsWithoutQueueName enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-		ginkgo.BeforeAll(func() {
+	ginkgo.When("with manageJobsWithoutQueueName enabled", func() {
+		ginkgo.BeforeEach(func() {
 			discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			serverVersionFetcher = kubeversion.NewServerVersionFetcher(discoveryClient)
@@ -192,15 +187,11 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 				jobframework.WithManagedJobsNamespaceSelector(mjnsSelector),
 				jobframework.WithKubeServerVersion(serverVersionFetcher),
 			))
-		})
-		ginkgo.BeforeEach(func() {
 			ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "pod-")
 		})
 
 		ginkgo.AfterEach(func() {
 			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
-		})
-		ginkgo.AfterAll(func() {
 			fwk.StopManager(ctx)
 		})
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it:
Updates the Pod webhook integration tests under `test/integration/singlecluster/webhook/jobs`.
* Removes `ginkgo.Ordered` and `ginkgo.ContinueOnFailure` from both top-level `When` blocks (`manageJobsWithoutQueueName` disabled and enabled).
* Moves discovery setup, manager `StartManager`/`StopManager`, and namespace creation from `BeforeAll`/`AfterAll` into `BeforeEach`/`AfterEach` (see [Parallelize Fair Sharing Integration Test (66% speedup) #8726](https://github.com/kubernetes-sigs/kueue/pull/8726)).
Continues the split from [Eliminate ginkgo.Ordered for singlecluster integration tests #9880](https://github.com/kubernetes-sigs/kueue/issues/9880).

#### Which issue(s) this PR fixes:
Part of #9880

#### Special notes for your reviewer:
* One file only (`pod_webhook_test.go`); nested `When` blocks for specs are unchanged.
* Two top-level `When` blocks with different manager configs (`manageJobsWithoutQueueName` false vs true); each block restarts the manager per spec.
* No changes to `suite_test.go` or `framework.go`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
