### PR TITLE
Fix flaky KubeRay E2E tests asserting total workload count instead of active count

### DIFF
--- a/test/e2e/singlecluster/extended/kuberay_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_test.go
@@ -354,13 +354,13 @@ print(ray.get([my_task.remote(i, 60) for i in range(3)]))`,
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Expected exactly 1 worker pod", podList))
 		})
 
-		// RayJob is top level job, the submitter job created by RayJob will not create its own workload, there will be only 1 workload
-		ginkgo.By("Waiting for 1 workloads", func() {
-			// 1 workload for the ray cluster
+		ginkgo.By("Waiting for exactly 1 non-finished admitted workload", func() {
 			workloadList := &kueue.WorkloadList{}
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.List(ctx, workloadList, client.InNamespace(ns.Name))).To(gomega.Succeed())
-				g.Expect(workloadList.Items).To(gomega.HaveLen(1), "Expected exactly 1 workload")
+				activeWorkloads := util.FindNonFinishedWorkloads(workloadList.Items)
+				g.Expect(activeWorkloads).To(gomega.HaveLen(1), "Expected exactly 1 non-finished workload")
+				g.Expect(workload.IsAdmitted(&activeWorkloads[0])).To(gomega.BeTrue(), "Expected admitted workload")
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 		})
 
@@ -552,13 +552,13 @@ print([ray.get(my_task.remote(i, 1)) for i in range(32)])`,
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Expected exactly 1 worker pod", podList))
 		})
 
-		// RayJob is top level job, the submitter job created by RayJob will not create its own workload, there will be only 1 workload
-		ginkgo.By("Waiting for 1 workloads", func() {
-			// 1 workload for the ray cluster
+		ginkgo.By("Waiting for exactly 1 non-finished admitted workload", func() {
 			workloadList := &kueue.WorkloadList{}
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.List(ctx, workloadList, client.InNamespace(ns.Name))).To(gomega.Succeed())
-				g.Expect(workloadList.Items).To(gomega.HaveLen(1), "Expected exactly 1 workload")
+				activeWorkloads := util.FindNonFinishedWorkloads(workloadList.Items)
+				g.Expect(activeWorkloads).To(gomega.HaveLen(1), "Expected exactly 1 non-finished workload")
+				g.Expect(workload.IsAdmitted(&activeWorkloads[0])).To(gomega.BeTrue(), "Expected admitted workload")
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 		})
 
@@ -890,13 +890,18 @@ app = HelloWorld.bind()`,
 			gomega.Expect(k8sClient.Create(ctx, rayService)).Should(gomega.Succeed())
 		})
 
-		ginkgo.By("Checking one workload is created and admitted", func() {
+		ginkgo.By("Checking one non-finished workload is created and admitted", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				workloadList := &kueue.WorkloadList{}
 				g.Expect(k8sClient.List(ctx, workloadList, client.InNamespace(ns.Name))).To(gomega.Succeed())
-				g.Expect(workloadList.Items).To(gomega.HaveLen(1), "Expected one workload in namespace")
-				wl := workloadList.Items[0]
-				g.Expect(workload.IsAdmitted(&wl)).Should(gomega.BeTrue(), "Expected admitted workload")
+				var activeWorkloads []kueue.Workload
+				for i := range workloadList.Items {
+					if !workload.IsFinished(&workloadList.Items[i]) {
+						activeWorkloads = append(activeWorkloads, workloadList.Items[i])
+					}
+				}
+				g.Expect(activeWorkloads).To(gomega.HaveLen(1), "Expected exactly 1 non-finished workload")
+				g.Expect(workload.IsAdmitted(&activeWorkloads[0])).To(gomega.BeTrue(), "Expected admitted workload")
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 		})
 

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1384,6 +1384,17 @@ func ExpectNewWorkloadSlice(ctx context.Context, k8sClient client.Client, oldWor
 	return newWorkload
 }
 
+// FindNonFinishedWorkloads returns the subset of workloads that are not finished.
+func FindNonFinishedWorkloads(workloads []kueue.Workload) []kueue.Workload {
+	var active []kueue.Workload
+	for i := range workloads {
+		if !workload.IsFinished(&workloads[i]) {
+			active = append(active, workloads[i])
+		}
+	}
+	return active
+}
+
 // ExpectWorkloadSliceAdmittedBeforeOldFinished watches workload events and asserts
 // that the old workload slice is not marked Finished before the new slice is Admitted.
 // The watcher must be started before the scale-up that triggers the replacement.


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/11611

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
