### PR TITLE
fix: prevent scheduler preemption in pod group e2e

### DIFF
--- a/pkg/util/testingjobs/pod/wrappers.go
+++ b/pkg/util/testingjobs/pod/wrappers.go
@@ -146,10 +146,9 @@ func (p *PodWrapper) PriorityClass(pc string) *PodWrapper {
 	return p
 }
 
-// PreemptionPolicy updates the preemption policy of the Pod.
-func (p *PodWrapper) PreemptionPolicy(policy corev1.PreemptionPolicy) *PodWrapper {
-	p.Spec.PreemptionPolicy = &policy
-	return p
+// WorkloadPriorityClass updates the Kueue workload priority class label of the Pod.
+func (p *PodWrapper) WorkloadPriorityClass(wpc string) *PodWrapper {
+	return p.Label(controllerconsts.WorkloadPriorityClassLabel, wpc)
 }
 
 // Name updated the name of the pod

--- a/pkg/util/testingjobs/pod/wrappers.go
+++ b/pkg/util/testingjobs/pod/wrappers.go
@@ -146,6 +146,12 @@ func (p *PodWrapper) PriorityClass(pc string) *PodWrapper {
 	return p
 }
 
+// PreemptionPolicy updates the preemption policy of the Pod.
+func (p *PodWrapper) PreemptionPolicy(policy corev1.PreemptionPolicy) *PodWrapper {
+	p.Spec.PreemptionPolicy = &policy
+	return p
+}
+
 // Name updated the name of the pod
 func (p *PodWrapper) Name(n string) *PodWrapper {
 	p.ObjectMeta.Name = n

--- a/pkg/util/testingjobs/pod/wrappers_test.go
+++ b/pkg/util/testingjobs/pod/wrappers_test.go
@@ -19,16 +19,13 @@ package pod
 import (
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 )
 
-func TestPreemptionPolicy(t *testing.T) {
-	p := MakePod("pod", "ns").PreemptionPolicy(corev1.PreemptNever).Obj()
+func TestWorkloadPriorityClass(t *testing.T) {
+	p := MakePod("pod", "ns").WorkloadPriorityClass("high").Obj()
 
-	if p.Spec.PreemptionPolicy == nil {
-		t.Fatalf("preemptionPolicy = nil, want %q", corev1.PreemptNever)
-	}
-	if got := *p.Spec.PreemptionPolicy; got != corev1.PreemptNever {
-		t.Fatalf("preemptionPolicy = %q, want %q", got, corev1.PreemptNever)
+	if got := p.Labels[controllerconstants.WorkloadPriorityClassLabel]; got != "high" {
+		t.Fatalf("workload priority class label = %q, want %q", got, "high")
 	}
 }

--- a/pkg/util/testingjobs/pod/wrappers_test.go
+++ b/pkg/util/testingjobs/pod/wrappers_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestPreemptionPolicy(t *testing.T) {
+	p := MakePod("pod", "ns").PreemptionPolicy(corev1.PreemptNever).Obj()
+
+	if p.Spec.PreemptionPolicy == nil {
+		t.Fatalf("preemptionPolicy = nil, want %q", corev1.PreemptNever)
+	}
+	if got := *p.Spec.PreemptionPolicy; got != corev1.PreemptNever {
+		t.Fatalf("preemptionPolicy = %q, want %q", got, corev1.PreemptNever)
+	}
+}

--- a/test/e2e/singlecluster/extended/pod_test.go
+++ b/test/e2e/singlecluster/extended/pod_test.go
@@ -429,10 +429,10 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 				eventWatcher.Stop()
 			})
 
-			highPriorityClass := utiltesting.MakePriorityClass("high-" + ns.Name).PriorityValue(100).Obj()
-			util.MustCreate(ctx, k8sClient, highPriorityClass)
+			highWorkloadPriorityClass := utiltestingapi.MakeWorkloadPriorityClass("high-" + ns.Name).PriorityValue(100).Obj()
+			util.MustCreate(ctx, k8sClient, highWorkloadPriorityClass)
 			ginkgo.DeferCleanup(func() {
-				gomega.Expect(k8sClient.Delete(ctx, highPriorityClass)).To(gomega.Succeed())
+				gomega.Expect(k8sClient.Delete(ctx, highWorkloadPriorityClass)).To(gomega.Succeed())
 			})
 
 			defaultPriorityGroup := podtesting.MakePod("default-priority-group", ns.Name).
@@ -463,8 +463,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 			highPriorityGroup := podtesting.MakePod("high-priority-group", ns.Name).
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				Queue(lq.Name).
-				PriorityClass(highPriorityClass.Name).
-				PreemptionPolicy(corev1.PreemptNever).
+				WorkloadPriorityClass(highWorkloadPriorityClass.Name).
 				RequestAndLimit(corev1.ResourceCPU, "1").
 				TerminationGracePeriod(1).
 				MakeGroup(2)

--- a/test/e2e/singlecluster/extended/pod_test.go
+++ b/test/e2e/singlecluster/extended/pod_test.go
@@ -464,6 +464,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				Queue(lq.Name).
 				PriorityClass(highPriorityClass.Name).
+				PreemptionPolicy(corev1.PreemptNever).
 				RequestAndLimit(corev1.ResourceCPU, "1").
 				TerminationGracePeriod(1).
 				MakeGroup(2)


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test
/kind flake
/area testing

#### Which issue(s) this PR fixes:

Fixes #11491

#### Special notes for your reviewer:

After analyzing the code, I believe the real issue is that another test within the same e2e file created a high-priority Pod group to verify Kueue's preemption behavior. This high-priority Pod used Kubernetes PriorityClass but didn't set `preemptionPolicy: Never`. Therefore, it not only affected Kueue-level priority determination but also triggered native Pod preemption in the Kubernetes default-scheduler.

In summary, the result is that a high-priority pod created by one test to verify Kueue preemption preempted a regular pod in another unrelated test. This is an example of environmental crosstalk/flake between e2e tests, unrelated to the business logic.

#### Does this PR introduce a user-facing change?

```release-note
None
```
