### PR TITLE
Attempt to deflake the Job e2e test

### DIFF
--- a/test/e2e/singlecluster/baseline/job_test.go
+++ b/test/e2e/singlecluster/baseline/job_test.go
@@ -555,7 +555,7 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, jobKey, createdJob)).Should(gomega.Succeed())
 					g.Expect(*createdJob.Spec.Suspend).Should(gomega.BeFalse())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
 


### PR DESCRIPTION
#### What type of PR is this?

#### What this PR does / why we need it:

When looping the e2e tests we sometimes encounter this fail: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_kueue/11715/pull-kueue-test-e2e-baseline-main-1-35/2059940875483484160

Also spot here: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_kueue/11722/pull-kueue-test-e2e-baseline-main-1-33/2059998327868493824

I don't know fully if the short timeout is the root cause, but likely it is, because this is an e2e test with multiple tests running in parallel. 



#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
