### PR TITLE
Automated cherry pick of #11347: Reorganize drop finalizers logic.

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -276,12 +276,9 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 		err = r.ignoreUnretryableError(log, err)
 	}()
 
-	dropFinalizers := false
-	if cJob, isComposable := job.(ComposableJob); isComposable {
-		dropFinalizers, err = cJob.Load(ctx, r.client, &req.NamespacedName)
-	} else {
-		err = r.client.Get(ctx, req.NamespacedName, object)
-		dropFinalizers = apierrors.IsNotFound(err) || !object.GetDeletionTimestamp().IsZero()
+	shouldFinalize, err := r.loadJob(ctx, &req.NamespacedName, job)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	if jws, implements := job.(JobWithSkip); implements {
@@ -290,42 +287,11 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	if dropFinalizers {
-		// Remove workload finalizer
-		workloads := &kueue.WorkloadList{}
-
-		if cJob, isComposable := job.(ComposableJob); isComposable {
-			var err error
-			workloads, err = cJob.ListChildWorkloads(ctx, r.client, req.NamespacedName)
-			if err != nil {
-				log.Error(err, "Removing finalizer")
-				return ctrl.Result{}, err
-			}
-		} else {
-			if err := r.client.List(ctx, workloads, client.InNamespace(req.Namespace), OwnerReferenceIndexFieldMatcher(job.GVK(), req.Name)); err != nil {
-				log.Error(err, "Unable to list child workloads")
-				return ctrl.Result{}, err
-			}
-		}
-		for i := range workloads.Items {
-			err := workload.RemoveFinalizer(ctx, r.client, &workloads.Items[i])
-			if client.IgnoreNotFound(err) != nil {
-				log.Error(err, "Removing finalizer")
-				return ctrl.Result{}, err
-			}
-		}
-
-		// Remove job finalizer
-		if !object.GetDeletionTimestamp().IsZero() {
-			if err = r.finalizeJob(ctx, job); err != nil {
-				return ctrl.Result{}, err
-			}
+	if shouldFinalize {
+		if err := r.finalize(ctx, req.NamespacedName, job); err != nil {
+			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
-	}
-
-	if err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	if features.Enabled(features.ManagedJobsNamespaceSelectorAlwaysRespected) {
@@ -645,6 +611,79 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 	// For elastic jobs, pod ungating is handled by the ElasticJobUngater controller.
 	log.V(3).Info("Job running with admitted workload, nothing to do")
 	return ctrl.Result{}, nil
+}
+
+// loadJob retrieves and loads the specified job resource into memory.
+// Returns true if the job should be finalized and an error if loading fails.
+func (r *JobReconciler) loadJob(ctx context.Context, key *types.NamespacedName, job GenericJob) (bool, error) {
+	if cJob, isComposable := job.(ComposableJob); isComposable {
+		return cJob.Load(ctx, r.client, key)
+	}
+	obj := job.Object()
+	if err := r.client.Get(ctx, *key, obj); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	return !obj.GetDeletionTimestamp().IsZero(), nil
+}
+
+// finalize removes finalizers from workloads and the job itself,
+// ensuring proper cleanup during object deletion.
+func (r *JobReconciler) finalize(ctx context.Context, key types.NamespacedName, job GenericJob) error {
+	// Remove workloads finalizer
+	if err := r.finalizeWorkloads(ctx, key, job); client.IgnoreNotFound(err) != nil {
+		return err
+	}
+
+	// Remove job finalizer
+	if !job.Object().GetDeletionTimestamp().IsZero() {
+		if err := r.finalizeJob(ctx, job); client.IgnoreNotFound(err) != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// getWorkloads retrieves a list of workloads associated with the specified job.
+func (r *JobReconciler) getWorkloads(ctx context.Context, key types.NamespacedName, job GenericJob) ([]kueue.Workload, error) {
+	log := ctrl.LoggerFrom(ctx)
+	workloads := &kueue.WorkloadList{}
+
+	var err error
+	if cJob, isComposable := job.(ComposableJob); isComposable {
+		workloads, err = cJob.ListChildWorkloads(ctx, r.client, key)
+	} else {
+		err = r.client.List(ctx, workloads,
+			client.InNamespace(key.Namespace),
+			OwnerReferenceIndexFieldMatcher(job.GVK(), key.Name),
+		)
+	}
+	if err != nil {
+		log.Error(err, "Unable to list child workloads")
+		return nil, err
+	}
+
+	return workloads.Items, nil
+}
+
+// finalizeWorkloads removes finalizers from workloads associated with the specified job.
+func (r *JobReconciler) finalizeWorkloads(ctx context.Context, key types.NamespacedName, job GenericJob) error {
+	log := ctrl.LoggerFrom(ctx)
+	workloads, err := r.getWorkloads(ctx, key, job)
+	if err != nil {
+		return err
+	}
+	for i := range workloads {
+		wl := &workloads[i]
+		if err := workload.RemoveFinalizer(ctx, r.client, wl); client.IgnoreNotFound(err) != nil {
+			log.Error(err, "Removing finalizer")
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *JobReconciler) handleQueueNameChange(ctx context.Context, job GenericJob, wl *kueue.Workload) error {

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -591,7 +591,8 @@ func TestReconciler(t *testing.T) {
 		featureGates map[featuregate.Feature]bool
 
 		reconcilerOptions []jobframework.Option
-		job               batchv1.Job
+		reconcileKey      *types.NamespacedName
+		job               *batchv1.Job
 		workloads         []kueue.Workload
 		otherJobs         []batchv1.Job
 		priorityClasses   []client.Object
@@ -600,6 +601,42 @@ func TestReconciler(t *testing.T) {
 		wantEvents        []utiltesting.EventRecord
 		wantErr           error
 	}{
+		"job is not found": {
+			reconcileKey: &types.NamespacedName{Namespace: "ns", Name: "deleted_job"},
+			job:          nil,
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					ControllerReference(gvk, "deleted_job", "deleted_job").
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					ControllerReference(gvk, "deleted_job", "deleted_job").
+					Obj(),
+			},
+		},
+		"job is deleted": {
+			job: baseJobWrapper.Clone().
+				DeletionTimestamp(now).
+				Finalizers(kueue.ResourceInUseFinalizerName).
+				Obj(),
+			wantJob: *baseJobWrapper.Clone().
+				DeletionTimestamp(now).
+				Finalizers(kueue.ResourceInUseFinalizerName).
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					ControllerReference(gvk, baseJobWrapper.GetName(), string(baseJobWrapper.GetUID())).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					ControllerReference(gvk, baseJobWrapper.GetName(), string(baseJobWrapper.GetUID())).
+					Obj(),
+			},
+		},
 		"PodsReady is set to False before Workload is Admitted": {
 			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:                     false,
@@ -608,7 +645,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job:     *baseJobWrapper.DeepCopy(),
+			job:     baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.DeepCopy(),
 			workloads: []kueue.Workload{*baseWorkloadWrapper.Clone().
 				AdmittedAt(false, now).
@@ -633,7 +670,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job:     *baseJobWrapper.DeepCopy(),
+			job:     baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.DeepCopy(),
 			workloads: []kueue.Workload{*baseWorkloadWrapper.Clone().
 				AdmittedAt(true, now).
@@ -658,7 +695,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Ready(9).
 				Active(10).
@@ -697,7 +734,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Ready(10).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -732,7 +769,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Ready(10).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -761,7 +798,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Ready(9).
 				Failed(1).
 				Obj(),
@@ -798,7 +835,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Ready(9).
 				Failed(1).
@@ -837,7 +874,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Ready(10).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -872,7 +909,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job:     *baseJobWrapper.DeepCopy(),
+			job:     baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.DeepCopy(),
 			workloads: []kueue.Workload{*baseWorkloadWrapper.Clone().
 				AdmittedAt(true, now).
@@ -903,7 +940,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Ready(10).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -938,7 +975,7 @@ func TestReconciler(t *testing.T) {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
 			},
-			job:     *baseJobWrapper.DeepCopy(),
+			job:     baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.DeepCopy(),
 			workloads: []kueue.Workload{*baseWorkloadWrapper.Clone().
 				AdmittedAt(true, now).
@@ -970,7 +1007,7 @@ func TestReconciler(t *testing.T) {
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
 			},
-			job: *baseJobWrapper.DeepCopy(),
+			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(false).
 				PodLabel(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
@@ -1000,7 +1037,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				SetAnnotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
 				SetAnnotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
 				UID("test-uid").
@@ -1036,7 +1073,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Label("toCopyKey", "toCopyValue").
 				Label("dontCopyKey", "dontCopyValue").
 				UID("test-uid").
@@ -1075,8 +1112,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
-				Obj(),
+			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(false).
 				PodLabel("ac-key", "ac-value").
@@ -1130,7 +1166,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -1224,7 +1260,7 @@ func TestReconciler(t *testing.T) {
 					},
 				}),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -1319,7 +1355,7 @@ func TestReconciler(t *testing.T) {
 					},
 				}),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -1414,7 +1450,7 @@ func TestReconciler(t *testing.T) {
 					},
 				}),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			workloads: []kueue.Workload{
@@ -1512,7 +1548,7 @@ func TestReconciler(t *testing.T) {
 					},
 				}),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -1607,7 +1643,7 @@ func TestReconciler(t *testing.T) {
 					},
 				}),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			workloads: []kueue.Workload{
@@ -1697,7 +1733,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -1757,7 +1793,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -1841,7 +1877,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -1925,7 +1961,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2009,7 +2045,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2094,7 +2130,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(true).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2168,8 +2204,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
-				Obj(),
+			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(true).
 				Obj(),
@@ -2243,8 +2278,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
-				Obj(),
+			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(true).
 				Obj(),
@@ -2318,8 +2352,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
-				Obj(),
+			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(true).
 				Obj(),
@@ -2393,7 +2426,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				NodeSelector("provisioning", "spot").
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2446,8 +2479,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
-				Obj(),
+			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(false).
 				PodAnnotation("annotation-key1", "common-value").
@@ -2561,7 +2593,7 @@ func TestReconciler(t *testing.T) {
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
 			},
-			job: *baseJobWrapper.DeepCopy(),
+			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(false).
 				PodLabel(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
@@ -2594,7 +2626,7 @@ func TestReconciler(t *testing.T) {
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
 			},
-			job:     *baseJobWrapper.DeepCopy(),
+			job:     baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.DeepCopy(),
 			workloads: []kueue.Workload{
 				*baseWorkloadWrapper.Clone().
@@ -2621,7 +2653,7 @@ func TestReconciler(t *testing.T) {
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
 			},
-			job:     *baseJobWrapper.DeepCopy(),
+			job:     baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.DeepCopy(),
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("a", "ns").
@@ -2656,7 +2688,7 @@ func TestReconciler(t *testing.T) {
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				SetAnnotation(JobMinParallelismAnnotation, "5").
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2704,7 +2736,7 @@ func TestReconciler(t *testing.T) {
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				SetAnnotation(JobMinParallelismAnnotation, "5").
 				Suspend(false).
 				Obj(),
@@ -2745,7 +2777,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				Queue("test-queue").
@@ -2787,7 +2819,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(true).
 				Queue("test-queue-new").
@@ -2826,7 +2858,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(true).
 				WorkloadPriorityClass(highWPCWrapper.Name).
@@ -2878,7 +2910,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(true).
 				PriorityClass(basePCWrapper.Name).
@@ -2922,7 +2954,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				Queue("test-queue").
@@ -2962,7 +2994,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *utiltestingjob.MakeJob("job", "ns").
+			job: utiltestingjob.MakeJob("job", "ns").
 				Suspend(false).
 				Obj(),
 			wantJob: *utiltestingjob.MakeJob("job", "ns").
@@ -2974,7 +3006,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				OwnerReference("parent", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Suspend(false).
@@ -3007,7 +3039,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				OwnerReference("parent", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Suspend(false).
@@ -3049,7 +3081,7 @@ func TestReconciler(t *testing.T) {
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				OwnerReference("parent", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Suspend(false).
@@ -3092,7 +3124,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				OwnerReference("parent", batchv1.SchemeGroupVersion.WithKind("Job")).
@@ -3138,7 +3170,7 @@ func TestReconciler(t *testing.T) {
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				Parallelism(5).
@@ -3179,7 +3211,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"when workload is evicted, suspend, reset startTime and restore node affinity": {
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(false).
 				StartTime(now).
 				NodeSelector("provisioning", "spot").
@@ -3220,7 +3252,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(true).
 				StartTime(now).
 				NodeSelector("provisioning", "spot").
@@ -3254,7 +3286,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(true).
 				NodeSelector("provisioning", "spot").
 				Active(10).
@@ -3287,7 +3319,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Condition(batchv1.JobCondition{
 					Type:    batchv1.JobComplete,
 					Status:  corev1.ConditionTrue,
@@ -3334,7 +3366,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().Obj(),
+			job: baseJobWrapper.DeepCopy(),
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("a", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
@@ -3377,7 +3409,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				Queue("test-queue").
@@ -3425,7 +3457,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				Queue("test-queue").
@@ -3473,7 +3505,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				Queue("test-queue").
@@ -3523,7 +3555,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
 				Obj(),
 			workloads: []kueue.Workload{},
@@ -3537,7 +3569,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				Label(controllerconsts.PrebuiltWorkloadLabel, "missing-workload").
@@ -3563,7 +3595,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
@@ -3610,7 +3642,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
@@ -3656,7 +3688,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
 				Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
@@ -3710,7 +3742,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().Toleration(corev1.Toleration{
+			job: baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
 				Operator: corev1.TolerationOpExists,
 				Effect:   corev1.TaintEffectNoSchedule,
@@ -3778,7 +3810,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().Toleration(corev1.Toleration{
+			job: baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
 				Operator: corev1.TolerationOpExists,
 				Effect:   corev1.TaintEffectNoSchedule,
@@ -3856,7 +3888,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().Toleration(corev1.Toleration{
+			job: baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
 				Operator: corev1.TolerationOpExists,
 				Effect:   corev1.TaintEffectNoSchedule,
@@ -3910,7 +3942,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(true).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -3964,7 +3996,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Suspend(true).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -4028,7 +4060,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -4058,7 +4090,7 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:                     false,
 				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
 			},
-			job: *baseJobWrapper.Clone().
+			job: baseJobWrapper.Clone().
 				Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().
@@ -4103,7 +4135,7 @@ func TestReconciler(t *testing.T) {
 					"managed-by-kueue": "true",
 				})),
 			},
-			job: *baseJobWrapper.
+			job: baseJobWrapper.
 				Clone().
 				Queue("test-queue").
 				Suspend(false).
@@ -4126,7 +4158,7 @@ func TestReconciler(t *testing.T) {
 				})),
 				jobframework.WithManageJobsWithoutQueueName(true),
 			},
-			job: *utiltestingjob.MakeJob("job", "labelled-ns").
+			job: utiltestingjob.MakeJob("job", "labelled-ns").
 				Queue("test-queue").
 				Suspend(true).
 				UID("test-uid").
@@ -4182,27 +4214,28 @@ func TestReconciler(t *testing.T) {
 					Label("managed-by-kueue", "true").
 					Obj()
 
-				objs := append(tc.priorityClasses, &tc.job, utiltestingapi.MakeResourceFlavor("default").Obj(), testNamespace, labelledNamespace)
-				kcBuilder := clientBuilder.
-					WithObjects(objs...)
-
-				if len(tc.otherJobs) > 0 {
-					kcBuilder = kcBuilder.WithLists(&batchv1.JobList{Items: tc.otherJobs})
+				objs := append(tc.priorityClasses, utiltestingapi.MakeResourceFlavor("default").Obj(), testNamespace, labelledNamespace)
+				if tc.job != nil {
+					objs = append(objs, tc.job)
 				}
 
-				for i := range tc.workloads {
-					kcBuilder = kcBuilder.WithStatusSubresource(&tc.workloads[i])
+				kClient := clientBuilder.
+					WithObjects(objs...).
+					WithLists(&batchv1.JobList{Items: tc.otherJobs}).
+					WithStatusSubresource(&kueue.Workload{}).
+					Build()
+
+				useesPrebuiltWorkload := false
+				if tc.job != nil {
+					// For prebuilt workloads we are skipping the ownership setup in the test body and
+					// expect the reconciler to do it.
+					_, useesPrebuiltWorkload = tc.job.Labels[controllerconsts.PrebuiltWorkloadLabel]
 				}
 
-				// For prebuilt workloads we are skipping the ownership setup in the test body and
-				// expect the reconciler to do it.
-				_, useesPrebuiltWorkload := tc.job.Labels[controllerconsts.PrebuiltWorkloadLabel]
-
-				kClient := kcBuilder.Build()
 				for _, testWl := range tc.workloads {
 					controller := metav1.GetControllerOfNoCopy(&testWl)
 					if !useesPrebuiltWorkload && controller == nil {
-						if err := ctrl.SetControllerReference(&tc.job, &testWl, kClient.Scheme()); err != nil {
+						if err := ctrl.SetControllerReference(tc.job, &testWl, kClient.Scheme()); err != nil {
 							t.Fatalf("Could not setup owner reference in Workloads: %v", err)
 						}
 					}
@@ -4217,16 +4250,19 @@ func TestReconciler(t *testing.T) {
 					t.Errorf("Error creating the reconciler: %v", err)
 				}
 
-				jobKey := client.ObjectKeyFromObject(&tc.job)
-				_, err = reconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: jobKey,
-				})
+				var reconcileRequest reconcile.Request
+				if tc.reconcileKey != nil {
+					reconcileRequest.NamespacedName = *tc.reconcileKey
+				} else {
+					reconcileRequest.NamespacedName = client.ObjectKeyFromObject(tc.job)
+				}
+				_, err = reconciler.Reconcile(ctx, reconcileRequest)
 				if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
 					t.Errorf("Reconcile returned error (-want,+got):\n%s", diff)
 				}
 
 				var gotJob batchv1.Job
-				if err := kClient.Get(ctx, jobKey, &gotJob); client.IgnoreNotFound(err) != nil {
+				if err := kClient.Get(ctx, reconcileRequest.NamespacedName, &gotJob); client.IgnoreNotFound(err) != nil {
 					t.Fatalf("Could not get Job after reconcile: %v", err)
 				}
 				if diff := cmp.Diff(tc.wantJob, gotJob, jobCmpOpts...); diff != "" {

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -634,7 +634,10 @@ func (p *Pod) Load(ctx context.Context, c client.Client, key *types.NamespacedNa
 
 	if len(nsKey) == 1 {
 		if err := c.Get(ctx, *key, &p.pod); err != nil {
-			return apierrors.IsNotFound(err), err
+			if client.IgnoreNotFound(err) != nil {
+				return false, err
+			}
+			return true, nil
 		}
 		p.isFound = true
 

--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -89,7 +89,7 @@ func (j *JobWrapper) GeneratedName(name string) *JobWrapper {
 
 // DeletionTimestamp sets the deletionTimestamp.
 func (j *JobWrapper) DeletionTimestamp(t time.Time) *JobWrapper {
-	j.ObjectMeta.DeletionTimestamp = new(metav1.NewTime(t))
+	j.ObjectMeta.DeletionTimestamp = ptr.To(metav1.NewTime(t))
 	return j
 }
 

--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -87,6 +87,18 @@ func (j *JobWrapper) GeneratedName(name string) *JobWrapper {
 	return j
 }
 
+// DeletionTimestamp sets the deletionTimestamp.
+func (j *JobWrapper) DeletionTimestamp(t time.Time) *JobWrapper {
+	j.ObjectMeta.DeletionTimestamp = new(metav1.NewTime(t))
+	return j
+}
+
+// Finalizers sets the finalizers.
+func (j *JobWrapper) Finalizers(finalizers ...string) *JobWrapper {
+	j.ObjectMeta.Finalizers = finalizers
+	return j
+}
+
 func (j *JobWrapper) BackoffLimit(limit int32) *JobWrapper {
 	j.Spec.BackoffLimit = ptr.To(limit)
 	return j


### PR DESCRIPTION
Cherry pick of #11347 on release-0.16.

#11347: Reorganize drop finalizers logic.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```