### PR TITLE
Fix MultiKueue on 1.36

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -44,7 +44,7 @@ INTEGRATION_API_LOG_LEVEL ?= 0
 # Folder where the e2e tests are located.
 E2E_TARGET ?= ./test/e2e/...
 E2E_K8S_VERSIONS ?= 1.34.8 1.35.5 1.36.1
-E2E_K8S_VERSION = 1.36
+E2E_K8S_VERSION ?= 1.36
 E2E_K8S_FULL_VERSION ?= $(filter $(E2E_K8S_VERSION).%,$(E2E_K8S_VERSIONS))
 # Default to E2E_K8S_VERSION.0 if no match is found
 E2E_K8S_FULL_VERSION := $(or $(E2E_K8S_FULL_VERSION),$(E2E_K8S_VERSION).0)

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -44,7 +44,7 @@ INTEGRATION_API_LOG_LEVEL ?= 0
 # Folder where the e2e tests are located.
 E2E_TARGET ?= ./test/e2e/...
 E2E_K8S_VERSIONS ?= 1.34.8 1.35.5 1.36.1
-E2E_K8S_VERSION ?= 1.36
+E2E_K8S_VERSION = 1.36
 E2E_K8S_FULL_VERSION ?= $(filter $(E2E_K8S_VERSION).%,$(E2E_K8S_VERSIONS))
 # Default to E2E_K8S_VERSION.0 if no match is found
 E2E_K8S_FULL_VERSION := $(or $(E2E_K8S_FULL_VERSION),$(E2E_K8S_VERSION).0)

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -359,6 +359,10 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 
 		if group.jobAdapter != nil {
 			if err := group.jobAdapter.SyncJob(ctx, w.client, group.remoteClients[remote].client, group.controllerKey, group.local.Name, w.origin); err != nil {
+				if errors.Is(err, jobframework.ErrPendingUnsuspend) {
+					log.V(3).Info("Local Job is pending unsuspension, requeuing", "workload", klog.KObj(group.local))
+					return reconcile.Result{RequeueAfter: jobframework.MultiKueuePendingUnsuspendRetryPeriod}, nil
+				}
 				log.V(2).Error(err, "copying remote controller status", "workerCluster", remote)
 				// we should retry this
 				return reconcile.Result{}, err
@@ -383,6 +387,10 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		// workload evicted on manager cluster
 		if workload.IsEvicted(group.local) {
 			if err := group.jobAdapter.SyncJob(ctx, w.client, remoteCl, group.controllerKey, group.local.Name, w.origin); err != nil {
+				if errors.Is(err, jobframework.ErrPendingUnsuspend) {
+					log.V(3).Info("Local Job is pending unsuspension, requeuing", "workload", klog.KObj(group.local))
+					return reconcile.Result{RequeueAfter: jobframework.MultiKueuePendingUnsuspendRetryPeriod}, nil
+				}
 				log.Error(err, "Syncing remote controller object")
 				// We'll retry this in the next reconciling.
 				return reconcile.Result{}, err
@@ -492,6 +500,10 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		}
 
 		if err := group.jobAdapter.SyncJob(ctx, w.client, remoteCl, group.controllerKey, group.local.Name, w.origin); err != nil {
+			if errors.Is(err, jobframework.ErrPendingUnsuspend) {
+				log.V(3).Info("Local Job is pending unsuspension, requeuing", "workload", klog.KObj(group.local))
+				return reconcile.Result{RequeueAfter: jobframework.MultiKueuePendingUnsuspendRetryPeriod}, nil
+			}
 			log.Error(err, "Syncing remote controller object")
 			// We'll retry this in the next reconciling.
 			return reconcile.Result{}, err

--- a/pkg/controller/jobframework/multikueue.go
+++ b/pkg/controller/jobframework/multikueue.go
@@ -18,6 +18,8 @@ package jobframework
 
 import (
 	"context"
+	"errors"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -26,6 +28,10 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 )
+
+var ErrPendingUnsuspend = errors.New("local object is pending unsuspension")
+
+const MultiKueuePendingUnsuspendRetryPeriod = 200 * time.Millisecond
 
 // MultiKueueAdapter interface needed for MultiKueue job delegation.
 type MultiKueueAdapter interface {

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -101,28 +102,57 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	return remoteClient.Create(ctx, &remoteJob)
 }
 
+func jobSuspendedConditionStatus(job *batchv1.Job) *corev1.ConditionStatus {
+	for i := range job.Status.Conditions {
+		if job.Status.Conditions[i].Type == batchv1.JobSuspended {
+			return &job.Status.Conditions[i].Status
+		}
+	}
+	return nil
+}
+
 func shouldSkipSyncForSuspendedLocalJob(log logr.Logger, localJob, remoteJob *batchv1.Job) bool {
 	localJobInfo := fromObject(localJob)
 
 	log.V(2).Info("Checking shouldSkipSyncForSuspendedLocalJob", "localJob", localJob, "remoteJob", remoteJob)
 	if !localJobInfo.IsSuspended() {
-		// do not skip any syncs if the local Job is unsuspnded
-		log.V(3).Info("Peforming the sync as the local Job is unsuspended")
-		return false
-	}
-	remoteJobInfo := fromObject(remoteJob)
-	if remoteJobInfo.IsSuspended() {
-		// Do not skip any syncs if the remote Job is also suspended
-		// This is needed to await for updating the status.active field
-		// when the remote Job is evicted; see: https://github.com/kubernetes-sigs/kueue/pull/8151
-		log.V(3).Info("Peforming the sync as the local and the remote Job are suspended")
+		// Do not skip any syncs if the local Job is unsuspended
+		log.V(3).Info("Performing the sync as the local Job is unsuspended")
 		return false
 	}
 
-	// We skip the sync when the localJob has suspend=true, and the remote job is suspend=false
-	// to prevent the race condition when the local Job is updated to suspend=false prematurely
-	// so that the injection of nodeSlectors does not work; see: https://github.com/kubernetes-sigs/kueue/pull/3685
-	log.V(2).Info("Skipping the sync when the localJob has suspend=true, and the remote job is suspend=false")
+	remoteConditionStatus := jobSuspendedConditionStatus(remoteJob)
+	localConditionStatus := jobSuspendedConditionStatus(localJob)
+
+	// If the remote Job has the JobSuspended condition (with any status), but the local Job does not,
+	// we must perform status synchronization to propagate the condition type. This ensures the local Job status
+	// is bootstrapped with the condition type before unsuspending, satisfying Kubernetes 1.36+ validation.
+	if remoteConditionStatus != nil && localConditionStatus == nil {
+		log.V(3).Info("Performing the sync to bootstrap the JobSuspended condition type to the local Job status")
+		return false
+	}
+
+	remoteJobInfo := fromObject(remoteJob)
+	if !remoteJobInfo.IsSuspended() {
+		// We skip the sync when the local Job is suspended but the remote Job is not
+		// to prevent the race condition when the local Job is updated to suspend=false prematurely
+		// so that the injection of nodeSelectors does not work (PR #3685)
+		log.V(2).Info("Skipping the sync for suspended local Job when remote Job is unsuspended")
+		return true
+	}
+
+	// If both the local and remote Jobs are suspended:
+	// We only need to perform the status synchronization if there is a meaningful difference to propagate:
+	// 1. The remote Job has the JobSuspended=True condition, but the local Job does not yet.
+	// 2. The remote Job has reached 0 active pods, but the local Job still reports active or ready pods (needed for eviction).
+	conditionTrigger := ptr.Deref(remoteConditionStatus, "") == corev1.ConditionTrue && ptr.Deref(localConditionStatus, "") != corev1.ConditionTrue
+	inactiveTrigger := !remoteJobInfo.IsActive() && localJobInfo.IsActive()
+
+	if conditionTrigger || inactiveTrigger {
+		log.V(3).Info("Performing the sync to propagate the status from a fully suspended remote Job", "conditionTrigger", conditionTrigger, "inactiveTrigger", inactiveTrigger)
+		return false
+	}
+	log.V(3).Info("Skipping the sync as the suspended status is already fully synchronized")
 	return true
 }
 

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -63,8 +63,12 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 
 	// the remote job exists
 	if err == nil {
-		if shouldSkipSyncForSuspendedLocalJob(log, &localJob, &remoteJob) {
+		action := syncActionForSuspendedLocalJob(log, &localJob, &remoteJob)
+		if action == skipSync {
 			return nil
+		}
+		if action == skipSyncAndRetryLater {
+			return jobframework.ErrPendingUnsuspend
 		}
 
 		if err := clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
@@ -102,58 +106,59 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	return remoteClient.Create(ctx, &remoteJob)
 }
 
-func jobSuspendedConditionStatus(job *batchv1.Job) *corev1.ConditionStatus {
+func hasJobSuspendedCondition(job *batchv1.Job) bool {
 	for i := range job.Status.Conditions {
-		if job.Status.Conditions[i].Type == batchv1.JobSuspended {
-			return &job.Status.Conditions[i].Status
+		if job.Status.Conditions[i].Type == batchv1.JobSuspended && job.Status.Conditions[i].Status == corev1.ConditionTrue {
+			return true
 		}
 	}
-	return nil
+	return false
 }
 
-func shouldSkipSyncForSuspendedLocalJob(log logr.Logger, localJob, remoteJob *batchv1.Job) bool {
+type syncAction int
+
+const (
+	syncJob syncAction = iota
+	skipSync
+	skipSyncAndRetryLater
+)
+
+func syncActionForSuspendedLocalJob(log logr.Logger, localJob, remoteJob *batchv1.Job) syncAction {
 	localJobInfo := fromObject(localJob)
 
-	log.V(2).Info("Checking shouldSkipSyncForSuspendedLocalJob", "localJob", localJob, "remoteJob", remoteJob)
+	log.V(2).Info("Checking syncActionForSuspendedLocalJob", "localJob", localJob, "remoteJob", remoteJob)
 	if !localJobInfo.IsSuspended() {
 		// Do not skip any syncs if the local Job is unsuspended
 		log.V(3).Info("Performing the sync as the local Job is unsuspended")
-		return false
-	}
-
-	remoteConditionStatus := jobSuspendedConditionStatus(remoteJob)
-	localConditionStatus := jobSuspendedConditionStatus(localJob)
-
-	// If the remote Job has the JobSuspended condition (with any status), but the local Job does not,
-	// we must perform status synchronization to propagate the condition type. This ensures the local Job status
-	// is bootstrapped with the condition type before unsuspending, satisfying Kubernetes 1.36+ validation.
-	if remoteConditionStatus != nil && localConditionStatus == nil {
-		log.V(3).Info("Performing the sync to bootstrap the JobSuspended condition type to the local Job status")
-		return false
+		return syncJob
 	}
 
 	remoteJobInfo := fromObject(remoteJob)
 	if !remoteJobInfo.IsSuspended() {
 		// We skip the sync when the local Job is suspended but the remote Job is not
-		// to prevent the race condition when the local Job is updated to suspend=false prematurely
-		// so that the injection of nodeSelectors does not work (PR #3685)
-		log.V(2).Info("Skipping the sync for suspended local Job when remote Job is unsuspended")
-		return true
+		// to prevent the race condition when the local Job gets a non-zero .Status.StartTime prematurely
+		// so that the injection of nodeSelectors does not work (PR #3685).
+		// In this case, a sync will ultimately happen, once the local job gets admitted
+		// (when MultiKueue notices an admitted remote) and consequently unsuspended.
+		// We return skipSyncAndRetryLater so that the reconciler retries the sync after a short delay,
+		// allowing time for the local Job controller to unsuspend the local Job.
+		log.V(2).Info("Skipping the sync for suspended local Job when remote Job is unsuspended; retrying later")
+		return skipSyncAndRetryLater
 	}
 
 	// If both the local and remote Jobs are suspended:
 	// We only need to perform the status synchronization if there is a meaningful difference to propagate:
 	// 1. The remote Job has the JobSuspended=True condition, but the local Job does not yet.
 	// 2. The remote Job has reached 0 active pods, but the local Job still reports active or ready pods (needed for eviction).
-	conditionTrigger := ptr.Deref(remoteConditionStatus, "") == corev1.ConditionTrue && ptr.Deref(localConditionStatus, "") != corev1.ConditionTrue
+	conditionTrigger := hasJobSuspendedCondition(remoteJob) && !hasJobSuspendedCondition(localJob)
 	inactiveTrigger := !remoteJobInfo.IsActive() && localJobInfo.IsActive()
 
 	if conditionTrigger || inactiveTrigger {
 		log.V(3).Info("Performing the sync to propagate the status from a fully suspended remote Job", "conditionTrigger", conditionTrigger, "inactiveTrigger", inactiveTrigger)
-		return false
+		return syncJob
 	}
 	log.V(3).Info("Skipping the sync as the suspended status is already fully synchronized")
-	return true
+	return skipSync
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -62,9 +62,7 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 
 	// the remote job exists
 	if err == nil {
-		if fromObject(&localJob).IsSuspended() && !fromObject(&localJob).IsActive() {
-			// Ensure the job is unsuspended before updating its status; otherwise, it will fail when patching the spec.
-			log.V(2).Info("Skipping the sync since the local job is still suspended")
+		if shouldSkipSyncForSuspendedLocalJob(log, &localJob, &remoteJob) {
 			return nil
 		}
 
@@ -101,6 +99,30 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	remoteJob.Spec.ManagedBy = nil
 
 	return remoteClient.Create(ctx, &remoteJob)
+}
+
+func shouldSkipSyncForSuspendedLocalJob(log logr.Logger, localJob, remoteJob *batchv1.Job) bool {
+	localJobInfo := fromObject(localJob)
+
+	if !localJobInfo.IsSuspended() {
+		// do not skip any syncs if the local Job is unsuspnded
+		log.V(3).Info("Peforming the sync as the local Job is unsuspended")
+		return false
+	}
+	remoteJobInfo := fromObject(remoteJob)
+	if remoteJobInfo.IsSuspended() {
+		// Do not skip any syncs if the remote Job is also suspended
+		// This is needed to await for updating the status.active field
+		// when the remote Job is evicted; see: https://github.com/kubernetes-sigs/kueue/pull/8151
+		log.V(3).Info("Peforming the sync as the local and the remote Job are suspended")
+		return false
+	}
+
+	// We skip the sync when the localJob has suspend=true, and the remote job is suspend=false
+	// to prevent the race condition when the local Job is updated to suspend=false prematurely
+	// so that the injection of nodeSlectors does not work; see: https://github.com/kubernetes-sigs/kueue/pull/3685
+	log.V(2).Info("Skipping the sync when the localJob has suspend=true, and the remote job is suspend=false")
+	return true
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -104,6 +104,7 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 func shouldSkipSyncForSuspendedLocalJob(log logr.Logger, localJob, remoteJob *batchv1.Job) bool {
 	localJobInfo := fromObject(localJob)
 
+	log.V(2).Info("Checking shouldSkipSyncForSuspendedLocalJob", "localJob", localJob, "remoteJob", remoteJob)
 	if !localJobInfo.IsSuspended() {
 		// do not skip any syncs if the local Job is unsuspnded
 		log.V(3).Info("Peforming the sync as the local Job is unsuspended")

--- a/test/e2e/multikueue/baseline/e2e_test.go
+++ b/test/e2e/multikueue/baseline/e2e_test.go
@@ -1636,20 +1636,27 @@ app = HelloWorld.bind()`,
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
+			lowPrioJob := &batchv1.Job{}
 			ginkgo.By("Checking that the low-priority job is not active", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
-					admittedJob := &batchv1.Job{}
-					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(lowJob), admittedJob)).To(gomega.Succeed())
-					g.Expect(admittedJob.Status.Active).To(gomega.Equal(int32(0)))
+					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(lowJob), lowPrioJob)).To(gomega.Succeed())
+					g.Expect(lowPrioJob.Status.Active).To(gomega.Equal(int32(0)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			ginkgo.By("Checking that the high-priority job is active", func() {
+			ginkgo.By("Checking that the high-priority workload was admitted", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
-					admittedJob := &batchv1.Job{}
+					g.Expect(k8sWorker2Client.Get(ctx, highWlKey, workerHighWorkload)).To(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(workerHighWorkload)).To(gomega.BeTrue())
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("high-priority is not admitted", workerHighWorkload))
+			})
+
+			ginkgo.By("Checking that the high-priority job is active", func() {
+				admittedJob := &batchv1.Job{}
+				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(highJob), admittedJob)).To(gomega.Succeed())
 					g.Expect(admittedJob.Status.Active).To(gomega.Equal(int32(1)))
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("Job high-priority is not active", admittedJob, lowPrioJob))
 			})
 
 			ginkgo.By("Checking that the low-priority workload is dispatched again after backoff", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area multikueue

#### What this PR does / why we need it:

My quick attempt to improve #11615 (which currently breaks some tests).

#### Which issue(s) this PR fixes:

Fixes #11614

#### Special notes for your reviewer:

Disclaimer: Result of my brainstorming with an AI bot.

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: fix MultiKueue to work on k8s 1.36.
MultiKueue now allows additional status syncs from worker to manager cluster to propagate the `JobSuspended=True` Condition.
```
