### PR TITLE
Automated cherry pick of #11378: [Fix] Prevent remote wl creation with stale ClusterName

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -766,7 +766,14 @@ func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group 
 		for workerName := range group.remotes {
 			nominatedWorkers = append(nominatedWorkers, workerName)
 		}
-		if group.local.Status.ClusterName == nil && !equality.Semantic.DeepEqual(group.local.Status.NominatedClusterNames, nominatedWorkers) {
+
+		if !equality.Semantic.DeepEqual(group.local.Status.NominatedClusterNames, nominatedWorkers) {
+			// ClusterName != nil indicates possibly stale cache (eviction just cleared ClusterName
+			// but the informer hasn't caught up yet). Avoid creating remote workloads without a
+			// confirmed nomination — wait for the cache to sync.
+			if group.local.Status.ClusterName != nil {
+				return reconcile.Result{}, nil
+			}
 			if err := workload.PatchAdmissionStatus(ctx, w.client, group.local, w.clock, func(wl *kueue.Workload) (bool, error) {
 				wl.Status.NominatedClusterNames = nominatedWorkers
 				return true, nil

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -2122,6 +2122,7 @@ func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
 		dispatcherMode   string
 		remotes          map[string]*kueue.Workload
 		nominatedWorkers []string
+		localClusterName *string
 		cond             *metav1.Condition
 		createErr        error
 		wantCreated      []string
@@ -2138,6 +2139,13 @@ func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
 			dispatcherMode: config.MultiKueueDispatcherModeAllAtOnce,
 			remotes:        map[string]*kueue.Workload{remoteNames[0]: {}, remoteNames[1]: {}},
 			wantCreated:    nil,
+		},
+		{
+			name:             "AllClusters: stale cache ClusterName set, nominations not confirmed — no remote workloads created",
+			dispatcherMode:   config.MultiKueueDispatcherModeAllAtOnce,
+			remotes:          map[string]*kueue.Workload{remoteNames[0]: nil, remoteNames[1]: nil},
+			localClusterName: ptr.To(remoteNames[0]),
+			wantCreated:      nil,
 		},
 		// Incremental dispatcher tests were moved to a separate file.
 		{
@@ -2171,6 +2179,7 @@ func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
 				Status: kueue.WorkloadStatus{
 					Conditions:            make([]metav1.Condition, 0, 1),
 					NominatedClusterNames: tt.nominatedWorkers,
+					ClusterName:           tt.localClusterName,
 				},
 			}
 


### PR DESCRIPTION
Cherry pick of #11378 on release-0.17.

#11378: [Fix] Prevent remote wl creation with stale ClusterName

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
MultiKueue: Fixed a bug in the AllAtOnce dispatcher where workloads evicted from a
worker cluster could fail to be re-admitted. Kueue now waits for the ongoing eviction to
complete before starting a new nomination and re-admission cycle.
```