### PR TITLE
MultiKueue: avoid unnecessary workload updates from AllAtOnce dispatcher due to reordered nominatedClusterNames

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -696,6 +696,14 @@ func (w *wlReconciler) syncToSingleCluster(ctx context.Context, log klog.Logger,
 	return reconcile.Result{}, errors.Join(errs...)
 }
 
+// nominatedClusterSetsEqual reports whether stored and current contain the same set of cluster names,
+// independent of order.
+func nominatedClusterSetsEqual(stored, current []string) bool {
+	slices.Sort(stored)
+	slices.Sort(current)
+	return slices.Equal(stored, current)
+}
+
 func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group *wlGroup) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx).WithValues("op", "nominateAndSynchronizeWorkers")
 	log.V(3).Info("Nominate and Synchronize Worker Clusters")
@@ -764,7 +772,7 @@ func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group 
 			nominatedWorkers = append(nominatedWorkers, workerName)
 		}
 
-		if !equality.Semantic.DeepEqual(group.local.Status.NominatedClusterNames, nominatedWorkers) {
+		if !nominatedClusterSetsEqual(group.local.Status.NominatedClusterNames, nominatedWorkers) {
 			// ClusterName != nil indicates possibly stale cache (eviction just cleared ClusterName
 			// but the informer hasn't caught up yet). Avoid creating remote workloads without a
 			// confirmed nomination — wait for the cache to sync.

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -1717,21 +1717,23 @@ func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
 	now := time.Now()
 
 	tests := []struct {
-		name             string
-		dispatcherMode   string
-		remotes          map[string]*kueue.Workload
-		nominatedWorkers []string
-		localClusterName *string
-		cond             *metav1.Condition
-		createErr        error
-		wantCreated      []string
-		wantErr          bool
+		name                      string
+		dispatcherMode            string
+		remotes                   map[string]*kueue.Workload
+		nominatedWorkers          []string
+		localClusterName          *string
+		cond                      *metav1.Condition
+		createErr                 error
+		wantCreated               []string
+		wantErr                   bool
+		wantNominatedClusterNames []string // if non-nil, asserts NominatedClusterNames after reconcile
 	}{
 		{
-			name:           "AllClusters: clone to all remotes, nominates all",
-			dispatcherMode: config.MultiKueueDispatcherModeAllAtOnce,
-			remotes:        map[string]*kueue.Workload{remoteNames[0]: nil, remoteNames[1]: nil},
-			wantCreated:    []string{remoteNames[0], remoteNames[1]},
+			name:                      "AllClusters: clone to all remotes, nominates all",
+			dispatcherMode:            config.MultiKueueDispatcherModeAllAtOnce,
+			remotes:                   map[string]*kueue.Workload{remoteNames[0]: nil, remoteNames[1]: nil},
+			wantCreated:               []string{remoteNames[0], remoteNames[1]},
+			wantNominatedClusterNames: []string{remoteNames[0], remoteNames[1]}, // stored sorted after patch
 		},
 		{
 			name:           "AllClusters: workloads already created on remotes, do not create again",
@@ -1745,6 +1747,14 @@ func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
 			remotes:          map[string]*kueue.Workload{remoteNames[0]: nil, remoteNames[1]: nil},
 			localClusterName: new(remoteNames[0]),
 			wantCreated:      nil,
+		},
+		{
+			name:                      "AllClusters: same set in reversed order does not trigger unnecessary patch",
+			dispatcherMode:            config.MultiKueueDispatcherModeAllAtOnce,
+			remotes:                   map[string]*kueue.Workload{remoteNames[0]: {}, remoteNames[1]: {}},
+			nominatedWorkers:          []string{remoteNames[1], remoteNames[0]}, // reversed (not sorted)
+			wantCreated:               nil,
+			wantNominatedClusterNames: []string{remoteNames[0], remoteNames[1]}, // sorted in-place even without a patch
 		},
 		// Incremental dispatcher tests were moved to a separate file.
 		{
@@ -1840,6 +1850,11 @@ func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
 			}
 			if diff := cmp.Diff(tt.wantCreated, gotCreated, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
 				t.Errorf("unexpected created remotes (-want/+got):\n%s", diff)
+			}
+			if tt.wantNominatedClusterNames != nil {
+				if diff := cmp.Diff(tt.wantNominatedClusterNames, local.Status.NominatedClusterNames); diff != "" {
+					t.Errorf("unexpected NominatedClusterNames (-want/+got):\n%s", diff)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Sort lists of current and previously stored nominated clusters before comparison. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11453 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MultiKueue: Fixed unnecessary `status.nominatedClusterNames` updates from the AllAtOnce
dispatcher when the set of nominated clusters did not change.
```
