### PR TITLE
[release-0.16] Fix duplicate replacement workload slices stuck during rapid scaling

### DIFF
--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -19,7 +19,6 @@ package workloadslicing
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"slices"
 
@@ -27,6 +26,7 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -211,72 +211,113 @@ func EnsureWorkloadSlices(
 		// Scale-up on admitted workload → create a new slice.
 		return nil, true, nil
 
-	case 2:
-		// Two active workload slices detected.
-		//
-		// This transient state typically occurs when a new slice has been created,
-		// and the old slice is pending deactivation. The system should resolve this
-		// by deactivating the old slice, after which processing will continue under "case #1".
-		oldWorkload := workloads[0]
-		newWorkload := workloads[1]
-
-		// Finish the old workload slice if:
-		// a. It lost its quota reservation, or
-		// b. It was explicitly evicted, or
-		// c. The new workload has been admitted (has quota reservation) AND has a replacement
-		//    annotation pointing to the old workload. This handles the case where the scheduler
-		//    admitted the new slice but failed to finish the old slice.
-		replacementKey := ReplacementForKey(&newWorkload)
-		oldWorkloadKey := workload.Key(&oldWorkload)
-		newWorkloadAdmittedAsReplacement := workload.HasQuotaReservation(&newWorkload) &&
-			replacementKey != nil && *replacementKey == oldWorkloadKey
-		shouldFinishOldSlice := !workload.HasQuotaReservation(&oldWorkload) ||
-			workload.IsEvicted(&oldWorkload) ||
-			newWorkloadAdmittedAsReplacement
-		if shouldFinishOldSlice {
-			// Finish the old workload slice as out of sync.
-			reason := kueue.WorkloadFinishedReasonOutOfSync
-			message := "The workload slice is out of sync with its parent job"
-			if err := workload.Finish(ctx, clnt, &oldWorkload, reason, message, clk, tracker); err != nil {
-				return nil, true, err
-			}
+	default:
+		selectedWorkload, err := normalizeActiveSlices(ctx, clnt, clk, workloads)
+		if err != nil {
+			return nil, true, err
+		}
+		if selectedWorkload == nil {
+			return nil, true, nil
 		}
 
-		// We consider the new workload slice only when evaluating against the incoming job (pod sets).
-		newCounts := workload.ExtractPodSetCountsFromWorkload(&newWorkload)
+		selectedCounts := workload.ExtractPodSetCountsFromWorkload(selectedWorkload)
 
-		// Check if new workload and job's pod sets are compatible (have the same keys and keys count)
-		if !jobPodSetsCounts.HasSamePodSetKeys(newCounts) {
+		if !jobPodSetsCounts.HasSamePodSetKeys(selectedCounts) {
 			return nil, false, nil
 		}
 
-		// Return an error if the new workload has a reserved quota and we didn't just finish
-		// the old workload due to the replacement annotation.
-		//
-		// A combination of a new workload with a reserved quota and an active old workload is considered an anomaly.
-		// This condition may indicate a race condition or external interference. Specifically, a new workload slice
-		// should never gain a quota reservation without the prior finalization of the old slice.
-		// However, if the new workload was admitted as a replacement (and we just finished the old slice above),
-		// this is the expected cleanup path and not an error.
-		if workload.HasQuotaReservation(&newWorkload) && !newWorkloadAdmittedAsReplacement {
-			return nil, true, errors.New("unexpected combination of old and new workload slices with reserved quota")
+		if jobPodSetsCounts.EqualTo(selectedCounts) {
+			return selectedWorkload, true, nil
 		}
 
-		// If the pod set counts match, return new workload slice.
-		if jobPodSetsCounts.EqualTo(newCounts) {
-			return &newWorkload, true, nil
+		if !workload.HasQuotaReservation(selectedWorkload) || ScaledDown(selectedCounts, jobPodSetsCounts) {
+			workload.ApplyPodSetCounts(selectedWorkload, jobPodSetsCounts)
+			if err := clnt.Update(ctx, selectedWorkload); err != nil {
+				return nil, true, fmt.Errorf("failed to update workload pod set counts: %w", err)
+			}
+			return selectedWorkload, true, nil
 		}
 
-		// Update new workload slice.
-		workload.ApplyPodSetCounts(&newWorkload, jobPodSetsCounts)
-		if err := clnt.Update(ctx, &newWorkload); err != nil {
-			return nil, true, fmt.Errorf("failed to update workload pod set counts: %w", err)
-		}
-		return &newWorkload, true, nil
-	default:
-		// More than two matching slices is unexpected and considered an error.
-		return nil, true, fmt.Errorf("unexpected number of matching workload slices: %d", len(workloads))
+		// Scale-up on admitted selected workload — create a new slice.
+		return nil, true, nil
 	}
+}
+
+// normalizeActiveSlices enforces the workload slice invariant:
+//   - One non-evicted admitted workload (latestWithQuotaReservation)
+//   - At most one non-evicted pending replacement that directly replaces it
+//   - When no non-evicted admitted workload exists, the newest non-evicted
+//     workload is kept
+//   - Evicted workloads are always finished (they hold quota that must be released)
+//
+// The input slice must be sorted oldest-first.
+func normalizeActiveSlices(
+	ctx context.Context,
+	clnt client.Client,
+	clk clock.Clock,
+	workloads []kueue.Workload,
+) (*kueue.Workload, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	var latestWithQuotaReservation, pendingReplacement, latestNonEvicted *kueue.Workload
+	for i := len(workloads) - 1; i >= 0; i-- {
+		wl := &workloads[i]
+		if workload.IsEvicted(wl) {
+			continue
+		}
+		if latestNonEvicted == nil {
+			latestNonEvicted = wl
+		}
+		if workload.HasQuotaReservation(wl) {
+			if latestWithQuotaReservation == nil {
+				latestWithQuotaReservation = wl
+			}
+		}
+	}
+
+	if latestWithQuotaReservation != nil {
+		latestWithQuotaReservationKey := workload.Key(latestWithQuotaReservation)
+		for i := len(workloads) - 1; i >= 0; i-- {
+			wl := &workloads[i]
+			if workload.HasQuotaReservation(wl) || workload.IsEvicted(wl) {
+				continue
+			}
+			if replKey := ReplacementForKey(wl); replKey != nil && *replKey == latestWithQuotaReservationKey {
+				pendingReplacement = wl
+				break
+			}
+		}
+	}
+
+	log.V(3).Info("Classified workload slices",
+		"total", len(workloads),
+		"latestWithQuotaReservation", klog.KObj(latestWithQuotaReservation),
+		"pendingReplacement", klog.KObj(pendingReplacement),
+		"latestNonEvicted", klog.KObj(latestNonEvicted))
+
+	var selectedWorkload *kueue.Workload
+	switch {
+	case pendingReplacement != nil:
+		selectedWorkload = pendingReplacement
+	case latestWithQuotaReservation != nil:
+		selectedWorkload = latestWithQuotaReservation
+	default:
+		selectedWorkload = latestNonEvicted
+	}
+
+	for i := range workloads {
+		wl := &workloads[i]
+		if wl == selectedWorkload || wl == latestWithQuotaReservation {
+			continue
+		}
+		log.V(2).Info("Finishing out-of-sync workload slice", "workload", workload.Key(wl))
+		if err := workload.Finish(ctx, clnt, wl, kueue.WorkloadFinishedReasonOutOfSync,
+			"The workload slice is out of sync with its parent job", clk, nil); err != nil {
+			return nil, err
+		}
+	}
+
+	return selectedWorkload, nil
 }
 
 // StartWorkloadSlicePods identifies pods associated with the provided workload

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -728,6 +728,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
 						ResourceVersion("1").
 						Creation(now).
+						Annotation(WorkloadSliceReplacementFor, string(workload.Key(utiltestingapi.MakeWorkload(testJobObject.Name+"-1", testJobObject.Namespace).Obj()))).
 						PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()).
 						Obj()).
 					Build(),
@@ -759,7 +760,6 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 				jobObjectGVK: testJobGVK,
 			},
 			want: want{
-				error:      true,
 				compatible: true,
 			},
 		},
@@ -805,6 +805,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
 						ResourceVersion("1").
 						Creation(now).
+						Annotation(WorkloadSliceReplacementFor, string(workload.Key(utiltestingapi.MakeWorkload(testJobObject.Name+"-1", testJobObject.Namespace).Obj()))).
 						PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()).
 						Obj()).Build(),
 				jobPodSets:   []kueue.PodSet{*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()},
@@ -817,6 +818,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 					OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
 					ResourceVersion("1").
 					Creation(now).
+					Annotation(WorkloadSliceReplacementFor, string(workload.Key(utiltestingapi.MakeWorkload(testJobObject.Name+"-1", testJobObject.Namespace).Obj()))).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()).
 					Obj(),
 			},
@@ -835,6 +837,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
 						ResourceVersion("1").
 						Creation(now).
+						Annotation(WorkloadSliceReplacementFor, string(workload.Key(utiltestingapi.MakeWorkload(testJobObject.Name+"-1", testJobObject.Namespace).Obj()))).
 						PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()).
 						Obj()).
 					Build(),
@@ -848,6 +851,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 					OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
 					ResourceVersion("2").
 					Creation(now).
+					Annotation(WorkloadSliceReplacementFor, string(workload.Key(utiltestingapi.MakeWorkload(testJobObject.Name+"-1", testJobObject.Namespace).Obj()))).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "1").Obj()).
 					Obj(),
 			},
@@ -866,6 +870,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
 						ResourceVersion("1").
 						Creation(now).
+						Annotation(WorkloadSliceReplacementFor, string(workload.Key(utiltestingapi.MakeWorkload(testJobObject.Name+"-1", testJobObject.Namespace).Obj()))).
 						PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()).
 						Obj()).
 					Build(),
@@ -879,11 +884,12 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 					OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
 					ResourceVersion("2").
 					Creation(now).
+					Annotation(WorkloadSliceReplacementFor, string(workload.Key(utiltestingapi.MakeWorkload(testJobObject.Name+"-1", testJobObject.Namespace).Obj()))).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
 					Obj(),
 			},
 		},
-		"TwoWorkloadSlices_NewIsUnreservedAndOutOfSync_UpdateFailure": {
+		"TwoWorkloadSlices_NewWithoutAnnotation_OldAdmitted_KeepsAdmitted": {
 			args: args{
 				clnt: testWorkloadClientBuilder().WithObjects(
 					utiltestingapi.MakeWorkload(testJobObject.Name+"-1", testJobObject.Namespace).
@@ -899,22 +905,12 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						Creation(now).
 						PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()).
 						Obj()).
-					WithInterceptorFuncs(interceptor.Funcs{
-						Update: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.UpdateOption) error {
-							// Assert that we are updating correct workload slice.
-							if obj.GetName() != testJobObject.Name+"-2" {
-								t.Errorf("unexptected workload update: %v", obj)
-							}
-							return errors.New("test-update-error")
-						},
-					}).
 					Build(),
 				jobPodSets:   []kueue.PodSet{*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()},
 				jobObject:    testJobObject,
 				jobObjectGVK: testJobGVK,
 			},
 			want: want{
-				error:      true,
 				compatible: true,
 			},
 		},
@@ -971,8 +967,8 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 				jobObjectGVK: testJobGVK,
 			},
 			want: want{
-				error:      true,
 				compatible: true,
+				workload:   testWorkload(testJobObject.Name+"-3", testResourceVersion+1, testPodSets(3)),
 			},
 		},
 	}
@@ -989,6 +985,150 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 			}
 			if gotCompatible != tt.want.compatible {
 				t.Errorf("EnsureWorkloadSlices() compatible = %v, want %v", gotCompatible, tt.want.compatible)
+			}
+		})
+	}
+}
+
+func TestNormalizeActiveSlices(t *testing.T) {
+	now := time.Now()
+	fakeClock := testingclock.NewFakeClock(now)
+
+	admitted := func(w *utiltestingapi.WorkloadWrapper) *utiltestingapi.WorkloadWrapper {
+		return w.ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").PodSets(
+			utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+		).Obj(), now)
+	}
+
+	type want struct {
+		survivor     string
+		keptAdmitted string
+		error        bool
+	}
+
+	tests := map[string]struct {
+		workloads []kueue.Workload
+		want      want
+	}{
+		"two admitted, keep newest": {
+			workloads: []kueue.Workload{
+				*admitted(utiltestingapi.MakeWorkload("wl-a", "ns").ResourceVersion("1").Creation(now.Add(-time.Minute)).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj())).Obj(),
+				*admitted(utiltestingapi.MakeWorkload("wl-b", "ns").ResourceVersion("1").Creation(now).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj())).Obj(),
+			},
+			want: want{survivor: "wl-b"},
+		},
+		"admitted + pending replacement, keep replacement": {
+			workloads: []kueue.Workload{
+				*admitted(utiltestingapi.MakeWorkload("wl-a", "ns").ResourceVersion("1").Creation(now.Add(-time.Minute)).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj())).Obj(),
+				*utiltestingapi.MakeWorkload("wl-b", "ns").ResourceVersion("1").Creation(now).
+					Annotation(WorkloadSliceReplacementFor, "ns/wl-a").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+			},
+			want: want{survivor: "wl-b", keptAdmitted: "wl-a"},
+		},
+		"evicted admitted + pending, keep pending and finish evicted": {
+			workloads: []kueue.Workload{
+				*admitted(utiltestingapi.MakeWorkload("wl-a", "ns").ResourceVersion("1").Creation(now.Add(-time.Minute)).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj())).
+					EvictedAt(now).Obj(),
+				*utiltestingapi.MakeWorkload("wl-b", "ns").ResourceVersion("1").Creation(now).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+			},
+			want: want{survivor: "wl-b"},
+		},
+		"forked DAG, both replace same finished target, keep newest": {
+			workloads: []kueue.Workload{
+				*admitted(utiltestingapi.MakeWorkload("wl-a", "ns").ResourceVersion("1").Creation(now.Add(-time.Minute)).
+					Annotation(WorkloadSliceReplacementFor, "ns/wl-old").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj())).Obj(),
+				*admitted(utiltestingapi.MakeWorkload("wl-b", "ns").ResourceVersion("1").Creation(now).
+					Annotation(WorkloadSliceReplacementFor, "ns/wl-old").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj())).Obj(),
+			},
+			want: want{survivor: "wl-b"},
+		},
+		"all non-admitted non-evicted, keep newest": {
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-a", "ns").ResourceVersion("1").Creation(now.Add(-time.Minute)).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+				*utiltestingapi.MakeWorkload("wl-b", "ns").ResourceVersion("1").Creation(now).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+			},
+			want: want{survivor: "wl-b"},
+		},
+		"all evicted, survivor is nil": {
+			workloads: []kueue.Workload{
+				*admitted(utiltestingapi.MakeWorkload("wl-a", "ns").ResourceVersion("1").Creation(now.Add(-time.Minute)).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj())).
+					EvictedAt(now).Obj(),
+				*admitted(utiltestingapi.MakeWorkload("wl-b", "ns").ResourceVersion("1").Creation(now).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj())).
+					EvictedAt(now).Obj(),
+			},
+			want: want{survivor: ""},
+		},
+		"admitted + pending without replacement annotation, keep admitted": {
+			workloads: []kueue.Workload{
+				*admitted(utiltestingapi.MakeWorkload("wl-a", "ns").ResourceVersion("1").Creation(now.Add(-time.Minute)).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj())).Obj(),
+				*utiltestingapi.MakeWorkload("wl-b", "ns").ResourceVersion("1").Creation(now).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+			},
+			want: want{survivor: "wl-a"},
+		},
+		"three workloads, admitted + two pending, keep replacement targeting admitted": {
+			workloads: []kueue.Workload{
+				*admitted(utiltestingapi.MakeWorkload("wl-a", "ns").ResourceVersion("1").Creation(now.Add(-2 * time.Minute)).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj())).Obj(),
+				*utiltestingapi.MakeWorkload("wl-b", "ns").ResourceVersion("1").Creation(now.Add(-time.Minute)).
+					Annotation(WorkloadSliceReplacementFor, "ns/wl-old").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+				*utiltestingapi.MakeWorkload("wl-c", "ns").ResourceVersion("1").Creation(now).
+					Annotation(WorkloadSliceReplacementFor, "ns/wl-a").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+			},
+			want: want{survivor: "wl-c", keptAdmitted: "wl-a"},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			testSchema := runtime.NewScheme()
+			_ = kueue.AddToScheme(testSchema)
+			var objs []client.Object
+			for i := range tc.workloads {
+				objs = append(objs, &tc.workloads[i])
+			}
+			clnt := fake.NewClientBuilder().
+				WithScheme(testSchema).
+				WithStatusSubresource(&kueue.Workload{}).
+				WithObjects(objs...).
+				Build()
+
+			survivor, err := normalizeActiveSlices(ctx, clnt, fakeClock, tc.workloads)
+			if (err != nil) != tc.want.error {
+				t.Fatalf("normalizeActiveSlices() error = %v, wantErr %v", err, tc.want.error)
+			}
+			gotName := ""
+			if survivor != nil {
+				gotName = survivor.Name
+			}
+			if gotName != tc.want.survivor {
+				t.Errorf("normalizeActiveSlices() survivor = %q, want %q", gotName, tc.want.survivor)
+			}
+
+			for i := range tc.workloads {
+				wl := &kueue.Workload{}
+				if err := clnt.Get(ctx, client.ObjectKeyFromObject(&tc.workloads[i]), wl); err != nil {
+					t.Fatalf("failed to get workload %s: %v", tc.workloads[i].Name, err)
+				}
+				kept := wl.Name == tc.want.survivor || wl.Name == tc.want.keptAdmitted
+				if !kept && !workload.IsFinished(wl) {
+					t.Errorf("workload %q should be finished but is not", wl.Name)
+				}
 			}
 		})
 	}

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -4188,6 +4188,65 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		util.ExpectFinishedWorkloadsTotalMetric(clusterQueue, highPriorityClass.Name, 0)
 		util.ExpectLQFinishedWorkloadsTotalMetric(localQueue, highPriorityClass.Name, 0)
 	})
+
+	ginkgo.It("Should handle rapid scale cycles without quota leaks", framework.SlowSpec, func() {
+		testJob := testingjob.MakeJob("stress-job", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "100m").
+			Parallelism(1).
+			Completions(100).
+			Obj()
+
+		ginkgo.By("creating the job and waiting for admission")
+		util.MustCreate(ctx, k8sClient, testJob)
+
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).ShouldNot(gomega.BeEmpty())
+			g.Expect(workload.IsAdmitted(&workloads.Items[0])).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
+			g.Expect(ptr.Deref(testJob.Spec.Suspend, false)).Should(gomega.BeFalse())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("rapidly cycling parallelism through scale-up and scale-down")
+		for i := range 10 {
+			// Cycle parallelism 1→2→3→4→1→... to alternate scale-up and scale-down.
+			targetParallelism := int32(1 + (i % 4))
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
+				testJob.Spec.Parallelism = ptr.To(targetParallelism)
+				g.Expect(k8sClient.Update(ctx, testJob)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		}
+
+		ginkgo.By("verifying convergence to exactly one active workload")
+		gomega.Eventually(func(g gomega.Gomega) {
+			wlList := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, wlList, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
+			var activeWorkloads []string
+			for i := range wlList.Items {
+				if workload.HasQuotaReservation(&wlList.Items[i]) && !workload.IsFinished(&wlList.Items[i]) {
+					activeWorkloads = append(activeWorkloads, wlList.Items[i].Name)
+				}
+			}
+			g.Expect(activeWorkloads).Should(gomega.HaveLen(1))
+		}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("verifying cluster queue usage does not exceed quota")
+		gomega.Eventually(func(g gomega.Gomega) {
+			cq := &kueue.ClusterQueue{}
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), cq)).Should(gomega.Succeed())
+			g.Expect(len(cq.Status.FlavorsUsage)).Should(gomega.BeEquivalentTo(1))
+			g.Expect(len(cq.Status.FlavorsUsage[0].Resources)).Should(gomega.BeEquivalentTo(1))
+			g.Expect(cq.Status.FlavorsUsage[0].Resources[0].Total.MilliValue()).Should(
+				gomega.BeNumerically("<=", int64(cpuNominalQuota)*1000))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	})
 })
 
 var _ = ginkgo.Describe("Job reconciliation", ginkgo.Ordered, func() {


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubernetes-sigs/kueue/pull/11327

/assign sohankunkerkar

```release-note
ElasticJobsViaWorkloadSlices: Fixed a bug where rapid elastic Job scaling could leave duplicate replacement Workload slices admitted indefinitely, causing quota to remain reserved.
```