### PR TITLE
[integration] Drop ginkgo.Ordered from ClusterQueue webhook singlecluster tests

### DIFF
--- a/test/integration/singlecluster/webhook/core/clusterqueue_test.go
+++ b/test/integration/singlecluster/webhook/core/clusterqueue_test.go
@@ -40,25 +40,20 @@ const (
 	flavorsMaxItems   = 64
 )
 
-var _ = ginkgo.Describe("ClusterQueue Webhook", ginkgo.Ordered, func() {
-	ginkgo.BeforeAll(func() {
-		fwk.StartManager(ctx, cfg, managerSetup)
-	})
-	ginkgo.AfterAll(func() {
-		fwk.StopManager(ctx)
-	})
-	var ns *corev1.Namespace
-	defaultFlavorFungibility := &kueue.FlavorFungibility{
-		WhenCanBorrow:  kueue.MayStopSearch,
-		WhenCanPreempt: kueue.TryNextFlavor,
-	}
+// defaultFlavorFungibility matches ClusterQueue defaulting (see apis defaulting).
+var defaultFlavorFungibility = &kueue.FlavorFungibility{
+	WhenCanBorrow:  kueue.MayStopSearch,
+	WhenCanPreempt: kueue.TryNextFlavor,
+}
 
+var _ = ginkgo.Describe("ClusterQueue Webhook", func() {
 	ginkgo.BeforeEach(func() {
+		fwk.StartManager(ctx, cfg, managerSetup)
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "core-")
 	})
-
 	ginkgo.AfterEach(func() {
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		fwk.StopManager(ctx)
 	})
 
 	ginkgo.When("Creating a ClusterQueue", func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it:
Updates the ClusterQueue webhook integration tests under `test/integration/singlecluster/webhook/core`.
* Removes `ginkgo.Ordered` from the `Describe` block.
* Moves manager `StartManager`/`StopManager` from `BeforeAll`/`AfterAll` into `BeforeEach`/`AfterEach` (see #8726).
* Hoists `defaultFlavorFungibility` to package scope (unchanged values).
Continues the split from #9880.

#### Which issue(s) this PR fixes:
Part of #9880

#### Special notes for your reviewer:
* One file only (`clusterqueue_test.go`).
* Namespace lifecycle is per-spec; manager lifecycle is now per-spec as well.
* No changes to `suite_test.go` or `test/integration/framework`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
