### PR TITLE
test: Removal of target test-multikueue-e2e-main from Makefile-test.mk

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -151,9 +151,6 @@ test-e2e-baseline-helm: test-e2e-baseline
 test-e2e-extended-helm: E2E_USE_HELM=true
 test-e2e-extended-helm: test-e2e-extended
 
-.PHONY: test-multikueue-e2e-main
-test-multikueue-e2e-main: test-multikueue-e2e-baseline test-multikueue-e2e-extended
-
 .PHONY: test-multikueue-e2e-baseline
 test-multikueue-e2e-baseline: E2E_NPROCS := 5
 test-multikueue-e2e-baseline: setup-e2e-env run-test-multikueue-e2e-baseline-$(E2E_KIND_VERSION:kindest/node:v%=%)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area multikueue
/area testing

#### What this PR does / why we need it:
This PR just removes target -> test-multikueue-e2e-main from Makefile-test.mk

#### Which issue(s) this PR fixes:

Part of  #11627

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
