### PR TITLE
fix: wrap JSON.parse in try-catch in useWebSocket

### DIFF
--- a/cmd/kueueviz/frontend/src/useWebSocket.js
+++ b/cmd/kueueviz/frontend/src/useWebSocket.js
@@ -43,8 +43,13 @@ const useWebSocket = (url) => {
     };
 
     ws.onmessage = (event) => {
-      const message = JSON.parse(event.data);
-      setData(message);
+      try {
+        const message = JSON.parse(event.data);
+        setData(message);
+      } catch (err) {
+        console.error('Failed to parse WebSocket message:', err);
+        setError('Received malformed data from the server.');
+      }
     };
 
     ws.onerror = (err) => {

--- a/cmd/kueueviz/frontend/src/useWebSocket.js
+++ b/cmd/kueueviz/frontend/src/useWebSocket.js
@@ -25,6 +25,21 @@ const WS_TOKEN_PROTOCOL_PREFIX = 'kueueviz.auth.';
 const encodeTokenForProtocol = (token) =>
   btoa(token).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 
+/**
+ * Parses a raw WebSocket message string as JSON.
+ * Returns { data, error } so callers can handle failures gracefully.
+ */
+export const parseWebSocketMessage = (raw) => {
+  try {
+    if (typeof raw !== 'string') {
+      throw new TypeError('expected string');
+    }
+    return { data: JSON.parse(raw), error: null };
+  } catch {
+    return { data: null, error: 'Received malformed data from the server.' };
+  }
+};
+
 const useWebSocket = (url) => {
   const [data, setData] = useState(null);
   const [error, setError] = useState(null);
@@ -43,12 +58,12 @@ const useWebSocket = (url) => {
     };
 
     ws.onmessage = (event) => {
-      try {
-        const message = JSON.parse(event.data);
-        setData(message);
-      } catch (err) {
-        console.error('Failed to parse WebSocket message:', err);
-        setError('Received malformed data from the server.');
+      const result = parseWebSocketMessage(event.data);
+      if (result.error) {
+        console.error('Failed to parse WebSocket message:', event.data);
+        setError(result.error);
+      } else {
+        setData(result.data);
       }
     };
 

--- a/cmd/kueueviz/frontend/src/useWebSocket.test.js
+++ b/cmd/kueueviz/frontend/src/useWebSocket.test.js
@@ -1,0 +1,102 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock modules that depend on browser globals so the pure parsing
+// function can be imported in the "node" test environment.
+vi.mock('./utils/urlHelper', () => ({
+  buildWebSocketUrl: vi.fn((path) => `ws://localhost${path}`),
+}));
+
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({ token: null }),
+}));
+
+vi.mock('./env', () => ({
+  env: {},
+}));
+
+import { parseWebSocketMessage } from './useWebSocket';
+
+// ---------------------------------------------------------------------------
+// parseWebSocketMessage
+// ---------------------------------------------------------------------------
+describe('parseWebSocketMessage', () => {
+  it('parses valid JSON object and returns data with no error', () => {
+    const result = parseWebSocketMessage('{"key":"value"}');
+    expect(result.data).toEqual({ key: 'value' });
+    expect(result.error).toBeNull();
+  });
+
+  it('parses a JSON array', () => {
+    const result = parseWebSocketMessage('[1, 2, 3]');
+    expect(result.data).toEqual([1, 2, 3]);
+    expect(result.error).toBeNull();
+  });
+
+  it('parses nested JSON objects', () => {
+    const input = JSON.stringify({
+      metadata: { name: 'test-workload', namespace: 'default' },
+      spec: { queueName: 'test-queue' },
+    });
+    const result = parseWebSocketMessage(input);
+    expect(result.data.metadata.name).toBe('test-workload');
+    expect(result.error).toBeNull();
+  });
+
+  it('returns error for plain text', () => {
+    const result = parseWebSocketMessage('hello world');
+    expect(result.data).toBeNull();
+    expect(result.error).toBe('Received malformed data from the server.');
+  });
+
+  it('returns error for empty string', () => {
+    const result = parseWebSocketMessage('');
+    expect(result.data).toBeNull();
+    expect(result.error).toBe('Received malformed data from the server.');
+  });
+
+  it('returns error for malformed JSON', () => {
+    const result = parseWebSocketMessage('{key: value}');
+    expect(result.data).toBeNull();
+    expect(result.error).toBe('Received malformed data from the server.');
+  });
+
+  it('returns error for truncated JSON', () => {
+    const result = parseWebSocketMessage('{"key": "val');
+    expect(result.data).toBeNull();
+    expect(result.error).toBe('Received malformed data from the server.');
+  });
+
+  it('returns error for undefined input', () => {
+    const result = parseWebSocketMessage(undefined);
+    expect(result.data).toBeNull();
+    expect(result.error).toBe('Received malformed data from the server.');
+  });
+
+  it('returns error for null input', () => {
+    const result = parseWebSocketMessage(null);
+    expect(result.data).toBeNull();
+    expect(result.error).toBe('Received malformed data from the server.');
+  });
+
+  it('returns error for numeric input', () => {
+    const result = parseWebSocketMessage(12345);
+    expect(result.data).toBeNull();
+    expect(result.error).toBe('Received malformed data from the server.');
+  });
+});


### PR DESCRIPTION
Closes #11574

The `onmessage` handler in `useWebSocket.js` calls `JSON.parse(event.data)` without any error handling. If the server sends a non-JSON frame (plain text, empty message, heartbeat ping), the parse throws an unhandled exception that freezes the entire UI.

Wraps the call in a try-catch block and sets an error state on parse failure so the UI can display it gracefully instead of crashing.

```release-note
KueueViz: Fixed a bug where non-JSON WebSocket messages from the backend could crash
the frontend. KueueViz now reports such messages as errors instead of freezing the UI.
```