### PR TITLE
docs: document cohort priority ordering on WorkloadPriorityClass page

### DIFF
--- a/site/content/en/docs/concepts/workload_priority_class.md
+++ b/site/content/en/docs/concepts/workload_priority_class.md
@@ -103,6 +103,10 @@ to learn how the priority class is obtained.
 The priority of workloads is used for:
 - Sorting the workloads in the ClusterQueues.
 - Determining whether a workload can preempt others.
+- Ordering workloads that need to borrow quota within the same [cohort](/docs/concepts/cluster_queue/#flavors-and-borrowing-semantics).
+  By default, higher-priority workloads are scheduled first; this can be disabled
+  by setting the `PrioritySortingWithinCohort` feature gate to `false`, in which case
+  Kueue falls back to ordering by `.metadata.creationTimestamp`.
 
 ## Mutability of priority fields
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The "Where workload's priority is used" section of the `WorkloadPriorityClass` concept page lists only two uses of workload priority: sorting within a ClusterQueue and determining preemption victims. 

It does not mention that priority also drives the order in which workloads borrow quota within a cohort, or that this behavior is gated by the `PrioritySortingWithinCohort` feature gate.

That behavior is already documented on the `ClusterQueue` page, but a user  reading the `WorkloadPriorityClass` page in isolation has no pointer to it.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
