### PR TITLE
fix(kueueviz): check error before null data on detail pages

### DIFF
--- a/cmd/kueueviz/frontend/src/LocalQueueDetail.jsx
+++ b/cmd/kueueviz/frontend/src/LocalQueueDetail.jsx
@@ -42,9 +42,9 @@ const LocalQueueDetail = () => {
     if (workloadsData) setWorkloads(workloadsData);
   }, [workloadsData]);
 
-  if (!queue) return <CircularProgress />;
   if (queueError) return <ErrorMessage error={queueError} />;
   if (workloadsError) return <ErrorMessage error={workloadsError} />;
+  if (!queue) return <CircularProgress />;
 
   return (
     <Paper className="parentContainer">

--- a/cmd/kueueviz/frontend/src/WorkloadDetail.jsx
+++ b/cmd/kueueviz/frontend/src/WorkloadDetail.jsx
@@ -40,8 +40,8 @@ const WorkloadDetail = () => {
     }
   }, [eventData]);
 
-  if (!workload) return <CircularProgress />;
   if (workloadError) return <ErrorMessage error={workloadError} />;
+  if (!workload) return <CircularProgress />;
 
   return (
     <Paper style={{ padding: '16px', marginTop: '20px', alignContent: 'left', alignItems: 'left' }}>


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area dashboard

#### What this PR does / why we need it:
Currently, the `WorkloadDetail.jsx` and `LocalQueueDetail.jsx` components check if the resource is null/undefined to render a loading spinner *before* checking if there is an active fetch or WebSocket error.

Because a connection failure prevents the resource state from ever being populated, it remains null indefinitely. Consequently, the component remains stuck in an infinite `CircularProgress` loading state, and the user is never shown the error boundary page.

This PR swaps the conditional logic to evaluate error states first, ensuring the error banner displays correctly upon fetch failure.

#### Which issue(s) this PR fixes:
Fixes #11700

#### Special notes for your reviewer:
None. Extremely simple logic swap.

#### Does this PR introduce a user-facing change?
Yes

```release-note
KueueViz: Fixed a bug where workload and local queue detail pages would get stuck on a loading spinner instead of showing connection/fetching error messages on failure.
```
