### PR TITLE
hack/testing: skip install-time operator deployment waits by default

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -103,6 +103,21 @@ function e2e_docker_pull_if_needed {
     return 1
 }
 
+function e2e_wait_for_operator_in_install {
+  local kubeconfig=$1
+  local ns=$2
+  local deployment_name=$3
+
+  if ! e2e_is_truthy "${E2E_WAIT_FOR_OPERATORS_IN_INSTALL:-false}"; then
+    echo "Skipping install-time wait for deployment/${deployment_name} in ${ns};" \
+         "BeforeSuite will verify readiness."
+    return 0
+  fi
+
+  kubectl --kubeconfig="${kubeconfig}" wait deploy/"${deployment_name}" \
+    -n "${ns}" --for=condition=available --timeout=5m
+}
+
 function e2e_deployment_exists {
     local kubeconfig=${1:-}
     local ns=$2
@@ -765,7 +780,7 @@ function install_appwrapper {
 
     cluster_kind_load_image "${name}" "${APPWRAPPER_IMAGE}"
     kubectl apply --kubeconfig="${kubeconfig}" --server-side -k "${APPWRAPPER_MANIFEST}"
-    kubectl wait --kubeconfig="${kubeconfig}" deploy/"${deployment_name}" -n "${ns}" --for=condition=available --timeout=5m
+    e2e_wait_for_operator_in_install "${kubeconfig}" "${ns}" "${deployment_name}"
 }
 
 # $1 cluster name
@@ -806,7 +821,7 @@ function install_jobset {
 
     cluster_kind_load_image "${name}" "${JOBSET_IMAGE}"
     kubectl apply --kubeconfig="${kubeconfig}" --server-side -f "${JOBSET_MANIFEST}"
-    kubectl wait --kubeconfig="${kubeconfig}" deploy/"${deployment_name}" -n "${ns}" --for=condition=available --timeout=5m
+    e2e_wait_for_operator_in_install "${kubeconfig}" "${ns}" "${deployment_name}"
 }
 
 # $1 cluster name
@@ -841,7 +856,7 @@ function install_kubeflow {
 
     cluster_kind_load_image "${name}" "${KUBEFLOW_IMAGE}"
     kubectl apply --kubeconfig="${kubeconfig}" --server-side -k "${KUBEFLOW_MANIFEST_PATCHED}"
-    kubectl wait --kubeconfig="${kubeconfig}" deploy/"${deployment_name}" -n "${ns}" --for=condition=available --timeout=5m
+    e2e_wait_for_operator_in_install "${kubeconfig}" "${ns}" "${deployment_name}"
 }
 
 # $1 cluster name
@@ -930,7 +945,8 @@ function install_mpi {
     cluster_kind_load_image "${name}" "${KUBEFLOW_MPI_IMAGE/#v}"
     curl -sSL "${KUBEFLOW_MPI_MANIFEST}" \
         | kubectl apply --kubeconfig="${kubeconfig}" --server-side -f -
-    kubectl wait --kubeconfig="${kubeconfig}" deploy/"${deployment_name}" -n "${ns}" --for=condition=available --timeout=5m || true
+    e2e_wait_for_operator_in_install "${kubeconfig}" "${ns}" "${deployment_name}"
+
 }
 
 # $1 cluster name
@@ -980,7 +996,7 @@ function install_kuberay {
         kubectl ${kubectl_args[@]+"${kubectl_args[@]}"} delete -k "${KUBERAY_MANIFEST}" --ignore-not-found=true
     fi
     kubectl ${kubectl_args[@]+"${kubectl_args[@]}"} create -k "${KUBERAY_MANIFEST}"
-    kubectl ${kubectl_args[@]+"${kubectl_args[@]}"} wait deploy/"${deployment_name}" -n "${ns}" --for=condition=available --timeout=5m || true
+    e2e_wait_for_operator_in_install "${kubeconfig}" "${ns}" "${deployment_name}"
 }
 
 # $1 cluster name
@@ -1021,7 +1037,7 @@ function install_lws {
 
     cluster_kind_load_image "${name}" "${LEADERWORKERSET_IMAGE/#v}"
     kubectl apply --kubeconfig="${kubeconfig}" --server-side -f "${LEADERWORKERSET_MANIFEST}"
-    kubectl wait --kubeconfig="${kubeconfig}" deploy/"${deployment_name}" -n "${ns}" --for=condition=available --timeout=5m || true
+    e2e_wait_for_operator_in_install "${kubeconfig}" "${ns}" "${deployment_name}"
 }
 
 # $1 cluster name


### PR DESCRIPTION
What type of PR is this?

/kind cleanup
/area testing

What this PR does / why we need it:

Skip the blocking kubectl wait --for=condition=available after each external operator install. These waits serialize setup unnecessarily — BeforeSuite already gates on operator readiness before any test runs.

The waits can be re-enabled via E2E_WAIT_FOR_OPERATORS_IN_INSTALL=true.
The Kubeflow Trainer webhook wait is intentionally kept unconditional, as the runtime resources applied immediately after depend on it.

Which issue(s) this PR fixes:
Fixes #

Special notes for your reviewer:
Only install_kubeflow_trainer retains a plain kubectl wait — it gates the overlays/runtimes apply that follows it.

Does this PR introduce a user-facing change?

```release-note
NONE
```
