### PR TITLE
Drop spec update RBAC from Kueue manager

### DIFF
--- a/charts/kueue/templates/rbac/role.yaml
+++ b/charts/kueue/templates/rbac/role.yaml
@@ -240,15 +240,11 @@ rules:
     resources:
       - admissionchecks
       - clusterqueues
-      - cohorts
-      - localqueues
-      - workloads
+      - resourceflavors
+      - topologies
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
       - update
       - watch
   - apiGroups:
@@ -256,7 +252,6 @@ rules:
     resources:
       - admissionchecks/finalizers
       - clusterqueues/finalizers
-      - localqueues/finalizers
       - resourceflavors/finalizers
       - topologies/finalizers
       - workloads/finalizers
@@ -278,6 +273,8 @@ rules:
   - apiGroups:
       - kueue.x-k8s.io
     resources:
+      - cohorts
+      - localqueues
       - multikueueclusters
       - multikueueconfigs
       - provisioningrequestconfigs
@@ -289,20 +286,13 @@ rules:
   - apiGroups:
       - kueue.x-k8s.io
     resources:
-      - resourceflavors
+      - workloads
     verbs:
+      - create
       - delete
       - get
       - list
-      - update
-      - watch
-  - apiGroups:
-      - kueue.x-k8s.io
-    resources:
-      - topologies
-    verbs:
-      - get
-      - list
+      - patch
       - update
       - watch
   - apiGroups:

--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -221,15 +221,11 @@ rules:
   resources:
   - admissionchecks
   - clusterqueues
-  - cohorts
-  - localqueues
-  - workloads
+  - resourceflavors
+  - topologies
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -237,7 +233,6 @@ rules:
   resources:
   - admissionchecks/finalizers
   - clusterqueues/finalizers
-  - localqueues/finalizers
   - resourceflavors/finalizers
   - topologies/finalizers
   - workloads/finalizers
@@ -259,6 +254,8 @@ rules:
 - apiGroups:
   - kueue.x-k8s.io
   resources:
+  - cohorts
+  - localqueues
   - multikueueclusters
   - multikueueconfigs
   - provisioningrequestconfigs
@@ -270,20 +267,13 @@ rules:
 - apiGroups:
   - kueue.x-k8s.io
   resources:
-  - resourceflavors
+  - workloads
   verbs:
+  - create
   - delete
   - get
   - list
-  - update
-  - watch
-- apiGroups:
-  - kueue.x-k8s.io
-  resources:
-  - topologies
-  verbs:
-  - get
-  - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/pkg/controller/core/admissioncheck_controller.go
+++ b/pkg/controller/core/admissioncheck_controller.go
@@ -81,7 +81,7 @@ func (r *AdmissionCheckReconciler) logger() logr.Logger {
 	return roletracker.WithReplicaRole(ctrl.Log.WithName(r.logName), r.roleTracker)
 }
 
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=admissionchecks,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=admissionchecks,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=admissionchecks/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=admissionchecks/finalizers,verbs=update
 

--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -153,7 +153,7 @@ func (r *ClusterQueueReconciler) logger() logr.Logger {
 
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;watch;update;patch
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=clusterqueues,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=clusterqueues,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=clusterqueues/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=clusterqueues/finalizers,verbs=update
 

--- a/pkg/controller/core/cohort_controller.go
+++ b/pkg/controller/core/cohort_controller.go
@@ -169,7 +169,7 @@ func (r *CohortReconciler) Generic(event.TypedGenericEvent[*kueue.Cohort]) bool 
 	return true
 }
 
-//+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=cohorts,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=cohorts,verbs=get;list;watch
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=cohorts/status,verbs=get;update;patch
 
 func (r *CohortReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -169,9 +169,8 @@ func (r *LocalQueueReconciler) NotifyWorkloadUpdate(oldWl, newWl *kueue.Workload
 }
 
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;watch;update;patch
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=localqueues,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=localqueues,verbs=get;list;watch
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=localqueues/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=localqueues/finalizers,verbs=update
 
 func (r *LocalQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var queueObj kueue.LocalQueue

--- a/pkg/controller/core/resourceflavor_controller.go
+++ b/pkg/controller/core/resourceflavor_controller.go
@@ -80,7 +80,7 @@ func (r *ResourceFlavorReconciler) logger() logr.Logger {
 	return roletracker.WithReplicaRole(ctrl.Log.WithName(r.logName), r.roleTracker)
 }
 
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=resourceflavors,verbs=get;list;watch;update;delete
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=resourceflavors,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=resourceflavors/finalizers,verbs=update
 
 func (r *ResourceFlavorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
 /kind cleanup
 /area tas
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

Reduces Kueue manager RBAC on Kueue API resources to remove unnecessary spec write permissions for configuration resources. Workload broad writes and ClusterQueue update are preserved as explicit exceptions, and finalizer update permissions are kept only for resources whose controllers mutate finalizers.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11270

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Reduced Kueue manager RBAC permissions for several Kueue configuration resources to avoid unnecessary spec write access.
```
