### PR TITLE
Automated cherry pick of #11730: Fix the flaky MultiKueue integration test

### DIFF
--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -325,7 +325,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			gomega.Eventually(func(g gomega.Gomega) {
 				createdJob := batchv1.Job{}
 				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
-				gomega.Expect(createdJob.Spec.Suspend).To(gomega.Equal(new(false)))
+				g.Expect(createdJob.Spec.Suspend).To(gomega.Equal(ptr.To(false)))
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 		})
 

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -321,6 +321,14 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
+		ginkgo.By("waiting for the Job on the manager to be unsuspended", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdJob := batchv1.Job{}
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
+				gomega.Expect(createdJob.Spec.Suspend).To(gomega.Equal(new(false)))
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+		})
+
 		ginkgo.By("updating the worker job status", func() {
 			startTime := metav1.NewTime(time.Now().Truncate(time.Second))
 			gomega.Eventually(func(g gomega.Gomega) {


### PR DESCRIPTION
Cherry pick of #11730 on release-0.17.

#11730: Fix the flaky MultiKueue integration test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup
/kind flake


```release-note
NONE
```