### PR TITLE
fix status update for local job

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter.go
+++ b/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter.go
@@ -57,13 +57,13 @@ func NewAdapter(gvk schema.GroupVersionKind) jobframework.MultiKueueAdapter {
 // SyncJob synchronizes a job resource between the local and remote clusters.
 // It ensures that the remote cluster has a corresponding object for the local job,
 // creating it if necessary, and updates the status of the local object based on the remote object.
-func (a *Adapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) error {
+func (a *Adapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) (deferred bool, err error) {
 	// Get the local object
 	localObj := &unstructured.Unstructured{}
 	localObj.SetGroupVersionKind(a.gvk)
-	err := localClient.Get(ctx, key, localObj)
+	err = localClient.Get(ctx, key, localObj)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Check if remote object already exists
@@ -71,16 +71,16 @@ func (a *Adapter) SyncJob(ctx context.Context, localClient client.Client, remote
 	remoteObj.SetGroupVersionKind(a.gvk)
 	err = remoteClient.Get(ctx, key, remoteObj)
 	if err != nil && !apierrors.IsNotFound(err) {
-		return err
+		return false, err
 	}
 
 	if apierrors.IsNotFound(err) {
 		// Create new remote object
-		return a.createRemoteObject(ctx, remoteClient, localObj, workloadName, origin)
+		return false, a.createRemoteObject(ctx, remoteClient, localObj, workloadName, origin)
 	}
 
 	// Update existing remote object status
-	return a.syncStatus(ctx, localClient, localObj, remoteObj)
+	return false, a.syncStatus(ctx, localClient, localObj, remoteObj)
 }
 
 func (a *Adapter) createRemoteObject(ctx context.Context, remoteClient client.Client, localObj *unstructured.Unstructured, workloadName, origin string) error {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -63,6 +63,25 @@ var (
 	singleClusterPreemptionTimeout = 5 * time.Minute
 )
 
+// syncDeferredRequeueAfter is the delay used to re-reconcile a workload after
+// the Job adapter reports a deferred sync: the local Job was still suspended
+// when SyncJob ran, so the remote status.Active was not propagated. The local
+// Job is unsuspended shortly afterwards by the jobframework reconciler, but
+// that transition does not wake this reconciler (we don't watch local Jobs),
+// so without a short requeue the next reconcile could be up to workerLostTimeout
+// away and status.Active would never catch up.
+//
+// Both directions are soft: the requeue loop self-terminates as soon as the
+// local Job is unsuspended, and any value here is bounded above by
+// workerLostTimeout, so neither too-short nor too-long is a correctness
+// problem. 2 s is just a comfortable middle ground: above the sub-second
+// unsuspend latency (so we don't spin), and well below anything a user would
+// notice. See https://github.com/kubernetes-sigs/kueue/issues/11115.
+//
+// This is the canonical explanation of the deferred-sync handling; other sites
+// in this package point here rather than repeating it.
+const syncDeferredRequeueAfter = 2 * time.Second
+
 type wlReconciler struct {
 	client            client.Client
 	helper            *admissioncheck.MultiKueueStoreHelper
@@ -360,7 +379,9 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		// it should not be problematic, but the "From remote xxxx:" could be lost ....
 
 		if group.jobAdapter != nil {
-			if err := group.jobAdapter.SyncJob(ctx, w.client, group.remoteClients[remote].client, group.controllerKey, group.local.Name, w.origin); err != nil {
+			// The deferred flag is irrelevant here: the remote workload is
+			// Finished, so determineStatusUpdate always syncs (never defers).
+			if _, err := group.jobAdapter.SyncJob(ctx, w.client, group.remoteClients[remote].client, group.controllerKey, group.local.Name, w.origin); err != nil {
 				log.V(2).Error(err, "copying remote controller status", "workerCluster", remote)
 				// we should retry this
 				return reconcile.Result{}, err
@@ -384,10 +405,17 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 
 		// workload evicted on manager cluster
 		if workload.IsEvicted(group.local) {
-			if err := group.jobAdapter.SyncJob(ctx, w.client, remoteCl, group.controllerKey, group.local.Name, w.origin); err != nil {
+			deferred, err := group.jobAdapter.SyncJob(ctx, w.client, remoteCl, group.controllerKey, group.local.Name, w.origin)
+			if err != nil {
 				log.Error(err, "Syncing remote controller object")
 				// We'll retry this in the next reconciling.
 				return reconcile.Result{}, err
+			}
+			if deferred {
+				// Eviction re-suspended the local Job; requeue short to retry the
+				// status sync instead of dropping it. See syncDeferredRequeueAfter.
+				log.V(3).Info("Sync deferred until local job is unsuspended; requeuing on short timer")
+				return reconcile.Result{RequeueAfter: syncDeferredRequeueAfter}, nil
 			}
 			return reconcile.Result{}, nil
 		}
@@ -493,7 +521,8 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 			return reconcile.Result{}, err
 		}
 
-		if err := group.jobAdapter.SyncJob(ctx, w.client, remoteCl, group.controllerKey, group.local.Name, w.origin); err != nil {
+		syncDeferred, err := group.jobAdapter.SyncJob(ctx, w.client, remoteCl, group.controllerKey, group.local.Name, w.origin)
+		if err != nil {
 			log.Error(err, "Syncing remote controller object")
 			// We'll retry this in the next reconciling.
 			return reconcile.Result{}, err
@@ -502,7 +531,14 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		if err := w.syncReservingRemoteState(ctx, group, reservingRemote, acs); err != nil {
 			return reconcile.Result{}, err
 		}
-		return reconcile.Result{RequeueAfter: w.workerLostTimeout}, nil
+		requeueAfter := w.workerLostTimeout
+		if syncDeferred {
+			// The local Job is still suspended; requeue short so the next SyncJob
+			// can propagate the remote status. See syncDeferredRequeueAfter.
+			log.V(3).Info("Sync deferred until local job is unsuspended; requeuing on short timer")
+			requeueAfter = syncDeferredRequeueAfter
+		}
+		return reconcile.Result{RequeueAfter: requeueAfter}, nil
 	} else if acs.State == kueue.CheckStateReady {
 		// If there is no reserving and the AC is ready, the connection with the reserving remote might
 		// be lost, keep the workload admitted for keepReadyTimeout and put it back in the queue after that.

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -29,6 +29,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
@@ -2004,5 +2005,109 @@ func TestConfigHandlerDelete(t *testing.T) {
 	}
 	if mockQ.Items[0].Name != "wl1" {
 		t.Errorf("expected workload wl1 to be queued, got %s", mockQ.Items[0].Name)
+	}
+}
+
+type deferredSyncStubAdapter struct {
+	deferred bool
+	syncErr  error
+}
+
+var _ jobframework.MultiKueueAdapter = (*deferredSyncStubAdapter)(nil)
+
+func (s *deferredSyncStubAdapter) SyncJob(_ context.Context, _, _ client.Client, _ types.NamespacedName, _, _ string) (bool, error) {
+	return s.deferred, s.syncErr
+}
+func (s *deferredSyncStubAdapter) DeleteRemoteObject(_ context.Context, _, _ client.Client, _ types.NamespacedName) error {
+	return nil
+}
+func (s *deferredSyncStubAdapter) IsJobManagedByKueue(_ context.Context, _ client.Client, _ types.NamespacedName) (bool, string, error) {
+	return true, "", nil
+}
+func (s *deferredSyncStubAdapter) GVK() schema.GroupVersionKind {
+	return batchv1.SchemeGroupVersion.WithKind("Job")
+}
+
+// TestReconcileGroup_SyncDeferred_ShortRequeue is a regression test for
+// https://github.com/kubernetes-sigs/kueue/issues/11115.
+//
+// When the manager has just admitted a workload and the worker has just
+// admitted its remote copy, the MultiKueue Job adapter's SyncJob may run
+// while the local manager Job is still suspended. In that case SyncJob
+// declines to propagate the remote Job's Status.Active and reports
+// deferred=true. The caller (reconcileGroup step 6) must honor that signal
+// and schedule a short re-reconcile — otherwise the next reconcile is
+// workerLostTimeout away and the manager Job's Status.Active never catches
+// up within any reasonable test or operator observation window.
+func TestReconcileGroup_SyncDeferred_ShortRequeue(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	now := time.Now()
+	fakeClock := testingclock.NewFakeClock(now)
+
+	const (
+		acName     = kueue.AdmissionCheckReference("ac1")
+		workerName = "worker1"
+	)
+
+	// Local manager workload: admitted on worker1, AC=Ready, no Evicted condition.
+	local := utiltestingapi.MakeWorkload("wl1", TestNamespace).
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq1").Obj(), now).
+		AdmittedAt(true, now).
+		AdmissionCheck(kueue.AdmissionCheckState{
+			Name:               acName,
+			State:              kueue.CheckStateReady,
+			LastTransitionTime: metav1.NewTime(now),
+		}).
+		ClusterName(workerName).
+		Obj()
+
+	// Remote workload on worker1: WorkloadAdmitted=True.
+	remote := utiltestingapi.MakeWorkload("wl1", TestNamespace).
+		Condition(metav1.Condition{
+			Type:               kueue.WorkloadAdmitted,
+			Status:             metav1.ConditionTrue,
+			Reason:             "Admitted",
+			LastTransitionTime: metav1.NewTime(now),
+		}).
+		Obj()
+
+	managerBuilder := getClientBuilder(ctx)
+	managerBuilder = managerBuilder.WithObjects(local).WithStatusSubresource(local)
+	managerClient := managerBuilder.Build()
+
+	workerBuilder := getClientBuilder(ctx)
+	workerBuilder = workerBuilder.WithObjects(remote).WithStatusSubresource(remote)
+	workerClient := NewNeverCachingClient(workerBuilder.Build())
+
+	group := &wlGroup{
+		local:       local,
+		localClient: managerClient,
+		remotes:     map[string]*kueue.Workload{workerName: remote},
+		remoteClients: map[string]*remoteClient{
+			workerName: {client: workerClient, origin: defaultOrigin},
+		},
+		acName:        acName,
+		jobAdapter:    &deferredSyncStubAdapter{deferred: true},
+		controllerKey: types.NamespacedName{Name: "job1", Namespace: TestNamespace},
+	}
+
+	reconciler := &wlReconciler{
+		client:            managerClient,
+		clock:             fakeClock,
+		workerLostTimeout: defaultWorkerLostTimeout,
+		recorder:          &utiltesting.EventRecorder{},
+		dispatcherName:    config.MultiKueueDispatcherModeAllAtOnce,
+	}
+
+	gotResult, gotErr := reconciler.reconcileGroup(ctx, group)
+	if gotErr != nil {
+		t.Fatalf("reconcileGroup returned unexpected error: %v", gotErr)
+	}
+
+	// Without the fix the requeue would be workerLostTimeout (5 minutes); with
+	// the deferred sync it must be the short syncDeferredRequeueAfter.
+	if gotResult.RequeueAfter != syncDeferredRequeueAfter {
+		t.Fatalf("reconcileGroup result has RequeueAfter=%v; want %v (sync was deferred)",
+			gotResult.RequeueAfter, syncDeferredRequeueAfter)
 	}
 }

--- a/pkg/controller/jobframework/multikueue.go
+++ b/pkg/controller/jobframework/multikueue.go
@@ -31,7 +31,18 @@ import (
 type MultiKueueAdapter interface {
 	// SyncJob creates the Job object in the worker cluster using remote client, if not already created.
 	// Copy the status from the remote job if already exists.
-	SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) error
+	//
+	// The returned deferred flag reports that the adapter intentionally skipped
+	// propagating the remote Job's status to the local Job (typically because the
+	// local Job is still suspended and a status patch would violate K8s
+	// suspend-validation rules). It is not an error: the caller should requeue the
+	// workload on a short timer so the sync can be retried once the local Job is
+	// unsuspended. Without that requeue the next reconcile may be up to
+	// workerLostTimeout away and the local Job's status.Active will not catch up.
+	// See https://github.com/kubernetes-sigs/kueue/issues/11115; for the design
+	// discussion see
+	// https://github.com/kubernetes-sigs/kueue/pull/11730#issuecomment-4566063844.
+	SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) (deferred bool, err error)
 	// DeleteRemoteObject deletes the Job in the worker cluster.
 	DeleteRemoteObject(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName) error
 	// IsJobManagedByKueue returns:

--- a/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter.go
@@ -39,22 +39,22 @@ type multiKueueAdapter struct{}
 
 var _ jobframework.MultiKueueAdapter = (*multiKueueAdapter)(nil)
 
-func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) error {
+func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) (bool, error) {
 	localAppWrapper := awv1beta2.AppWrapper{}
 	err := localClient.Get(ctx, key, &localAppWrapper)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	remoteAppWrapper := awv1beta2.AppWrapper{}
 	err = remoteClient.Get(ctx, key, &remoteAppWrapper)
 	if client.IgnoreNotFound(err) != nil {
-		return err
+		return false, err
 	}
 
 	// if the remote exists, just copy the status
 	if err == nil {
-		return clientutil.PatchStatus(ctx, localClient, &localAppWrapper, func() (bool, error) {
+		return false, clientutil.PatchStatus(ctx, localClient, &localAppWrapper, func() (bool, error) {
 			localAppWrapper.Status = remoteAppWrapper.Status
 			return true, nil
 		})
@@ -72,7 +72,7 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	// clear the managedBy to enable the remote AppWrapper controller to take over
 	remoteAppWrapper.Spec.ManagedBy = nil
 
-	return remoteClient.Create(ctx, &remoteAppWrapper)
+	return false, remoteClient.Create(ctx, &remoteAppWrapper)
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter_test.go
@@ -73,7 +73,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*baseAppWrapperManagedByKueueBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "aw1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "aw1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersAppWrappers: []awv1beta2.AppWrapper{
@@ -99,7 +100,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "aw1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "aw1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersAppWrappers: []awv1beta2.AppWrapper{
@@ -129,7 +131,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "aw1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "aw1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersAppWrappers: []awv1beta2.AppWrapper{
@@ -204,7 +207,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*baseAppWrapperManagedByKueueBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "aw1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "aw1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersAppWrappers: []awv1beta2.AppWrapper{
 				*baseAppWrapperManagedByKueueBuilder.DeepCopy(),

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -46,40 +46,44 @@ type multiKueueAdapter struct{}
 
 var _ jobframework.MultiKueueAdapter = (*multiKueueAdapter)(nil)
 
-func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) error {
+func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	localJob := batchv1.Job{}
 	err := localClient.Get(ctx, key, &localJob)
 	if err != nil {
 		log.Error(err, "Failed to get local job", "job", key)
-		return err
+		return false, err
 	}
 
 	remoteJob := batchv1.Job{}
 	err = remoteClient.Get(ctx, key, &remoteJob)
 	if client.IgnoreNotFound(err) != nil {
-		return err
+		return false, err
 	}
 
 	// the remote job exists
 	if err == nil {
-		statusUpdate := determineStatusUpdate(ctx, log, &localJob, &remoteJob)
+		statusUpdate, deferred := determineStatusUpdate(ctx, log, &localJob, &remoteJob)
 		if !equality.Semantic.DeepEqual(localJob.Status, *statusUpdate) {
 			if err := clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
 				localJob.Status = *statusUpdate
 				return true, nil
 			}); err != nil {
-				return err
+				return false, err
 			}
 		}
 
-		// Sync elastic workload if needed.
+		// Sync elastic workload if needed. Propagate deferred: an elastic sync
+		// does not unsuspend the local Job, so if determineStatusUpdate deferred
+		// the status sync it is still deferred and the caller must requeue.
 		if needElasticJobSync(log, workloadName, &localJob, &remoteJob) {
-			return syncElasticJob(ctx, remoteClient, log, workloadName, &localJob, &remoteJob)
+			return deferred, syncElasticJob(ctx, remoteClient, log, workloadName, &localJob, &remoteJob)
 		}
 
-		return nil
+		// Surface determineStatusUpdate's deferred flag to the caller; see
+		// MultiKueueAdapter.SyncJob for the contract.
+		return deferred, nil
 	}
 
 	remoteJob = batchv1.Job{
@@ -99,10 +103,16 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	// clear the managedBy enables the batch/Job controller to take over
 	remoteJob.Spec.ManagedBy = nil
 
-	return remoteClient.Create(ctx, &remoteJob)
+	return false, remoteClient.Create(ctx, &remoteJob)
 }
 
-func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remoteJob *batchv1.Job) *batchv1.JobStatus {
+// determineStatusUpdate returns the JobStatus to write to the local Job, plus
+// a deferred flag. deferred is true only for the "local suspended, remote
+// unsuspended, not finished" branch — the one case where the real remote
+// status.Active is intentionally NOT propagated. See MultiKueueAdapter.SyncJob
+// for what the caller does with it. Returning both from one function keeps the
+// deferred condition from drifting out of sync with the branches it describes.
+func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remoteJob *batchv1.Job) (status *batchv1.JobStatus, deferred bool) {
 	localJobInfo := fromObject(localJob)
 
 	log.V(3).Info("Determining status update for a MultiKueue Job", "localJob", localJob, "remoteJob", remoteJob)
@@ -111,7 +121,7 @@ func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remot
 		// This is safe as the local Job has already reached its final spec.
 		// We expect no validation errors from further spec changes.
 		log.V(3).Info("Performing the sync as the local Job is unsuspended")
-		return &remoteJob.Status
+		return &remoteJob.Status, false
 	}
 	remoteJobInfo := fromObject(remoteJob)
 	if remoteJobInfo.IsSuspended() {
@@ -119,13 +129,13 @@ func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remot
 		// This is needed to await for updating the status.active field
 		// when the remote Job is evicted; see: https://github.com/kubernetes-sigs/kueue/pull/8151
 		log.V(3).Info("Peforming the sync as the local and the remote Job are both suspended")
-		return &remoteJob.Status
+		return &remoteJob.Status, false
 	}
 	if _, _, finished := remoteJobInfo.Finished(ctx); finished {
 		// Sync status if the remote Job is finished.
 		// Without this, the local Job could get stuck in the suspended state.
 		log.V(2).Info("Performing the sync as the remote Job is finished")
-		return &remoteJob.Status
+		return &remoteJob.Status, false
 	}
 
 	// Remaining case: local Job is suspended, remote Job is unsuspended but not finished.
@@ -151,10 +161,10 @@ func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remot
 				LastProbeTime:      metav1.Now(),
 			})
 		log.V(2).Info("Updating the suspended local Job to comply with Kubernetes validation rules", "oldStatus", localJob.Status, "newStatus", newLocalStatus)
-		return newLocalStatus
+		return newLocalStatus, true
 	}
 
-	return &localJob.Status
+	return &localJob.Status, true
 }
 
 func setJobStatusCondition(list []batchv1.JobCondition, condition batchv1.JobCondition) []batchv1.JobCondition {

--- a/pkg/controller/jobs/job/job_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter_test.go
@@ -74,7 +74,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*baseJobManagedByKueueBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersJobs: []batchv1.Job{
@@ -100,7 +101,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersJobs: []batchv1.Job{
@@ -130,7 +132,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersJobs: []batchv1.Job{
 				*baseJobManagedByKueueBuilder.Clone().
@@ -160,7 +163,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersJobs: []batchv1.Job{
@@ -234,7 +238,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*baseJobManagedByKueueBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersJobs: []batchv1.Job{
 				*baseJobManagedByKueueBuilder.DeepCopy(),
@@ -303,6 +308,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 	}
 	type want struct {
 		err       bool
+		deferred  bool
 		localJob  *batchv1.Job
 		remoteJob *batchv1.Job
 	}
@@ -607,6 +613,39 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 					Obj(),
 			},
 		},
+		// Regression test for #11115: when an elastic sync is needed AND the local
+		// Job is still suspended (remote unsuspended and not finished), SyncJob must
+		// still report deferred=true — the deferred flag must not be dropped on the
+		// elastic-sync return path.
+		"ElasticJob_DeferredWhenLocalSuspended": {
+			fields: fields{
+				featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			},
+			args: args{
+				// local: suspended (default), elastic, parallelism 22.
+				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Parallelism(22).
+					Condition(runningJobCondition).
+					Obj()).Build(),
+				// remote: unsuspended and not finished, elastic, parallelism unset
+				// (mismatch with local -> needElasticJobSync is true).
+				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Suspend(false).
+					PrebuiltWorkloadLabel("test-workload").
+					Condition(runningJobCondition).
+					Obj()).Build(),
+				key:          client.ObjectKeyFromObject(newJob().Obj()),
+				workloadName: jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration("test", "", gvk, 0),
+			},
+			// localJob/remoteJob left nil: the deferred path patches the local
+			// JobSuspended condition with a wall-clock timestamp not worth asserting
+			// here. This case guards the deferred flag, not the patched objects.
+			want: want{
+				deferred: true,
+			},
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -616,9 +655,13 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 			adapter := &multiKueueAdapter{}
 			ctx, _ := utiltesting.ContextWithLog(t)
 
-			// Function call under test with result (error) assertion.
-			if err := adapter.SyncJob(ctx, tt.args.localClient, tt.args.remoteClient, tt.args.key, tt.args.workloadName, tt.args.origin); (err != nil) != tt.want.err {
-				t.Errorf("SyncJob() error = %v, wantErr %v", err, tt.want.err)
+			// Function call under test with result (deferred, error) assertion.
+			gotDeferred, gotErr := adapter.SyncJob(ctx, tt.args.localClient, tt.args.remoteClient, tt.args.key, tt.args.workloadName, tt.args.origin)
+			if (gotErr != nil) != tt.want.err {
+				t.Errorf("SyncJob() error = %v, wantErr %v", gotErr, tt.want.err)
+			}
+			if gotDeferred != tt.want.deferred {
+				t.Errorf("SyncJob() deferred = %v, want %v for case %q", gotDeferred, tt.want.deferred, name)
 			}
 
 			// Side effect assertion: changes to the local job. Must have (not nil) both the client and the job.
@@ -642,5 +685,44 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// Test_multiKueueAdapter_SyncJob_DeferredWhenLocalSuspended covers the race
+// observed in https://github.com/kubernetes-sigs/kueue/issues/11115. When the
+// remote Job is already unsuspended (and not finished) but the local Job is
+// still suspended, SyncJob cannot propagate status.Active to the local Job
+// without violating K8s 1.36 suspend-validation rules. In that case SyncJob
+// must report deferred=true so the multikueue reconciler can requeue on a
+// short timer; without that signal the workload reconciler waits its default
+// workerLostTimeout requeue and the manager Job's status.Active never catches up.
+func Test_multiKueueAdapter_SyncJob_DeferredWhenLocalSuspended(t *testing.T) {
+	schema := runtime.NewScheme()
+	_ = scheme.AddToScheme(schema)
+	_ = kueue.AddToScheme(schema)
+
+	newJob := func() *utiltestingjob.JobWrapper {
+		return utiltestingjob.MakeJob("test", TestNamespace).ResourceVersion("1")
+	}
+
+	localJob := newJob().Obj() // Suspend defaults to true on JobWrapper
+	remoteJob := newJob().
+		Suspend(false).
+		Active(1).
+		Obj()
+
+	localClient := fake.NewClientBuilder().WithScheme(schema).WithObjects(localJob).Build()
+	remoteClient := fake.NewClientBuilder().WithScheme(schema).WithObjects(remoteJob).Build()
+
+	adapter := &multiKueueAdapter{}
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	deferred, err := adapter.SyncJob(ctx, localClient, remoteClient,
+		client.ObjectKeyFromObject(localJob), "" /*workloadName*/, "" /*origin*/)
+	if err != nil {
+		t.Fatalf("SyncJob() unexpected error = %v", err)
+	}
+	if !deferred {
+		t.Fatalf("SyncJob() deferred = false; want true (local suspended, remote unsuspended and not finished)")
 	}
 }

--- a/pkg/controller/jobs/jobset/jobset_multikueue_adapter.go
+++ b/pkg/controller/jobs/jobset/jobset_multikueue_adapter.go
@@ -39,22 +39,22 @@ type multiKueueAdapter struct{}
 
 var _ jobframework.MultiKueueAdapter = (*multiKueueAdapter)(nil)
 
-func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) error {
+func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) (bool, error) {
 	localJob := jobset.JobSet{}
 	err := localClient.Get(ctx, key, &localJob)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	remoteJob := jobset.JobSet{}
 	err = remoteClient.Get(ctx, key, &remoteJob)
 	if client.IgnoreNotFound(err) != nil {
-		return err
+		return false, err
 	}
 
 	// if the remote exists, just copy the status
 	if err == nil {
-		return clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
+		return false, clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
 			localJob.Status = remoteJob.Status
 			return true, nil
 		})
@@ -71,7 +71,7 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	// clear the managedBy enables the JobSet controller to take over
 	remoteJob.Spec.ManagedBy = nil
 
-	return remoteClient.Create(ctx, &remoteJob)
+	return false, remoteClient.Create(ctx, &remoteJob)
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/jobset/jobset_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/jobset/jobset_multikueue_adapter_test.go
@@ -68,7 +68,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*baseJobSetManagedByKueueBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "jobset1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "jobset1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersJobSets: []jobsetapi.JobSet{
@@ -105,7 +106,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "jobset1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "jobset1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersJobSets: []jobsetapi.JobSet{
@@ -170,7 +172,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "jobset1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "jobset1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersJobSets: []jobsetapi.JobSet{
@@ -280,7 +283,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*baseJobSetManagedByKueueBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "jobset1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "jobset1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersJobSets: []jobsetapi.JobSet{
 				*baseJobSetManagedByKueueBuilder.DeepCopy(),

--- a/pkg/controller/jobs/kubeflow/jobs/jaxjob/jaxjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/jaxjob/jaxjob_multikueue_adapter_test.go
@@ -70,7 +70,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*jaxJobBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "jaxjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "jaxjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersJAXJobs: []kftraining.JAXJob{
@@ -96,7 +97,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "jaxjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "jaxjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersJAXJobs: []kftraining.JAXJob{
@@ -128,7 +130,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "jaxjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "jaxjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersJAXJobs: []kftraining.JAXJob{
 				*jaxJobBuilder.Clone().
@@ -202,7 +205,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*jaxJobBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "jaxjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "jaxjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersJAXJobs: []kftraining.JAXJob{
 				*jaxJobBuilder.DeepCopy(),

--- a/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_multikueue_adapter_test.go
@@ -71,7 +71,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "paddlejob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "paddlejob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersPaddleJobs: []kftraining.PaddleJob{
@@ -97,7 +98,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "paddlejob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "paddlejob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersPaddleJobs: []kftraining.PaddleJob{
@@ -129,7 +131,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "paddlejob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "paddlejob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersPaddleJobs: []kftraining.PaddleJob{
 				*paddleJobBuilder.Clone().
@@ -203,7 +206,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*paddleJobBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "paddlejob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "paddlejob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersPaddleJobs: []kftraining.PaddleJob{
 				*paddleJobBuilder.DeepCopy(),

--- a/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorch_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorch_multikueue_adapter_test.go
@@ -70,7 +70,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*pyTorchJobBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "pytorchjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "pytorchjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersPyTorchJobs: []kftraining.PyTorchJob{
@@ -96,7 +97,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "pytorchjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "pytorchjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersPyTorchJobs: []kftraining.PyTorchJob{
@@ -128,7 +130,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "pytorchjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "pytorchjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersPyTorchJobs: []kftraining.PyTorchJob{
 				*pyTorchJobBuilder.Clone().
@@ -202,7 +205,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*pyTorchJobBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "pytorchjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "pytorchjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersPyTorchJobs: []kftraining.PyTorchJob{
 				*pyTorchJobBuilder.DeepCopy(),

--- a/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_multikueue_adapter_test.go
@@ -70,7 +70,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*tfJobBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "tfjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "tfjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersTFJobs: []kftraining.TFJob{
@@ -96,7 +97,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "tfjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "tfjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersTFJobs: []kftraining.TFJob{
@@ -128,7 +130,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "tfjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "tfjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersTFJobs: []kftraining.TFJob{
 				*tfJobBuilder.Clone().
@@ -202,7 +205,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*tfJobBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "tfjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "tfjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersTFJobs: []kftraining.TFJob{
 				*tfJobBuilder.DeepCopy(),

--- a/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_multikueue_adapter_test.go
@@ -70,7 +70,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*xgboostJobBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "xgboostjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "xgboostjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersXGBoostJobs: []kftraining.XGBoostJob{
@@ -96,7 +97,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "xgboostjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "xgboostjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersXGBoostJobs: []kftraining.XGBoostJob{
@@ -128,7 +130,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "xgboostjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "xgboostjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersXGBoostJobs: []kftraining.XGBoostJob{
@@ -203,7 +206,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*xgboostJobBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "xgboostjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "xgboostjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersXGBoostJobs: []kftraining.XGBoostJob{
 				*xgboostJobBuilder.DeepCopy(),

--- a/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_multikueue_adapter.go
+++ b/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_multikueue_adapter.go
@@ -93,21 +93,21 @@ func (a adapter[PtrT, T]) SyncJob(
 	localClient client.Client,
 	remoteClient client.Client,
 	key types.NamespacedName,
-	workloadName, origin string) error {
+	workloadName, origin string) (bool, error) {
 	localJob := PtrT(new(T))
 	err := localClient.Get(ctx, key, localJob)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	remoteJob := PtrT(new(T))
 	err = remoteClient.Get(ctx, key, remoteJob)
 	if client.IgnoreNotFound(err) != nil {
-		return err
+		return false, err
 	}
 
 	if err == nil {
-		return clientutil.PatchStatus(ctx, localClient, localJob, func() (bool, error) {
+		return false, clientutil.PatchStatus(ctx, localClient, localJob, func() (bool, error) {
 			// if the remote exists, just copy the status
 			a.copyStatus(localJob, remoteJob)
 			return true, nil
@@ -123,7 +123,7 @@ func (a adapter[PtrT, T]) SyncJob(
 	// clearing the managedBy enables the controller to take over
 	a.fromObject(remoteJob).SetManagedBy(nil)
 
-	return remoteClient.Create(ctx, remoteJob)
+	return false, remoteClient.Create(ctx, remoteJob)
 }
 
 func (a adapter[PtrT, T]) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_multikueue_adapter.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_multikueue_adapter.go
@@ -42,24 +42,24 @@ var _ jobframework.MultiKueueAdapter = (*multiKueueAdapter)(nil)
 var _ jobframework.MultiKueueWatcher = (*multiKueueAdapter)(nil)
 var _ jobframework.MultiKueueMultiWorkloadAdapter = (*multiKueueAdapter)(nil)
 
-func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) error {
+func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) (bool, error) {
 	localLWS := leaderworkersetv1.LeaderWorkerSet{}
 	err := localClient.Get(ctx, key, &localLWS)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	remoteLWS := leaderworkersetv1.LeaderWorkerSet{}
 	err = remoteClient.Get(ctx, key, &remoteLWS)
 	if client.IgnoreNotFound(err) != nil {
-		return err
+		return false, err
 	}
 
 	// If the remote exists, skip status sync.
 	// LWS doesn't support managedBy, so the local LWS controller would
 	// immediately overwrite any status we sync from the worker cluster.
 	if err == nil {
-		return nil
+		return false, nil
 	}
 
 	remoteLWS = leaderworkersetv1.LeaderWorkerSet{
@@ -78,7 +78,7 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 
 	// Use IgnoreAlreadyExists because LWS has multiple workloads (one per replica),
 	// and they may all try to create the same LWS concurrently.
-	return client.IgnoreAlreadyExists(remoteClient.Create(ctx, &remoteLWS))
+	return false, client.IgnoreAlreadyExists(remoteClient.Create(ctx, &remoteLWS))
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_multikueue_adapter_test.go
@@ -62,7 +62,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).UID("manager-uid-123").Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "lws1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "lws1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
 				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).UID("manager-uid-123").Obj(),
@@ -87,7 +88,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "lws1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "lws1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
 				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).
@@ -178,7 +180,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).UID("manager-uid-123").Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "lws1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "lws1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
 				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).UID("manager-uid-123").Obj(),

--- a/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter.go
+++ b/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter.go
@@ -39,22 +39,22 @@ type multiKueueAdapter struct{}
 
 var _ jobframework.MultiKueueAdapter = (*multiKueueAdapter)(nil)
 
-func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) error {
+func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) (bool, error) {
 	localJob := kfmpi.MPIJob{}
 	err := localClient.Get(ctx, key, &localJob)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	remoteJob := kfmpi.MPIJob{}
 	err = remoteClient.Get(ctx, key, &remoteJob)
 	if client.IgnoreNotFound(err) != nil {
-		return err
+		return false, err
 	}
 
 	// if the remote exists, just copy the status
 	if err == nil {
-		return clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
+		return false, clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
 			localJob.Status = remoteJob.Status
 			return true, nil
 		})
@@ -71,7 +71,7 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	// clear the managedBy enables the controller to take over
 	remoteJob.Spec.RunPolicy.ManagedBy = nil
 
-	return remoteClient.Create(ctx, &remoteJob)
+	return false, remoteClient.Create(ctx, &remoteJob)
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter_test.go
@@ -67,7 +67,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*mpiJobBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "mpijob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "mpijob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersMpiJobs: []kfmpi.MPIJob{
@@ -93,7 +94,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "mpijob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "mpijob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersMpiJobs: []kfmpi.MPIJob{
@@ -125,7 +127,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "mpijob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "mpijob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.Clone().
@@ -208,7 +211,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*mpiJobBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "mpijob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "mpijob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.DeepCopy(),

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter.go
@@ -39,21 +39,21 @@ type multiKueueAdapter struct{}
 
 var _ jobframework.MultiKueueAdapter = (*multiKueueAdapter)(nil)
 
-func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) error {
+func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	localPod := corev1.Pod{}
 	err := localClient.Get(ctx, key, &localPod)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	groupName := GetPodGroupName(&localPod)
 	if groupName == "" {
-		return syncLocalPodWithRemote(ctx, localClient, remoteClient, &localPod, workloadName, origin, &log)
+		return false, syncLocalPodWithRemote(ctx, localClient, remoteClient, &localPod, workloadName, origin, &log)
 	}
 
-	return syncPodGroup(ctx, localClient, remoteClient, key, workloadName, origin, groupName)
+	return false, syncPodGroup(ctx, localClient, remoteClient, key, workloadName, origin, groupName)
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter_test.go
@@ -88,7 +88,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*basePodBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: basePodName, Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: basePodName, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersPods: []corev1.Pod{
@@ -115,7 +116,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: basePodName, Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: basePodName, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersPods: []corev1.Pod{
@@ -158,7 +160,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: basePodName, Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: basePodName, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			// The remote PodScheduled=False/Unschedulable condition must not overwrite
@@ -218,7 +221,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: basePodName, Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: basePodName, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersPods: []corev1.Pod{
@@ -282,7 +286,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*podGroup[2].DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersPods: []corev1.Pod{
 				*podGroup[0].DeepCopy(),
@@ -311,7 +316,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersPods: []corev1.Pod{
 				*podGroup[0].DeepCopy(),
@@ -357,7 +363,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*basePodBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: basePodName, Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: basePodName, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersPods: []corev1.Pod{
 				*basePodBuilder.DeepCopy(),
@@ -377,7 +384,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*podGroupWithWlAnnotations[2].DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersPods: []corev1.Pod{
 				*podGroupWithWlAnnotations[0].DeepCopy(),

--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -99,22 +99,22 @@ func (a *adapter[PtrT, T]) SyncJob(
 	remoteClient client.Client,
 	key types.NamespacedName,
 	workloadName, origin string,
-) error {
+) (bool, error) {
 	localJob := PtrT(new(T))
 	err := localClient.Get(ctx, key, localJob)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	remoteJob := PtrT(new(T))
 	err = remoteClient.Get(ctx, key, remoteJob)
 	if client.IgnoreNotFound(err) != nil {
-		return err
+		return false, err
 	}
 
 	// if the remote exists, just copy the status
 	if err == nil {
-		return clientutil.PatchStatus(ctx, localClient, localJob, func() (bool, error) {
+		return false, clientutil.PatchStatus(ctx, localClient, localJob, func() (bool, error) {
 			a.copyStatus(localJob, remoteJob)
 			return true, nil
 		})
@@ -129,7 +129,7 @@ func (a *adapter[PtrT, T]) SyncJob(
 	// clearing the managedBy enables the controller to take over
 	a.setManagedBy(remoteJob, nil)
 
-	return remoteClient.Create(ctx, remoteJob)
+	return false, remoteClient.Create(ctx, remoteJob)
 }
 
 func (a *adapter[PtrT, T]) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
@@ -69,7 +69,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*rayClusterBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersRayClusters: []rayv1.RayCluster{
@@ -95,7 +96,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersRayClusters: []rayv1.RayCluster{
@@ -127,7 +129,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersRayClusters: []rayv1.RayCluster{
 				*rayClusterBuilder.Clone().
@@ -210,7 +213,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*rayClusterBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersRayClusters: []rayv1.RayCluster{
 				*rayClusterBuilder.DeepCopy(),

--- a/pkg/controller/jobs/rayjob/rayjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_multikueue_adapter_test.go
@@ -68,7 +68,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*rayJobBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersRayJobs: []rayv1.RayJob{
@@ -94,7 +95,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersRayJobs: []rayv1.RayJob{
@@ -126,7 +128,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersRayJobs: []rayv1.RayJob{
 				*rayJobBuilder.Clone().
@@ -209,7 +212,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*rayJobBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersRayJobs: []rayv1.RayJob{
 				*rayJobBuilder.DeepCopy(),

--- a/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter_test.go
@@ -68,7 +68,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*rayServiceBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayservice1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayservice1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersRayServices: []rayv1.RayService{
@@ -98,7 +99,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayservice1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayservice1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersRayServices: []rayv1.RayService{
@@ -142,7 +144,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayservice1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayservice1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersRayServices: []rayv1.RayService{
 				*rayServiceBuilder.Clone().
@@ -233,7 +236,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*rayServiceBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayservice1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayservice1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersRayServices: []rayv1.RayService{
 				*rayServiceBuilder.DeepCopy(),

--- a/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter.go
+++ b/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter.go
@@ -37,24 +37,24 @@ type multiKueueAdapter struct{}
 
 var _ jobframework.MultiKueueAdapter = (*multiKueueAdapter)(nil)
 
-func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) error {
+func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) (bool, error) {
 	localStatefulSet := appsv1.StatefulSet{}
 	err := localClient.Get(ctx, key, &localStatefulSet)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	remoteStatefulSet := appsv1.StatefulSet{}
 	err = remoteClient.Get(ctx, key, &remoteStatefulSet)
 	if client.IgnoreNotFound(err) != nil {
-		return err
+		return false, err
 	}
 
 	// If the remote exists, skip status sync.
 	// StatefulSet doesn't support managedBy, so the local StatefulSet controller
 	// would immediately overwrite any status we sync from the worker cluster.
 	if err == nil {
-		return nil
+		return false, nil
 	}
 
 	remoteStatefulSet = appsv1.StatefulSet{
@@ -70,7 +70,7 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	}
 	remoteStatefulSet.Annotations[kueue.MultiKueueOriginUIDAnnotation] = string(localStatefulSet.UID)
 
-	return remoteClient.Create(ctx, &remoteStatefulSet)
+	return false, remoteClient.Create(ctx, &remoteStatefulSet)
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter_test.go
@@ -63,7 +63,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "statefulset1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "statefulset1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersStatefulSets: []appsv1.StatefulSet{
 				*utiltestingstatefulset.MakeStatefulSet("statefulset1", TestNamespace).
@@ -92,7 +93,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "statefulset1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "statefulset1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersStatefulSets: []appsv1.StatefulSet{
 				*utiltestingstatefulset.MakeStatefulSet("statefulset1", TestNamespace).
@@ -148,7 +150,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "statefulset1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "statefulset1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersStatefulSets: []appsv1.StatefulSet{
 				*utiltestingstatefulset.MakeStatefulSet("statefulset1", TestNamespace).

--- a/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter.go
+++ b/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter.go
@@ -40,22 +40,22 @@ type multiKueueAdapter struct{}
 
 var _ jobframework.MultiKueueAdapter = (*multiKueueAdapter)(nil)
 
-func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) error {
+func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) (bool, error) {
 	localJob := kftrainerapi.TrainJob{}
 	err := localClient.Get(ctx, key, &localJob)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	remoteJob := kftrainerapi.TrainJob{}
 	err = remoteClient.Get(ctx, key, &remoteJob)
 	if client.IgnoreNotFound(err) != nil {
-		return err
+		return false, err
 	}
 
 	// if the remote exists, just copy the status
 	if err == nil {
-		return clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
+		return false, clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
 			localJob.Status = remoteJob.Status
 			return true, nil
 		})
@@ -77,7 +77,7 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		return p.Manager == runtimePatchManagerName
 	})
 
-	return remoteClient.Create(ctx, &remoteJob)
+	return false, remoteClient.Create(ctx, &remoteJob)
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter_test.go
@@ -68,7 +68,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*baseTrainJobManagedByKueueBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "trainjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "trainjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersTrainJobs: []kftrainerapi.TrainJob{
@@ -91,7 +92,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "trainjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "trainjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersTrainJobs: []kftrainerapi.TrainJob{
@@ -130,7 +132,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "trainjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "trainjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersTrainJobs: []kftrainerapi.TrainJob{
@@ -189,7 +192,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "trainjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "trainjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 
 			wantManagersTrainJobs: []kftrainerapi.TrainJob{
@@ -293,7 +297,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*baseTrainJobManagedByKueueBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "trainjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "trainjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
 			},
 			wantManagersTrainJobs: []kftrainerapi.TrainJob{
 				*baseTrainJobManagedByKueueBuilder.DeepCopy(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test
/kind flake
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Fix the "remaining case" (local Job is suspended, remote Job is unsuspended but not finished) in pkg/controller/jobs/job/job_multikueue_adapter.go:149, where the worker sends exactly one status update while the the local is still suspended.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11115 

#### Special notes for your reviewer:
ill attach my analysis and logs used in identifying the bug.
I understand that this can but classified as a not-bug but intended use case, in that situation we might want to change the test parameters? 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MultiKueue: Fixed a bug that could leave stale status for Kubernetes Jobs in the manager
cluster when the worker-cluster Job reached steady state quickly and stopped getting
updates while the manager-cluster Job was still suspended.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-queue job status synchronization when a local job is temporarily suspended: the controller now treats this as an intentional deferred sync and retries status reconciliation on a shorter interval instead of waiting for the usual timeout.
  * Updated eviction/reservation reconciliation paths to correctly handle deferred sync behavior without surfacing it as an error.

* **Tests**
  * Added regression coverage to confirm deferred sync results in the shorter requeue timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->