### PR TITLE
KEP: Improve observability of inadmissible workloads

### DIFF
--- a/keps/10852-inadmissible-workloads-observability/README.md
+++ b/keps/10852-inadmissible-workloads-observability/README.md
@@ -246,16 +246,19 @@ To separate different blocks and keep the status field highly structured, when
 the `QuotaReserved` status is `False`, the controller will resolve the reason
 field according to a strict priority hierarchy. Lower tier numbers represent
 structural failures and block scheduling early, thus taking absolute precedence
-over higher tiers:
+over higher tiers.
 
-| Tier | Classification | Reason Token | Description / Scenario | Location in Memory |
-| :--- | :--- | :--- | :--- | :--- |
-| **Tier 1** | Workload Deactivation | `Deactivated` | Workload is explicitly deactivated (`spec.active: false`). | None |
-| **Tier 2** | Structural Blockers | `Misconfigured` | Permanent structural error preventing admission (e.g., non-existent/inactive LocalQueue or ClusterQueue, resource flavor mismatch, DRA misconfiguration). | Missing local/cluster queue - None<br>ResourceFlavor mismatch - `ClusterQueue.inadmissibleWorkloads`<br>DRA issues - None |
-| **Tier 3** | Structural Quota Blockers | `ExceedsMaxQuota` | Workload requests resource quantities exceeding ClusterQueue or Cohort maximum limits. | `ClusterQueue.inadmissibleWorkloads` |
-| **Tier 4** | Orchestration & Administrative Holds | `Suspended`, `AdmissionGated`, `WaitingForPodsReady` | Workload is structurally valid, but admission is halted due to:<br>- Administrative hold (the queue's StopPolicy is active).<br>- Gated state (AdmissionGatedBy annotation).<br>- Scheduling hold (waiting for previously admitted workloads to reach PodsReady under waitForPodsReady configuration). | AdmissionGated - None<br>StopPolicy - None<br>WaitingForPodsReady - blocks and waits |
-| **Tier 5** | Resource Deficits | `WaitingForQuota` | Workload fits within the maximum limits of the ClusterQueue or Cohort, but the cluster currently lacks sufficient unreserved capacity (including when preemption is required but is blocked by preemption gates). | `ClusterQueue.inadmissibleWorkloads` |
-| **Tier 6** | Active Queueing | `PendingEvaluation` | Workload is submitted, structurally valid, resides actively in the queue, and is awaiting its capacity evaluation. Set also after eviction. | `ClusterQueue.heap` |
+Tiers are evaluated either at the **workload-wide** level (independent of flavor
+assignments) or at the **per-flavor** assignment level:
+
+| Tier | Scope | Classification | Reason Token | Description / Scenario | Location in Memory |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **Tier 1** | Workload-wide | Workload Deactivation | `Deactivated` | Workload is explicitly deactivated (`spec.active: false`). | None |
+| **Tier 2** | Mixed | Structural Blockers | `Misconfigured` | Permanent structural error preventing admission:<br>- Missing local/cluster queue (Workload-wide)<br>- Resource flavor mismatch (Per-flavor)<br>- DRA misconfiguration (Workload-wide) | Missing local/cluster queue - None<br>ResourceFlavor mismatch - `ClusterQueue.inadmissibleWorkloads`<br>DRA issues - None |
+| **Tier 3** | Per-flavor | Structural Quota Blockers | `ExceedsMaxQuota` | Workload requests resource quantities exceeding ClusterQueue or Cohort maximum limits. | `ClusterQueue.inadmissibleWorkloads` |
+| **Tier 4** | Workload-wide | Orchestration & Administrative Holds | `Suspended`, `AdmissionGated`, `WaitingForPodsReady` | Workload is structurally valid, but admission is halted due to:<br>- Administrative hold (the queue's StopPolicy is active).<br>- Gated state (AdmissionGatedBy annotation).<br>- Scheduling hold (waiting for previously admitted workloads to reach PodsReady under waitForPodsReady configuration). | AdmissionGated - None<br>StopPolicy - None<br>WaitingForPodsReady - blocks and waits |
+| **Tier 5** | Per-flavor | Resource Deficits | `WaitingForQuota` | Workload fits within the maximum limits of the ClusterQueue or Cohort, but the cluster currently lacks sufficient unreserved capacity (including when preemption is required but is blocked by preemption gates). | `ClusterQueue.inadmissibleWorkloads` |
+| **Tier 6** | Workload-wide | Active Queueing | `PendingEvaluation` | Workload is submitted, structurally valid, resides actively in the queue, and is awaiting its capacity evaluation. Set also after eviction. | `ClusterQueue.heap` |
 
 *Note: Precedence Resolution examples:*
 - *If a workload requests resource quantities exceeding the ClusterQueue
@@ -268,29 +271,16 @@ over higher tiers:
 
 #### Multi-Flavor Precedence Resolution
 
-When a workload is evaluated against multiple `ResourceFlavor` paths
-within a ClusterQueue, different flavors may yield different admission blocks.
-For example:
-- **Flavor A**: The workload has a structural affinity or taint mismatch
-  (resolves to Tier 2 `Misconfigured`).
-- **Flavor B**: The workload is structurally compatible but requests resource
-  quantities that exceed the ClusterQueue or Cohort maximum limits (resolves
-  to Tier 3 `ExceedsMaxQuota`).
-
-In scenarios where multiple flavors are checked:
-1. A structurally compatible flavor path (even if it currently has quota or
-   limits deficits like Tier 3 `ExceedsMaxQuota` or Tier 5 `WaitingForQuota`)
-   is a closer candidate for scheduling than a structurally incompatible
-   flavor path (Tier 2 `Misconfigured`).
-2. Therefore, when combining diagnostics across multiple flavors, the reasons
-   from compatible flavor paths (e.g., `ExceedsMaxQuota` or `WaitingForQuota`)
-   take precedence and are reported in the status, instead of reporting the
-   structural incompatibility (`Misconfigured`) of the other flavors.
+When a workload is evaluated against multiple `ResourceFlavor` paths within a
+ClusterQueue, Kueue attempts to find the most schedulable assignment. If
+scheduling fails, the blocker tier and reason reported in the workload status
+are emitted from the most schedulable flavor assignment candidate (i.e., the
+candidate that blocks at the highest tier number).
 
 This ensures that operators receive actionable alerts regarding the closest
 viable scheduling path (e.g., a limits or capacity block on a compatible
-flavor) rather than getting generic configuration mismatch reports from
-incompatible flavors.
+flavor) rather than generic configuration mismatch reports from incompatible
+flavors.
 
 ### Admitted Condition Initialization and Lifecycle
 

--- a/keps/10852-inadmissible-workloads-observability/README.md
+++ b/keps/10852-inadmissible-workloads-observability/README.md
@@ -253,18 +253,18 @@ over higher tiers:
 | **Tier 1** | Workload Deactivation | `Deactivated` | Workload is explicitly deactivated (`spec.active: false`). | None |
 | **Tier 2** | Structural Blockers | `Misconfigured` | Permanent structural error preventing admission (e.g., non-existent/inactive LocalQueue or ClusterQueue, resource flavor mismatch, DRA misconfiguration). | Missing local/cluster queue - None<br>ResourceFlavor mismatch - `ClusterQueue.inadmissibleWorkloads`<br>DRA issues - None |
 | **Tier 3** | Structural Quota Blockers | `ExceedsMaxQuota` | Workload requests resource quantities exceeding ClusterQueue or Cohort maximum limits. | `ClusterQueue.inadmissibleWorkloads` |
-| **Tier 4** | Orchestration & Administrative Holds | `Suspended`, `AdmissionGated`, `WaitingForPodsReady` | Workload is structurally valid, but admission is halted due to:<br>- Administrative hold (workload.spec.active is true or the queue's StopPolicy is active).<br>- Gated state (AdmissionGatedBy annotation).<br>- Scheduling hold (waiting for previously admitted workloads to reach PodsReady under waitForPodsReady configuration). | AdmissionGated - None<br>StopPolicy - None<br>WaitingForPodsReady - blocks and waits |
+| **Tier 4** | Orchestration & Administrative Holds | `Suspended`, `AdmissionGated`, `WaitingForPodsReady` | Workload is structurally valid, but admission is halted due to:<br>- Administrative hold (the queue's StopPolicy is active).<br>- Gated state (AdmissionGatedBy annotation).<br>- Scheduling hold (waiting for previously admitted workloads to reach PodsReady under waitForPodsReady configuration). | AdmissionGated - None<br>StopPolicy - None<br>WaitingForPodsReady - blocks and waits |
 | **Tier 5** | Resource Deficits | `WaitingForQuota` | Workload fits within the maximum limits of the ClusterQueue or Cohort, but the cluster currently lacks sufficient unreserved capacity (including when preemption is required but is blocked by preemption gates). | `ClusterQueue.inadmissibleWorkloads` |
 | **Tier 6** | Active Queueing | `PendingEvaluation` | Workload is submitted, structurally valid, resides actively in the queue, and is awaiting its capacity evaluation. Set also after eviction. | `ClusterQueue.heap` |
 
->*Note: Precedence Resolution examples:*
->- *If a workload requests resource quantities exceeding the ClusterQueue
->  maximum limits (Tier 3) but is also blocked by an unsatisfied
->  admission gate (Tier 4), the resolved reason is written as
->  `ExceedsMaxQuota` due to Tier 3 priority.*
->- *If a workload is waiting for capacity (Tier 5) but also has unsatisfied
->  admission gates (Tier 4), the resolved reason is written as
->  `AdmissionGated` due to Tier 4 priority.*
+*Note: Precedence Resolution examples:*
+- *If a workload requests resource quantities exceeding the ClusterQueue
+  maximum limits (Tier 3) but is also blocked by an unsatisfied
+  admission gate (Tier 4), the resolved reason is written as
+  `ExceedsMaxQuota` due to Tier 3 priority.*
+- *If a workload is waiting for capacity (Tier 5) but also has unsatisfied
+  admission gates (Tier 4), the resolved reason is written as
+  `AdmissionGated` due to Tier 4 priority.*
 
 #### Multi-Flavor Precedence Resolution
 
@@ -366,7 +366,10 @@ tracking:
 This ensures that pending workloads are fully tracked from the moment of their
 creation, regardless of whether explicit status initialization is active.
 
-The exact label mapping matrix is detailed below:
+When the `reason` label is `NoReservation` (the workload lacks a quota
+reservation), the `underlying_cause` label maps 1:1 to the `QuotaReserved`
+condition's reason (covering all 6 precedence tiers). Representative examples
+of these mapping combinations are detailed below:
 
 | Admitted Reason | QuotaReserved Reason | `reason` Label | `underlying_cause` Label | Description / Scenario |
 | :--- | :--- | :--- | :--- | :--- |
@@ -500,7 +503,7 @@ status:
 ### Test Plan
 
 [x] I/we understand the owners of the involved components may require updates to
-existing tests to make this code solid enough prior to committing the changes
+existing tests to make this code solid enough before committing the changes
 necessary to implement this enhancement.
 
 #### Unit Tests

--- a/keps/10852-inadmissible-workloads-observability/README.md
+++ b/keps/10852-inadmissible-workloads-observability/README.md
@@ -19,6 +19,7 @@
   - [Upgrade Path](#upgrade-path)
   - [Downgrade Path](#downgrade-path)
 - [Design Details](#design-details)
+  - [API Changes](#api-changes)
   - [Tiered Reason Precedence &amp; Resolution](#tiered-reason-precedence--resolution)
     - [1. Flavor-Independent (Workload-wide) Reasons](#1-flavor-independent-workload-wide-reasons)
     - [2. Nominated Flavor Reasons](#2-nominated-flavor-reasons)
@@ -246,6 +247,58 @@ being updated.
 
 ## Design Details
 
+### API Changes
+
+The following new condition reason constants are introduced in the API package:
+
+```go
+const (
+	// WorkloadNoMatchingFlavor indicates that the workload cannot be scheduled
+	// because no resource flavor matches its nodeSelector or taints.
+	WorkloadNoMatchingFlavor = "NoMatchingFlavor"
+
+	// WorkloadExceedsMaxQuota indicates that the workload requests resources
+	// exceeding the maximum capacity limits of the ClusterQueue or Cohort.
+	WorkloadExceedsMaxQuota = "ExceedsMaxQuota"
+
+	// WorkloadBorrowingLimitReached indicates that allocating resources would
+	// cause the ClusterQueue to exceed its borrowing limit constraint.
+	WorkloadBorrowingLimitReached = "BorrowingLimitReached"
+
+	// WorkloadWaitingForQuota indicates that the workload is waiting for
+	// sufficient unused quota to become available in the ClusterQueue/Cohort.
+	WorkloadWaitingForQuota = "WaitingForQuota"
+
+	// WorkloadTopologyPlacementFailed indicates that the workload has topology
+	// requirements that cannot be satisfied with the current cluster topology usage.
+	WorkloadTopologyPlacementFailed = "TopologyPlacementFailed"
+
+	// WorkloadWaitingForPreemptedWorkloads indicates that the workload is waiting
+	// for preempted workloads to release their quota.
+	WorkloadWaitingForPreemptedWorkloads = "WaitingForPreemptedWorkloads"
+
+	// WorkloadMisconfigured indicates that the workload is inadmissible due to
+	// misconfiguration, such as missing LocalQueue or ClusterQueue.
+	WorkloadMisconfigured = "Misconfigured"
+
+	// WorkloadSuspended indicates that the workload is inadmissible because
+	// the LocalQueue or ClusterQueue StopPolicy is active.
+	WorkloadSuspended = "Suspended"
+
+	// WorkloadPendingEvaluation indicates that the workload is pending evaluation in the scheduling queue.
+	WorkloadPendingEvaluation = "PendingEvaluation"
+
+	// WorkloadAdmittedReasonNoReservation indicates that the workload has no reservation.
+	WorkloadAdmittedReasonNoReservation = "NoReservation"
+
+	// WorkloadAdmittedUnsatisfiedChecks indicates that the workload has not all checks ready.
+	WorkloadAdmittedUnsatisfiedChecks = "UnsatisfiedChecks"
+
+	// WorkloadAdmittedPendingDelayedTopologyRequests indicates that there are pending delayed topology requests.
+	WorkloadAdmittedPendingDelayedTopologyRequests = "PendingDelayedTopologyRequests"
+)
+```
+
 ### Tiered Reason Precedence & Resolution
 
 To separate different blocks and keep the status field highly structured, when
@@ -281,6 +334,12 @@ scheduler. Lower numbers represent more severe blocks.
 | **3** | `WaitingForQuota` | General capacity wait (total unused nominal capacity in the ClusterQueue/Cohort is less than the workload request). | `ClusterQueue.inadmissibleWorkloads` |
 | **4** | `TopologyPlacementFailed` | TAS workload only. Nominal capacity exists, but capacity is fragmented across domains preventing contiguous placement. | `ClusterQueue.inadmissibleWorkloads` |
 | **5** | `WaitingForPreemptedWorkloads` | Evictions have been issued; waiting for victims to terminate and release their capacity. | `ClusterQueue.heap` |
+
+*Note on preemption transition dynamics*: Between the moment evictions are
+issued and the victims actually terminate, subsequent scheduler evaluation
+cycles may see the same workload as `WaitingForQuota` (quota not yet freed)
+rather than `WaitingForPreemptedWorkloads`. The reason can oscillate until
+victims release quota.
 
 #### 3. Pending Evaluation
 This is the lowest precedence state, applicable to workloads that are active
@@ -326,6 +385,17 @@ resolved as follows:
    If the workload has not yet been evaluated by the scheduler (e.g., newly
    created), the reason defaults to `PendingEvaluation`.
 
+*Note on Scheduling Equivalence Hashing (Reason Staleness)*:
+If `SchedulingEquivalenceHashing` is enabled (the default setting) and a
+workload's scheduling hash is recorded in `noFitSchedulingHashes` (indicating
+that an equivalent workload recently failed to schedule), any newly queued or
+updated equivalent workload bypasses the scheduler and is placed directly
+into the inadmissible workloads list. Because these workloads bypass scheduler
+evaluation entirely, their status conditions are not updated and they retain
+their existing reason (e.g. `PendingEvaluation` for new workloads, or their
+previous failure reason), creating a temporary staleness window until a cluster
+event clears the equivalence hashes.
+
 #### Resolution Examples
 
 * **Example 1 (Flavor-Independent precedence resolution)**:
@@ -355,10 +425,11 @@ resolved as follows:
 ### Admitted Condition Initialization and Lifecycle
 
 When the `UnadmittedWorkloadsExplicitStatus` feature gate is enabled, both
-status conditions are explicitly initialized to `False` during the first
-reconciliation cycle to enable continuous tracking from workload creation,
-with their reasons dynamically resolved based on the workload state and queue
-parameters:
+status conditions are explicitly initialized to `False` during reconciliation
+only if the respective condition is absent from the workload status. This
+prevents overwriting existing conditions or resetting their timestamps on
+controller restarts. Their reasons are dynamically resolved based on the
+workload state and queue parameters:
 - `QuotaReserved`: `False` (with the reason dynamically resolved according to
   the Tiered Precedence model, e.g., `PendingEvaluation` for normal active
   queueing, `Deactivated` if inactive, or `Misconfigured` if queue validation

--- a/keps/10852-inadmissible-workloads-observability/README.md
+++ b/keps/10852-inadmissible-workloads-observability/README.md
@@ -472,14 +472,12 @@ status:
     status: "False"
     reason: PendingEvaluation # Tier 8 Reason: Awaiting initial scheduler evaluation
     message: "Workload is pending evaluation in the scheduling queue"
-    observedGeneration: 1
   # Admitted condition is ONLY initialized/present on creation if the
   # UnadmittedWorkloadsExplicitStatus gate is ENABLED. If disabled, it is absent.
   - type: Admitted
     status: "False"
     reason: NoReservation
     message: "The workload has no reservation"
-    observedGeneration: 1
 ```
 
 ##### Scenario 2: Waiting for Cluster Capacity (Waiting for Quota)
@@ -494,7 +492,6 @@ status:
     status: "False"
     reason: Pending
     message: "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor default-flavor, 2 more needed"
-    observedGeneration: 1
 ```
 
 * **After KEP-10852:** Updated status:
@@ -505,14 +502,12 @@ status:
     status: "False"
     reason: WaitingForQuota # Tier 6 Reason
     message: "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor default-flavor, 2 more needed"
-    observedGeneration: 1
   # Admitted condition is ONLY initialized/present if the
   # UnadmittedWorkloadsExplicitStatus gate is ENABLED. If disabled, it remains absent.
   - type: Admitted
     status: "False"
     reason: NoReservation
     message: "The workload has no reservation"
-    observedGeneration: 1
 ```
 
 ##### Scenario 3: Configuration Error (Missing Queue)
@@ -527,7 +522,6 @@ status:
     status: "False"
     reason: Inadmissible
     message: "LocalQueue local-queue doesn't exist"
-    observedGeneration: 1
 ```
 
 * **After KEP-10852:** Updated status:
@@ -538,14 +532,12 @@ status:
     status: "False"
     reason: Misconfigured
     message: "LocalQueue local-queue doesn't exist"
-    observedGeneration: 1
   # Admitted condition is ONLY initialized/present if the
   # UnadmittedWorkloadsExplicitStatus gate is ENABLED. If disabled, it remains absent.
   - type: Admitted
     status: "False"
     reason: NoReservation
     message: "The workload has no reservation"
-    observedGeneration: 1
 ```
 
 ##### Scenario 4: Configuration Error (No Matching Flavor)

--- a/keps/10852-inadmissible-workloads-observability/README.md
+++ b/keps/10852-inadmissible-workloads-observability/README.md
@@ -25,6 +25,10 @@
     - [Simplification: Removal of NoReservationUnsatisfiedChecks Reason](#simplification-removal-of-noreservationunsatisfiedchecks-reason)
   - [Prometheus Metrics Schema](#prometheus-metrics-schema)
   - [Troubleshooting &amp; End-User Inspection](#troubleshooting--end-user-inspection)
+    - [Concrete Status Scenarios (Before &amp; After)](#concrete-status-scenarios-before--after)
+      - [Scenario 1: Newly Created Workload (Initial Reconcile)](#scenario-1-newly-created-workload-initial-reconcile)
+      - [Scenario 2: Waiting for Cluster Capacity (Waiting for Quota)](#scenario-2-waiting-for-cluster-capacity-waiting-for-quota)
+      - [Scenario 3: Configuration Error (e.g. Missing Queue or Flavor Mismatch)](#scenario-3-configuration-error-eg-missing-queue-or-flavor-mismatch)
   - [Future Work](#future-work)
   - [Test Plan](#test-plan)
     - [Unit Tests](#unit-tests)
@@ -374,6 +378,107 @@ administrators can access these granular reasons to enable automated
 troubleshooting scripts and more precise Grafana dashboards, allowing them to
 quickly distinguish between cluster-wide resource exhaustion and individual
 workload configuration errors.
+
+#### Concrete Status Scenarios (Before & After)
+
+Below are detailed before-and-after YAML comparisons highlighting the changes across common scheduling states.
+
+##### Scenario 1: Newly Created Workload (Initial Reconcile)
+
+Newly submitted workloads in the scheduling queue awaiting their first evaluation.
+
+* **Before KEP-10852:** Both conditions are completely absent from the status:
+```yaml
+status: {}
+```
+
+* **After KEP-10852:** Explicitly updated status:
+```yaml
+status:
+  conditions:
+  # QuotaReserved condition is ONLY initialized/present on creation if the
+  # UnadmittedWorkloadsExplicitStatus gate is ENABLED. If disabled, it is absent.
+  - type: QuotaReserved
+    status: "False"
+    reason: PendingEvaluation # Tier 6 Reason: Awaiting initial scheduler evaluation
+    message: "Workload is pending evaluation in the scheduling queue"
+    observedGeneration: 1
+  # Admitted condition is ONLY initialized/present on creation if the
+  # UnadmittedWorkloadsExplicitStatus gate is ENABLED. If disabled, it is absent.
+  - type: Admitted
+    status: "False"
+    reason: NoReservation
+    message: "The workload has no reservation"
+    observedGeneration: 1
+```
+
+##### Scenario 2: Waiting for Cluster Capacity (Waiting for Quota)
+
+The workload is structurally valid but must wait because the ClusterQueue has insufficient capacity.
+
+* **Before KEP-10852:** Uses generic `Pending` reason and the `Admitted` condition is completely absent:
+```yaml
+status:
+  conditions:
+  - type: QuotaReserved
+    status: "False"
+    reason: Pending
+    message: "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor default-flavor, 2 more needed"
+    observedGeneration: 1
+```
+
+* **After KEP-10852:** Updated status:
+```yaml
+status:
+  conditions:
+  - type: QuotaReserved
+    status: "False"
+    reason: WaitingForQuota # Tier 5 Reason
+    message: "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor default-flavor, 2 more needed"
+    observedGeneration: 1
+  # Admitted condition is ONLY initialized/present if the
+  # UnadmittedWorkloadsExplicitStatus gate is ENABLED. If disabled, it remains absent.
+  - type: Admitted
+    status: "False"
+    reason: NoReservation
+    message: "The workload has no reservation"
+    observedGeneration: 1
+```
+
+##### Scenario 3: Configuration Error (e.g. Missing Queue or Flavor Mismatch)
+
+The workload points to a non-existent queue, blocking scheduling evaluation early.
+
+* **Before KEP-10852:**
+```yaml
+status:
+  conditions:
+  - type: QuotaReserved
+    status: "False"
+    reason: Inadmissible
+    message: "LocalQueue local-queue doesn't exist"
+    observedGeneration: 1
+```
+
+* **After KEP-10852:** Updated status:
+```yaml
+status:
+  conditions:
+  - type: QuotaReserved
+    status: "False"
+    reason: Misconfigured # Tier 2 Reason
+    message: "LocalQueue local-queue doesn't exist"
+    observedGeneration: 1
+  # Admitted condition is ONLY initialized/present if the
+  # UnadmittedWorkloadsExplicitStatus gate is ENABLED. If disabled, it remains absent.
+  - type: Admitted
+    status: "False"
+    reason: NoReservation
+    message: "The workload has no reservation"
+    observedGeneration: 1
+```
+
+
 
 ### Future Work
 

--- a/keps/10852-inadmissible-workloads-observability/README.md
+++ b/keps/10852-inadmissible-workloads-observability/README.md
@@ -280,7 +280,7 @@ scheduler. Lower numbers represent more severe blocks.
 | **2** | `BorrowingLimitReached` | Total unused capacity in the Cohort is sufficient, but allocating resources would cause the ClusterQueue to exceed its borrowing limit policy constraint. | `ClusterQueue.inadmissibleWorkloads` |
 | **3** | `WaitingForQuota` | General capacity wait (total unused nominal capacity in the ClusterQueue/Cohort is less than the workload request). | `ClusterQueue.inadmissibleWorkloads` |
 | **4** | `TopologyPlacementFailed` | TAS workload only. Nominal capacity exists, but capacity is fragmented across domains preventing contiguous placement. | `ClusterQueue.inadmissibleWorkloads` |
-| **5** | `PendingPreemption` | Evictions have been issued; waiting for victims to terminate and release their capacity. | `ClusterQueue.heap` |
+| **5** | `WaitingForPreemptedWorkloads` | Evictions have been issued; waiting for victims to terminate and release their capacity. | `ClusterQueue.heap` |
 
 #### 3. Pending Evaluation
 This is the lowest precedence state, applicable to workloads that are active
@@ -342,7 +342,7 @@ resolved as follows:
   groups (evaluated sequentially).
   - **First Step**: `podset-a` is evaluated first. It is assigned a flavor that
     requires preemption, so its status is set to `Preempt` (with reason
-    `PendingPreemption`, Precedence 5). Since it successfully received a
+    `WaitingForPreemptedWorkloads`, Precedence 5). Since it successfully received a
     flavor assignment, the scheduler continues to the next group.
   - **Second Step**: `podset-b` is evaluated next. All of its candidate flavors
     are blocked because they request resources exceeding limits, so its status

--- a/keps/10852-inadmissible-workloads-observability/README.md
+++ b/keps/10852-inadmissible-workloads-observability/README.md
@@ -59,9 +59,15 @@ separate feature gates:
   the `QuotaReserved` and `Admitted` conditions during reconciliations and
   scheduler cycles to use the new tiered reasons instead of the generic
   "Pending".
-- `UnadmittedWorkloadsExplicitStatus`: Controls whether both status conditions
-  (`QuotaReserved` and `Admitted`) are explicitly initialized to `False` during
-  the very first reconciliation cycle of a newly created workload.
+- `UnadmittedWorkloadsExplicitStatus`: Gates the immediate, proactive
+  initialization of both `QuotaReserved` and `Admitted` status conditions
+  to `False` (with `PendingEvaluation` and `NoReservation` reasons) during
+  a workload's first reconciliation. 
+  * **When enabled:** Both conditions are explicitly written immediately
+    upon creation, ensuring continuous status-based lifecycle tracking.
+  * **When disabled (default):** Workloads are created with empty status
+    conditions (saving API server write volume under heavy load), and
+    conditions are only updated on subsequent scheduler cycles.
 
 ## Motivation
 
@@ -159,7 +165,8 @@ their configurations immediately.
 As a platform team, we want to construct a unified Grafana dashboard to track
 queue queueing characteristics in real-time. We need to distinguish between
 workloads waiting for normal quota capacity (a standard queueing event) versus
-workloads blocked because they exceed maximum bounds or fail administrative holds.
+workloads blocked because they request resources exceeding maximum limits or
+because their LocalQueue or ClusterQueue has an active `StopPolicy`.
 The two-level label scheme (`reason` and `underlying_cause`) allows our team to
 plot a stacked area chart showing queue metrics broken down by blocking category,
 improving platform diagnostics.

--- a/keps/10852-inadmissible-workloads-observability/README.md
+++ b/keps/10852-inadmissible-workloads-observability/README.md
@@ -255,17 +255,19 @@ assignments) or at the **per-flavor** assignment level:
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | **Tier 1** | Workload-wide | Workload Deactivation | `Deactivated` | Workload is explicitly deactivated (`spec.active: false`). | None |
 | **Tier 2** | Mixed | Structural Blockers | `Misconfigured` | Permanent structural error preventing admission:<br>- Missing local/cluster queue (Workload-wide)<br>- Resource flavor mismatch (Per-flavor)<br>- DRA misconfiguration (Workload-wide) | Missing local/cluster queue - None<br>ResourceFlavor mismatch - `ClusterQueue.inadmissibleWorkloads`<br>DRA issues - None |
-| **Tier 3** | Per-flavor | Structural Quota Blockers | `ExceedsMaxQuota` | Workload requests resource quantities exceeding ClusterQueue or Cohort maximum limits. | `ClusterQueue.inadmissibleWorkloads` |
+| **Tier 3** | Per-flavor | Structural Quota Blockers | `ExceedsMaxQuota` | Workload requests resource quantities exceeding ClusterQueue nominal limits (when no cohort) or the Cohort's total maximum capacity limits (`val > CohortTotalQuota`). | `ClusterQueue.inadmissibleWorkloads` |
 | **Tier 4** | Workload-wide | Orchestration & Administrative Holds | `Suspended`, `AdmissionGated`, `WaitingForPodsReady` | Workload is structurally valid, but admission is halted due to:<br>- Administrative hold (the queue's StopPolicy is active).<br>- Gated state (AdmissionGatedBy annotation).<br>- Scheduling hold (waiting for previously admitted workloads to reach PodsReady under waitForPodsReady configuration). | AdmissionGated - None<br>StopPolicy - None<br>WaitingForPodsReady - blocks and waits |
-| **Tier 5** | Per-flavor | Resource Deficits | `WaitingForQuota` | Workload fits within the maximum limits of the ClusterQueue or Cohort, but the cluster currently lacks sufficient unreserved capacity (including when preemption is required but is blocked by preemption gates). | `ClusterQueue.inadmissibleWorkloads` |
-| **Tier 6** | Workload-wide | Active Queueing | `PendingEvaluation` | Workload is submitted, structurally valid, resides actively in the queue, and is awaiting its capacity evaluation. Set also after eviction. | `ClusterQueue.heap` |
+| **Tier 5** | Per-flavor | Policy Quota Limits | `BorrowingLimitReached` | Total unused capacity in the Cohort is sufficient, but allocating resources would cause the ClusterQueue to exceed its borrowing limit policy constraint (`val > NominalQuota + BorrowingLimit`). | `ClusterQueue.inadmissibleWorkloads` |
+| **Tier 6** | Per-flavor | Resource Deficits | `WaitingForQuota`, `TopologyPlacementFailed` | Parallel capacity-wait reasons:<br>- `WaitingForQuota`: General capacity wait (total unused nominal capacity in the ClusterQueue/Cohort is less than the workload request: `val > available`).<br>- `TopologyPlacementFailed`: TAS workload only. Nominal capacity exists (`val <= available`), but capacity is fragmented across domains preventing contiguous placement. | `ClusterQueue.inadmissibleWorkloads` |
+| **Tier 7** | Workload-wide | Admission Progressing | `PreemptionPending` | Evictions have been issued; waiting for victims to terminate and release their capacity. | None |
+| **Tier 8** | Workload-wide | Active Queueing | `PendingEvaluation` | Workload is submitted, structurally valid, resides actively in the queue, and is awaiting its capacity evaluation. Set also after eviction. | `ClusterQueue.heap` |
 
 *Note: Precedence Resolution examples:*
 - *If a workload requests resource quantities exceeding the ClusterQueue
   maximum limits (Tier 3) but is also blocked by an unsatisfied
   admission gate (Tier 4), the resolved reason is written as
   `ExceedsMaxQuota` due to Tier 3 priority.*
-- *If a workload is waiting for capacity (Tier 5) but also has unsatisfied
+- *If a workload is waiting for capacity (Tier 6) but also has unsatisfied
   admission gates (Tier 4), the resolved reason is written as
   `AdmissionGated` due to Tier 4 priority.*
 
@@ -400,7 +402,7 @@ status:
   # UnadmittedWorkloadsExplicitStatus gate is ENABLED. If disabled, it is absent.
   - type: QuotaReserved
     status: "False"
-    reason: PendingEvaluation # Tier 6 Reason: Awaiting initial scheduler evaluation
+    reason: PendingEvaluation # Tier 8 Reason: Awaiting initial scheduler evaluation
     message: "Workload is pending evaluation in the scheduling queue"
     observedGeneration: 1
   # Admitted condition is ONLY initialized/present on creation if the
@@ -433,7 +435,7 @@ status:
   conditions:
   - type: QuotaReserved
     status: "False"
-    reason: WaitingForQuota # Tier 5 Reason
+    reason: WaitingForQuota # Tier 6 Reason
     message: "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor default-flavor, 2 more needed"
     observedGeneration: 1
   # Admitted condition is ONLY initialized/present if the
@@ -498,7 +500,7 @@ necessary to implement this enhancement.
 
 #### Unit Tests
 
-- **Precedence Tier Resolver Tests**: Verify correct classification across all 6 precedence tiers,
+- **Precedence Tier Resolver Tests**: Verify correct classification across all 8 precedence tiers,
   confirming proper ranking decisions (e.g., structural flavor issues take absolute priority over
   requeue suspensions).
 - **Metrics Lifecycle Unit Tests**: Verify dynamic metric updates, correct

--- a/keps/10852-inadmissible-workloads-observability/README.md
+++ b/keps/10852-inadmissible-workloads-observability/README.md
@@ -259,11 +259,8 @@ const (
 
 	// WorkloadExceedsMaxQuota indicates that the workload requests resources
 	// exceeding the maximum capacity limits of the ClusterQueue or Cohort.
+	// This also includes exceeding ClusterQueue nominal + borrowingLimit constraints.
 	WorkloadExceedsMaxQuota = "ExceedsMaxQuota"
-
-	// WorkloadBorrowingLimitReached indicates that allocating resources would
-	// cause the ClusterQueue to exceed its borrowing limit constraint.
-	WorkloadBorrowingLimitReached = "BorrowingLimitReached"
 
 	// WorkloadWaitingForQuota indicates that the workload is waiting for
 	// sufficient unused quota to become available in the ClusterQueue/Cohort.
@@ -291,8 +288,8 @@ const (
 	// WorkloadAdmittedReasonNoReservation indicates that the workload has no reservation.
 	WorkloadAdmittedReasonNoReservation = "NoReservation"
 
-	// WorkloadAdmittedUnsatisfiedChecks indicates that the workload has not all checks ready.
-	WorkloadAdmittedUnsatisfiedChecks = "UnsatisfiedChecks"
+	// WorkloadAdmittedUnsatisfiedAdmissionChecks indicates that the workload has not all checks ready.
+	WorkloadAdmittedUnsatisfiedAdmissionChecks = "UnsatisfiedAdmissionChecks"
 
 	// WorkloadAdmittedPendingDelayedTopologyRequests indicates that there are pending delayed topology requests.
 	WorkloadAdmittedPendingDelayedTopologyRequests = "PendingDelayedTopologyRequests"
@@ -329,11 +326,10 @@ scheduler. Lower numbers represent more severe blocks.
 
 | Precedence | Reason Token | Description / Scenario | Location in Memory |
 | :--- | :--- | :--- | :--- |
-| **1** | `ExceedsMaxQuota` | Workload requests resource quantities exceeding ClusterQueue nominal limits (when no cohort) or the Cohort's total maximum capacity limits. | `ClusterQueue.inadmissibleWorkloads` |
-| **2** | `BorrowingLimitReached` | Total unused capacity in the Cohort is sufficient, but allocating resources would cause the ClusterQueue to exceed its borrowing limit policy constraint. | `ClusterQueue.inadmissibleWorkloads` |
-| **3** | `WaitingForQuota` | General capacity wait (total unused nominal capacity in the ClusterQueue/Cohort is less than the workload request). | `ClusterQueue.inadmissibleWorkloads` |
-| **4** | `TopologyPlacementFailed` | TAS workload only. Nominal capacity exists, but capacity is fragmented across domains preventing contiguous placement. | `ClusterQueue.inadmissibleWorkloads` |
-| **5** | `WaitingForPreemptedWorkloads` | Evictions have been issued; waiting for victims to terminate and release their capacity. | `ClusterQueue.heap` |
+| **1** | `ExceedsMaxQuota` | Workload requests resource quantities exceeding the absolute maximum allowed capacity (ClusterQueue nominal limits when no cohort, Cohort's total maximum capacity limits, or the ClusterQueue nominal + borrowingLimit constraint). | `ClusterQueue.inadmissibleWorkloads` |
+| **2** | `WaitingForQuota` | General capacity wait (total unused nominal capacity in the ClusterQueue/Cohort is less than the workload request). | `ClusterQueue.inadmissibleWorkloads` |
+| **3** | `TopologyPlacementFailed` | TAS workload only. Nominal capacity exists, but capacity is fragmented across domains preventing contiguous placement. | `ClusterQueue.inadmissibleWorkloads` |
+| **4** | `WaitingForPreemptedWorkloads` | Evictions have been issued; waiting for victims to terminate and release their capacity. | `ClusterQueue.heap` |
 
 *Note on preemption transition dynamics*: Between the moment evictions are
 issued and the victims actually terminate, subsequent scheduler evaluation
@@ -412,7 +408,7 @@ event clears the equivalence hashes.
   groups (evaluated sequentially).
   - **First Step**: `podset-a` is evaluated first. It is assigned a flavor that
     requires preemption, so its status is set to `Preempt` (with reason
-    `WaitingForPreemptedWorkloads`, Precedence 5). Since it successfully received a
+    `WaitingForPreemptedWorkloads`, Precedence 4). Since it successfully received a
     flavor assignment, the scheduler continues to the next group.
   - **Second Step**: `podset-b` is evaluated next. All of its candidate flavors
     are blocked because they request resources exceeding limits, so its status
@@ -420,7 +416,7 @@ event clears the equivalence hashes.
     this podset failed flavor assignment, the scheduler exits early.
   - **Result**: `ExceedsMaxQuota` is reported as the representative reason
     for the workload because it is the most severe blocker (Precedence 1 vs
-    Precedence 5) among all evaluated podsets.
+    Precedence 4) among all evaluated podsets.
 
 ### Admitted Condition Initialization and Lifecycle
 
@@ -450,7 +446,7 @@ Instead:
   admission checks.
 - Once quota reservation is successfully obtained (`QuotaReserved` status is
   `True`), if admission checks are still pending, the `Admitted` condition
-  will transition its reason to `UnsatisfiedChecks`.
+  will transition its reason to `UnsatisfiedAdmissionChecks`.
 
 ### Prometheus Metrics Schema
 
@@ -460,7 +456,7 @@ A set of metrics is introduced to track unadmitted workloads when the
   ClusterQueue level. It includes the following labels:
   - `cluster_queue`: The name of the ClusterQueue.
   - `reason`: Mapped 1:1 to the reason for the `Admitted` condition
-    being `False` (e.g., `NoReservation`, `UnsatisfiedChecks`,
+    being `False` (e.g., `NoReservation`, `UnsatisfiedAdmissionChecks`,
     `PendingDelayedTopologyRequests`).
   - `underlying_cause`: Mapped 1:1 to the proposed priority reasons for the
     `QuotaReserved` condition status being `False` (e.g., `PendingEvaluation`,
@@ -472,7 +468,7 @@ A set of metrics is introduced to track unadmitted workloads when the
   - `namespace`: The namespace of the LocalQueue.
   - `cluster_queue`: The name of the ClusterQueue.
   - `reason`: Mapped 1:1 to the reason for the `Admitted` condition
-    being `False` (e.g., `NoReservation`, `UnsatisfiedChecks`,
+    being `False` (e.g., `NoReservation`, `UnsatisfiedAdmissionChecks`,
     `PendingDelayedTopologyRequests`).
   - `underlying_cause`: Mapped 1:1 to the proposed priority reasons for the
     `QuotaReserved` condition status being `False` (e.g., `PendingEvaluation`,
@@ -481,7 +477,7 @@ A set of metrics is introduced to track unadmitted workloads when the
 
 If a workload has successfully obtained a quota reservation (`QuotaReserved` is `True`),
 the `underlying_cause` label is populated as follows:
-- For `UnsatisfiedChecks`: Set to `ChecksNotReady`.
+- For `UnsatisfiedAdmissionChecks`: Set to `ChecksNotReady`.
 - For `PendingDelayedTopologyRequests`: Set to `PendingTopology`.
 
 **Handling of Missing or Unset Status Conditions**
@@ -506,7 +502,7 @@ of these mapping combinations are detailed below:
 | :--- | :--- | :--- | :--- | :--- |
 | `NoReservation` | `False (WaitingForQuota)` | `NoReservation` | `WaitingForQuota` | Workload is waiting for queue capacity. |
 | `NoReservation` | `False (Misconfigured)` | `NoReservation` | `Misconfigured` | Workload has structural/configuration errors. |
-| `UnsatisfiedChecks` | `True (N/A)` | `UnsatisfiedChecks` | `ChecksNotReady` | Quota is reserved, but blocked by pending admission checks. |
+| `UnsatisfiedAdmissionChecks` | `True (N/A)` | `UnsatisfiedAdmissionChecks` | `ChecksNotReady` | Quota is reserved, but blocked by pending admission checks. |
 | `PendingDelayedTopologyRequests` | `True (N/A)` | `PendingDelayedTopologyRequests` | `PendingTopology` | Quota is reserved, but blocked by delayed topology paths. |
 
 

--- a/keps/10852-inadmissible-workloads-observability/README.md
+++ b/keps/10852-inadmissible-workloads-observability/README.md
@@ -65,7 +65,7 @@ separate feature gates:
   a workload's first reconciliation. 
   * **When enabled:** Both conditions are explicitly written immediately
     upon creation, ensuring continuous status-based lifecycle tracking.
-  * **When disabled (default):** Workloads are created with empty status
+  * **When disabled:** Workloads are created with empty status
     conditions (saving API server write volume under heavy load), and
     conditions are only updated on subsequent scheduler cycles.
 

--- a/keps/10852-inadmissible-workloads-observability/README.md
+++ b/keps/10852-inadmissible-workloads-observability/README.md
@@ -20,7 +20,12 @@
   - [Downgrade Path](#downgrade-path)
 - [Design Details](#design-details)
   - [Tiered Reason Precedence &amp; Resolution](#tiered-reason-precedence--resolution)
-    - [Multi-Flavor Precedence Resolution](#multi-flavor-precedence-resolution)
+    - [1. Flavor-Independent (Workload-wide) Reasons](#1-flavor-independent-workload-wide-reasons)
+    - [2. Nominated Flavor Reasons](#2-nominated-flavor-reasons)
+    - [3. Pending Evaluation](#3-pending-evaluation)
+    - [Multi-PodSet Reason Resolution](#multi-podset-reason-resolution)
+    - [Resolution Algorithm](#resolution-algorithm)
+    - [Resolution Examples](#resolution-examples)
   - [Admitted Condition Initialization and Lifecycle](#admitted-condition-initialization-and-lifecycle)
     - [Simplification: Removal of NoReservationUnsatisfiedChecks Reason](#simplification-removal-of-noreservationunsatisfiedchecks-reason)
   - [Prometheus Metrics Schema](#prometheus-metrics-schema)
@@ -28,7 +33,8 @@
     - [Concrete Status Scenarios (Before &amp; After)](#concrete-status-scenarios-before--after)
       - [Scenario 1: Newly Created Workload (Initial Reconcile)](#scenario-1-newly-created-workload-initial-reconcile)
       - [Scenario 2: Waiting for Cluster Capacity (Waiting for Quota)](#scenario-2-waiting-for-cluster-capacity-waiting-for-quota)
-      - [Scenario 3: Configuration Error (e.g. Missing Queue or Flavor Mismatch)](#scenario-3-configuration-error-eg-missing-queue-or-flavor-mismatch)
+      - [Scenario 3: Configuration Error (Missing Queue)](#scenario-3-configuration-error-missing-queue)
+      - [Scenario 4: Configuration Error (No Matching Flavor)](#scenario-4-configuration-error-no-matching-flavor)
   - [Future Work](#future-work)
   - [Test Plan](#test-plan)
     - [Unit Tests](#unit-tests)
@@ -248,41 +254,103 @@ field according to a strict priority hierarchy. Lower tier numbers represent
 structural failures and block scheduling early, thus taking absolute precedence
 over higher tiers.
 
-Tiers are evaluated either at the **workload-wide** level (independent of flavor
-assignments) or at the **per-flavor** assignment level:
+Tiers are evaluated at three levels of precedence:
 
-| Tier | Scope | Classification | Reason Token | Description / Scenario | Location in Memory |
-| :--- | :--- | :--- | :--- | :--- | :--- |
-| **Tier 1** | Workload-wide | Workload Deactivation | `Deactivated` | Workload is explicitly deactivated (`spec.active: false`). | None |
-| **Tier 2** | Mixed | Structural Blockers | `Misconfigured` | Permanent structural error preventing admission:<br>- Missing local/cluster queue (Workload-wide)<br>- Resource flavor mismatch (Per-flavor)<br>- DRA misconfiguration (Workload-wide) | Missing local/cluster queue - None<br>ResourceFlavor mismatch - `ClusterQueue.inadmissibleWorkloads`<br>DRA issues - None |
-| **Tier 3** | Per-flavor | Structural Quota Blockers | `ExceedsMaxQuota` | Workload requests resource quantities exceeding ClusterQueue nominal limits (when no cohort) or the Cohort's total maximum capacity limits (`val > CohortTotalQuota`). | `ClusterQueue.inadmissibleWorkloads` |
-| **Tier 4** | Workload-wide | Orchestration & Administrative Holds | `Suspended`, `AdmissionGated`, `WaitingForPodsReady` | Workload is structurally valid, but admission is halted due to:<br>- Administrative hold (the queue's StopPolicy is active).<br>- Gated state (AdmissionGatedBy annotation).<br>- Scheduling hold (waiting for previously admitted workloads to reach PodsReady under waitForPodsReady configuration). | AdmissionGated - None<br>StopPolicy - None<br>WaitingForPodsReady - blocks and waits |
-| **Tier 5** | Per-flavor | Policy Quota Limits | `BorrowingLimitReached` | Total unused capacity in the Cohort is sufficient, but allocating resources would cause the ClusterQueue to exceed its borrowing limit policy constraint (`val > NominalQuota + BorrowingLimit`). | `ClusterQueue.inadmissibleWorkloads` |
-| **Tier 6** | Per-flavor | Resource Deficits | `WaitingForQuota`, `TopologyPlacementFailed` | Parallel capacity-wait reasons:<br>- `WaitingForQuota`: General capacity wait (total unused nominal capacity in the ClusterQueue/Cohort is less than the workload request: `val > available`).<br>- `TopologyPlacementFailed`: TAS workload only. Nominal capacity exists (`val <= available`), but capacity is fragmented across domains preventing contiguous placement. | `ClusterQueue.inadmissibleWorkloads` |
-| **Tier 7** | Workload-wide | Admission Progressing | `PreemptionPending` | Evictions have been issued; waiting for victims to terminate and release their capacity. | None |
-| **Tier 8** | Workload-wide | Active Queueing | `PendingEvaluation` | Workload is submitted, structurally valid, resides actively in the queue, and is awaiting its capacity evaluation. Set also after eviction. | `ClusterQueue.heap` |
+#### 1. Flavor-Independent (Workload-wide) Reasons
+These blockers are independent of flavor assignment and take absolute precedence
+over any nominated flavor checks. If any of these are active, flavor assignment
+is not evaluated or reported.
 
-*Note: Precedence Resolution examples:*
-- *If a workload requests resource quantities exceeding the ClusterQueue
-  maximum limits (Tier 3) but is also blocked by an unsatisfied
-  admission gate (Tier 4), the resolved reason is written as
-  `ExceedsMaxQuota` due to Tier 3 priority.*
-- *If a workload is waiting for capacity (Tier 6) but also has unsatisfied
-  admission gates (Tier 4), the resolved reason is written as
-  `AdmissionGated` due to Tier 4 priority.*
+| Precedence | Reason Token | Description / Scenario | Location in Memory |
+| :--- | :--- | :--- | :--- |
+| **1** | `Deactivated` | Workload is explicitly deactivated (`spec.active: false`). | None |
+| **2** | `Misconfigured` | Workload points to a non-existent queue or has invalid DRA configs. | None |
+| **3** | `NoMatchingFlavor` | Workload requests a flavor that does not exist or whose taints it does not tolerate. | `ClusterQueue.inadmissibleWorkloads` |
+| **4** | `Suspended` | Administrative hold (the queue's StopPolicy is active). | None |
+| **5** | `AdmissionGated` | Gated state (AdmissionGatedBy annotation). | None |
+| **6** | `WaitingForPodsReady` | Scheduling hold (waiting for previously admitted workloads to reach PodsReady under `waitForPodsReady` configuration). | blocks and waits |
 
-#### Multi-Flavor Precedence Resolution
+#### 2. Nominated Flavor Reasons
+These blockers apply to the nominated flavor assignment selected by the
+scheduler. Lower numbers represent more severe blocks.
 
-When a workload is evaluated against multiple `ResourceFlavor` paths within a
-ClusterQueue, Kueue attempts to find the most schedulable assignment. If
-scheduling fails, the blocker tier and reason reported in the workload status
-are emitted from the most schedulable flavor assignment candidate (i.e., the
-candidate that blocks at the highest tier number).
+| Precedence | Reason Token | Description / Scenario | Location in Memory |
+| :--- | :--- | :--- | :--- |
+| **1** | `ExceedsMaxQuota` | Workload requests resource quantities exceeding ClusterQueue nominal limits (when no cohort) or the Cohort's total maximum capacity limits. | `ClusterQueue.inadmissibleWorkloads` |
+| **2** | `BorrowingLimitReached` | Total unused capacity in the Cohort is sufficient, but allocating resources would cause the ClusterQueue to exceed its borrowing limit policy constraint. | `ClusterQueue.inadmissibleWorkloads` |
+| **3** | `WaitingForQuota` | General capacity wait (total unused nominal capacity in the ClusterQueue/Cohort is less than the workload request). | `ClusterQueue.inadmissibleWorkloads` |
+| **4** | `TopologyPlacementFailed` | TAS workload only. Nominal capacity exists, but capacity is fragmented across domains preventing contiguous placement. | `ClusterQueue.inadmissibleWorkloads` |
+| **5** | `PendingPreemption` | Evictions have been issued; waiting for victims to terminate and release their capacity. | `ClusterQueue.heap` |
 
-This ensures that operators receive actionable alerts regarding the closest
-viable scheduling path (e.g., a limits or capacity block on a compatible
-flavor) rather than generic configuration mismatch reports from incompatible
-flavors.
+#### 3. Pending Evaluation
+This is the lowest precedence state, applicable to workloads that are active
+in the queue but have not yet been evaluated by the scheduler.
+
+| Precedence | Reason Token | Description / Scenario | Location in Memory |
+| :--- | :--- | :--- | :--- |
+| **1** | `PendingEvaluation` | Workload is active in the queue, awaiting initial scheduler evaluation. | `ClusterQueue.heap` |
+
+#### Multi-PodSet Reason Resolution
+
+If a workload defines multiple podsets, flavor assignment is evaluated
+sequentially by podset groups.
+
+If a podset group fails to be assigned a flavor, the scheduler exits early,
+skipping subsequent groups. Consequently, the representative reason for the
+workload is resolved as the most severe reason among the first failing podset
+group's reason and any preceding groups' reasons (as shown in Example 2
+below).
+
+#### Resolution Algorithm
+
+The final reason reported in the workload's `QuotaReserved` condition is
+resolved as follows:
+
+1. **Step 1: Check Flavor-Independent Blockers**
+   If any Flavor-Independent blocker is active (e.g., the workload is
+   deactivated, misconfigured, has no matching flavors, is suspended, gated,
+   or waiting for pods ready), the blocker with the **highest precedence**
+   (lowest number in the Flavor-Independent table) is selected.
+   * *Note on `NoMatchingFlavor`*: This is determined if flavor matching fails
+     for all attempted flavor combinations during the scheduling cycle.
+
+2. **Step 2: Evaluate Nominated Flavor (if no Flavor-Independent blockers match)**
+   If no Flavor-Independent blockers apply, Kueue reports the reason for the
+   nominated flavor assignment (the candidate assignment closest to being
+   runnable, which Kueue selected during the flavor assignment phase).
+   * If the workload defines multiple podsets, this representative reason is
+     resolved to the **most severe reason** among all evaluated podsets (as
+     detailed in Multi-PodSet Reason Resolution).
+
+3. **Step 3: Default to Pending Evaluation**
+   If the workload has not yet been evaluated by the scheduler (e.g., newly
+   created), the reason defaults to `PendingEvaluation`.
+
+#### Resolution Examples
+
+* **Example 1 (Flavor-Independent precedence resolution)**:
+  A workload is deactivated (`spec.active: false`, Precedence 1) and points to
+  a suspended ClusterQueue (`Suspended`, Precedence 4).
+  - **Result**: `Deactivated` is reported. Although the workload is bypassed by
+    the scheduler queue and not read from the ClusterQueue, the workload
+    controller still reconciles it to update status conditions. Since
+    `Deactivated` (Precedence 1) has higher precedence than `Suspended`
+    (Precedence 4), the controller reports `Deactivated`.
+
+* **Example 2 (Multi-PodSet Precedence Resolution)**:
+  A workload defines two podsets (`podset-a` and `podset-b`) in different podset
+  groups (evaluated sequentially).
+  - **First Step**: `podset-a` is evaluated first. It is assigned a flavor that
+    requires preemption, so its status is set to `Preempt` (with reason
+    `PendingPreemption`, Precedence 5). Since it successfully received a
+    flavor assignment, the scheduler continues to the next group.
+  - **Second Step**: `podset-b` is evaluated next. All of its candidate flavors
+    are blocked because they request resources exceeding limits, so its status
+    is set to `NoFit` (with reason `ExceedsMaxQuota`, Precedence 1). Because
+    this podset failed flavor assignment, the scheduler exits early.
+  - **Result**: `ExceedsMaxQuota` is reported as the representative reason
+    for the workload because it is the most severe blocker (Precedence 1 vs
+    Precedence 5) among all evaluated podsets.
 
 ### Admitted Condition Initialization and Lifecycle
 
@@ -447,7 +515,7 @@ status:
     observedGeneration: 1
 ```
 
-##### Scenario 3: Configuration Error (e.g. Missing Queue or Flavor Mismatch)
+##### Scenario 3: Configuration Error (Missing Queue)
 
 The workload points to a non-existent queue, blocking scheduling evaluation early.
 
@@ -468,7 +536,7 @@ status:
   conditions:
   - type: QuotaReserved
     status: "False"
-    reason: Misconfigured # Tier 2 Reason
+    reason: Misconfigured
     message: "LocalQueue local-queue doesn't exist"
     observedGeneration: 1
   # Admitted condition is ONLY initialized/present if the
@@ -480,17 +548,48 @@ status:
     observedGeneration: 1
 ```
 
+##### Scenario 4: Configuration Error (No Matching Flavor)
+
+The workload fails to match any resource flavor (e.g., due to unsatisfied
+node labels/taints or conflicting node selectors/affinity).
+
+* **Before KEP-10852:**
+```yaml
+status:
+  conditions:
+  - type: QuotaReserved
+    status: "False"
+    reason: Inadmissible
+    message: "couldn't find matching flavor for pod set main"
+```
+
+* **After KEP-10852:** Updated status:
+```yaml
+status:
+  conditions:
+  - type: QuotaReserved
+    status: "False"
+    reason: NoMatchingFlavor
+    message: "couldn't find matching flavor for pod set main"
+  # Admitted condition is ONLY initialized/present if the
+  # UnadmittedWorkloadsExplicitStatus gate is ENABLED. If disabled, it remains absent.
+  - type: Admitted
+    status: "False"
+    reason: NoReservation
+    message: "The workload has no reservation"
+```
+
 
 
 ### Future Work
 
 - **Skip Scheduling Queue for Specific Inadmissible Workloads**: Avoid adding
-  workloads that fail due to a `ResourceFlavor` mismatch (Tier 2
-  `Misconfigured`) or exceed limits (Tier 3 `ExceedsMaxQuota`) to the
-  `inadmissibleWorkloads` list. Since these workloads cannot become
-  schedulable until a cluster configuration changes (such as creating a
-  missing resource flavor or increasing maximum limits), keeping them out of
-  the active scheduling loop reduces scheduler evaluation overhead.
+  workloads that fail due to a flavor mismatch (`NoMatchingFlavor`) or exceed
+  limits (`ExceedsMaxQuota`) to the `inadmissibleWorkloads` list. Since these
+  workloads cannot become schedulable until a cluster configuration changes
+  (such as creating a missing resource flavor or increasing maximum limits),
+  keeping them out of the active scheduling loop reduces scheduler evaluation
+  overhead.
 
 ### Test Plan
 

--- a/keps/10852-inadmissible-workloads-observability/README.md
+++ b/keps/10852-inadmissible-workloads-observability/README.md
@@ -1,0 +1,446 @@
+# KEP-10852: Inadmissible Workloads Observability
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+    - [Story 1: Operator Alerting for Configuration Errors](#story-1-operator-alerting-for-configuration-errors)
+    - [Story 2: Platform Team Diagnostics and Dashboards](#story-2-platform-team-diagnostics-and-dashboards)
+    - [Story 3: Programmatic Clients and Automation Tools](#story-3-programmatic-clients-and-automation-tools)
+  - [Notes/Constraints/Caveats](#notesconstraintscaveats)
+    - [API and Backwards Compatibility](#api-and-backwards-compatibility)
+    - [Status Patch Co-location for Performance](#status-patch-co-location-for-performance)
+  - [Risks and Mitigations](#risks-and-mitigations)
+    - [API Server Write Volume and Load](#api-server-write-volume-and-load)
+- [Upgrade / Downgrade &amp; Backwards Compatibility Strategy](#upgrade--downgrade--backwards-compatibility-strategy)
+  - [Upgrade Path](#upgrade-path)
+  - [Downgrade Path](#downgrade-path)
+- [Design Details](#design-details)
+  - [Tiered Reason Precedence &amp; Resolution](#tiered-reason-precedence--resolution)
+    - [Multi-Flavor Precedence Resolution](#multi-flavor-precedence-resolution)
+  - [Admitted Condition Initialization and Lifecycle](#admitted-condition-initialization-and-lifecycle)
+    - [Simplification: Removal of NoReservationUnsatisfiedChecks Reason](#simplification-removal-of-noreservationunsatisfiedchecks-reason)
+  - [Prometheus Metrics Schema](#prometheus-metrics-schema)
+  - [Troubleshooting &amp; End-User Inspection](#troubleshooting--end-user-inspection)
+  - [Future Work](#future-work)
+  - [Test Plan](#test-plan)
+    - [Unit Tests](#unit-tests)
+    - [Integration Tests](#integration-tests)
+  - [Graduation Criteria](#graduation-criteria)
+    - [Beta (v0.19)](#beta-v019)
+    - [GA (v0.20)](#ga-v020)
+- [Alternatives Considered](#alternatives-considered)
+  - [Introducing a New Separate Status Condition Instead of Updating QuotaReserved Reasons](#introducing-a-new-separate-status-condition-instead-of-updating-quotareserved-reasons)
+<!-- /toc -->
+
+## Summary
+
+This KEP introduces enhanced observability for pending and inadmissible
+workloads in Kueue. The feature improves diagnostic capabilities by
+distinguishing configuration-related failures (such as resource flavor
+mismatches, missing local queues, and requests exceeding maximum limits) from
+general resource availability waits. It introduces granular, priority-tiered
+status reasons for when a workload lacks a quota reservation (`QuotaReserved`
+condition status is `False`), along with a detailed set of Prometheus
+metrics to monitor and alert on unadmitted workloads.
+
+To ensure safe operational rollouts, the functionality is divided behind two
+separate feature gates:
+- `UnadmittedWorkloadsObservability`: Controls the overall feature.
+  It enables the granular Prometheus metrics (`kueue_unadmitted_workloads`
+  and `kueue_local_queue_unadmitted_workloads`) and updates status reasons for
+  the `QuotaReserved` and `Admitted` conditions during reconciliations and
+  scheduler cycles to use the new tiered reasons instead of the generic
+  "Pending".
+- `UnadmittedWorkloadsExplicitStatus`: Controls whether both status conditions
+  (`QuotaReserved` and `Admitted`) are explicitly initialized to `False` during
+  the very first reconciliation cycle of a newly created workload.
+
+## Motivation
+
+Currently, when a workload cannot be admitted due to incompatibility with any
+available `ResourceFlavor` (e.g., untolerated taints, node affinity mismatch, or
+incorrect label/selector values), the `QuotaReserved` condition is set to
+`False` with a generic reason of `Pending`. 
+
+Using `Pending` as a reason is sub-optimal because a status condition's `Reason`
+field is intended to provide actionable context for its `Status` (answering the
+question: "Why is the quota not reserved?"). Saying a condition is `False` due
+to being `Pending` merely restates the wait state instead of providing the
+underlying cause.
+
+Programmatic clients, dashboard operators, and monitoring tools cannot easily
+distinguish a configuration-related "flavor mismatch" or "missing queue" state
+from a workload that is simply waiting for capacity under an otherwise valid
+configuration.
+
+Furthermore, the existing pending workloads metrics (`kueue_pending_workloads`
+and `kueue_local_queue_pending_workloads`) only categorize pending workloads under
+two statuses:
+- `active`: In the admission queue.
+- `inadmissible`: Failed admission attempt and waiting for cluster conditions
+  to change.
+
+Note that the "Inadmissible" condition `Reason` is currently used both for
+misconfigured queue setups (such as referencing a non-existent queue) and for
+suspended/inactive queues. **Crucially, workloads referencing a non-existent
+`LocalQueue` or `ClusterQueue` are not counted in these metrics, as they never
+successfully enter any queue structure in the manager or cache.**
+
+This lack of granularity and the overlapping terminology create substantial
+operational confusion:
+1. Workloads with critical configuration issues (such as referencing a missing
+   queue) are completely omitted from the pending metrics instead of being
+   flagged as problematic.
+2. All other valid workloads that are simply waiting for resource availability
+   are grouped together under the same massive, generic `inadmissible` label,
+   making it impossible to distinguish between a healthy capacity wait state
+   and actual configuration errors.
+
+This lack of granularity and terminology conflict makes it difficult to detect,
+alert on, and resolve workloads stuck due to configuration faults versus those
+that are waiting normally for cluster capacity.
+
+### Goals
+
+- Introduce a priority-ordered list of reasons for when the `QuotaReserved`
+  condition status is `False` to separate structural/configuration issues from
+  normal capacity waiting states.
+- Introduce metrics (`kueue_unadmitted_workloads` and
+  `kueue_local_queue_unadmitted_workloads`) detailing the reasons and
+  underlying causes of why workloads are unadmitted.
+- Initialize status conditions to `False` on the first reconciliation cycle
+  of a workload to allow continuous lifetime tracking that matches tracking
+  from workload status and the metrics.
+
+### Non-Goals
+
+- Modifying the underlying workload admission state machine or scheduling
+  decisions.
+- Automatically correcting or mutating workload specs when configurations are
+  invalid.
+- Exposing scheduling queue internals beyond standard condition transitions and
+  aggregated metrics.
+
+## Proposal
+
+To address the limitations in diagnostics, the proposal details:
+1. Standardized reasons for the `QuotaReserved` condition (when status is `False`)
+   resolved by a priority tier model.
+2. Dynamic first-cycle initialization of status conditions to guarantee
+   detailed lifecycle visibility.
+3. Decoupling the `Admitted` and `QuotaReserved` lifecycle by removing the
+   hybrid reason `NoReservationUnsatisfiedChecks`.
+4. A multi-level metrics reporting schema to provide detailed alerts for
+   common configuration mistakes.
+
+### User Stories
+
+#### Story 1: Operator Alerting for Configuration Errors
+
+As a cluster operator, I want to create Prometheus alerts when a tenant submits
+a workload with a typo in their `LocalQueue` label or an invalid
+toleration configuration that prevents resource flavor matching. Currently,
+these workloads are either omitted from metrics or included into a generic
+`inadmissible` group, making specific alerting impossible without writing custom
+controllers. With the new `kueue_unadmitted_workloads` metric, we can define
+alerts targeting the `Misconfigured` underlying cause, notifying tenants to fix
+their configurations immediately.
+
+#### Story 2: Platform Team Diagnostics and Dashboards
+
+As a platform team, we want to construct a unified Grafana dashboard to track
+queue queueing characteristics in real-time. We need to distinguish between
+workloads waiting for normal quota capacity (a standard queueing event) versus
+workloads blocked because they exceed maximum bounds or fail administrative holds.
+The two-level label scheme (`reason` and `underlying_cause`) allows our team to
+plot a stacked area chart showing queue metrics broken down by blocking category,
+improving platform diagnostics.
+
+#### Story 3: Programmatic Clients and Automation Tools
+
+As a developer building orchestration tools on top of Kueue, I want to
+programmatically inspect the status of a workload and execute recovery tasks.
+With distinct, parseable reason tokens like `WaitingForQuota` or `Misconfigured` instead
+of the generic `Pending` status string, programmatic clients can take separate,
+automated actions (such as auto-canceling misconfigured jobs or scaling up
+node groups for capacity-bound jobs) without needing fragile regex matches on the
+condition's message text.
+
+### Notes/Constraints/Caveats
+
+#### API and Backwards Compatibility
+
+Replacing the legacy `Pending` reason token for the `QuotaReserved` condition
+with granular tokens might affect external programmatic clients that strictly
+string-match on the `Pending` reason. While the condition status (`False`) remains
+unchanged, this change presents a potential risk for legacy client integrations.
+
+To minimize this risk:
+- The feature is isolated behind feature gates. Although the gates are enabled
+  by default starting in the initial Beta milestone (v0.19), operators can
+  disable them to revert to legacy behavior if needed.
+- External systems are encouraged to match on condition status first, and use standard
+  reason tokens as a supplementary classification.
+
+#### Status Patch Co-location for Performance
+
+To prevent double-patching and keep API request count minimal, first-cycle status writes
+are co-located within existing update routines:
+- **No Admission Checks**: The reconciler initializes both conditions to `False` in
+  exactly one unified status patch.
+- **With Admission Checks**: The registration of pending admission checks and the
+  initialization of the `False` status conditions are batched together into a single
+  API transaction.
+
+### Risks and Mitigations
+
+#### API Server Write Volume and Load
+
+Initializing conditions to `False` on the first reconciliation cycle of newly created
+workloads increases the total number of API writes per workload, which could generate
+significant API server load and database write spikes under high workload submission
+velocities.
+
+To mitigate this concern:
+- The status initialization logic is decoupled from the main metric gates and
+  placed behind a distinct feature gate (`UnadmittedWorkloadsExplicitStatus`).
+- This separation allows operators to disable explicit status write overhead under heavy
+  load environments while still benefiting from real-time Prometheus metrics.
+- Performance scaling validation will be monitored and analyzed using early
+  feedback from the opt-in backport to v0.18.
+
+## Upgrade / Downgrade & Backwards Compatibility Strategy
+
+### Upgrade Path
+
+Upon enabling the feature gates, existing workloads will have their status reasons
+updated to the new tiered values during their next reconciliation or scheduler
+cycle.
+
+### Downgrade Path
+
+Disabling the feature gates will cause Kueue to revert to using the generic
+"Pending" reason. Existing metrics series for unadmitted workloads will stop
+being updated.
+
+## Design Details
+
+### Tiered Reason Precedence & Resolution
+
+To separate different blocks and keep the status field highly structured, when
+the `QuotaReserved` status is `False`, the controller will resolve the reason
+field according to a strict priority hierarchy. Lower tier numbers represent
+structural failures and block scheduling early, thus taking absolute precedence
+over higher tiers:
+
+| Tier | Classification | Reason Token | Description / Scenario | Location in Memory |
+| :--- | :--- | :--- | :--- | :--- |
+| **Tier 1** | Workload Deactivation | `Deactivated` | Workload is explicitly deactivated (`spec.active: false`). | None |
+| **Tier 2** | Structural Blockers | `Misconfigured` | Permanent structural error preventing admission (e.g., non-existent/inactive LocalQueue or ClusterQueue, resource flavor mismatch, DRA misconfiguration). | Missing local/cluster queue - None<br>ResourceFlavor mismatch - `ClusterQueue.inadmissibleWorkloads`<br>DRA issues - None |
+| **Tier 3** | Structural Quota Blockers | `ExceedsMaxQuota` | Workload requests resource quantities exceeding ClusterQueue or Cohort maximum limits. | `ClusterQueue.inadmissibleWorkloads` |
+| **Tier 4** | Orchestration & Administrative Holds | `Suspended`, `AdmissionGated`, `WaitingForPodsReady` | Workload is structurally valid, but admission is halted due to:<br>- Administrative hold (workload.spec.active is true or the queue's StopPolicy is active).<br>- Gated state (AdmissionGatedBy annotation).<br>- Scheduling hold (waiting for previously admitted workloads to reach PodsReady under waitForPodsReady configuration). | AdmissionGated - None<br>StopPolicy - None<br>WaitingForPodsReady - blocks and waits |
+| **Tier 5** | Resource Deficits | `WaitingForQuota` | Workload fits within the maximum limits of the ClusterQueue or Cohort, but the cluster currently lacks sufficient unreserved capacity (including when preemption is required but is blocked by preemption gates). | `ClusterQueue.inadmissibleWorkloads` |
+| **Tier 6** | Active Queueing | `PendingEvaluation` | Workload is submitted, structurally valid, resides actively in the queue, and is awaiting its capacity evaluation. Set also after eviction. | `ClusterQueue.heap` |
+
+>*Note: Precedence Resolution examples:*
+>- *If a workload requests resource quantities exceeding the ClusterQueue
+>  maximum limits (Tier 3) but is also blocked by an unsatisfied
+>  admission gate (Tier 4), the resolved reason is written as
+>  `ExceedsMaxQuota` due to Tier 3 priority.*
+>- *If a workload is waiting for capacity (Tier 5) but also has unsatisfied
+>  admission gates (Tier 4), the resolved reason is written as
+>  `AdmissionGated` due to Tier 4 priority.*
+
+#### Multi-Flavor Precedence Resolution
+
+When a workload is evaluated against multiple `ResourceFlavor` paths
+within a ClusterQueue, different flavors may yield different admission blocks.
+For example:
+- **Flavor A**: The workload has a structural affinity or taint mismatch
+  (resolves to Tier 2 `Misconfigured`).
+- **Flavor B**: The workload is structurally compatible but requests resource
+  quantities that exceed the ClusterQueue or Cohort maximum limits (resolves
+  to Tier 3 `ExceedsMaxQuota`).
+
+In scenarios where multiple flavors are checked:
+1. A structurally compatible flavor path (even if it currently has quota or
+   limits deficits like Tier 3 `ExceedsMaxQuota` or Tier 5 `WaitingForQuota`)
+   is a closer candidate for scheduling than a structurally incompatible
+   flavor path (Tier 2 `Misconfigured`).
+2. Therefore, when combining diagnostics across multiple flavors, the reasons
+   from compatible flavor paths (e.g., `ExceedsMaxQuota` or `WaitingForQuota`)
+   take precedence and are reported in the status, instead of reporting the
+   structural incompatibility (`Misconfigured`) of the other flavors.
+
+This ensures that operators receive actionable alerts regarding the closest
+viable scheduling path (e.g., a limits or capacity block on a compatible
+flavor) rather than getting generic configuration mismatch reports from
+incompatible flavors.
+
+### Admitted Condition Initialization and Lifecycle
+
+When the `UnadmittedWorkloadsExplicitStatus` feature gate is enabled, both
+status conditions are explicitly initialized to `False` during the first
+reconciliation cycle to enable continuous tracking from workload creation,
+with their reasons dynamically resolved based on the workload state and queue
+parameters:
+- `QuotaReserved`: `False` (with the reason dynamically resolved according to
+  the Tiered Precedence model, e.g., `PendingEvaluation` for normal active
+  queueing, `Deactivated` if inactive, or `Misconfigured` if queue validation
+  fails early).
+- `Admitted`: `False` (with the reason dynamically resolved to `NoReservation`
+  on the first cycle).
+
+#### Simplification: Removal of NoReservationUnsatisfiedChecks Reason
+
+To simplify status reasoning and decouple the `QuotaReserved` and `Admitted`
+condition lifecycles, this design explicitly avoids using the hybrid reason
+`NoReservationUnsatisfiedChecks` at all when a workload simultaneously lacks a
+quota reservation and has unsatisfied admission checks.
+
+Instead:
+- A workload without a quota reservation will always have its `Admitted`
+  condition reason set to `NoReservation`, regardless of the state of its
+  admission checks.
+- Once quota reservation is successfully obtained (`QuotaReserved` status is
+  `True`), if admission checks are still pending, the `Admitted` condition
+  will transition its reason to `UnsatisfiedChecks`.
+
+### Prometheus Metrics Schema
+
+A set of metrics is introduced to track unadmitted workloads when the
+`Admitted` condition status is `False`. The metrics are:
+- `kueue_unadmitted_workloads`: Tracks unadmitted workloads at the
+  ClusterQueue level. It includes the following labels:
+  - `cluster_queue`: The name of the ClusterQueue.
+  - `reason`: Mapped 1:1 to the reason for the `Admitted` condition
+    being `False` (e.g., `NoReservation`, `UnsatisfiedChecks`,
+    `PendingDelayedTopologyRequests`).
+  - `underlying_cause`: Mapped 1:1 to the proposed priority reasons for the
+    `QuotaReserved` condition status being `False` (e.g., `PendingEvaluation`,
+    `Misconfigured`, `Suspended`, `WaitingForPodsReady`, `WaitingForQuota`,
+    `AdmissionGated`).
+- `kueue_local_queue_unadmitted_workloads`: Tracks unadmitted workloads at the
+  LocalQueue level. It includes the following labels:
+  - `name`: The name of the LocalQueue.
+  - `namespace`: The namespace of the LocalQueue.
+  - `cluster_queue`: The name of the ClusterQueue.
+  - `reason`: Mapped 1:1 to the reason for the `Admitted` condition
+    being `False` (e.g., `NoReservation`, `UnsatisfiedChecks`,
+    `PendingDelayedTopologyRequests`).
+  - `underlying_cause`: Mapped 1:1 to the proposed priority reasons for the
+    `QuotaReserved` condition status being `False` (e.g., `PendingEvaluation`,
+    `Misconfigured`, `Suspended`, `WaitingForPodsReady`, `WaitingForQuota`,
+    `AdmissionGated`).
+
+If a workload has successfully obtained a quota reservation (`QuotaReserved` is `True`),
+the `underlying_cause` label is populated as follows:
+- For `UnsatisfiedChecks`: Set to `ChecksNotReady`.
+- For `PendingDelayedTopologyRequests`: Set to `PendingTopology`.
+
+**Handling of Missing or Unset Status Conditions**
+
+If the `UnadmittedWorkloadsExplicitStatus` feature gate is disabled, a newly
+created workload will have no status conditions set. For the purpose of metrics
+tracking:
+- The missing `Admitted` condition is assumed to represent `False` with the
+  reason `NoReservation`.
+- The missing `QuotaReserved` condition is assumed to represent `False` with the
+  reason `PendingEvaluation`.
+
+This ensures that pending workloads are fully tracked from the moment of their
+creation, regardless of whether explicit status initialization is active.
+
+The exact label mapping matrix is detailed below:
+
+| Admitted Reason | QuotaReserved Reason | `reason` Label | `underlying_cause` Label | Description / Scenario |
+| :--- | :--- | :--- | :--- | :--- |
+| `NoReservation` | `False (WaitingForQuota)` | `NoReservation` | `WaitingForQuota` | Workload is waiting for queue capacity. |
+| `NoReservation` | `False (Misconfigured)` | `NoReservation` | `Misconfigured` | Workload has structural/configuration errors. |
+| `UnsatisfiedChecks` | `True (N/A)` | `UnsatisfiedChecks` | `ChecksNotReady` | Quota is reserved, but blocked by pending admission checks. |
+| `PendingDelayedTopologyRequests` | `True (N/A)` | `PendingDelayedTopologyRequests` | `PendingTopology` | Quota is reserved, but blocked by delayed topology paths. |
+
+
+### Troubleshooting & End-User Inspection
+
+Users can inspect why a workload is pending by looking at the `QuotaReserved`
+and `Admitted` conditions in the Workload status, as well as the Detailed
+Workload Status (`.status.admissionChecks`). By using `kubectl get workload`,
+administrators can access these granular reasons to enable automated
+troubleshooting scripts and more precise Grafana dashboards, allowing them to
+quickly distinguish between cluster-wide resource exhaustion and individual
+workload configuration errors.
+
+### Future Work
+
+- **Skip Scheduling Queue for Specific Inadmissible Workloads**: Avoid adding
+  workloads that fail due to a `ResourceFlavor` mismatch (Tier 2
+  `Misconfigured`) or exceed limits (Tier 3 `ExceedsMaxQuota`) to the
+  `inadmissibleWorkloads` list. Since these workloads cannot become
+  schedulable until a cluster configuration changes (such as creating a
+  missing resource flavor or increasing maximum limits), keeping them out of
+  the active scheduling loop reduces scheduler evaluation overhead.
+
+### Test Plan
+
+[x] I/we understand the owners of the involved components may require updates to
+existing tests to make this code solid enough prior to committing the changes
+necessary to implement this enhancement.
+
+#### Unit Tests
+
+- **Precedence Tier Resolver Tests**: Verify correct classification across all 6 precedence tiers,
+  confirming proper ranking decisions (e.g., structural flavor issues take absolute priority over
+  requeue suspensions).
+- **Metrics Lifecycle Unit Tests**: Verify dynamic metric updates, correct
+  label resolution under diverse workload states, and correct timeseries cleanup.
+- **Webhook Status Update Integration Unit Tests**: Verify proper batching of initial condition writes
+  and registration tasks, confirming exactly one single write transaction is performed.
+
+#### Integration Tests
+
+- **Lifecycle Integration Tests**: Submit various valid and invalid workloads (such as missing queues,
+  unsatisfied limits, and normal capacity wait queues) and assert that:
+  - Status conditions are properly initialized to `False` (when the gate is active).
+  - Condition reasons and metric values are updated to match the expected design matrix.
+  - Deleting or admitting the workloads decrements dynamic metrics back to zero.
+- **Scale and Load Testing**: Run scale benchmarks (up to 5,000 workloads) to evaluate API server write
+  latency and controller CPU profiles when `UnadmittedWorkloadsExplicitStatus` is enabled.
+
+### Graduation Criteria
+
+#### Beta (v0.19)
+
+- Feature gates enabled by default.
+- Unit and integration tests for unadmitted metrics and status conditions.
+- Initial Alpha backport to v0.18 via cherry-pick release to collect early
+  opt-in feedback.
+- Validate scale performance of first-cycle status writes (when
+  `UnadmittedWorkloadsExplicitStatus` is enabled) under heavy load to ensure
+  no API server saturation or request latency issues.
+
+#### GA (v0.20)
+
+- Feature gates locked to true.
+
+## Alternatives Considered
+
+### Introducing a New Separate Status Condition Instead of Updating QuotaReserved Reasons
+
+An alternative considered was leaving the existing `QuotaReserved` condition's reason as a generic
+`Pending` value to eliminate backwards-compatibility risks for older scripts, and instead introducing
+a separate condition type (such as `QuotaAllocated` or `QuotaAcquisition`) to carry the granular,
+tiered reasons.
+
+- **Pros**: Zero backwards-compatibility risk for legacy scripts that expect the exact string `Pending`
+  on the `QuotaReserved` condition.
+- **Cons**: Substantially increases status API complexity and introduces condition redundancy. Under
+  Kubernetes API design guidelines, a status condition's `Reason` is explicitly intended to explain
+  the cause of its `Status`. Creating a parallel condition simply to explain the reason of another
+  active condition violates typical API design structures, cluttering the status surface of the
+  Workload resource. Therefore, updating the existing condition reasons with proper documentation
+  and feature gate isolation was chosen as the correct architecture.

--- a/keps/10852-inadmissible-workloads-observability/kep.yaml
+++ b/keps/10852-inadmissible-workloads-observability/kep.yaml
@@ -24,7 +24,7 @@ latest-milestone: "v0.19"
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   beta: "v0.19"
-  stable: "v0.20"
+  stable: "TBD"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled

--- a/keps/10852-inadmissible-workloads-observability/kep.yaml
+++ b/keps/10852-inadmissible-workloads-observability/kep.yaml
@@ -8,6 +8,7 @@ reviewers:
   - "@kshalot"
   - "@mimowo"
   - "@mwielgus"
+  - "@amy"
 approvers:
   - "@mimowo"
   - "@tenzen-y"

--- a/keps/10852-inadmissible-workloads-observability/kep.yaml
+++ b/keps/10852-inadmissible-workloads-observability/kep.yaml
@@ -7,6 +7,7 @@ creation-date: 2026-05-28
 reviewers:
   - "@kshalot"
   - "@mimowo"
+  - "@mwielgus"
 approvers:
   - "@mimowo"
   - "@tenzen-y"

--- a/keps/10852-inadmissible-workloads-observability/kep.yaml
+++ b/keps/10852-inadmissible-workloads-observability/kep.yaml
@@ -1,0 +1,36 @@
+title: Inadmissible workloads observability
+kep-number: 10852
+authors:
+  - "@j-skiba"
+status: implementable
+creation-date: 2026-05-28
+reviewers:
+  - "@kshalot"
+  - "@mimowo"
+approvers:
+  - "@mimowo"
+  - "@tenzen-y"
+
+# The target maturity stage in the current dev cycle for this KEP.
+stage: beta
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v0.19"
+
+# The milestone at which this feature was, or is targeted to be, at each stage.
+milestone:
+  beta: "v0.19"
+  stable: "v0.20"
+
+# The following PRR answers are required at alpha release
+# List the feature gate name and the components for which it must be enabled
+feature-gates:
+  - name: UnadmittedWorkloadsObservability
+  - name: UnadmittedWorkloadsExplicitStatus
+disable-supported: true
+
+metrics:
+  - kueue_unadmitted_workloads
+  - kueue_local_queue_unadmitted_workloads


### PR DESCRIPTION
#### What type of PR is this?
/kind kep

#### What this PR does / why we need it:

Currently, Kueue marks workloads that fail admission due to configuration or structural errors (such as resource flavor mismatches) with a generic `Pending` reason. This makes it difficult for operators, dashboards, and programmatic tools to distinguish between a workload that is simply waiting for cluster capacity versus one that is completely misconfigured.

To resolve this, the proposal introduces:
*   **Tiered Priority Reasons:** A strict 6-tier hierarchy for the `QuotaReserved` condition (when `False`) to separate structural bugs (e.g., `Misconfigured`, `ExceedsMaxQuota`) from normal capacity wait states (`WaitingForQuota`).
*   **Granular Metrics:** New Prometheus metrics (`kueue_unadmitted_workloads` and `kueue_local_queue_unadmitted_workloads`) tracking fine-grained reasons and underlying causes for unadmitted workloads.
*   **Explicit Status Initialization:** An optional feature gate to initialize conditions to `False` on the first reconciliation loop for continuous lifetime tracking.
*   **Decoupled Lifecycles:** Simplification of status reasoning by removing the hybrid `NoReservationUnsatisfiedChecks` reason.

These improvements will allow for precise alerting, better dashboards, and automated recovery tasks by programmatic clients.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #10852

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature-gated observability for inadmissible workloads: tiered Prometheus metrics, clearer admission/reservation reason categories, and a stricter precedence model for reservation-related status.
  * Optional explicit initialization of admission-related conditions to False so missing/unset conditions have defined semantics and metrics reflect explicit states.

* **Documentation**
  * Full KEP with troubleshooting, before/after status examples, test plan, graduation criteria, and design rationale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->