### PR TITLE
Automated cherry pick of #11721: Fix ObjectRetentionPolicy for orphaned Workloads.
#11744: Return error on FinalizeOrphanedWorkload.

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -207,6 +207,9 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	if isOrphanedWorkload(&wl) {
 		err := workload.FinalizeOrphanedWorkload(ctx, r.client, r.clock, &wl, true)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 		// If it was deleted, there is nothing to do.
 		// Otherwise, we still need to handle finished workload logic.
 		if !features.Enabled(features.FinishOrphanedWorkloads) || !wl.DeletionTimestamp.IsZero() {

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -207,7 +207,11 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	if isOrphanedWorkload(&wl) {
 		err := workload.FinalizeOrphanedWorkload(ctx, r.client, r.clock, &wl, true)
-		return ctrl.Result{}, err
+		// If it was deleted, there is nothing to do.
+		// Otherwise, we still need to handle finished workload logic.
+		if !features.Enabled(features.FinishOrphanedWorkloads) || !wl.DeletionTimestamp.IsZero() {
+			return ctrl.Result{}, err
+		}
 	}
 
 	if features.Enabled(features.MultiKueueOrchestratedPreemption) {

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -2590,7 +2590,7 @@ func TestReconcile(t *testing.T) {
 			reconcilerOpts: []Option{
 				WithWorkloadRetention(
 					&workloadRetentionConfig{
-						afterFinished: new(util.MediumTimeout),
+						afterFinished: ptr.To(util.MediumTimeout),
 					},
 				),
 			},
@@ -2617,7 +2617,7 @@ func TestReconcile(t *testing.T) {
 			reconcilerOpts: []Option{
 				WithWorkloadRetention(
 					&workloadRetentionConfig{
-						afterFinished: new(util.MediumTimeout),
+						afterFinished: ptr.To(util.MediumTimeout),
 					},
 				),
 			},

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -2577,6 +2577,28 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		},
+		"should handle finished workload logic for orphaned workloads when FinishOrphanedWorkloads enabled": {
+			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: true},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Finalizers(kueue.ResourceInUseFinalizerName).
+				FinishedAt(now).
+				Obj(),
+			reconcilerOpts: []Option{
+				WithWorkloadRetention(
+					&workloadRetentionConfig{
+						afterFinished: new(util.MediumTimeout),
+					},
+				),
+			},
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Finalizers(kueue.ResourceInUseFinalizerName).
+				FinishedAt(now).
+				Obj(),
+			wantError: nil,
+			wantResult: reconcile.Result{
+				RequeueAfter: util.MediumTimeout,
+			},
+		},
 		"shouldn't delete the workload because, object retention not configured": {
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				Condition(metav1.Condition{

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -397,6 +397,10 @@ var (
 	}
 )
 
+var (
+	errTest = stderrors.New("test error")
+)
+
 func TestReconcile(t *testing.T) {
 	// the clock is primarily used with second rounded times
 	// use the current time trimmed.
@@ -404,14 +408,14 @@ func TestReconcile(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(now)
 
 	cases := map[string]struct {
-		featureGates map[featuregate.Feature]bool
-
+		featureGates              map[featuregate.Feature]bool
 		workload                  *kueue.Workload
 		additionalObjects         []client.Object
 		cq                        *kueue.ClusterQueue
 		lq                        *kueue.LocalQueue
 		resourceClaims            []*resourcev1.ResourceClaim
 		resourceClaimTemplates    []*resourcev1.ResourceClaimTemplate
+		patchErr                  error
 		wantDRAResourceTotal      *int64
 		wantWorkloadsInQueue      *int
 		wantWorkload              *kueue.Workload
@@ -2581,7 +2585,7 @@ func TestReconcile(t *testing.T) {
 			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: true},
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				Finalizers(kueue.ResourceInUseFinalizerName).
-				FinishedAt(now).
+				JobUID("job_uid").
 				Obj(),
 			reconcilerOpts: []Option{
 				WithWorkloadRetention(
@@ -2591,13 +2595,38 @@ func TestReconcile(t *testing.T) {
 				),
 			},
 			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
-				Finalizers(kueue.ResourceInUseFinalizerName).
-				FinishedAt(now).
+				JobUID("job_uid").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadFinished,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueue.WorkloadFinishedReasonOwnerNotFound,
+					Message: "The workload's owner no longer exists",
+				}).
 				Obj(),
 			wantError: nil,
 			wantResult: reconcile.Result{
 				RequeueAfter: util.MediumTimeout,
 			},
+		},
+		"shouldn't handle finished workload logic for orphaned workloads on error when FinishOrphanedWorkloads enabled": {
+			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: true},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Finalizers(kueue.ResourceInUseFinalizerName).
+				JobUID("job_uid").
+				Obj(),
+			reconcilerOpts: []Option{
+				WithWorkloadRetention(
+					&workloadRetentionConfig{
+						afterFinished: new(util.MediumTimeout),
+					},
+				),
+			},
+			patchErr: errTest,
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Finalizers(kueue.ResourceInUseFinalizerName).
+				JobUID("job_uid").
+				Obj(),
+			wantError: errTest,
 		},
 		"shouldn't delete the workload because, object retention not configured": {
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
@@ -3174,7 +3203,14 @@ func TestReconcile(t *testing.T) {
 				clientBuilder := utiltesting.NewClientBuilder().
 					WithObjects(objs...).
 					WithStatusSubresource(objs...).
-					WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
+					WithInterceptorFuncs(interceptor.Funcs{
+						SubResourcePatch: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+							if tc.patchErr != nil {
+								return tc.patchErr
+							}
+							return utiltesting.TreatSSAAsStrategicMerge(ctx, client, subResourceName, obj, patch, opts...)
+						},
+					})
 				cl := clientBuilder.Build()
 				recorder := &utiltesting.EventRecorder{}
 

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -3821,6 +3821,7 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 	var (
 		enableWaitForPodsReady  bool
 		afterDeactivatedByKueue *metav1.Duration
+		afterFinished           *metav1.Duration
 
 		ns *corev1.Namespace
 		fl *kueue.ResourceFlavor
@@ -3847,6 +3848,7 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 			ObjectRetentionPolicies: &configapi.ObjectRetentionPolicies{
 				Workloads: &configapi.WorkloadRetentionPolicy{
 					AfterDeactivatedByKueue: afterDeactivatedByKueue,
+					AfterFinished:           afterFinished,
 				},
 			},
 			WaitForPodsReady: waitForPodsReady,
@@ -3877,6 +3879,9 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, fl, true)
 
 		fwk.StopManager(ctx)
+
+		afterDeactivatedByKueue = nil
+		afterFinished = nil
 	})
 
 	ginkgo.When("WaitForPodsReady disabled", func() {
@@ -3928,6 +3933,63 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), createdJob)).Should(gomega.Succeed())
 						g.Expect(createdJob.GetDeletionTimestamp()).To(gomega.BeNil())
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+			})
+		})
+
+		ginkgo.When("tiny finish retention period", func() {
+			ginkgo.BeforeEach(func() {
+				enableWaitForPodsReady = true
+				afterFinished = &metav1.Duration{Duration: util.TinyTimeout}
+			})
+
+			ginkgo.It("should delete orphaned Workload after finishing if the Job is deleted with PropagationPolicy=DeletePropagationOrphan", func() {
+				job := testingjob.MakeJob("job", ns.Name).
+					Queue(kueue.LocalQueueName(lq.Name)).
+					Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+					Obj()
+				util.MustCreate(ctx, k8sClient, job)
+
+				wlKey := types.NamespacedName{
+					Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+					Namespace: ns.Name,
+				}
+				wl := &kueue.Workload{}
+
+				ginkgo.By("Waiting for the Workload to be created", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Admitting the Workload", func() {
+					admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(cq.Name)).
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1m").
+							Count(wl.Spec.PodSets[0].Count).
+							Obj()).
+						Obj()
+					util.SetQuotaReservation(ctx, k8sClient, wlKey, admission)
+					util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, wl)
+				})
+
+				// In a real scenario, it should be cleared after deletion.
+				// But sometimes the Job reconciler runs faster than the Workload reconciler.
+				// To reproduce that exact scenario, we should make the Workload orphaned.
+				ginkgo.By("Clear ownerReferences", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
+						wl.OwnerReferences = nil
+						g.Expect(k8sClient.Update(ctx, wl)).To(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Delete the Job with PropagationPolicy=DeletePropagationOrphan", func() {
+					gomega.Expect(k8sClient.Delete(ctx, job, &client.DeleteOptions{PropagationPolicy: new(metav1.DeletePropagationOrphan)})).To(gomega.Succeed())
+				})
+
+				ginkgo.By("Checking that the Workload is deleted", func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, wl, false)
 				})
 			})
 		})

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -3941,6 +3941,8 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 			ginkgo.BeforeEach(func() {
 				enableWaitForPodsReady = true
 				afterFinished = &metav1.Duration{Duration: util.TinyTimeout}
+
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.FinishOrphanedWorkloads, true)
 			})
 
 			ginkgo.It("should delete orphaned Workload after finishing if the Job is deleted with PropagationPolicy=DeletePropagationOrphan", func() {
@@ -3985,7 +3987,7 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 				})
 
 				ginkgo.By("Delete the Job with PropagationPolicy=DeletePropagationOrphan", func() {
-					gomega.Expect(k8sClient.Delete(ctx, job, &client.DeleteOptions{PropagationPolicy: new(metav1.DeletePropagationOrphan)})).To(gomega.Succeed())
+					gomega.Expect(k8sClient.Delete(ctx, job, &client.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationOrphan)})).To(gomega.Succeed())
 				})
 
 				ginkgo.By("Checking that the Workload is deleted", func() {


### PR DESCRIPTION
Cherry pick of #11721 #11744 on release-0.17.

#11721: Fix ObjectRetentionPolicy for orphaned Workloads.
#11744: Return error on FinalizeOrphanedWorkload.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

```release-note
ObjectRetentionPolicies: Fixed a bug that doesn't allow the deletion of orphaned finished workloads.
```