### PR TITLE
test: increase timeout for fair sharing scheduling test

### DIFF
--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -858,8 +858,16 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cq2, 2)
 
 			ginkgo.By("Expected Total Admitted Workloads and Weighted Share")
-			util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 1)
-			util.ExpectAdmittedWorkloadsTotalMetric(cq2, "", 2)
+
+			// This safely retries for up to 30 seconds without crashing
+			gomega.Eventually(func() {
+				util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 1)
+			}, 3*util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Eventually(func() {
+				util.ExpectAdmittedWorkloadsTotalMetric(cq2, "", 2)
+			}, 3*util.Timeout, util.Interval).Should(gomega.Succeed())
+
 			util.ExpectClusterQueueWeightedShareMetric(cq1, 1000)
 			util.ExpectClusterQueueWeightedShareMetric(cq2, 0.0)
 		})

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -858,7 +858,6 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cq2, 2)
 
 			ginkgo.By("Expected Total Admitted Workloads and Weighted Share")
-
 			util.ExpectAdmittedWorkloadsTotalMetricWithTimeout(cq1, "", 1, util.MediumTimeout)
 			util.ExpectAdmittedWorkloadsTotalMetricWithTimeout(cq2, "", 2, util.MediumTimeout)
 

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -859,14 +859,8 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 
 			ginkgo.By("Expected Total Admitted Workloads and Weighted Share")
 
-			// This safely retries for up to 30 seconds without crashing
-			gomega.Eventually(func() {
-				util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 1)
-			}, 3*util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			gomega.Eventually(func() {
-				util.ExpectAdmittedWorkloadsTotalMetric(cq2, "", 2)
-			}, 3*util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.ExpectAdmittedWorkloadsTotalMetricWithTimeout(cq1, "", 1, util.MediumTimeout)
+			util.ExpectAdmittedWorkloadsTotalMetricWithTimeout(cq2, "", 2, util.MediumTimeout)
 
 			util.ExpectClusterQueueWeightedShareMetric(cq1, 1000)
 			util.ExpectClusterQueueWeightedShareMetric(cq2, 0.0)

--- a/test/util/metrics.go
+++ b/test/util/metrics.go
@@ -109,6 +109,9 @@ func ExpectReservingActiveWorkloadsMetric(cq *kueue.ClusterQueue, value int) {
 	expectGaugeMetric(metrics.ReservingActiveWorkloads, lvs, gomega.Equal(float64(value)))
 }
 
+// ExpectAdmittedWorkloadsTotalMetricWithTimeout asserts that the total number of admitted
+// workloads in a specific ClusterQueue equals the expected value within a custom timeout window.
+// This method provides an explicit configuration override for heavily throttled CI environments.
 func ExpectAdmittedWorkloadsTotalMetricWithTimeout(cq *kueue.ClusterQueue, priorityClass string, v int, timeout time.Duration, customLabels ...string) {
 	ginkgo.GinkgoHelper()
 	expectCounterMetricWithTimeout(metrics.AdmittedWorkloadsTotal, v,
@@ -229,6 +232,9 @@ func ExpectLQFinishedWorkloadsGaugeMetric(lq *kueue.LocalQueue, count int) {
 	expectGaugeMetric(metrics.LocalQueueFinishedWorkloads, lvs, gomega.Equal(float64(count)))
 }
 
+// expectCounterMetricWithTimeout polls a Prometheus counter metric until its value
+// matches the expected count or the custom timeout duration expires. It utilizes
+// gomega.Eventually to gracefully retry assertions without crashing the test harness.
 func expectCounterMetricWithTimeout(metric *prometheus.CounterVec, count int, timeout time.Duration, lvs ...string) {
 	ginkgo.GinkgoHelper()
 	gomega.Eventually(func(g gomega.Gomega) {

--- a/test/util/metrics.go
+++ b/test/util/metrics.go
@@ -17,6 +17,8 @@ limitations under the License.
 package util
 
 import (
+	"time"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
@@ -107,10 +109,14 @@ func ExpectReservingActiveWorkloadsMetric(cq *kueue.ClusterQueue, value int) {
 	expectGaugeMetric(metrics.ReservingActiveWorkloads, lvs, gomega.Equal(float64(value)))
 }
 
-func ExpectAdmittedWorkloadsTotalMetric(cq *kueue.ClusterQueue, priorityClass string, v int, customLabels ...string) {
+func ExpectAdmittedWorkloadsTotalMetricWithTimeout(cq *kueue.ClusterQueue, priorityClass string, v int, timeout time.Duration, customLabels ...string) {
 	ginkgo.GinkgoHelper()
-	expectCounterMetric(metrics.AdmittedWorkloadsTotal, v,
-		append([]string{cq.Name, priorityClass, roletracker.RoleStandalone}, customLabels...)...)
+	expectCounterMetricWithTimeout(metrics.AdmittedWorkloadsTotal, v,
+		timeout, append([]string{cq.Name, priorityClass, roletracker.RoleStandalone}, customLabels...)...)
+}
+
+func ExpectAdmittedWorkloadsTotalMetric(cq *kueue.ClusterQueue, priorityClass string, v int, customLabels ...string) {
+	ExpectAdmittedWorkloadsTotalMetricWithTimeout(cq, priorityClass, v, Timeout, customLabels...)
 }
 
 func ExpectAdmissionWaitTimeMetric(cq *kueue.ClusterQueue, priorityClass string, count int) {
@@ -223,13 +229,17 @@ func ExpectLQFinishedWorkloadsGaugeMetric(lq *kueue.LocalQueue, count int) {
 	expectGaugeMetric(metrics.LocalQueueFinishedWorkloads, lvs, gomega.Equal(float64(count)))
 }
 
-func expectCounterMetric(metric *prometheus.CounterVec, count int, lvs ...string) {
+func expectCounterMetricWithTimeout(metric *prometheus.CounterVec, count int, timeout time.Duration, lvs ...string) {
 	ginkgo.GinkgoHelper()
 	gomega.Eventually(func(g gomega.Gomega) {
 		v, err := testutil.GetCounterMetricValue(metric.WithLabelValues(lvs...))
 		g.Expect(err).ToNot(gomega.HaveOccurred())
 		g.Expect(int(v)).Should(gomega.Equal(count))
-	}, Timeout, Interval).Should(gomega.Succeed())
+	}, timeout, Interval).Should(gomega.Succeed())
+}
+
+func expectCounterMetric(metric *prometheus.CounterVec, count int, lvs ...string) {
+	expectCounterMetricWithTimeout(metric, count, Timeout, lvs...)
 }
 
 func ExpectLQAdmissionWaitTimeMetric(lq *kueue.LocalQueue, priorityClass string, count int) {

--- a/test/util/metrics.go
+++ b/test/util/metrics.go
@@ -119,6 +119,7 @@ func ExpectAdmittedWorkloadsTotalMetricWithTimeout(cq *kueue.ClusterQueue, prior
 }
 
 func ExpectAdmittedWorkloadsTotalMetric(cq *kueue.ClusterQueue, priorityClass string, v int, customLabels ...string) {
+	ginkgo.GinkgoHelper()
 	ExpectAdmittedWorkloadsTotalMetricWithTimeout(cq, priorityClass, v, Timeout, customLabels...)
 }
 
@@ -245,6 +246,7 @@ func expectCounterMetricWithTimeout(metric *prometheus.CounterVec, count int, ti
 }
 
 func expectCounterMetric(metric *prometheus.CounterVec, count int, lvs ...string) {
+	ginkgo.GinkgoHelper()
 	expectCounterMetricWithTimeout(metric, count, Timeout, lvs...)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Fixing the flaky tests by increasing timeout to 30 seconds

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9952

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added configurable timeout support for metrics assertions to improve polling reliability in integration tests.
  * Updated an integration test to use the timeout-enabled assertions, reducing flakiness and improving stability of admitted-workload checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->