### PR TITLE
Automated cherry pick of #11492: Set TerminationGracePeriod=1s for e2e tests using BehaviorWaitForDeletion

### DIFF
--- a/pkg/util/testingjobs/jobset/wrappers.go
+++ b/pkg/util/testingjobs/jobset/wrappers.go
@@ -223,6 +223,14 @@ func (j *JobSetWrapper) ManagedBy(c string) *JobSetWrapper {
 	return j
 }
 
+// TerminationGracePeriod sets the termination grace period for all replicated jobs.
+func (j *JobSetWrapper) TerminationGracePeriod(seconds int64) *JobSetWrapper {
+	for i := range j.Spec.ReplicatedJobs {
+		j.Spec.ReplicatedJobs[i].Template.Spec.Template.Spec.TerminationGracePeriodSeconds = &seconds
+	}
+	return j
+}
+
 // OwnerReference adds a ownerReference to the default container.
 func (j *JobSetWrapper) OwnerReference(ownerName string, ownerGVK schema.GroupVersionKind) *JobSetWrapper {
 	utiltesting.AppendOwnerReference(j, ownerGVK, ownerName, ownerName, ptr.To(true), ptr.To(true))

--- a/pkg/util/testingjobs/pytorchjob/wrappers_pytorchjob.go
+++ b/pkg/util/testingjobs/pytorchjob/wrappers_pytorchjob.go
@@ -272,8 +272,7 @@ func (j *PyTorchJobWrapper) ManagedBy(c string) *PyTorchJobWrapper {
 	return j
 }
 
-func (j *PyTorchJobWrapper) TerminationGracePeriodSeconds(seconds int64) *PyTorchJobWrapper {
-	j.Spec.PyTorchReplicaSpecs[kftraining.PyTorchJobReplicaTypeMaster].Template.Spec.TerminationGracePeriodSeconds = ptr.To(seconds)
-	j.Spec.PyTorchReplicaSpecs[kftraining.PyTorchJobReplicaTypeWorker].Template.Spec.TerminationGracePeriodSeconds = ptr.To(seconds)
+func (j *PyTorchJobWrapper) TerminationGracePeriod(replicaType kftraining.ReplicaType, seconds int64) *PyTorchJobWrapper {
+	j.Spec.PyTorchReplicaSpecs[replicaType].Template.Spec.TerminationGracePeriodSeconds = ptr.To(seconds)
 	return j
 }

--- a/test/e2e/certmanager/certmanager_test.go
+++ b/test/e2e/certmanager/certmanager_test.go
@@ -70,6 +70,7 @@ var _ = ginkgo.Describe("CertManager", ginkgo.Ordered, func() {
 				Queue("main").
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				Suspend(false).
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sClient, testJob)
 

--- a/test/e2e/dra/dra_test.go
+++ b/test/e2e/dra/dra_test.go
@@ -136,6 +136,7 @@ var _ = ginkgo.Describe("DRA", func() {
 				RequestAndLimit(corev1.ResourceCPU, "200m").
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				ResourceClaimTemplate("gpu", "large-gpu-template").
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sClient, job)
 
@@ -438,6 +439,7 @@ var _ = ginkgo.Describe("DRA", func() {
 				// Extended resources require both requests AND limits
 				RequestAndLimit(corev1.ResourceName(extendedResourceName), "10"). // Exceeds quota of 4
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sClient, job)
 

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -840,6 +840,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				).
 				RequestAndLimit("replicated-job-1", corev1.ResourceCPU, "100m").
 				RequestAndLimit("replicated-job-1", corev1.ResourceMemory, "100M").
+				TerminationGracePeriod(1).
 				Obj()
 
 			ginkgo.By("Creating the jobSet", func() {
@@ -1301,6 +1302,7 @@ app = HelloWorld.bind()`,
 				WorkloadPriorityClass(managerLowWPC.Name).
 				Queue(kueue.LocalQueueName(managerLq.Name)).
 				RequestAndLimit(extraResourceGPUHighCost, "2").
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sManagerClient, lowJob)
 
@@ -1331,6 +1333,7 @@ app = HelloWorld.bind()`,
 				WorkloadPriorityClass(managerHighWPC.Name).
 				Queue(kueue.LocalQueueName(managerLq.Name)).
 				RequestAndLimit(extraResourceGPUHighCost, "2").
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sManagerClient, highJob)
 
@@ -1466,6 +1469,7 @@ app = HelloWorld.bind()`,
 				RequestAndLimit(corev1.ResourceMemory, "0.1G").
 				RequestAndLimit(extraResourceGPUHighCost, "2").
 				RequestAndLimit(extraResourceGPULowCost, "1").
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sManagerClient, lowJob)
 
@@ -1499,6 +1503,7 @@ app = HelloWorld.bind()`,
 				RequestAndLimit(corev1.ResourceMemory, "0.1G").
 				RequestAndLimit(extraResourceGPUHighCost, "1").
 				RequestAndLimit(extraResourceGPULowCost, "2").
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sManagerClient, highJob)
 
@@ -1556,6 +1561,7 @@ app = HelloWorld.bind()`,
 				RequestAndLimit(corev1.ResourceMemory, "0.1G").
 				RequestAndLimit(extraResourceGPUHighCost, "1").
 				RequestAndLimit(extraResourceGPULowCost, "2").
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sManagerClient, lowJob)
 
@@ -1597,6 +1603,7 @@ app = HelloWorld.bind()`,
 				RequestAndLimit(corev1.ResourceMemory, "0.1G").
 				RequestAndLimit(extraResourceGPUHighCost, "1").
 				RequestAndLimit(extraResourceGPULowCost, "2").
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sManagerClient, highJob)
 
@@ -1668,6 +1675,7 @@ app = HelloWorld.bind()`,
 				Queue(kueue.LocalQueueName(managerLq.Name)).
 				RequestAndLimit(extraResourceGPUHighCost, "2").
 				RequestAndLimit(extraResourceGPULowCost, "1").
+				TerminationGracePeriod(1).
 				Obj()
 			ginkgo.By("Creating the first job", func() {
 				util.MustCreate(ctx, k8sManagerClient, job1)
@@ -1701,6 +1709,7 @@ app = HelloWorld.bind()`,
 				Queue(kueue.LocalQueueName(managerLq.Name)).
 				RequestAndLimit(extraResourceGPUHighCost, "1").
 				RequestAndLimit(extraResourceGPULowCost, "2").
+				TerminationGracePeriod(1).
 				Obj()
 			ginkgo.By("Creating the second job", func() {
 				util.MustCreate(ctx, k8sManagerClient, job2)

--- a/test/e2e/multikueue/tas_test.go
+++ b/test/e2e/multikueue/tas_test.go
@@ -545,6 +545,7 @@ var _ = ginkgo.Describe("MultiKueue TAS with asymmetric quotas", func() {
 			PodAnnotation(kueue.PodSetPreferredTopologyAnnotation, corev1.LabelHostname).
 			Request(corev1.ResourceCPU, "1500m").
 			Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+			TerminationGracePeriod(1).
 			Obj()
 		util.MustCreate(ctx, k8sManagerClient, job)
 
@@ -595,6 +596,7 @@ var _ = ginkgo.Describe("MultiKueue TAS with asymmetric quotas", func() {
 			PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, corev1.LabelHostname).
 			Request(corev1.ResourceCPU, "500m").
 			Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+			TerminationGracePeriod(1).
 			Obj()
 		util.MustCreate(ctx, k8sManagerClient, job)
 

--- a/test/e2e/multikueuedra/dra_test.go
+++ b/test/e2e/multikueuedra/dra_test.go
@@ -182,6 +182,7 @@ var _ = ginkgo.Describe("MultiKueue with DRA", ginkgo.Label("feature:dra", "area
 				RequestAndLimit(corev1.ResourceCPU, "200m").
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				ResourceClaimTemplate("gpu", "gpu-template").
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sManagerClient, job)
 
@@ -282,6 +283,7 @@ var _ = ginkgo.Describe("MultiKueue with DRA", ginkgo.Label("feature:dra", "area
 				RequestAndLimit(corev1.ResourceCPU, "200m").
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				ResourceClaimTemplate("gpu", "missing-rct").
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sManagerClient, job)
 
@@ -325,6 +327,7 @@ var _ = ginkgo.Describe("MultiKueue with DRA", ginkgo.Label("feature:dra", "area
 				RequestAndLimit(corev1.ResourceCPU, "200m").
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				ResourceClaimTemplate("gpu", "worker1-only-rct").
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sManagerClient, job)
 
@@ -401,6 +404,7 @@ var _ = ginkgo.Describe("MultiKueue with DRA", ginkgo.Label("feature:dra", "area
 				RequestAndLimit(corev1.ResourceCPU, "200m").
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				ResourceClaimTemplate("gpu", "multi-pod-gpu-template").
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sManagerClient, job)
 

--- a/test/e2e/sequential/extended/managejobswithoutqueuename_test.go
+++ b/test/e2e/sequential/extended/managejobswithoutqueuename_test.go
@@ -426,6 +426,7 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Label("feature:mana
 			ginkgo.By("creating a pod without a queue name", func() {
 				testPod = testingpod.MakePod("test-pod", ns.Name).
 					Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+					TerminationGracePeriod(1).
 					Obj()
 				util.MustCreate(ctx, k8sClient, testPod)
 			})
@@ -479,6 +480,7 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Label("feature:mana
 					RequestAndLimit(corev1.ResourceCPU, "1").
 					RequestAndLimit(corev1.ResourceMemory, "2Gi").
 					Replicas(2).
+					TerminationGracePeriod(1).
 					Obj()
 				util.MustCreate(ctx, k8sClient, testDeploy)
 			})

--- a/test/e2e/sequential/extended/workloadidentifierannotations_test.go
+++ b/test/e2e/sequential/extended/workloadidentifierannotations_test.go
@@ -121,7 +121,7 @@ var _ = ginkgo.Describe("WorkloadIdentifierAnnotations", ginkgo.Ordered, ginkgo.
 			lwsName := strings.Repeat("a", 52)
 			lws := leaderworkersettesting.MakeLeaderWorkerSet(lwsName, ns.Name).
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
-				Size(3).Replicas(1).Queue(lq.Name).Obj()
+				Size(3).Replicas(1).Queue(lq.Name).TerminationGracePeriod(1).Obj()
 
 			ginkgo.By("create a LeaderWorkerSet", func() {
 				util.MustCreate(ctx, k8sClient, lws)

--- a/test/e2e/singlecluster/baseline/e2e_v1beta1_test.go
+++ b/test/e2e/singlecluster/baseline/e2e_v1beta1_test.go
@@ -46,6 +46,7 @@ var _ = ginkgo.Describe("Kueue v1beta1", ginkgo.Label("area:singlecluster", "fea
 			Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 			RequestAndLimit(corev1.ResourceCPU, "1").
 			RequestAndLimit(corev1.ResourceMemory, "20Mi").
+			TerminationGracePeriod(1).
 			Obj()
 		jobKey = client.ObjectKeyFromObject(sampleJob)
 	})

--- a/test/e2e/singlecluster/baseline/fair_sharing_test.go
+++ b/test/e2e/singlecluster/baseline/fair_sharing_test.go
@@ -99,6 +99,7 @@ var _ = ginkgo.Describe("Fair Sharing", ginkgo.Label("area:singlecluster", "feat
 					Completions(3).
 					RequestAndLimit(corev1.ResourceCPU, "1").
 					RequestAndLimit(corev1.ResourceMemory, "200Mi").
+					TerminationGracePeriod(1).
 					Obj()
 				util.MustCreate(ctx, k8sClient, job)
 			}

--- a/test/e2e/singlecluster/baseline/job_test.go
+++ b/test/e2e/singlecluster/baseline/job_test.go
@@ -55,6 +55,7 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 			Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 			RequestAndLimit(corev1.ResourceCPU, "200m").
 			RequestAndLimit(corev1.ResourceMemory, "20Mi").
+			TerminationGracePeriod(1).
 			Obj()
 		jobKey = client.ObjectKeyFromObject(sampleJob)
 	})
@@ -322,6 +323,7 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 					PriorityClass(highPriorityClass.Name).
 					RequestAndLimit(corev1.ResourceCPU, "1").
 					NodeSelector("instance-type", "on-demand"). // target the same flavor to cause preemption
+					TerminationGracePeriod(1).
 					Obj()
 				util.MustCreate(ctx, k8sClient, job)
 
@@ -359,6 +361,7 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 					WorkloadPriorityClass(highWorkloadPriorityClass.Name).
 					RequestAndLimit(corev1.ResourceCPU, "1").
 					NodeSelector("instance-type", "on-demand"). // target the same flavor to cause preemption
+					TerminationGracePeriod(1).
 					Obj()
 				util.MustCreate(ctx, k8sClient, job)
 
@@ -434,6 +437,7 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 					WorkloadPriorityClass(midPriority).
 					Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 					NodeSelector("instance-type", "on-demand").
+					TerminationGracePeriod(1).
 					Obj()
 				util.MustCreate(ctx, k8sClient, sampleJob)
 			})
@@ -477,6 +481,7 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 					WorkloadPriorityClass(lowPriority).
 					Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 					NodeSelector("instance-type", "on-demand").
+					TerminationGracePeriod(1).
 					Obj()
 				util.MustCreate(ctx, k8sClient, sampleJob2)
 			})
@@ -536,6 +541,7 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 			lowJob := testingjob.MakeJob("low", ns.Name).
 				Queue(kueue.LocalQueueName(localQueue.Name)).
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				TerminationGracePeriod(1).
 				Parallelism(1).
 				NodeSelector("instance-type", "on-demand").
 				Containers(
@@ -575,6 +581,7 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 				PriorityClass(highPriorityClass.Name).
 				Request(corev1.ResourceCPU, "1").
 				NodeSelector("instance-type", "on-demand").
+				TerminationGracePeriod(1).
 				Obj()
 
 			ginkgo.By("Creating a high-priority job", func() {
@@ -641,6 +648,7 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 					Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 					NodeSelector("instance-type", "on-demand").
 					RequestAndLimit(corev1.ResourceCPU, "2").
+					TerminationGracePeriod(1).
 					Obj()
 				util.MustCreate(ctx, k8sClient, sampleJob)
 			})

--- a/test/e2e/singlecluster/baseline/metrics_test.go
+++ b/test/e2e/singlecluster/baseline/metrics_test.go
@@ -261,6 +261,7 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Label("area:singlecluster", "feature:m
 				Queue(kueue.LocalQueueName(localQueue.Name)).
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				RequestAndLimit(corev1.ResourceCPU, "1").
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sClient, createdJob)
 
@@ -388,6 +389,7 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Label("area:singlecluster", "feature:m
 				Queue(kueue.LocalQueueName(localQueue1.Name)).
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				RequestAndLimit(corev1.ResourceCPU, "1").
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sClient, lowerJob1)
 
@@ -408,6 +410,7 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Label("area:singlecluster", "feature:m
 				Queue(kueue.LocalQueueName(localQueue2.Name)).
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				RequestAndLimit(corev1.ResourceCPU, "1").
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sClient, lowerJob2)
 
@@ -429,6 +432,7 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Label("area:singlecluster", "feature:m
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				PriorityClass(highPriorityClass.Name).
 				RequestAndLimit(corev1.ResourceCPU, "3").
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sClient, blockerJob)
 
@@ -450,6 +454,7 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Label("area:singlecluster", "feature:m
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				PriorityClass(highPriorityClass.Name).
 				RequestAndLimit(corev1.ResourceCPU, "4").
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sClient, higherJob1)
 
@@ -458,6 +463,7 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Label("area:singlecluster", "feature:m
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				PriorityClass(highPriorityClass.Name).
 				RequestAndLimit(corev1.ResourceCPU, "4").
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sClient, higherJob2)
 		})

--- a/test/e2e/singlecluster/baseline/statefulset_test.go
+++ b/test/e2e/singlecluster/baseline/statefulset_test.go
@@ -249,6 +249,7 @@ var _ = ginkgo.Describe("StatefulSet integration", ginkgo.Label("area:singleclus
 				RequestAndLimit(corev1.ResourceCPU, "200m").
 				Replicas(0).
 				Queue(lq.Name).
+				TerminationGracePeriod(1).
 				Obj()
 			ginkgo.By("Create StatefulSet", func() {
 				util.MustCreate(ctx, k8sClient, statefulSet)
@@ -348,6 +349,7 @@ var _ = ginkgo.Describe("StatefulSet integration", ginkgo.Label("area:singleclus
 				RequestAndLimit(corev1.ResourceCPU, "200m").
 				Replicas(3).
 				Queue(fmt.Sprintf("%s-invalid", localQueueName)).
+				TerminationGracePeriod(1).
 				Obj()
 			ginkgo.By("Create StatefulSet", func() {
 				util.MustCreate(ctx, k8sClient, statefulSet)

--- a/test/e2e/singlecluster/baseline/visibility_test.go
+++ b/test/e2e/singlecluster/baseline/visibility_test.go
@@ -468,6 +468,7 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 						Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 						RequestAndLimit(corev1.ResourceCPU, "2").
 						PriorityClass(jobCase.priority).
+						TerminationGracePeriod(1).
 						Obj()
 					util.MustCreate(ctx, k8sClient, job)
 				}

--- a/test/e2e/singlecluster/extended/pytorchjob_test.go
+++ b/test/e2e/singlecluster/extended/pytorchjob_test.go
@@ -86,6 +86,7 @@ var _ = ginkgo.Describe("PyTorch integration", ginkgo.Label("area:singlecluster"
 				Image(kftraining.PyTorchJobReplicaTypeMaster, util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				Request(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceCPU, "1").
 				Request(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceMemory, "200Mi").
+				TerminationGracePeriod(kftraining.PyTorchJobReplicaTypeMaster, 1).
 				Obj()
 
 			ginkgo.By("Create a PyTorch", func() {

--- a/test/e2e/singlecluster/extended/tas_test.go
+++ b/test/e2e/singlecluster/extended/tas_test.go
@@ -585,6 +585,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", ginkgo.Label("area:singleclus
 				RequestAndLimit(corev1.ResourceMemory, "20Mi").
 				PodAnnotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sClient, sampleJob)
 

--- a/test/e2e/tas/baseline/hotswap_test.go
+++ b/test/e2e/tas/baseline/hotswap_test.go
@@ -142,6 +142,7 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 					PodAnnotation(kueue.PodSetSliceSizeAnnotation, "2").
 					CompletionMode(batchv1.IndexedCompletion).
 					BackoffLimit(1).
+					TerminationGracePeriod(1).
 					Obj()
 
 				util.MustCreate(ctx, k8sClient, sampleJob)
@@ -231,6 +232,7 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 						Effect:            corev1.TaintEffectNoExecute,
 						TolerationSeconds: &tolerationSeconds,
 					}).
+					TerminationGracePeriod(1).
 					Obj()
 
 				util.MustCreate(ctx, k8sClient, sampleJob)
@@ -320,6 +322,7 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 					CompletionMode(batchv1.IndexedCompletion).
 					BackoffLimit(1).
 					SchedulingGate(artificialGate).
+					TerminationGracePeriod(1).
 					Obj()
 
 				util.MustCreate(ctx, k8sClient, sampleJob)
@@ -456,6 +459,7 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 					PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, utiltesting.DefaultBlockTopologyLevel).
 					CompletionMode(batchv1.IndexedCompletion).
 					BackoffLimit(1).
+					TerminationGracePeriod(1).
 					Obj()
 
 				util.MustCreate(ctx, k8sClient, sampleJob)

--- a/test/e2e/tas/baseline/job_test.go
+++ b/test/e2e/tas/baseline/job_test.go
@@ -237,6 +237,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Job", func() {
 				RequestAndLimit(extraResource, "1").
 				PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, utiltesting.DefaultBlockTopologyLevel).
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sClient, sampleJob)
 
@@ -293,6 +294,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Job", func() {
 				Indexed(true).
 				RequestAndLimit(extraResource, "1").
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sClient, sampleJob)
 

--- a/test/e2e/tas/baseline/pod_group_test.go
+++ b/test/e2e/tas/baseline/pod_group_test.go
@@ -137,7 +137,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Pod group", func() {
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				Request(extraResource, "1").
 				Limit(extraResource, "1")
-			podGroup := basePod.MakeIndexedGroup(numPods)
+			podGroup := basePod.TerminationGracePeriod(1).MakeIndexedGroup(numPods)
 
 			for _, pod := range podGroup {
 				util.MustCreate(ctx, k8sClient, pod)
@@ -219,7 +219,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Pod group", func() {
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				Request(extraResource, "1").
 				Limit(extraResource, "1")
-			podGroup := basePod.MakeIndexedGroup(numPods)
+			podGroup := basePod.TerminationGracePeriod(1).MakeIndexedGroup(numPods)
 
 			for _, pod := range podGroup {
 				util.MustCreate(ctx, k8sClient, pod)

--- a/test/e2e/tas/extended/hotswap_test.go
+++ b/test/e2e/tas/extended/hotswap_test.go
@@ -145,6 +145,7 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 				).
 				RequestAndLimit(replicatedJobName, extraResource, "1").
 				RequestAndLimit(replicatedJobName, corev1.ResourceCPU, "200m").
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sClient, sampleJob)
 
@@ -224,6 +225,7 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 				).
 				RequestAndLimit(replicatedJobName, extraResource, "1").
 				RequestAndLimit(replicatedJobName, corev1.ResourceCPU, "200m").
+				TerminationGracePeriod(1).
 				Obj()
 			util.MustCreate(ctx, k8sClient, sampleJob)
 


### PR DESCRIPTION
Cherry pick of #11492 on release-0.17.

#11492: Set TerminationGracePeriod=1s for e2e tests using BehaviorWaitForDeletion

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```