### PR TITLE
fix(kueueviz): prevent flashing empty states on list pages

### DIFF
--- a/cmd/kueueviz/frontend/src/ClusterQueues.jsx
+++ b/cmd/kueueviz/frontend/src/ClusterQueues.jsx
@@ -25,12 +25,9 @@ import UsageBar, { aggregateResourceForQueue, computeEffectiveQuota, discoverRes
 
 const ClusterQueues = () => {
   const { data: clusterQueues, error } = useWebSocket('/ws/cluster-queues');
-  const [queues, setQueues] = useState([]);
-
-  useEffect(() => {
-    if (clusterQueues && Array.isArray(clusterQueues)) {
-      setQueues([...clusterQueues].sort((a, b) => (a.name || '').localeCompare(b.name || '')));
-    }
+  const queues = React.useMemo(() => {
+    if (!clusterQueues || !Array.isArray(clusterQueues)) return [];
+    return [...clusterQueues].sort((a, b) => (a.name || '').localeCompare(b.name || ''));
   }, [clusterQueues]);
 
   const resourceNames = discoverResourceNames(queues);

--- a/cmd/kueueviz/frontend/src/ClusterQueues.jsx
+++ b/cmd/kueueviz/frontend/src/ClusterQueues.jsx
@@ -40,7 +40,11 @@ const ClusterQueues = () => {
   return (
     <Paper className="parentContainer">
       <Typography variant="h4" gutterBottom>Cluster Queues</Typography>
-      {queues.length === 0 ? (
+      {clusterQueues === null ? (
+        <Box display="flex" justifyContent="center" my={4}>
+          <CircularProgress />
+        </Box>
+      ) : queues.length === 0 ? (
         <Typography>No Cluster Queues found.</Typography>
       ) : (
         <TableContainer component={Paper} className="tableContainerWithBorder">

--- a/cmd/kueueviz/frontend/src/Cohorts.jsx
+++ b/cmd/kueueviz/frontend/src/Cohorts.jsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 import React, { useState, useEffect, useMemo } from 'react';
 import { Link } from 'react-router-dom';
-import { Typography, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Box, ToggleButton, ToggleButtonGroup, List, ListItem, ListItemButton, ListItemText, Collapse, IconButton, Chip } from '@mui/material';
+import { Typography, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Box, ToggleButton, ToggleButtonGroup, List, ListItem, ListItemButton, ListItemText, Collapse, IconButton, Chip, CircularProgress } from '@mui/material';
 import { ExpandMore, ChevronRight, ViewList, AccountTree } from '@mui/icons-material';
 import useWebSocket from './useWebSocket';
 import './App.css';

--- a/cmd/kueueviz/frontend/src/Cohorts.jsx
+++ b/cmd/kueueviz/frontend/src/Cohorts.jsx
@@ -119,7 +119,11 @@ const Cohorts = () => {
         </ToggleButtonGroup>
       </Box>
 
-      {cohortList.length === 0 ? (
+      {cohorts === null ? (
+        <Box display="flex" justifyContent="center" my={4}>
+          <CircularProgress />
+        </Box>
+      ) : cohortList.length === 0 ? (
         <Typography>No Cohorts found.</Typography>
       ) : viewMode === 'tree' ? (
         <TableContainer component={Paper} className="tableContainerWithBorder">

--- a/cmd/kueueviz/frontend/src/Cohorts.jsx
+++ b/cmd/kueueviz/frontend/src/Cohorts.jsx
@@ -90,16 +90,14 @@ const CohortTreeNode = ({ cohort, depth = 0 }) => {
 
 const Cohorts = () => {
   const { data: cohorts, error } = useWebSocket('/ws/cohorts');
-  const [cohortList, setCohortList] = useState([]);
-  const [viewMode, setViewMode] = useState('list');
-
-  useEffect(() => {
-    if (cohorts && Array.isArray(cohorts)) {
-      setCohortList([...cohorts].sort((a, b) => (a.name || '').localeCompare(b.name || '')));
-    }
+  const cohortList = React.useMemo(() => {
+    if (!cohorts || !Array.isArray(cohorts)) return [];
+    return [...cohorts].sort((a, b) => (a.name || '').localeCompare(b.name || ''));
   }, [cohorts]);
 
-  const cohortTree = useMemo(() => buildCohortTree(cohortList), [cohortList]);
+  const [viewMode, setViewMode] = useState('list');
+
+  const cohortTree = React.useMemo(() => buildCohortTree(cohortList), [cohortList]);
 
   if (error) return <ErrorMessage error={error} />;
 

--- a/cmd/kueueviz/frontend/src/LocalQueues.jsx
+++ b/cmd/kueueviz/frontend/src/LocalQueues.jsx
@@ -25,14 +25,11 @@ import { toNumber, formatResourceValue, discoverResourceNames } from './UsageBar
 
 const LocalQueues = () => {
   const { data: localQueues, error } = useWebSocket('/ws/local-queues');
-  const [queues, setQueues] = useState([]);
-
-  useEffect(() => {
-    if (localQueues && Array.isArray(localQueues)) {
-      setQueues([...localQueues].sort((a, b) =>
-        (a.namespace || '').localeCompare(b.namespace || '') || (a.name || '').localeCompare(b.name || '')
-      ));
-    }
+  const queues = React.useMemo(() => {
+    if (!localQueues || !Array.isArray(localQueues)) return [];
+    return [...localQueues].sort((a, b) =>
+      (a.namespace || '').localeCompare(b.namespace || '') || (a.name || '').localeCompare(b.name || '')
+    );
   }, [localQueues]);
 
   if (error) return <ErrorMessage error={error} />;

--- a/cmd/kueueviz/frontend/src/LocalQueues.jsx
+++ b/cmd/kueueviz/frontend/src/LocalQueues.jsx
@@ -52,7 +52,11 @@ const LocalQueues = () => {
   return (
     <Paper className="parentContainer">
       <Typography variant="h4" gutterBottom>Local Queues</Typography>
-      {queues.length === 0 ? (
+      {localQueues === null ? (
+        <Box display="flex" justifyContent="center" my={4}>
+          <CircularProgress />
+        </Box>
+      ) : queues.length === 0 ? (
         <Typography>No Local Queues found.</Typography>
       ) : (
         <TableContainer component={Paper} className="tableContainerWithBorder">

--- a/cmd/kueueviz/frontend/src/ResourceFlavors.jsx
+++ b/cmd/kueueviz/frontend/src/ResourceFlavors.jsx
@@ -37,7 +37,11 @@ const ResourceFlavors = () => {
   return (
     <Paper className="parentContainer">
       <Typography variant="h4" gutterBottom>Resource Flavors</Typography>
-      {resourceFlavors.length === 0 ? (
+      {flavors === null ? (
+        <Box display="flex" justifyContent="center" my={4}>
+          <CircularProgress />
+        </Box>
+      ) : resourceFlavors.length === 0 ? (
         <Typography>No Resource Flavors found.</Typography>
       ) : (
         <TableContainer component={Paper} className="tableContainerWithBorder">

--- a/cmd/kueueviz/frontend/src/ResourceFlavors.jsx
+++ b/cmd/kueueviz/frontend/src/ResourceFlavors.jsx
@@ -24,12 +24,9 @@ import ViewYamlButton from './ViewYamlButton';
 
 const ResourceFlavors = () => {
   const { data: flavors, error } = useWebSocket('/ws/resource-flavors');
-  const [resourceFlavors, setResourceFlavors] = useState([]);
-
-  useEffect(() => {
-    if (flavors && Array.isArray(flavors)) {
-      setResourceFlavors([...flavors].sort((a, b) => (a.name || '').localeCompare(b.name || '')));
-    }
+  const resourceFlavors = React.useMemo(() => {
+    if (!flavors || !Array.isArray(flavors)) return [];
+    return [...flavors].sort((a, b) => (a.name || '').localeCompare(b.name || ''));
   }, [flavors]);
 
   if (error) return <ErrorMessage error={error} />;

--- a/cmd/kueueviz/frontend/src/Workloads.jsx
+++ b/cmd/kueueviz/frontend/src/Workloads.jsx
@@ -84,7 +84,11 @@ const Workloads = () => {
         </Select>
       </FormControl>
       
-      {workloads.length === 0 ? (
+      {workloadsData === null ? (
+        <Box display="flex" justifyContent="center" my={4}>
+          <CircularProgress />
+        </Box>
+      ) : workloads.length === 0 ? (
         <Typography>
           {selectedNamespace === '' 
             ? 'No workloads found in any namespace.' 

--- a/cmd/kueueviz/frontend/src/Workloads.jsx
+++ b/cmd/kueueviz/frontend/src/Workloads.jsx
@@ -28,23 +28,16 @@ const Workloads = () => {
   
   // Fetch namespaces from our new endpoint
   const { data: namespacesData, error: namespacesError } = useWebSocket('/ws/namespaces');
-  const [namespaces, setNamespaces] = useState([]);
-  
+  const namespaces = React.useMemo(() => {
+    return namespacesData?.namespaces || [];
+  }, [namespacesData]);
+
   // Fetch workloads with namespace filter
   const workloadsUrl = selectedNamespace === '' ? '/ws/workloads' : `/ws/workloads?namespace=${selectedNamespace}`;
   const { data: workloadsData, error: workloadsError } = useWebSocket(workloadsUrl);
-  const [workloads, setWorkloads] = useState([]);
-  
-  useEffect(() => {
-    if (namespacesData?.namespaces) {
-      // Make sure we're getting an array of strings, not complex objects
-      const namespaceNames = namespacesData.namespaces;
-      setNamespaces(namespaceNames);
-    }
-  }, [namespacesData]);
-  
-  useEffect(() => {
-    setWorkloads(workloadsData?.workloads?.items || []);
+
+  const workloads = React.useMemo(() => {
+    return workloadsData?.workloads?.items || [];
   }, [workloadsData]);
 
   const error = workloadsError || namespacesError;


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area dashboard

#### What this PR does / why we need it:
In `ClusterQueues.jsx`, `Cohorts.jsx`, `LocalQueues.jsx`, `ResourceFlavors.jsx`, and `Workloads.jsx`, the components initialized state as an empty array `[]`.

Before the WebSocket establishes a connection and streams down the initial cluster data, the render conditions immediately evaluated a length of 0, resulting in a flash of "No resources found" or similar empty-state banners. Once the stream delivered the resource list, the empty-state banner disappeared and the table rendered. This created a highly jarring visual flash on every refresh.

This PR differentiates between the uninitialized state (raw WebSocket data is `null`) and a genuinely empty list (WebSocket data is fetched and has 0 items). We show a clean `CircularProgress` loading spinner during the initialization window, and only display the empty text if the list is confirmed empty.

#### Which issue(s) this PR fixes:
Fixes #11708

#### Special notes for your reviewer:
None.

#### Does this PR introduce a user-facing change?
Yes

```release-note
KueueViz: Fixed a bug where list pages briefly flashed "No resources found" empty state messages before data finished loading over the WebSocket connection.
```