### PR TITLE
Trigger backoff if nominated multikueue clusters are not yet connected

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -795,9 +795,16 @@ func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group 
 		nominatedWorkers = group.local.Status.NominatedClusterNames
 	}
 
+	var errs []error
+	for _, nom := range nominatedWorkers {
+		if _, ok := group.remoteClients[nom]; !ok {
+			log.V(3).Info("Nominated cluster not yet connected", "cluster", nom)
+			errs = append(errs, fmt.Errorf("cluster %s: %w", nom, admissioncheck.ErrNoRemoteClientForNominatedCluster))
+		}
+	}
+
 	log.V(4).Info("Synchronize nominated worker clusters", "dispatcherName", w.dispatcherName, "nominatedWorkerClusterNames", nominatedWorkers)
 
-	var errs []error
 	for rem, remoteWl := range group.remotes {
 		if slices.Contains(nominatedWorkers, rem) {
 			if remoteWl == nil {

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -1778,6 +1778,15 @@ func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
 			nominatedWorkers: remoteNames,
 			wantCreated:      remoteNames,
 		},
+		{
+			name:                      "External controller: nominated worker cluster not yet connected",
+			dispatcherMode:            externalMultiKueueDispatcherController,
+			remotes:                   map[string]*kueue.Workload{remoteNames[0]: nil},
+			nominatedWorkers:          []string{remoteNames[0], remoteNames[1]},
+			wantCreated:               []string{remoteNames[0]},
+			wantErr:                   true,
+			wantNominatedClusterNames: []string{remoteNames[0], remoteNames[1]},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/util/admissioncheck/admissioncheck.go
+++ b/pkg/util/admissioncheck/admissioncheck.go
@@ -33,9 +33,10 @@ import (
 )
 
 var (
-	ErrNilParametersRef = errors.New("missing parameters reference")
-	ErrBadParametersRef = errors.New("bad parameters reference")
-	ErrNoActiveClusters = errors.New("no active clusters")
+	ErrNilParametersRef                  = errors.New("missing parameters reference")
+	ErrBadParametersRef                  = errors.New("bad parameters reference")
+	ErrNoActiveClusters                  = errors.New("no active clusters")
+	ErrNoRemoteClientForNominatedCluster = errors.New("no remote client for nominated cluster")
 )
 
 type objAsPtr[T any] interface {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind regression

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->
/area multikueue
#### What this PR does / why we need it:

Before #11559, remoteClientsForAC returned ErrNoActiveClusters, this propagated up through readGroup, Reconcile, controller-runtime applied exponential backoff, eventually retried and clusters were connected by then.

After #11559, remoteClientsForAC returns an empty map, readGroup succeeds with an empty wlGroup.remotes, reconcileGroup, in nominateAndSynchronizeWorkers, it iterates over an empty map of remotes and returns (Result{}, nil). So, result is no requeue, no error, workload is left hanging in a Pending state.

This PR introduces a fail-fast check in `nominateAndSynchronizeWorkers`.
If any cluster in the `nominatedWorkers` list is missing from the connected `remoteClients` map, it now returns a new `ErrNoRemoteClientForNominatedCluster` error. This successfully triggers the controller-runtime exponential backoff, automatically retrying the sync until the cluster finishes connecting.

This way it does not break `workerLostTimeout` feature for admitted workloads, which #11559 brought back on.

> 	// Return an empty map (rather than an error) when all configured clusters
	// are disconnected or reconnecting. This allows readGroup to construct an
	// empty group, so reconcileGroup can apply the workerLostTimeout delay via
	// the existing "reserving remote lost" branch instead of failing with
	// ErrNoActiveClusters and retrying via controller-runtime backoff.

Tested locally, was able to reproduce the issue. Added logging indicated cases when remoteClient was not ready, and after few retries remoteClient was ready for worker1 and then for worker2.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11631

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
