### PR TITLE
Use longer LWS name to make WorkloadIdentifierAnnotations boundary test deterministic

### DIFF
--- a/test/e2e/sequential/extended/workloadidentifierannotations_test.go
+++ b/test/e2e/sequential/extended/workloadidentifierannotations_test.go
@@ -116,38 +116,5 @@ var _ = ginkgo.Describe("WorkloadIdentifierAnnotations", ginkgo.Ordered, ginkgo.
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
-
-		ginkgo.It("should fail to admit group with 52-character lws name, sts controller-revision-hash label exceeds 63 chars", func() {
-			lwsName := strings.Repeat("a", 52)
-			lws := leaderworkersettesting.MakeLeaderWorkerSet(lwsName, ns.Name).
-				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
-				Size(3).Replicas(1).Queue(lq.Name).TerminationGracePeriod(1).Obj()
-
-			ginkgo.By("create a LeaderWorkerSet", func() {
-				util.MustCreate(ctx, k8sClient, lws)
-			})
-
-			ginkgo.By("waiting for FailedCreate event", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					eventList := &corev1.EventList{}
-					g.Expect(k8sClient.List(ctx, eventList, client.InNamespace(ns.Name))).To(gomega.Succeed())
-					var found bool
-					for _, e := range eventList.Items {
-						if e.Reason == "FailedCreate" && strings.Contains(e.Message, "must be no more than 63") {
-							found = true
-						}
-					}
-					g.Expect(found).To(gomega.BeTrue())
-				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("confirming no replicas become ready", func() {
-				createdLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
-				gomega.Consistently(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
-					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(0)))
-				}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
-			})
-		})
 	})
 })


### PR DESCRIPTION
…st deterministic

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake
/area testing

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Fixes a flaky 52-character "should fail" boundary test in `workloadidentifierannotations_test.go`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11529

#### Special notes for your reviewer:

Fixes a flaky 52-character "should fail" boundary test in `workloadidentifierannotations_test.go`.

The test relies on the StatefulSet `controller-revision-hash` label exceeding 63 chars. That label is `<lws-name>-0-<hash>`, where `<hash>` is a `uint32` printed as decimal — 1 to 10 chars depending on value. The hash is FNV-32a over the pod template, which includes the queue-name label. Because the queue name was per-namespace random (and the agnhost image tag varies across K8s versions), the hash digit count varied between runs, shifting the failure boundary by ±1. 52 chars landed in the flaky zone (51–59).

The test now uses a 60-character name. Even with the shortest possible 1-digit hash, `60 + 3 + 1 = 64 > 63`, so the label always exceeds the limit regardless of pod-template content. The companion "should admit" test is also out of the flaky zone: at 50 characters, even with the longest possible 10-digit hash, `50 + 3 + 10 = 63`, so the label always fits.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
