### PR TITLE
[integration] Drop ginkgo.Ordered from LocalQueue controller singlecluster tests

### DIFF
--- a/test/integration/singlecluster/controller/core/localqueue_controller_test.go
+++ b/test/integration/singlecluster/controller/core/localqueue_controller_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("Queue controller", ginkgo.Label("controller:localqueue", "area:core"), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("Queue controller", ginkgo.Label("controller:localqueue", "area:core"), func() {
 	const (
 		flavorModelC = "model-c"
 		flavorModelD = "model-d"
@@ -75,15 +75,8 @@ var _ = ginkgo.Describe("Queue controller", ginkgo.Label("controller:localqueue"
 		ac *kueue.AdmissionCheck
 	)
 
-	ginkgo.BeforeAll(func() {
-		fwk.StartManager(ctx, cfg, managerSetup)
-	})
-
-	ginkgo.AfterAll(func() {
-		fwk.StopManager(ctx)
-	})
-
 	ginkgo.BeforeEach(func() {
+		fwk.StartManager(ctx, cfg, managerSetup)
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "core-queue-")
 	})
 
@@ -111,6 +104,7 @@ var _ = ginkgo.Describe("Queue controller", ginkgo.Label("controller:localqueue"
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, &rf, true)
 		}
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, ac, true)
+		fwk.StopManager(ctx)
 	})
 
 	ginkgo.It("Should update conditions when clusterQueues that its localQueue references are updated", framework.SlowSpec, func() {
@@ -546,7 +540,7 @@ var _ = ginkgo.Describe("Queue controller", ginkgo.Label("controller:localqueue"
 	})
 })
 
-var _ = ginkgo.Describe("Queue controller metrics filtering", ginkgo.Label("controller:localqueue", "area:core"), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("Queue controller metrics filtering", ginkgo.Label("controller:localqueue", "area:core"), func() {
 	var (
 		ns              *corev1.Namespace
 		clusterQueue    *kueue.ClusterQueue
@@ -558,7 +552,7 @@ var _ = ginkgo.Describe("Queue controller metrics filtering", ginkgo.Label("cont
 		}
 	)
 
-	ginkgo.BeforeAll(func() {
+	ginkgo.BeforeEach(func() {
 		customCfg := &configapi.Configuration{
 			ControllerManager: configapi.ControllerManager{
 				Metrics: configapi.ControllerMetrics{
@@ -573,15 +567,7 @@ var _ = ginkgo.Describe("Queue controller metrics filtering", ginkgo.Label("cont
 				},
 			},
 		}
-
 		fwk.StartManager(ctx, cfg, managerAndControllerSetup(customCfg))
-	})
-
-	ginkgo.AfterAll(func() {
-		fwk.StopManager(ctx)
-	})
-
-	ginkgo.BeforeEach(func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "core-queue-metrics-")
 
 		ac = utiltestingapi.MakeAdmissionCheck("ac").ControllerName("ac-controller").Obj()
@@ -612,6 +598,7 @@ var _ = ginkgo.Describe("Queue controller metrics filtering", ginkgo.Label("cont
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, &rf, true)
 		}
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, ac, true)
+		fwk.StopManager(ctx)
 	})
 
 	ginkgo.It("Should expose metrics based on LocalQueue labels", func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it:
Updates two `Describe` blocks in `test/integration/singlecluster/controller/core/localqueue_controller_test.go`:
- `Queue controller`
- `Queue controller metrics filtering`
- Removes `ginkgo.Ordered` and `ginkgo.ContinueOnFailure` from those blocks only.
- Moves `StartManager`/`StopManager` from `BeforeAll`/`AfterAll` into `BeforeEach`/`AfterEach` (see [Parallelize Fair Sharing Integration Test (66% speedup) #8726](https://github.com/kubernetes-sigs/kueue/pull/8726)).
Continues the split from [Eliminate ginkgo.Ordered for singlecluster integration tests #9880](https://github.com/kubernetes-sigs/kueue/issues/9880). Follows [LocalQueue webhook #11466](https://github.com/kubernetes-sigs/kueue/pull/11466).

#### Which issue(s) this PR fixes:
Part of #9880

#### Special notes for your reviewer:
- Two `Describe` blocks in one file; inner hooks are unchanged.
- Metrics block keeps `managerAndControllerSetup(customCfg)` unchanged.
- No changes to `suite_test.go` or `test/integration/framework`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
