### PR TITLE
Automated cherry pick of #11596: Finish Workloads corresponding to Jobs deleted with --cascede=orphan

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -807,8 +807,9 @@ func updateDelayedTopologyRequest(local, remote *kueue.Workload) {
 func cloneForCreate(orig *kueue.Workload, origin string) *kueue.Workload {
 	remoteWl := &kueue.Workload{}
 	remoteWl.ObjectMeta = api.CloneObjectMetaForCreation(&orig.ObjectMeta)
+	delete(remoteWl.Labels, constants.JobUIDLabel)
 	if remoteWl.Labels == nil {
-		remoteWl.Labels = make(map[string]string)
+		remoteWl.Labels = make(map[string]string, 1)
 	}
 	remoteWl.Labels[kueue.MultiKueueOriginLabel] = origin
 	orig.Spec.DeepCopyInto(&remoteWl.Spec)

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -52,6 +52,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/dra"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -193,10 +194,9 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	log := ctrl.LoggerFrom(ctx)
 	log.V(2).Info("Reconcile Workload")
 
-	if len(wl.OwnerReferences) == 0 && !wl.DeletionTimestamp.IsZero() {
-		// manual deletion triggered by the user
-		err := workload.RemoveFinalizer(ctx, r.client, &wl)
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+	if isOrphanedWorkload(&wl) {
+		err := workload.FinalizeOrphanedWorkload(ctx, r.client, r.clock, &wl, true, r.roleTracker)
+		return ctrl.Result{}, err
 	}
 
 	finishedCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadFinished)
@@ -571,6 +571,29 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// isOrphanedWorkload determines if a workload is orphaned and should be finalized.
+//
+// A workload is considered orphaned when it meets **both** of the following conditions:
+//  1. It has no OwnerReferences.
+//  2. Either:
+//     - Its DeletionTimestamp is set (it's in the process of being deleted), OR
+//     - It has a JobUIDLabel (controllerconsts.JobUIDLabel), meaning it was
+//     previously owned by a Job whose OwnerReference was later removed.
+func isOrphanedWorkload(wl *kueue.Workload) bool {
+	// If it has an owner, it cannot be orphaned.
+	if len(wl.OwnerReferences) > 0 {
+		return false
+	}
+
+	// Check if the workload is actively being deleted.
+	if !wl.DeletionTimestamp.IsZero() {
+		return true
+	}
+
+	// Check if the workload is associated with a specific Job UID.
+	return features.Enabled(features.FinishOrphanedWorkloads) && wl.Labels[controllerconsts.JobUIDLabel] != ""
 }
 
 // isDisabledRequeuedByClusterQueueStopped returns true if the workload is unset requeued by cluster queue stopped.

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -739,6 +739,44 @@ func TestReconcile(t *testing.T) {
 				Obj(),
 			wantWorkload: nil,
 		},
+		"remove finalizer for deleted orphaned workload with FinishOrphanedWorkloads enabled": {
+			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: true},
+			workload: utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
+				DeletionTimestamp(now).
+				Obj(),
+			wantWorkload: nil,
+		},
+		"remove finalizer for deleted orphaned workload with FinishOrphanedWorkloads disabled": {
+			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: false},
+			workload: utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
+				DeletionTimestamp(now).
+				Obj(),
+			wantWorkload: nil,
+		},
+		"remove finalizer for orphaned workload with JobUID label and FinishOrphanedWorkloads enabled": {
+			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: true},
+			workload: utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
+				JobUID("job_uid").
+				Obj(),
+			wantWorkload: nil,
+		},
+		"remove finalizer for orphaned workload with JobUID label and FinishOrphanedWorkloads disabled": {
+			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: false},
+			workload: utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
+				JobUID("job_uid").
+				Condition(metav1.Condition{
+					Type:   "Finished",
+					Status: "True",
+				}).
+				Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
+				JobUID("job_uid").
+				Condition(metav1.Condition{
+					Type:   "Finished",
+					Status: "True",
+				}).
+				Obj(),
+		},
 		"don't remove finalizer for owned finished workload": {
 			workload: utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 				Condition(metav1.Condition{

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -672,33 +672,13 @@ func (r *JobReconciler) getWorkloads(ctx context.Context, key types.NamespacedNa
 
 // finalizeWorkloads removes finalizers from workloads associated with the specified job.
 func (r *JobReconciler) finalizeWorkloads(ctx context.Context, key types.NamespacedName, job GenericJob) error {
-	log := ctrl.LoggerFrom(ctx)
 	workloads, err := r.getWorkloads(ctx, key, job)
 	if err != nil {
 		return err
 	}
 	for i := range workloads {
 		wl := &workloads[i]
-
-		// Finish the orphaned workload. This can happen when the workload is readmitted
-		// after eviction (e.g., waitForPodsReady) due to the workload waiting retention policy.
-		// We need to finish the workload to prevent such a situation.
-		// For example, a Deployment-owned pod deleted after PodsReady timeout eviction.
-		if features.Enabled(features.FinishOrphanedWorkloads) && controllerutil.HasControllerReference(wl) {
-			log.V(2).Info("Workload is orphaned; finishing to release quota")
-			err := workload.Finish(ctx, r.client, wl, kueue.WorkloadFinishedReasonOwnerNotFound,
-				"The workload's owner no longer exists", r.clock, r.roleTracker)
-			if err != nil {
-				if client.IgnoreNotFound(err) != nil {
-					log.Error(err, "Finishing orphaned workload")
-					return err
-				}
-				return nil
-			}
-		}
-
-		if err := workload.RemoveFinalizer(ctx, r.client, wl); client.IgnoreNotFound(err) != nil {
-			log.Error(err, "Removing finalizer")
+		if err := workload.FinalizeOrphanedWorkload(ctx, r.client, r.clock, wl, controllerutil.HasControllerReference(wl), r.roleTracker); err != nil {
 			return err
 		}
 	}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -1400,6 +1401,32 @@ func CreatePodsReadyCondition(status metav1.ConditionStatus, reason, message str
 		LastTransitionTime: metav1.NewTime(clock.Now()),
 		// ObservedGeneration is added via workload.SetConditionAndUpdate
 	}
+}
+
+func FinalizeOrphanedWorkload(ctx context.Context, c client.Client, clk clock.Clock, wl *kueue.Workload, canFinish bool, tracker *roletracker.RoleTracker) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	// Only Finish workloads that are not currently being deleted.
+	if features.Enabled(features.FinishOrphanedWorkloads) && wl.DeletionTimestamp.IsZero() && canFinish {
+		log.V(2).Info("Workload is orphaned; finishing to release quota")
+		if err := Finish(ctx, c, wl, kueue.WorkloadFinishedReasonOwnerNotFound,
+			"The workload's owner no longer exists", clk, tracker); err != nil {
+			if client.IgnoreNotFound(err) != nil {
+				log.Error(err, "Failed to finish Workload")
+				return err
+			}
+			return nil
+		}
+	}
+
+	if err := RemoveFinalizer(ctx, c, wl); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			log.Error(err, "Failed to remove finalizer")
+			return err
+		}
+	}
+
+	return nil
 }
 
 func RemoveFinalizer(ctx context.Context, c client.Client, wl *kueue.Workload) error {

--- a/test/e2e/config/default/controller_manager_config.yaml
+++ b/test/e2e/config/default/controller_manager_config.yaml
@@ -39,6 +39,7 @@ featureGates:
   LocalQueueMetrics: true
   ElasticJobsViaWorkloadSlices: true
   TASReplaceNodeOnNodeTaints: true
+  FinishOrphanedWorkloads: true
 tls:
   minVersion: "VersionTLS12"
   # this is the default ciphersuite for golang 1.25

--- a/test/e2e/singlecluster/baseline/job_test.go
+++ b/test/e2e/singlecluster/baseline/job_test.go
@@ -126,6 +126,8 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 			gomega.Expect(util.DeleteAllJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
 			// Force remove workloads to be sure that cluster queue can be removed.
 			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			// To make sure all orphaned pods deleted after PropagationPolicy=DeletePropagationOrphan.
+			gomega.Expect(util.DeleteAllPodsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, localQueue, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandRF, true)
@@ -221,6 +223,32 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 			ginkgo.By(fmt.Sprintf("Wait for the workload %q to finish", wlLookupKey), func() {
 				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
 			})
+		})
+
+		ginkgo.It("Should finish workload if the job is deleted with PropagationPolicy=DeletePropagationOrphan", func() {
+			job := testingjob.MakeJob("job", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				Obj()
+			util.MustCreate(ctx, k8sClient, job)
+
+			wlLookupKey := types.NamespacedName{
+				Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+				Namespace: ns.Name,
+			}
+
+			ginkgo.By(fmt.Sprintf("Wait for the workload %q to be admitted", wlLookupKey), func() {
+				util.ExpectWorkloadsToBeAdmittedByKeys(ctx, k8sClient, wlLookupKey)
+			})
+
+			gomega.Expect(k8sClient.Delete(ctx, job, &client.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationOrphan)})).To(gomega.Succeed())
+
+			createdWl := &kueue.Workload{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWl)).To(gomega.Succeed())
+				g.Expect(workload.IsFinished(createdWl)).To(gomega.BeTrue())
+				g.Expect(createdWl.Finalizers).To(gomega.BeEmpty())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
 		ginkgo.It("Should run with prebuilt workload", func() {


### PR DESCRIPTION
Cherry pick of #11596 on release-0.16.

#11596: Finish Workloads corresponding to Jobs deleted with --cascede=orphan

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
Fixed a bug that prevented finishing the Workloads corresponding to Jobs deleted with --cascade=orphan.
The fix is behind the FinishOrphanedWorkloads feature gate (alpha, disabled by default).
```