### PR TITLE
[integration] Drop ginkgo.Ordered from Workload preemption metrics singlecluster tests

### DIFF
--- a/test/integration/singlecluster/controller/core/workload_preemption_eviction_metrics_test.go
+++ b/test/integration/singlecluster/controller/core/workload_preemption_eviction_metrics_test.go
@@ -34,15 +34,7 @@ const (
 	pePendingHighPriority int32 = 1
 )
 
-var _ = ginkgo.Describe("Workload eviction to pending metrics", ginkgo.Label("controller:workload", "area:core"), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-	ginkgo.BeforeAll(func() {
-		fwk.StartManager(ctx, cfg, managerAndSchedulerSetup)
-	})
-
-	ginkgo.AfterAll(func() {
-		fwk.StopManager(ctx)
-	})
-
+var _ = ginkgo.Describe("Workload eviction to pending metrics", ginkgo.Label("controller:workload", "area:core"), func() {
 	var (
 		ns          *corev1.Namespace
 		alphaFlavor *kueue.ResourceFlavor
@@ -51,6 +43,7 @@ var _ = ginkgo.Describe("Workload eviction to pending metrics", ginkgo.Label("co
 	)
 
 	ginkgo.BeforeEach(func() {
+		fwk.StartManager(ctx, cfg, managerAndSchedulerSetup)
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "pe-pending-metrics-")
 		alphaFlavor = utiltestingapi.MakeResourceFlavor("alpha").Obj()
 		util.MustCreate(ctx, k8sClient, alphaFlavor)
@@ -72,6 +65,7 @@ var _ = ginkgo.Describe("Workload eviction to pending metrics", ginkgo.Label("co
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, alphaFlavor, true)
+		fwk.StopManager(ctx)
 	})
 
 	ginkgo.It("should record workload_eviction_latency_seconds when a preemptee returns to Pending", func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it:
Updates the **Workload eviction to pending metrics** `Describe` block in `test/integration/singlecluster/controller/core/workload_preemption_eviction_metrics_test.go`.
- Removes `ginkgo.Ordered` and `ginkgo.ContinueOnFailure` from that `Describe` block only.
- Moves `StartManager`/`StopManager` from `BeforeAll`/`AfterAll` into `BeforeEach`/`AfterEach` (see [Parallelize Fair Sharing Integration Test (66% speedup) #8726](https://github.com/kubernetes-sigs/kueue/pull/8726)).
- Keeps `managerAndSchedulerSetup` unchanged.
Continues the split from [Eliminate ginkgo.Ordered for singlecluster integration tests #9880](https://github.com/kubernetes-sigs/kueue/issues/9880). Follows [#11524](https://github.com/kubernetes-sigs/kueue/pull/11524) and [#11525](https://github.com/kubernetes-sigs/kueue/pull/11525).

#### Which issue(s) this PR fixes:
Part of #9880

#### Special notes for your reviewer:
- One `Describe` block only; test logic and `BeforeEach` resource setup are unchanged.
- No changes to `suite_test.go` or `test/integration/framework`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
