### PR TITLE
Documentation: Multikueue tests are split into Extended and Baseline test suites 

### DIFF
--- a/site/content/en/docs/contribution_guidelines/testing.md
+++ b/site/content/en/docs/contribution_guidelines/testing.md
@@ -114,7 +114,8 @@ make test-e2e-certmanager
 make test-e2e-kueueviz
 make test-tas-e2e-baseline
 make test-tas-e2e-extended
-make test-multikueue-e2e-main
+make test-multikueue-e2e-baseline
+make test-multikueue-e2e-extended
 make test-multikueue-e2e-sequential
 ```
 
@@ -134,14 +135,14 @@ Use `E2E_MODE=dev` to create-or-reuse a kind cluster, rebuild/redeploy Kueue, ru
 E2E_MODE=dev make kind-image-build test-e2e-baseline
 
 # MultiKueue dev mode
-E2E_MODE=dev make kind-image-build test-multikueue-e2e-main
+E2E_MODE=dev make kind-image-build test-multikueue-e2e-baseline
 
 # Loop a suite (until it fails) while keeping the cluster
 E2E_MODE=dev GINKGO_ARGS="--until-it-fails" make kind-image-build test-e2e-baseline
 
 # Skip reinstallation of kueue (works only in dev mode)
 E2E_MODE=dev E2E_SKIP_REINSTALL=true make kind-image-build test-e2e-baseline
-E2E_MODE=dev E2E_SKIP_REINSTALL=true make kind-image-build test-multikueue-e2e-main
+E2E_MODE=dev E2E_SKIP_REINSTALL=true make kind-image-build test-multikueue-e2e-baseline
 
 # Skip re-pulling dependency images and re-importing them into kind when already present (dev mode only)
 E2E_MODE=dev E2E_SKIP_IMAGE_RELOAD=true make kind-image-build test-e2e-baseline
@@ -177,7 +178,7 @@ To use a **released** or **staging** Kueue image instead of building from source
 ```shell
 # Released version
 E2E_MODE=dev IMAGE_TAG=registry.k8s.io/kueue/kueue:v0.16.0 make test-e2e-baseline
-E2E_MODE=dev IMAGE_TAG=registry.k8s.io/kueue/kueue:v0.16.0 make test-multikueue-e2e-main
+E2E_MODE=dev IMAGE_TAG=registry.k8s.io/kueue/kueue:v0.16.0 make test-multikueue-e2e-baseline
 
 # Staging image (e.g. from a PR or nightly)
 E2E_MODE=dev IMAGE_TAG=us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue:main make test-e2e-baseline
@@ -192,7 +193,7 @@ This is useful to reproduce issues on a specific released version (e.g. for on-c
 
 ### Legacy: interactive attach mode
 
-Run `E2E_RUN_ONLY_ENV=true make kind-image-build test-multikueue-e2e-main` and wait for the `Do you want to cleanup? [Y/n] ` to appear (CI-style behavior).
+Run `E2E_RUN_ONLY_ENV=true make kind-image-build test-multikueue-e2e-baseline` and wait for the `Do you want to cleanup? [Y/n] ` to appear (CI-style behavior).
 
 The cluster is ready, and now you can run tests from another terminal:
 ```shell

--- a/site/content/zh-CN/docs/contribution_guidelines/testing.md
+++ b/site/content/zh-CN/docs/contribution_guidelines/testing.md
@@ -112,7 +112,8 @@ make test-e2e-certmanager
 make test-e2e-kueueviz
 make test-tas-e2e-baseline
 make test-tas-e2e-extended
-make test-multikueue-e2e-main
+make test-multikueue-e2e-baseline
+make test-multikueue-e2e-extended
 make test-multikueue-e2e-sequential
 ```
 
@@ -132,14 +133,14 @@ E2E_K8S_FULL_VERSION=1.35.0 make test-e2e-baseline
 E2E_MODE=dev make kind-image-build test-e2e-baseline
 
 # MultiKueue 的 dev 模式
-E2E_MODE=dev make kind-image-build test-multikueue-e2e-main
+E2E_MODE=dev make kind-image-build test-multikueue-e2e-baseline
 
 # 循环运行（直到失败），同时保留集群
 E2E_MODE=dev GINKGO_ARGS="--until-it-fails" make kind-image-build test-e2e-baseline
 
 # 跳过重新安装 kueue（仅在 dev 模式下有效）
 E2E_MODE=dev E2E_SKIP_REINSTALL=true make kind-image-build test-e2e-baseline
-E2E_MODE=dev E2E_SKIP_REINSTALL=true make kind-image-build test-multikueue-e2e-main
+E2E_MODE=dev E2E_SKIP_REINSTALL=true make kind-image-build test-multikueue-e2e-baseline
 
 # 跳过重新拉取依赖镜像并将其重新导入 kind（仅 dev 模式）
 E2E_MODE=dev E2E_SKIP_IMAGE_RELOAD=true make kind-image-build test-e2e-baseline
@@ -174,7 +175,7 @@ Kueue 控制器镜像始终会重新加载到集群中，除非设置了 `E2E_SK
 ```shell
 # 已发布版本
 E2E_MODE=dev IMAGE_TAG=registry.k8s.io/kueue/kueue:v0.16.0 make test-e2e-baseline
-E2E_MODE=dev IMAGE_TAG=registry.k8s.io/kueue/kueue:v0.16.0 make test-multikueue-e2e-main
+E2E_MODE=dev IMAGE_TAG=registry.k8s.io/kueue/kueue:v0.16.0 make test-multikueue-e2e-baseline
 
 # 预发布镜像（例如来自 PR 或每日构建）
 E2E_MODE=dev IMAGE_TAG=us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue:main make test-e2e-baseline
@@ -189,7 +190,7 @@ E2E_MODE=dev IMAGE_TAG=us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue
 
 ### 旧方式：交互式附加模式 {#legacy-interactive-attach-mode}
 
-运行 `E2E_RUN_ONLY_ENV=true make kind-image-build test-multikueue-e2e-main` 并等待 `Do you want to cleanup? [Y/n] ` 出现（CI 风格行为）。
+运行 `E2E_RUN_ONLY_ENV=true make kind-image-build test-multikueue-e2e-baseline` 并等待 `Do you want to cleanup? [Y/n] ` 出现（CI 风格行为）。
 
 集群已准备就绪，现在你可以从另一个终端运行测试：
 ```shell


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation
/area multikueue


#### What this PR does / why we need it:
This PR just includes the updation of testing.md files because we had split the Multikueue e2e tests into baseline and extended tests for CI clock time reduction 

#### Which issue(s) this PR fixes:
Part of #11627

#### Special notes for your reviewer:
Its just a documentation fix 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
