### PR TITLE
Align reclaimWithinCohort docs with API godoc.Fixes 7749

### DIFF
--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -441,12 +441,15 @@ The fields above do the following:
   Workloads from other ClusterQueues in the cohort that are using more than
   their nominal quota. The possible values are:
   - `Never` (default): do not preempt Workloads in the cohort.
-  - `LowerPriority`: if the pending Workload fits within the nominal
-    quota of its ClusterQueue, only preempt Workloads in the cohort that have
-    lower priority than the pending Workload.
-  - `Any`: if the pending Workload fits within the nominal quota of its
-    ClusterQueue, preempt any Workload in the cohort, irrespective of
-    priority.
+  - `LowerPriority`: **Classic Preemption** if the pending Workload fits within
+    the nominal quota of its ClusterQueue, only preempt Workloads in the cohort
+    that have lower priority than the pending Workload. **Fair Sharing** only
+    preempt Workloads in the cohort that have lower priority than the pending
+    Workload and that satisfy the Fair Sharing preemption strategies.
+  - `Any`: **Classic Preemption** if the pending Workload fits within the
+    nominal quota of its ClusterQueue, preempt any Workload in the cohort,
+    irrespective of priority. **Fair Sharing** preempt Workloads in the cohort
+    that satisfy the Fair Sharing preemption strategies.
 
 - `borrowWithinCohort` determines whether a pending Workload can preempt
   Workloads from other ClusterQueues that are using more than their nominal

--- a/site/content/zh-CN/docs/concepts/cluster_queue.md
+++ b/site/content/zh-CN/docs/concepts/cluster_queue.md
@@ -414,8 +414,8 @@ spec:
 - `reclaimWithinCohort` 确定是否可以预留
   cohort 中使用更多配额的 Workloads。可能的值是：
   - `Never`（默认）：不要预留 cohort 中的 Workloads。
-  - `LowerPriority`：如果待处理的工作负载适合其 ClusterQueue 的配额，则仅预留 cohort 中优先级较低的 Workloads。
-  - `Any`：如果待处理的工作负载适合其 ClusterQueue 的配额，则预留 cohort 中的任何 Workloads，无论优先级如何。
+  - `LowerPriority`：**经典抢占**下，若待处理工作负载可容纳在其 ClusterQueue 的名义配额内，则仅预留 cohort 中优先级较低的 Workloads。**公平共享**下，仅预留 cohort 中优先级低于待处理工作负载且满足公平共享抢占策略的 Workloads。
+  - `Any`：**经典抢占**下，若待处理工作负载可容纳在其 ClusterQueue 的名义配额内，则预留 cohort 中任意优先级的 Workloads。**公平共享**下，预留 cohort 中满足公平共享抢占策略的 Workloads。
 
 - `borrowWithinCohort` 确定是否可以预留
   Workloads 从其他 ClusterQueues 如果工作负载需要借用。


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/area website

#### What this PR does / why we need it:
Updates the `reclaimWithinCohort` bullets in the ClusterQueue concept docs to match the `ReclaimWithinCohort` godoc in `clusterqueue_types.go`, as suggested in #7749.

#### Which issue(s) this PR fixes:
Fixes #7749

#### Special notes for your reviewer:
- Wording is aligned with `apis/kueue/v1beta2/clusterqueue_types.go` (same text exists in v1beta1).
- Chinese translation updated in parallel for consistency.
#### Does this PR introduce a user-facing change?

release-note
```release-note
NONE
````

