### PR TITLE
Automated cherry pick of #11750: Move core integrations from extended to baseline

### DIFF
--- a/test/e2e/singlecluster/baseline/pod_test.go
+++ b/test/e2e/singlecluster/baseline/pod_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package extended
+package baseline
 
 import (
 	"fmt"

--- a/test/e2e/singlecluster/baseline/tas_test.go
+++ b/test/e2e/singlecluster/baseline/tas_test.go
@@ -14,27 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package extended
+package baseline
 
 import (
 	"fmt"
 
-	kftrainerapi "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/jobs/jobset"
-	workloadtrainjob "sigs.k8s.io/kueue/pkg/controller/jobs/trainjob"
+	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
+	podcontroller "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
+	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	"sigs.k8s.io/kueue/pkg/util/tas"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
-	testingjobset "sigs.k8s.io/kueue/pkg/util/testingjobs/jobset"
-	testingtrainjob "sigs.k8s.io/kueue/pkg/util/testingjobs/trainjob"
+	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
+	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 	"sigs.k8s.io/kueue/test/util"
 )
 
@@ -49,7 +47,95 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", ginkgo.Label("area:singleclus
 		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
 	})
 
-	ginkgo.When("Creating a JobSet requesting TAS", func() {
+	ginkgo.When("Creating a Job requesting TAS", func() {
+		var (
+			topology     *kueue.Topology
+			onDemandRF   *kueue.ResourceFlavor
+			localQueue   *kueue.LocalQueue
+			clusterQueue *kueue.ClusterQueue
+		)
+		ginkgo.BeforeEach(func() {
+			topology = utiltestingapi.MakeDefaultOneLevelTopology("hostname-" + ns.Name)
+			util.MustCreate(ctx, k8sClient, topology)
+
+			onDemandRF = utiltestingapi.MakeResourceFlavor("on-demand-"+ns.Name).
+				NodeLabel("instance-type", "on-demand").TopologyName(topology.Name).Obj()
+			util.MustCreate(ctx, k8sClient, onDemandRF)
+			clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue-" + ns.Name).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(onDemandRF.Name).
+						Resource(corev1.ResourceCPU, "1").
+						Resource(corev1.ResourceMemory, "1Gi").
+						Obj(),
+				).
+				Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+
+			localQueue = utiltestingapi.MakeLocalQueue("main", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+		})
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteAllJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			// Force remove workloads to be sure that cluster queue can be removed.
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandRF, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+		})
+
+		ginkgo.It("should admit a Job via TAS", func() {
+			sampleJob := testingjob.MakeJob("test-job", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				RequestAndLimit(corev1.ResourceCPU, "700m").
+				RequestAndLimit(corev1.ResourceMemory, "20Mi").
+				PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, corev1.LabelHostname).
+				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+				Obj()
+			util.MustCreate(ctx, k8sClient, sampleJob)
+
+			createdWorkload := &kueue.Workload{}
+			wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(sampleJob.Name, sampleJob.UID), Namespace: ns.Name}
+
+			ginkgo.By(fmt.Sprintf("await for admission of workload %q", wlLookupKey), func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+					g.Expect(createdWorkload.Status.Admission).ShouldNot(gomega.BeNil())
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			// The job might have finished at this point. That shouldn't be a problem for the purpose of this test
+			jobKey := client.ObjectKeyFromObject(sampleJob)
+			util.ExpectJobUnsuspendedWithNodeSelectors(ctx, k8sClient, jobKey, map[string]string{
+				"instance-type": "on-demand",
+			})
+
+			ginkgo.By("verify TopologyAssignment", func() {
+				gomega.Expect(createdWorkload.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(1))
+				gomega.Expect(createdWorkload.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+					tas.V1Beta2From(&tas.TopologyAssignment{
+						Levels: []string{
+							corev1.LabelHostname,
+						},
+						Domains: []tas.TopologyDomainAssignment{
+							{
+								Count: 1,
+								Values: []string{
+									"kind-worker",
+								},
+							},
+						},
+					}),
+				))
+			})
+
+			ginkgo.By(fmt.Sprintf("verify the workload %q gets finished", wlLookupKey), func() {
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
+			})
+		})
+	})
+
+	ginkgo.When("Creating a Pod requesting TAS", func() {
 		var (
 			topology     *kueue.Topology
 			onDemandRF   *kueue.ResourceFlavor
@@ -89,178 +175,35 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", ginkgo.Label("area:singleclus
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
 		})
 
-		ginkgo.It("should admit a JobSet via TAS", func() {
-			jobSet := testingjobset.MakeJobSet("test-jobset", ns.Name).
+		ginkgo.It("should admit a single Pod via TAS", func() {
+			p := testingpod.MakePod("test-pod", ns.Name).
 				Queue(localQueue.Name).
-				ReplicatedJobs(
-					testingjobset.ReplicatedJobRequirements{
-						Name:        "rj1",
-						Image:       util.GetAgnHostImage(),
-						Args:        util.BehaviorExitFast,
-						Replicas:    1,
-						Parallelism: 1,
-						Completions: 1,
-						PodAnnotations: map[string]string{
-							kueue.PodSetRequiredTopologyAnnotation: corev1.LabelHostname,
-						},
-					},
-					testingjobset.ReplicatedJobRequirements{
-						Name:        "rj2",
-						Image:       util.GetAgnHostImage(),
-						Args:        util.BehaviorExitFast,
-						Replicas:    1,
-						Parallelism: 1,
-						Completions: 1,
-						PodAnnotations: map[string]string{
-							kueue.PodSetRequiredTopologyAnnotation: corev1.LabelHostname,
-						},
-					},
-				).
-				RequestAndLimit("rj1", corev1.ResourceCPU, "200m").
-				RequestAndLimit("rj1", corev1.ResourceMemory, "20Mi").
-				RequestAndLimit("rj2", corev1.ResourceCPU, "200m").
-				RequestAndLimit("rj2", corev1.ResourceMemory, "20Mi").
+				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, corev1.LabelHostname).
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				RequestAndLimit(corev1.ResourceMemory, "200Mi").
 				Obj()
 
-			ginkgo.By("Creating the JobSet", func() {
-				util.MustCreate(ctx, k8sClient, jobSet)
+			ginkgo.By("Creating the Pod", func() {
+				util.MustCreate(ctx, k8sClient, p)
+				gomega.Expect(p.Spec.SchedulingGates).To(gomega.ContainElements(
+					corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName},
+					corev1.PodSchedulingGate{Name: kueue.TopologySchedulingGate},
+				))
 			})
 
-			ginkgo.By("waiting for the JobSet to be unsuspended", func() {
-				jobSetKey := client.ObjectKeyFromObject(jobSet)
+			ginkgo.By("waiting for the Pod to be unsuspended", func() {
+				jobSetKey := client.ObjectKeyFromObject(p)
 				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, jobSetKey, jobSet)).To(gomega.Succeed())
-					g.Expect(jobSet.Spec.Suspend).Should(gomega.Equal(ptr.To(false)))
+					g.Expect(k8sClient.Get(ctx, jobSetKey, p)).To(gomega.Succeed())
+					g.Expect(p.Spec.NodeSelector).To(gomega.Equal(map[string]string{
+						"instance-type":      "on-demand",
+						corev1.LabelHostname: "kind-worker",
+					}))
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			ginkgo.By("verify the JobSet has nodeSelector set", func() {
-				gomega.Expect(jobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.NodeSelector).To(gomega.Equal(
-					map[string]string{
-						"instance-type": "on-demand",
-					},
-				))
-			})
-
-			wlLookupKey := types.NamespacedName{Name: jobset.GetWorkloadNameForJobSet(jobSet.Name, jobSet.UID), Namespace: ns.Name}
-			createdWorkload := &kueue.Workload{}
-
-			ginkgo.By(fmt.Sprintf("await for admission of workload %q and verify TopologyAssignment", wlLookupKey), func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
-					g.Expect(createdWorkload.Status.Admission).ShouldNot(gomega.BeNil())
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
-				gomega.Expect(createdWorkload.Status.Admission).ShouldNot(gomega.BeNil())
-				gomega.Expect(createdWorkload.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(2))
-				gomega.Expect(createdWorkload.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
-					tas.V1Beta2From(&tas.TopologyAssignment{
-						Levels: []string{corev1.LabelHostname},
-						Domains: []tas.TopologyDomainAssignment{{
-							Count:  1,
-							Values: []string{"kind-worker"},
-						}},
-					}),
-				))
-				gomega.Expect(createdWorkload.Status.Admission.PodSetAssignments[1].TopologyAssignment).Should(gomega.BeComparableTo(
-					tas.V1Beta2From(&tas.TopologyAssignment{
-						Levels: []string{corev1.LabelHostname},
-						Domains: []tas.TopologyDomainAssignment{{
-							Count:  1,
-							Values: []string{"kind-worker"},
-						}},
-					}),
-				))
-			})
-
-			ginkgo.By(fmt.Sprintf("verify the workload %q gets finished", wlLookupKey), func() {
-				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
-			})
-		})
-	})
-
-	ginkgo.When("Creating a TrainJob requesting TAS", func() {
-		var (
-			topology     *kueue.Topology
-			onDemandRF   *kueue.ResourceFlavor
-			clusterQueue *kueue.ClusterQueue
-			localQueue   *kueue.LocalQueue
-		)
-		ginkgo.BeforeEach(func() {
-			topology = utiltestingapi.MakeDefaultOneLevelTopology("hostname-" + ns.Name)
-			util.MustCreate(ctx, k8sClient, topology)
-
-			onDemandRF = utiltestingapi.MakeResourceFlavor("on-demand-"+ns.Name).
-				NodeLabel("instance-type", "on-demand").
-				TopologyName(topology.Name).
-				Obj()
-
-			util.MustCreate(ctx, k8sClient, onDemandRF)
-
-			clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue-" + ns.Name).
-				ResourceGroup(
-					*utiltestingapi.MakeFlavorQuotas(onDemandRF.Name).
-						Resource(corev1.ResourceCPU, "1").
-						Resource(corev1.ResourceMemory, "1Gi").
-						Obj(),
-				).
-				Obj()
-			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
-
-			localQueue = utiltestingapi.MakeLocalQueue("main", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
-			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
-		})
-		ginkgo.AfterEach(func() {
-			gomega.Expect(util.DeleteAllTrainJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
-			// Force remove workloads to be sure that cluster queue can be removed.
-			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
-			gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
-			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
-			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandRF, true)
-			util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
-		})
-
-		ginkgo.It("should admit a TrainJob via TAS", func() {
-			trainjob := testingtrainjob.MakeTrainJob("trainjob-test", ns.Name).
-				RuntimeRefName("torch-distributed").
-				Queue(localQueue.Name).
-				// Even if we override the image coming from the TrainingRuntime, we still need to set the command and args
-				TrainerImage(util.GetAgnHostImage(), []string{"/agnhost"}, util.BehaviorExitFast).
-				TrainerRequest(corev1.ResourceCPU, "500m").
-				TrainerRequest(corev1.ResourceMemory, "200Mi").
-				PodTemplateOverrides([]kftrainerapi.PodTemplateOverride{
-					{
-						TargetJobs: []kftrainerapi.PodTemplateOverrideTargetJob{
-							{Name: "node"},
-						},
-						Metadata: &metav1.ObjectMeta{
-							Annotations: map[string]string{kueue.PodSetRequiredTopologyAnnotation: corev1.LabelHostname},
-						},
-					},
-				}).
-				Obj()
-
-			ginkgo.By("Creating the TrainJob", func() {
-				util.MustCreate(ctx, k8sClient, trainjob)
-			})
-
-			ginkgo.By("waiting for the TrainJob to be unsuspended", func() {
-				trainjobKey := client.ObjectKeyFromObject(trainjob)
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, trainjobKey, trainjob)).To(gomega.Succeed())
-					g.Expect(trainjob.Spec.Suspend).Should(gomega.Equal(ptr.To(false)))
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("verify the TrainJob has nodeSelector set", func() {
-				gomega.Expect(trainjob.Spec.PodTemplateOverrides).To(gomega.HaveLen(2))
-				gomega.Expect(trainjob.Spec.PodTemplateOverrides[1].Spec.NodeSelector).To(gomega.Equal(
-					map[string]string{
-						"instance-type": "on-demand",
-					},
-				))
-			})
-
-			wlLookupKey := types.NamespacedName{Name: workloadtrainjob.GetWorkloadNameForTrainJob(trainjob.Name, trainjob.UID), Namespace: ns.Name}
+			wlLookupKey := types.NamespacedName{Name: podcontroller.GetWorkloadNameForPod(p.Name, p.UID), Namespace: ns.Name}
 			createdWorkload := &kueue.Workload{}
 
 			ginkgo.By(fmt.Sprintf("await for admission of workload %q and verify TopologyAssignment", wlLookupKey), func() {
@@ -275,6 +218,66 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", ginkgo.Label("area:singleclus
 						Levels: []string{corev1.LabelHostname},
 						Domains: []tas.TopologyDomainAssignment{{
 							Count:  1,
+							Values: []string{"kind-worker"},
+						}},
+					}),
+				))
+			})
+
+			ginkgo.By(fmt.Sprintf("verify the workload %q gets finished", wlLookupKey), func() {
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
+			})
+		})
+
+		ginkgo.It("should admit a Pod group via TAS", func() {
+			group := testingpod.MakePod("group", ns.Name).
+				Queue(localQueue.Name).
+				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+				Annotation(kueue.PodSetRequiredTopologyAnnotation, corev1.LabelHostname).
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				RequestAndLimit(corev1.ResourceMemory, "200Mi").
+				MakeGroup(2)
+
+			ginkgo.By("Creating the Pod group", func() {
+				for _, p := range group {
+					util.MustCreate(ctx, k8sClient, p)
+					gomega.Expect(p.Spec.SchedulingGates).To(gomega.ContainElements(
+						corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName},
+						corev1.PodSchedulingGate{Name: kueue.TopologySchedulingGate},
+					))
+				}
+			})
+
+			ginkgo.By("waiting for the Pod to be ungated", func() {
+				// Verify that the Pods start with the appropriate selector.
+				gomega.Eventually(func(g gomega.Gomega) {
+					for _, origPod := range group {
+						var p corev1.Pod
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(origPod), &p)).To(gomega.Succeed())
+						g.Expect(p.Spec.SchedulingGates).To(gomega.BeEmpty())
+						g.Expect(p.Spec.NodeSelector).To(gomega.Equal(map[string]string{
+							"instance-type":      "on-demand",
+							corev1.LabelHostname: "kind-worker",
+						}))
+					}
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			wlLookupKey := client.ObjectKey{Namespace: ns.Name, Name: "group"}
+			createdWorkload := &kueue.Workload{}
+
+			ginkgo.By(fmt.Sprintf("await for admission of workload %q and verify TopologyAssignment", wlLookupKey), func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+					g.Expect(createdWorkload.Status.Admission).ShouldNot(gomega.BeNil())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				gomega.Expect(createdWorkload.Status.Admission).ShouldNot(gomega.BeNil())
+				gomega.Expect(createdWorkload.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(1))
+				gomega.Expect(createdWorkload.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+					tas.V1Beta2From(&tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{{
+							Count:  2,
 							Values: []string{"kind-worker"},
 						}},
 					}),


### PR DESCRIPTION
Cherry pick of #11750 on release-0.16.

#11750: Move core integrations from extended to baseline

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```