### PR TITLE
test(e2e): retry cluster creation on port collision (#11278)

### DIFF
--- a/hack/retry.sh
+++ b/hack/retry.sh
@@ -17,8 +17,12 @@
 # echoes it; stderr passes through. Designed to be invoked from Make $(shell ...)
 # where the captured stdout becomes the variable value.
 #
+# Advanced features:
+#   --continue-if "CMD": Evaluates CMD upon failure. If it fails, retries are aborted immediately (fail-fast).
+#   --cleanup "CMD": Evaluates CMD before starting the next retry attempt.
+#
 # Usage:
-#   retry.sh [--attempts N] [--delay SECONDS] [--retry-condition "CMD"] [--cleanup "CMD"] -- <command> [args...]
+#   retry.sh [--attempts N] [--delay SECONDS] [--continue-if "CMD"] [--cleanup "CMD"] -- <command> [args...]
 #
 # Defaults: --attempts 4, --delay 5
 # Exit:     0 on first success, 1 if all attempts fail, 2 on usage error.
@@ -27,14 +31,14 @@ set -u
 
 attempts=4
 delay=5
-retry_condition=""
+continue_if=""
 cleanup=""
 
 while [ $# -gt 0 ]; do
     case $1 in
         --attempts)        attempts=$2; shift 2 ;;
         --delay)           delay=$2;    shift 2 ;;
-        --retry-condition) retry_condition=$2; shift 2 ;;
+        --continue-if)     continue_if=$2; shift 2 ;;
         --cleanup)         cleanup=$2; shift 2 ;;
         --)                shift; break ;;
         -*)                echo "retry: unknown flag: $1" 1>&2; exit 2 ;;
@@ -56,10 +60,10 @@ for i in $(seq 1 "$attempts"); do
     echo "retry [$i/$attempts] failed" 1>&2
 
     if [ "$i" -lt "$attempts" ]; then
-        if [ -n "$retry_condition" ]; then
+        if [ -n "$continue_if" ]; then
             # Evaluate the fail-fast condition
-            if ! eval "$retry_condition"; then
-                echo "retry: aborting early as retry condition failed (fail-fast)" 1>&2
+            if ! eval "$continue_if"; then
+                echo "retry: aborting early as continue-if condition failed (fail-fast)" 1>&2
                 exit 1
             fi
         fi
@@ -67,7 +71,10 @@ for i in $(seq 1 "$attempts"); do
         if [ -n "$cleanup" ]; then
             # Run the cleanup command before the next attempt
             echo "retry: running cleanup command..." 1>&2
-            eval "$cleanup"
+            if ! eval "$cleanup"; then
+                echo "retry: cleanup command failed, aborting retries" 1>&2
+                exit 1
+            fi
         fi
 
         sleep "$delay"

--- a/hack/retry.sh
+++ b/hack/retry.sh
@@ -18,7 +18,7 @@
 # where the captured stdout becomes the variable value.
 #
 # Usage:
-#   retry.sh [--attempts N] [--delay SECONDS] -- <command> [args...]
+#   retry.sh [--attempts N] [--delay SECONDS] [--retry-condition "CMD"] [--cleanup "CMD"] -- <command> [args...]
 #
 # Defaults: --attempts 4, --delay 5
 # Exit:     0 on first success, 1 if all attempts fail, 2 on usage error.
@@ -27,14 +27,18 @@ set -u
 
 attempts=4
 delay=5
+retry_condition=""
+cleanup=""
 
 while [ $# -gt 0 ]; do
     case $1 in
-        --attempts) attempts=$2; shift 2 ;;
-        --delay)    delay=$2;    shift 2 ;;
-        --)         shift; break ;;
-        -*)         echo "retry: unknown flag: $1" 1>&2; exit 2 ;;
-        *)          break ;;
+        --attempts)        attempts=$2; shift 2 ;;
+        --delay)           delay=$2;    shift 2 ;;
+        --retry-condition) retry_condition=$2; shift 2 ;;
+        --cleanup)         cleanup=$2; shift 2 ;;
+        --)                shift; break ;;
+        -*)                echo "retry: unknown flag: $1" 1>&2; exit 2 ;;
+        *)                 break ;;
     esac
 done
 
@@ -50,6 +54,23 @@ for i in $(seq 1 "$attempts"); do
         exit 0
     fi
     echo "retry [$i/$attempts] failed" 1>&2
-    [ "$i" -lt "$attempts" ] && sleep "$delay"
+
+    if [ "$i" -lt "$attempts" ]; then
+        if [ -n "$retry_condition" ]; then
+            # Evaluate the fail-fast condition
+            if ! eval "$retry_condition"; then
+                echo "retry: aborting early as retry condition failed (fail-fast)" 1>&2
+                exit 1
+            fi
+        fi
+
+        if [ -n "$cleanup" ]; then
+            # Run the cleanup command before the next attempt
+            echo "retry: running cleanup command..." 1>&2
+            eval "$cleanup"
+        fi
+
+        sleep "$delay"
+    fi
 done
 exit 1

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -424,29 +424,23 @@ function cluster_create {
         cat "$kind_config"
     fi
 
-    local max_attempts=3
-    local attempt=1
-    local created=0
-    while [ "$attempt" -le "$max_attempts" ]; do
-        echo "Creating kind cluster '$cluster' (attempt $attempt/$max_attempts)..."
-        if $KIND create cluster --name "$cluster" --image "$E2E_KIND_VERSION" --config "$kind_config" --kubeconfig="$kubeconfig" --wait 1m -v 5 > "$ARTIFACTS/$cluster-create.log" 2>&1; then
-            created=1
-            break
-        fi
-        echo "Attempt $attempt failed. Log:"
-        cat "$ARTIFACTS/$cluster-create.log"
-        if ! grep -q "port is already allocated" "$ARTIFACTS/$cluster-create.log"; then
-            echo "Failure is not a port collision — not retrying."
-            break
-        fi
-        echo "Port collision detected on attempt $attempt. Cleaning up and retrying in 3s..."
-        $KIND delete cluster --name "$cluster" 2>/dev/null || true
-        attempt=$((attempt + 1))
-        sleep 3
-    done
-    if [ "$created" -eq 0 ]; then
-        echo "ERROR: unable to start the $cluster cluster after $max_attempts attempts"
-        cat "$ARTIFACTS/$cluster-create.log"
+    local log_file="$ARTIFACTS/$cluster-create.log"
+    local create_cmd="$KIND create cluster --name \"$cluster\" --image \"$E2E_KIND_VERSION\" --config \"$kind_config\" --kubeconfig=\"$kubeconfig\" --wait 1m -v 5 > \"$log_file\" 2>&1"
+
+    local retry_condition="grep -q 'port is already allocated' \"$log_file\""
+
+    local cleanup_cmd="$KIND delete cluster --name \"$cluster\" 2>/dev/null || true"
+
+    echo "Creating kind cluster '$cluster'..."
+    if ! "${ROOT_DIR}/hack/retry.sh" \
+        --attempts 3 \
+        --delay 3 \
+        --retry-condition "$retry_condition" \
+        --cleanup "$cleanup_cmd" \
+        -- bash -c "$create_cmd"; then
+
+        echo "ERROR: unable to start the $cluster cluster after retries." >&2
+        cat "$log_file" >&2
         return 1
     fi
 

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -425,21 +425,19 @@ function cluster_create {
     fi
 
     local log_file="$ARTIFACTS/$cluster-create.log"
-    local create_cmd="$KIND create cluster --name \"$cluster\" --image \"$E2E_KIND_VERSION\" --config \"$kind_config\" --kubeconfig=\"$kubeconfig\" --wait 1m -v 5 > \"$log_file\" 2>&1"
-
-    local retry_condition="grep -q 'port is already allocated' \"$log_file\""
-
-    local cleanup_cmd="$KIND delete cluster --name \"$cluster\" 2>/dev/null || true"
+    local create_cmd="$KIND create cluster --name \"$cluster\" --image \"$E2E_KIND_VERSION\" --config \"$kind_config\" --kubeconfig=\"$kubeconfig\" --wait 5m -v 5 > \"$log_file\" 2>&1"
+    local continue_if="grep -q 'port is already allocated' \"$log_file\""
+    local cleanup_cmd="if [ -f \"$log_file\" ]; then mv \"$log_file\" \"${log_file}.failed-\$(date +%s)\"; fi; $KIND delete cluster --name \"$cluster\" 2>/dev/null || true"
 
     echo "Creating kind cluster '$cluster'..."
     if ! "${ROOT_DIR}/hack/retry.sh" \
         --attempts 3 \
         --delay 3 \
-        --retry-condition "$retry_condition" \
+        --continue-if "$continue_if" \
         --cleanup "$cleanup_cmd" \
         -- bash -c "$create_cmd"; then
 
-        echo "ERROR: unable to start the $cluster cluster after retries." >&2
+        echo "ERROR: Unable to start the $cluster cluster after retries." >&2
         cat "$log_file" >&2
         return 1
     fi

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -424,13 +424,6 @@ function cluster_create {
         cat "$kind_config"
     fi
 
-<<<<<<< HEAD
-    if ! $KIND create cluster --name "$cluster" --image "$E2E_KIND_VERSION" \
-            --config "$kind_config" --kubeconfig="$kubeconfig" --wait 5m -v 5 \
-            > "$ARTIFACTS/$cluster-create.log" 2>&1; then
-        echo "ERROR: Unable to create kind cluster '$cluster'." >&2
-        cat "$ARTIFACTS/$cluster-create.log" >&2
-=======
     local max_attempts=3
     local attempt=1
     local created=0
@@ -454,7 +447,6 @@ function cluster_create {
     if [ "$created" -eq 0 ]; then
         echo "ERROR: unable to start the $cluster cluster after $max_attempts attempts"
         cat "$ARTIFACTS/$cluster-create.log"
->>>>>>> 280150c6a (test(e2e): retry cluster creation on port collision (#11278))
         return 1
     fi
 

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -424,11 +424,37 @@ function cluster_create {
         cat "$kind_config"
     fi
 
+<<<<<<< HEAD
     if ! $KIND create cluster --name "$cluster" --image "$E2E_KIND_VERSION" \
             --config "$kind_config" --kubeconfig="$kubeconfig" --wait 5m -v 5 \
             > "$ARTIFACTS/$cluster-create.log" 2>&1; then
         echo "ERROR: Unable to create kind cluster '$cluster'." >&2
         cat "$ARTIFACTS/$cluster-create.log" >&2
+=======
+    local max_attempts=3
+    local attempt=1
+    local created=0
+    while [ "$attempt" -le "$max_attempts" ]; do
+        echo "Creating kind cluster '$cluster' (attempt $attempt/$max_attempts)..."
+        if $KIND create cluster --name "$cluster" --image "$E2E_KIND_VERSION" --config "$kind_config" --kubeconfig="$kubeconfig" --wait 1m -v 5 > "$ARTIFACTS/$cluster-create.log" 2>&1; then
+            created=1
+            break
+        fi
+        echo "Attempt $attempt failed. Log:"
+        cat "$ARTIFACTS/$cluster-create.log"
+        if ! grep -q "port is already allocated" "$ARTIFACTS/$cluster-create.log"; then
+            echo "Failure is not a port collision — not retrying."
+            break
+        fi
+        echo "Port collision detected on attempt $attempt. Cleaning up and retrying in 3s..."
+        $KIND delete cluster --name "$cluster" 2>/dev/null || true
+        attempt=$((attempt + 1))
+        sleep 3
+    done
+    if [ "$created" -eq 0 ]; then
+        echo "ERROR: unable to start the $cluster cluster after $max_attempts attempts"
+        cat "$ARTIFACTS/$cluster-create.log"
+>>>>>>> 280150c6a (test(e2e): retry cluster creation on port collision (#11278))
         return 1
     fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
/kind bug

Fixes #11278

#### What this PR does / why we need it:

### The Error

* Multiple concurrent CI jobs randomly pull the same ephemeral port from the host OS network.
* KinD cluster creation crashes with `port is already allocated`, causing a 100% infrastructure test failure.

### The Solution

* Wrap the KinD cluster creation step inside a 3-attempt retry loop with a 3-second sleep.
* After a failure, KinD deletes the broken setup and requests a brand new random port.
* Use a `grep` guard to only retry specifically when the "port is already allocated" string appears.
* Avoid retrying real bugs like configuration mistakes, missing dependencies, or bad test code.
* Keep ports completely dynamic so multiple separate Pull Request test jobs can still run in parallel.
* Fix this directly inside `hack/testing/e2e-common.sh` to permanently stabilize all E2E test suites at once.

```release-note
NONE
```