### PR TITLE
Automated cherry pick of #11679: Shard sequential baseline E2E tests

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -205,8 +205,18 @@ test-e2e-certmanager: setup-e2e-env run-test-e2e-certmanager-$(E2E_KIND_VERSION:
 ##   Run only Admission Fair Sharing tests: GINKGO_ARGS="--label-filter=feature:admissionfairsharing" make test-e2e-sequential-baseline
 ##   Run only Certs tests: GINKGO_ARGS="--label-filter=feature:certs" make test-e2e-sequential-baseline
 ##   Run only Failure Recovery Policy tests: GINKGO_ARGS="--label-filter=feature:failurerecoverypolicy" make test-e2e-sequential-baseline
+##   Run only shard 0 tests: make test-e2e-sequential-baseline-shard-0
+##   Run only shard 1 tests: make test-e2e-sequential-baseline-shard-1
 .PHONY: test-e2e-sequential-baseline
 test-e2e-sequential-baseline: setup-e2e-env run-test-e2e-sequential-baseline-$(E2E_KIND_VERSION:kindest/node:v%=%)
+
+.PHONY: test-e2e-sequential-baseline-shard-0
+test-e2e-sequential-baseline-shard-0: GINKGO_ARGS=--label-filter=shard-0
+test-e2e-sequential-baseline-shard-0: test-e2e-sequential-baseline
+
+.PHONY: test-e2e-sequential-baseline-shard-1
+test-e2e-sequential-baseline-shard-1: GINKGO_ARGS=--label-filter=shard-1
+test-e2e-sequential-baseline-shard-1: test-e2e-sequential-baseline
 
 .PHONY: test-e2e-sequential-baseline-helm
 test-e2e-sequential-baseline-helm: E2E_USE_HELM=true

--- a/test/e2e/sequential/baseline/admission_fair_sharing_test.go
+++ b/test/e2e/sequential/baseline/admission_fair_sharing_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("Admission Fair Sharing", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("Admission Fair Sharing", ginkgo.Label("feature:admissionfairsharing", shard0), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		ns *corev1.Namespace
 		rf *kueue.ResourceFlavor

--- a/test/e2e/sequential/baseline/default_config_test.go
+++ b/test/e2e/sequential/baseline/default_config_test.go
@@ -44,7 +44,7 @@ const (
 	testLabelValue = "true"
 )
 
-var _ = ginkgo.Describe("Default configuration tests", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("Default configuration tests", ginkgo.Label(shard0), ginkgo.Ordered, func() {
 	ginkgo.Context("Certs", func() {
 		var (
 			ns             *corev1.Namespace

--- a/test/e2e/sequential/baseline/failure_recovery_policy_test.go
+++ b/test/e2e/sequential/baseline/failure_recovery_policy_test.go
@@ -41,7 +41,7 @@ const (
 	podTerminationGracePeriodSeconds = 1
 )
 
-var _ = ginkgo.Describe("Failure Recovery Policy", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("Failure Recovery Policy", ginkgo.Label("feature:failurerecoverypolicy", shard1), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		job *batchv1.Job
 		ns  *corev1.Namespace

--- a/test/e2e/sequential/baseline/objectretentionpolicies_test.go
+++ b/test/e2e/sequential/baseline/objectretentionpolicies_test.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("ObjectRetentionPolicies", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("ObjectRetentionPolicies", ginkgo.Label("feature:objectretentionpolicies", shard1), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		ns *corev1.Namespace
 		rf *kueue.ResourceFlavor
@@ -133,7 +133,7 @@ var _ = ginkgo.Describe("ObjectRetentionPolicies", ginkgo.Ordered, ginkgo.Contin
 	})
 })
 
-var _ = ginkgo.Describe("ObjectRetentionPolicies with TinyTimeout", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("ObjectRetentionPolicies with TinyTimeout", ginkgo.Label(shard1), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		ns *corev1.Namespace
 		rf *kueue.ResourceFlavor
@@ -267,7 +267,7 @@ var _ = ginkgo.Describe("ObjectRetentionPolicies with TinyTimeout", ginkgo.Order
 	})
 })
 
-var _ = ginkgo.Describe("ObjectRetentionPolicies with TinyTimeout and RequeuingLimitExceeded", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("ObjectRetentionPolicies with TinyTimeout and RequeuingLimitExceeded", ginkgo.Label(shard1), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		ns *corev1.Namespace
 		rf *kueue.ResourceFlavor

--- a/test/e2e/sequential/baseline/podintegrationautoenablement_test.go
+++ b/test/e2e/sequential/baseline/podintegrationautoenablement_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("Auto-Enablement of Pod Integration for Pod-Dependent Frameworks", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("Auto-Enablement of Pod Integration for Pod-Dependent Frameworks", ginkgo.Label("feature:podintegrationautoenablement", shard1), ginkgo.Ordered, func() {
 	var (
 		ns           *corev1.Namespace
 		defaultRf    *kueue.ResourceFlavor

--- a/test/e2e/sequential/baseline/reconcile_test.go
+++ b/test/e2e/sequential/baseline/reconcile_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("Job reconciliation with ManagedJobsNamespaceSelectorAlwaysRespected", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("Job reconciliation with ManagedJobsNamespaceSelectorAlwaysRespected", ginkgo.Label("feature:managedjobsnamespaceselectoralwaysrespected", shard0), ginkgo.Ordered, func() {
 	const (
 		cqName = "cluster-queue"
 		rfName = "default"

--- a/test/e2e/sequential/baseline/suite_test.go
+++ b/test/e2e/sequential/baseline/suite_test.go
@@ -31,6 +31,11 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
+const (
+	shard0 = "shard-0"
+	shard1 = "shard-1"
+)
+
 var (
 	k8sClient       client.WithWatch
 	cfg             *rest.Config

--- a/test/e2e/sequential/baseline/visibility_server_test.go
+++ b/test/e2e/sequential/baseline/visibility_server_test.go
@@ -38,7 +38,7 @@ const (
 	customVisibilityPort      = 9444
 )
 
-var _ = ginkgo.Describe("Visibility Server", func() {
+var _ = ginkgo.Describe("Visibility Server", ginkgo.Label("feature:visibility", shard0), ginkgo.Ordered, func() {
 	var originalDeployment appsv1.Deployment
 	var originalService corev1.Service
 	var cq *kueue.ClusterQueue

--- a/test/e2e/sequential/baseline/waitforpodsready_test.go
+++ b/test/e2e/sequential/baseline/waitforpodsready_test.go
@@ -44,7 +44,7 @@ const (
 	metricsReaderClusterRoleName = "kueue-metrics-reader"
 )
 
-var _ = ginkgo.Describe("WaitForPodsReady with tiny Timeout and no RecoveryTimeout", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("WaitForPodsReady with tiny Timeout and no RecoveryTimeout", ginkgo.Label("feature:waitforpodsready", shard1), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		ns    *corev1.Namespace
 		rf    *kueue.ResourceFlavor
@@ -201,7 +201,7 @@ var _ = ginkgo.Describe("WaitForPodsReady with tiny Timeout and no RecoveryTimeo
 	})
 })
 
-var _ = ginkgo.Describe("WaitForPodsReady with default Timeout and a tiny RecoveryTimeout", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("WaitForPodsReady with default Timeout and a tiny RecoveryTimeout", ginkgo.Label(shard1), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		ns    *corev1.Namespace
 		rf    *kueue.ResourceFlavor
@@ -348,7 +348,7 @@ var _ = ginkgo.Describe("WaitForPodsReady with default Timeout and a tiny Recove
 	})
 })
 
-var _ = ginkgo.Describe("WaitForPodsReady with default Timeout and a long RecoveryTimeout", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("WaitForPodsReady with default Timeout and a long RecoveryTimeout", ginkgo.Label(shard0), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		ns    *corev1.Namespace
 		rf    *kueue.ResourceFlavor


### PR DESCRIPTION
Cherry pick of #11679 on release-0.16.

#11679: Shard sequential baseline E2E tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```