### PR TITLE
Fix skills/README.md

### DIFF
--- a/cmd/experimental/skills/README.md
+++ b/cmd/experimental/skills/README.md
@@ -12,8 +12,16 @@
 
 ### Agent-readable references
 
+> Tip: keep them separated with blank lines, for a nicer human-eye rendering.
+> 
+> Do **not** make this a bulleted list; each `@` should come at the start of a line.
+
 @kueue-who-preempted/SKILL.md
+
 @kueue-lineage/SKILL.md
+
 @kueue-flake-debugger/SKILL.md
+
 @kueue-release-notes/SKILL.md
+
 @reviewer/README.md

--- a/cmd/experimental/skills/README.md
+++ b/cmd/experimental/skills/README.md
@@ -2,11 +2,14 @@
 
 | Skill | Triggers on |
 |---|---|
-| [kueue-who-preempted](kueue-who-preempted.md) | "who preempted my workload", "why was my workload evicted", "what kicked out my job", preemption investigation |
-| [kueue-lineage](kueue-lineage.md) | "what pods are running for my workload", "trace workload to pods", "show me the jobs for this workload", lineage/ownership questions |
-| [kueue-flake-debugger](kueue-flake-debugger.md) | "debug a flake", "investigate test failure", "test timed out", "CI flake" |
+| [kueue-who-preempted](kueue-who-preempted/SKILL.md) | "who preempted my workload", "why was my workload evicted", "what kicked out my job", preemption investigation |
+| [kueue-lineage](kueue-lineage/SKILL.md) | "what pods are running for my workload", "trace workload to pods", "show me the jobs for this workload", lineage/ownership questions |
+| [kueue-flake-debugger](kueue-flake-debugger/SKILL.md) | "debug a flake", "investigate test failure", "test timed out", "CI flake" |
 | [kueue-release-notes](kueue-release-notes/SKILL.md) | Review or propose a concise PR release note focused on the user-observable change. |
-@kueue-who-preempted.md
-@kueue-lineage.md
-@kueue-flake-debugger.md
+| [reviewer/](reviewer/README.md) | "review this PR", "review this code", any code review of kueue changes |
+
+@kueue-who-preempted/SKILL.md
+@kueue-lineage/SKILL.md
+@kueue-flake-debugger/SKILL.md
+@kueue-release-notes/SKILL.md
 @reviewer/README.md

--- a/cmd/experimental/skills/README.md
+++ b/cmd/experimental/skills/README.md
@@ -8,6 +8,10 @@
 | [kueue-release-notes](kueue-release-notes/SKILL.md) | Review or propose a concise PR release note focused on the user-observable change. |
 | [reviewer/](reviewer/README.md) | "review this PR", "review this code", any code review of kueue changes |
 
+---
+
+### Agent-readable references
+
 @kueue-who-preempted/SKILL.md
 @kueue-lineage/SKILL.md
 @kueue-flake-debugger/SKILL.md


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

/area skills

#### What this PR does / why we need it:

It fixes a few issues in our main README.md for skills:

- the clickable links got broken (in #10819)
- the set of skills diverged between the table and `@`-links (in #11336)
- the blank line separating the table and `@`-links got removed, leading to surprising rendering (in #11336)

#### Which issue(s) this PR fixes:

none

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
