### PR TITLE
MultiKueue: generalize nomination skip during eviction

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -529,6 +529,13 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		requeueAfterSynchronize = requeueIn
 	}
 
+	// 8. Skip nomination while eviction is still in progress or the
+	// admission check is not yet Pending.
+	if workload.ShouldSkipClusterNomination(acs, group.local, group.IsElasticWorkload()) {
+		log.V(3).Info("Skipping cluster nomination phase")
+		return reconcile.Result{RequeueAfter: requeueAfterSynchronize}, nil
+	}
+
 	res, err := w.nominateAndSynchronizeWorkers(ctx, group)
 	if err == nil && (res.RequeueAfter == 0 || requeueAfterSynchronize < res.RequeueAfter) {
 		res.RequeueAfter = requeueAfterSynchronize
@@ -773,12 +780,6 @@ func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group 
 		}
 
 		if !nominatedClusterSetsEqual(group.local.Status.NominatedClusterNames, nominatedWorkers) {
-			// ClusterName != nil indicates possibly stale cache (eviction just cleared ClusterName
-			// but the informer hasn't caught up yet). Avoid creating remote workloads without a
-			// confirmed nomination — wait for the cache to sync.
-			if group.local.Status.ClusterName != nil {
-				return reconcile.Result{}, nil
-			}
 			if err := workload.PatchAdmissionStatus(ctx, w.client, group.local, w.clock, func(wl *kueue.Workload) (bool, error) {
 				wl.Status.NominatedClusterNames = nominatedWorkers
 				return true, nil

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -1742,11 +1742,12 @@ func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
 			wantCreated:    nil,
 		},
 		{
-			name:             "AllClusters: stale cache ClusterName set, nominations not confirmed — no remote workloads created",
-			dispatcherMode:   config.MultiKueueDispatcherModeAllAtOnce,
-			remotes:          map[string]*kueue.Workload{remoteNames[0]: nil, remoteNames[1]: nil},
-			localClusterName: new(remoteNames[0]),
-			wantCreated:      nil,
+			name:                      "AllClusters: nominate all workers when called directly with ClusterName set",
+			dispatcherMode:            config.MultiKueueDispatcherModeAllAtOnce,
+			remotes:                   map[string]*kueue.Workload{remoteNames[0]: nil, remoteNames[1]: nil},
+			localClusterName:          new(remoteNames[0]),
+			wantCreated:               []string{remoteNames[0], remoteNames[1]},
+			wantNominatedClusterNames: []string{remoteNames[0], remoteNames[1]},
 		},
 		{
 			name:                      "AllClusters: same set in reversed order does not trigger unnecessary patch",

--- a/pkg/controller/workloaddispatcher/incrementaldispatcher.go
+++ b/pkg/controller/workloaddispatcher/incrementaldispatcher.go
@@ -38,6 +38,7 @@ import (
 	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/workload"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
 const (
@@ -100,14 +101,8 @@ func (r *IncrementalDispatcherReconciler) Reconcile(ctx context.Context, req ctr
 		return reconcile.Result{}, err
 	}
 
-	if mkAc == nil || mkAc.State != kueue.CheckStatePending {
-		log.V(3).Info("AdmissionCheckState is not in Pending, skip the reconciliation")
-		return reconcile.Result{}, nil
-	}
-
-	// The workload is already assigned to a cluster, no need to nominate workers.
-	if wl.Status.ClusterName != nil {
-		log.V(3).Info("The workload is already assigned to a cluster, no need to nominate workers")
+	if workload.ShouldSkipClusterNomination(mkAc, wl, workloadslicing.IsElasticWorkload(wl)) {
+		log.V(3).Info("Skipping cluster nomination phase")
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -1901,6 +1901,22 @@ func ClusterName(wl *kueue.Workload) string {
 	return ptr.Deref(wl.Status.ClusterName, "")
 }
 
+// ShouldSkipClusterNomination returns true if cluster nomination should be
+// skipped. This covers the case when eviction is ongoing (ClusterName is still
+// assigned while the admission check transitions through Retry), as well as
+// any other state where the admission check is not Pending.
+// Elastic workloads are exempt from the stale-ClusterName check because they
+// intentionally set ClusterName on new slices to target the same worker cluster.
+func ShouldSkipClusterNomination(acs *kueue.AdmissionCheckState, wl *kueue.Workload, isElastic bool) bool {
+	if acs == nil || acs.State != kueue.CheckStatePending {
+		return true
+	}
+	if isElastic {
+		return false
+	}
+	return wl.Status.ClusterName != nil
+}
+
 func PriorityChanged(log logr.Logger, old, new *kueue.Workload) bool {
 	// Updates to Pod Priority are not supported.
 	if IsPodPriorityClass(old) || !IsWorkloadPriorityClass(new) {

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -3524,3 +3524,101 @@ func TestSumTotalRequestsWithDRAFromAdmission(t *testing.T) {
 		t.Errorf("gpu-logical = %v, want 2", gpuVal)
 	}
 }
+
+func TestShouldSkipClusterNomination(t *testing.T) {
+	cases := map[string]struct {
+		acs       *kueue.AdmissionCheckState
+		wl        *kueue.Workload
+		isElastic bool
+		want      bool
+	}{
+		"nil admission check state": {
+			acs:  nil,
+			wl:   &kueue.Workload{},
+			want: true,
+		},
+		"admission check Pending, no ClusterName": {
+			acs: &kueue.AdmissionCheckState{
+				State: kueue.CheckStatePending,
+			},
+			wl:   &kueue.Workload{},
+			want: false,
+		},
+		"admission check Retry": {
+			acs: &kueue.AdmissionCheckState{
+				State: kueue.CheckStateRetry,
+			},
+			wl:   &kueue.Workload{},
+			want: true,
+		},
+		"admission check Ready": {
+			acs: &kueue.AdmissionCheckState{
+				State: kueue.CheckStateReady,
+			},
+			wl:   &kueue.Workload{},
+			want: true,
+		},
+		"admission check Rejected": {
+			acs: &kueue.AdmissionCheckState{
+				State: kueue.CheckStateRejected,
+			},
+			wl:   &kueue.Workload{},
+			want: true,
+		},
+		"admission check Pending, ClusterName set (eviction ongoing)": {
+			acs: &kueue.AdmissionCheckState{
+				State: kueue.CheckStatePending,
+			},
+			wl: &kueue.Workload{
+				Status: kueue.WorkloadStatus{
+					ClusterName: new("worker1"),
+				},
+			},
+			want: true,
+		},
+		"admission check Pending, ClusterName set, elastic workload": {
+			acs: &kueue.AdmissionCheckState{
+				State: kueue.CheckStatePending,
+			},
+			wl: &kueue.Workload{
+				Status: kueue.WorkloadStatus{
+					ClusterName: new("worker1"),
+				},
+			},
+			isElastic: true,
+			want:      false,
+		},
+		"admission check Retry, ClusterName set (eviction ongoing)": {
+			acs: &kueue.AdmissionCheckState{
+				State: kueue.CheckStateRetry,
+			},
+			wl: &kueue.Workload{
+				Status: kueue.WorkloadStatus{
+					ClusterName: new("worker1"),
+				},
+			},
+			want: true,
+		},
+		"admission check Retry, ClusterName set, elastic workload": {
+			acs: &kueue.AdmissionCheckState{
+				State: kueue.CheckStateRetry,
+			},
+			wl: &kueue.Workload{
+				Status: kueue.WorkloadStatus{
+					ClusterName: new("worker1"),
+				},
+			},
+			isElastic: true,
+			want:      true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := ShouldSkipClusterNomination(tc.acs, tc.wl, tc.isElastic)
+			if got != tc.want {
+				t.Errorf("ShouldSkipClusterNomination() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area multikueue

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Centralizes the cluster nomination skip logic into a shared `ShouldSkipClusterNomination` helper in `pkg/workload/workload.go`, called from `reconcileGroup` so all dispatchers (AllAtOnce, Incremental,
External) benefit without duplicating the check. Previously each dispatcher had to independently guard against nominating
clusters while eviction is ongoing (`ClusterName` still assigned, admission check not yet `Pending`). This was error-prone and required non-obvious checks from external dispatcher authors.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11452

#### Special notes for your reviewer:
- The skip gate is placed **after** preemption-gate handling in `reconcileGroup`, so preemption orchestration is not affected.
- The stale-cache guard removed from `nominateAndSynchronizeWorkers` (AllAtOnce path) is now covered by the common check upstream.
- The Incremental dispatcher retains its own call to the shared helper since it is a separate controller.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
     NONE

```
