### PR TITLE
Shard MultiKueue sequential E2E tests

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -162,6 +162,14 @@ test-multikueue-e2e-main: setup-e2e-env test-multikueue-e2e-parallel-builds run-
 .PHONY: test-multikueue-e2e-sequential
 test-multikueue-e2e-sequential: setup-e2e-env test-multikueue-e2e-parallel-builds run-test-e2e-multikueue-sequential-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
+.PHONY: test-multikueue-e2e-sequential-shard-0
+test-multikueue-e2e-sequential-shard-0: GINKGO_ARGS=--label-filter=shard-0
+test-multikueue-e2e-sequential-shard-0: test-multikueue-e2e-sequential
+
+.PHONY: test-multikueue-e2e-sequential-shard-1
+test-multikueue-e2e-sequential-shard-1: GINKGO_ARGS=--label-filter=shard-1
+test-multikueue-e2e-sequential-shard-1: test-multikueue-e2e-sequential
+
 .PHONY: test-multikueue-e2e-helm
 test-multikueue-e2e-helm: E2E_USE_HELM=true
 test-multikueue-e2e-helm: test-multikueue-e2e

--- a/test/e2e/multikueue/sequential/e2e_test.go
+++ b/test/e2e/multikueue/sequential/e2e_test.go
@@ -207,7 +207,7 @@ var _ = ginkgo.Describe("MultiKueue Sequential", func() {
 		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sWorker2Client, worker2Ns)
 	})
 
-	ginkgo.When("Incremental mode", ginkgo.Ordered, func() {
+	ginkgo.Describe("Incremental mode", ginkgo.Label(shard0), ginkgo.Ordered, func() {
 		var defaultManagerKueueCfg *kueueconfig.Configuration
 
 		ginkgo.BeforeAll(func() {
@@ -297,7 +297,7 @@ var _ = ginkgo.Describe("MultiKueue Sequential", func() {
 		})
 	})
 
-	ginkgo.When("The connection to a worker cluster is unreliable", func() {
+	ginkgo.Describe("The connection to a worker cluster is unreliable", ginkgo.Label(shard1), func() {
 		ginkgo.It("Should update the cluster status to reflect the connection state", func() {
 			worker1Cq2 := utiltestingapi.MakeClusterQueue("q2").
 				ResourceGroup(
@@ -368,7 +368,7 @@ var _ = ginkgo.Describe("MultiKueue Sequential", func() {
 		})
 	})
 
-	ginkgo.When("Connection via ClusterProfile no plugins", ginkgo.Ordered, func() {
+	ginkgo.Describe("Connection via ClusterProfile no plugins", ginkgo.Label(shard0), ginkgo.Ordered, func() {
 		var (
 			workerCluster3         *kueue.MultiKueueCluster
 			defaultManagerKueueCfg *kueueconfig.Configuration
@@ -466,7 +466,7 @@ var _ = ginkgo.Describe("MultiKueue Sequential", func() {
 		})
 	})
 
-	ginkgo.When("Connection via ClusterProfile with plugins", ginkgo.Ordered, func() {
+	ginkgo.Describe("Connection via ClusterProfile with plugins", ginkgo.Label(shard0), ginkgo.Ordered, func() {
 		const (
 			secretReaderPath    = "/plugins/secretreader-plugin"
 			volumeName          = "plugins"
@@ -697,7 +697,7 @@ var _ = ginkgo.Describe("MultiKueue Sequential", func() {
 		})
 	})
 
-	ginkgo.When("MultiKueueOrchestratedPreemption is enabled", ginkgo.Ordered, func() {
+	ginkgo.Describe("MultiKueueOrchestratedPreemption is enabled", ginkgo.Label(shard1), ginkgo.Ordered, func() {
 		var defaultManagerKueueCfg, defaultWorker1KueueCfg, defaultWorker2KueueCfg *kueueconfig.Configuration
 
 		ginkgo.BeforeAll(func() {

--- a/test/e2e/multikueue/sequential/suite_test.go
+++ b/test/e2e/multikueue/sequential/suite_test.go
@@ -34,6 +34,11 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
+const (
+	shard0 = "shard-0"
+	shard1 = "shard-1"
+)
+
 var (
 	managerK8SVersion  *versionutil.Version
 	managerClusterName string


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup
/area testing

#### What this PR does / why we need it:
Splits `pull-kueue-test-e2e-multikueue-sequential-main` into:

  `test-multikueue-e2e-sequential-shard-0`
  `test-multikueue-e2e-sequential-shard-1`

changed `ginkgo.when` to `ginkgo.describe` too for consistency.

#### Which issue(s) this PR fixes:

Part of #11670

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
