### PR TITLE
Automated cherry pick of #11634: Use MediumTimeout for workload admission waits for test-e2e-multikueue

### DIFF
--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -1544,7 +1544,7 @@ func expectWorkloadsToBeAdmittedAndGetWorkerName(ctx context.Context, client cli
 	ginkgo.GinkgoHelper()
 	createdWorkload := &kueue.Workload{}
 	var workerName string
-	util.ExpectWorkloadsToBeAdmittedByKeys(ctx, client, wlLookupKey)
+	util.ExpectWorkloadsToBeAdmittedByKeysWithTimeout(ctx, client, util.MediumTimeout, wlLookupKey)
 	gomega.Eventually(func(g gomega.Gomega) {
 		g.Expect(client.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 		admissionCheckMessage := admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(acName)).Message

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -512,6 +512,16 @@ func ExpectWorkloadsToBeAdmitted(ctx context.Context, k8sClient client.Client, w
 
 func ExpectWorkloadsToBeAdmittedByKeys(ctx context.Context, k8sClient client.Client, wlKeys ...client.ObjectKey) {
 	ginkgo.GinkgoHelper()
+	expectWorkloadsToBeAdmittedByKeysWithTimeout(ctx, k8sClient, Timeout, wlKeys...)
+}
+
+func ExpectWorkloadsToBeAdmittedByKeysWithTimeout(ctx context.Context, k8sClient client.Client, timeout time.Duration, wlKeys ...client.ObjectKey) {
+	ginkgo.GinkgoHelper()
+	expectWorkloadsToBeAdmittedByKeysWithTimeout(ctx, k8sClient, timeout, wlKeys...)
+}
+
+func expectWorkloadsToBeAdmittedByKeysWithTimeout(ctx context.Context, k8sClient client.Client, timeout time.Duration, wlKeys ...client.ObjectKey) {
+	ginkgo.GinkgoHelper()
 	wlKeys = uniqueKeys(wlKeys)
 	wlObjects := make([]*kueue.Workload, len(wlKeys))
 	gomega.Eventually(func(g gomega.Gomega) {
@@ -519,7 +529,7 @@ func ExpectWorkloadsToBeAdmittedByKeys(ctx context.Context, k8sClient client.Cli
 		admitted := filter(all, workload.IsAdmitted)
 		copy(wlObjects, all)
 		g.Expect(workloadKeys(admitted)).Should(gomega.Equal(wlKeys))
-	}, Timeout, Interval).Should(gomega.Succeed(), AssertMsg("Unexpected workloads are admitted", wlObjects...))
+	}, timeout, Interval).Should(gomega.Succeed(), AssertMsg("Unexpected workloads are admitted", wlObjects...))
 }
 
 func ExpectWorkloadsToBeAdmittedCount(ctx context.Context, k8sClient client.Client, count int, wls ...*kueue.Workload) {


### PR DESCRIPTION
Cherry pick of #11634 on release-0.16.

#11634: Use MediumTimeout for workload admission waits for test-e2e-multikueue

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

```release-note
NONE
```