### PR TITLE
Automated cherry pick of #11635: Skip Netlify builds without site changes

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,6 +12,8 @@
 
 [context.deploy-preview]
   command = "hugo --enableGitInfo --buildFuture -b $DEPLOY_PRIME_URL"
+  # Runs from "site"; "." includes docs, and "../netlify.toml" includes config changes.
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../netlify.toml"
 
 [context.branch-deploy]
   command = "hugo --enableGitInfo --buildFuture -b $DEPLOY_PRIME_URL"


### PR DESCRIPTION
Cherry pick of #11635 on release-0.16.

#11635: Skip Netlify builds without site changes

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
NONE
```