### PR TITLE
fix(kueueviz): useMemo in detail pages to prevent stale rendering on transitions

### DIFF
--- a/cmd/kueueviz/frontend/src/ClusterQueueDetail.jsx
+++ b/cmd/kueueviz/frontend/src/ClusterQueueDetail.jsx
@@ -28,17 +28,15 @@ const ClusterQueueDetail = () => {
   const url = `/ws/cluster-queue/${clusterQueueName}`;
   const { data: clusterQueueData, error } = useWebSocket(url);
 
-  const [clusterQueue, setClusterQueue] = useState(null);
   const [showReservation, setShowReservation] = useState(false);
 
-  useEffect(() => {
-    if (clusterQueueData) {
-      const sorted = { ...clusterQueueData };
-      if (sorted.queues) {
-        sorted.queues = [...sorted.queues].sort((a, b) => (a.name || '').localeCompare(b.name || ''));
-      }
-      setClusterQueue(sorted);
+  const clusterQueue = React.useMemo(() => {
+    if (!clusterQueueData) return null;
+    const sorted = { ...clusterQueueData };
+    if (sorted.queues) {
+      sorted.queues = [...sorted.queues].sort((a, b) => (a.name || '').localeCompare(b.name || ''));
     }
+    return sorted;
   }, [clusterQueueData]);
 
   if (error) return <ErrorMessage error={error} />;

--- a/cmd/kueueviz/frontend/src/CohortDetail.jsx
+++ b/cmd/kueueviz/frontend/src/CohortDetail.jsx
@@ -27,16 +27,13 @@ const CohortDetail = () => {
   const url = `/ws/cohort/${cohortName}`;
   const { data: cohortData, error } = useWebSocket(url);
 
-  const [cohortDetails, setCohortDetails] = useState(null);
-
-  useEffect(() => {
-    if (cohortData) {
-      const sorted = { ...cohortData };
-      if (sorted.clusterQueues) {
-        sorted.clusterQueues = [...sorted.clusterQueues].sort((a, b) => (a.name || '').localeCompare(b.name || ''));
-      }
-      setCohortDetails(sorted);
+  const cohortDetails = React.useMemo(() => {
+    if (!cohortData) return null;
+    const sorted = { ...cohortData };
+    if (sorted.clusterQueues) {
+      sorted.clusterQueues = [...sorted.clusterQueues].sort((a, b) => (a.name || '').localeCompare(b.name || ''));
     }
+    return sorted;
   }, [cohortData]);
 
   if (error) return <ErrorMessage error={error} />;


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area dashboard

#### What this PR does / why we need it:
In `CohortDetail.jsx` and `ClusterQueueDetail.jsx`, the components copied the incoming WebSocket data into a local component `useState` and utilized `useEffect` to trigger sorting actions upon data arrival. 

Using `useEffect` + `useState` to copy and sort derived state is a React anti-pattern that triggers an extra unnecessary render pass and creates a state lag during transitions. This causes the details and graphs of a previously loaded page to briefly bleed/flash on screen when navigating between detail routes.

This PR:
1. Replaces the `useState` and `useEffect` state blocks with synchronous `useMemo` hooks to derive and sort lists instantly in a single render pass.
2. Synchronizes route transitions, ensuring the UI immediately falls back to the loading state (`CircularProgress`) when route params change and the WebSocket connection restarts, eliminating all visual bleeding.

#### Which issue(s) this PR fixes:
Fixes #11876

#### Special notes for your reviewer:
None.

#### Does this PR introduce a user-facing change?
Yes

```release-note
KueueViz: Fixed a layout-bleed bug where switching directly between detail pages briefly rendered stale queue data from the previously visited resource.
```