### PR TITLE
fix: fix MultiKueue workload requeue delay when worker connection is lost

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -128,6 +128,7 @@ type remoteClient struct {
 	adapters     map[string]jobframework.MultiKueueAdapter
 
 	connecting           atomic.Bool
+	disconnected         atomic.Bool
 	failedConnAttempts   uint
 	retryConnNextAttempt metav1.Time
 
@@ -292,6 +293,7 @@ func (rc *remoteClient) setConfig(watchCtx context.Context, config *clientConfig
 	}
 
 	rc.connecting.Store(false)
+	rc.disconnected.Store(false)
 	rc.resetFailedConnAttempt()
 	return nil, nil
 }
@@ -487,6 +489,15 @@ func (rc *remoteClient) StopWatchers() {
 	}
 }
 
+// disconnect stops the watchers and marks the client as disconnected without
+// removing it from the clustersReconciler's remoteClients map. This allows the
+// workload reconciler to detect that the cluster was previously available but
+// is now unreachable, and apply the workerLostTimeout delay before requeuing.
+func (rc *remoteClient) disconnect() {
+	rc.StopWatchers()
+	rc.disconnected.Store(true)
+}
+
 func (rc *remoteClient) queueWorkloadEvent(ctx context.Context, wlKey types.NamespacedName) {
 	localWl := &kueue.Workload{}
 	if err := rc.localClient.Get(ctx, wlKey, localWl); err == nil {
@@ -511,7 +522,7 @@ func (rc *remoteClient) queueWatchEndedEvent(ctx context.Context) {
 func (rc *remoteClient) runGC(ctx context.Context) {
 	log := ctrl.LoggerFrom(ctx)
 
-	if rc.connecting.Load() {
+	if rc.connecting.Load() || rc.disconnected.Load() {
 		log.V(5).Info("Skip disconnected client")
 		return
 	}
@@ -631,6 +642,17 @@ func (c *clustersReconciler) stopAndRemoveCluster(clusterName string) {
 	}
 }
 
+// disconnectCluster marks the remoteClient for clusterName as disconnected
+// without removing it from the map. This allows the workload reconciler to
+// detect the disconnection and apply the workerLostTimeout delay.
+func (c *clustersReconciler) disconnectCluster(clusterName string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if rc, found := c.remoteClients[clusterName]; found {
+		rc.disconnect()
+	}
+}
+
 // findOrCreateRemoteClient returns the remoteClient for clusterName, creating
 // one if absent. Only the brief map operation runs under c.lock.
 func (c *clustersReconciler) findOrCreateRemoteClient(clusterName, origin string) *remoteClient {
@@ -694,7 +716,7 @@ func (c *clustersReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 	clientConfig, reason, err := c.loadClientConfig(ctx, cluster)
 	if err != nil {
 		log.Error(err, "loading client config failed")
-		c.stopAndRemoveCluster(req.Name)
+		c.disconnectCluster(req.Name)
 		if updateErr := c.updateStatus(ctx, cluster, false, reason, fmt.Sprintf("load client config failed: %v", err)); updateErr != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to update MultiKueueCluster status: %w after failing to load client config: %w", updateErr, err)
 		}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -231,12 +231,13 @@ func (rc *remoteClient) increaseFailedConnAttempt() *time.Duration {
 }
 
 // setConfig - will try to recreate the k8s client and restart watching if the new config is different than
-// the one currently used or a reconnect was requested.
+// the one currently used, a reconnect was requested, or the client was marked as disconnected.
 // If the encountered error is not permanent the duration after which a retry should be done is returned.
 func (rc *remoteClient) setConfig(watchCtx context.Context, config *clientConfig) (*time.Duration, error) {
 	configChanged := !equality.Semantic.DeepEqual(config, rc.config)
 	connecting := rc.connecting.Load()
-	if !configChanged && !connecting {
+	disconnected := rc.disconnected.Load()
+	if !configChanged && !connecting && !disconnected {
 		return nil, nil
 	}
 
@@ -495,6 +496,7 @@ func (rc *remoteClient) StopWatchers() {
 // is now unreachable, and apply the workerLostTimeout delay before requeuing.
 func (rc *remoteClient) disconnect() {
 	rc.StopWatchers()
+	rc.connecting.Store(true)
 	rc.disconnected.Store(true)
 }
 

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -318,6 +318,9 @@ func TestUpdateConfig(t *testing.T) {
 					Generation(1).
 					Obj(),
 			},
+			wantRemoteClients: map[string]*remoteClient{
+				"worker1": newTestClient(ctx, []byte("worker1 old kubeconfig"), nil, nil),
+			},
 			wantCancelCalled: 1,
 			wantErr:          fmt.Errorf("failed to load client config, reason: BadKubeConfig, error: %w", errors.New("open : no such file or directory")),
 		},
@@ -499,7 +502,9 @@ func TestUpdateConfig(t *testing.T) {
 					Generation(1).
 					Obj(),
 			},
-			wantRemoteClients: map[string]*remoteClient{},
+			wantRemoteClients: map[string]*remoteClient{
+				"worker1": newTestClient(ctx, []byte("worker1 old kubeconfig"), nil, nil),
+			},
 			wantCancelCalled:  1,
 			wantErr:           fmt.Errorf("failed to load client config, reason: InsecureKubeConfig, error: %w", errors.New("tokenFile is not allowed")),
 		},

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -864,6 +864,54 @@ func TestReconnectBackoff(t *testing.T) {
 	}
 }
 
+func TestDisconnectedClientReconnectsWithSameConfig(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	kubeconfig := testKubeconfig("worker1")
+
+	cluster := utiltestingapi.MakeMultiKueueCluster("worker1").
+		KubeConfig(kueue.SecretLocationType, "worker1").
+		Active(metav1.ConditionFalse, "BadKubeConfig", "load client config failed", 1).
+		Generation(1).
+		Obj()
+	secret := makeTestSecret("worker1", kubeconfig)
+
+	builder := getClientBuilder(ctx)
+	builder = builder.WithObjects(cluster, &secret)
+	builder = builder.WithStatusSubresource(&kueue.MultiKueueCluster{})
+	c := builder.Build()
+
+	adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
+	reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileCreds{}, nil)
+	reconciler.rootContext = ctx
+
+	var buildCalls int
+	inner := fakeClientBuilder(ctx)
+	reconciler.builderOverride = func(builderCtx context.Context, cfg *clientConfig, opts client.Options) (SelectivelyCachingClient, error) {
+		buildCalls++
+		return inner(builderCtx, cfg, opts)
+	}
+
+	rc := newTestClient(ctx, []byte(kubeconfig), nil, nil)
+	rc.builderOverride = reconciler.builderOverride
+	rc.disconnected.Store(true)
+	reconciler.remoteClients["worker1"] = rc
+	defer rc.StopWatchers()
+
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "worker1"}})
+	if err != nil {
+		t.Fatalf("unexpected reconcile error: %v", err)
+	}
+	if buildCalls != 1 {
+		t.Fatalf("builder invocations: want 1, got %d", buildCalls)
+	}
+	if rc.connecting.Load() {
+		t.Error("connecting should be cleared after successful reconnect")
+	}
+	if rc.disconnected.Load() {
+		t.Error("disconnected should be cleared after successful reconnect")
+	}
+}
+
 func TestRemoteClientGC(t *testing.T) {
 	baseJobBuilder := testingjob.MakeJob("job1", TestNamespace)
 	baseWlBuilder := utiltestingapi.MakeWorkload("wl1", TestNamespace).ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "test-uuid")

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -505,8 +505,8 @@ func TestUpdateConfig(t *testing.T) {
 			wantRemoteClients: map[string]*remoteClient{
 				"worker1": newTestClient(ctx, []byte("worker1 old kubeconfig"), nil, nil),
 			},
-			wantCancelCalled:  1,
-			wantErr:           fmt.Errorf("failed to load client config, reason: InsecureKubeConfig, error: %w", errors.New("tokenFile is not allowed")),
+			wantCancelCalled: 1,
+			wantErr:          fmt.Errorf("failed to load client config, reason: InsecureKubeConfig, error: %w", errors.New("tokenFile is not allowed")),
 		},
 		"skip insecure kubeconfig validation": {
 			reconcileFor: "worker1",

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -258,15 +258,17 @@ func (w *wlReconciler) remoteClientsForAC(ctx context.Context, acName kueue.Admi
 	clients := make(map[string]*remoteClient, len(cfg.Spec.Clusters))
 	for _, clusterName := range cfg.Spec.Clusters {
 		if client, found := w.clusters.controllerFor(clusterName); found {
-			// Skip the client if its reconnect is ongoing.
-			if !client.connecting.Load() {
+			// Skip the client if its reconnect is ongoing or it is disconnected.
+			if !client.connecting.Load() && !client.disconnected.Load() {
 				clients[clusterName] = client
 			}
 		}
 	}
-	if len(clients) == 0 {
-		return nil, admissioncheck.ErrNoActiveClusters
-	}
+	// Return an empty map (rather than an error) when all configured clusters
+	// are disconnected or reconnecting. This allows readGroup to construct an
+	// empty group, so reconcileGroup can apply the workerLostTimeout delay via
+	// the existing "reserving remote lost" branch instead of failing with
+	// ErrNoActiveClusters and retrying via controller-runtime backoff.
 	return clients, nil
 }
 

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -1329,7 +1329,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				g.Expect(acs.State).To(gomega.Equal(kueue.CheckStateReady))
 				g.Expect(acs.Message).To(gomega.Equal(`The workload got reservation on "worker1"`))
 				g.Expect(apimeta.IsStatusConditionTrue(createdWorkload.Status.Conditions, kueue.WorkloadAdmitted)).To(gomega.BeTrue())
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			util.ExpectEventAppeared(managerTestCluster.ctx, managerTestCluster.client, eventsv1.Event{
 				Reason: "MultiKueue",
 				Type:   corev1.EventTypeNormal,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake
/area testing

#### Which issue(s) this PR fixes:

Fixes #11496

#### Special notes for your reviewer:

```
cause: When a cluster connection is lost, `stopAndRemoveCluster()` completely removes the `remoteClient` from the map, causing the workload reconciler to be unable to detect the disconnected cluster, returning an `ErrNoActiveClusters` error and triggering the controller-runtime backoff instead of the `workerLostTimeout` delay mechanism.

Fix: Instead, mark disconnected clients as disconnected and retain them in the map, enabling the workload reconciler to:

	- Detect cluster disconnections
	- Apply the `workerLostTimeout` delay even if all clusters are disconnected
	- Properly handle cleanup when connections are restored
```

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: Fixed a bug where a lost connection to a worker cluster failed to trigger the "workerLostTimeout" delay mechanism for workload requeuing.
```
