### PR TITLE
Fix standalone RayCluster generation loop

### DIFF
--- a/pkg/controller/jobs/raycluster/common.go
+++ b/pkg/controller/jobs/raycluster/common.go
@@ -337,6 +337,7 @@ func GetWorkloadslicingRayClusterCustomAnnotations(ctx context.Context, c client
 		log := ctrl.LoggerFrom(ctx)
 
 		rayClusterGeneration := ""
+		includeRayClusterGeneration := true
 
 		var rayClusterObj rayv1.RayCluster
 		err := c.Get(ctx, types.NamespacedName{
@@ -350,17 +351,29 @@ func GetWorkloadslicingRayClusterCustomAnnotations(ctx context.Context, c client
 				return nil, fmt.Errorf("failed to get RayCluster %s: %w", rayClusterName, err)
 			}
 		} else {
-			rayClusterGeneration = strconv.FormatInt(rayClusterObj.GetGeneration(), 10)
+			if isStandaloneRayCluster(jobObject, rayClusterName) {
+				includeRayClusterGeneration = false
+			} else {
+				rayClusterGeneration = strconv.FormatInt(rayClusterObj.GetGeneration(), 10)
+			}
 		}
 
 		podSetsJSON, err := SerializePodSetCounts(podSets)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal updated podsets: %w", err)
 		}
-		return map[string]string{
+		annotations := map[string]string{
 			RayClusterPodsetReplicaSizesAnnotation: string(podSetsJSON),
-			RayClusterGenerationAnnotation:         rayClusterGeneration,
-		}, nil
+		}
+		if includeRayClusterGeneration {
+			annotations[RayClusterGenerationAnnotation] = rayClusterGeneration
+		}
+		return annotations, nil
 	}
 	return nil, nil
+}
+
+func isStandaloneRayCluster(jobObject client.Object, rayClusterName string) bool {
+	_, isRayCluster := jobObject.(*rayv1.RayCluster)
+	return isRayCluster && rayClusterName != "" && jobObject.GetName() == rayClusterName
 }

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -1089,6 +1089,7 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 		rayClusterName   string
 		registerRayType  bool
 		createRayCluster bool
+		standalone       bool
 		wantAnnotation   map[string]string
 		wantErr          bool
 	}{
@@ -1115,6 +1116,22 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 			createRayCluster: true,
 			wantAnnotation: map[string]string{
 				RayClusterGenerationAnnotation:         "0",
+				RayClusterPodsetReplicaSizesAnnotation: `[{"name":"head","count":1},{"name":"worker","count":3}]`,
+			},
+		},
+		"standalone raycluster does not track its own generation": {
+			annotations: map[string]string{
+				workloadslicing.EnabledAnnotationKey: workloadslicing.EnabledAnnotationValue,
+			},
+			podSets: []kueue.PodSet{
+				{Name: "head", Count: 1},
+				{Name: "worker", Count: 3},
+			},
+			rayClusterName:   "test-raycluster",
+			registerRayType:  true,
+			createRayCluster: true,
+			standalone:       true,
+			wantAnnotation: map[string]string{
 				RayClusterPodsetReplicaSizesAnnotation: `[{"name":"head","count":1},{"name":"worker","count":3}]`,
 			},
 		},
@@ -1192,22 +1209,29 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 
 			builder := fake.NewClientBuilder().WithScheme(scheme)
 
+			var jobObject client.Object
 			if tc.createRayCluster {
 				rayCluster := testingrayutil.MakeCluster("test-raycluster", "default").Obj()
+				if tc.standalone {
+					rayCluster.SetAnnotations(tc.annotations)
+					jobObject = rayCluster
+				}
 				builder = builder.WithObjects(rayCluster)
 			}
 
 			c := builder.Build()
 
-			obj := &metav1.ObjectMeta{
-				Name:        "test-object",
-				Namespace:   "default",
-				Annotations: tc.annotations,
+			if jobObject == nil {
+				obj := &metav1.ObjectMeta{
+					Name:        "test-object",
+					Namespace:   "default",
+					Annotations: tc.annotations,
+				}
+				// Use a corev1.ConfigMap as a simple client.Object wrapper.
+				jobObject = &corev1.ConfigMap{ObjectMeta: *obj}
 			}
-			// Use a corev1.ConfigMap as a simple client.Object wrapper
-			cm := &corev1.ConfigMap{ObjectMeta: *obj}
 
-			got, err := GetWorkloadslicingRayClusterCustomAnnotations(t.Context(), c, cm, tc.podSets, tc.rayClusterName)
+			got, err := GetWorkloadslicingRayClusterCustomAnnotations(t.Context(), c, jobObject, tc.podSets, tc.rayClusterName)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("GetWorkloadslicingCustomAnnotations() expected error but got nil")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area integrations

#### What this PR does / why we need it:

Stops standalone elastic RayClusters from writing their own generation back into the `kueue.x-k8s.io/raycluster-generation` annotation.

The annotation is still used for RayJob and RayService, where the top-level object needs to account for the generation of an underlying RayCluster.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11599

#### Special notes for your reviewer:

The generation annotation is skipped only when the object being annotated is the same standalone RayCluster that was fetched for the generation.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
