### PR TITLE
Fix the flaky MultiKueue integration test

### DIFF
--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -348,6 +348,14 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
+		ginkgo.By("waiting for the Job on the manager to be unsuspended", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdJob := batchv1.Job{}
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
+				gomega.Expect(createdJob.Spec.Suspend).To(gomega.Equal(new(false)))
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+		})
+
 		ginkgo.By("updating the worker job status", func() {
 			startTime := metav1.NewTime(time.Now().Truncate(time.Second))
 			gomega.Eventually(func(g gomega.Gomega) {

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -352,7 +352,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			gomega.Eventually(func(g gomega.Gomega) {
 				createdJob := batchv1.Job{}
 				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
-				gomega.Expect(createdJob.Spec.Suspend).To(gomega.Equal(new(false)))
+				g.Expect(createdJob.Spec.Suspend).To(gomega.Equal(new(false)))
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 		})
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind flake

#### What this PR does / why we need it:

Prepare for https://github.com/kubernetes-sigs/kueue/pull/10936

When retrying the tests I encountered the flake, when the `status.Active=0` instead of the expected.

However, this makes because MultiKueue does not guarantee all status updates will be synced. This may happen if we update the worker while the manager is suspended. 

This issue was possible before the PR but very unlikely, because it is racy in nature. Now it is more likely because it takes more time to start syncing the status, due to the extra validation in the core k8s.

The fix is to just plumb the test making sure we start updating the worker only once the manager is ready for it - so we are sure our update is not skipped.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
