### PR TITLE
Automated cherry pick of #11649: [v2] Fix MultiKueue to work on 1.36

### DIFF
--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -136,14 +136,11 @@ func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remot
 	//    (remote admitted -> MultiKueue AdmissionCheck ready -> local admitted -> local unsuspended).
 	// 3. However, to avoid clashing with K8s 1.36 validation rules
 	//    (since https://github.com/kubernetes/kubernetes/pull/135104 until https://github.com/kubernetes/kubernetes/pull/139287)
-	//    we manually patch a "JobSuspended=True" condition and "Active=0" to unblock further spec updates.
-	//    Similarly, to make 1.35 happy, we patch "StartTime = nil".
-	// As long as we're on a K8s version unaffected by #3, we could just do:
-	//   return &localJob.Status
-	newLocalStatus := localJob.Status.DeepCopy()
-	newLocalStatus.Active = 0
-	newLocalStatus.StartTime = nil
+	//    we manually patch a "JobSuspended=True" condition to unblock further spec updates.
+	// Once we're on a K8s version unaffected by #3, the "if" block below can be removed.
+
 	if !isJobStatusConditionTrue(localJob.Status.Conditions, batchv1.JobSuspended) {
+		newLocalStatus := localJob.Status.DeepCopy()
 		newLocalStatus.Conditions = setJobStatusCondition(newLocalStatus.Conditions,
 			batchv1.JobCondition{
 				Type:               batchv1.JobSuspended,
@@ -153,9 +150,11 @@ func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remot
 				LastTransitionTime: metav1.Now(),
 				LastProbeTime:      metav1.Now(),
 			})
+		log.V(2).Info("Updating the suspended local Job to comply with Kubernetes validation rules", "oldStatus", localJob.Status, "newStatus", newLocalStatus)
+		return newLocalStatus
 	}
-	log.V(2).Info("Updating the suspended local Job to comply with Kubernetes validation rules", "oldStatus", localJob.Status, "newStatus", newLocalStatus)
-	return newLocalStatus
+
+	return &localJob.Status
 }
 
 func setJobStatusCondition(list []batchv1.JobCondition, condition batchv1.JobCondition) []batchv1.JobCondition {

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -64,15 +65,14 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 
 	// the remote job exists
 	if err == nil {
-		if shouldSkipSyncForSuspendedLocalJob(log, &localJob, &remoteJob) {
-			return nil
-		}
-
-		if err := clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
-			localJob.Status = remoteJob.Status
-			return true, nil
-		}); err != nil {
-			return err
+		statusUpdate := determineStatusUpdate(ctx, log, &localJob, &remoteJob)
+		if !equality.Semantic.DeepEqual(localJob.Status, *statusUpdate) {
+			if err := clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
+				localJob.Status = *statusUpdate
+				return true, nil
+			}); err != nil {
+				return err
+			}
 		}
 
 		// Sync elastic workload if needed.
@@ -103,7 +103,7 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	return remoteClient.Create(ctx, &remoteJob)
 }
 
-func shouldSkipSyncForSuspendedLocalJob(log logr.Logger, localJob, remoteJob *batchv1.Job) bool {
+func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remoteJob *batchv1.Job) *batchv1.JobStatus {
 	localJobInfo := fromObject(localJob)
 
 	if !localJobInfo.IsSuspended() {
@@ -119,25 +119,63 @@ func shouldSkipSyncForSuspendedLocalJob(log logr.Logger, localJob, remoteJob *ba
 		log.V(3).Info("Peforming the sync as the local and the remote Job are suspended")
 		return &remoteJob.Status
 	}
-	if localJob.Status.StartTime == nil {
-		newLocalStatus := localJob.Status.DeepCopy()
-		newLocalStatus.Active = 0
-		newConditions, _ := ensureJobConditionStatus(newLocalStatus.Conditions,
-			batchv1.JobSuspended,
-			corev1.ConditionTrue,
-			"MultiKueueAdapted",
-			"Set by MultiKueue adapted",
-			time.Now())
-		log.V(2).Info("Updating the localJob suspended Job without startTime to set the JobSuspended=True condition")
-		newLocalStatus.Conditions = newConditions
-		return newLocalStatus
+	if _, _, finished := remoteJobInfo.Finished(ctx); finished {
+		log.V(2).Info("Remote job is finished, returning the remote job status")
+		return &remoteJob.Status
 	}
+	newLocalStatus := localJob.Status.DeepCopy()
+	newLocalStatus.Active = 0
+	newLocalStatus.StartTime = nil
+	newConditions, _ := ensureJobConditionStatus(newLocalStatus.Conditions,
+		batchv1.JobSuspended,
+		corev1.ConditionTrue,
+		"MultiKueueAdapter",
+		"Set by MultiKueue adapter",
+		time.Now())
+	log.V(2).Info("Updating the localJob suspended Job to set the JobSuspended=True condition")
+	newLocalStatus.Conditions = newConditions
+	return newLocalStatus
+}
 
-	// We skip the sync when the localJob has suspend=true, and the remote job is suspend=false
-	// to prevent the race condition when the local Job is updated to suspend=false prematurely
-	// so that the injection of nodeSlectors does not work; see: https://github.com/kubernetes-sigs/kueue/pull/3685
-	log.V(2).Info("Skipping the sync when the localJob has suspend=true, and the remote job is suspend=false")
-	return true
+// ensureJobConditionStatus appends or updates an existing job condition of the
+// given type with the given status value. Note that this function will not
+// append to the conditions list if the new condition's status is false
+// (because going from nothing to false is meaningless); it can, however,
+// update the status condition to false. The function returns a bool to let the
+// caller know if the list was changed (either appended or updated).
+func ensureJobConditionStatus(list []batchv1.JobCondition, cType batchv1.JobConditionType, status corev1.ConditionStatus, reason, message string, now time.Time) ([]batchv1.JobCondition, bool) {
+	if condition := findConditionByType(list, cType); condition != nil {
+		if condition.Status != status {
+			*condition = *newCondition(cType, status, reason, message, now)
+			return list, true
+		}
+		return list, false
+	}
+	// A condition with that type doesn't exist in the list.
+	if status != corev1.ConditionFalse {
+		return append(list, *newCondition(cType, status, reason, message, now)), true
+	}
+	return list, false
+}
+
+func findConditionByType(list []batchv1.JobCondition, cType batchv1.JobConditionType) *batchv1.JobCondition {
+	for i := range list {
+		if list[i].Type == cType {
+			return &list[i]
+		}
+	}
+	return nil
+}
+
+func newCondition(conditionType batchv1.JobConditionType, status corev1.ConditionStatus, reason, message string, now time.Time) *batchv1.JobCondition {
+	return &batchv1.JobCondition{
+		Type:               conditionType,
+		Status:             status,
+		LastProbeTime:      metav1.NewTime(now),
+		LastTransitionTime: metav1.NewTime(now),
+		Reason:             reason,
+		Message:            message,
+	}
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -105,21 +105,22 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remoteJob *batchv1.Job) *batchv1.JobStatus {
 	localJobInfo := fromObject(localJob)
 
+	log.V(3).Info("Determining status update for a MultiKueue Job", "localJob", localJob, "remoteJob", remoteJob)
 	if !localJobInfo.IsSuspended() {
 		// do not skip any syncs if the local Job is unsuspnded
-		log.V(3).Info("Peforming the sync as the local Job is unsuspended")
-		return false
+		log.V(3).Info("Performing the sync as the local Job is unsuspended")
+		return &remoteJob.Status
 	}
 	remoteJobInfo := fromObject(remoteJob)
 	if remoteJobInfo.IsSuspended() {
 		// Do not skip any syncs if the remote Job is also suspended
 		// This is needed to await for updating the status.active field
 		// when the remote Job is evicted; see: https://github.com/kubernetes-sigs/kueue/pull/8151
-		log.V(3).Info("Peforming the sync as the local and the remote Job are suspended")
+		log.V(3).Info("Peforming the sync as the local and the remote Job are both suspended")
 		return &remoteJob.Status
 	}
 	if _, _, finished := remoteJobInfo.Finished(ctx); finished {
-		log.V(2).Info("Remote job is finished, returning the remote job status")
+		log.V(2).Info("Performing the sync as the remote Job is finished")
 		return &remoteJob.Status
 	}
 	newLocalStatus := localJob.Status.DeepCopy()
@@ -134,7 +135,7 @@ func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remot
 			LastTransitionTime: metav1.Now(),
 			LastProbeTime:      metav1.Now(),
 		})
-	log.V(2).Info("Updating the localJob suspended Job to set the JobSuspended=True condition")
+	log.V(2).Info("Updating the suspended local Job with JobSuspended=True condition")
 	return newLocalStatus
 }
 

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
@@ -126,56 +125,28 @@ func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remot
 	newLocalStatus := localJob.Status.DeepCopy()
 	newLocalStatus.Active = 0
 	newLocalStatus.StartTime = nil
-	newConditions, _ := ensureJobConditionStatus(newLocalStatus.Conditions,
-		batchv1.JobSuspended,
-		corev1.ConditionTrue,
-		"MultiKueueAdapter",
-		"Set by MultiKueue adapter",
-		time.Now())
+	newLocalStatus.Conditions = setJobStatusCondition(newLocalStatus.Conditions,
+		batchv1.JobCondition{
+			Type:   batchv1.JobSuspended,
+			Status: corev1.ConditionTrue,
+			Reason: "MultiKueueAdapter",
+			Message: "Set by MultiKueue adapter",
+			LastTransitionTime: metav1.Now(),
+			LastProbeTime: metav1.Now(),
+		})
 	log.V(2).Info("Updating the localJob suspended Job to set the JobSuspended=True condition")
-	newLocalStatus.Conditions = newConditions
 	return newLocalStatus
 }
 
-// ensureJobConditionStatus appends or updates an existing job condition of the
-// given type with the given status value. Note that this function will not
-// append to the conditions list if the new condition's status is false
-// (because going from nothing to false is meaningless); it can, however,
-// update the status condition to false. The function returns a bool to let the
-// caller know if the list was changed (either appended or updated).
-func ensureJobConditionStatus(list []batchv1.JobCondition, cType batchv1.JobConditionType, status corev1.ConditionStatus, reason, message string, now time.Time) ([]batchv1.JobCondition, bool) {
-	if condition := findConditionByType(list, cType); condition != nil {
-		if condition.Status != status {
-			*condition = *newCondition(cType, status, reason, message, now)
-			return list, true
-		}
-		return list, false
-	}
-	// A condition with that type doesn't exist in the list.
-	if status != corev1.ConditionFalse {
-		return append(list, *newCondition(cType, status, reason, message, now)), true
-	}
-	return list, false
-}
-
-func findConditionByType(list []batchv1.JobCondition, cType batchv1.JobConditionType) *batchv1.JobCondition {
+func setJobStatusCondition(list []batchv1.JobCondition, condition batchv1.JobCondition) []batchv1.JobCondition {
 	for i := range list {
-		if list[i].Type == cType {
-			return &list[i]
+		if list[i].Type == condition.Type {
+			list[i] = condition
+			return list
 		}
 	}
-	return nil
-}
-
-func newCondition(conditionType batchv1.JobConditionType, status corev1.ConditionStatus, reason, message string, now time.Time) *batchv1.JobCondition {
-	return &batchv1.JobCondition{
-		Type:               conditionType,
-		Status:             status,
-		LastProbeTime:      metav1.NewTime(now),
-		LastTransitionTime: metav1.NewTime(now),
-		Reason:             reason,
-		Message:            message,
-	}
+	list = append(list, condition)
+	return list
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -136,22 +136,25 @@ func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remot
 	//    (remote admitted -> MultiKueue AdmissionCheck ready -> local admitted -> local unsuspended).
 	// 3. However, to avoid clashing with K8s 1.36 validation rules
 	//    (since https://github.com/kubernetes/kubernetes/pull/135104 until https://github.com/kubernetes/kubernetes/pull/139287)
-	//    we manually patch a "JobSuspended=True" condition to unblock further spec updates.
+	//    we manually patch a "JobSuspended=True" condition and "Active=0" to unblock further spec updates.
+	//    Similarly, to make 1.35 happy, we patch "StartTime = nil".
 	// As long as we're on a K8s version unaffected by #3, we could just do:
 	//   return &localJob.Status
 	newLocalStatus := localJob.Status.DeepCopy()
 	newLocalStatus.Active = 0
 	newLocalStatus.StartTime = nil
-	newLocalStatus.Conditions = setJobStatusCondition(newLocalStatus.Conditions,
-		batchv1.JobCondition{
-			Type:               batchv1.JobSuspended,
-			Status:             corev1.ConditionTrue,
-			Reason:             "MultiKueueAdapter",
-			Message:            "Set by MultiKueue adapter",
-			LastTransitionTime: metav1.Now(),
-			LastProbeTime:      metav1.Now(),
-		})
-	log.V(2).Info("Updating the suspended local Job with JobSuspended=True condition")
+	if !isJobStatusConditionTrue(localJob.Status.Conditions, batchv1.JobSuspended) {
+		newLocalStatus.Conditions = setJobStatusCondition(newLocalStatus.Conditions,
+			batchv1.JobCondition{
+				Type:               batchv1.JobSuspended,
+				Status:             corev1.ConditionTrue,
+				Reason:             "MultiKueueAdapter",
+				Message:            "Set by MultiKueue adapter",
+				LastTransitionTime: metav1.Now(),
+				LastProbeTime:      metav1.Now(),
+			})
+	}
+	log.V(2).Info("Updating the suspended local Job to comply with Kubernetes validation rules", "oldStatus", localJob.Status, "newStatus", newLocalStatus)
 	return newLocalStatus
 }
 
@@ -164,6 +167,15 @@ func setJobStatusCondition(list []batchv1.JobCondition, condition batchv1.JobCon
 	}
 	list = append(list, condition)
 	return list
+}
+
+func isJobStatusConditionTrue(conditions []batchv1.JobCondition, condType batchv1.JobConditionType) bool {
+	for _, c := range conditions {
+		if c.Type == condType {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -127,12 +127,12 @@ func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remot
 	newLocalStatus.StartTime = nil
 	newLocalStatus.Conditions = setJobStatusCondition(newLocalStatus.Conditions,
 		batchv1.JobCondition{
-			Type:   batchv1.JobSuspended,
-			Status: corev1.ConditionTrue,
-			Reason: "MultiKueueAdapter",
-			Message: "Set by MultiKueue adapter",
+			Type:               batchv1.JobSuspended,
+			Status:             corev1.ConditionTrue,
+			Reason:             "MultiKueueAdapter",
+			Message:            "Set by MultiKueue adapter",
 			LastTransitionTime: metav1.Now(),
-			LastProbeTime: metav1.Now(),
+			LastProbeTime:      metav1.Now(),
 		})
 	log.V(2).Info("Updating the localJob suspended Job to set the JobSuspended=True condition")
 	return newLocalStatus

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -115,7 +117,20 @@ func shouldSkipSyncForSuspendedLocalJob(log logr.Logger, localJob, remoteJob *ba
 		// This is needed to await for updating the status.active field
 		// when the remote Job is evicted; see: https://github.com/kubernetes-sigs/kueue/pull/8151
 		log.V(3).Info("Peforming the sync as the local and the remote Job are suspended")
-		return false
+		return &remoteJob.Status
+	}
+	if localJob.Status.StartTime == nil {
+		newLocalStatus := localJob.Status.DeepCopy()
+		newLocalStatus.Active = 0
+		newConditions, _ := ensureJobConditionStatus(newLocalStatus.Conditions,
+			batchv1.JobSuspended,
+			corev1.ConditionTrue,
+			"MultiKueueAdapted",
+			"Set by MultiKueue adapted",
+			time.Now())
+		log.V(2).Info("Updating the localJob suspended Job without startTime to set the JobSuspended=True condition")
+		newLocalStatus.Conditions = newConditions
+		return newLocalStatus
 	}
 
 	// We skip the sync when the localJob has suspend=true, and the remote job is suspend=false

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -107,22 +107,38 @@ func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remot
 
 	log.V(3).Info("Determining status update for a MultiKueue Job", "localJob", localJob, "remoteJob", remoteJob)
 	if !localJobInfo.IsSuspended() {
-		// do not skip any syncs if the local Job is unsuspnded
+		// Sync status if the local Job is unsuspended.
+		// This is safe as the local Job has already reached its final spec.
+		// We expect no validation errors from further spec changes.
 		log.V(3).Info("Performing the sync as the local Job is unsuspended")
 		return &remoteJob.Status
 	}
 	remoteJobInfo := fromObject(remoteJob)
 	if remoteJobInfo.IsSuspended() {
-		// Do not skip any syncs if the remote Job is also suspended
+		// Sync status if both local and remote Job are suspended.
 		// This is needed to await for updating the status.active field
 		// when the remote Job is evicted; see: https://github.com/kubernetes-sigs/kueue/pull/8151
 		log.V(3).Info("Peforming the sync as the local and the remote Job are both suspended")
 		return &remoteJob.Status
 	}
 	if _, _, finished := remoteJobInfo.Finished(ctx); finished {
+		// Sync status if the remote Job is finished.
+		// Without this, the local Job could get stuck in the suspended state.
 		log.V(2).Info("Performing the sync as the remote Job is finished")
 		return &remoteJob.Status
 	}
+
+	// Remaining case: local Job is suspended, remote Job is unsuspended but not finished.
+	// In this case:
+	// 1. We essentially want *no sync* (to avoid prematurely setting non-zero .status.startTime
+	//    which could block further spec updates; see: https://github.com/kubernetes-sigs/kueue/pull/3685).
+	// 2. We rely on the MultiKueue admission lifecycle to eventually bring localJob to unsuspended state
+	//    (remote admitted -> MultiKueue AdmissionCheck ready -> local admitted -> local unsuspended).
+	// 3. However, to avoid clashing with K8s 1.36 validation rules
+	//    (since https://github.com/kubernetes/kubernetes/pull/135104 until https://github.com/kubernetes/kubernetes/pull/139287)
+	//    we manually patch a "JobSuspended=True" condition to unblock further spec updates.
+	// As long as we're on a K8s version unaffected by #3, we could just do:
+	//   return &localJob.Status
 	newLocalStatus := localJob.Status.DeepCopy()
 	newLocalStatus.Active = 0
 	newLocalStatus.StartTime = nil

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -62,9 +62,7 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 
 	// the remote job exists
 	if err == nil {
-		if fromObject(&localJob).IsSuspended() && !fromObject(&localJob).IsActive() {
-			// Ensure the job is unsuspended before updating its status; otherwise, it will fail when patching the spec.
-			log.V(2).Info("Skipping the sync since the local job is still suspended")
+		if shouldSkipSyncForSuspendedLocalJob(log, &localJob, &remoteJob) {
 			return nil
 		}
 
@@ -101,6 +99,30 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	remoteJob.Spec.ManagedBy = nil
 
 	return remoteClient.Create(ctx, &remoteJob)
+}
+
+func shouldSkipSyncForSuspendedLocalJob(log logr.Logger, localJob, remoteJob *batchv1.Job) bool {
+	localJobInfo := fromObject(localJob)
+
+	if !localJobInfo.IsSuspended() {
+		// do not skip any syncs if the local Job is unsuspnded
+		log.V(3).Info("Peforming the sync as the local Job is unsuspended")
+		return false
+	}
+	remoteJobInfo := fromObject(remoteJob)
+	if remoteJobInfo.IsSuspended() {
+		// Do not skip any syncs if the remote Job is also suspended
+		// This is needed to await for updating the status.active field
+		// when the remote Job is evicted; see: https://github.com/kubernetes-sigs/kueue/pull/8151
+		log.V(3).Info("Peforming the sync as the local and the remote Job are suspended")
+		return false
+	}
+
+	// We skip the sync when the localJob has suspend=true, and the remote job is suspend=false
+	// to prevent the race condition when the local Job is updated to suspend=false prematurely
+	// so that the injection of nodeSlectors does not work; see: https://github.com/kubernetes-sigs/kueue/pull/3685
+	log.V(2).Info("Skipping the sync when the localJob has suspend=true, and the remote job is suspend=false")
+	return true
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/job/job_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter_test.go
@@ -35,7 +35,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
@@ -527,7 +526,10 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"ElasticJob_WorkloadNameOnlyChange_EdgeCase": {
 			fields: fields{
-				featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+				featureGates: map[featuregate.Feature]bool{
+					features.ElasticJobsViaWorkloadSlices:          true,
+					features.WorkloadIdentifierAnnotations: false,
+				},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
@@ -549,14 +551,17 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 				remoteJob: newJob().
 					ResourceVersion("2").
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					SetAnnotation(constants.PrebuiltWorkloadAnnotation, "test-workload-new").
+					PrebuiltWorkloadLabel("test-workload-new").
 					Condition(runningJobCondition).
 					Obj(),
 			},
 		},
 		"ElasticJob_RemoteOutOfSync": {
 			fields: fields{
-				featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+				featureGates: map[featuregate.Feature]bool{
+					features.ElasticJobsViaWorkloadSlices:          true,
+					features.WorkloadIdentifierAnnotations: false,
+				},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
@@ -581,8 +586,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 				remoteJob: newJob().
 					ResourceVersion("2").
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					PrebuiltWorkloadLabel("test-workload").
-					SetAnnotation(constants.PrebuiltWorkloadAnnotation, "job-test-f53b2").
+					PrebuiltWorkloadLabel("job-test-f53b2").
 					Parallelism(22).
 					Condition(runningJobCondition).
 					Obj(),
@@ -590,7 +594,10 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		},
 		"ElasticJob_RemoteOutOfSync_PatchFailure": {
 			fields: fields{
-				featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+				featureGates: map[featuregate.Feature]bool{
+					features.ElasticJobsViaWorkloadSlices:          true,
+					features.WorkloadIdentifierAnnotations: false,
+				},
 			},
 			args: args{
 				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().

--- a/pkg/controller/jobs/job/job_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter_test.go
@@ -527,7 +527,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		"ElasticJob_WorkloadNameOnlyChange_EdgeCase": {
 			fields: fields{
 				featureGates: map[featuregate.Feature]bool{
-					features.ElasticJobsViaWorkloadSlices:          true,
+					features.ElasticJobsViaWorkloadSlices:  true,
 					features.WorkloadIdentifierAnnotations: false,
 				},
 			},
@@ -559,7 +559,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		"ElasticJob_RemoteOutOfSync": {
 			fields: fields{
 				featureGates: map[featuregate.Feature]bool{
-					features.ElasticJobsViaWorkloadSlices:          true,
+					features.ElasticJobsViaWorkloadSlices:  true,
 					features.WorkloadIdentifierAnnotations: false,
 				},
 			},
@@ -595,7 +595,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 		"ElasticJob_RemoteOutOfSync_PatchFailure": {
 			fields: fields{
 				featureGates: map[featuregate.Feature]bool{
-					features.ElasticJobsViaWorkloadSlices:          true,
+					features.ElasticJobsViaWorkloadSlices:  true,
 					features.WorkloadIdentifierAnnotations: false,
 				},
 			},

--- a/pkg/controller/jobs/job/job_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
@@ -113,7 +114,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
-		"skip to sync intermediate status from remote suspended job": {
+		"sync intermediate status from remote suspended job": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersJobs: []batchv1.Job{
 				*baseJobManagedByKueueBuilder.Clone().
@@ -134,6 +135,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			wantManagersJobs: []batchv1.Job{
 				*baseJobManagedByKueueBuilder.Clone().
 					Suspend(true).
+					Active(2).
 					Obj(),
 			},
 			wantWorkerJobs: []batchv1.Job{
@@ -372,7 +374,10 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 				key: client.ObjectKeyFromObject(newJob().Obj()),
 			},
 			want: want{
-				localJob: newJob().Obj(),
+				localJob: newJob().
+					ResourceVersion("2").
+					Condition(runningJobCondition).
+					Obj(),
 				remoteJob: newJob().
 					Condition(runningJobCondition).
 					Obj(),
@@ -406,7 +411,10 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 				key: client.ObjectKeyFromObject(newJob().Obj()),
 			},
 			want: want{
-				localJob: newJob().Obj(),
+				localJob: newJob().
+					ResourceVersion("2").
+					Condition(runningJobCondition).
+					Obj(),
 				remoteJob: newJob().
 					Condition(runningJobCondition).
 					Obj(),
@@ -539,8 +547,9 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 					Condition(runningJobCondition).
 					Obj(),
 				remoteJob: newJob().
-					ResourceVersion("1").
+					ResourceVersion("2").
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					SetAnnotation(constants.PrebuiltWorkloadAnnotation, "test-workload-new").
 					Condition(runningJobCondition).
 					Obj(),
 			},
@@ -570,10 +579,11 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 					Condition(runningJobCondition).
 					Obj(),
 				remoteJob: newJob().
-					ResourceVersion("1").
+					ResourceVersion("2").
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 					PrebuiltWorkloadLabel("test-workload").
-					Parallelism(1).
+					SetAnnotation(constants.PrebuiltWorkloadAnnotation, "job-test-f53b2").
+					Parallelism(22).
 					Condition(runningJobCondition).
 					Obj(),
 			},
@@ -602,6 +612,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 				workloadName: jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration("test", "", gvk, 0),
 			},
 			want: want{
+				err: true,
 				localJob: newJob().
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 					Parallelism(22).

--- a/test/e2e/multikueuedra/dra_test.go
+++ b/test/e2e/multikueuedra/dra_test.go
@@ -269,7 +269,7 @@ var _ = ginkgo.Describe("MultiKueue with DRA", ginkgo.Label("feature:dra", "area
 						Status: corev1.ConditionTrue,
 					},
 					cmpopts.IgnoreFields(batchv1.JobCondition{}, "LastTransitionTime", "LastProbeTime", "Reason", "Message"))))
-			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("Job", createdJob))
 		})
 
 		ginkgo.It("Should handle workload when ResourceClaimTemplate is missing on worker", func() {

--- a/test/e2e/multikueuedra/dra_test.go
+++ b/test/e2e/multikueuedra/dra_test.go
@@ -261,13 +261,15 @@ var _ = ginkgo.Describe("MultiKueue with DRA", ginkgo.Label("feature:dra", "area
 			util.ExpectObjectToBeDeletedOnClusters(ctx, job, k8sWorker1Client, k8sWorker2Client)
 
 			createdJob := &batchv1.Job{}
-			gomega.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(job), createdJob)).To(gomega.Succeed())
-			gomega.Expect(createdJob.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(
-				batchv1.JobCondition{
-					Type:   batchv1.JobComplete,
-					Status: corev1.ConditionTrue,
-				},
-				cmpopts.IgnoreFields(batchv1.JobCondition{}, "LastTransitionTime", "LastProbeTime", "Reason", "Message"))))
+			gomega.Eventually(func(g gomega.Gomega) {
+				gomega.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(job), createdJob)).To(gomega.Succeed())
+				gomega.Expect(createdJob.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(
+					batchv1.JobCondition{
+						Type:   batchv1.JobComplete,
+						Status: corev1.ConditionTrue,
+					},
+					cmpopts.IgnoreFields(batchv1.JobCondition{}, "LastTransitionTime", "LastProbeTime", "Reason", "Message"))))
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 		})
 
 		ginkgo.It("Should handle workload when ResourceClaimTemplate is missing on worker", func() {


### PR DESCRIPTION
Cherry pick of #11649 on release-0.17.

#11649: [v2] Fix MultiKueue to work on 1.36

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
MultiKueue: Fixed admission for Kubernetes Jobs on Kubernetes 1.36 clusters by ensuring all Job status updates comply with the updated Kubernetes Job validation rules. See kubernetes/kubernetes#139281 for more details.
```