### PR TITLE
fix: prevent crash when error is not a string in ErrorMessage

### DIFF
--- a/cmd/kueueviz/frontend/src/ErrorMessage.jsx
+++ b/cmd/kueueviz/frontend/src/ErrorMessage.jsx
@@ -20,13 +20,23 @@ import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import './App.css';
 
+/**
+ * Converts an error of any type to a displayable string.
+ * Handles plain strings, Error objects, and arbitrary objects/events.
+ */
+export const errorToString = (error) => {
+  if (typeof error === 'string') return error;
+  if (error && typeof error.message === 'string' && error.message.length > 0) return error.message;
+  return JSON.stringify(error);
+};
+
 const ErrorMessage = ({ error }) => {
   const [expanded, setExpanded] = useState(false);
   
   if (!error) return null;
 
   // Extract the first line as the summary
-  const errorString = typeof error === 'string' ? error : (error.message || JSON.stringify(error));
+  const errorString = errorToString(error);
   const lines = errorString.split('\n');
   const errorSummary = lines[0];
   

--- a/cmd/kueueviz/frontend/src/ErrorMessage.jsx
+++ b/cmd/kueueviz/frontend/src/ErrorMessage.jsx
@@ -26,7 +26,8 @@ const ErrorMessage = ({ error }) => {
   if (!error) return null;
 
   // Extract the first line as the summary
-  const lines = error.split('\n');
+  const errorString = typeof error === 'string' ? error : (error.message || JSON.stringify(error));
+  const lines = errorString.split('\n');
   const errorSummary = lines[0];
   
   // The rest is considered details

--- a/cmd/kueueviz/frontend/src/ErrorMessage.test.js
+++ b/cmd/kueueviz/frontend/src/ErrorMessage.test.js
@@ -1,0 +1,83 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect } from 'vitest';
+import { errorToString } from './ErrorMessage';
+
+// ---------------------------------------------------------------------------
+// errorToString
+// ---------------------------------------------------------------------------
+describe('errorToString', () => {
+  it('returns plain strings unchanged', () => {
+    expect(errorToString('something went wrong')).toBe('something went wrong');
+  });
+
+  it('preserves multi-line strings', () => {
+    const input = 'line one\nline two\nline three';
+    expect(errorToString(input)).toBe(input);
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(errorToString('')).toBe('');
+  });
+
+  it('extracts message from Error objects', () => {
+    const err = new Error('connection refused');
+    expect(errorToString(err)).toBe('connection refused');
+  });
+
+  it('extracts message from TypeError', () => {
+    const err = new TypeError('cannot read property');
+    expect(errorToString(err)).toBe('cannot read property');
+  });
+
+  it('extracts message from objects with a message property', () => {
+    const obj = { message: 'custom error message', code: 500 };
+    expect(errorToString(obj)).toBe('custom error message');
+  });
+
+  it('JSON-stringifies objects without a message property', () => {
+    const obj = { code: 404, reason: 'not found' };
+    expect(errorToString(obj)).toBe(JSON.stringify(obj));
+  });
+
+  it('JSON-stringifies objects with an empty message', () => {
+    const obj = { message: '', code: 500 };
+    expect(errorToString(obj)).toBe(JSON.stringify(obj));
+  });
+
+  it('handles WebSocket-like event objects', () => {
+    // WebSocket error events are plain objects with no useful message
+    const event = { isTrusted: true, type: 'error' };
+    expect(errorToString(event)).toBe(JSON.stringify(event));
+  });
+
+  it('handles number input', () => {
+    expect(errorToString(42)).toBe('42');
+  });
+
+  it('handles boolean input', () => {
+    expect(errorToString(true)).toBe('true');
+  });
+
+  it('handles null input', () => {
+    expect(errorToString(null)).toBe('null');
+  });
+
+  it('handles undefined input', () => {
+    expect(errorToString(undefined)).toBe(undefined);
+  });
+});


### PR DESCRIPTION
Closes #11565 

Currently, `ErrorMessage.jsx` calls `error.split('\n')` assuming that `error` is always a primitive string. 

If the component receives an actual `Error` object or a standard WebSocket event (which is common during connection disruptions), it throws `TypeError: error.split is not a function` and crashes the entire error display container.

This PR adds type-checking and safe string coercion (`error.message || JSON.stringify(error)`) to convert non-string errors to strings safely before splitting.

```release-note
KueueViz: Fixed frontend crashes caused by non-string errors in the error display.
```

