### PR TITLE
[integration] Drop ginkgo.Ordered from ResourceFlavor controller singlecluster tests

### DIFF
--- a/test/integration/singlecluster/controller/core/resourceflavor_controller_test.go
+++ b/test/integration/singlecluster/controller/core/resourceflavor_controller_test.go
@@ -27,23 +27,17 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("ResourceFlavor controller", ginkgo.Label("controller:resourceflavor", "area:core"), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("ResourceFlavor controller", ginkgo.Label("controller:resourceflavor", "area:core"), func() {
 	var ns *corev1.Namespace
 
-	ginkgo.BeforeAll(func() {
-		fwk.StartManager(ctx, cfg, managerSetup)
-	})
-
-	ginkgo.AfterAll(func() {
-		fwk.StopManager(ctx)
-	})
-
 	ginkgo.BeforeEach(func() {
+		fwk.StartManager(ctx, cfg, managerSetup)
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "core-resourceflavor-")
 	})
 
 	ginkgo.AfterEach(func() {
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		fwk.StopManager(ctx)
 	})
 
 	ginkgo.When("one clusterQueue references resourceFlavors", func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it:
Updates the **ResourceFlavor controller** `Describe` block in `test/integration/singlecluster/controller/core/resourceflavor_controller_test.go`.
- Removes `ginkgo.Ordered` and `ginkgo.ContinueOnFailure` from that `Describe` block only.
- Moves manager `StartManager`/`StopManager` from `BeforeAll`/`AfterAll` into `BeforeEach`/`AfterEach` (see [Parallelize Fair Sharing Integration Test (66% speedup) #8726](https://github.com/kubernetes-sigs/kueue/pull/8726)).
Continues the split from [Eliminate ginkgo.Ordered for singlecluster integration tests #9880](https://github.com/kubernetes-sigs/kueue/issues/9880). Follows webhook work including [ResourceFlavor webhook #11467](https://github.com/kubernetes-sigs/kueue/pull/11467) and [AdmissionCheck controller #11524](https://github.com/kubernetes-sigs/kueue/pull/11524).

#### Which issue(s) this PR fixes:
Part of #9880

#### Special notes for your reviewer:
- One `Describe` block only; inner `When` hooks are unchanged.
- No changes to `suite_test.go` or `test/integration/framework`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
