### PR TITLE
fix: retry GitHub release manifest downloads on transient 404

### DIFF
--- a/hack/retry.sh
+++ b/hack/retry.sh
@@ -18,19 +18,21 @@
 # where the captured stdout becomes the variable value.
 #
 # Advanced features:
+#   --exponential:       Double the delay after each failed attempt.
 #   --continue-if "CMD": Evaluates CMD upon failure. If it fails, retries are aborted immediately (fail-fast).
 #   --cleanup "CMD": Evaluates CMD before starting the next retry attempt.
 #
 # Usage:
-#   retry.sh [--attempts N] [--delay SECONDS] [--continue-if "CMD"] [--cleanup "CMD"] -- <command> [args...]
+#   retry.sh [--attempts N] [--delay SECONDS] [--exponential] [--continue-if "CMD"] [--cleanup "CMD"] -- <command> [args...]
 #
-# Defaults: --attempts 4, --delay 5
+# Defaults: --attempts 4, --delay 5 (no exponential backoff)
 # Exit:     0 on first success, 1 if all attempts fail, 2 on usage error.
 
 set -u
 
 attempts=4
 delay=5
+exponential=false
 continue_if=""
 cleanup=""
 
@@ -38,6 +40,7 @@ while [ $# -gt 0 ]; do
     case $1 in
         --attempts)        attempts=$2; shift 2 ;;
         --delay)           delay=$2;    shift 2 ;;
+        --exponential)     exponential=true; shift ;;
         --continue-if)     continue_if=$2; shift 2 ;;
         --cleanup)         cleanup=$2; shift 2 ;;
         --)                shift; break ;;
@@ -57,7 +60,11 @@ for i in $(seq 1 "$attempts"); do
         printf '%s' "$out"
         exit 0
     fi
-    echo "retry [$i/$attempts] failed" 1>&2
+    if [ "$i" -lt "$attempts" ]; then
+        echo "retry [$i/$attempts] failed, retrying in ${delay}s..." 1>&2
+    else
+        echo "retry [$i/$attempts] failed" 1>&2
+    fi
 
     if [ "$i" -lt "$attempts" ]; then
         if [ -n "$continue_if" ]; then
@@ -78,6 +85,9 @@ for i in $(seq 1 "$attempts"); do
         fi
 
         sleep "$delay"
+        if [ "$exponential" = "true" ]; then
+            delay=$((delay * 2))
+        fi
     fi
 done
 exit 1

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -103,6 +103,16 @@ function e2e_docker_pull_if_needed {
     return 1
 }
 
+function e2e_kubectl_apply_url {
+    local url="$1"
+    shift
+    local extra_args=("$@")
+    local manifest
+
+    manifest=$("${ROOT_DIR}/hack/retry.sh" --attempts 7 --delay 2 --exponential -- curl -fsSL "${url}") || return 1
+    echo "${manifest}" | kubectl apply --server-side -f - "${extra_args[@]}"
+}
+
 function e2e_wait_for_operator_in_install {
   local kubeconfig=$1
   local ns=$2
@@ -837,7 +847,7 @@ function install_jobset {
     fi
 
     cluster_kind_load_image "${name}" "${JOBSET_IMAGE}"
-    kubectl apply --kubeconfig="${kubeconfig}" --server-side -f "${JOBSET_MANIFEST}"
+    e2e_kubectl_apply_url "${JOBSET_MANIFEST}" --kubeconfig="${kubeconfig}"
     e2e_wait_for_operator_in_install "${kubeconfig}" "${ns}" "${deployment_name}"
 }
 
@@ -1053,7 +1063,7 @@ function install_lws {
     fi
 
     cluster_kind_load_image "${name}" "${LEADERWORKERSET_IMAGE/#v}"
-    kubectl apply --kubeconfig="${kubeconfig}" --server-side -f "${LEADERWORKERSET_MANIFEST}"
+    e2e_kubectl_apply_url "${LEADERWORKERSET_MANIFEST}" --kubeconfig="${kubeconfig}"
     e2e_wait_for_operator_in_install "${kubeconfig}" "${ns}" "${deployment_name}"
 }
 
@@ -1133,7 +1143,7 @@ function install_cert_manager {
         fi
     fi
 
-    kubectl apply --kubeconfig="${kubeconfig}" --server-side -f "${CERTMANAGER_MANIFEST}"
+    e2e_kubectl_apply_url "${CERTMANAGER_MANIFEST}" --kubeconfig="${kubeconfig}"
     kubectl wait --kubeconfig="${kubeconfig}" deploy/cert-manager -n "${ns}" --for=condition=available --timeout=5m
     kubectl wait --kubeconfig="${kubeconfig}" deploy/cert-manager-webhook -n "${ns}" --for=condition=available --timeout=5m || true
     kubectl wait --kubeconfig="${kubeconfig}" deploy/cert-manager-cainjector -n "${ns}" --for=condition=available --timeout=5m || true
@@ -1171,7 +1181,7 @@ function install_prometheus_operator {
 
     cluster_kind_load_image "${name}" "${PROMETHEUS_OPERATOR_IMAGE}"
     cluster_kind_load_image "${name}" "${PROMETHEUS_CONFIG_RELOADER_IMAGE}"
-    kubectl apply --kubeconfig="${kubeconfig}" --server-side -f "${PROMETHEUS_OPERATOR_BUNDLE}"
+    e2e_kubectl_apply_url "${PROMETHEUS_OPERATOR_BUNDLE}" --kubeconfig="${kubeconfig}"
     kubectl wait deploy/"${deployment_name}" -n "${ns}" \
         --for=condition=available --timeout=5m --kubeconfig="${kubeconfig}"
     kubectl apply --kubeconfig="${kubeconfig}" --server-side \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
`kubectl apply -f <URL>` does not retry on HTTP errors. Based on the prow logs, the failure is a transient 404 when downloading a GitHub release asset — the same URL works fine shortly after.

To fix this, added `e2e_kubectl_apply_url` helper that retries `curl -fsSL` with 7 attempts and exponential backoff using `hack/retry.sh`, then pipes the result into `kubectl apply --server-side -f -`. This matches the retry behavior already in place for image pulls in `e2e_docker_pull_if_needed`.

Also added `--exponential` flag to `hack/retry.sh` to support backoff.

Applied to `PROMETHEUS_OPERATOR_BUNDLE`, `JOBSET_MANIFEST`, `LEADERWORKERSET_MANIFEST`, and `CERTMANAGER_MANIFEST`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11657

#### Special notes for your reviewer:

Successful runs:
```bash
retry [1/7]: curl -fsSL https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.89.0/bundle.yaml
```

Recovered runs:
```bash
retry [1/7]: curl -fsSL https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.89.0/bundle.yaml
curl: (56) The requested URL returned error: 404
retry [1/7] failed, retrying in 2s...
retry [2/7]: curl -fsSL https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.89.0/bundle.yaml
curl: (56) The requested URL returned error: 404
retry [2/7] failed, retrying in 4s...
retry [3/7]: curl -fsSL https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.89.0/bundle.yaml
customresourcedefinition.apiextensions.k8s.io/alertmanagerconfigs.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/podmonitors.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/probes.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/prometheusagents.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/prometheuses.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/prometheusrules.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/scrapeconfigs.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/thanosrulers.monitoring.coreos.com serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/prometheus-operator serverside-applied
clusterrole.rbac.authorization.k8s.io/prometheus-operator serverside-applied
deployment.apps/prometheus-operator serverside-applied
serviceaccount/prometheus-operator serverside-applied
service/prometheus-operator serverside-applied
```

Failed runs:
```bash
retry [1/7]: curl -fsSL https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.89.0/nonexistent.yaml
curl: (56) The requested URL returned error: 404
retry [1/7] failed, retrying in 2s...
retry [2/7]: curl -fsSL https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.89.0/nonexistent.yaml
curl: (56) The requested URL returned error: 404
retry [2/7] failed, retrying in 4s...
...
retry [7/7]: curl -fsSL https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.89.0/nonexistent.yaml
curl: (56) The requested URL returned error: 404
retry [7/7] failed
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
