### PR TITLE
Allow quota reserving workloads to be filtered directly in the kube API server

### DIFF
--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -1113,6 +1113,7 @@ const (
 // +kubebuilder:printcolumn:name="Finished",JSONPath=".status.conditions[?(@.type=='Finished')].status",type="string",description="Workload finished"
 // +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type="date",description="Time this workload was created"
 // +kubebuilder:resource:shortName={kwl,kueueworkload,kueueworkloads}
+// +kubebuilder:selectablefield:JSONPath=.status.admission.clusterQueue
 
 // Workload is the Schema for the workloads API
 // +kubebuilder:validation:XValidation:rule="has(self.status) && has(self.status.conditions) && self.status.conditions.exists(c, c.type == 'QuotaReserved' && c.status == 'True') && has(self.status.admission) ? size(self.spec.podSets) == size(self.status.admission.podSetAssignments) : true", message="podSetAssignments must have the same number of podSets as the spec"

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -18007,6 +18007,8 @@ spec:
               rule: '(has(oldSelf.status) && has(oldSelf.status.conditions) && oldSelf.status.conditions.exists(c, c.type == ''QuotaReserved'' && c.status == ''True'')) && (has(self.status) && has(self.status.conditions) && self.status.conditions.exists(c, c.type == ''QuotaReserved'' && c.status == ''True'')) && has(oldSelf.spec.queueName) && has(self.spec.queueName) ? oldSelf.spec.queueName == self.spec.queueName : true'
             - message: maximumExecutionTimeSeconds is immutable while workload quota reserved
               rule: ((has(oldSelf.status) && has(oldSelf.status.conditions) && oldSelf.status.conditions.exists(c, c.type == 'Admitted' && c.status == 'True')) && (has(self.status) && has(self.status.conditions) && self.status.conditions.exists(c, c.type == 'Admitted' && c.status == 'True')))?((has(oldSelf.spec.maximumExecutionTimeSeconds)?oldSelf.spec.maximumExecutionTimeSeconds:0) ==  (has(self.spec.maximumExecutionTimeSeconds)?self.spec.maximumExecutionTimeSeconds:0)):true
+      selectableFields:
+        - jsonPath: .status.admission.clusterQueue
       served: true
       storage: true
       subresources:

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -19139,6 +19139,8 @@ spec:
             && self.status.conditions.exists(c, c.type == 'Admitted' && c.status ==
             'True')))?((has(oldSelf.spec.maximumExecutionTimeSeconds)?oldSelf.spec.maximumExecutionTimeSeconds:0)
             ==  (has(self.spec.maximumExecutionTimeSeconds)?self.spec.maximumExecutionTimeSeconds:0)):true
+    selectableFields:
+    - jsonPath: .status.admission.clusterQueue
     served: true
     storage: true
     subresources:

--- a/test/integration/singlecluster/kueuectl/list_test.go
+++ b/test/integration/singlecluster/kueuectl/list_test.go
@@ -285,6 +285,24 @@ wl2                                             very-long-local-queue-name      
 			gomega.Expect(output.String()).Should(gomega.ContainSubstring("wl-cq2b"))
 			gomega.Expect(output.String()).ShouldNot(gomega.ContainSubstring("wl-pending"))
 			gomega.Expect(output.String()).ShouldNot(gomega.ContainSubstring("very-long-workload-name"))
+
+			ginkgo.By("filtering for workloads without quota reserved")
+			streams, _, output, errOutput = genericiooptions.NewTestIOStreams()
+			configFlags = CreateConfigFlagsWithRestConfig(cfg, streams)
+			kueuectl = app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams, Clock: testingclock.NewFakeClock(time.Now())})
+			kueuectl.SetArgs([]string{"list", "workload", "--field-selector",
+				"status.admission.clusterQueue=", "--namespace", ns.Name})
+			err = kueuectl.Execute()
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
+			gomega.Expect(errOutput.String()).Should(gomega.BeEmpty())
+			gomega.Expect(output.String()).Should(gomega.ContainSubstring("wl-pending"))
+			gomega.Expect(output.String()).Should(gomega.ContainSubstring("wl1"))
+			gomega.Expect(output.String()).Should(gomega.ContainSubstring("wl2"))
+			gomega.Expect(output.String()).Should(gomega.ContainSubstring("very-long-workload-name"))
+			gomega.Expect(output.String()).ShouldNot(gomega.ContainSubstring("wl-cq1"))
+			gomega.Expect(output.String()).ShouldNot(gomega.ContainSubstring("wl-cq2a"))
+			gomega.Expect(output.String()).ShouldNot(gomega.ContainSubstring("wl-cq2b"))
 		})
 	})
 

--- a/test/integration/singlecluster/kueuectl/list_test.go
+++ b/test/integration/singlecluster/kueuectl/list_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	testingclock "k8s.io/utils/clock/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app"
@@ -235,6 +236,55 @@ wl2                                             very-long-local-queue-name      
 					duration.HumanDuration(executeTime.Sub(wl1.CreationTimestamp.Time)),
 					duration.HumanDuration(executeTime.Sub(wl2.CreationTimestamp.Time)),
 				)))
+		})
+
+		ginkgo.It("Should filter workloads by status.admission.clusterQueue field selector", func() {
+			wlCQ1 := utiltestingapi.MakeWorkload("wl-cq1", ns.Name).Queue("lq1").Obj()
+			util.MustCreate(ctx, k8sClient, wlCQ1)
+			util.SetQuotaReservation(ctx, k8sClient, client.ObjectKeyFromObject(wlCQ1), utiltestingapi.MakeAdmission("cq1").Obj())
+
+			wlCQ2a := utiltestingapi.MakeWorkload("wl-cq2a", ns.Name).Queue("lq1").Obj()
+			util.MustCreate(ctx, k8sClient, wlCQ2a)
+			util.SetQuotaReservation(ctx, k8sClient, client.ObjectKeyFromObject(wlCQ2a), utiltestingapi.MakeAdmission("cq2").Obj())
+
+			wlCQ2b := utiltestingapi.MakeWorkload("wl-cq2b", ns.Name).Queue("lq1").Obj()
+			util.MustCreate(ctx, k8sClient, wlCQ2b)
+			util.SetQuotaReservation(ctx, k8sClient, client.ObjectKeyFromObject(wlCQ2b), utiltestingapi.MakeAdmission("cq2").Obj())
+
+			wlPending := utiltestingapi.MakeWorkload("wl-pending", ns.Name).Queue("lq1").Obj()
+			util.MustCreate(ctx, k8sClient, wlPending)
+
+			ginkgo.By("filtering for a specific ClusterQueue")
+			streams, _, output, errOutput := genericiooptions.NewTestIOStreams()
+			configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
+			kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams, Clock: testingclock.NewFakeClock(time.Now())})
+			kueuectl.SetArgs([]string{"list", "workload", "--field-selector",
+				"status.admission.clusterQueue=cq2", "--namespace", ns.Name})
+			err := kueuectl.Execute()
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
+			gomega.Expect(errOutput.String()).Should(gomega.BeEmpty())
+			gomega.Expect(output.String()).Should(gomega.ContainSubstring("wl-cq2a"))
+			gomega.Expect(output.String()).Should(gomega.ContainSubstring("wl-cq2b"))
+			gomega.Expect(output.String()).ShouldNot(gomega.ContainSubstring("wl-cq1"))
+			gomega.Expect(output.String()).ShouldNot(gomega.ContainSubstring("wl-pending"))
+			gomega.Expect(output.String()).ShouldNot(gomega.ContainSubstring("very-long-workload-name"))
+
+			ginkgo.By("filtering for any ClusterQueue (all reserved workloads)")
+			streams, _, output, errOutput = genericiooptions.NewTestIOStreams()
+			configFlags = CreateConfigFlagsWithRestConfig(cfg, streams)
+			kueuectl = app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams, Clock: testingclock.NewFakeClock(time.Now())})
+			kueuectl.SetArgs([]string{"list", "workload", "--field-selector",
+				"status.admission.clusterQueue!=", "--namespace", ns.Name})
+			err = kueuectl.Execute()
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
+			gomega.Expect(errOutput.String()).Should(gomega.BeEmpty())
+			gomega.Expect(output.String()).Should(gomega.ContainSubstring("wl-cq1"))
+			gomega.Expect(output.String()).Should(gomega.ContainSubstring("wl-cq2a"))
+			gomega.Expect(output.String()).Should(gomega.ContainSubstring("wl-cq2b"))
+			gomega.Expect(output.String()).ShouldNot(gomega.ContainSubstring("wl-pending"))
+			gomega.Expect(output.String()).ShouldNot(gomega.ContainSubstring("very-long-workload-name"))
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

Adds `status.admission.clusterQueue` as a selectable field on the Workload CRD (v1beta2), so users can filter workloads server-side with `--field-selector`.

This allows users to efficiently query QuotaReserving workloads by ClusterQueue:
- Filter for a specific CQ: `kubectl get workloads --field-selector status.admission.clusterQueue=my-cq`
- Filter across all CQs: `kubectl get workloads --field-selector status.admission.clusterQueue!=`

Only added to `v1beta2` because when both versions have the same `selectableFields`, Kubernetes moves them to the top-level CRD spec, which breaks validation when the per-version schemas differ.

This also works with `kueuectl` since it passes through the field selectors to kubectl. Example command: `kubectl kueue list workloads --field-selector status.admission.clusterQueue=my-cq`


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially Fixes #11567 

This only partially fixes the issue since it allows filtering for a subset of statuses. The ideal fix IMO would be to add a `status.phase` field in Workload CRD and expose it as a field selector, similar to how pods work. But that's a lot more work (new field, controller changes, likely a KEP). This seemed like a quick win — at least for filtering all quota-reserving and admitted workloads which is my immediate usecase.

For context: workload status today is derived from `status.conditions` by a `workload.Status()` helper. kueuectl uses this client-side for its `--status` flag, but `status.conditions` can't be used as a CRD field selector.

#### Special notes for your reviewer:

Needs `CustomResourceFieldSelectors` feature gate (on by default since K8s 1.30, GA since 1.31).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Workload CRD now supports `--field-selector status.admission.clusterQueue=<name>` to filter by ClusterQueue server-side. `status.admission.clusterQueue` is set when a workload reserves quota in the CQ.
```