### PR TITLE
relax large-scale scheduler threshold from CI data

### DIFF
--- a/test/performance/scheduler/configs/large-scale/rangespec.yaml
+++ b/test/performance/scheduler/configs/large-scale/rangespec.yaml
@@ -21,6 +21,6 @@ clusterQueueClassesMinUsage:
 
 wlClassesMaxAvgTimeToAdmissionMs:
   # mean×1.2 rounded up to nearest 1000ms
-  large: 119_000   # mean=98803ms
+  large: 128_000   # mean=105604ms
   medium: 308_000  # mean=256413ms
   small: 841_000   # mean=700379ms


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:
Relax large workload admission threshold in `large-scale/rangespec.yaml`.

The original `119_000ms` bound was calculated from 19 successful main runs (#11422), but two of those runs appear to have undercounted admission latency (took <1s) (ref: https://github.com/kubernetes-sigs/kueue/issues/11870). Excluding such outliers we get a new mean of `105604ms` and applying the calibration rule (`mean × 1.20`) we get `127000ms`.
#### Which issue(s) this PR fixes:
Fixes #11857

#### Special notes for your reviewer:
Even though the flake happened in 0.18 branch some runs did fail on main too (passed on retry). 
https://storage.googleapis.com/kubernetes-ci-logs/logs/periodic-kueue-test-large-scale-scheduling-perf-main/2061015505006759936/artifacts/test-large-scale-performance-scheduler-fail-1/junit.xml (121870ms)
https://storage.googleapis.com/kubernetes-ci-logs/logs/periodic-kueue-test-large-scale-scheduling-perf-main/2060290472051478528/artifacts/test-large-scale-performance-scheduler-fail-1/junit.xml (120245ms)
#### Does this PR introduce a user-facing change?
```release-note
NONE
```
