### PR TITLE
fix: skip markPodsFailed for unhealthy TAS workloads pending second-pass scheduling

### DIFF
--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -557,6 +557,12 @@ func (r *nodeReconciler) reconcileWorkloadsOnNode(
 	unhealthyWorkloads := sets.New[types.NamespacedName]()
 	notUnhealthyWorkloads := sets.New[types.NamespacedName]()
 	podsToTerminateMap := make(map[types.NamespacedName][]*corev1.Pod)
+	// pendingSecondPassWorkloads tracks unhealthy workloads where this node was
+	// already recorded in a prior reconcile and other pods are still progressing
+	// on different nodes. In that case second-pass scheduling is in flight, so we
+	// must not fail retry pods on the unhealthy node — doing so would consume
+	// BackoffLimit before the second-pass eviction runs.
+	pendingSecondPassWorkloads := sets.New[types.NamespacedName]()
 
 	for wlKey := range allTASWorkloads {
 		var wl kueue.Workload
@@ -572,6 +578,15 @@ func (r *nodeReconciler) reconcileWorkloadsOnNode(
 		switch result.status {
 		case workloadUnhealthy:
 			unhealthyWorkloads.Insert(wlKey)
+			if workload.HasUnhealthyNode(&wl, nodeName) {
+				progressingElsewhere, err := r.hasProgressingPodsOnOtherNodes(ctx, &wl, nodeName)
+				if err != nil {
+					return ctrl.Result{}, err
+				}
+				if progressingElsewhere {
+					pendingSecondPassWorkloads.Insert(wlKey)
+				}
+			}
 		case workloadHealthy:
 			notUnhealthyWorkloads.Insert(wlKey)
 		}
@@ -593,7 +608,7 @@ func (r *nodeReconciler) reconcileWorkloadsOnNode(
 	}
 
 	for wlKey, pods := range podsToTerminateMap {
-		if evictedWorkloads.Has(wlKey) {
+		if evictedWorkloads.Has(wlKey) || pendingSecondPassWorkloads.Has(wlKey) {
 			continue
 		}
 		if err := r.markPodsFailed(ctx, pods); err != nil {
@@ -715,6 +730,20 @@ func (r *nodeReconciler) hasProgressingPods(ctx context.Context, wl *kueue.Workl
 		return pod.DeletionTimestamp.IsZero() && !utilpod.IsTerminated(pod)
 	})
 	return hasProgressingPods, nil
+}
+
+func (r *nodeReconciler) hasProgressingPodsOnOtherNodes(ctx context.Context, wl *kueue.Workload, nodeName string) (bool, error) {
+	sliceName := workloadslicing.SliceName(wl)
+	pods, err := ListPodsForWorkloadSlice(ctx, r.client, wl.Namespace, sliceName)
+	if err != nil {
+		return false, err
+	}
+	return slices.ContainsFunc(pods, func(pod *corev1.Pod) bool {
+		if pod.Spec.NodeName == "" || pod.Spec.NodeName == nodeName {
+			return false
+		}
+		return pod.DeletionTimestamp.IsZero() && !utilpod.IsTerminated(pod)
+	}), nil
 }
 
 func checkTaintTolerations(logger logr.Logger, taint *corev1.Taint, podSets []kueue.PodSet) taintToleration {

--- a/pkg/controller/tas/node_controller_test.go
+++ b/pkg/controller/tas/node_controller_test.go
@@ -194,6 +194,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 		wantRequeue        time.Duration
 		wantEvictedCond    *metav1.Condition
 		wantPatchedPods    []string
+		wantNotPatchedPods []string
 		featureGates       map[featuregate.Feature]bool
 		// ignoreUnhealthyNodes is used only when we expect the unhealthy nodes list to be cleared.
 		// Patching the status in tests (via fake client and strategic merge interceptor)
@@ -965,6 +966,49 @@ func TestNodeFailureReconciler(t *testing.T) {
 				features.TASReplaceNodeOnPodTermination: true,
 			},
 		},
+		"Node has NoSchedule taint, already in unhealthyNodes, sibling running elsewhere -> stray pod NOT patched (second-pass in flight)": {
+			initObjs: []client.Object{
+				baseNode.Clone().StatusConditions(corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: now}).
+					Label(corev1.LabelHostname, nodeName).
+					Taints(corev1.Taint{Key: "foo", Effect: corev1.TaintEffectNoSchedule}).Obj(),
+				baseNode.Clone().Name(nodeName2).StatusConditions(corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: now}).
+					Label(corev1.LabelHostname, nodeName2).Obj(),
+				// nodeName already recorded as unhealthy from the prior reconcile
+				func() *kueue.Workload {
+					wl := workloadWithTwoNodes.DeepCopy()
+					wl.Status.UnhealthyNodes = []kueue.UnhealthyNode{{Name: nodeName}}
+					return wl
+				}(),
+				// replacement pod still pending on the tainted node (this is the second reconcile)
+				testingpod.MakePod("pending-pod-1", nsName).
+					Annotation(kueue.WorkloadAnnotation, wlName).
+					Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
+					NodeSelector(corev1.LabelHostname, nodeName).
+					StatusPhase(corev1.PodPending).Obj(),
+				// sibling pod progressing on the healthy node — second-pass scheduling is in flight
+				testingpod.MakePod("running-pod-2", nsName).
+					Annotation(kueue.WorkloadAnnotation, wlName).
+					Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
+					NodeName(nodeName2).
+					StatusPhase(corev1.PodRunning).Obj(),
+			},
+			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
+			wantUnhealthyNodes: []kueue.UnhealthyNode{{Name: nodeName}},
+			// markPodsFailed must be skipped to preserve BackoffLimit while second-pass scheduling runs
+			wantNotPatchedPods: []string{"pending-pod-1"},
+			featureGates: map[featuregate.Feature]bool{
+				features.TASReplaceNodeOnNodeTaints:     true,
+				features.TASReplaceNodeOnPodTermination: true,
+			},
+		},
 		"Node has untolerated NoSchedule taint, pod is Gated -> Healthy": {
 			initObjs: []client.Object{
 				baseNode.Clone().StatusConditions(corev1.NodeCondition{
@@ -1145,6 +1189,16 @@ func TestNodeFailureReconciler(t *testing.T) {
 				}
 				if targetCond == nil || targetCond.Status != corev1.ConditionTrue || targetCond.Reason != podTerminatedByKueueConditionReason {
 					t.Errorf("Expected %s condition to be True with Reason %s, got %v", podTerminatedByKueueConditionType, podTerminatedByKueueConditionReason, targetCond)
+				}
+			}
+			for _, podName := range tc.wantNotPatchedPods {
+				pod := &corev1.Pod{}
+				if err := cl.Get(ctx, types.NamespacedName{Name: podName, Namespace: nsName}, pod); err != nil {
+					t.Errorf("Expected pod %s to still exist: %v", podName, err)
+					continue
+				}
+				if pod.Status.Phase == corev1.PodFailed {
+					t.Errorf("Expected pod %s NOT to be Failed, but markPodsFailed was called on it", podName)
 				}
 			}
 		})


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake
/area tas
/area testing

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

Fixes a race in TAS node replacement when `TASReplaceNodeOnNodeTaints` is enabled.

When a node is tainted and a pod is replaced, the node controller may call `markPodsFailed` on the pending replacement pod (old node selector, unschedulable) on a later reconcile, after the node is already listed in `status.unhealthyNodes`. That consumes the Job's `BackoffLimit` before second-pass scheduling can evict
the workload and reschedule it (e.g. to another rack).

This change skips `markPodsFailed` only when the unhealthy node was recorded in a prior reconcile **and** the workload still has progressing pods on other nodes. All other cases (including all pods still pending on a failed node) are unchanged.

Repro: e2e `Should evict the workload if replacement is not possible due to taint` (flaky in #11617).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11617

/cc @mimowo 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
