### PR TITLE
[release-0.16] Finish old workload slice only after new slice is admitted

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -370,16 +370,13 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 		// - the new workload is not admitted.
 		// In a single-cluster context, this should lead to Job suspension.
 		// In a MultiKueue context, this should also trigger removal of remote workload/Job objects.
+		// Copy ClusterName from old slice before admission (needed for MultiKueue).
 		if features.Enabled(features.ElasticJobsViaWorkloadSlices) && oldWorkloadSlice != nil {
 			e.Obj.Status.ClusterName = oldWorkloadSlice.WorkloadInfo.Obj.Status.ClusterName
-			if err := s.replaceWorkloadSlice(ctx, oldWorkloadSlice.WorkloadInfo.ClusterQueue, e.Obj, oldWorkloadSlice.WorkloadInfo.Obj.DeepCopy()); err != nil {
-				log.Error(err, "Failed to replace workload slice")
-				continue
-			}
 		}
 
 		e.status = nominated
-		if err := s.admit(ctx, e, cq); err != nil {
+		if err := s.admit(ctx, e, cq, oldWorkloadSlice); err != nil {
 			e.inadmissibleMsg = fmt.Sprintf("Failed to admit workload: %v", err)
 		}
 	}
@@ -651,7 +648,7 @@ func updateAssignmentForTAS(log logr.Logger, snapshot *schdcache.Snapshot, cq *s
 // admit sets the admitting clusterQueue and flavors into the workload of
 // the entry, and asynchronously updates the object in the apiserver after
 // assuming it in the cache.
-func (s *Scheduler) admit(ctx context.Context, e *entry, cq *schdcache.ClusterQueueSnapshot) error {
+func (s *Scheduler) admit(ctx context.Context, e *entry, cq *schdcache.ClusterQueueSnapshot, oldWorkloadSlice *preemption.Target) error {
 	log := ctrl.LoggerFrom(ctx)
 	admission := &kueue.Admission{
 		ClusterQueue:      e.ClusterQueue,
@@ -679,6 +676,11 @@ func (s *Scheduler) admit(ctx context.Context, e *entry, cq *schdcache.ClusterQu
 			s.recordWorkloadAdmissionMetrics(newWorkload, e.Obj, admission, consideredStr)
 
 			log.V(2).Info("Workload successfully admitted and assigned flavors", "assignments", admission.PodSetAssignments)
+			if features.Enabled(features.ElasticJobsViaWorkloadSlices) && oldWorkloadSlice != nil {
+				if err := s.replaceWorkloadSlice(ctx, oldWorkloadSlice.WorkloadInfo.ClusterQueue, e.Obj, oldWorkloadSlice.WorkloadInfo.Obj.DeepCopy()); err != nil {
+					log.Error(err, "Failed to finish old workload slice after admitting replacement; job reconciler will handle recovery")
+				}
+			}
 			return
 		}
 		// Ignore errors because the workload or clusterQueue could have been deleted

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -4872,9 +4872,9 @@ func TestSchedule(t *testing.T) {
 			},
 			eventCmpOpts: ignoreEventMessageCmpOpts,
 			wantEvents: []utiltesting.EventRecord{
-				utiltesting.MakeEventRecord("sales", "foo-1", kueue.WorkloadSliceReplaced, corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("sales", "foo-2", "QuotaReserved", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("sales", "foo-2", "Admitted", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("sales", "foo-1", kueue.WorkloadSliceReplaced, corev1.EventTypeNormal).Obj(),
 			},
 		},
 		"pending admission check with nofit and fit flavors": {

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -4189,63 +4189,47 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		util.ExpectLQFinishedWorkloadsTotalMetric(localQueue, highPriorityClass.Name, 0)
 	})
 
-	ginkgo.It("Should handle rapid scale cycles without quota leaks", framework.SlowSpec, func() {
-		testJob := testingjob.MakeJob("stress-job", ns.Name).
+	ginkgo.It("Should not finish old workload-slice before new slice is admitted", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlices, true)
+
+		elasticJob := testingjob.MakeJob("job-slice-ordering", ns.Name).
 			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 			Queue(kueue.LocalQueueName(localQueue.Name)).
 			Request(corev1.ResourceCPU, "100m").
 			Parallelism(1).
-			Completions(100).
+			Completions(3).
 			Obj()
 
-		ginkgo.By("creating the job and waiting for admission")
-		util.MustCreate(ctx, k8sClient, testJob)
+		ginkgo.By("creating an elastic job")
+		util.MustCreate(ctx, k8sClient, elasticJob)
 
+		ginkgo.By("the original workload slice is admitted")
+		workloads := util.ExpectWorkloadsInNamespace(ctx, k8sClient, elasticJob.Namespace, 1)
+		oldWorkloadSlice := &workloads[0]
+		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, oldWorkloadSlice)
+		util.ExpectJobUnsuspendedWithNodeSelectors(ctx, k8sClient, client.ObjectKeyFromObject(elasticJob), nil)
+
+		ginkgo.By("setting up a watch on workloads before scaling")
+		watchClient, ok := k8sClient.(client.WithWatch)
+		gomega.Expect(ok).Should(gomega.BeTrue(), "k8sClient must implement client.WithWatch")
+		watcher, err := watchClient.Watch(ctx, &kueue.WorkloadList{}, &client.ListOptions{
+			Namespace: elasticJob.Namespace,
+		})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		defer watcher.Stop()
+
+		ginkgo.By("scaling the job up within quota")
 		gomega.Eventually(func(g gomega.Gomega) {
-			workloads := &kueue.WorkloadList{}
-			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
-			g.Expect(workloads.Items).ShouldNot(gomega.BeEmpty())
-			g.Expect(workload.IsAdmitted(&workloads.Items[0])).Should(gomega.BeTrue())
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(elasticJob), elasticJob)).Should(gomega.Succeed())
+			elasticJob.Spec.Parallelism = ptr.To[int32](2)
+			g.Expect(k8sClient.Update(ctx, elasticJob)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
-			g.Expect(ptr.Deref(testJob.Spec.Suspend, false)).Should(gomega.BeFalse())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		ginkgo.By("verifying the old slice is not finished when the new slice becomes admitted")
+		util.ExpectWorkloadSliceAdmittedBeforeOldFinished(watcher, oldWorkloadSlice.Name, util.Timeout)
 
-		ginkgo.By("rapidly cycling parallelism through scale-up and scale-down")
-		for i := range 10 {
-			// Cycle parallelism 1→2→3→4→1→... to alternate scale-up and scale-down.
-			targetParallelism := int32(1 + (i % 4))
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
-				testJob.Spec.Parallelism = ptr.To(targetParallelism)
-				g.Expect(k8sClient.Update(ctx, testJob)).Should(gomega.Succeed())
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		}
-
-		ginkgo.By("verifying convergence to exactly one active workload")
-		gomega.Eventually(func(g gomega.Gomega) {
-			wlList := &kueue.WorkloadList{}
-			g.Expect(k8sClient.List(ctx, wlList, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
-			var activeWorkloads []string
-			for i := range wlList.Items {
-				if workload.HasQuotaReservation(&wlList.Items[i]) && !workload.IsFinished(&wlList.Items[i]) {
-					activeWorkloads = append(activeWorkloads, wlList.Items[i].Name)
-				}
-			}
-			g.Expect(activeWorkloads).Should(gomega.HaveLen(1))
-		}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
-
-		ginkgo.By("verifying cluster queue usage does not exceed quota")
-		gomega.Eventually(func(g gomega.Gomega) {
-			cq := &kueue.ClusterQueue{}
-			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), cq)).Should(gomega.Succeed())
-			g.Expect(len(cq.Status.FlavorsUsage)).Should(gomega.BeEquivalentTo(1))
-			g.Expect(len(cq.Status.FlavorsUsage[0].Resources)).Should(gomega.BeEquivalentTo(1))
-			g.Expect(cq.Status.FlavorsUsage[0].Resources[0].Total.MilliValue()).Should(
-				gomega.BeNumerically("<=", int64(cpuNominalQuota)*1000))
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		ginkgo.By("old workload is finished")
+		util.ExpectWorkloadToFinish(ctx, k8sClient, client.ObjectKeyFromObject(oldWorkloadSlice))
 	})
 })
 

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -55,6 +55,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
@@ -1542,4 +1543,40 @@ func waitForDummyWorkloadToRunOnNode(ctx context.Context, c client.Client, node 
 			}, cmpopts.IgnoreFields(batchv1.JobCondition{}, "LastTransitionTime", "LastProbeTime", "Reason", "Message"))))
 		}, LongTimeout, Interval).Should(gomega.Succeed(), AssertMsg(fmt.Sprintf("Dummy workload did not complete on node %s", node.Name), &createdDummyJob))
 	})
+}
+
+// ExpectWorkloadSliceAdmittedBeforeOldFinished watches workload events and asserts
+// that the old workload slice is not marked Finished before the new slice is Admitted.
+func ExpectWorkloadSliceAdmittedBeforeOldFinished(watcher watch.Interface, oldWorkloadName string, timeout time.Duration) {
+	ginkgo.GinkgoHelper()
+	oldSliceFinished := false
+	newSliceAdmitted := false
+	timeoutCh := time.After(timeout)
+	for !newSliceAdmitted {
+		select {
+		case evt, ok := <-watcher.ResultChan():
+			gomega.Expect(ok).Should(gomega.BeTrue(), "watch channel closed unexpectedly")
+			if evt.Type == watch.Error {
+				status, _ := evt.Object.(*metav1.Status)
+				gomega.Expect(evt.Type).ShouldNot(gomega.Equal(watch.Error), fmt.Sprintf("watch error: %v", status))
+			}
+			if evt.Type != watch.Modified {
+				continue
+			}
+			wl, isWorkload := evt.Object.(*kueue.Workload)
+			gomega.Expect(isWorkload).Should(gomega.BeTrue())
+
+			if wl.Name == oldWorkloadName && workload.IsFinished(wl) {
+				oldSliceFinished = true
+			}
+			if wl.Name != oldWorkloadName && workload.IsAdmitted(wl) {
+				gomega.Expect(oldSliceFinished).Should(gomega.BeFalse(),
+					"old workload slice was finished before new slice was admitted")
+				newSliceAdmitted = true
+			}
+		case <-timeoutCh:
+			gomega.Expect(newSliceAdmitted).Should(gomega.BeTrue(),
+				"timed out waiting for new workload slice to be admitted")
+		}
+	}
 }


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubernetes-sigs/kueue/pull/11195 and https://github.com/kubernetes-sigs/kueue/pull/11292

/assign sohankunkerkar

```release-note
ElasticJobsViaWorkloadSlices: Fix quota leak during elastic workload scale-up where old slice was finished before replacement slice was admitted.
```