### PR TITLE
Extend nominal-first preemptioin to cohort-level nominal quotas in hierarchical setups

### DIFF
--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -379,14 +379,21 @@ func runFirstFsStrategy(preemptionCtx *preemptionCtx, candidates []*workload.Inf
 	var targets []*Target
 	var retryCandidates []*workload.Info
 
-	// If the preemptor CQ stays within nominal quota for the contested
-	// resources (including the incoming workload, already simulated),
-	// preemption is allowed regardless of DRS (nominal entitlement).
-	// When true, all cross-CQ candidates are preempted unconditionally
-	// (bypassing the strategy check), so no retryCandidates are produced
-	// and runSecondFsStrategy has nothing to do.
-	preemptorWithinNominal := features.Enabled(features.FairSharingPreemptWithinNominal) &&
-		queueWithinNominalInResourcesNeedingPreemption(preemptionCtx)
+	// FairSharingPreemptWithinNominal uses a two-tier bypass:
+	// 1. Preemptor CQ within nominal on contested FRs → global bypass (#9494).
+	// 2. Closest ancestor cohort within nominal → bypass only for candidates
+	//    outside that cohort subtree (prevents sibling flapping, #9466).
+	var preemptorCQWithinNominal bool
+	var protectionCohort *schdcache.CohortSnapshot
+	if features.Enabled(features.FairSharingPreemptWithinNominal) {
+		frs := preemptionCtx.frsNeedPreemption
+		cq := preemptionCtx.preemptorCQ
+		if schdcache.IsWithinNominalInResources(cq, frs) {
+			preemptorCQWithinNominal = true
+		} else {
+			protectionCohort = closestAncestorWithinNominal(cq, frs)
+		}
+	}
 	for candCQ := range ordering.Iter() {
 		if candCQ.InClusterQueuePreemption() {
 			candWl := candCQ.PopWorkload()
@@ -402,7 +409,7 @@ func runFirstFsStrategy(preemptionCtx *preemptionCtx, candidates []*workload.Inf
 			continue
 		}
 
-		if preemptorWithinNominal {
+		if preemptorCQWithinNominal || (protectionCohort != nil && !cqInCohortSubtree(candCQ.GetTargetCq(), protectionCohort)) {
 			candWl := candCQ.PopWorkload()
 			preemptionCtx.snapshot.RemoveWorkload(candWl)
 			targets = append(targets, &Target{
@@ -656,19 +663,22 @@ func queueUnderNominalInResourcesNeedingPreemption(preemptionCtx *preemptionCtx)
 	return true
 }
 
-// queueWithinNominalInResourcesNeedingPreemption checks whether the preemptor
-// or any ancestor cohort is within subtree nominal quota for all contested
-// flavor-resources. This allows fair-sharing preemption to bypass DRS when a
-// CQ borrows from its parent cohort's pool while that cohort is not borrowing
-// upward.
-func queueWithinNominalInResourcesNeedingPreemption(preemptionCtx *preemptionCtx) bool {
-	frs := preemptionCtx.frsNeedPreemption
-	cq := preemptionCtx.preemptorCQ
-	if schdcache.IsWithinNominalInResources(cq, frs) {
-		return true
-	}
+// closestAncestorWithinNominal returns the first (lowest) ancestor cohort that is
+// within subtree nominal on all contested flavor-resources, or nil if none is
+// found before reaching root.
+func closestAncestorWithinNominal(cq *schdcache.ClusterQueueSnapshot, frs sets.Set[resources.FlavorResource]) *schdcache.CohortSnapshot {
 	for ancestor := range cq.PathParentToRoot() {
 		if schdcache.IsWithinNominalInResources(ancestor, frs) {
+			return ancestor
+		}
+	}
+	return nil
+}
+
+// cqInCohortSubtree returns true if cohort appears on candidateCQ's path to root.
+func cqInCohortSubtree(candidateCQ *schdcache.ClusterQueueSnapshot, cohort *schdcache.CohortSnapshot) bool {
+	for ancestor := range candidateCQ.PathParentToRoot() {
+		if ancestor == cohort {
 			return true
 		}
 	}

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -656,18 +656,23 @@ func queueUnderNominalInResourcesNeedingPreemption(preemptionCtx *preemptionCtx)
 	return true
 }
 
-// queueWithinNominalInResourcesNeedingPreemption checks whether the
-// preemptor CQ's usage is at or below nominal quota (usage <= nominal)
-// for all flavor-resources needing preemption.
-// The difference from queueUnderNominalInResourcesNeedingPreemption is
-// that this treats usage exactly equal to nominal as "within nominal."
+// queueWithinNominalInResourcesNeedingPreemption checks whether the preemptor
+// or any ancestor cohort is within subtree nominal quota for all contested
+// flavor-resources. This allows fair-sharing preemption to bypass DRS when a
+// CQ borrows from its parent cohort's pool while that cohort is not borrowing
+// upward.
 func queueWithinNominalInResourcesNeedingPreemption(preemptionCtx *preemptionCtx) bool {
-	for fr := range preemptionCtx.frsNeedPreemption {
-		if preemptionCtx.preemptorCQ.Borrowing(fr) {
-			return false
+	frs := preemptionCtx.frsNeedPreemption
+	cq := preemptionCtx.preemptorCQ
+	if schdcache.IsWithinNominalInResources(cq, frs) {
+		return true
+	}
+	for ancestor := range cq.PathParentToRoot() {
+		if schdcache.IsWithinNominalInResources(ancestor, frs) {
+			return true
 		}
 	}
-	return true
+	return false
 }
 
 // buildCQPath constructs a path like "/parent/.../cq" for a given ClusterQueue snapshot.

--- a/pkg/scheduler/preemption/preemption_fair_test.go
+++ b/pkg/scheduler/preemption/preemption_fair_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package preemption
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -885,7 +886,7 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: unitWl.Clone().Name("a1").Obj(),
 			targetCQ: "a",
 			wantPreempted: sets.New(
-				targetKeyReason("/b1", kueue.InCohortFairSharingReason),
+				targetKeyReason("/b1", kueue.InCohortReclamationReason),
 			),
 		},
 		// CQ "a": 3 CPU nominal on premium, 0 on cheap.
@@ -940,6 +941,87 @@ func TestFairPreemptions(t *testing.T) {
 			incoming:      unitWl.Clone().Name("a_incoming").Obj(),
 			targetCQ:      "a",
 			wantPreempted: sets.New(targetKeyReason("/b_prem1", kueue.InCohortReclamationReason)),
+		},
+		// Hierarchical topology (kubernetes-sigs/kueue#9466):
+		//
+		//                    ROOT (20/20, quota=10)
+		//                   /            \
+		//          cohort-1 (6/10)    cohort-2 (14/0)
+		//         /            \              \
+		//   cq-1 (3/0)    cq-2 (3/1)    cq-hogger (14/0)
+		//     |               |                   |
+		//  cq1-0..2        cq2-0..2          hog-0..13
+		//
+		// ROOT subtreeQuota = 10 (own) + 10 (cohort-1 subtree) + 0 (cohort-2) = 20.
+		// cohort-1 subtree quota = 9 (cohort) + 0 (cq-1) + 1 (cq-2) = 10 CPU.
+		// cohort-1 usage = 6 < 10, so it is within subtree nominal.
+		// ROOT usage = 14 (hogger) + 6 (cohort-1) = 20 = ROOT subtreeQuota (full).
+		//
+		// Incoming: 4 CPU on cq-1 (0 nominal, fully borrowing from cohort-1 pool).
+		// Preemption needed: ROOT available = 0. After removing each 1-CPU hog,
+		// ROOT available increases by 1. Need 4 preemptions for 4 CPU to fit.
+		// cohort-1 is within nominal (6/10) → DRS bypass applies.
+		// Expectation: preempt 4 hogs from cq-hogger with InCohortReclamation.
+		"reclaim from sibling cohort when parent cohort within nominal": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("ROOT").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "10").Obj()).
+					Obj(),
+				utiltestingapi.MakeCohort("cohort-1").
+					Parent("ROOT").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "9").Obj()).
+					Obj(),
+				utiltestingapi.MakeCohort("cohort-2").
+					Parent("ROOT").
+					Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					Cohort("cohort-1").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "0").Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("cq-2").
+					Cohort("cohort-1").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "1").Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+					}).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("cq-hogger").
+					Cohort("cohort-2").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "0").Obj()).
+					Obj(),
+			},
+			admitted: func() []kueue.Workload {
+				wls := make([]kueue.Workload, 0, 20)
+				for i := range 14 {
+					wls = append(wls, *unitWl.Clone().Name(fmt.Sprintf("hog-%d", i)).Priority(-1).SimpleReserveQuota("cq-hogger", "default", now).Obj())
+				}
+				for i := range 3 {
+					wls = append(wls, *unitWl.Clone().Name(fmt.Sprintf("cq1-%d", i)).SimpleReserveQuota("cq-1", "default", now).Obj())
+				}
+				for i := range 3 {
+					wls = append(wls, *unitWl.Clone().Name(fmt.Sprintf("cq2-%d", i)).SimpleReserveQuota("cq-2", "default", now).Obj())
+				}
+				return wls
+			}(),
+			incoming: utiltestingapi.MakeWorkload("cq1-incoming", "").Request(corev1.ResourceCPU, "4").Obj(),
+			targetCQ: "cq-1",
+			wantPreempted: sets.New(
+				targetKeyReason("/hog-0", kueue.InCohortReclamationReason),
+				targetKeyReason("/hog-1", kueue.InCohortReclamationReason),
+				targetKeyReason("/hog-10", kueue.InCohortReclamationReason),
+				targetKeyReason("/hog-11", kueue.InCohortReclamationReason),
+			),
 		},
 	}
 	for name, tc := range cases {

--- a/pkg/scheduler/preemption/preemption_fair_test.go
+++ b/pkg/scheduler/preemption/preemption_fair_test.go
@@ -942,7 +942,7 @@ func TestFairPreemptions(t *testing.T) {
 			targetCQ:      "a",
 			wantPreempted: sets.New(targetKeyReason("/b_prem1", kueue.InCohortReclamationReason)),
 		},
-		// Hierarchical topology (#9466) + multi-flavor DRS (nominal-first pattern):
+		// Hierarchical nominal bypass (#9466) + sibling protection (pajakd review):
 		//
 		//                    ROOT (premium 20/20, quota=10)
 		//                   /            \
@@ -953,14 +953,14 @@ func TestFairPreemptions(t *testing.T) {
 		//  cq1-0..2         cq2-0..2          hog-00..13
 		//  cq1_cheap1..5
 		//
-		// cq-1: 3 premium (borrowed) + 5 cheap (borrowed) → high aggregate DRS.
-		// cohort-1: premium usage 6 < 10 → within subtree nominal on contested premium.
-		// cq-1: NOT within CQ nominal on premium (0 nominal).
+		// Preemption is required: ROOT premium is saturated; incoming 4 on cq-1.
+		// cohort-1 is within nominal on contested premium (protection cohort).
+		// cq-1: high aggregate DRS from cheap; NOT within CQ nominal on premium.
 		//
-		// Incoming: 4 premium CPU on cq-1.
-		// Without ancestor bypass: DRS strategy path applies (InCohortFairSharing from hogger).
-		// With ancestor bypass (cohort-1 within nominal on premium): InCohortReclamation from hogger.
-		"reclaim from sibling when parent within nominal despite high DRS on other flavor": {
+		// Per-candidate subtree check:
+		//   - cq-2 (inside cohort-1): DRS only — must NOT appear in targets.
+		//   - cq-hogger (outside cohort-1): bypass → InCohortReclamation from hog-00..03.
+		"sibling under same within-nominal cohort uses DRS not bypass": {
 			flavors: []*kueue.ResourceFlavor{
 				utiltestingapi.MakeResourceFlavor("premium").Obj(),
 				utiltestingapi.MakeResourceFlavor("cheap").Obj(),

--- a/pkg/scheduler/preemption/preemption_fair_test.go
+++ b/pkg/scheduler/preemption/preemption_fair_test.go
@@ -942,36 +942,43 @@ func TestFairPreemptions(t *testing.T) {
 			targetCQ:      "a",
 			wantPreempted: sets.New(targetKeyReason("/b_prem1", kueue.InCohortReclamationReason)),
 		},
-		// Hierarchical topology (kubernetes-sigs/kueue#9466):
+		// Hierarchical topology (#9466) + multi-flavor DRS (nominal-first pattern):
 		//
-		//                    ROOT (20/20, quota=10)
+		//                    ROOT (premium 20/20, quota=10)
 		//                   /            \
-		//          cohort-1 (6/10)    cohort-2 (14/0)
+		//          cohort-1 (prem 6/10)  cohort-2 (prem 14/0)
 		//         /            \              \
-		//   cq-1 (3/0)    cq-2 (3/1)    cq-hogger (14/0)
+		//   cq-1 (3 prem/0 + 5 cheap/0)  cq-2 (3/1)    cq-hogger (14/0)
 		//     |               |                   |
-		//  cq1-0..2        cq2-0..2          hog-0..13
+		//  cq1-0..2         cq2-0..2          hog-00..13
+		//  cq1_cheap1..5
 		//
-		// ROOT subtreeQuota = 10 (own) + 10 (cohort-1 subtree) + 0 (cohort-2) = 20.
-		// cohort-1 subtree quota = 9 (cohort) + 0 (cq-1) + 1 (cq-2) = 10 CPU.
-		// cohort-1 usage = 6 < 10, so it is within subtree nominal.
-		// ROOT usage = 14 (hogger) + 6 (cohort-1) = 20 = ROOT subtreeQuota (full).
+		// cq-1: 3 premium (borrowed) + 5 cheap (borrowed) → high aggregate DRS.
+		// cohort-1: premium usage 6 < 10 → within subtree nominal on contested premium.
+		// cq-1: NOT within CQ nominal on premium (0 nominal).
 		//
-		// Incoming: 4 CPU on cq-1 (0 nominal, fully borrowing from cohort-1 pool).
-		// Preemption needed: ROOT available = 0. After removing each 1-CPU hog,
-		// ROOT available increases by 1. Need 4 preemptions for 4 CPU to fit.
-		// cohort-1 is within nominal (6/10) → DRS bypass applies.
-		// Expectation: preempt 4 hogs from cq-hogger with InCohortReclamation.
-		"reclaim from sibling cohort when parent cohort within nominal": {
+		// Incoming: 4 premium CPU on cq-1.
+		// Without ancestor bypass: DRS strategy path applies (InCohortFairSharing from hogger).
+		// With ancestor bypass (cohort-1 within nominal on premium): InCohortReclamation from hogger.
+		"reclaim from sibling when parent within nominal despite high DRS on other flavor": {
+			flavors: []*kueue.ResourceFlavor{
+				utiltestingapi.MakeResourceFlavor("premium").Obj(),
+				utiltestingapi.MakeResourceFlavor("cheap").Obj(),
+			},
+			assignmentFlavor: "premium",
 			cohorts: []*kueue.Cohort{
 				utiltestingapi.MakeCohort("ROOT").
-					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
-						Resource(corev1.ResourceCPU, "10").Obj()).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("premium").Resource(corev1.ResourceCPU, "10").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("cheap").Resource(corev1.ResourceCPU, "10").Obj(),
+					).
 					Obj(),
 				utiltestingapi.MakeCohort("cohort-1").
 					Parent("ROOT").
-					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
-						Resource(corev1.ResourceCPU, "9").Obj()).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("premium").Resource(corev1.ResourceCPU, "9").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("cheap").Resource(corev1.ResourceCPU, "10").Obj(),
+					).
 					Obj(),
 				utiltestingapi.MakeCohort("cohort-2").
 					Parent("ROOT").
@@ -980,15 +987,21 @@ func TestFairPreemptions(t *testing.T) {
 			clusterQueues: []*kueue.ClusterQueue{
 				utiltestingapi.MakeClusterQueue("cq-1").
 					Cohort("cohort-1").
-					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
-						Resource(corev1.ResourceCPU, "0").Obj()).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("premium").Resource(corev1.ResourceCPU, "0").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("cheap").Resource(corev1.ResourceCPU, "0").Obj(),
+					).
 					Preemption(kueue.ClusterQueuePreemption{
 						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					FlavorFungibility(kueue.FlavorFungibility{
+						WhenCanBorrow:  kueue.MayStopSearch,
+						WhenCanPreempt: kueue.MayStopSearch,
 					}).
 					Obj(),
 				utiltestingapi.MakeClusterQueue("cq-2").
 					Cohort("cohort-1").
-					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("premium").
 						Resource(corev1.ResourceCPU, "1").Obj()).
 					Preemption(kueue.ClusterQueuePreemption{
 						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
@@ -997,30 +1010,33 @@ func TestFairPreemptions(t *testing.T) {
 					Obj(),
 				utiltestingapi.MakeClusterQueue("cq-hogger").
 					Cohort("cohort-2").
-					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("premium").
 						Resource(corev1.ResourceCPU, "0").Obj()).
 					Obj(),
 			},
 			admitted: func() []kueue.Workload {
-				wls := make([]kueue.Workload, 0, 20)
+				wls := make([]kueue.Workload, 0, 25)
 				for i := range 14 {
-					wls = append(wls, *unitWl.Clone().Name(fmt.Sprintf("hog-%d", i)).Priority(-1).SimpleReserveQuota("cq-hogger", "default", now).Obj())
+					wls = append(wls, *unitWl.Clone().Name(fmt.Sprintf("hog-%02d", i)).Priority(-1).SimpleReserveQuota("cq-hogger", "premium", now).Obj())
 				}
 				for i := range 3 {
-					wls = append(wls, *unitWl.Clone().Name(fmt.Sprintf("cq1-%d", i)).SimpleReserveQuota("cq-1", "default", now).Obj())
+					wls = append(wls, *unitWl.Clone().Name(fmt.Sprintf("cq1-%d", i)).SimpleReserveQuota("cq-1", "premium", now).Obj())
+				}
+				for i := range 5 {
+					wls = append(wls, *unitWl.Clone().Name(fmt.Sprintf("cq1_cheap%d", i+1)).SimpleReserveQuota("cq-1", "cheap", now).Obj())
 				}
 				for i := range 3 {
-					wls = append(wls, *unitWl.Clone().Name(fmt.Sprintf("cq2-%d", i)).SimpleReserveQuota("cq-2", "default", now).Obj())
+					wls = append(wls, *unitWl.Clone().Name(fmt.Sprintf("cq2-%d", i)).SimpleReserveQuota("cq-2", "premium", now).Obj())
 				}
 				return wls
 			}(),
 			incoming: utiltestingapi.MakeWorkload("cq1-incoming", "").Request(corev1.ResourceCPU, "4").Obj(),
 			targetCQ: "cq-1",
 			wantPreempted: sets.New(
-				targetKeyReason("/hog-0", kueue.InCohortReclamationReason),
-				targetKeyReason("/hog-1", kueue.InCohortReclamationReason),
-				targetKeyReason("/hog-10", kueue.InCohortReclamationReason),
-				targetKeyReason("/hog-11", kueue.InCohortReclamationReason),
+				targetKeyReason("/hog-00", kueue.InCohortReclamationReason),
+				targetKeyReason("/hog-01", kueue.InCohortReclamationReason),
+				targetKeyReason("/hog-02", kueue.InCohortReclamationReason),
+				targetKeyReason("/hog-03", kueue.InCohortReclamationReason),
 			),
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

Extends the CQ level nominal quota prioritisation to hierarchical cohorts even when DRS is high. An [earlier PR](https://github.com/kubernetes-sigs/kueue/pull/10149) already handled admission ordering. This also handles preemptions which is the final part required to close the issue.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9466 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
FairSharing: In fair sharing preemption, bypass DRS strategy gates when the preemptor ClusterQueue or an ancestor cohort is within subtree nominal on contested resources, allowing preemption even if the preemptor CQ has high aggregate DRS from borrowing on other flavors.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fair-sharing preemption decisions across hierarchical queue cohorts.
  * Prevented workloads in protected nominal cohorts from being preempted unnecessarily.
  * Corrected preemption reasons for workloads reclaimed within the same cohort.

* **Tests**
  * Added coverage for sibling queues under a shared nominal cohort.
  * Updated expected preemption behavior and reasons for affected scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->