### PR TITLE
[release-0.17] feat: add more test for scheduler and preemption

### DIFF
--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -816,9 +816,19 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 		reason           RequeueReason
 		lastAssignment   *workload.AssignmentClusterQueueState
 		wantInadmissible bool
+		wantSticky       bool
 	}{
 		"failure after nomination": {
 			reason:           RequeueReasonFailedAfterNomination,
+			wantInadmissible: false,
+		},
+		"pending preemption": {
+			reason:           RequeueReasonPendingPreemption,
+			wantInadmissible: false,
+			wantSticky:       true,
+		},
+		"preemption failed": {
+			reason:           RequeueReasonPreemptionFailed,
 			wantInadmissible: false,
 		},
 		"namespace doesn't match": {
@@ -878,6 +888,11 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 			gotInadmissible := cq.inadmissibleWorkloads.hasKey(workload.Key(wl))
 			if diff := cmp.Diff(tc.wantInadmissible, gotInadmissible); diff != "" {
 				t.Errorf("Unexpected inadmissible status (-want,+got):\n%s", diff)
+			}
+
+			gotSticky := cq.sw.matches(workload.Key(wl))
+			if diff := cmp.Diff(tc.wantSticky, gotSticky); diff != "" {
+				t.Errorf("Unexpected sticky status (-want,+got):\n%s", diff)
 			}
 
 			if ok := cq.RequeueIfNotPresent(ctx, workload.NewInfo(wl), tc.reason); ok {

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -18,6 +18,7 @@ package preemption
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"slices"
@@ -4397,6 +4398,108 @@ func TestPreemptionWhenWorkloadModifiedConcurrently(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestIssuePreemptionsCountsFailures(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	ctx, log := utiltesting.ContextWithLog(t)
+	cqName := kueue.ClusterQueueReference("standalone")
+	rf := utiltestingapi.MakeResourceFlavor("default").Obj()
+	cq := utiltestingapi.MakeClusterQueue(string(cqName)).
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("default").
+				Resource(corev1.ResourceCPU, "6").
+				Obj(),
+		).
+		Preemption(kueue.ClusterQueuePreemption{
+			WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
+		}).
+		Obj()
+	targetWl := utiltestingapi.MakeWorkload("low", "").
+		UID("low-uid").
+		ResourceVersion("1").
+		Priority(-1).
+		Request(corev1.ResourceCPU, "2").
+		ReserveQuotaAt(
+			utiltestingapi.MakeAdmission(cqName).
+				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "2000m").
+					Obj()).
+				Obj(),
+			now,
+		).
+		Obj()
+	incomingWl := utiltestingapi.MakeWorkload("in", "").
+		UID("wl-in").
+		ResourceVersion("1").
+		Label(controllerconstants.JobUIDLabel, "job-in").
+		Priority(1).
+		Request(corev1.ResourceCPU, "2").
+		Obj()
+
+	var patchCount int
+	cl := utiltesting.NewClientBuilder().
+		WithObjects(targetWl).
+		WithStatusSubresource(&kueue.Workload{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+				patchCount++
+				if _, ok := obj.(*kueue.Workload); ok && subResourceName == "status" {
+					return errors.New("simulate API server error while preempting workload")
+				}
+				return utiltesting.TreatSSAAsStrategicMerge(ctx, c, subResourceName, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	cqCache := schdcache.New(cl)
+	cqCache.AddOrUpdateResourceFlavor(log, rf)
+	if err := cqCache.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Couldn't add ClusterQueue to cache: %v", err)
+	}
+
+	recorder := &utiltesting.EventRecorder{}
+	store := preemptexpectations.New()
+	preemptor := New(cl, workload.Ordering{}, recorder, nil, false, clocktesting.NewFakeClock(now), nil, store, nil)
+
+	snapshot, err := cqCache.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error while building snapshot: %v", err)
+	}
+	wlInfo := workload.NewInfo(incomingWl)
+	wlInfo.ClusterQueue = cqName
+	targetInfo := workload.NewInfo(targetWl)
+	targetInfo.ClusterQueue = cqName
+	targets := []*Target{{
+		WorkloadInfo: targetInfo,
+		Reason:       kueue.InClusterQueueReason,
+		WorkloadCq:   snapshot.ClusterQueue(cqName),
+	}}
+
+	preempted, failedPreemptions, err := preemptor.IssuePreemptions(ctx, cqCache, wlInfo, targets, snapshot.ClusterQueue(cqName))
+	if err == nil {
+		t.Fatal("Expected preemption error")
+	}
+	if preempted != 0 {
+		t.Errorf("Reported %d preemptions, want 0", preempted)
+	}
+	if failedPreemptions != 1 {
+		t.Errorf("Reported %d failed preemptions, want 1", failedPreemptions)
+	}
+	if patchCount != 1 {
+		t.Errorf("Observed %d status patches, want 1", patchCount)
+	}
+
+	var gotTarget kueue.Workload
+	if err := cl.Get(ctx, client.ObjectKeyFromObject(targetWl), &gotTarget); err != nil {
+		t.Fatalf("Failed getting target workload: %v", err)
+	}
+	if workload.IsEvicted(&gotTarget) {
+		t.Error("Target workload should not be marked evicted after failed preemption patch")
+	}
+	if !store.Satisfied(log, client.ObjectKeyFromObject(targetWl)) {
+		t.Error("Preemption expectation should be released after failed preemption patch")
 	}
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -228,6 +228,20 @@ func setPreemptionGated(e *entry, preemptionGatedMsg string) {
 	e.LastAssignment = nil
 }
 
+// markPreemptionOutcome records the outcome of IssuePreemptions and
+// clears the cached flavor assignment so the next cycle reconsiders
+// every flavor.
+func (e *entry) markPreemptionOutcome(preempted, errors int) {
+	e.LastAssignment = nil
+	if preempted != 0 {
+		e.inadmissibleMsg += fmt.Sprintf(". Pending the preemption of %d workload(s)", preempted)
+		e.requeueReason = qcache.RequeueReasonPendingPreemption
+	} else if errors > 0 {
+		e.inadmissibleMsg += fmt.Sprintf(". Preempting %d workload(s) failed, will retry.", errors)
+		e.requeueReason = qcache.RequeueReasonPreemptionFailed
+	}
+}
+
 func (s *Scheduler) reportSkippedPreemptions(p map[kueue.ClusterQueueReference]int) {
 	for cqName, count := range p {
 		metrics.ReportAdmissionCyclePreemptionSkips(cqName, count, s.customLabels.CQGet(cqName), s.roleTracker)
@@ -364,19 +378,11 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 		preemptionTargets, oldWorkloadSlice := workloadslicing.FindReplacedSliceTarget(e.Obj, e.preemptionTargets)
 
 		if e.assignment.RepresentativeMode() == flavorassigner.Preempt {
-			// If preemptions are issued, the next attempt should try all the flavors.
-			e.LastAssignment = nil
 			preempted, errors, err := s.preemptor.IssuePreemptions(ctx, s.cache, &e.Info, preemptionTargets, e.clusterQueueSnapshot)
 			if err != nil {
 				log.Error(err, "Failed to preempt workloads")
 			}
-			if preempted != 0 {
-				e.inadmissibleMsg += fmt.Sprintf(". Pending the preemption of %d workload(s)", preempted)
-				e.requeueReason = qcache.RequeueReasonPendingPreemption
-			} else if errors > 0 {
-				e.inadmissibleMsg += fmt.Sprintf(". Preempting %d workload(s) failed, will retry.", errors)
-				e.requeueReason = qcache.RequeueReasonPreemptionFailed
-			}
+			e.markPreemptionOutcome(preempted, errors)
 			continue
 		}
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -7314,6 +7314,66 @@ func TestRequeueAndUpdate(t *testing.T) {
 	}
 }
 
+func TestEntryMarkPreemptionOutcome(t *testing.T) {
+	assignmentState := &workload.AssignmentClusterQueueState{}
+
+	cases := map[string]struct {
+		preempted             int
+		errors                int
+		wantMessage           string
+		wantRequeueReason     qcache.RequeueReason
+		wantLastAssignmentNil bool
+	}{
+		"pending preemption": {
+			preempted:             2,
+			wantMessage:           "fits with preemption. Pending the preemption of 2 workload(s)",
+			wantRequeueReason:     qcache.RequeueReasonPendingPreemption,
+			wantLastAssignmentNil: true,
+		},
+		"failed preemption": {
+			errors:                2,
+			wantMessage:           "fits with preemption. Preempting 2 workload(s) failed, will retry.",
+			wantRequeueReason:     qcache.RequeueReasonPreemptionFailed,
+			wantLastAssignmentNil: true,
+		},
+		"preempted takes precedence over errors": {
+			preempted:             1,
+			errors:                1,
+			wantMessage:           "fits with preemption. Pending the preemption of 1 workload(s)",
+			wantRequeueReason:     qcache.RequeueReasonPendingPreemption,
+			wantLastAssignmentNil: true,
+		},
+		"no outcome": {
+			wantMessage:           "fits with preemption",
+			wantRequeueReason:     qcache.RequeueReasonGeneric,
+			wantLastAssignmentNil: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			e := entry{
+				inadmissibleMsg: "fits with preemption",
+				Info: workload.Info{
+					LastAssignment: assignmentState,
+				},
+			}
+
+			e.markPreemptionOutcome(tc.preempted, tc.errors)
+
+			if e.inadmissibleMsg != tc.wantMessage {
+				t.Errorf("Unexpected inadmissible message\nwant: %q\ngot:  %q", tc.wantMessage, e.inadmissibleMsg)
+			}
+			if e.requeueReason != tc.wantRequeueReason {
+				t.Errorf("Unexpected requeue reason\nwant: %q\ngot:  %q", tc.wantRequeueReason, e.requeueReason)
+			}
+			if got := e.LastAssignment == nil; got != tc.wantLastAssignmentNil {
+				t.Errorf("Unexpected LastAssignment nil status\nwant: %v\ngot:  %v", tc.wantLastAssignmentNil, got)
+			}
+		})
+	}
+}
+
 func TestEntryComparerLess(t *testing.T) {
 	now := time.Now()
 	cohort := kueue.CohortReference("test-cohort")

--- a/test/integration/singlecluster/scheduler/preemption_test.go
+++ b/test/integration/singlecluster/scheduler/preemption_test.go
@@ -19,6 +19,7 @@ package scheduler
 import (
 	"errors"
 	"fmt"
+	"sync/atomic"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/onsi/ginkgo/v2"
@@ -151,7 +152,8 @@ var _ = ginkgo.Describe("Preemption", func() {
 		})
 
 		ginkgo.It("Should retry on failed preemptions", func() {
-			attempt := 0
+			var attempt atomic.Int32
+			var allowPreemption atomic.Bool
 			fakeSubResourcePatchSpec = func(obj client.Object) (fakeClientUsage, error) {
 				wl, ok := obj.(*kueue.Workload)
 				if !ok {
@@ -165,8 +167,8 @@ var _ = ginkgo.Describe("Preemption", func() {
 					return fallThrough, nil
 				}
 
-				attempt++
-				if attempt < 3 {
+				attempt.Add(1)
+				if !allowPreemption.Load() {
 					return emitResponse, errors.New("simulate API server error while preempting workload")
 				}
 				return fallThrough, nil
@@ -189,10 +191,23 @@ var _ = ginkgo.Describe("Preemption", func() {
 				Obj()
 			util.MustCreate(ctx, k8sClient, highWl)
 
+			ginkgo.By("Waiting for failed preemption to be recorded")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(highWl), highWl)).To(gomega.Succeed())
+				cond := apimeta.FindStatusCondition(highWl.Status.Conditions, kueue.WorkloadQuotaReserved)
+				g.Expect(cond).NotTo(gomega.BeNil())
+				g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+				g.Expect(cond.Message).To(gomega.ContainSubstring("Preempting"))
+				g.Expect(cond.Message).To(gomega.ContainSubstring("failed, will retry"))
+				g.Expect(attempt.Load()).To(gomega.BeNumerically(">=", 1))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			allowPreemption.Store(true)
 			util.FinishEvictionForWorkloads(ctx, k8sClient, lowWl)
 
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, highWl)
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, lowWl)
+			gomega.Expect(attempt.Load()).To(gomega.BeNumerically(">=", 2))
 		})
 
 		ginkgo.It("Should preempt newer Workloads with the same priority when there is not enough quota", framework.SlowSpec, func() {


### PR DESCRIPTION
Manual cherry-pick of #10894 to release-0.17. Replaces the closed automated CP #11697, which needed a manual fix for the missing entry.markPreemptionOutcome helper on the release branch. Local verification: go test ./pkg/cache/queue ./pkg/scheduler/preemption ./pkg/scheduler -run 'TestBestEffortFIFORequeueIfNotPresent|TestIssuePreemptionsCountsFailures|TestEntryMarkPreemptionOutcome'.
```release-note
NONE
```