### PR TITLE
Cherry pick of #11649: [v2] Fix MultiKueue to work on 1.36

### DIFF
--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -136,14 +136,11 @@ func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remot
 	//    (remote admitted -> MultiKueue AdmissionCheck ready -> local admitted -> local unsuspended).
 	// 3. However, to avoid clashing with K8s 1.36 validation rules
 	//    (since https://github.com/kubernetes/kubernetes/pull/135104 until https://github.com/kubernetes/kubernetes/pull/139287)
-	//    we manually patch a "JobSuspended=True" condition and "Active=0" to unblock further spec updates.
-	//    Similarly, to make 1.35 happy, we patch "StartTime = nil".
-	// As long as we're on a K8s version unaffected by #3, we could just do:
-	//   return &localJob.Status
-	newLocalStatus := localJob.Status.DeepCopy()
-	newLocalStatus.Active = 0
-	newLocalStatus.StartTime = nil
+	//    we manually patch a "JobSuspended=True" condition to unblock further spec updates.
+	// Once we're on a K8s version unaffected by #3, the "if" block below can be removed.
+
 	if !isJobStatusConditionTrue(localJob.Status.Conditions, batchv1.JobSuspended) {
+		newLocalStatus := localJob.Status.DeepCopy()
 		newLocalStatus.Conditions = setJobStatusCondition(newLocalStatus.Conditions,
 			batchv1.JobCondition{
 				Type:               batchv1.JobSuspended,
@@ -153,9 +150,11 @@ func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remot
 				LastTransitionTime: metav1.Now(),
 				LastProbeTime:      metav1.Now(),
 			})
+		log.V(2).Info("Updating the suspended local Job to comply with Kubernetes validation rules", "oldStatus", localJob.Status, "newStatus", newLocalStatus)
+		return newLocalStatus
 	}
-	log.V(2).Info("Updating the suspended local Job to comply with Kubernetes validation rules", "oldStatus", localJob.Status, "newStatus", newLocalStatus)
-	return newLocalStatus
+
+	return &localJob.Status
 }
 
 func setJobStatusCondition(list []batchv1.JobCondition, condition batchv1.JobCondition) []batchv1.JobCondition {

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -105,10 +105,10 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remoteJob *batchv1.Job) *batchv1.JobStatus {
 	localJobInfo := fromObject(localJob)
 
-	log.V(2).Info("Checking shouldSkipSyncForSuspendedLocalJob", "localJob", localJob, "remoteJob", remoteJob)
+	log.V(3).Info("Determining status update for a MultiKueue Job", "localJob", localJob, "remoteJob", remoteJob)
 	if !localJobInfo.IsSuspended() {
 		// do not skip any syncs if the local Job is unsuspnded
-		log.V(3).Info("Peforming the sync as the local Job is unsuspended")
+		log.V(3).Info("Performing the sync as the local Job is unsuspended")
 		return &remoteJob.Status
 	}
 	remoteJobInfo := fromObject(remoteJob)
@@ -116,11 +116,11 @@ func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remot
 		// Do not skip any syncs if the remote Job is also suspended
 		// This is needed to await for updating the status.active field
 		// when the remote Job is evicted; see: https://github.com/kubernetes-sigs/kueue/pull/8151
-		log.V(3).Info("Peforming the sync as the local and the remote Job are suspended")
+		log.V(3).Info("Peforming the sync as the local and the remote Job are both suspended")
 		return &remoteJob.Status
 	}
 	if _, _, finished := remoteJobInfo.Finished(ctx); finished {
-		log.V(2).Info("Remote job is finished, returning the remote job status")
+		log.V(2).Info("Performing the sync as the remote Job is finished")
 		return &remoteJob.Status
 	}
 	newLocalStatus := localJob.Status.DeepCopy()
@@ -135,7 +135,7 @@ func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remot
 			LastTransitionTime: metav1.Now(),
 			LastProbeTime:      metav1.Now(),
 		})
-	log.V(2).Info("Updating the localJob suspended Job to set the JobSuspended=True condition")
+	log.V(2).Info("Updating the suspended local Job with JobSuspended=True condition")
 	return newLocalStatus
 }
 

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/api"
@@ -63,29 +62,15 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 
 	// the remote job exists
 	if err == nil {
-		if features.Enabled(features.MultiKueueBatchJobWithManagedBy) {
-			if fromObject(&localJob).IsSuspended() && !fromObject(&localJob).IsActive() {
-				// Ensure the job is unsuspended before updating its status; otherwise, it will fail when patching the spec.
-				log.V(2).Info("Skipping the sync since the local job is still suspended")
-				return nil
-			}
-			// Elastic workload sync takes precedence over status updates.
-			if needElasticJobSync(log, workloadName, &localJob, &remoteJob) {
-				if err := syncElasticJob(ctx, remoteClient, log, workloadName, &localJob, &remoteJob); err != nil {
-					return err
-				}
-			}
-			return clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
-				localJob.Status = remoteJob.Status
-				return true, nil
-			})
+		if shouldSkipSyncForSuspendedLocalJob(log, &localJob, &remoteJob) {
+			return nil
 		}
 
-		if _, _, remoteFinished := fromObject(&remoteJob).Finished(ctx); remoteFinished {
-			return clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
-				localJob.Status = remoteJob.Status
-				return true, nil
-			})
+		if err := clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
+			localJob.Status = remoteJob.Status
+			return true, nil
+		}); err != nil {
+			return err
 		}
 
 		// Sync elastic workload if needed.
@@ -107,22 +92,40 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	// drop the templates cleanup labels
 	cleanLabels(&remoteJob.Spec.Template)
 
-	// add the prebuilt workload
-	if remoteJob.Labels == nil {
-		remoteJob.Labels = map[string]string{}
-	}
-	remoteJob.Labels[constants.PrebuiltWorkloadLabel] = workloadName
-	remoteJob.Labels[kueue.MultiKueueOriginLabel] = origin
+	// Add prebuilt workload name and multikueue origin
+	jobframework.SetMultiKueueMeta(&remoteJob, workloadName, origin)
 
-	if features.Enabled(features.MultiKueueBatchJobWithManagedBy) {
-		// clear the managedBy enables the batch/Job controller to take over
-		remoteJob.Spec.ManagedBy = nil
-	}
+	// clear the managedBy enables the batch/Job controller to take over
+	remoteJob.Spec.ManagedBy = nil
 
 	return remoteClient.Create(ctx, &remoteJob)
 }
 
-func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, remoteClient client.Client, key types.NamespacedName) error {
+func shouldSkipSyncForSuspendedLocalJob(log logr.Logger, localJob, remoteJob *batchv1.Job) bool {
+	localJobInfo := fromObject(localJob)
+
+	if !localJobInfo.IsSuspended() {
+		// do not skip any syncs if the local Job is unsuspnded
+		log.V(3).Info("Peforming the sync as the local Job is unsuspended")
+		return false
+	}
+	remoteJobInfo := fromObject(remoteJob)
+	if remoteJobInfo.IsSuspended() {
+		// Do not skip any syncs if the remote Job is also suspended
+		// This is needed to await for updating the status.active field
+		// when the remote Job is evicted; see: https://github.com/kubernetes-sigs/kueue/pull/8151
+		log.V(3).Info("Peforming the sync as the local and the remote Job are suspended")
+		return false
+	}
+
+	// We skip the sync when the localJob has suspend=true, and the remote job is suspend=false
+	// to prevent the race condition when the local Job is updated to suspend=false prematurely
+	// so that the injection of nodeSlectors does not work; see: https://github.com/kubernetes-sigs/kueue/pull/3685
+	log.V(2).Info("Skipping the sync when the localJob has suspend=true, and the remote job is suspend=false")
+	return true
+}
+
+func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {
 	job := batchv1.Job{}
 	job.SetName(key.Name)
 	job.SetNamespace(key.Namespace)
@@ -130,10 +133,6 @@ func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, remoteClient
 }
 
 func (b *multiKueueAdapter) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName) (bool, string, error) {
-	if !features.Enabled(features.MultiKueueBatchJobWithManagedBy) {
-		return true, "", nil
-	}
-
 	job := batchv1.Job{}
 	err := c.Get(ctx, key, &job)
 	if err != nil {
@@ -156,18 +155,18 @@ func (*multiKueueAdapter) GetEmptyList() client.ObjectList {
 	return &batchv1.JobList{}
 }
 
-func (*multiKueueAdapter) WorkloadKeyFor(o runtime.Object) (types.NamespacedName, error) {
+func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedName, error) {
 	job, isJob := o.(*batchv1.Job)
 	if !isJob {
-		return types.NamespacedName{}, errors.New("not a job")
+		return nil, errors.New("not a job")
 	}
 
-	prebuiltWl, hasPrebuiltWorkload := job.Labels[constants.PrebuiltWorkloadLabel]
-	if !hasPrebuiltWorkload {
-		return types.NamespacedName{}, fmt.Errorf("no prebuilt workload found for job: %s", klog.KObj(job))
+	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(job)
+	if prebuiltWorkload == "" {
+		return nil, fmt.Errorf("no prebuilt workload found for job: %s", klog.KObj(job))
 	}
 
-	return types.NamespacedName{Name: prebuiltWl, Namespace: job.Namespace}, nil
+	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: job.Namespace}}, nil
 }
 
 // needElasticJobSync determines if a remote Job requires synchronization due to elastic job features.
@@ -200,7 +199,8 @@ func needElasticJobSync(log logr.Logger, workloadName string, localJob, remoteJo
 			"newWorkloadName", newWorkloadName)
 		return false
 	}
-	return oldParallelism != newParallelism || remoteJob.Labels == nil || remoteJob.Labels[constants.PrebuiltWorkloadLabel] != workloadName
+
+	return oldParallelism != newParallelism || remoteJob.Labels == nil || jobframework.PrebuiltWorkloadNameFor(remoteJob) != workloadName
 }
 
 // syncElasticJob updates the remote job's workload label and parallelism to match the local job configuration.
@@ -214,21 +214,17 @@ func syncElasticJob(ctx context.Context, remoteClient client.Client, log logr.Lo
 
 	// Update a remote job's workload slice name and parallelism if needed.
 	if err := clientutil.Patch(ctx, remoteClient, remoteJob, func() (bool, error) {
-		// Update the workload name label.
-		labelsChanged := false
-		if remoteJob.Labels == nil {
-			remoteJob.Labels = map[string]string{constants.PrebuiltWorkloadLabel: workloadName}
-			labelsChanged = true
-		} else {
-			if cur, ok := remoteJob.Labels[constants.PrebuiltWorkloadLabel]; !ok || cur != workloadName {
-				remoteJob.Labels[constants.PrebuiltWorkloadLabel] = workloadName
-				labelsChanged = true
-			}
-		}
-
 		// Update parallelism.
 		remoteJob.Spec.Parallelism = localJob.Spec.Parallelism
-		return oldParallelism != newParallelism || labelsChanged, nil
+		changed := oldParallelism != newParallelism
+
+		// Update the workload name value.
+		if cur := jobframework.PrebuiltWorkloadNameFor(remoteJob); cur == "" || cur != workloadName {
+			jobframework.SetPrebuiltWorkloadName(remoteJob, workloadName)
+			changed = true
+		}
+
+		return changed, nil
 	}); err != nil {
 		return fmt.Errorf("failed to patch remote job: %w", err)
 	}

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -123,17 +123,16 @@ func determineStatusUpdate(log logr.Logger, localJob, remoteJob *batchv1.Job) *b
 	}
 	if localJob.Status.StartTime == nil {
 		newLocalStatus := localJob.Status.DeepCopy()
-		newConditions, updated := ensureJobConditionStatus(newLocalStatus.Conditions,
+		newLocalStatus.Active = 0
+		newConditions, _ := ensureJobConditionStatus(newLocalStatus.Conditions,
 			batchv1.JobSuspended,
 			corev1.ConditionTrue,
 			"MultiKueueAdapted",
 			"Set by MultiKueue adapted",
 			time.Now())
-		if updated {
-			log.V(2).Info("Updating the localJob suspended Job without startTime to set the JobSuspended=True condition")
-			newLocalStatus.Conditions = newConditions
-			return newLocalStatus
-		}
+		log.V(2).Info("Updating the localJob suspended Job without startTime to set the JobSuspended=True condition")
+		newLocalStatus.Conditions = newConditions
+		return newLocalStatus
 	}
 
 	// We skip the sync when the localJob has suspend=true, and the remote job is suspend=false

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -62,7 +64,8 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 
 	// the remote job exists
 	if err == nil {
-		if shouldSkipSyncForSuspendedLocalJob(log, &localJob, &remoteJob) {
+		if statusUpdate := determineStatusUpdate(log, &localJob, &remoteJob); statusUpdate != nil {
+			localJob.Status = *statusUpdate
 			return nil
 		}
 
@@ -101,13 +104,14 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	return remoteClient.Create(ctx, &remoteJob)
 }
 
-func shouldSkipSyncForSuspendedLocalJob(log logr.Logger, localJob, remoteJob *batchv1.Job) bool {
+func determineStatusUpdate(log logr.Logger, localJob, remoteJob *batchv1.Job) *batchv1.JobStatus {
 	localJobInfo := fromObject(localJob)
 
+	log.V(2).Info("Checking shouldSkipSyncForSuspendedLocalJob", "localJob", localJob, "remoteJob", remoteJob)
 	if !localJobInfo.IsSuspended() {
 		// do not skip any syncs if the local Job is unsuspnded
 		log.V(3).Info("Peforming the sync as the local Job is unsuspended")
-		return false
+		return &remoteJob.Status
 	}
 	remoteJobInfo := fromObject(remoteJob)
 	if remoteJobInfo.IsSuspended() {
@@ -115,14 +119,69 @@ func shouldSkipSyncForSuspendedLocalJob(log logr.Logger, localJob, remoteJob *ba
 		// This is needed to await for updating the status.active field
 		// when the remote Job is evicted; see: https://github.com/kubernetes-sigs/kueue/pull/8151
 		log.V(3).Info("Peforming the sync as the local and the remote Job are suspended")
-		return false
+		return &remoteJob.Status
+	}
+	if localJob.Status.StartTime == nil {
+		newLocalStatus := localJob.Status.DeepCopy()
+		newConditions, updated := ensureJobConditionStatus(newLocalStatus.Conditions,
+			batchv1.JobSuspended,
+			corev1.ConditionTrue,
+			"MultiKueueAdapted",
+			"Set by MultiKueue adapted",
+			time.Now())
+		if updated {
+			log.V(2).Info("Updating the localJob suspended Job without startTime to set the JobSuspended=True condition")
+			newLocalStatus.Conditions = newConditions
+			return newLocalStatus
+		}
 	}
 
 	// We skip the sync when the localJob has suspend=true, and the remote job is suspend=false
 	// to prevent the race condition when the local Job is updated to suspend=false prematurely
 	// so that the injection of nodeSlectors does not work; see: https://github.com/kubernetes-sigs/kueue/pull/3685
 	log.V(2).Info("Skipping the sync when the localJob has suspend=true, and the remote job is suspend=false")
-	return true
+	return nil
+}
+
+// ensureJobConditionStatus appends or updates an existing job condition of the
+// given type with the given status value. Note that this function will not
+// append to the conditions list if the new condition's status is false
+// (because going from nothing to false is meaningless); it can, however,
+// update the status condition to false. The function returns a bool to let the
+// caller know if the list was changed (either appended or updated).
+func ensureJobConditionStatus(list []batchv1.JobCondition, cType batchv1.JobConditionType, status corev1.ConditionStatus, reason, message string, now time.Time) ([]batchv1.JobCondition, bool) {
+	if condition := findConditionByType(list, cType); condition != nil {
+		if condition.Status != status {
+			*condition = *newCondition(cType, status, reason, message, now)
+			return list, true
+		}
+		return list, false
+	}
+	// A condition with that type doesn't exist in the list.
+	if status != corev1.ConditionFalse {
+		return append(list, *newCondition(cType, status, reason, message, now)), true
+	}
+	return list, false
+}
+
+func findConditionByType(list []batchv1.JobCondition, cType batchv1.JobConditionType) *batchv1.JobCondition {
+	for i := range list {
+		if list[i].Type == cType {
+			return &list[i]
+		}
+	}
+	return nil
+}
+
+func newCondition(conditionType batchv1.JobConditionType, status corev1.ConditionStatus, reason, message string, now time.Time) *batchv1.JobCondition {
+	return &batchv1.JobCondition{
+		Type:               conditionType,
+		Status:             status,
+		LastProbeTime:      metav1.NewTime(now),
+		LastTransitionTime: metav1.NewTime(now),
+		Reason:             reason,
+		Message:            message,
+	}
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -136,22 +136,25 @@ func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remot
 	//    (remote admitted -> MultiKueue AdmissionCheck ready -> local admitted -> local unsuspended).
 	// 3. However, to avoid clashing with K8s 1.36 validation rules
 	//    (since https://github.com/kubernetes/kubernetes/pull/135104 until https://github.com/kubernetes/kubernetes/pull/139287)
-	//    we manually patch a "JobSuspended=True" condition to unblock further spec updates.
+	//    we manually patch a "JobSuspended=True" condition and "Active=0" to unblock further spec updates.
+	//    Similarly, to make 1.35 happy, we patch "StartTime = nil".
 	// As long as we're on a K8s version unaffected by #3, we could just do:
 	//   return &localJob.Status
 	newLocalStatus := localJob.Status.DeepCopy()
 	newLocalStatus.Active = 0
 	newLocalStatus.StartTime = nil
-	newLocalStatus.Conditions = setJobStatusCondition(newLocalStatus.Conditions,
-		batchv1.JobCondition{
-			Type:               batchv1.JobSuspended,
-			Status:             corev1.ConditionTrue,
-			Reason:             "MultiKueueAdapter",
-			Message:            "Set by MultiKueue adapter",
-			LastTransitionTime: metav1.Now(),
-			LastProbeTime:      metav1.Now(),
-		})
-	log.V(2).Info("Updating the suspended local Job with JobSuspended=True condition")
+	if !isJobStatusConditionTrue(localJob.Status.Conditions, batchv1.JobSuspended) {
+		newLocalStatus.Conditions = setJobStatusCondition(newLocalStatus.Conditions,
+			batchv1.JobCondition{
+				Type:               batchv1.JobSuspended,
+				Status:             corev1.ConditionTrue,
+				Reason:             "MultiKueueAdapter",
+				Message:            "Set by MultiKueue adapter",
+				LastTransitionTime: metav1.Now(),
+				LastProbeTime:      metav1.Now(),
+			})
+	}
+	log.V(2).Info("Updating the suspended local Job to comply with Kubernetes validation rules", "oldStatus", localJob.Status, "newStatus", newLocalStatus)
 	return newLocalStatus
 }
 
@@ -164,6 +167,15 @@ func setJobStatusCondition(list []batchv1.JobCondition, condition batchv1.JobCon
 	}
 	list = append(list, condition)
 	return list
+}
+
+func isJobStatusConditionTrue(conditions []batchv1.JobCondition, condType batchv1.JobConditionType) bool {
+	for _, c := range conditions {
+		if c.Type == condType {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -64,16 +65,14 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 
 	// the remote job exists
 	if err == nil {
-		if statusUpdate := determineStatusUpdate(log, &localJob, &remoteJob); statusUpdate != nil {
-			localJob.Status = *statusUpdate
-			return nil
-		}
-
-		if err := clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
-			localJob.Status = remoteJob.Status
-			return true, nil
-		}); err != nil {
-			return err
+		statusUpdate := determineStatusUpdate(ctx, log, &localJob, &remoteJob)
+		if !equality.Semantic.DeepEqual(localJob.Status, *statusUpdate) {
+			if err := clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
+				localJob.Status = *statusUpdate
+				return true, nil
+			}); err != nil {
+				return err
+			}
 		}
 
 		// Sync elastic workload if needed.
@@ -104,7 +103,7 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	return remoteClient.Create(ctx, &remoteJob)
 }
 
-func determineStatusUpdate(log logr.Logger, localJob, remoteJob *batchv1.Job) *batchv1.JobStatus {
+func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remoteJob *batchv1.Job) *batchv1.JobStatus {
 	localJobInfo := fromObject(localJob)
 
 	log.V(2).Info("Checking shouldSkipSyncForSuspendedLocalJob", "localJob", localJob, "remoteJob", remoteJob)
@@ -121,25 +120,22 @@ func determineStatusUpdate(log logr.Logger, localJob, remoteJob *batchv1.Job) *b
 		log.V(3).Info("Peforming the sync as the local and the remote Job are suspended")
 		return &remoteJob.Status
 	}
-	if localJob.Status.StartTime == nil {
-		newLocalStatus := localJob.Status.DeepCopy()
-		newLocalStatus.Active = 0
-		newConditions, _ := ensureJobConditionStatus(newLocalStatus.Conditions,
-			batchv1.JobSuspended,
-			corev1.ConditionTrue,
-			"MultiKueueAdapted",
-			"Set by MultiKueue adapted",
-			time.Now())
-		log.V(2).Info("Updating the localJob suspended Job without startTime to set the JobSuspended=True condition")
-		newLocalStatus.Conditions = newConditions
-		return newLocalStatus
+	if _, _, finished := remoteJobInfo.Finished(ctx); finished {
+		log.V(2).Info("Remote job is finished, returning the remote job status")
+		return &remoteJob.Status
 	}
-
-	// We skip the sync when the localJob has suspend=true, and the remote job is suspend=false
-	// to prevent the race condition when the local Job is updated to suspend=false prematurely
-	// so that the injection of nodeSlectors does not work; see: https://github.com/kubernetes-sigs/kueue/pull/3685
-	log.V(2).Info("Skipping the sync when the localJob has suspend=true, and the remote job is suspend=false")
-	return nil
+	newLocalStatus := localJob.Status.DeepCopy()
+	newLocalStatus.Active = 0
+	newLocalStatus.StartTime = nil
+	newConditions, _ := ensureJobConditionStatus(newLocalStatus.Conditions,
+		batchv1.JobSuspended,
+		corev1.ConditionTrue,
+		"MultiKueueAdapter",
+		"Set by MultiKueue adapter",
+		time.Now())
+	log.V(2).Info("Updating the localJob suspended Job to set the JobSuspended=True condition")
+	newLocalStatus.Conditions = newConditions
+	return newLocalStatus
 }
 
 // ensureJobConditionStatus appends or updates an existing job condition of the

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
@@ -127,56 +126,28 @@ func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remot
 	newLocalStatus := localJob.Status.DeepCopy()
 	newLocalStatus.Active = 0
 	newLocalStatus.StartTime = nil
-	newConditions, _ := ensureJobConditionStatus(newLocalStatus.Conditions,
-		batchv1.JobSuspended,
-		corev1.ConditionTrue,
-		"MultiKueueAdapter",
-		"Set by MultiKueue adapter",
-		time.Now())
+	newLocalStatus.Conditions = setJobStatusCondition(newLocalStatus.Conditions,
+		batchv1.JobCondition{
+			Type:   batchv1.JobSuspended,
+			Status: corev1.ConditionTrue,
+			Reason: "MultiKueueAdapter",
+			Message: "Set by MultiKueue adapter",
+			LastTransitionTime: metav1.Now(),
+			LastProbeTime: metav1.Now(),
+		})
 	log.V(2).Info("Updating the localJob suspended Job to set the JobSuspended=True condition")
-	newLocalStatus.Conditions = newConditions
 	return newLocalStatus
 }
 
-// ensureJobConditionStatus appends or updates an existing job condition of the
-// given type with the given status value. Note that this function will not
-// append to the conditions list if the new condition's status is false
-// (because going from nothing to false is meaningless); it can, however,
-// update the status condition to false. The function returns a bool to let the
-// caller know if the list was changed (either appended or updated).
-func ensureJobConditionStatus(list []batchv1.JobCondition, cType batchv1.JobConditionType, status corev1.ConditionStatus, reason, message string, now time.Time) ([]batchv1.JobCondition, bool) {
-	if condition := findConditionByType(list, cType); condition != nil {
-		if condition.Status != status {
-			*condition = *newCondition(cType, status, reason, message, now)
-			return list, true
-		}
-		return list, false
-	}
-	// A condition with that type doesn't exist in the list.
-	if status != corev1.ConditionFalse {
-		return append(list, *newCondition(cType, status, reason, message, now)), true
-	}
-	return list, false
-}
-
-func findConditionByType(list []batchv1.JobCondition, cType batchv1.JobConditionType) *batchv1.JobCondition {
+func setJobStatusCondition(list []batchv1.JobCondition, condition batchv1.JobCondition) []batchv1.JobCondition {
 	for i := range list {
-		if list[i].Type == cType {
-			return &list[i]
+		if list[i].Type == condition.Type {
+			list[i] = condition
+			return list
 		}
 	}
-	return nil
-}
-
-func newCondition(conditionType batchv1.JobConditionType, status corev1.ConditionStatus, reason, message string, now time.Time) *batchv1.JobCondition {
-	return &batchv1.JobCondition{
-		Type:               conditionType,
-		Status:             status,
-		LastProbeTime:      metav1.NewTime(now),
-		LastTransitionTime: metav1.NewTime(now),
-		Reason:             reason,
-		Message:            message,
-	}
+	list = append(list, condition)
+	return list
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -107,22 +107,38 @@ func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remot
 
 	log.V(3).Info("Determining status update for a MultiKueue Job", "localJob", localJob, "remoteJob", remoteJob)
 	if !localJobInfo.IsSuspended() {
-		// do not skip any syncs if the local Job is unsuspnded
+		// Sync status if the local Job is unsuspended.
+		// This is safe as the local Job has already reached its final spec.
+		// We expect no validation errors from further spec changes.
 		log.V(3).Info("Performing the sync as the local Job is unsuspended")
 		return &remoteJob.Status
 	}
 	remoteJobInfo := fromObject(remoteJob)
 	if remoteJobInfo.IsSuspended() {
-		// Do not skip any syncs if the remote Job is also suspended
+		// Sync status if both local and remote Job are suspended.
 		// This is needed to await for updating the status.active field
 		// when the remote Job is evicted; see: https://github.com/kubernetes-sigs/kueue/pull/8151
 		log.V(3).Info("Peforming the sync as the local and the remote Job are both suspended")
 		return &remoteJob.Status
 	}
 	if _, _, finished := remoteJobInfo.Finished(ctx); finished {
+		// Sync status if the remote Job is finished.
+		// Without this, the local Job could get stuck in the suspended state.
 		log.V(2).Info("Performing the sync as the remote Job is finished")
 		return &remoteJob.Status
 	}
+
+	// Remaining case: local Job is suspended, remote Job is unsuspended but not finished.
+	// In this case:
+	// 1. We essentially want *no sync* (to avoid prematurely setting non-zero .status.startTime
+	//    which could block further spec updates; see: https://github.com/kubernetes-sigs/kueue/pull/3685).
+	// 2. We rely on the MultiKueue admission lifecycle to eventually bring localJob to unsuspended state
+	//    (remote admitted -> MultiKueue AdmissionCheck ready -> local admitted -> local unsuspended).
+	// 3. However, to avoid clashing with K8s 1.36 validation rules
+	//    (since https://github.com/kubernetes/kubernetes/pull/135104 until https://github.com/kubernetes/kubernetes/pull/139287)
+	//    we manually patch a "JobSuspended=True" condition to unblock further spec updates.
+	// As long as we're on a K8s version unaffected by #3, we could just do:
+	//   return &localJob.Status
 	newLocalStatus := localJob.Status.DeepCopy()
 	newLocalStatus.Active = 0
 	newLocalStatus.StartTime = nil

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -128,12 +128,12 @@ func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remot
 	newLocalStatus.StartTime = nil
 	newLocalStatus.Conditions = setJobStatusCondition(newLocalStatus.Conditions,
 		batchv1.JobCondition{
-			Type:   batchv1.JobSuspended,
-			Status: corev1.ConditionTrue,
-			Reason: "MultiKueueAdapter",
-			Message: "Set by MultiKueue adapter",
+			Type:               batchv1.JobSuspended,
+			Status:             corev1.ConditionTrue,
+			Reason:             "MultiKueueAdapter",
+			Message:            "Set by MultiKueue adapter",
 			LastTransitionTime: metav1.Now(),
-			LastProbeTime: metav1.Now(),
+			LastProbeTime:      metav1.Now(),
 		})
 	log.V(2).Info("Updating the localJob suspended Job to set the JobSuspended=True condition")
 	return newLocalStatus

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/api"
@@ -64,14 +65,32 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 
 	// the remote job exists
 	if err == nil {
-		statusUpdate := determineStatusUpdate(ctx, log, &localJob, &remoteJob)
-		if !equality.Semantic.DeepEqual(localJob.Status, *statusUpdate) {
-			if err := clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
-				localJob.Status = *statusUpdate
-				return true, nil
-			}); err != nil {
-				return err
+		if features.Enabled(features.MultiKueueBatchJobWithManagedBy) {
+			// Elastic workload sync takes precedence over status updates.
+			if needElasticJobSync(log, workloadName, &localJob, &remoteJob) {
+				if err := syncElasticJob(ctx, remoteClient, log, workloadName, &localJob, &remoteJob); err != nil {
+					return err
+				}
 			}
+
+			statusUpdate := determineStatusUpdate(ctx, log, &localJob, &remoteJob)
+			if !equality.Semantic.DeepEqual(localJob.Status, *statusUpdate) {
+				if err := clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
+					localJob.Status = *statusUpdate
+					return true, nil
+				}); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		}
+
+		if _, _, remoteFinished := fromObject(&remoteJob).Finished(ctx); remoteFinished {
+			return clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
+				localJob.Status = remoteJob.Status
+				return true, nil
+			})
 		}
 
 		// Sync elastic workload if needed.
@@ -93,11 +112,17 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	// drop the templates cleanup labels
 	cleanLabels(&remoteJob.Spec.Template)
 
-	// Add prebuilt workload name and multikueue origin
-	jobframework.SetMultiKueueMeta(&remoteJob, workloadName, origin)
+	// add the prebuilt workload
+	if remoteJob.Labels == nil {
+		remoteJob.Labels = map[string]string{}
+	}
+	remoteJob.Labels[constants.PrebuiltWorkloadLabel] = workloadName
+	remoteJob.Labels[kueue.MultiKueueOriginLabel] = origin
 
-	// clear the managedBy enables the batch/Job controller to take over
-	remoteJob.Spec.ManagedBy = nil
+	if features.Enabled(features.MultiKueueBatchJobWithManagedBy) {
+		// clear the managedBy enables the batch/Job controller to take over
+		remoteJob.Spec.ManagedBy = nil
+	}
 
 	return remoteClient.Create(ctx, &remoteJob)
 }
@@ -177,7 +202,7 @@ func isJobStatusConditionTrue(conditions []batchv1.JobCondition, condType batchv
 	return false
 }
 
-func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {
+func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, remoteClient client.Client, key types.NamespacedName) error {
 	job := batchv1.Job{}
 	job.SetName(key.Name)
 	job.SetNamespace(key.Namespace)
@@ -185,6 +210,10 @@ func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Cli
 }
 
 func (b *multiKueueAdapter) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName) (bool, string, error) {
+	if !features.Enabled(features.MultiKueueBatchJobWithManagedBy) {
+		return true, "", nil
+	}
+
 	job := batchv1.Job{}
 	err := c.Get(ctx, key, &job)
 	if err != nil {
@@ -207,18 +236,18 @@ func (*multiKueueAdapter) GetEmptyList() client.ObjectList {
 	return &batchv1.JobList{}
 }
 
-func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedName, error) {
+func (*multiKueueAdapter) WorkloadKeyFor(o runtime.Object) (types.NamespacedName, error) {
 	job, isJob := o.(*batchv1.Job)
 	if !isJob {
-		return nil, errors.New("not a job")
+		return types.NamespacedName{}, errors.New("not a job")
 	}
 
-	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(job)
-	if prebuiltWorkload == "" {
-		return nil, fmt.Errorf("no prebuilt workload found for job: %s", klog.KObj(job))
+	prebuiltWl, hasPrebuiltWorkload := job.Labels[constants.PrebuiltWorkloadLabel]
+	if !hasPrebuiltWorkload {
+		return types.NamespacedName{}, fmt.Errorf("no prebuilt workload found for job: %s", klog.KObj(job))
 	}
 
-	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: job.Namespace}}, nil
+	return types.NamespacedName{Name: prebuiltWl, Namespace: job.Namespace}, nil
 }
 
 // needElasticJobSync determines if a remote Job requires synchronization due to elastic job features.
@@ -251,8 +280,7 @@ func needElasticJobSync(log logr.Logger, workloadName string, localJob, remoteJo
 			"newWorkloadName", newWorkloadName)
 		return false
 	}
-
-	return oldParallelism != newParallelism || remoteJob.Labels == nil || jobframework.PrebuiltWorkloadNameFor(remoteJob) != workloadName
+	return oldParallelism != newParallelism || remoteJob.Labels == nil || remoteJob.Labels[constants.PrebuiltWorkloadLabel] != workloadName
 }
 
 // syncElasticJob updates the remote job's workload label and parallelism to match the local job configuration.
@@ -266,17 +294,21 @@ func syncElasticJob(ctx context.Context, remoteClient client.Client, log logr.Lo
 
 	// Update a remote job's workload slice name and parallelism if needed.
 	if err := clientutil.Patch(ctx, remoteClient, remoteJob, func() (bool, error) {
-		// Update parallelism.
-		remoteJob.Spec.Parallelism = localJob.Spec.Parallelism
-		changed := oldParallelism != newParallelism
-
-		// Update the workload name value.
-		if cur := jobframework.PrebuiltWorkloadNameFor(remoteJob); cur == "" || cur != workloadName {
-			jobframework.SetPrebuiltWorkloadName(remoteJob, workloadName)
-			changed = true
+		// Update the workload name label.
+		labelsChanged := false
+		if remoteJob.Labels == nil {
+			remoteJob.Labels = map[string]string{constants.PrebuiltWorkloadLabel: workloadName}
+			labelsChanged = true
+		} else {
+			if cur, ok := remoteJob.Labels[constants.PrebuiltWorkloadLabel]; !ok || cur != workloadName {
+				remoteJob.Labels[constants.PrebuiltWorkloadLabel] = workloadName
+				labelsChanged = true
+			}
 		}
 
-		return changed, nil
+		// Update parallelism.
+		remoteJob.Spec.Parallelism = localJob.Spec.Parallelism
+		return oldParallelism != newParallelism || labelsChanged, nil
 	}); err != nil {
 		return fmt.Errorf("failed to patch remote job: %w", err)
 	}

--- a/pkg/controller/jobs/job/job_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
@@ -111,7 +112,12 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
+<<<<<<< HEAD
 		"skip to sync intermediate status from remote suspended job": {
+=======
+		"sync intermediate status from remote suspended job": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+>>>>>>> Catch finished jobs
 			managersJobs: []batchv1.Job{
 				*baseJobManagedByKueueBuilder.Clone().
 					Suspend(true).
@@ -131,6 +137,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			wantManagersJobs: []batchv1.Job{
 				*baseJobManagedByKueueBuilder.Clone().
 					Suspend(true).
+					Active(2).
 					Obj(),
 			},
 			wantWorkerJobs: []batchv1.Job{
@@ -439,7 +446,10 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 				key: client.ObjectKeyFromObject(newJob().Obj()),
 			},
 			want: want{
-				localJob: newJob().Obj(),
+				localJob: newJob().
+					ResourceVersion("2").
+					Condition(runningJobCondition).
+					Obj(),
 				remoteJob: newJob().
 					Condition(runningJobCondition).
 					Obj(),
@@ -476,7 +486,10 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 				key: client.ObjectKeyFromObject(newJob().Obj()),
 			},
 			want: want{
-				localJob: newJob().Obj(),
+				localJob: newJob().
+					ResourceVersion("2").
+					Condition(runningJobCondition).
+					Obj(),
 				remoteJob: newJob().
 					Condition(runningJobCondition).
 					Obj(),
@@ -698,8 +711,9 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 					Condition(runningJobCondition).
 					Obj(),
 				remoteJob: newJob().
-					ResourceVersion("1").
+					ResourceVersion("2").
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					SetAnnotation(constants.PrebuiltWorkloadAnnotation, "test-workload-new").
 					Condition(runningJobCondition).
 					Obj(),
 			},
@@ -762,10 +776,11 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 					Condition(runningJobCondition).
 					Obj(),
 				remoteJob: newJob().
-					ResourceVersion("1").
+					ResourceVersion("2").
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 					PrebuiltWorkloadLabel("test-workload").
-					Parallelism(1).
+					SetAnnotation(constants.PrebuiltWorkloadAnnotation, "job-test-f53b2").
+					Parallelism(22).
 					Condition(runningJobCondition).
 					Obj(),
 			},
@@ -831,6 +846,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 				workloadName: jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration("test", "", gvk, 0),
 			},
 			want: want{
+				err: true,
 				localJob: newJob().
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 					Parallelism(22).

--- a/pkg/controller/jobs/job/job_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter_test.go
@@ -35,7 +35,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
@@ -112,12 +111,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
-<<<<<<< HEAD
-		"skip to sync intermediate status from remote suspended job": {
-=======
 		"sync intermediate status from remote suspended job": {
-			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
->>>>>>> Catch finished jobs
 			managersJobs: []batchv1.Job{
 				*baseJobManagedByKueueBuilder.Clone().
 					Suspend(true).
@@ -713,7 +707,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 				remoteJob: newJob().
 					ResourceVersion("2").
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					SetAnnotation(constants.PrebuiltWorkloadAnnotation, "test-workload-new").
+					PrebuiltWorkloadLabel("test-workload-new").
 					Condition(runningJobCondition).
 					Obj(),
 			},
@@ -778,8 +772,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 				remoteJob: newJob().
 					ResourceVersion("2").
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					PrebuiltWorkloadLabel("test-workload").
-					SetAnnotation(constants.PrebuiltWorkloadAnnotation, "job-test-f53b2").
+					PrebuiltWorkloadLabel("job-test-f53b2").
 					Parallelism(22).
 					Condition(runningJobCondition).
 					Obj(),

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -1255,20 +1255,27 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
+			lowPrioJob := &batchv1.Job{}
 			ginkgo.By("Checking that the low-priority job is not active", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
-					admittedJob := &batchv1.Job{}
-					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(lowJob), admittedJob)).To(gomega.Succeed())
-					g.Expect(admittedJob.Status.Active).To(gomega.Equal(int32(0)))
+					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(lowJob), lowPrioJob)).To(gomega.Succeed())
+					g.Expect(lowPrioJob.Status.Active).To(gomega.Equal(int32(0)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			ginkgo.By("Checking that the high-priority job is active", func() {
+			ginkgo.By("Checking that the high-priority workload was admitted", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
-					admittedJob := &batchv1.Job{}
+					g.Expect(k8sWorker2Client.Get(ctx, highWlKey, workerHighWorkload)).To(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(workerHighWorkload)).To(gomega.BeTrue())
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("high-priority is not admitted", workerHighWorkload))
+			})
+
+			ginkgo.By("Checking that the high-priority job is active", func() {
+				admittedJob := &batchv1.Job{}
+				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(highJob), admittedJob)).To(gomega.Succeed())
 					g.Expect(admittedJob.Status.Active).To(gomega.Equal(int32(1)))
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("Job high-priority is not active", admittedJob, lowPrioJob))
 			})
 
 			ginkgo.By("Checking that the low-priority workload is dispatched again after backoff", func() {

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -1255,27 +1255,20 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			lowPrioJob := &batchv1.Job{}
 			ginkgo.By("Checking that the low-priority job is not active", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(lowJob), lowPrioJob)).To(gomega.Succeed())
-					g.Expect(lowPrioJob.Status.Active).To(gomega.Equal(int32(0)))
+					admittedJob := &batchv1.Job{}
+					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(lowJob), admittedJob)).To(gomega.Succeed())
+					g.Expect(admittedJob.Status.Active).To(gomega.Equal(int32(0)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			ginkgo.By("Checking that the high-priority workload was admitted", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sWorker2Client.Get(ctx, highWlKey, workerHighWorkload)).To(gomega.Succeed())
-					g.Expect(workload.IsAdmitted(workerHighWorkload)).To(gomega.BeTrue())
-				}, util.LongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("high-priority is not admitted", workerHighWorkload))
-			})
-
 			ginkgo.By("Checking that the high-priority job is active", func() {
-				admittedJob := &batchv1.Job{}
 				gomega.Eventually(func(g gomega.Gomega) {
+					admittedJob := &batchv1.Job{}
 					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(highJob), admittedJob)).To(gomega.Succeed())
 					g.Expect(admittedJob.Status.Active).To(gomega.Equal(int32(1)))
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("Job high-priority is not active", admittedJob, lowPrioJob))
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Checking that the low-priority workload is dispatched again after backoff", func() {


### PR DESCRIPTION
Cherry pick of #11649 on release-0.16.

#11649: [v2] Fix MultiKueue to work on 1.36

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### Warning

This cherrypick is far from automated.
(I started from `hack/cherry_pick_pull.sh` - but needed multiple conflict resolutions & follow-up interventions).

#### What type of PR is this?
/kind bug


```release-note
MultiKueue: Fixed admission for Kubernetes Jobs on Kubernetes 1.36 clusters by ensuring all Job status updates comply with the updated Kubernetes Job validation rules. See kubernetes/kubernetes#139281 for more details.
```