### PR TITLE
Remove a duplicated unit test case in job_multikueue_adapter_test.go

### DIFF
--- a/pkg/controller/jobs/job/job_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter_test.go
@@ -402,24 +402,6 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 					Obj(),
 			},
 		},
-		"RemoteJobInProgress_LocalIsNotManaged": {
-			args: args{
-				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().Obj()).Build(),
-				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
-					Condition(runningJobCondition).
-					Obj()).Build(),
-				key: client.ObjectKeyFromObject(newJob().Obj()),
-			},
-			want: want{
-				localJob: newJob().
-					ResourceVersion("2").
-					Condition(runningJobCondition).
-					Obj(),
-				remoteJob: newJob().
-					Condition(runningJobCondition).
-					Obj(),
-			},
-		},
 		"RemoteJobFinished_Completed": {
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().Suspend(false).Obj()).Build(),


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area multikueue

#### What this PR does / why we need it:

It removes [this test case](https://github.com/kubernetes-sigs/kueue/blob/67d6dbd04055aea01ca74436615f98e2c9aa40a6/pkg/controller/jobs/job/job_multikueue_adapter_test.go#L405-L422) which is currently exactly identical to [this one](https://github.com/kubernetes-sigs/kueue/blob/67d6dbd04055aea01ca74436615f98e2c9aa40a6/pkg/controller/jobs/job/job_multikueue_adapter_test.go#L368-L385) (except the description).

How did that happen? Originally (in #6445 ), they differed by the value of a feature gate: explicitly true

https://github.com/kubernetes-sigs/kueue/blob/831b2d6fa0bbede10648dfee74aaa6b765f32685/pkg/controller/jobs/job/job_multikueue_adapter_test.go#L432-L436

vs. implicitly false

https://github.com/kubernetes-sigs/kueue/blob/831b2d6fa0bbede10648dfee74aaa6b765f32685/pkg/controller/jobs/job/job_multikueue_adapter_test.go#L474-L475

When promoting FG to stable (in #8877 ), setting FG to true was removed but the other test case remained intact, and so became identical.

#### Which issue(s) this PR fixes:

none

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
