### PR TITLE
apis: add shortNames to Kueue CRDs

### DIFF
--- a/apis/kueue/v1beta1/admissioncheck_types.go
+++ b/apis/kueue/v1beta1/admissioncheck_types.go
@@ -105,7 +105,7 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:deprecatedversion:warning="This version is deprecated. Use v1beta2 instead."
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName={ac}
 
 // AdmissionCheck is the Schema for the admissionchecks API
 type AdmissionCheck struct {

--- a/apis/kueue/v1beta1/cohort_types.go
+++ b/apis/kueue/v1beta1/cohort_types.go
@@ -82,7 +82,7 @@ type CohortStatus struct {
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:deprecatedversion:warning="This version is deprecated. Use v1beta2 instead."
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName={co}
 // +kubebuilder:subresource:status
 
 // Cohort defines the Cohorts API.

--- a/apis/kueue/v1beta1/multikueue_types.go
+++ b/apis/kueue/v1beta1/multikueue_types.go
@@ -94,7 +94,7 @@ type MultiKueueClusterStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:deprecatedversion:warning="This version is deprecated. Use v1beta2 instead."
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName={mkc}
 
 // +kubebuilder:printcolumn:name="Connected",JSONPath=".status.conditions[?(@.type=='Active')].status",type="string",description="MultiKueueCluster is connected"
 // +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type="date",description="Time this workload was created"
@@ -133,7 +133,7 @@ type MultiKueueConfigSpec struct {
 // +genclient
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName={mkconf}
 
 // MultiKueueConfig is the Schema for the multikueue API
 type MultiKueueConfig struct {

--- a/apis/kueue/v1beta1/provisioningrequestconfig_types.go
+++ b/apis/kueue/v1beta1/provisioningrequestconfig_types.go
@@ -162,7 +162,7 @@ type Parameter string
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:deprecatedversion:warning="This version is deprecated. Use v1beta2 instead."
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName={prc}
 
 // ProvisioningRequestConfig is the Schema for the provisioningrequestconfig API
 type ProvisioningRequestConfig struct {

--- a/apis/kueue/v1beta1/topology_types.go
+++ b/apis/kueue/v1beta1/topology_types.go
@@ -125,7 +125,7 @@ type TopologyLevel struct {
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:deprecatedversion:warning="This version is deprecated. Use v1beta2 instead."
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName={topo}
 
 // Topology is the Schema for the topology API
 type Topology struct {

--- a/apis/kueue/v1beta1/workloadpriorityclass_types.go
+++ b/apis/kueue/v1beta1/workloadpriorityclass_types.go
@@ -24,7 +24,7 @@ import (
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:deprecatedversion:warning="This version is deprecated. Use v1beta2 instead."
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName={wpc}
 // +kubebuilder:printcolumn:name="Value",JSONPath=".value",type=integer,description="Value of workloadPriorityClass's Priority"
 
 // WorkloadPriorityClass is the Schema for the workloadPriorityClass API

--- a/apis/kueue/v1beta2/admissioncheck_types.go
+++ b/apis/kueue/v1beta2/admissioncheck_types.go
@@ -106,7 +106,7 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName={ac}
 
 // AdmissionCheck is the Schema for the admissionchecks API
 type AdmissionCheck struct {

--- a/apis/kueue/v1beta2/cohort_types.go
+++ b/apis/kueue/v1beta2/cohort_types.go
@@ -84,7 +84,7 @@ type CohortStatus struct {
 // +genclient:nonNamespaced
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName={co}
 // +kubebuilder:subresource:status
 
 // Cohort defines the Cohorts API.

--- a/apis/kueue/v1beta2/multikueue_types.go
+++ b/apis/kueue/v1beta2/multikueue_types.go
@@ -116,7 +116,7 @@ type MultiKueueClusterStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName={mkc}
 
 // +kubebuilder:printcolumn:name="Connected",JSONPath=".status.conditions[?(@.type=='Active')].status",type="string",description="MultiKueueCluster is connected"
 // +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type="date",description="Time this workload was created"
@@ -182,7 +182,7 @@ const (
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName={mkconf}
 
 // MultiKueueConfig is the Schema for the multikueue API
 type MultiKueueConfig struct {

--- a/apis/kueue/v1beta2/provisioningrequestconfig_types.go
+++ b/apis/kueue/v1beta2/provisioningrequestconfig_types.go
@@ -165,7 +165,7 @@ type Parameter string
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName={prc}
 
 // ProvisioningRequestConfig is the Schema for the provisioningrequestconfig API
 type ProvisioningRequestConfig struct {

--- a/apis/kueue/v1beta2/topology_types.go
+++ b/apis/kueue/v1beta2/topology_types.go
@@ -138,7 +138,7 @@ type TopologyLevel struct {
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName={topo}
 
 // Topology is the Schema for the topology API
 type Topology struct {

--- a/apis/kueue/v1beta2/workloadpriorityclass_types.go
+++ b/apis/kueue/v1beta2/workloadpriorityclass_types.go
@@ -24,7 +24,7 @@ import (
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName={wpc}
 // +kubebuilder:printcolumn:name="Value",JSONPath=".value",type=integer,description="Value of workloadPriorityClass's Priority"
 
 // WorkloadPriorityClass is the Schema for the workloadPriorityClass API

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
@@ -33,6 +33,8 @@ spec:
     kind: AdmissionCheck
     listKind: AdmissionCheckList
     plural: admissionchecks
+    shortNames:
+      - ac
     singular: admissioncheck
   scope: Cluster
   versions:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_cohorts.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_cohorts.yaml
@@ -43,6 +43,8 @@ spec:
     kind: Cohort
     listKind: CohortList
     plural: cohorts
+    shortNames:
+      - co
     singular: cohort
   scope: Cluster
   versions:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
@@ -43,6 +43,8 @@ spec:
     kind: MultiKueueCluster
     listKind: MultiKueueClusterList
     plural: multikueueclusters
+    shortNames:
+      - mkc
     singular: multikueuecluster
   scope: Cluster
   versions:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueconfigs.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueconfigs.yaml
@@ -33,6 +33,8 @@ spec:
     kind: MultiKueueConfig
     listKind: MultiKueueConfigList
     plural: multikueueconfigs
+    shortNames:
+      - mkconf
     singular: multikueueconfig
   scope: Cluster
   versions:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_provisioningrequestconfigs.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_provisioningrequestconfigs.yaml
@@ -33,6 +33,8 @@ spec:
     kind: ProvisioningRequestConfig
     listKind: ProvisioningRequestConfigList
     plural: provisioningrequestconfigs
+    shortNames:
+      - prc
     singular: provisioningrequestconfig
   scope: Cluster
   versions:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_topologies.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_topologies.yaml
@@ -33,6 +33,8 @@ spec:
     kind: Topology
     listKind: TopologyList
     plural: topologies
+    shortNames:
+      - topo
     singular: topology
   scope: Cluster
   versions:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloadpriorityclasses.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloadpriorityclasses.yaml
@@ -33,6 +33,8 @@ spec:
     kind: WorkloadPriorityClass
     listKind: WorkloadPriorityClassList
     plural: workloadpriorityclasses
+    shortNames:
+      - wpc
     singular: workloadpriorityclass
   scope: Cluster
   versions:

--- a/cmd/experimental/kueue-priority-booster/charts/kueue-priority-booster/values.yaml
+++ b/cmd/experimental/kueue-priority-booster/charts/kueue-priority-booster/values.yaml
@@ -13,11 +13,11 @@ kueuePriorityBooster:
     timeSharing:
       interval: "30m"
       negativeBoost: 100000
-    # Optional: limit to workloads matching this label selector (omit = all workloads).
-    # workloadSelector:
-    #   matchLabels:
-    #     tier: batch
-    # Optional: exclude workloads with Spec.Priority greater than this (nil priority = 0).
-    # maxWorkloadPriority: 1000
+      # Optional: limit to workloads matching this label selector (omit = all workloads).
+      # workloadSelector:
+      #   matchLabels:
+      #     tier: batch
+      # Optional: exclude workloads with Spec.Priority greater than this (nil priority = 0).
+      # maxWorkloadPriority: 1000
 kueue:
   enabled: false

--- a/config/components/crd/bases/kueue.x-k8s.io_admissionchecks.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_admissionchecks.yaml
@@ -11,6 +11,8 @@ spec:
     kind: AdmissionCheck
     listKind: AdmissionCheckList
     plural: admissionchecks
+    shortNames:
+    - ac
     singular: admissioncheck
   scope: Cluster
   versions:

--- a/config/components/crd/bases/kueue.x-k8s.io_cohorts.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_cohorts.yaml
@@ -11,6 +11,8 @@ spec:
     kind: Cohort
     listKind: CohortList
     plural: cohorts
+    shortNames:
+    - co
     singular: cohort
   scope: Cluster
   versions:

--- a/config/components/crd/bases/kueue.x-k8s.io_multikueueclusters.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_multikueueclusters.yaml
@@ -11,6 +11,8 @@ spec:
     kind: MultiKueueCluster
     listKind: MultiKueueClusterList
     plural: multikueueclusters
+    shortNames:
+    - mkc
     singular: multikueuecluster
   scope: Cluster
   versions:

--- a/config/components/crd/bases/kueue.x-k8s.io_multikueueconfigs.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_multikueueconfigs.yaml
@@ -11,6 +11,8 @@ spec:
     kind: MultiKueueConfig
     listKind: MultiKueueConfigList
     plural: multikueueconfigs
+    shortNames:
+    - mkconf
     singular: multikueueconfig
   scope: Cluster
   versions:

--- a/config/components/crd/bases/kueue.x-k8s.io_provisioningrequestconfigs.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_provisioningrequestconfigs.yaml
@@ -11,6 +11,8 @@ spec:
     kind: ProvisioningRequestConfig
     listKind: ProvisioningRequestConfigList
     plural: provisioningrequestconfigs
+    shortNames:
+    - prc
     singular: provisioningrequestconfig
   scope: Cluster
   versions:

--- a/config/components/crd/bases/kueue.x-k8s.io_topologies.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_topologies.yaml
@@ -11,6 +11,8 @@ spec:
     kind: Topology
     listKind: TopologyList
     plural: topologies
+    shortNames:
+    - topo
     singular: topology
   scope: Cluster
   versions:

--- a/config/components/crd/bases/kueue.x-k8s.io_workloadpriorityclasses.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloadpriorityclasses.yaml
@@ -11,6 +11,8 @@ spec:
     kind: WorkloadPriorityClass
     listKind: WorkloadPriorityClassList
     plural: workloadpriorityclasses
+    shortNames:
+    - wpc
     singular: workloadpriorityclass
   scope: Cluster
   versions:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind feature

#### What this PR does / why we need it:

Several Kueue CRDs were missing `shortNames`, making them verbose to use with `kubectl`. This PR adds short names to the remaining resources so operators can use concise aliases like `kubectl get ac` or `kubectl get topo`.

  | Resource | Short Name(s) added |
  |---|---|
  | `AdmissionCheck` | `ac` |
  | `Cohort` | `co` |
  | `MultiKueueCluster` | `mkc` |
  | `MultiKueueConfig` | `mkconf` |
  | `ProvisioningRequestConfig` | `prc` |
  | `Topology` | `topo` |
  | `WorkloadPriorityClass` | `wpc` |

  Resources that already had short names (`ClusterQueue`→`cq`, `LocalQueue`→`lq`, `ResourceFlavor`→`rf`, `Workload`→`kwl`) are unchanged.

  Changes are applied to both `v1beta1` and `v1beta2` API type files, the generated CRD YAML under `config/components/crd/bases/`, and the Helm chart CRD templates under `charts/kueue/templates/crd/`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add kubectl short names for AdmissionCheck (ac), Cohort (co), MultiKueueCluster (mkc), MultiKueueConfig (mkconf), ProvisioningRequestConfig (prc), Topology (topo), and WorkloadPriorityClass (wpc).
```

/cc @mimowo 
