### PR TITLE
Add retry to build_kind_node_image func in e2e-common.sh

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -57,7 +57,8 @@ function build_kind_node_image {
     fi
 
     echo "Building kind node image: $E2E_KIND_VERSION (K8s v$KIND_VERSION)"
-    $KIND build node-image "v$KIND_VERSION" --image "$E2E_KIND_VERSION"
+    "${ROOT_DIR}/hack/retry.sh" --attempts 3 --delay 5 -- \
+        "$KIND" build node-image "v$KIND_VERSION" --image "$E2E_KIND_VERSION"
 }
 
 function e2e_is_truthy {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Add retry to build_kind_node_image func in e2e-common.sh
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11792 

#### Special notes for your reviewer:
```
$ make test-e2e-certmanager-upgrade E2E_KIND_VERSION=kindest/node:v0.0.0-bogus
...
Building kind node image: kueue/kind-node:v0.0.0-bogus (K8s v0.0.0-bogus)
retry [1/3]:/kueue/hack/testing/../../bin/kind build node-image v0.0.0-bogus --image kueue/kind-node:v0.0.0-bogus
Detected build type: "release"
Building using release "v0.0.0-bogus" artifacts
Starting to build Kubernetes
Downloading "https://dl.k8s.io/v0.0.0-bogus/kubernetes-server-linux-amd64.tar.gz"
Failed to build Kubernetes: error downloading file: error response from "https://dl.k8s.io/v0.0.0-bogus/kubernetes-server-linux-amd64.tar.gz": HTTP 404
ERROR: error building node image: failed to build kubernetes: error downloading file: error response from "https://dl.k8s.io/v0.0.0-bogus/kubernetes-server-linux-amd64.tar.gz": HTTP 404
retry [1/3] failed
retry [2/3]:/kueue/hack/testing/../../bin/kind build node-image v0.0.0-bogus --image kueue/kind-node:v0.0.0-bogus
Detected build type: "release"
Building using release "v0.0.0-bogus" artifacts
Starting to build Kubernetes
Downloading "https://dl.k8s.io/v0.0.0-bogus/kubernetes-server-linux-amd64.tar.gz"
Failed to build Kubernetes: error downloading file: error response from "https://dl.k8s.io/v0.0.0-bogus/kubernetes-server-linux-amd64.tar.gz": HTTP 404
ERROR: error building node image: failed to build kubernetes: error downloading file: error response from "https://dl.k8s.io/v0.0.0-bogus/kubernetes-server-linux-amd64.tar.gz": HTTP 404
retry [2/3] failed
retry [3/3]:/kueue/hack/testing/../../bin/kind build node-image v0.0.0-bogus --image kueue/kind-node:v0.0.0-bogus
Detected build type: "release"
Building using release "v0.0.0-bogus" artifacts
Starting to build Kubernetes
Downloading "https://dl.k8s.io/v0.0.0-bogus/kubernetes-server-linux-amd64.tar.gz"
Failed to build Kubernetes: error downloading file: error response from "https://dl.k8s.io/v0.0.0-bogus/kubernetes-server-linux-amd64.tar.gz": HTTP 404
ERROR: error building node image: failed to build kubernetes: error downloading file: error response from "https://dl.k8s.io/v0.0.0-bogus/kubernetes-server-linux-amd64.tar.gz": HTTP 404
retry [3/3] failed
Skipping artifact collection for 'kind': cluster does not exist.
Deleting cluster "kind" ...
make: *** [Makefile-test.mk:405: run-test-e2e-certmanager-upgrade-0.0.0-bogus] Error 1
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
