### PR TITLE
test: fix flaky admissioncheck deletion test

### DIFF
--- a/test/integration/singlecluster/controller/core/admissioncheck_controller_test.go
+++ b/test/integration/singlecluster/controller/core/admissioncheck_controller_test.go
@@ -71,14 +71,21 @@ var _ = ginkgo.Describe("AdmissionCheck controller", ginkgo.Label("controller:ad
 		})
 
 		ginkgo.It("Should delete the admissionCheck when the corresponding clusterQueue no longer uses the admissionCheck", func() {
-			ginkgo.By("Try to delete admissionCheck")
-			gomega.Expect(util.DeleteObject(ctx, k8sClient, admissionCheck)).To(gomega.Succeed())
 			var ac kueue.AdmissionCheck
+
+			ginkgo.By("Wait for the finalizer to be added")
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(admissionCheck), &ac)).To(gomega.Succeed())
-				g.Expect(ac.GetFinalizers()).Should(gomega.BeComparableTo([]string{kueue.ResourceInUseFinalizerName}))
+				g.Expect(ac.GetFinalizers()).Should(gomega.ContainElement(kueue.ResourceInUseFinalizerName))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			gomega.Expect(ac.GetDeletionTimestamp()).ShouldNot(gomega.BeNil())
+
+			ginkgo.By("Try to delete admissionCheck")
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, admissionCheck)).To(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(admissionCheck), &ac)).To(gomega.Succeed())
+				g.Expect(ac.GetDeletionTimestamp()).ShouldNot(gomega.BeNil())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("Update clusterQueue's cohort")
 			var cq kueue.ClusterQueue
@@ -109,14 +116,21 @@ var _ = ginkgo.Describe("AdmissionCheck controller", ginkgo.Label("controller:ad
 		})
 
 		ginkgo.It("Should delete the admissionCheck when the corresponding clusterQueue is deleted", func() {
-			gomega.Expect(util.DeleteObject(ctx, k8sClient, admissionCheck)).To(gomega.Succeed())
-
 			var rf kueue.AdmissionCheck
+
+			ginkgo.By("Wait for the finalizer to be added")
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(admissionCheck), &rf)).To(gomega.Succeed())
-				g.Expect(rf.GetFinalizers()).Should(gomega.BeComparableTo([]string{kueue.ResourceInUseFinalizerName}))
+				g.Expect(rf.GetFinalizers()).Should(gomega.ContainElement(kueue.ResourceInUseFinalizerName))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			gomega.Expect(rf.GetDeletionTimestamp()).ShouldNot(gomega.BeNil())
+
+			ginkgo.By("Try to delete admissionCheck")
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, admissionCheck)).To(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(admissionCheck), &rf)).To(gomega.Succeed())
+				g.Expect(rf.GetDeletionTimestamp()).ShouldNot(gomega.BeNil())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			gomega.Expect(util.DeleteObject(ctx, k8sClient, clusterQueue)).To(gomega.Succeed())
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, admissionCheck, false)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
The integration test for the AdmissionCheck controller was flaking 
with a "404 Not Found" error. This was caused by a race condition 
where the test attempted to delete the AdmissionCheck object 
immediately after creation, before the controller had a chance to 
attach the 'kueue.x-k8s.io/resource-in-use' finalizer. 

Because the finalizer was missing, the API server instantly and 
permanently deleted the object instead of marking it with a 
DeletionTimestamp, causing subsequent assertions to fail.

This commit fixes the flake by adding an assertion to wait for 
the finalizer to be present on the AdmissionCheck object before 
issuing the delete command.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11694

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
