### PR TITLE
Dynamic Sharding for Integration Tests

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -35,7 +35,14 @@ TEST_LOG_LEVEL ?= -3
 INTEGRATION_NPROCS ?= 4
 INTEGRATION_NPROCS_MULTIKUEUE ?= 3
 # Folder where the integration tests are located.
+ifdef INTEGRATION_TOTAL_SHARDS
+INTEGRATION_TARGET := $(shell ./hack/testing/shard-integration-tests.sh $(INTEGRATION_SHARD_INDEX) $(INTEGRATION_TOTAL_SHARDS))
+ifeq ($(INTEGRATION_TARGET),)
+$(error Aborting execution due to invalid sharding parameters (INTEGRATION_SHARD_INDEX / INTEGRATION_TOTAL_SHARDS))
+endif
+else
 INTEGRATION_TARGET ?= ./test/integration/singlecluster/...
+endif
 INTEGRATION_TARGET_MULTIKUEUE ?= ./test/integration/multikueue/...
 # Verbosity level for apiserver logging.
 # The logging is disabled if 0.

--- a/hack/testing/shard-integration-tests.sh
+++ b/hack/testing/shard-integration-tests.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ==============================================================================
+# Dynamic Round-Robin Integration Test Sharding Helper Script
+# ==============================================================================
+# This script discovers all Go test packages inside a specified path and
+# dynamically assigns them into a specific shard using round-robin distribution.
+# All debug information is streamed to stderr (>&2) to keep stdout clean for Ginkgo.
+# ==============================================================================
+
+MAX_SHARDS=16
+INTEGRATION_SHARD_INDEX=$1
+INTEGRATION_TOTAL_SHARDS=$2
+TARGET_PATTERN=${3:-./test/integration/singlecluster/...}
+
+if [ -z "$INTEGRATION_SHARD_INDEX" ] || [ -z "$INTEGRATION_TOTAL_SHARDS" ]; then
+    echo "Error: INTEGRATION_SHARD_INDEX and INTEGRATION_TOTAL_SHARDS are required arguments." >&2
+    echo "Usage: $0 <integration_shard_index> <integration_total_shards> [target_pattern]" >&2
+    exit 1
+fi
+
+if [ "$INTEGRATION_TOTAL_SHARDS" -le 0 ] || [ "$INTEGRATION_TOTAL_SHARDS" -gt "$MAX_SHARDS" ]; then
+    echo "Error: INTEGRATION_TOTAL_SHARDS ($INTEGRATION_TOTAL_SHARDS) must be between 1 and $MAX_SHARDS." >&2
+    exit 1
+fi
+
+if [ "$INTEGRATION_SHARD_INDEX" -lt 0 ] || [ "$INTEGRATION_SHARD_INDEX" -ge "$INTEGRATION_TOTAL_SHARDS" ]; then
+    echo "Error: INTEGRATION_SHARD_INDEX ($INTEGRATION_SHARD_INDEX) must be between 0 and $((INTEGRATION_TOTAL_SHARDS - 1))." >&2
+    exit 1
+fi
+
+# Store discovered package paths in an array.
+# Note: 'go list' outputs packages in deterministic lexicographical order.
+# This ensures package distribution remains perfectly stable across shards.
+packages=()
+while read -r pkg; do
+    if [ -n "$pkg" ]; then
+        packages+=("$pkg")
+    fi
+done < <(go list "$TARGET_PATTERN" | sed 's|^sigs.k8s.io/kueue/|./|')
+total_targets=${#packages[@]}
+
+if [ "$total_targets" -eq 0 ]; then
+    echo "Error: Discovered 0 integration test packages matching pattern '$TARGET_PATTERN'." >&2
+    exit 1
+fi
+
+# Print detailed debugging overview to stderr (>&2) so Ginkgo command capture remains clean
+echo "================================================================================" >&2
+echo "Test Sharding Evaluation Summary (Total Targets = $total_targets)" >&2
+echo "================================================================================" >&2
+
+for (( i = 0; i < total_targets; i++ )); do
+    pkg="${packages[i]}"
+    current_modulus=$(( i % INTEGRATION_TOTAL_SHARDS ))
+
+    if [ "$current_modulus" -eq "$INTEGRATION_SHARD_INDEX" ]; then
+        echo "[*] [Shard $current_modulus] $pkg" >&2
+        # Standard output streams shard's paths for Ginkgo capture
+        echo "$pkg"
+    else
+        echo "[ ] [Shard $current_modulus] $pkg" >&2
+    fi
+done
+
+echo "================================================================================" >&2


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing


#### What this PR does / why we need it:
Introduce sharding for integration tests. Adding a new shard will
require a small change to [test-infra](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml). We can discontinue sharding based on baseline/extended, and
simply increase the number of shards when the test runs become too slow.

This change is backwards-compatible: no-op until `TOTAL_SHARDS` is set.

Data from running locally. Each shard was run sequentially, so there is no contention. Baseline is make test-integration, including both baseline and extended suite. 
| #Shards | Shard Run Times | Wall Time | Improvement vs Baseline |
|---|---|---|---|
| **1** | 20m34s | 20m34s | 0.0% |
| **2** | 9m43s, 10m42s | 10m42s | 48.0% |
| **3** | 7m51s, 6m30s, 5m42s | 7m51s | 61.8% |
| **4** | 4m37s, 7m18s, 4m38s, 3m16s | 7m18s | 64.5% |
| **5** | 3m51s, 2m06s, 3m35s, 7m49s, 2m27s | 7m49s | 62.0% |

#### Which issue(s) this PR fixes:
Part of #11536

#### Special notes for your reviewer:
Mostly LLM generated. I endorse the changes.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
