### PR TITLE
[integration] Drop ginkgo.Ordered from StatefulSet controller singlecluster tests

### DIFF
--- a/test/integration/singlecluster/controller/jobs/statefulset/statefulset_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/statefulset/statefulset_controller_test.go
@@ -33,17 +33,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("StatefulSet controller", ginkgo.Label("job:statefulset", "area:jobs"), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-	ginkgo.BeforeAll(func() {
-		fwk.StartManager(ctx, cfg, managerSetup(
-			jobframework.WithKubeServerVersion(serverVersionFetcher),
-			jobframework.WithEnabledFrameworks([]string{"statefulset"}),
-		))
-	})
-	ginkgo.AfterAll(func() {
-		fwk.StopManager(ctx)
-	})
-
+var _ = ginkgo.Describe("StatefulSet controller", ginkgo.Label("job:statefulset", "area:jobs"), func() {
 	var (
 		ns *corev1.Namespace
 		fl *kueue.ResourceFlavor
@@ -52,6 +42,10 @@ var _ = ginkgo.Describe("StatefulSet controller", ginkgo.Label("job:statefulset"
 	)
 
 	ginkgo.BeforeEach(func() {
+		fwk.StartManager(ctx, cfg, managerSetup(
+			jobframework.WithKubeServerVersion(serverVersionFetcher),
+			jobframework.WithEnabledFrameworks([]string{"statefulset"}),
+		))
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "sts-")
 
 		fl = utiltestingapi.MakeResourceFlavor("fl").Obj()
@@ -72,6 +66,7 @@ var _ = ginkgo.Describe("StatefulSet controller", ginkgo.Label("job:statefulset"
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, fl, true)
+		fwk.StopManager(ctx)
 	})
 
 	ginkgo.It("Should create distinct workloads for StatefulSets with generateName", func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it:
Updates the `Describe` block in `test/integration/singlecluster/controller/jobs/statefulset/statefulset_controller_test.go`:
- `StatefulSet controller`
- Removes `ginkgo.Ordered` and `ginkgo.ContinueOnFailure` from that block.
- Moves manager `StartManager`/`StopManager` from `BeforeAll`/`AfterAll` into `BeforeEach`/`AfterEach` (see [Parallelize Fair Sharing Integration Test (66% speedup) #8726](https://github.com/kubernetes-sigs/kueue/pull/8726)).
Continues the split from [Eliminate ginkgo.Ordered for singlecluster integration tests #9880](https://github.com/kubernetes-sigs/kueue/issues/9880). First `controller/jobs` PR after completing `controller/core` ([#11545](https://github.com/kubernetes-sigs/kueue/pull/11545)).

#### Which issue(s) this PR fixes:
Part of #9880

#### Special notes for your reviewer:
- Single `Describe` block, two `It` specs; no inner `When` hook changes.
- Keeps `jobframework.WithEnabledFrameworks([]string{"statefulset"})` in manager setup.
- No changes to `suite_test.go` or `test/integration/framework`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
