### PR TITLE
[integration] Drop ginkgo.Ordered from ClusterQueue controller singlecluster tests

### DIFF
--- a/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
@@ -57,7 +57,7 @@ const (
 	flavorCPUArchB = "arch-b"
 )
 
-var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Label("controller:clusterqueue", "area:core"), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Label("controller:clusterqueue", "area:core"), func() {
 	var (
 		ns               *corev1.Namespace
 		emptyUsedFlavors = []kueue.FlavorUsage{
@@ -88,21 +88,15 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Label("controller:clus
 		}
 	)
 
-	ginkgo.BeforeAll(func() {
-		fwk.StartManager(ctx, cfg, managerSetup)
-	})
-
-	ginkgo.AfterAll(func() {
-		fwk.StopManager(ctx)
-	})
-
 	ginkgo.BeforeEach(func() {
 		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LocalQueueMetrics, true)
+		fwk.StartManager(ctx, cfg, managerSetup)
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "core-clusterqueue-")
 	})
 
 	ginkgo.AfterEach(func() {
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		fwk.StopManager(ctx)
 	})
 
 	ginkgo.When("Reconciling clusterQueue usage status", func() {
@@ -1215,7 +1209,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Label("controller:clus
 	})
 })
 
-var _ = ginkgo.Describe("ClusterQueue controller with RoleTracker", ginkgo.Label("controller:clusterqueue", "area:core"), ginkgo.Ordered, ginkgo.Serial, func() {
+var _ = ginkgo.Describe("ClusterQueue controller with RoleTracker", ginkgo.Label("controller:clusterqueue", "area:core"), func() {
 	var (
 		electedChan   chan struct{}
 		trackerCancel context.CancelFunc


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it:
Updates two `Describe` blocks in `test/integration/singlecluster/controller/core/clusterqueue_controller_test.go`:
- `ClusterQueue controller`
- `ClusterQueue controller with RoleTracker`
- Removes `ginkgo.Ordered` and `ginkgo.ContinueOnFailure` from the main block; moves `StartManager`/`StopManager` from `BeforeAll`/`AfterAll` into `BeforeEach`/`AfterEach`.
- Removes `ginkgo.Ordered` and `ginkgo.Serial` from the RoleTracker block (manager hooks were already per-spec).
See [Parallelize Fair Sharing Integration Test (66% speedup) #8726](https://github.com/kubernetes-sigs/kueue/pull/8726).
Continues the split from [Eliminate ginkgo.Ordered for singlecluster integration tests #9880](https://github.com/kubernetes-sigs/kueue/issues/9880). Follows [ClusterQueue webhook #11499](https://github.com/kubernetes-sigs/kueue/pull/11499) and [#11541](https://github.com/kubernetes-sigs/kueue/pull/11541).

#### Which issue(s) this PR fixes:
Part of #9880

#### Special notes for your reviewer:
- Two `Describe` blocks in one file; inner `When` hooks are unchanged.
- RoleTracker block: no hook relocation, only decorator removal.
- No changes to `suite_test.go` or `test/integration/framework`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
