### PR TITLE
[release-0.17] fix: PodsReady and Stop for SparkApplication framework

### DIFF
--- a/pkg/controller/jobs/sparkapplication/sparkapplication_controller.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_controller.go
@@ -299,7 +299,26 @@ func (j *SparkApplication) Finished(ctx context.Context) (message string, succes
 }
 
 func (j *SparkApplication) PodsReady(ctx context.Context) bool {
-	return j.Status.AppState.State == sparkv1beta2.ApplicationStateRunning
+	// Driver must be running.
+	if j.Status.AppState.State != sparkv1beta2.ApplicationStateRunning {
+		return false
+	}
+	// And every requested executor must have reported a Running/Completed state.
+	// AppState.State alone goes to Running as soon as the driver starts even if
+	// executors are stuck (e.g. unschedulable), which would let the
+	// waitForPodsReady timeout never fire on heterogeneous resource shortages.
+	expected := int(ptr.Deref(j.Spec.Executor.Instances, 0))
+	if expected == 0 {
+		return true
+	}
+	ready := 0
+	for _, st := range j.Status.ExecutorState {
+		switch st {
+		case sparkv1beta2.ExecutorStateRunning, sparkv1beta2.ExecutorStateCompleted:
+			ready++
+		}
+	}
+	return ready >= expected
 }
 
 func SetupIndexes(ctx context.Context, indexer client.FieldIndexer) error {

--- a/pkg/controller/jobs/sparkapplication/sparkapplication_controller_test.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_controller_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package sparkapplication
 
 import (
+	"fmt"
 	"maps"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -28,12 +30,17 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/featuregate"
+	testingclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/podset"
@@ -49,6 +56,7 @@ var (
 	}
 	workloadCmpOpts = cmp.Options{
 		cmpopts.EquateEmpty(),
+		cmpopts.SortSlices(func(a, b metav1.Condition) bool { return a.Type < b.Type }),
 		cmpopts.IgnoreFields(kueue.Workload{}, "TypeMeta"),
 		cmpopts.IgnoreFields(metav1.ObjectMeta{}, "Name", "Labels", "ResourceVersion", "OwnerReferences", "Finalizers"),
 		cmpopts.IgnoreFields(kueue.WorkloadSpec{}, "Priority"),
@@ -544,12 +552,73 @@ func TestRestorePodSetsInfo(t *testing.T) {
 }
 
 func TestReconciler(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+
 	testNamespace := utiltesting.MakeNamespaceWrapper("ns").Label(corev1.LabelMetadataName, "ns").Obj()
+	const testSparkAppUID types.UID = "test-sparkapp-uid"
 	testSparkApp := sparkapplicationtesting.MakeSparkApplication("test-sparkapp", testNamespace.Name)
+
+	// Helpers for the PodsReady cases: build a SparkApplication whose status
+	// simulates "driver Running and N executors in the given state". The
+	// framework calls PodsReady() during Reconcile and we assert the resulting
+	// Workload condition.
+	withUID := func(s *sparkappv1beta2.SparkApplication) *sparkappv1beta2.SparkApplication {
+		s.UID = testSparkAppUID
+		return s
+	}
+	withExecutorsRunning := func(s *sparkappv1beta2.SparkApplication, n int32) *sparkappv1beta2.SparkApplication {
+		s.Spec.Executor.Instances = ptr.To(n)
+		s.Status.AppState.State = sparkappv1beta2.ApplicationStateRunning
+		states := make(map[string]sparkappv1beta2.ExecutorState, n)
+		for i := int32(1); i <= n; i++ {
+			states[fmt.Sprintf("%s-exec-%d", s.Name, i)] = sparkappv1beta2.ExecutorStateRunning
+		}
+		s.Status.ExecutorState = states
+		return s
+	}
+	withDriverRunningOnly := func(s *sparkappv1beta2.SparkApplication, expected int32) *sparkappv1beta2.SparkApplication {
+		s.Spec.Executor.Instances = ptr.To(expected)
+		s.Status.AppState.State = sparkappv1beta2.ApplicationStateRunning
+		// No ExecutorState entries — simulates the Spark Operator state where
+		// AppState flips to Running as soon as the driver starts even though
+		// executors haven't reported ready yet (the bug this fix addresses).
+		return s
+	}
+
+	// Build a workload whose PodSets are derived from the same SparkApplication
+	// the framework will Reconcile, so EquivalentToWorkload returns true and
+	// the workload is treated as "matching" rather than recreated.
+	makeAdmittedWorkload := func(s *sparkappv1beta2.SparkApplication) *utiltestingapi.WorkloadWrapper {
+		t.Helper()
+		podSets, err := (*SparkApplication)(s).PodSets(t.Context())
+		if err != nil {
+			t.Fatalf("PodSets returned error during test setup: %v", err)
+		}
+		psas := make([]kueue.PodSetAssignment, 0, len(podSets))
+		for i := range podSets {
+			psas = append(psas, utiltestingapi.MakePodSetAssignment(podSets[i].Name).Count(podSets[i].Count).Obj())
+		}
+		return utiltestingapi.MakeWorkload("wl", testNamespace.Name).
+			Finalizers(kueue.ResourceInUseFinalizerName).
+			ControllerReference(gvk, s.Name, string(s.UID)).
+			PodSets(podSets...).
+			ReserveQuotaAt(
+				utiltestingapi.MakeAdmission("cq").PodSets(psas...).Obj(),
+				now,
+			).
+			AdmittedAt(true, now)
+	}
+
+	baseWaitForPodsReadyConf := &configapi.WaitForPodsReady{}
+
+	// SparkApp variants used by the PodsReady cases.
+	sparkAppDriverRunningOnly := withDriverRunningOnly(withUID(testSparkApp.DeepCopy()), 2)
+	sparkAppAllExecutorsReady := withExecutorsRunning(withUID(testSparkApp.DeepCopy()), 2)
 
 	cases := map[string]struct {
 		reconcilerOptions []jobframework.Option
 		sparkApp          *sparkappv1beta2.SparkApplication
+		workloads         []kueue.Workload
 		wantWorkloads     []kueue.Workload
 	}{
 		"workload is created with the corresponding podsets": {
@@ -567,20 +636,77 @@ func TestReconciler(t *testing.T) {
 					Obj(),
 			},
 		},
+		"PodsReady stays False/WaitForStart while AppState=Running but no executors reported ready": {
+			reconcilerOptions: []jobframework.Option{
+				jobframework.WithManageJobsWithoutQueueName(true),
+				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
+				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
+			},
+			sparkApp: sparkAppDriverRunningOnly,
+			workloads: []kueue.Workload{
+				*makeAdmittedWorkload(sparkAppDriverRunningOnly).Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*makeAdmittedWorkload(sparkAppDriverRunningOnly).
+					Condition(metav1.Condition{
+						Type:    kueue.WorkloadPodsReady,
+						Status:  metav1.ConditionFalse,
+						Reason:  kueue.WorkloadWaitForStart,
+						Message: "Not all pods are ready or succeeded",
+					}).
+					Obj(),
+			},
+		},
+		"PodsReady becomes True/Started after AppState=Running and all executors reach Running": {
+			reconcilerOptions: []jobframework.Option{
+				jobframework.WithManageJobsWithoutQueueName(true),
+				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
+				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
+			},
+			sparkApp: sparkAppAllExecutorsReady,
+			workloads: []kueue.Workload{
+				*makeAdmittedWorkload(sparkAppAllExecutorsReady).Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*makeAdmittedWorkload(sparkAppAllExecutorsReady).
+					Condition(metav1.Condition{
+						Type:    kueue.WorkloadPodsReady,
+						Status:  metav1.ConditionTrue,
+						Reason:  kueue.WorkloadStarted,
+						Message: "All pods reached readiness and the workload is running",
+					}).
+					Obj(),
+			},
+		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
 
-			clientBuilder := utiltesting.NewClientBuilder(sparkappv1beta2.AddToScheme)
-			kClient := clientBuilder.WithObjects(tc.sparkApp, testNamespace).Build()
+			clientBuilder := utiltesting.NewClientBuilder(sparkappv1beta2.AddToScheme).
+				WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
+			kClient := clientBuilder.
+				WithObjects(tc.sparkApp, testNamespace).
+				WithStatusSubresource(&kueue.Workload{}).
+				Build()
+			// Pre-existing workloads must be created via the client (not WithObjects)
+			// so that the status subresource is initialized correctly.
+			for i := range tc.workloads {
+				if err := kClient.Create(ctx, &tc.workloads[i]); err != nil {
+					t.Fatalf("Could not create pre-existing workload: %v", err)
+				}
+			}
 			indexer := utiltesting.AsIndexer(clientBuilder)
 			if err := SetupIndexes(ctx, indexer); err != nil {
 				t.Fatalf("Could not setup indexes: %v", err)
 			}
-			recorder := record.NewBroadcaster().NewRecorder(kClient.Scheme(), corev1.EventSource{Component: "test"})
-			reconciler, err := NewReconciler(ctx, kClient, indexer, recorder, tc.reconcilerOptions...)
+			recorder := &utiltesting.EventRecorder{}
+			reconciler, err := NewReconciler(ctx, kClient, indexer, recorder,
+				append(tc.reconcilerOptions,
+					jobframework.WithCache(schdcache.New(kClient)),
+					jobframework.WithClock(testingclock.NewFakeClock(now)),
+				)...)
 			if err != nil {
 				t.Errorf("Error creating the reconciler: %v", err)
 			}

--- a/test/integration/singlecluster/controller/jobs/sparkapplication/sparkapplication_test_util.go
+++ b/test/integration/singlecluster/controller/jobs/sparkapplication/sparkapplication_test_util.go
@@ -188,6 +188,7 @@ func waitForPodsReadyEnabledForSparkApplication(ctx context.Context, k8sClient c
 	if podsReadyTestSpec.BeforeAppState != nil {
 		ginkgo.By("Update the SparkApplication status to simulate initial progress")
 		createdSparkApplication.Status.AppState.State = *podsReadyTestSpec.BeforeAppState
+		createdSparkApplication.Status.ExecutorState = executorStatesForAppState(createdSparkApplication, *podsReadyTestSpec.BeforeAppState)
 		gomega.ExpectWithOffset(1, k8sClient.Status().Update(ctx, createdSparkApplication)).Should(gomega.Succeed())
 		gomega.ExpectWithOffset(1, k8sClient.Get(ctx, lookupKey, createdSparkApplication)).Should(gomega.Succeed())
 	}
@@ -207,6 +208,7 @@ func waitForPodsReadyEnabledForSparkApplication(ctx context.Context, k8sClient c
 
 	ginkgo.By("Update the SparkApplication status to simulate progress")
 	createdSparkApplication.Status.AppState.State = podsReadyTestSpec.AppState
+	createdSparkApplication.Status.ExecutorState = executorStatesForAppState(createdSparkApplication, podsReadyTestSpec.AppState)
 	gomega.ExpectWithOffset(1, k8sClient.Status().Update(ctx, createdSparkApplication)).Should(gomega.Succeed())
 	gomega.ExpectWithOffset(1, k8sClient.Get(ctx, lookupKey, createdSparkApplication)).Should(gomega.Succeed())
 
@@ -226,4 +228,24 @@ func waitForPodsReadyEnabledForSparkApplication(ctx context.Context, k8sClient c
 			),
 		)
 	}, util.Timeout, util.Interval).Should(gomega.Succeed())
+}
+
+// executorStatesForAppState mirrors what Spark Operator would publish in
+// Status.ExecutorState given the SparkApplication's AppState. PodsReady
+// requires len(running/completed executors) >= Spec.Executor.Instances, so
+// tests that simulate AppState=Running must also simulate matching executor
+// states; any other AppState clears the map.
+func executorStatesForAppState(sparkApp *sparkv1beta2.SparkApplication, state sparkv1beta2.ApplicationStateType) map[string]sparkv1beta2.ExecutorState {
+	if state != sparkv1beta2.ApplicationStateRunning {
+		return nil
+	}
+	instances := ptr.Deref(sparkApp.Spec.Executor.Instances, 0)
+	if instances <= 0 {
+		return nil
+	}
+	states := make(map[string]sparkv1beta2.ExecutorState, instances)
+	for i := int32(1); i <= instances; i++ {
+		states[fmt.Sprintf("%s-exec-%d", sparkApp.Name, i)] = sparkv1beta2.ExecutorStateRunning
+	}
+	return states
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

  Manual cherry-pick of #11676 for `release-0.17`.

  The automated `/cherrypick release-0.17` failed because the original PR was authored on top of #11310 (`[TrainJob] Remove global state`), which changed the `GenericJob`
  interface signatures by adding a `client.Client` parameter to `PodsReady`, `PodSets`, `RunWithPodSetsInfo`, and `ReclaimablePods`. #11310 is a refactor and was not
  cherry-picked to `release-0.17`, so the patch from #11676 cannot apply cleanly.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11675 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
SparkApplication: Fixed a bug where `PodsReady` returned true based on driver state alone, so workloads
with stuck executors never reached `waitForPodsReady.timeout`.
```
