### PR TITLE
test: increase StatefulSet pod gating timeout in MultiKueue e2e

### DIFF
--- a/test/e2e/multikueue/baseline/e2e_test.go
+++ b/test/e2e/multikueue/baseline/e2e_test.go
@@ -513,7 +513,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 					for _, pod := range pods.Items {
 						g.Expect(utilpod.HasGate(&pod, podconstants.SchedulingGateName)).To(gomega.BeTrue())
 					}
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Deleting the statefulset", func() {


### PR DESCRIPTION
/kind flake
/area multikueue
/area testing

## What type of PR is this?

This PR fixes a flaky StatefulSet MultiKueue e2e test caused by insufficient timeout during pod-gating verification.

## What this PR does / why we need it:

The StatefulSet MultiKueue e2e test intermittently fails because manager-side pods are not always labeled with `GroupNameLabel` within the default `util.Timeout` window.

Unlike Deployment and LWS workloads, StatefulSet pods are created sequentially using `OrderedReady`, which delays pod creation and asynchronous label propagation by the pod reconciler under CI load.

This PR updates the StatefulSet pod-gating assertion timeout from `util.Timeout` to `util.MediumTimeout` to provide enough time for reconciliation and reduce CI flakes.

## Error Summary

### Error

The test failed because no pods were found during the manager-cluster gating verification step.

The query depends on `GroupNameLabel`, which is added asynchronously by the pod reconciler after pod creation.

Under CI load, StatefulSet sequential pod creation delayed label propagation beyond the 10s timeout window.

### Solution 

Replace `util.Timeout` with `util.MediumTimeout` in the StatefulSet pod-gating assertion.

This gives the pod reconciler enough time to apply `GroupNameLabel` to all manager-side pods.

The change is test-only and reduces flaky failures without affecting production behavior.

## Which issue(s) this PR fixes:

Fixes #11351


```release-note
NONE
```