### PR TITLE
[integration] Drop ginkgo.Ordered from Concurrent Admission singlecluster tests

### DIFF
--- a/test/integration/singlecluster/controller/concurrentadmission/concurrent_admission_test.go
+++ b/test/integration/singlecluster/controller/concurrentadmission/concurrent_admission_test.go
@@ -34,25 +34,19 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("Concurrent Admission", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("Concurrent Admission", func() {
 	var (
 		ns *corev1.Namespace
 	)
 
 	ginkgo.BeforeEach(func() {
 		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ConcurrentAdmission, true)
+		fwk.StartManager(ctx, cfg, managerAndSchedulerSetup(&configapi.Configuration{}))
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "concurrent-")
 	})
 
 	ginkgo.AfterEach(func() {
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
-	})
-
-	ginkgo.BeforeAll(func() {
-		fwk.StartManager(ctx, cfg, managerAndSchedulerSetup(&configapi.Configuration{}))
-	})
-
-	ginkgo.AfterAll(func() {
 		fwk.StopManager(ctx)
 	})
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it:
Updates the **Concurrent Admission** `Describe` block in `test/integration/singlecluster/controller/concurrentadmission/concurrent_admission_test.go`.
- Removes `ginkgo.Ordered` and `ginkgo.ContinueOnFailure` from that `Describe` block only.
- Moves `StartManager`/`StopManager` from `BeforeAll`/`AfterAll` into `BeforeEach`/`AfterEach` (see [Parallelize Fair Sharing Integration Test (66% speedup) #8726](https://github.com/kubernetes-sigs/kueue/pull/8726)).
- Keeps `managerAndSchedulerSetup` and `SetFeatureGateDuringTest` for `ConcurrentAdmission` unchanged.
Continues the split from [Eliminate ginkgo.Ordered for singlecluster integration tests #9880](https://github.com/kubernetes-sigs/kueue/issues/9880). Follows [#11526](https://github.com/kubernetes-sigs/kueue/pull/11526).

#### Which issue(s) this PR fixes:
Part of #9880

#### Special notes for your reviewer:
- One `Describe` block only; inner `When` hooks are unchanged.
- No changes to `suite_test.go` or `test/integration/framework`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
