### PR TITLE
fix(kueueviz): prevent flashing zero counts on dashboard and fix dependencies

### DIFF
--- a/cmd/kueueviz/frontend/src/Dashboard.jsx
+++ b/cmd/kueueviz/frontend/src/Dashboard.jsx
@@ -66,11 +66,13 @@ const Dashboard = () => {
           toast.error(`Workload ${workload.metadata?.name} was preempted: ${workload.preemption.reason}`);
         }
       });
+      setLoading(false);
     }
-    if (kueueError || namespacesError) setError(kueueError || namespacesError);
-
-    setLoading(false);
-  }, [kueueData, kueueError]);
+    if (kueueError || namespacesError) {
+      setError(kueueError || namespacesError);
+      setLoading(false);
+    }
+  }, [kueueData, kueueError, namespacesError]);
 
   if (error) {
     return <ErrorMessage error={error} />;


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area dashboard

#### What this PR does / why we need it:
In `Dashboard.jsx`, the component unconditionally sets `loading` to `false` at the end of the `useEffect` block, even when `kueueData` is `null` on mount. This causes the UI to immediately transition away from the loading spinner and render the dashboard widgets with `0` values. Once the WebSocket connects and streams the data, the widgets flash to their correct counts.

Additionally, `namespacesError` was used inside the `useEffect` hook but was missing from its dependency array.

This PR:
1. Swaps `setLoading(false)` to only execute when `kueueData` is successfully received, or when an error (`kueueError` or `namespacesError`) is captured.
2. Adds `namespacesError` to the `useEffect` dependency array.

This ensures a clean loading transition with absolutely no zero-value flashes on mount.

#### Which issue(s) this PR fixes:
Fixes #11852

#### Special notes for your reviewer:
None.

#### Does this PR introduce a user-facing change?
Yes

```release-note
KueueViz: Fixed a bug where the dashboard briefly displayed zero counts for all metrics on page load before the WebSocket connection finished loading.
```