### PR TITLE
[Fix][Flaky] LeaderWorkerSet integration when LeaderWorkerSet created Rolling update with maxSurge

### DIFF
--- a/test/e2e/singlecluster/extended/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/extended/leaderworkerset_test.go
@@ -737,13 +737,23 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 			})
 
 			ginkgo.By(fmt.Sprintf("Wait for the surge workloads to be created with maxSurge=%d", maxSurge), func() {
-				wl := &kueue.Workload{}
+				surgeWorkloadNames := sets.New[string]()
+				for i := lwsReplicas; i < lwsReplicas+maxSurge; i++ {
+					surgeWorkloadNames.Insert(util.WorkloadKeyForLeaderWorkerSet(lws, strconv.Itoa(i)).Name)
+				}
+				seenSurgeWorkloads := sets.New[string]()
 				gomega.Eventually(func(g gomega.Gomega) {
-					for i := lwsReplicas; i < lwsReplicas+maxSurge; i++ {
-						g.Expect(k8sClient.Get(ctx, util.WorkloadKeyForLeaderWorkerSet(lws, strconv.Itoa(i)), wl)).To(gomega.Succeed(),
-							"workload for surge group %d should exist", i)
+					wls := &kueue.WorkloadList{}
+					g.Expect(k8sClient.List(ctx, wls, client.InNamespace(lws.Namespace))).To(gomega.Succeed())
+					for _, wl := range wls.Items {
+						if surgeWorkloadNames.Has(wl.Name) {
+							seenSurgeWorkloads.Insert(wl.Name)
+						}
 					}
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+					g.Expect(seenSurgeWorkloads).To(gomega.Equal(surgeWorkloadNames),
+						"expected to observe all %d surge workloads %v, seen so far: %v",
+						maxSurge, surgeWorkloadNames.UnsortedList(), seenSurgeWorkloads.UnsortedList())
+				}, util.MediumTimeout, util.ShortInterval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By(fmt.Sprintf("Verify rolling update completes successfully with %d replicas running", lwsReplicas), func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Fix LeaderWorkerSet integration when LeaderWorkerSet created Rolling update with maxSurge

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10986 

#### Special notes for your reviewer:
I have used an Agent to fix this flaky test and perform thorough analysis, as part of the AC of this [issue](https://github.com/kubernetes-sigs/kueue/issues/11055), ill attach the analysis.md to the comments below

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
