### PR TITLE
[integration] Drop ginkgo.Ordered from Cohort webhook singlecluster tests

### DIFF
--- a/test/integration/singlecluster/webhook/core/cohort_test.go
+++ b/test/integration/singlecluster/webhook/core/cohort_test.go
@@ -33,11 +33,11 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("Cohort Webhook", ginkgo.Ordered, func() {
-	ginkgo.BeforeAll(func() {
+var _ = ginkgo.Describe("Cohort Webhook", func() {
+	ginkgo.BeforeEach(func() {
 		fwk.StartManager(ctx, cfg, managerSetup)
 	})
-	ginkgo.AfterAll(func() {
+	ginkgo.AfterEach(func() {
 		fwk.StopManager(ctx)
 	})
 	ginkgo.When("Creating a Cohort", func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it:
Updates the Cohort webhook integration tests under `test/integration/singlecluster/webhook/core`.
* Removes `ginkgo.Ordered` from the `Describe` block.
* Moves manager `StartManager`/`StopManager` from `BeforeAll`/`AfterAll` into `BeforeEach`/`AfterEach` (see #8726).
Continues the split from #9880.

#### Which issue(s) this PR fixes:
Part of #9880

#### Special notes for your reviewer:
* One file only (`cohort_test.go`).
* No namespace lifecycle changes; tests use cluster-scoped `Cohort` objects.
* No changes to `suite_test.go` or `test/integration/framework`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
