### PR TITLE
Create variants function in ConcurrentAdmission controller accepts fl…

### DIFF
--- a/pkg/controller/concurrentadmission/controller.go
+++ b/pkg/controller/concurrentadmission/controller.go
@@ -143,7 +143,7 @@ func (r *variantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	if len(variants) < len(flavorOrder) {
 		log.V(3).Info("Too few variants, creating new ones", "desired", len(flavorOrder), "actual", len(variants))
-		if err := r.createVariants(ctx, parent, variants, flavorOrder); err != nil {
+		if err := r.createVariants(ctx, parent, variants, cq.Spec.ResourceGroups[0].Flavors); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -230,15 +230,15 @@ func (r *variantReconciler) getClusterQueue(ctx context.Context, wl *kueue.Workl
 	return cq, nil
 }
 
-func (r *variantReconciler) createVariants(ctx context.Context, parent *kueue.Workload, variants []kueue.Workload, resourceFlavors map[kueue.ResourceFlavorReference]int) error {
+func (r *variantReconciler) createVariants(ctx context.Context, parent *kueue.Workload, variants []kueue.Workload, resourceFlavors []kueue.FlavorQuotas) error {
 	log := ctrl.LoggerFrom(ctx)
-	for flavor := range resourceFlavors {
-		if r.hasVariantWithFlavor(ctx, variants, flavor) {
+	for _, flavorQuota := range resourceFlavors {
+		if r.hasVariantWithFlavor(ctx, variants, flavorQuota.Name) {
 			continue
 		}
 
-		variant := generateVariant(parent, flavor)
-		log.V(3).Info("Creating variant for flavor", "flavor", flavor, "variant", variant.Name)
+		variant := generateVariant(parent, flavorQuota.Name)
+		log.V(3).Info("Creating variant for flavor", "flavor", flavorQuota.Name, "variant", variant.Name)
 
 		// Set the owner reference to the parent workload
 		if err := ctrl.SetControllerReference(parent, variant, r.client.Scheme()); err != nil {
@@ -249,7 +249,7 @@ func (r *variantReconciler) createVariants(ctx context.Context, parent *kueue.Wo
 			log.V(3).Info("Failed to create variant", "variant", klog.KObj(variant), "error", err)
 			return err
 		}
-		log.V(3).Info("Variant created", "variant", klog.KObj(variant), "flavor", flavor)
+		log.V(3).Info("Variant created", "variant", klog.KObj(variant), "flavor", flavorQuota.Name)
 		r.recorder.Eventf(parent, nil, corev1.EventTypeNormal, ReasonCreatedVariant, ReasonCreatedVariant, "Variant Workload %q created", klog.KObj(variant))
 	}
 	return nil


### PR DESCRIPTION
…avors slice instead of flavors map

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Create variants function in ConcurrentAdmission controller accepts flavors slice instead of flavors map
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #10920 

#### Special notes for your reviewer:
keps/8691-concurrent-admission/README.md

|The `VariantsController` leverages the existing implementation of scheduling logic in Kueue, where Workloads are sorted
by priorities and creation timestamps and then picked-up by the scheduler one per scheduling cycle (per ClusterQueue).
This means when creating Variants the controller should ensure more favorable Variants are ahead of less favorable ones in the queue.

origin createVariants goes through map with for range, which is non deterministic. I replaced it with slice where `0` idx is high priority, and `len - 1` is lowest priority, with this change we create highest priority first all the time 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
