### PR TITLE
Automated cherry pick of #11296: Prevent finishing workload immediately after creation.

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -199,24 +199,6 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// Finish orphaned workloads whose controller owner no longer exists.
-	// The ownerReference still points to a non-existent object (e.g., a
-	// Deployment-owned pod deleted after PodsReady timeout eviction).
-	if features.Enabled(features.FinishOrphanedWorkloads) && wl.DeletionTimestamp.IsZero() {
-		if ownerGone, err := r.isControllerOwnerGone(ctx, &wl); err != nil {
-			return ctrl.Result{}, err
-		} else if ownerGone {
-			log.V(2).Info("Workload is orphaned, finishing to release quota")
-			if err := workload.Finish(ctx, r.client, &wl, kueue.WorkloadFinishedReasonOwnerNotFound, "The workload's owner no longer exists", r.clock, r.roleTracker); err != nil {
-				return ctrl.Result{}, client.IgnoreNotFound(err)
-			}
-			if err := workload.RemoveFinalizer(ctx, r.client, &wl); err != nil {
-				return ctrl.Result{}, client.IgnoreNotFound(err)
-			}
-			return ctrl.Result{}, nil
-		}
-	}
-
 	finishedCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadFinished)
 	if finishedCond != nil && finishedCond.Status == metav1.ConditionTrue {
 		if !features.Enabled(features.ObjectRetentionPolicies) || r.workloadRetention == nil || r.workloadRetention.afterFinished == nil {
@@ -1092,34 +1074,6 @@ func (r *WorkloadReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.Conf
 		Watches(&kueue.ClusterQueue{}, wqh).
 		Watches(&kueue.LocalQueue{}, wqh).
 		Complete(WithLeadingManager(mgr, r, &kueue.Workload{}, cfg))
-}
-
-// isControllerOwnerGone checks whether the controller owner of the workload
-// still exists. Returns true if the controller owner reference points to an
-// object that no longer exists (NotFound) or whose UID no longer matches.
-// This is used to detect stale workloads whose owning pod was deleted
-// (e.g., by eviction) and replaced by a new pod from a Deployment.
-func (r *WorkloadReconciler) isControllerOwnerGone(ctx context.Context, wl *kueue.Workload) (bool, error) {
-	ref := metav1.GetControllerOf(wl)
-	if ref == nil {
-		return false, nil
-	}
-	obj := &metav1.PartialObjectMetadata{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: ref.APIVersion,
-			Kind:       ref.Kind,
-		},
-	}
-	key := client.ObjectKey{Namespace: wl.Namespace, Name: ref.Name}
-	if err := r.client.Get(ctx, key, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return true, nil
-		}
-		return false, err
-	}
-	// A different UID means the original owner was deleted and a new object
-	// with the same name was created.
-	return obj.UID != ref.UID, nil
 }
 
 // admittedNotReadyWorkload returns the underlying cause and remaining time for

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -2837,23 +2837,6 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 		},
-		"workload with gone controller owner should be finished": {
-			featureGates: map[featuregate.Feature]bool{
-				features.FinishOrphanedWorkloads: true,
-			},
-			workload: utiltestingapi.MakeWorkload("wl", "ns").
-				ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "deleted-job", "gone-uid").
-				Obj(),
-			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
-				ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "deleted-job", "gone-uid").
-				Condition(metav1.Condition{
-					Type:    kueue.WorkloadFinished,
-					Status:  metav1.ConditionTrue,
-					Reason:  kueue.WorkloadFinishedReasonOwnerNotFound,
-					Message: "The workload's owner no longer exists",
-				}).
-				Obj(),
-		},
 	}
 	for name, tc := range cases {
 		for _, enabled := range []bool{false, true} {

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -687,7 +687,7 @@ func (r *JobReconciler) finalizeWorkloads(ctx context.Context, key types.Namespa
 		if features.Enabled(features.FinishOrphanedWorkloads) && controllerutil.HasControllerReference(wl) {
 			log.V(2).Info("Workload is orphaned; finishing to release quota")
 			err := workload.Finish(ctx, r.client, wl, kueue.WorkloadFinishedReasonOwnerNotFound,
-				"The workload's owner no longer exists", r.clock)
+				"The workload's owner no longer exists", r.clock, r.roleTracker)
 			if err != nil {
 				if client.IgnoreNotFound(err) != nil {
 					log.Error(err, "Finishing orphaned workload")

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -45,6 +45,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -678,6 +679,24 @@ func (r *JobReconciler) finalizeWorkloads(ctx context.Context, key types.Namespa
 	}
 	for i := range workloads {
 		wl := &workloads[i]
+
+		// Finish the orphaned workload. This can happen when the workload is readmitted
+		// after eviction (e.g., waitForPodsReady) due to the workload waiting retention policy.
+		// We need to finish the workload to prevent such a situation.
+		// For example, a Deployment-owned pod deleted after PodsReady timeout eviction.
+		if features.Enabled(features.FinishOrphanedWorkloads) && controllerutil.HasControllerReference(wl) {
+			log.V(2).Info("Workload is orphaned; finishing to release quota")
+			err := workload.Finish(ctx, r.client, wl, kueue.WorkloadFinishedReasonOwnerNotFound,
+				"The workload's owner no longer exists", r.clock)
+			if err != nil {
+				if client.IgnoreNotFound(err) != nil {
+					log.Error(err, "Finishing orphaned workload")
+					return err
+				}
+				return nil
+			}
+		}
+
 		if err := workload.RemoveFinalizer(ctx, r.client, wl); client.IgnoreNotFound(err) != nil {
 			log.Error(err, "Removing finalizer")
 			return err
@@ -1163,9 +1182,11 @@ func expectedRunningPodSets(ctx context.Context, c client.Client, wl *kueue.Work
 // EquivalentToWorkload checks if the job corresponds to the workload
 func EquivalentToWorkload(ctx context.Context, c client.Client, job GenericJob, wl *kueue.Workload) (bool, error) {
 	owner := metav1.GetControllerOf(wl)
-	// Indexes don't work in unit tests, so we explicitly check for the
-	// owner here.
 	if owner.Name != job.Object().GetName() {
+		return false, nil
+	}
+
+	if features.Enabled(features.FinishOrphanedWorkloads) && owner.UID != job.Object().GetUID() {
 		return false, nil
 	}
 

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -601,7 +601,8 @@ func TestReconciler(t *testing.T) {
 		wantEvents        []utiltesting.EventRecord
 		wantErr           error
 	}{
-		"job is not found": {
+		"job is not found with FinishOrphanedWorkloads disabled": {
+			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: false},
 			reconcileKey: &types.NamespacedName{Namespace: "ns", Name: "deleted_job"},
 			job:          nil,
 			workloads: []kueue.Workload{
@@ -616,7 +617,31 @@ func TestReconciler(t *testing.T) {
 					Obj(),
 			},
 		},
-		"job is deleted": {
+		"job is not found with FinishOrphanedWorkloads enabled": {
+			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: true},
+			reconcileKey: &types.NamespacedName{Namespace: "ns", Name: "deleted_job"},
+			job:          nil,
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					ControllerReference(gvk, "deleted_job", "deleted_job").
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					ControllerReference(gvk, "deleted_job", "deleted_job").
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadFinished,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(now),
+						Reason:             kueue.WorkloadFinishedReasonOwnerNotFound,
+						Message:            "The workload's owner no longer exists",
+					}).
+					Obj(),
+			},
+		},
+		"job is deleted with FinishOrphanedWorkloads disabled": {
+			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: false},
 			job: baseJobWrapper.Clone().
 				DeletionTimestamp(now).
 				Finalizers(kueue.ResourceInUseFinalizerName).
@@ -634,6 +659,35 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("wl", "ns").
 					ControllerReference(gvk, baseJobWrapper.GetName(), string(baseJobWrapper.GetUID())).
+					Obj(),
+			},
+		},
+		"job is deleted with FinishOrphanedWorkloads enabled": {
+			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: true},
+			job: baseJobWrapper.Clone().
+				DeletionTimestamp(now).
+				Finalizers(kueue.ResourceInUseFinalizerName).
+				Obj(),
+			wantJob: *baseJobWrapper.Clone().
+				DeletionTimestamp(now).
+				Finalizers(kueue.ResourceInUseFinalizerName).
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					ControllerReference(gvk, baseJobWrapper.GetName(), string(baseJobWrapper.GetUID())).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					ControllerReference(gvk, baseJobWrapper.GetName(), string(baseJobWrapper.GetUID())).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadFinished,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(now),
+						Reason:             kueue.WorkloadFinishedReasonOwnerNotFound,
+						Message:            "The workload's owner no longer exists",
+					}).
 					Obj(),
 			},
 		},

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -3597,7 +3597,8 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		},
-		"finalize workload for non existent pod": {
+		"finalize workload for non existent pod with FinishOrphanedWorkloads disabled": {
+			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: false},
 			reconcileKey: &types.NamespacedName{Namespace: "ns", Name: "deleted_pod"},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("test-group", "ns").
@@ -3608,6 +3609,29 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("test-group", "ns").
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "deleted_pod", "").
+					Obj(),
+			},
+			workloadCmpOpts: defaultWorkloadCmpOpts,
+		},
+		"finalize workload for non existent pod with FinishOrphanedWorkloads enabled": {
+			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: true},
+			reconcileKey: &types.NamespacedName{Namespace: "ns", Name: "deleted_pod"},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("test-group", "ns").
+					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "deleted_pod", "").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("test-group", "ns").
+					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "deleted_pod", "").
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadFinished,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(now),
+						Reason:             kueue.WorkloadFinishedReasonOwnerNotFound,
+						Message:            "The workload's owner no longer exists",
+					}).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,


### PR DESCRIPTION
Cherry pick of #11296 on release-0.16.

#11296: Prevent finishing workload immediately after creation.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
Workloads: Fixed a bug where, with the `FinishOrphanedWorkloads` feature gate enabled,
Workloads could be marked `Finished` immediately after owner Job or JobSet creation.
```