### PR TITLE
VisibilityOnDemand: disable MutatingAdmissionPolicy plugin

### DIFF
--- a/pkg/visibility/server.go
+++ b/pkg/visibility/server.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	mutatingadmissionpolicy "k8s.io/apiserver/pkg/admission/plugin/policy/mutating"
 	validatingadmissionpolicy "k8s.io/apiserver/pkg/admission/plugin/policy/validating"
 	"k8s.io/apiserver/pkg/admission/plugin/resourcequota"
 	mutatingwebhook "k8s.io/apiserver/pkg/admission/plugin/webhook/mutating"
@@ -58,6 +59,7 @@ var (
 	// Admission plugins that are enabled by default in the kubeapi server
 	// but are not required for the visibility server.
 	disabledPlugins = []string{
+		mutatingadmissionpolicy.PluginName,
 		validatingadmissionpolicy.PluginName,
 		resourcequota.PluginName,
 		validatingwebhook.PluginName,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This disables the unused MutatingAdmissionPolicy admission plugin for the
visibility server.

With Kubernetes libraries that include MutatingAdmissionPolicy in the
recommended admission plugin order, the visibility server can initialize
informers for MutatingAdmissionPolicy and MutatingAdmissionPolicyBinding.
Kueue does not need these resources for the visibility server, so this can
lead to repeated forbidden list/watch errors in the controller-manager logs.

This change follows the same approach already used for other unused
admission plugins in the visibility server: disable the plugin instead of
granting extra RBAC permissions for resources that are not used.

#### Which issue(s) this PR fixes:

Fixes #11848

#### Special notes for your reviewer:

I reproduced the issue with the following commands:

```shell
kind create cluster --image kindest/node:v1.32.11

helm install kueue oci://registry.k8s.io/kueue/charts/kueue \
  --version=0.18.0 \
  --namespace kueue-system \
  --create-namespace

kubectl logs -n kueue-system deploy/kueue-controller-manager
```

Before this change, the controller-manager logs contained forbidden
list/watch errors for MutatingAdmissionPolicy and
MutatingAdmissionPolicyBinding resources.

I verified the fix on a fresh kind cluster with a locally built image:

```shell
kind delete cluster --name kueue-map-fix || true

kind create cluster \
  --name kueue-map-fix \
  --image kindest/node:v1.32.11

make kind-image-build \
  IMAGE_REPO=localhost/kueue \
  RELEASE_BRANCH=map-fix

kind load docker-image localhost/kueue:map-fix --name kueue-map-fix

helm install kueue ./charts/kueue \
  --namespace kueue-system \
  --create-namespace \
  --set controllerManager.manager.image.repository=localhost/kueue \
  --set controllerManager.manager.image.tag=map-fix \
  --set controllerManager.manager.image.pullPolicy=IfNotPresent

kubectl logs -n kueue-system deploy/kueue-controller-manager
```

#### Does this PR introduce a user-facing change?

```release-note
VisibilityOnDemand: Fixed forbidden list/watch errors caused by unused
MutatingAdmissionPolicy informers in the visibility server.
```
