### PR TITLE
Increase backoffLimit for jobs and fix TAS assignment assertion in hotswap e2e tests

### DIFF
--- a/pkg/util/testingjobs/jobset/wrappers.go
+++ b/pkg/util/testingjobs/jobset/wrappers.go
@@ -239,7 +239,7 @@ func (j *JobSetWrapper) TerminationGracePeriod(seconds int64) *JobSetWrapper {
 // BackoffLimit sets the backoffLimit for all replicated jobs.
 func (j *JobSetWrapper) BackoffLimit(limit int32) *JobSetWrapper {
 	for i := range j.Spec.ReplicatedJobs {
-		j.Spec.ReplicatedJobs[i].Template.Spec.BackoffLimit = ptr.To[int32](limit)
+		j.Spec.ReplicatedJobs[i].Template.Spec.BackoffLimit = new(limit)
 	}
 	return j
 }

--- a/pkg/util/testingjobs/jobset/wrappers.go
+++ b/pkg/util/testingjobs/jobset/wrappers.go
@@ -50,6 +50,7 @@ type ReplicatedJobRequirements struct {
 	Replicas       int32
 	Parallelism    int32
 	Completions    int32
+	BackoffLimit   *int32
 	Labels         map[string]string
 	Annotations    map[string]string
 	PodAnnotations map[string]string
@@ -83,8 +84,12 @@ func (j *JobSetWrapper) ReplicatedJobs(replicatedJobs ...ReplicatedJobRequiremen
 		jt.Spec.Parallelism = new(req.Parallelism)
 		jt.Spec.Completions = new(req.Completions)
 		jt.Spec.Template.Annotations = req.PodAnnotations
-		if len(req.Image) > 0 {
+		if req.BackoffLimit != nil {
+			jt.Spec.BackoffLimit = req.BackoffLimit
+		} else if len(req.Image) > 0 {
 			jt.Spec.BackoffLimit = ptr.To[int32](0)
+		}
+		if len(req.Image) > 0 {
 			spec := &jt.Spec.Template.Spec
 			spec.RestartPolicy = corev1.RestartPolicyNever
 			spec.TerminationGracePeriodSeconds = ptr.To[int64](0)
@@ -227,6 +232,14 @@ func (j *JobSetWrapper) ManagedBy(c string) *JobSetWrapper {
 func (j *JobSetWrapper) TerminationGracePeriod(seconds int64) *JobSetWrapper {
 	for i := range j.Spec.ReplicatedJobs {
 		j.Spec.ReplicatedJobs[i].Template.Spec.Template.Spec.TerminationGracePeriodSeconds = &seconds
+	}
+	return j
+}
+
+// BackoffLimit sets the backoffLimit for all replicated jobs.
+func (j *JobSetWrapper) BackoffLimit(limit int32) *JobSetWrapper {
+	for i := range j.Spec.ReplicatedJobs {
+		j.Spec.ReplicatedJobs[i].Template.Spec.BackoffLimit = ptr.To[int32](limit)
 	}
 	return j
 }

--- a/test/e2e/tas/baseline/hotswap_test.go
+++ b/test/e2e/tas/baseline/hotswap_test.go
@@ -166,7 +166,7 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 					"kind-worker", "kind-worker2", "kind-worker3",
 				})
 			})
-			chosenPod := pods.Items[0]
+			chosenPod := findPodOnNode(pods.Items, "kind-worker")
 			node := &corev1.Node{}
 
 			ginkgo.By(fmt.Sprintf("Simulate failure of node hosting pod %s", chosenPod.Name), func() {
@@ -231,7 +231,7 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 					"kind-worker", "kind-worker2",
 				})
 			})
-			chosenPod := pods.Items[0]
+			chosenPod := findPodOnNode(pods.Items, "kind-worker")
 			node := &corev1.Node{}
 			ginkgo.By(fmt.Sprintf("Simulate failure of node hosting pod %s", chosenPod.Name), func() {
 				gomega.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: chosenPod.Spec.NodeName}, node)).To(gomega.Succeed())
@@ -304,7 +304,7 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 						"kind-worker", "kind-worker2",
 					})
 				})
-				chosenPod := pods.Items[0]
+				chosenPod := findPodOnNode(pods.Items, "kind-worker")
 				node := &corev1.Node{}
 
 				ginkgo.By(fmt.Sprintf("Tainting node hosting pod %s", chosenPod.Name), func() {
@@ -395,7 +395,7 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 						"kind-worker", "kind-worker2", "kind-worker3",
 					})
 				})
-				chosenPod := pods.Items[0]
+				chosenPod := findPodOnNode(pods.Items, "kind-worker")
 				node := &corev1.Node{}
 
 				ginkgo.By(fmt.Sprintf("Tainting node hosting pod %s with NoExecute", chosenPod.Name), func() {
@@ -621,7 +621,7 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 				ginkgo.By("Verify initial topology assignment of the workload", func() {
 					expectWorkloadTopologyAssignment(ctx, k8sClient, wlKey, numPods, initialNodes)
 				})
-				chosenPod := pods.Items[0]
+				chosenPod := findPodOnNode(pods.Items, "kind-worker")
 				node := &corev1.Node{}
 
 				ginkgo.By(fmt.Sprintf("Tainting node hosting pod %s with NoSchedule", chosenPod.Name), func() {
@@ -722,4 +722,16 @@ func findPod(ctx context.Context, k8sClient client.Client, g gomega.Gomega, nsNa
 		}
 	}
 	return nil
+}
+
+func findPodOnNode(pods []corev1.Pod, nodeName string) corev1.Pod {
+	var foundPod corev1.Pod
+	for _, p := range pods {
+		if p.Spec.NodeName == nodeName {
+			foundPod = p
+			break
+		}
+	}
+	gomega.Expect(foundPod).ToNot(gomega.BeZero(), "Failed to find a pod running on node %s", nodeName)
+	return foundPod
 }

--- a/test/e2e/tas/baseline/hotswap_test.go
+++ b/test/e2e/tas/baseline/hotswap_test.go
@@ -159,14 +159,14 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Not all pods are scheduled and running", pods))
 			})
 
-			wlName := pods.Items[0].Annotations[kueue.WorkloadAnnotation]
+			chosenPod := findPodOnNode(pods.Items, "kind-worker")
+			wlName := chosenPod.Annotations[kueue.WorkloadAnnotation]
 			wlKey := client.ObjectKey{Name: wlName, Namespace: ns.Name}
 			ginkgo.By("Verify initial topology assignment of the workload", func() {
 				expectWorkloadTopologyAssignment(ctx, k8sClient, wlKey, 3, []string{
 					"kind-worker", "kind-worker2", "kind-worker3",
 				})
 			})
-			chosenPod := findPodOnNode(pods.Items, "kind-worker")
 			node := &corev1.Node{}
 
 			ginkgo.By(fmt.Sprintf("Simulate failure of node hosting pod %s", chosenPod.Name), func() {
@@ -224,14 +224,14 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Not all pods are scheduled and running", pods))
 			})
 
-			wlName := pods.Items[0].Annotations[kueue.WorkloadAnnotation]
+			chosenPod := findPodOnNode(pods.Items, "kind-worker")
+			wlName := chosenPod.Annotations[kueue.WorkloadAnnotation]
 			wlKey := client.ObjectKey{Name: wlName, Namespace: ns.Name}
 			ginkgo.By("Verify initial topology assignment of the workload", func() {
 				expectWorkloadTopologyAssignment(ctx, k8sClient, wlKey, 2, []string{
 					"kind-worker", "kind-worker2",
 				})
 			})
-			chosenPod := findPodOnNode(pods.Items, "kind-worker")
 			node := &corev1.Node{}
 			ginkgo.By(fmt.Sprintf("Simulate failure of node hosting pod %s", chosenPod.Name), func() {
 				gomega.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: chosenPod.Spec.NodeName}, node)).To(gomega.Succeed())
@@ -297,14 +297,14 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 					}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 				})
 
-				wlName := pods.Items[0].Annotations[kueue.WorkloadAnnotation]
+				chosenPod := findPodOnNode(pods.Items, "kind-worker")
+				wlName := chosenPod.Annotations[kueue.WorkloadAnnotation]
 				wlKey := client.ObjectKey{Name: wlName, Namespace: ns.Name}
 				ginkgo.By("Verify initial topology assignment of the workload", func() {
 					expectWorkloadTopologyAssignment(ctx, k8sClient, wlKey, numPods, []string{
 						"kind-worker", "kind-worker2",
 					})
 				})
-				chosenPod := findPodOnNode(pods.Items, "kind-worker")
 				node := &corev1.Node{}
 
 				ginkgo.By(fmt.Sprintf("Tainting node hosting pod %s", chosenPod.Name), func() {
@@ -388,14 +388,14 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 					}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 				})
 
-				wlName := pods.Items[0].Annotations[kueue.WorkloadAnnotation]
+				chosenPod := findPodOnNode(pods.Items, "kind-worker")
+				wlName := chosenPod.Annotations[kueue.WorkloadAnnotation]
 				wlKey := client.ObjectKey{Name: wlName, Namespace: ns.Name}
 				ginkgo.By("Verify initial topology assignment of the workload", func() {
 					expectWorkloadTopologyAssignment(ctx, k8sClient, wlKey, numPods, []string{
 						"kind-worker", "kind-worker2", "kind-worker3",
 					})
 				})
-				chosenPod := findPodOnNode(pods.Items, "kind-worker")
 				node := &corev1.Node{}
 
 				ginkgo.By(fmt.Sprintf("Tainting node hosting pod %s with NoExecute", chosenPod.Name), func() {
@@ -615,13 +615,13 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 				})
 
-				wlName := pods.Items[0].Annotations[kueue.WorkloadAnnotation]
+				chosenPod := findPodOnNode(pods.Items, "kind-worker")
+				wlName := chosenPod.Annotations[kueue.WorkloadAnnotation]
 				wlKey := client.ObjectKey{Name: wlName, Namespace: ns.Name}
 				initialNodes := []string{"kind-worker", "kind-worker2", "kind-worker3"}
 				ginkgo.By("Verify initial topology assignment of the workload", func() {
 					expectWorkloadTopologyAssignment(ctx, k8sClient, wlKey, numPods, initialNodes)
 				})
-				chosenPod := findPodOnNode(pods.Items, "kind-worker")
 				node := &corev1.Node{}
 
 				ginkgo.By(fmt.Sprintf("Tainting node hosting pod %s with NoSchedule", chosenPod.Name), func() {

--- a/test/e2e/tas/baseline/hotswap_test.go
+++ b/test/e2e/tas/baseline/hotswap_test.go
@@ -268,7 +268,7 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 					PodAnnotation(kueue.PodSetSliceRequiredTopologyAnnotation, utiltesting.DefaultRackTopologyLevel).
 					PodAnnotation(kueue.PodSetSliceSizeAnnotation, "2").
 					CompletionMode(batchv1.IndexedCompletion).
-					BackoffLimit(1).
+					BackoffLimit(3).
 					TerminationGracePeriod(1).
 					Obj()
 
@@ -351,7 +351,7 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 					RequestAndLimit(extraResource, "1").
 					PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, utiltesting.DefaultBlockTopologyLevel).
 					CompletionMode(batchv1.IndexedCompletion).
-					BackoffLimit(1).
+					BackoffLimit(3).
 					Toleration(corev1.Toleration{
 						Key:               "key1",
 						Operator:          corev1.TolerationOpEqual,
@@ -447,7 +447,7 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 					RequestAndLimit(extraResource, "1").
 					PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, utiltesting.DefaultBlockTopologyLevel).
 					CompletionMode(batchv1.IndexedCompletion).
-					BackoffLimit(1).
+					BackoffLimit(3).
 					SchedulingGate(artificialGate).
 					TerminationGracePeriod(1).
 					Obj()
@@ -585,7 +585,7 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered,
 					RequestAndLimit(extraResource, "1").
 					PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, utiltesting.DefaultBlockTopologyLevel).
 					CompletionMode(batchv1.IndexedCompletion).
-					BackoffLimit(1).
+					BackoffLimit(3).
 					TerminationGracePeriod(1).
 					Obj()
 


### PR DESCRIPTION
#### What type of PR is this?
/kind flake
/area tas

#### What this PR does / why we need it:

- Increase `backoffLimit` for jobs in hotswap e2e tests to mitigate the flake https://github.com/kubernetes-sigs/kueue/issues/11617
- Improves assertion of TAS assignment that previously was based on order of pods returned from `List` API call.

The root of the issue is described there - https://github.com/kubernetes-sigs/kueue/pull/11621 - and should be handled there too in the long run.

This PR just allows the tests to run more smoothly.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #11617

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
