### PR TITLE
Automated cherry pick of #11383: Add hack/retry.sh script that is used for KUBEBUILDER_ASSETS to imple…

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -20,7 +20,11 @@ GO_TEST_FLAGS ?= -race
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION ?= 1.35
-KUBEBUILDER_ASSETS = $(or $(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path),$(error setup-envtest failed to download binaries. KUBEBUILDER_ASSETS is empty))
+ENVTEST_RETRY_ATTEMPTS ?= 4
+ENVTEST_RETRY_DELAY ?= 5
+KUBEBUILDER_ASSETS = $(or \
+	$(shell $(PROJECT_DIR)/hack/retry.sh --attempts $(ENVTEST_RETRY_ATTEMPTS) --delay $(ENVTEST_RETRY_DELAY) -- $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path), \
+	$(error setup-envtest failed to download binaries. KUBEBUILDER_ASSETS is empty))
 
 TEST_LOG_LEVEL ?= -3
 

--- a/cmd/experimental/kueue-populator/Makefile
+++ b/cmd/experimental/kueue-populator/Makefile
@@ -19,8 +19,12 @@ ENVTEST := $(BIN_DIR)/setup-envtest
 GINKGO := $(BIN_DIR)/ginkgo
 GOTESTSUM := $(BIN_DIR)/gotestsum
 ARTIFACTS ?= $(ROOT_DIR)/artifacts
-ENVTEST_K8S_VERSION ?= 1.34
-KUBEBUILDER_ASSETS = $(or $(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path),$(error setup-envtest failed to download binaries. KUBEBUILDER_ASSETS is empty))
+ENVTEST_K8S_VERSION ?= 1.35
+ENVTEST_RETRY_ATTEMPTS ?= 4
+ENVTEST_RETRY_DELAY ?= 5
+KUBEBUILDER_ASSETS = $(or \
+	$(shell $(ROOT_DIR)/hack/retry.sh --attempts $(ENVTEST_RETRY_ATTEMPTS) --delay $(ENVTEST_RETRY_DELAY) -- $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path), \
+	$(error setup-envtest failed to download binaries. KUBEBUILDER_ASSETS is empty))
 INTEGRATION_NPROCS ?= 4
 CONTROLLER_GEN := $(BIN_DIR)/controller-gen
 YAML_PROCESSOR = $(BIN_DIR)/yaml-processor

--- a/hack/retry.sh
+++ b/hack/retry.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Retry a command on failure. Captures the command's stdout on success and
+# echoes it; stderr passes through. Designed to be invoked from Make $(shell ...)
+# where the captured stdout becomes the variable value.
+#
+# Usage:
+#   retry.sh [--attempts N] [--delay SECONDS] -- <command> [args...]
+#
+# Defaults: --attempts 4, --delay 5
+# Exit:     0 on first success, 1 if all attempts fail, 2 on usage error.
+
+set -u
+
+attempts=4
+delay=5
+
+while [ $# -gt 0 ]; do
+    case $1 in
+        --attempts) attempts=$2; shift 2 ;;
+        --delay)    delay=$2;    shift 2 ;;
+        --)         shift; break ;;
+        -*)         echo "retry: unknown flag: $1" 1>&2; exit 2 ;;
+        *)          break ;;
+    esac
+done
+
+if [ $# -eq 0 ]; then
+    echo "retry: no command given" 1>&2
+    exit 2
+fi
+
+for i in $(seq 1 "$attempts"); do
+    echo "retry [$i/$attempts]: $*" 1>&2
+    if out=$("$@"); then
+        printf '%s' "$out"
+        exit 0
+    fi
+    echo "retry [$i/$attempts] failed" 1>&2
+    [ "$i" -lt "$attempts" ] && sleep "$delay"
+done
+exit 1


### PR DESCRIPTION
Cherry pick of #11383 on release-0.16.

#11383: Add hack/retry.sh script that is used for KUBEBUILDER_ASSETS to imple…

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind flake


```release-note
NONE
```