### PR TITLE
TAS: Compact assignments by hostname prefix

### DIFF
--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -43,6 +43,7 @@
     - [Topology assignment representation](#topology-assignment-representation)
       - [Until v1beta1](#until-v1beta1)
       - [Since v1beta2](#since-v1beta2)
+      - [Encoding assignments by hostname prefix](#encoding-assignments-by-hostname-prefix)
     - [Node failures](#node-failures)
       - [Until v0.13](#until-v013)
       - [Since v0.14](#since-v014)
@@ -1345,12 +1346,56 @@ The main motivation behind the new format is the etcd size limit of 1.5MiB per s
   
   - Multiple slices allow optimizing even further, if desired. \
     Our simulations of more complex algorithms (e.g. heuristic pruning of prefix tree) allowed fitting over 100k nodes. \
-    (However, at that point we reached a tradeoff between bytesize, encoding time, and conceptual simplicity. Resolving that tradeoff is out of scope of this design; the important thing is that the proposed data format supports various specific algorithms).
+    (However, at that point we reached a tradeoff between byte size, encoding time, and conceptual simplicity. \
+    Fully resolving that tradeoff is out of scope of this design; the important thing is that the proposed data format
+    supports various specific algorithms. The hostname-prefix algorithm currently used by Kueue is described below.)
 
 - In the long term, as the number of nodes grows, at some point we'll inevitably hit the 1.5MiB limit anyway. \
   When this happens, we foresee a need to store the slices as separate CRD instances (see [description](#topologyassignmentslices-as-separate-crd-instances) in the "Alternatives" section). \
   While the v1beta2 format does not yet do that, by introducing `Slices` we come much closer to this. \
   Once there is a need, we can promote (some of) `Slices` to instances of a standalone CRD - but the appropriate type system is already there.
+
+##### Encoding assignments by hostname prefix
+
+The `TASAssignmentsEncodingByHostnamePrefix` feature gate is Beta (enabled by default) starting in v0.19. It only
+changes how v1beta2 `TopologyAssignment` objects are encoded: no node-pool or topology meaning is inferred from
+hostnames, and decoding preserves domain order and Pod counts. Disabling the feature gate restores the previous
+single-slice encoder but does not affect reading existing multi-slice assignments. New assignments must then fit the
+single-slice representation and object-size limit; otherwise they can fail to persist.
+
+When the feature gate is enabled, Kueue builds the hostname-prefix encoding first. If it needs multiple slices but the
+assignment is within the per-slice domain limit, Kueue serializes both encodings and keeps the smaller one. Assignments
+that exceed the per-slice domain limit always use the hostname-prefix encoding. When the lowest topology level is
+`kubernetes.io/hostname`, Kueue:
+
+1. Finds reusable hostname prefixes ending in `-`, preferring the longest prefix shared by multiple domains.
+2. Splits consecutive domains with the same selected prefix into runs without reordering domains.
+3. Backs off to shorter prefixes when the runs would exceed the `TopologyAssignment` slice-count limit, and chunks
+   every run at the per-slice domain limit.
+4. Compacts each resulting slice independently, including common prefixes and suffixes, universal topology values,
+   and universal Pod counts.
+
+The encoder does not sort domains. The scheduler orders domains by their full topology values before producing
+hostname-only assignments, and the encoder preserves that order so encoding and decoding remain mutually inverse.
+When the lowest topology level is not `kubernetes.io/hostname`, no prefix is reusable, or no prefix selection fits the
+slice limit, Kueue forms a single compact slice until the per-slice domain limit requires domain-count chunking.
+
+For example, the consecutive domains
+`gke-c-pool-a-hash1-aa: 3`, `gke-c-pool-a-hash1-bb: 3`,
+`gke-c-pool-b-hash2-cc: 4`, and `gke-c-pool-b-hash2-dd: 5` become two slices:
+
+```text
+prefix: gke-c-pool-a-hash1-, roots: [aa, bb], podCounts.universal: 3
+prefix: gke-c-pool-b-hash2-, roots: [cc, dd], podCounts.individual: [4, 5]
+```
+
+The grouping phase is intentionally prefix-only. Per-slice compaction can still extract a common suffix, such as the
+DNS suffix in AWS EKS node names, but suffixes do not define runs. Symmetric grouping would require evaluating both
+prefix- and suffix-based results, increasing encoding latency and complexity, so it is out of scope.
+
+The strategy is most effective when ordered hostnames share reusable `-`-delimited prefixes. Names without that
+structure, including UUID-style names, may not reduce the encoded size beyond required chunking while still incurring
+the prefix-analysis cost.
 
 #### Node failures
 

--- a/keps/2724-topology-aware-scheduling/kep.yaml
+++ b/keps/2724-topology-aware-scheduling/kep.yaml
@@ -51,6 +51,7 @@ feature-gates:
   - name: TASRespectNodeAffinityPreferred
   - name: TASHandleOverlappingFlavors
   - name: TASRecomputeAssignmentWithinSchedulingCycle
+  - name: TASAssignmentsEncodingByHostnamePrefix
   - name: SkipReassignmentForPodOwnedWorkloads
 disable-supported: true
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -183,6 +183,12 @@ const (
 	// before graduation or deprecation.
 	TASBalancedPlacement featuregate.Feature = "TASBalancedPlacement"
 
+	// owner: @ShaanveerS
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-scheduling
+	//
+	// Enable grouping v1beta2 TopologyAssignments by reusable hostname prefixes.
+	TASAssignmentsEncodingByHostnamePrefix featuregate.Feature = "TASAssignmentsEncodingByHostnamePrefix"
+
 	// owner: @alaypatel07
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2941-DRA
 	//
@@ -596,6 +602,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	TASBalancedPlacement: {
 		{Version: version.MustParse("0.15"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	TASAssignmentsEncodingByHostnamePrefix: {
+		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
 	},
 	KueueDRAIntegration: {
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -202,10 +202,10 @@ func (a *Assignment) Message() string {
 	return builder.String()
 }
 
-func (a *Assignment) ToAPI() []kueue.PodSetAssignment {
+func (a *Assignment) ToAPI(log logr.Logger) []kueue.PodSetAssignment {
 	psFlavors := make([]kueue.PodSetAssignment, len(a.PodSets))
 	for i := range psFlavors {
-		psFlavors[i] = a.PodSets[i].toAPI()
+		psFlavors[i] = a.PodSets[i].toAPI(log)
 	}
 	return psFlavors
 }
@@ -383,7 +383,7 @@ func (psa *PodSetAssignment) error(err error) {
 
 type ResourceAssignment map[corev1.ResourceName]*FlavorAssignment
 
-func (psa *PodSetAssignment) toAPI() kueue.PodSetAssignment {
+func (psa *PodSetAssignment) toAPI(log logr.Logger) kueue.PodSetAssignment {
 	flavors := make(map[corev1.ResourceName]kueue.ResourceFlavorReference, len(psa.Flavors))
 	// Only include resources with assigned flavors (filters out zero-quantity requests for undefined resources).
 	resourceUsage := make(corev1.ResourceList, len(psa.Flavors))
@@ -396,7 +396,7 @@ func (psa *PodSetAssignment) toAPI() kueue.PodSetAssignment {
 		Flavors:                flavors,
 		ResourceUsage:          resourceUsage,
 		Count:                  new(psa.Count),
-		TopologyAssignment:     tas.V1Beta2From(psa.TopologyAssignment),
+		TopologyAssignment:     tas.V1Beta2From(psa.TopologyAssignment, tas.WithLogger(log)),
 		DelayedTopologyRequest: psa.DelayedTopologyRequest,
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -850,7 +850,7 @@ func (s *Scheduler) admit(ctx context.Context, e *entry, cq *schdcache.ClusterQu
 	log := ctrl.LoggerFrom(ctx)
 	admission := &kueue.Admission{
 		ClusterQueue:      e.ClusterQueue,
-		PodSetAssignments: e.assignment.ToAPI(),
+		PodSetAssignments: e.assignment.ToAPI(log),
 	}
 
 	consideredStr := flavorassigner.FormatFlavorAssignmentAttemptsForEvents(e.assignment)

--- a/pkg/util/tas/tas_assignment.go
+++ b/pkg/util/tas/tas_assignment.go
@@ -17,13 +17,17 @@ limitations under the License.
 package tas
 
 import (
+	"encoding/json"
 	"iter"
 	"slices"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
 )
 
@@ -36,6 +40,28 @@ type TopologyDomainAssignment struct {
 	Values []string
 	Count  int32
 }
+
+type v1Beta2FromOptions struct {
+	logger logr.Logger
+}
+
+// V1Beta2FromOption configures V1Beta2From.
+type V1Beta2FromOption func(*v1Beta2FromOptions)
+
+// WithLogger configures the logger used while selecting the v1beta2 encoding.
+func WithLogger(logger logr.Logger) V1Beta2FromOption {
+	return func(options *v1Beta2FromOptions) {
+		options.logger = logger
+	}
+}
+
+const (
+	// maxDomainsPerTopologyAssignmentSlice mirrors the v1beta2 Roots and Individual pod count MaxItems limit.
+	maxDomainsPerTopologyAssignmentSlice = 100_000
+
+	// maxTopologyAssignmentSlices mirrors the v1beta2 TopologyAssignment Slices MaxItems limit.
+	maxTopologyAssignmentSlices = 1_000
+)
 
 func valueAtIndex(values kueue.TopologyAssignmentSliceLevelValues, idx int) string {
 	if univ := values.Universal; univ != nil {
@@ -196,66 +222,294 @@ func fillSingleCompactSliceValues(
 	}
 }
 
-// singleCompactSliceEncoding translates a v1beta1 TopologyAssignment
-// to a v1beta2 counterpart consisting of a single slice,
-// in which the "compressing options" (Prefix, Suffix,
-// Universal values for placement labels as well as Pod counts)
-// are used as much as possible.
-func singleCompactSliceEncoding(ta *TopologyAssignment) *kueue.TopologyAssignment {
-	n := len(ta.Domains)
-	if n == 0 {
-		return &kueue.TopologyAssignment{
-			Levels: ta.Levels,
-			Slices: []kueue.TopologyAssignmentSlice{},
-		}
-	}
-
-	levelCount := len(ta.Levels)
-	slice := &kueue.TopologyAssignmentSlice{
+// compactSliceEncoding translates a group of topology domains to a single
+// v1beta2 TopologyAssignmentSlice, in which the "compressing options" (Prefix,
+// Suffix, Universal values for placement labels as well as Pod counts) are used
+// as much as possible.
+func compactSliceEncoding(levels []string, domains []TopologyDomainAssignment) kueue.TopologyAssignmentSlice {
+	n := len(domains)
+	slice := kueue.TopologyAssignmentSlice{
 		DomainCount:    int32(n),
-		ValuesPerLevel: make([]kueue.TopologyAssignmentSliceLevelValues, levelCount),
+		ValuesPerLevel: make([]kueue.TopologyAssignmentSliceLevelValues, len(levels)),
 	}
 
-	for i := range levelCount {
+	for levelIdx := range levels {
 		levelValuesProvider := func() iter.Seq[string] {
 			return func(yield func(string) bool) {
-				for j := range n {
-					if !yield(ta.Domains[j].Values[i]) {
+				for _, domain := range domains {
+					if !yield(domain.Values[levelIdx]) {
 						return
 					}
 				}
 			}
 		}
-		fillSingleCompactSliceValues(&slice.ValuesPerLevel[i], levelValuesProvider)
+		fillSingleCompactSliceValues(&slice.ValuesPerLevel[levelIdx], levelValuesProvider)
 	}
 
+	firstPodCount := domains[0].Count
 	podCounts := make([]int32, 0, n)
 	samePodCounts := true
-	for i := range n {
-		podCounts = append(podCounts, ta.Domains[i].Count)
-		if i > 0 && ta.Domains[i].Count != ta.Domains[i-1].Count {
+	for _, domain := range domains {
+		podCounts = append(podCounts, domain.Count)
+		if domain.Count != firstPodCount {
 			samePodCounts = false
 		}
 	}
 	if samePodCounts {
-		slice.PodCounts.Universal = &podCounts[0]
+		slice.PodCounts.Universal = &firstPodCount
 	} else {
 		slice.PodCounts.Individual = podCounts
 	}
-	return &kueue.TopologyAssignment{
-		Levels: ta.Levels,
-		Slices: []kueue.TopologyAssignmentSlice{*slice},
-	}
+	return slice
 }
 
 // V1Beta2From translates a v1beta1 TopologyAssignment into the v1beta2 format.
 // The choice of a specific v1beta2 representation is an implementation detail,
 // which may change in the future. (See KEP-2724).
-func V1Beta2From(ta *TopologyAssignment) *kueue.TopologyAssignment {
+func V1Beta2From(ta *TopologyAssignment, options ...V1Beta2FromOption) *kueue.TopologyAssignment {
 	if ta == nil {
 		return nil
 	}
-	return singleCompactSliceEncoding(ta)
+	opts := &v1Beta2FromOptions{logger: ctrl.Log}
+	for _, option := range options {
+		if option != nil {
+			option(opts)
+		}
+	}
+	if !features.Enabled(features.TASAssignmentsEncodingByHostnamePrefix) {
+		return singleCompactTopologyAssignmentEncoding(ta)
+	}
+	return compactTopologyAssignmentEncoding(opts.logger, ta)
+}
+
+// compactTopologyAssignmentEncoding chooses the smaller serialized encoding
+// when both forms are valid. Assignments above the single-slice domain limit
+// always use hostname-prefix encoding.
+func compactTopologyAssignmentEncoding(log logr.Logger, ta *TopologyAssignment) *kueue.TopologyAssignment {
+	prefixEncoded := compactTopologyAssignmentEncodingWithHostnamePrefixRuns(ta)
+	if len(prefixEncoded.Slices) <= 1 {
+		return prefixEncoded
+	}
+	if len(ta.Domains) > maxDomainsPerTopologyAssignmentSlice {
+		log.V(4).Info("Topology assignment exceeds the single-slice domain limit; using hostname-prefix encoding",
+			"domainCount", len(ta.Domains),
+			"maxDomainsPerSlice", maxDomainsPerTopologyAssignmentSlice,
+		)
+		return prefixEncoded
+	}
+
+	singleEncoded := singleCompactTopologyAssignmentEncoding(ta)
+	prefixJSON, prefixErr := json.Marshal(prefixEncoded)
+	singleJSON, singleErr := json.Marshal(singleEncoded)
+	if prefixErr != nil {
+		log.Error(prefixErr, "Failed to marshal hostname-prefix topology assignment while comparing encodings",
+			"domainCount", len(ta.Domains),
+			"sliceCount", len(prefixEncoded.Slices),
+		)
+	}
+	if singleErr != nil {
+		log.Error(singleErr, "Failed to marshal single-slice topology assignment while comparing encodings",
+			"domainCount", len(ta.Domains),
+		)
+	}
+	if prefixErr != nil || singleErr != nil {
+		return prefixEncoded
+	}
+	if len(singleJSON) < len(prefixJSON) {
+		log.V(5).Info("Selected single-slice topology assignment encoding after serialized-size comparison",
+			"domainCount", len(ta.Domains),
+			"hostnamePrefixSliceCount", len(prefixEncoded.Slices),
+			"singleSliceBytes", len(singleJSON),
+			"hostnamePrefixBytes", len(prefixJSON),
+		)
+		return singleEncoded
+	}
+	log.V(6).Info("Selected hostname-prefix topology assignment encoding after serialized-size comparison",
+		"domainCount", len(ta.Domains),
+		"hostnamePrefixSliceCount", len(prefixEncoded.Slices),
+		"singleSliceBytes", len(singleJSON),
+		"hostnamePrefixBytes", len(prefixJSON),
+	)
+	return prefixEncoded
+}
+
+// singleCompactTopologyAssignmentEncoding represents an empty assignment with no
+// slices and every non-empty assignment with exactly one maximally compacted
+// slice.
+func singleCompactTopologyAssignmentEncoding(ta *TopologyAssignment) *kueue.TopologyAssignment {
+	out := &kueue.TopologyAssignment{
+		Levels: ta.Levels,
+		Slices: []kueue.TopologyAssignmentSlice{},
+	}
+	if len(ta.Domains) > 0 {
+		out.Slices = append(out.Slices, compactSliceEncoding(ta.Levels, ta.Domains))
+	}
+	return out
+}
+
+// compactTopologyAssignmentEncodingWithHostnamePrefixRuns splits contiguous
+// hostname-level domains with reusable hostname prefixes into multiple slices.
+// For example, for hostnames ["pool-a-node-0", "pool-a-node-1",
+// "pool-b-node-0"], the first two domains form a slice with prefix
+// "pool-a-node-" and roots ["0", "1"], and the last domain forms a separate
+// slice. If no reusable hostname key is available, this function only chunks
+// domains at maxDomainsPerTopologyAssignmentSlice.
+//
+// Prefix keys are chosen from longest to shortest, backing off until the
+// resulting run chunks fit the v1beta2 slice limit. Local
+// BenchmarkV1Beta2From results on an Intel i9-14900K were approximately 2-6 ms
+// for 40k-node cases and 20 ms for the sorted 150k-node GKE-style split case.
+func compactTopologyAssignmentEncodingWithHostnamePrefixRuns(ta *TopologyAssignment) *kueue.TopologyAssignment {
+	domains := ta.Domains
+	var prefixKeys []string
+	if len(domains) > 1 && len(ta.Levels) > 0 && IsLowestLevelHostname(ta.Levels) {
+		prefixKeys = reusableHostnamePrefixKeys(ta.Levels, domains)
+	}
+
+	out := &kueue.TopologyAssignment{
+		Levels: ta.Levels,
+		Slices: []kueue.TopologyAssignmentSlice{},
+	}
+
+	for _, run := range compactDomainRuns(domains, prefixKeys) {
+		for chunk := range slices.Chunk(run, maxDomainsPerTopologyAssignmentSlice) {
+			out.Slices = append(out.Slices, compactSliceEncoding(ta.Levels, chunk))
+		}
+	}
+	return out
+}
+
+// compactDomainRuns returns consecutive sub-slices of domains grouped by prefix key.
+// Keys [a, a, b, a] produce domain ranges [0:2], [2:3], and [3:4].
+// An empty prefixKeys slice means that all domains form one run.
+func compactDomainRuns(domains []TopologyDomainAssignment, prefixKeys []string) [][]TopologyDomainAssignment {
+	if len(domains) == 0 {
+		return nil
+	}
+	if len(prefixKeys) == 0 {
+		return [][]TopologyDomainAssignment{domains}
+	}
+
+	runs := make([][]TopologyDomainAssignment, 0)
+	start := 0
+	for i := 1; i < len(domains); i++ {
+		if prefixKeys[i] == prefixKeys[start] {
+			continue
+		}
+		runs = append(runs, domains[start:i])
+		start = i
+	}
+	return append(runs, domains[start:])
+}
+
+// reusableHostnamePrefixKeys returns reusable '-' delimited hostname prefix keys
+// for each domain. It tries the longest reusable prefixes first. If they would
+// produce more than maxTopologyAssignmentSlices slices, it retries with shorter
+// prefixes, merging groups that share the shorter prefix. If no prefix depth
+// fits, it returns nil so the caller encodes all domains as one run, chunked only
+// at maxDomainsPerTopologyAssignmentSlice.
+//
+// A prefix is reusable when it occurs at least twice in the assignment:
+// "pool-a-node-0" and "pool-a-node-1" receive the key "pool-a-node-".
+func reusableHostnamePrefixKeys(levels []string, domains []TopologyDomainAssignment) []string {
+	levelIdx := len(levels) - 1
+	prefixIndex := indexHostnamePrefixes(levelIdx, domains)
+	return selectHostnamePrefixKeys(levelIdx, domains, prefixIndex)
+}
+
+type hostnamePrefixIndex struct {
+	offsets  []int
+	ends     []int
+	counts   map[string]int
+	maxDepth int
+}
+
+// indexHostnamePrefixes indexes all prefix candidates and counts their
+// occurrences. This phase is O(n*m*k) in time and O(n*k) in space, where n is
+// the number of domains, m is the length of the longest domain, and k is the
+// maximum number of '-' characters in a domain.
+func indexHostnamePrefixes(levelIdx int, domains []TopologyDomainAssignment) hostnamePrefixIndex {
+	// prefixOffsets maps domains[i] to its range in prefixEnds:
+	// prefixEnds[prefixOffsets[i]:prefixOffsets[i+1]].
+	prefixOffsets := make([]int, len(domains)+1)
+	// prefixEnds stores the end offset of each candidate prefix. We reserve space
+	// for four candidates per hostname to reduce allocation overhead for common
+	// cloud naming patterns. The slice grows if needed.
+	prefixEnds := make([]int, 0, len(domains)*4)
+	// prefixCounts counts each prefix up to two occurrences, which is sufficient
+	// to determine whether it is reusable.
+	prefixCounts := make(map[string]int, len(domains))
+	// maxPrefixDepth records the largest number of candidates in a hostname and
+	// sets the initial depth for phase 2.
+	maxPrefixDepth := 0
+	for i, domain := range domains {
+		hostname := domain.Values[levelIdx]
+		for end := 0; end+1 < len(hostname); end++ {
+			if hostname[end] != '-' {
+				continue
+			}
+			prefixEnd := end + 1
+			prefixEnds = append(prefixEnds, prefixEnd)
+			prefix := hostname[:prefixEnd]
+			if prefixCounts[prefix] < 2 {
+				prefixCounts[prefix]++
+			}
+		}
+		prefixOffsets[i+1] = len(prefixEnds)
+		maxPrefixDepth = max(maxPrefixDepth, prefixOffsets[i+1]-prefixOffsets[i])
+	}
+	return hostnamePrefixIndex{
+		offsets:  prefixOffsets,
+		ends:     prefixEnds,
+		counts:   prefixCounts,
+		maxDepth: maxPrefixDepth,
+	}
+}
+
+// selectHostnamePrefixKeys tries prefix depths from longest to shortest until
+// the resulting grouping fits maxTopologyAssignmentSlices. This phase is
+// O(n*m*k^2) in time and O(n) in additional space, where n is the number of
+// domains, m is the length of the longest domain, and k is the maximum number of
+// '-' characters in a domain.
+func selectHostnamePrefixKeys(levelIdx int, domains []TopologyDomainAssignment, prefixIndex hostnamePrefixIndex) []string {
+	keys := make([]string, len(domains))
+	for prefixDepth := prefixIndex.maxDepth; prefixDepth >= 1; prefixDepth-- {
+		clear(keys)
+		for i, domain := range domains {
+			hostname := domain.Values[levelIdx]
+			start, end := prefixIndex.offsets[i], prefixIndex.offsets[i+1]
+			for j := min(end-start, prefixDepth) - 1; j >= 0; j-- {
+				prefix := hostname[:prefixIndex.ends[start+j]]
+				if prefixIndex.counts[prefix] < 2 {
+					continue
+				}
+				keys[i] = prefix
+				break
+			}
+		}
+
+		sliceCount := 0
+		start := 0
+		for i := 1; i < len(domains); i++ {
+			if keys[i] == keys[start] {
+				continue
+			}
+			sliceCount += chunkCount(i-start, maxDomainsPerTopologyAssignmentSlice)
+			start = i
+		}
+		sliceCount += chunkCount(len(domains)-start, maxDomainsPerTopologyAssignmentSlice)
+
+		if sliceCount <= maxTopologyAssignmentSlices {
+			return keys
+		}
+	}
+
+	return nil
+}
+
+// chunkCount returns the number of fixed-size chunks needed for length items.
+func chunkCount(length, chunkSize int) int {
+	return (length + chunkSize - 1) / chunkSize
 }
 
 // CountPodsInAssignment returns total pod count across all domains.

--- a/pkg/util/tas/tas_assignment_performance_test.go
+++ b/pkg/util/tas/tas_assignment_performance_test.go
@@ -29,11 +29,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 )
 
-const (
-	targetNodeCount = 40_000
-)
+// maxTopologyAssignmentJSONBytes is the test budget used to verify assignment
+// scalability. The encoder does not branch on serialized size.
+const maxTopologyAssignmentJSONBytes = 1_500_000
 
 // Generate n hex numbers of given length,
 // ensuring they're distinct (and otherwise quasi-random).
@@ -148,6 +149,20 @@ func (config nodeBasedNaming) generate(nodes int) []string {
 	return res
 }
 
+type gkeNodePoolBasedNaming struct {
+	pools int
+}
+
+func (n gkeNodePoolBasedNaming) generate(nodes int) []string {
+	res := make([]string, nodes)
+	for i := range nodes {
+		poolID := i % n.pools
+		nodeID := i / n.pools
+		res[i] = fmt.Sprintf("gke-cluster-pool-%04d-%08x-%04x", poolID, poolID, nodeID)
+	}
+	return res
+}
+
 func internalSinglePodsOn(nodes []string) *TopologyAssignment {
 	res := &TopologyAssignment{
 		Levels:  []string{corev1.LabelHostname},
@@ -171,13 +186,13 @@ func jsonBytes(v any) []byte {
 }
 
 func isTooLarge(ta *kueue.TopologyAssignment) bool {
-	return len(jsonBytes(ta)) > 1_500_000
+	return len(jsonBytes(ta)) > maxTopologyAssignmentJSONBytes
 }
 
-func approxMaxNodesFor(naming namingScheme) int {
+func approxMaxNodesFor(tc performanceTestCase) int {
 	step := 1_000 // We search with a reduced resolution, to speed up the test
 	ceiling := 300_000
-	nodeNames := naming.generate(ceiling)
+	nodeNames := tc.naming.generate(ceiling)
 	found := sort.Search(ceiling/step, func(n int) bool {
 		// Here we rely on "well-prefixing"; see the comment on "nodeNaming".
 		return isTooLarge(V1Beta2From(internalSinglePodsOn(nodeNames[:n*step])))
@@ -186,8 +201,19 @@ func approxMaxNodesFor(naming namingScheme) int {
 }
 
 type performanceTestCase struct {
-	name   string
-	naming namingScheme
+	name               string
+	naming             namingScheme
+	targetNodeCount    int
+	sortNodeNames      bool
+	skipApproxMaxNodes bool
+}
+
+func (tc performanceTestCase) generateNodeNames(nodes int) []string {
+	nodeNames := tc.naming.generate(nodes)
+	if tc.sortNodeNames {
+		slices.Sort(nodeNames)
+	}
+	return nodeNames
 }
 
 var performanceTestCases = []performanceTestCase{
@@ -202,6 +228,7 @@ var performanceTestCases = []performanceTestCase{
 
 			fixedPrefixAndSuffixLength: 20,
 		},
+		targetNodeCount: 40_000,
 	},
 	{
 		name: "pool-and-node-based naming (10 node pools)",
@@ -214,6 +241,7 @@ var performanceTestCases = []performanceTestCase{
 			poolIDLength:               22,
 			fixedPrefixAndSuffixLength: 20,
 		},
+		targetNodeCount: 40_000,
 	},
 	{
 		name: "region-and-IP-based naming (100 regions)",
@@ -226,6 +254,7 @@ var performanceTestCases = []performanceTestCase{
 
 			fixedPrefixAndSuffixLength: 20,
 		},
+		targetNodeCount: 40_000,
 	},
 	{
 		name: "region-and-IP-based naming (1 region)",
@@ -234,6 +263,7 @@ var performanceTestCases = []performanceTestCase{
 			regionIDLength:             14,
 			fixedPrefixAndSuffixLength: 20,
 		},
+		targetNodeCount: 40_000,
 	},
 	{
 		name: "node-only-based naming",
@@ -241,15 +271,32 @@ var performanceTestCases = []performanceTestCase{
 			nodeIDLength:               8, // reached in VKE
 			fixedPrefixAndSuffixLength: 20,
 		},
+		targetNodeCount: 40_000,
+	},
+	{
+		name: "GKE node-pool naming (1000 node pools)",
+		naming: gkeNodePoolBasedNaming{
+			pools: 1000,
+		},
+		targetNodeCount:    150_000,
+		sortNodeNames:      true,
+		skipApproxMaxNodes: true,
 	},
 }
 
 func TestByteSizeLimit(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASAssignmentsEncodingByHostnamePrefix, true)
 	for _, tc := range performanceTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			nodesLimit := approxMaxNodesFor(tc.naming)
-			if nodesLimit < targetNodeCount {
-				t.Errorf("Nodes limit for naming %q is too low: got approx. %d, want >= %d", tc.name, nodesLimit, targetNodeCount)
+			ta := V1Beta2From(internalSinglePodsOn(tc.generateNodeNames(tc.targetNodeCount)))
+			assertTopologyAssignmentSize(t, ta, tc.targetNodeCount)
+
+			if tc.skipApproxMaxNodes {
+				return
+			}
+			nodesLimit := approxMaxNodesFor(tc)
+			if nodesLimit < tc.targetNodeCount {
+				t.Errorf("Nodes limit for naming %q is too low: got approx. %d, want >= %d", tc.name, nodesLimit, tc.targetNodeCount)
 			} else {
 				t.Logf("Nodes limit for naming %q is approx. %d", tc.name, nodesLimit)
 			}
@@ -257,19 +304,37 @@ func TestByteSizeLimit(t *testing.T) {
 	}
 }
 
-func BenchmarkV1Beta2From(b *testing.B) {
-	for _, tc := range performanceTestCases {
-		nodeNames := tc.naming.generate(targetNodeCount)
+func assertTopologyAssignmentSize(t *testing.T, ta *kueue.TopologyAssignment, wantDomains int) {
+	t.Helper()
+	if got := len(ta.Slices); got > maxTopologyAssignmentSlices {
+		t.Errorf("unexpected slice count: got %d, want <= %d", got, maxTopologyAssignmentSlices)
+	}
+	for i, slice := range ta.Slices {
+		if slice.DomainCount > maxDomainsPerTopologyAssignmentSlice {
+			t.Errorf("slice %d has too many domains: got %d, want <= %d", i, slice.DomainCount, maxDomainsPerTopologyAssignmentSlice)
+		}
+	}
+	if got := TotalDomainCount(ta); got != wantDomains {
+		t.Errorf("unexpected total domain count: got %d, want %d", got, wantDomains)
+	}
+	if bytes := len(jsonBytes(ta)); bytes > maxTopologyAssignmentJSONBytes {
+		t.Errorf("topology assignment is too large: got %d bytes, want <= %d", bytes, maxTopologyAssignmentJSONBytes)
+	}
+}
 
-		// For our current strategy (just extract single common prefix & suffix),
-		// having node names sorted is an adverse scenario for benchmarking.
-		// (This is because longer common prefix & suffix will "hold" for longer).
-		// If we ever wish to test other approaches, we may want to also have
-		// a variant of this benchmark when node names get shuffled quasi-randomly.
+func BenchmarkV1Beta2From(b *testing.B) {
+	features.SetFeatureGateDuringTest(b, features.TASAssignmentsEncodingByHostnamePrefix, true)
+	for _, tc := range performanceTestCases {
+		nodeNames := tc.naming.generate(tc.targetNodeCount)
+
+		// For our current strategy (split into hostname prefix runs),
+		// having node names sorted matches scheduler-created hostname-only assignments.
+		// (This is because assignments are sorted by level values before encoding;
+		// for multi-level assignments, hostnames are only sorted within higher levels).
 		slices.Sort(nodeNames)
 		ta := internalSinglePodsOn(nodeNames)
 
-		desc := fmt.Sprintf("Naming scheme %q, %d nodes", tc.name, targetNodeCount)
+		desc := fmt.Sprintf("Naming scheme %q, %d nodes", tc.name, tc.targetNodeCount)
 		b.Run(desc, func(b *testing.B) {
 			for b.Loop() {
 				var _ = V1Beta2From(ta)

--- a/pkg/util/tas/tas_assignment_test.go
+++ b/pkg/util/tas/tas_assignment_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tas
 
 import (
+	"fmt"
 	"slices"
 	"testing"
 
@@ -26,6 +27,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 )
 
 type testCase struct {
@@ -616,6 +618,486 @@ func TestV1Beta2FromInternal_forNil(t *testing.T) {
 	if got != nil {
 		t.Errorf("unexpected result for nil: %+v", got)
 	}
+}
+
+func TestCompactTopologyAssignmentEncodingWithHostnamePrefixRuns(t *testing.T) {
+	tests := map[string]struct {
+		internal *TopologyAssignment
+		want     *kueue.TopologyAssignment
+	}{
+		"GKE node pools": {
+			internal: &TopologyAssignment{
+				Levels: []string{corev1.LabelHostname},
+				Domains: []TopologyDomainAssignment{
+					{Values: []string{"gke-c-pool-a-hash1-aa"}, Count: 3},
+					{Values: []string{"gke-c-pool-a-hash1-bb"}, Count: 3},
+					{Values: []string{"gke-c-pool-b-hash2-cc"}, Count: 4},
+					{Values: []string{"gke-c-pool-b-hash2-dd"}, Count: 5},
+				},
+			},
+			want: &kueue.TopologyAssignment{
+				Levels: []string{corev1.LabelHostname},
+				Slices: []kueue.TopologyAssignmentSlice{
+					{
+						DomainCount: 2,
+						PodCounts: kueue.TopologyAssignmentSlicePodCounts{
+							Universal: ptr.To[int32](3),
+						},
+						ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
+							{
+								Individual: &kueue.TopologyAssignmentSliceLevelIndividualValues{
+									Prefix: new("gke-c-pool-a-hash1-"),
+									Roots:  []string{"aa", "bb"},
+								},
+							},
+						},
+					},
+					{
+						DomainCount: 2,
+						PodCounts: kueue.TopologyAssignmentSlicePodCounts{
+							Individual: []int32{4, 5},
+						},
+						ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
+							{
+								Individual: &kueue.TopologyAssignmentSliceLevelIndividualValues{
+									Prefix: new("gke-c-pool-b-hash2-"),
+									Roots:  []string{"cc", "dd"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"AWS EKS private DNS names": {
+			internal: &TopologyAssignment{
+				Levels: []string{corev1.LabelHostname},
+				Domains: []TopologyDomainAssignment{
+					{Values: []string{"ip-10-24-34-0.us-west-2.compute.internal"}, Count: 2},
+					{Values: []string{"ip-10-24-34-1.us-west-2.compute.internal"}, Count: 2},
+					{Values: []string{"ip-10-24-35-0.us-west-2.compute.internal"}, Count: 3},
+					{Values: []string{"ip-10-24-35-1.us-west-2.compute.internal"}, Count: 4},
+				},
+			},
+			want: &kueue.TopologyAssignment{
+				Levels: []string{corev1.LabelHostname},
+				Slices: []kueue.TopologyAssignmentSlice{
+					{
+						DomainCount: 2,
+						PodCounts: kueue.TopologyAssignmentSlicePodCounts{
+							Universal: new(int32(2)),
+						},
+						ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
+							{
+								Individual: &kueue.TopologyAssignmentSliceLevelIndividualValues{
+									Prefix: new("ip-10-24-34-"),
+									Suffix: new(".us-west-2.compute.internal"),
+									Roots:  []string{"0", "1"},
+								},
+							},
+						},
+					},
+					{
+						DomainCount: 2,
+						PodCounts: kueue.TopologyAssignmentSlicePodCounts{
+							Individual: []int32{3, 4},
+						},
+						ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
+							{
+								Individual: &kueue.TopologyAssignmentSliceLevelIndividualValues{
+									Prefix: new("ip-10-24-35-"),
+									Suffix: new(".us-west-2.compute.internal"),
+									Roots:  []string{"0", "1"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"Azure AKS VMSS node pools": {
+			internal: &TopologyAssignment{
+				Levels: []string{corev1.LabelHostname},
+				Domains: []TopologyDomainAssignment{
+					{Values: []string{"aks-nodepool1-12345678-vmss000000"}, Count: 1},
+					{Values: []string{"aks-nodepool1-12345678-vmss000001"}, Count: 1},
+					{Values: []string{"aks-nodepool2-87654321-vmss000000"}, Count: 2},
+					{Values: []string{"aks-nodepool2-87654321-vmss000001"}, Count: 3},
+				},
+			},
+			want: &kueue.TopologyAssignment{
+				Levels: []string{corev1.LabelHostname},
+				Slices: []kueue.TopologyAssignmentSlice{
+					{
+						DomainCount: 2,
+						PodCounts: kueue.TopologyAssignmentSlicePodCounts{
+							Universal: new(int32(1)),
+						},
+						ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
+							{
+								Individual: &kueue.TopologyAssignmentSliceLevelIndividualValues{
+									Prefix: new("aks-nodepool1-12345678-vmss00000"),
+									Roots:  []string{"0", "1"},
+								},
+							},
+						},
+					},
+					{
+						DomainCount: 2,
+						PodCounts: kueue.TopologyAssignmentSlicePodCounts{
+							Individual: []int32{2, 3},
+						},
+						ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
+							{
+								Individual: &kueue.TopologyAssignmentSliceLevelIndividualValues{
+									Prefix: new("aks-nodepool2-87654321-vmss00000"),
+									Roots:  []string{"0", "1"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"on-premises UUID node names": {
+			internal: &TopologyAssignment{
+				Levels: []string{corev1.LabelHostname},
+				Domains: []TopologyDomainAssignment{
+					{Values: []string{"550e8400-e29b-41d4-a716-446655440000"}, Count: 1},
+					{Values: []string{"6ba7b810-9dad-11d1-80b4-00c04fd430c8"}, Count: 2},
+					{Values: []string{"f47ac10b-58cc-4372-a567-0e02b2c3d479"}, Count: 3},
+				},
+			},
+			want: &kueue.TopologyAssignment{
+				Levels: []string{corev1.LabelHostname},
+				Slices: []kueue.TopologyAssignmentSlice{
+					{
+						DomainCount: 3,
+						PodCounts: kueue.TopologyAssignmentSlicePodCounts{
+							Individual: []int32{1, 2, 3},
+						},
+						ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
+							{
+								Individual: &kueue.TopologyAssignmentSliceLevelIndividualValues{
+									Roots: []string{
+										"550e8400-e29b-41d4-a716-446655440000",
+										"6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+										"f47ac10b-58cc-4372-a567-0e02b2c3d479",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := compactTopologyAssignmentEncodingWithHostnamePrefixRuns(tc.internal)
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("unexpected result (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCompactTopologyAssignmentEncodingWithHostnamePrefixRuns_withoutHostnameLevel(t *testing.T) {
+	internal := &TopologyAssignment{
+		Levels: []string{"cloud.example.com/rack"},
+		Domains: []TopologyDomainAssignment{
+			{Values: []string{"rack-a"}, Count: 1},
+			{Values: []string{"rack-b"}, Count: 2},
+		},
+	}
+
+	got := compactTopologyAssignmentEncodingWithHostnamePrefixRuns(internal)
+	if gotSlices := len(got.Slices); gotSlices != 1 {
+		t.Fatalf("unexpected number of slices: got %d, want 1", gotSlices)
+	}
+	if diff := cmp.Diff(internal, InternalFrom(got), cmpopts.EquateEmpty()); diff != "" {
+		t.Errorf("unexpected round trip (-want,+got):\n%s", diff)
+	}
+}
+
+func TestV1Beta2FromInternal_hostnamePrefixFeatureGateAndFallback(t *testing.T) {
+	tests := map[string]struct {
+		enabled                    bool
+		domainCount                int
+		wantHostnamePrefixEncoding bool
+	}{
+		"enabled keeps one-slice hostname-prefix encoding": {
+			enabled:                    true,
+			domainCount:                1,
+			wantHostnamePrefixEncoding: true,
+		},
+		"enabled uses smaller single-slice encoding": {
+			enabled:     true,
+			domainCount: 4,
+		},
+		"enabled uses smaller hostname-prefix encoding": {
+			enabled:                    true,
+			domainCount:                20,
+			wantHostnamePrefixEncoding: true,
+		},
+		"disabled uses single-slice encoding": {
+			enabled:     false,
+			domainCount: 20,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.TASAssignmentsEncodingByHostnamePrefix, tc.enabled)
+			internal := hostnamePrefixAssignment(tc.domainCount)
+
+			want := singleCompactTopologyAssignmentEncoding(internal)
+			if tc.wantHostnamePrefixEncoding {
+				want = compactTopologyAssignmentEncodingWithHostnamePrefixRuns(internal)
+			}
+			got := V1Beta2From(internal)
+			if diff := cmp.Diff(want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("unexpected result (-want,+got):\n%s", diff)
+			}
+			if diff := cmp.Diff(internal, InternalFrom(got), cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("unexpected round trip (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCompactTopologyAssignmentEncodingWithHostnamePrefixRuns_preservesDomainOrder(t *testing.T) {
+	internal := &TopologyAssignment{
+		Levels: []string{corev1.LabelHostname},
+		Domains: []TopologyDomainAssignment{
+			{Values: []string{"gke-c-pool-a-hash1-aa"}, Count: 1},
+			{Values: []string{"gke-c-pool-b-hash2-cc"}, Count: 2},
+			{Values: []string{"gke-c-pool-a-hash1-bb"}, Count: 3},
+			{Values: []string{"gke-c-pool-b-hash2-dd"}, Count: 4},
+		},
+	}
+
+	encoded := compactTopologyAssignmentEncodingWithHostnamePrefixRuns(internal)
+	if gotSlices := len(encoded.Slices); gotSlices != 4 {
+		t.Fatalf("unexpected number of slices: got %d, want 4", gotSlices)
+	}
+	got := InternalFrom(encoded)
+	if diff := cmp.Diff(internal.Domains, got.Domains); diff != "" {
+		t.Fatalf("hostname-prefix encoding must preserve domain order (-want,+got):\n%s", diff)
+	}
+}
+
+func TestV1Beta2FromInternal_largeHostnameAssignmentWithManyPools(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASAssignmentsEncodingByHostnamePrefix, true)
+	const (
+		poolCount    = 2_000
+		nodesPerPool = 100
+		domainCount  = poolCount * nodesPerPool
+	)
+
+	internal := &TopologyAssignment{
+		Levels:  []string{corev1.LabelHostname},
+		Domains: make([]TopologyDomainAssignment, domainCount),
+	}
+	for poolID := range poolCount {
+		for nodeID := range nodesPerPool {
+			i := poolID*nodesPerPool + nodeID
+			internal.Domains[i] = TopologyDomainAssignment{
+				Values: []string{fmt.Sprintf("gke-cluster-pool-%04d-%08x-%04x", poolID, poolID, nodeID)},
+				Count:  1,
+			}
+		}
+	}
+
+	got := V1Beta2From(internal)
+	if len(got.Slices) != 2 {
+		t.Fatalf("unexpected number of slices: got %d, want 2", len(got.Slices))
+	}
+	for i, slice := range got.Slices {
+		if slice.DomainCount != maxDomainsPerTopologyAssignmentSlice {
+			t.Errorf("unexpected domain count for slice %d: got %d, want %d", i, slice.DomainCount, maxDomainsPerTopologyAssignmentSlice)
+		}
+	}
+	if got := TotalDomainCount(got); got != domainCount {
+		t.Errorf("unexpected total domain count: got %d, want %d", got, domainCount)
+	}
+}
+
+func TestReusableHostnamePrefixKeys(t *testing.T) {
+	tests := map[string]struct {
+		domains []TopologyDomainAssignment
+		want    []string
+	}{
+		"longest reusable prefixes": {
+			domains: []TopologyDomainAssignment{
+				{Values: []string{"gke-c-pool-a-hash1-aa"}},
+				{Values: []string{"gke-c-pool-a-hash1-bb"}},
+				{Values: []string{"gke-c-pool-b-hash2-cc"}},
+				{Values: []string{"gke-c-pool-b-hash2-dd"}},
+			},
+			want: []string{
+				"gke-c-pool-a-hash1-",
+				"gke-c-pool-a-hash1-",
+				"gke-c-pool-b-hash2-",
+				"gke-c-pool-b-hash2-",
+			},
+		},
+		"no reusable prefix": {
+			domains: []TopologyDomainAssignment{
+				{Values: []string{"node-a"}},
+				{Values: []string{"host-b"}},
+			},
+			want: []string{"", ""},
+		},
+		"no delimiter": {
+			domains: []TopologyDomainAssignment{
+				{Values: []string{"nodea"}},
+				{Values: []string{"hostb"}},
+			},
+			want: nil,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := reusableHostnamePrefixKeys([]string{corev1.LabelHostname}, tc.domains)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("unexpected prefix keys (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestReusableHostnamePrefixKeys_backsOffToFitSliceLimit(t *testing.T) {
+	domains := make([]TopologyDomainAssignment, maxTopologyAssignmentSlices+1)
+	want := make([]string, len(domains))
+	for i := range domains {
+		group := "x"
+		if i%2 == 1 {
+			group = "y"
+		}
+		domains[i].Values = []string{fmt.Sprintf("a-%s-%04d", group, i)}
+		want[i] = "a-"
+	}
+
+	got := reusableHostnamePrefixKeys([]string{corev1.LabelHostname}, domains)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected prefix keys after backoff (-want,+got):\n%s", diff)
+	}
+}
+
+func TestCompactTopologyAssignmentEncodingWithHostnamePrefixRuns_fallsBackWhenNoPrefixDepthFitsSliceLimit(t *testing.T) {
+	internal := &TopologyAssignment{
+		Levels:  []string{corev1.LabelHostname},
+		Domains: make([]TopologyDomainAssignment, maxTopologyAssignmentSlices+1),
+	}
+	for i := range internal.Domains {
+		prefix := "a-x"
+		if i%2 == 1 {
+			prefix = "b-y"
+		}
+		internal.Domains[i] = TopologyDomainAssignment{
+			Values: []string{fmt.Sprintf("%s-%04d", prefix, i)},
+			Count:  1,
+		}
+	}
+
+	if got := reusableHostnamePrefixKeys(internal.Levels, internal.Domains); got != nil {
+		t.Errorf("expected no usable prefix depth, got %v", got)
+	}
+
+	got := compactTopologyAssignmentEncodingWithHostnamePrefixRuns(internal)
+	if gotSlices := len(got.Slices); gotSlices != 1 {
+		t.Fatalf("unexpected number of slices: got %d, want 1", gotSlices)
+	}
+	if diff := cmp.Diff(internal, InternalFrom(got), cmpopts.EquateEmpty()); diff != "" {
+		t.Errorf("unexpected round trip (-want,+got):\n%s", diff)
+	}
+}
+
+func TestCompactDomainRuns(t *testing.T) {
+	domains := make([]TopologyDomainAssignment, 4)
+	for i := range domains {
+		domains[i] = TopologyDomainAssignment{
+			Values: []string{fmt.Sprintf("node-%04d", i)},
+			Count:  1,
+		}
+	}
+
+	tests := map[string]struct {
+		domains    []TopologyDomainAssignment
+		prefixKeys []string
+		want       []int
+	}{
+		"empty": {
+			want: nil,
+		},
+		"no prefix keys": {
+			domains: domains,
+			want:    []int{4},
+		},
+		"groups consecutive domains": {
+			domains:    domains,
+			prefixKeys: []string{"prefix-a-", "prefix-a-", "prefix-b-", "prefix-a-"},
+			want:       []int{2, 1, 1},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			runs := compactDomainRuns(tc.domains, tc.prefixKeys)
+			got := make([]int, len(runs))
+			for i := range runs {
+				got[i] = len(runs[i])
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("unexpected run lengths (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestChunkCount(t *testing.T) {
+	tests := map[string]struct {
+		length    int
+		chunkSize int
+		want      int
+	}{
+		"empty":         {length: 0, chunkSize: 100, want: 0},
+		"partial chunk": {length: 1, chunkSize: 100, want: 1},
+		"exact chunk":   {length: 100, chunkSize: 100, want: 1},
+		"two chunks":    {length: 101, chunkSize: 100, want: 2},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := chunkCount(tc.length, tc.chunkSize); got != tc.want {
+				t.Errorf("unexpected chunk count: got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func hostnamePrefixAssignment(domainCount int) *TopologyAssignment {
+	domainsPerPrefix := domainCount / 2
+	internal := &TopologyAssignment{
+		Levels:  []string{corev1.LabelHostname},
+		Domains: make([]TopologyDomainAssignment, domainCount),
+	}
+	for i := range domainCount {
+		prefix := "a"
+		nodeID := i
+		if i >= domainsPerPrefix {
+			prefix = "b"
+			nodeID -= domainsPerPrefix
+		}
+		internal.Domains[i] = TopologyDomainAssignment{
+			Values: []string{fmt.Sprintf("pool-%s-node-%05d", prefix, nodeID)},
+			Count:  1,
+		}
+	}
+	return internal
 }
 
 func TestInternalFromV1Beta2(t *testing.T) {

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -405,6 +405,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.17"
+- name: TASAssignmentsEncodingByHostnamePrefix
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
 - name: TASBalancedPlacement
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -405,6 +405,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.17"
+- name: TASAssignmentsEncodingByHostnamePrefix
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
 - name: TASBalancedPlacement
   versionedSpecs:
   - default: false


### PR DESCRIPTION

#### What type of PR is this?
/kind feature
/area tas


#### What this PR does / why we need it:
Instead of producing a single slice with the shortest common hostname prefix, domains are now grouped by their longest reusable `-` delimited prefixes and split into separate slices, enabling support for workloads up to 150k nodes. 

Direct encoder benchmarks
Pattern | Nodes | Old time (ms) | New time (ms) | Time multiplier | Old assignment (bytes) | New assignment (bytes) | Size delta
-- | -- | -- | -- | -- | -- | -- | --
GKE | 100 | 0.002216 | 0.017675 | 7.976x | 1,590 | 1,590 | 0.00%
GKE | 1k | 0.018583 | 0.188143 | 10.125x | 15,190 | 15,190 | 0.00%
GKE | 5k | 0.076125 | 0.896545 | 11.777x | 100,173 | 158,048 | +57.78%
GKE | 10k | 0.1471 | 1.5644 | 10.63x | 200,174 | 179,048 | -10.55%
GKE | 50k | 0.7854 | 5.9468 | 7.57x | 1,000,174 | 388,048 | -61.20%
GKE | 100k | 1.7099 | 11.5962 | 6.78x | 2,000,175 | 639,048 | -68.05%
AWS | 100 | 0.003553 | 0.020595 | 5.797x | 693 | 693 | 0.00%
AWS | 1k | 0.030577 | 0.216183 | 7.070x | 7,762 | 6,228 | -19.76%
AWS | 5k | 0.153792 | 1.148865 | 7.470x | 40,442 | 30,958 | -23.45%
AWS | 10k | 0.3016 | 2.1889 | 7.26x | 83,327 | 61,961 | -25.64%
AWS | 50k | 1.5448 | 11.5039 | 7.45x | 450,503 | 309,169 | -31.37%
AWS | 100k | 3.0024 | 24.5209 | 8.17x | 1,100,872 | 618,205 | -43.84%
Azure | 100 | 0.002322 | 0.015346 | 6.610x | 1,591 | 1,591 | 0.00%
Azure | 1k | 0.020090 | 0.165827 | 8.254x | 15,191 | 15,191 | 0.00%
Azure | 5k | 0.072536 | 0.766203 | 10.563x | 130,168 | 159,048 | +22.19%
Azure | 10k | 0.1450 | 1.2738 | 8.78x | 260,169 | 180,048 | -30.80%
Azure | 50k | 0.7440 | 4.6125 | 6.20x | 1,300,169 | 389,048 | -70.08%
Azure | 100k | 1.5512 | 9.2775 | 5.98x | 2,600,170 | 640,048 | -75.38%
UUID | 100 | 0.001226 | 0.023464 | 19.139x | 4,042 | 4,042 | 0.00%
UUID | 1k | 0.009582 | 0.294172 | 30.700x | 39,143 | 39,143 | 0.00%
UUID | 5k | 0.045578 | 1.429439 | 31.362x | 195,143 | 195,143 | 0.00%
Worst case (slice limit) | 100 | 0.001391 | 0.024752 | 17.794x | 969 | 9,048 | +833.75%
Worst case (slice limit) | 1k | 0.011234 | 0.235879 | 20.997x | 8,170 | 90,048 | +1,002.18%


Full lifecycle integration benchmarks: admit → hot swap → evict
Nodes | Old median [min-max] (ms) | New median [min-max] (ms) | Time multiplier | 
-- | -- | -- | -- | 
100 | 1,774.273 [1,768.871-1,777.804] | 1,775.098 [1,772.503-1,779.693] | 1.0005x | 
1k | 1,781.401 [1,778.819-1,787.363] | 1,781.658 [1,778.236-1,787.594] | 1.0001x | 
5k | 1,807.988 [1,797.871-1,815.443] | 1,892.991 [1,879.670-1,948.831] | 1.0470x | 
10k | 2,028.767 [1,979.794-2,078.671] | 2,026.164 [1,922.617-2,051.664] | 0.999x | 
50k | 2,859.787 [2,850.856-2,898.009] | 2,779.407 [2,619.970-2,873.861] | 0.972x | 
100k | Failed: admission status write was too large | 3,867.652 [3,691.238-3,927.467] | N/A | 


JSON size crossover points
| Pattern | new algo stays smaller from ~ | Just before, old/new bytes | At crossover, old/new bytes |
|---|---:|---:|---:|
| GKE | 8.6k nodes | 8,617: 172,513 / 172,516 | 8,618: 172,533 / 172,520 |
| AWS | 257 nodes | 256: 1,629 / 1,629 | 257: 2,145 / 1,749 |
| Azure| 6.3k nodes | 6,312: 164,280 / 164,296 | 6,313: 164,306 / 164,300 |


GKE: encoding took 11.40 ms, with ~52% in phase 1, ~21% in phase 2, and ~24% in output encoding.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3968606c-705c-4ade-875b-43a8c18818b0" />

UUID: encoding took 36.24 ms, with ~73% in phase 1, ~23% in phase 2, and ~3% in output encoding.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ee63bc62-d8a7-4e21-b197-264069d1f743" />

#### Which issue(s) this PR fixes:
Fixes #8257
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
TAS: Added the `TASAssignmentsEncodingByHostnamePrefix` feature gate (Beta, enabled by default). When enabled, Kueue uses hostname-prefix encoding for all hostname-level topology assignments, improving compaction for large assignments and supporting assignments that exceed the legacy single-slice limits. 

The new encoding allows the use of TAS for workloads spanning more than 100k nodes for most clusters. You can find more detailed compaction statistics in the PR description.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Improvements**
  * Made topology assignment encoding more compact by using a single-slice representation when it fits within domain/slice limits and the JSON byte-size budget.
  * When needed, added hostname-prefix run splitting to reduce size while preserving domain order and per-slice constraints.
* **Performance**
  * Updated performance and sizing checks to better reflect realistic node naming and JSON byte-size limits.
* **Feature Gate**
  * Added the required feature gate: `TASAssignmentsEncodingByHostnamePrefix`.
* **Tests**
  * Expanded unit tests to cover single-slice selection, hostname-prefix run behavior, splitting, and round-trip/order guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->