### PR TITLE
KEP-2941: Add event-driven DeviceClass tracking

### DIFF
--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -76,12 +76,14 @@ tags, and then generate with `hack/update-toc.sh`.
     - [Alpha](#alpha)
       - [KueueDRAIntegration (v0.14)](#kueuedraintegration-v014)
       - [KueueDRAIntegrationExtendedResource (v0.17)](#kueuedraintegrationextendedresource-v017)
+      - [KueueDRAIntegrationExtendedResource (v0.18)](#kueuedraintegrationextendedresource-v018)
       - [KueueDRAIntegrationPartitionableDevices (v0.18)](#kueuedraintegrationpartitionabledevices-v018)
     - [Beta](#beta)
       - [KueueDRAIntegration (v0.18)](#kueuedraintegration-v018)
       - [KueueDRAIntegrationExtendedResource](#kueuedraintegrationextendedresource)
     - [GA](#ga)
       - [KueueDRAIntegration](#kueuedraintegration)
+      - [KueueDRAIntegrationExtendedResource](#kueuedraintegrationextendedresource-1)
 - [Implementation History](#implementation-history)
 - [Drawbacks](#drawbacks)
 - [Alternatives](#alternatives)
@@ -958,16 +960,22 @@ itself, not the DeviceClass name, so multiple matching DeviceClasses do not affe
    and the scheduler may resolve differently. `waitForPodsReady` handles scheduling failures.
    See [Risks and Mitigations](#risks-and-mitigations) for the full breakdown.
 
-3. DeviceClass `extendedResourceName` updated: the field indexer reflects the updated mapping
-   on the next reconciliation cycle. The same TOCTOU considerations as scenario 2 apply.
+3. DeviceClass `extendedResourceName` updated: the DeviceClass event handler triggers the
+   workload controller's Reconcile, and only the pending workloads requesting the affected
+   `extendedResourceName` are requeued (resolved via the workload index). The same TOCTOU
+   considerations as scenario 2 apply.
 
 #### Late DeviceClass Creation
 
-For Alpha, if a DeviceClass does not exist when a workload is created, the extended resource
-is treated as a normal (non-DRA) extended resource. A subsequent reconciliation cycle
-(e.g., triggered by other workload or queue events) re-evaluates the workload after the
-DeviceClass is created. Event-driven re-reconciliation on DeviceClass creation will be
-evaluated as a Beta graduation criterion.
+If a DeviceClass does not exist when a workload is created, the extended resource
+is treated as a normal (non-DRA) extended resource and may become inadmissible if the
+ClusterQueue only has quota for the DeviceClass-mapped logical name.
+
+The workload controller watches DeviceClass objects for create, update, and delete events.
+When a DeviceClass changes, only the pending workloads requesting the specific
+`extendedResourceName` from that DeviceClass are requeued for re-evaluation. Workloads
+with domain-qualified resources that are not DRA-backed (e.g., `example.com/gpu` without
+a corresponding DeviceClass) skip DRA processing entirely.
 
 ### Partitionable Devices
 
@@ -1508,6 +1516,14 @@ tracks adding this). This follows the same pattern as upstream K8s integration t
 - extended resource detection and resource translation
 - double-counting prevention with `deviceClassMappings`
 
+##### KueueDRAIntegrationExtendedResource (v0.18)
+
+- event-driven DeviceClass tracking for late DeviceClass creation
+- DRABackedResources cache to ensure non-DRA workloads with domain-qualified resources
+  skip DRA processing
+- workload index by extended resource names for targeted DeviceClass event handling
+- integration and e2e tests for DeviceClass lifecycle scenarios
+
 ##### KueueDRAIntegrationPartitionableDevices (v0.18)
 
 - support for partitionable devices via counter-based quota (KEP-4815, beta in k8s 1.36)
@@ -1525,8 +1541,6 @@ tracks adding this). This follows the same pattern as upstream K8s integration t
 
 ##### KueueDRAIntegrationExtendedResource
 
-- user adoption feedback
-- re-evaluate event-driven DeviceClass tracking for late DeviceClass creation
 - re-evaluate post-scheduling quota reconciliation for DeviceClass drift
 - re-evaluate the need for indexing of resourceSlices for CEL performance lookups
 - re-evaluate pool-aware flavor assignment for counter resources
@@ -1544,6 +1558,12 @@ tracks adding this). This follows the same pattern as upstream K8s integration t
 
 - the feature gate in stable
 - TAS + DRA integration and testing
+
+##### KueueDRAIntegrationExtendedResource
+
+- the feature gate in stable
+- user adoption feedback confirms stability
+- re-evaluate DeviceClass watcher performance at scale
 
 ## Implementation History
 

--- a/site/content/en/docs/concepts/dynamic_resource_allocation.md
+++ b/site/content/en/docs/concepts/dynamic_resource_allocation.md
@@ -147,8 +147,3 @@ The following limitations apply to the alpha release:
   ([KEP-5075](https://github.com/kubernetes/enhancements/issues/5075),
   [KEP-5691](https://github.com/kubernetes/enhancements/issues/5691))
   that is not yet available.
-- **No DeviceClass watcher**: If a `DeviceClass` is created after a workload
-  was already rejected, the workload is not immediately retried. It will be
-  re-evaluated when the next cluster event triggers inadmissible workload
-  requeuing (e.g., another workload completes or quota changes). To avoid
-  delays, ensure the `DeviceClass` exists before submitting workloads.

--- a/site/content/en/docs/tasks/manage/setup_dra.md
+++ b/site/content/en/docs/tasks/manage/setup_dra.md
@@ -153,13 +153,6 @@ spec:
       expression: device.driver == "gpu.example.com"
 ```
 
-{{% alert title="Important" color="warning" %}}
-The `DeviceClass` must exist **before** users submit workloads. There is no
-DeviceClass watcher in alpha. If a `DeviceClass` is created after a workload
-was marked inadmissible, the workload will not be re-evaluated until the next
-cluster event that triggers inadmissible workload requeuing (e.g., another
-workload completes or quota changes).
-{{% /alert %}}
 
 No `deviceClassMappings` configuration is needed for this path. Kueue
 auto-discovers the mapping by indexing `DeviceClass` objects.


### PR DESCRIPTION
Signed-off-by: Pannaga Rao Bhoja Ramamanohara

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

Updates KEP-2941 to document the event-driven DeviceClass tracking mechanism for extended resources:

 - DeviceClass watcher: Workload controller watches DeviceClass create/update/delete events to promptly re-evaluate affected workloads
- DRABackedResources cache: Tracks which extended resource names are backed by DeviceClasses, so workloads with domain-qualified resources that have no corresponding DeviceClass (e.g., example.com/gpu without a DeviceClass) skip DRA processing entirely
- Workload index by extended resource names: Enables targeted requeue of only the workloads requesting the affected extendedResourceName, instead of listing all pending workloads on every DeviceClass event


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
