### PR TITLE
Automated cherry pick of #11893: Optimize the "singlecluster/extended" e2e test suites by sharding

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -177,6 +177,11 @@ test-multikueue-e2e-sequential-shard-1: test-multikueue-e2e-sequential
 test-multikueue-e2e-helm: E2E_USE_HELM=true
 test-multikueue-e2e-helm: test-multikueue-e2e
 
+## Label Taxonomy:
+##   Features: appwrapper,jaxjob,jobset,kuberay,leaderworkerset,pytorchjob,trainjob
+##
+## Examples:
+##   Run only AppWrapper tests: GINKGO_ARGS="--label-filter=feature:appwrapper" make test-e2e-extended
 .PHONY: test-e2e-extended
 test-e2e-extended: test-e2e-extended-shard-0 test-e2e-extended-shard-1
 
@@ -188,17 +193,25 @@ test-e2e-extended: test-e2e-extended-shard-0 test-e2e-extended-shard-1
 .PHONY: test-e2e-extended-shard-0
 test-e2e-extended-shard-0: E2E_NPROCS := 4
 test-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=shard-0
-test-e2e-extended-shard-0: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-shard-0-$(E2E_KIND_VERSION:kindest/node:v%=%)
+test-e2e-extended-shard-0: export JOBSET_VERSION := $(JOBSET_VERSION)
+test-e2e-extended-shard-0: export LEADERWORKERSET_VERSION := $(LEADERWORKERSET_VERSION)
+test-e2e-extended-shard-0: export KUBERAY_VERSION := $(KUBERAY_VERSION)
+test-e2e-extended-shard-0: export RAY_VERSION := $(RAY_VERSION)
+test-e2e-extended-shard-0: export RAYMINI_VERSION := $(RAYMINI_VERSION)
+test-e2e-extended-shard-0: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 ## Label Taxonomy:
-##   Features: appwrapper,jaxjob,pytorchjob,tas,trainjob
+##   Features: appwrapper,jaxjob,pytorchjob,trainjob
 ##
 ## Examples:
 ##   Run only AppWrapper tests: GINKGO_ARGS="--label-filter=feature:appwrapper" make test-e2e-extended-shard-1
 .PHONY: test-e2e-extended-shard-1
 test-e2e-extended-shard-1: E2E_NPROCS := 4
 test-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=shard-1
-test-e2e-extended-shard-1: setup-e2e-env run-test-e2e-extended-shard-1-$(E2E_KIND_VERSION:kindest/node:v%=%)
+test-e2e-extended-shard-1: export APPWRAPPER_VERSION := $(APPWRAPPER_VERSION)
+test-e2e-extended-shard-1: export KUBEFLOW_VERSION := $(KUBEFLOW_VERSION)
+test-e2e-extended-shard-1: export KUBEFLOW_TRAINER_VERSION := $(KUBEFLOW_TRAINER_VERSION)
+test-e2e-extended-shard-1: setup-e2e-env run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 ## Label Taxonomy:
 ##   Features: certs,deployment,job,fairsharing,kueuectl,metrics,pod,statefulset,visibility,e2e_v1beta1,ha
@@ -286,34 +299,15 @@ run-test-e2e-baseline-%:
 		E2E_USE_HELM=$(E2E_USE_HELM) \
 		./hack/testing/e2e-test.sh
 
-run-test-e2e-extended-shard-0-%: K8S_VERSION = $(@:run-test-e2e-extended-shard-0-%=%)
-run-test-e2e-extended-shard-0-%:
+run-test-e2e-extended-%: K8S_VERSION = $(@:run-test-e2e-extended-%=%)
+run-test-e2e-extended-%:
 	@echo Running extended e2e for k8s ${K8S_VERSION}
 	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
 		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
 		E2E_MODE=$(E2E_MODE) \
 		E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
 		E2E_ENFORCE_OPERATOR_UPDATE=$(E2E_ENFORCE_OPERATOR_UPDATE) \
-		JOBSET_VERSION=$(JOBSET_VERSION) \
-		LEADERWORKERSET_VERSION=$(LEADERWORKERSET_VERSION) \
-		KUBERAY_VERSION=$(KUBERAY_VERSION) RAY_VERSION=$(RAY_VERSION) RAYMINI_VERSION=$(RAYMINI_VERSION) USE_RAY_FOR_TESTS=$(USE_RAY_FOR_TESTS) \
-		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="singlecluster/extended" \
-		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
-		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
-		E2E_USE_HELM=$(E2E_USE_HELM) \
-		./hack/testing/e2e-test.sh
-
-run-test-e2e-extended-shard-1-%: K8S_VERSION = $(@:run-test-e2e-extended-shard-1-%=%)
-run-test-e2e-extended-shard-1-%:
-	@echo Running extended e2e for k8s ${K8S_VERSION}
-	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
-		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
-		E2E_MODE=$(E2E_MODE) \
-		E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
-		E2E_ENFORCE_OPERATOR_UPDATE=$(E2E_ENFORCE_OPERATOR_UPDATE) \
-		APPWRAPPER_VERSION=$(APPWRAPPER_VERSION) \
-		KUBEFLOW_VERSION=$(KUBEFLOW_VERSION) \
-		KUBEFLOW_TRAINER_VERSION=$(KUBEFLOW_TRAINER_VERSION) \
+		USE_RAY_FOR_TESTS=$(USE_RAY_FOR_TESTS) \
 		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="singlecluster/extended" \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
 		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -177,14 +177,28 @@ test-multikueue-e2e-sequential-shard-1: test-multikueue-e2e-sequential
 test-multikueue-e2e-helm: E2E_USE_HELM=true
 test-multikueue-e2e-helm: test-multikueue-e2e
 
+.PHONY: test-e2e-extended
+test-e2e-extended: test-e2e-extended-shard-0 test-e2e-extended-shard-1
+
 ## Label Taxonomy:
-##   Features: appwrapper,jaxjob,jobset,kuberay,leaderworkerset,pytorchjob,tas,trainjob
+##   Features: jobset,kuberay,leaderworkerset
 ##
 ## Examples:
-##   Run only AppWrapper tests: GINKGO_ARGS="--label-filter=feature:appwrapper" make test-e2e-extended
-.PHONY: test-e2e-extended
-test-e2e-extended: E2E_NPROCS := 4
-test-e2e-extended: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
+##   Run only LeaderWorkerSet tests: GINKGO_ARGS="--label-filter=feature:leaderworkerset" make test-e2e-extended-shard-0
+.PHONY: test-e2e-extended-shard-0
+test-e2e-extended-shard-0: E2E_NPROCS := 4
+test-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=shard-0
+test-e2e-extended-shard-0: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-shard-0-$(E2E_KIND_VERSION:kindest/node:v%=%)
+
+## Label Taxonomy:
+##   Features: appwrapper,jaxjob,pytorchjob,tas,trainjob
+##
+## Examples:
+##   Run only AppWrapper tests: GINKGO_ARGS="--label-filter=feature:appwrapper" make test-e2e-extended-shard-1
+.PHONY: test-e2e-extended-shard-1
+test-e2e-extended-shard-1: E2E_NPROCS := 4
+test-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=shard-1
+test-e2e-extended-shard-1: setup-e2e-env run-test-e2e-extended-shard-1-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 ## Label Taxonomy:
 ##   Features: certs,deployment,job,fairsharing,kueuectl,metrics,pod,statefulset,visibility,e2e_v1beta1,ha
@@ -272,8 +286,25 @@ run-test-e2e-baseline-%:
 		E2E_USE_HELM=$(E2E_USE_HELM) \
 		./hack/testing/e2e-test.sh
 
-run-test-e2e-extended-%: K8S_VERSION = $(@:run-test-e2e-extended-%=%)
-run-test-e2e-extended-%:
+run-test-e2e-extended-shard-0-%: K8S_VERSION = $(@:run-test-e2e-extended-shard-0-%=%)
+run-test-e2e-extended-shard-0-%:
+	@echo Running extended e2e for k8s ${K8S_VERSION}
+	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
+		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
+		E2E_MODE=$(E2E_MODE) \
+		E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
+		E2E_ENFORCE_OPERATOR_UPDATE=$(E2E_ENFORCE_OPERATOR_UPDATE) \
+		JOBSET_VERSION=$(JOBSET_VERSION) \
+		LEADERWORKERSET_VERSION=$(LEADERWORKERSET_VERSION) \
+		KUBERAY_VERSION=$(KUBERAY_VERSION) RAY_VERSION=$(RAY_VERSION) RAYMINI_VERSION=$(RAYMINI_VERSION) USE_RAY_FOR_TESTS=$(USE_RAY_FOR_TESTS) \
+		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="singlecluster/extended" \
+		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
+		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
+		E2E_USE_HELM=$(E2E_USE_HELM) \
+		./hack/testing/e2e-test.sh
+
+run-test-e2e-extended-shard-1-%: K8S_VERSION = $(@:run-test-e2e-extended-shard-1-%=%)
+run-test-e2e-extended-shard-1-%:
 	@echo Running extended e2e for k8s ${K8S_VERSION}
 	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
 		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
@@ -281,11 +312,8 @@ run-test-e2e-extended-%:
 		E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
 		E2E_ENFORCE_OPERATOR_UPDATE=$(E2E_ENFORCE_OPERATOR_UPDATE) \
 		APPWRAPPER_VERSION=$(APPWRAPPER_VERSION) \
-		JOBSET_VERSION=$(JOBSET_VERSION) \
 		KUBEFLOW_VERSION=$(KUBEFLOW_VERSION) \
 		KUBEFLOW_TRAINER_VERSION=$(KUBEFLOW_TRAINER_VERSION) \
-		LEADERWORKERSET_VERSION=$(LEADERWORKERSET_VERSION) \
-		KUBERAY_VERSION=$(KUBERAY_VERSION) RAY_VERSION=$(RAY_VERSION) RAYMINI_VERSION=$(RAYMINI_VERSION) USE_RAY_FOR_TESTS=$(USE_RAY_FOR_TESTS) \
 		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="singlecluster/extended" \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
 		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+declare -r SHARD_0="shard-0"
+declare -r SHARD_1="shard-1"
+
 export KUSTOMIZE="$ROOT_DIR"/bin/kustomize
 export GINKGO="$ROOT_DIR"/bin/ginkgo
 export KIND="$ROOT_DIR"/bin/kind
@@ -172,18 +175,18 @@ function e2e_crd_exists {
     kubectl ${kubectl_args[@]+"${kubectl_args[@]}"} get crd "${crd}" >/dev/null 2>&1
 }
 
-if [[ -n ${APPWRAPPER_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(appwrapper|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+if [[ -n ${APPWRAPPER_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(appwrapper|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
     export APPWRAPPER_MANIFEST=${ROOT_DIR}/dep-crds/appwrapper/config/default
     export APPWRAPPER_IMAGE=quay.io/ibm/appwrapper:${APPWRAPPER_VERSION}
 fi
 
-if [[ -n ${JOBSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(jobset|tas|trainjob|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+if [[ -n ${JOBSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_0 || "$GINKGO_ARGS" =~ feature:(jobset|tas|trainjob|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
     export JOBSET_MANIFEST="https://github.com/kubernetes-sigs/jobset/releases/download/${JOBSET_VERSION}/manifests.yaml"
     export JOBSET_IMAGE=registry.k8s.io/jobset/jobset:${JOBSET_VERSION}
     export JOBSET_CRDS=${ROOT_DIR}/dep-crds/jobset-operator/
 fi
 
-if [[ -n ${KUBEFLOW_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(jaxjob|pytorchjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+if [[ -n ${KUBEFLOW_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(jaxjob|pytorchjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
     export KUBEFLOW_MANIFEST_ORIG=${ROOT_DIR}/dep-crds/training-operator/manifests/overlays/standalone/kustomization.yaml
     export KUBEFLOW_MANIFEST_PATCHED=${ROOT_DIR}/test/e2e/config/multikueue/kubeflow-manifest-patch
     # Extract the Kubeflow Training Operator image name and version tag from the manifest.
@@ -196,7 +199,7 @@ if [[ -n ${KUBEFLOW_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(jaxjob|pytorchjob)
     export KUBEFLOW_IMAGE=${KUBEFLOW_IMAGE_NAME}:${KUBEFLOW_IMAGE_VERSION}
 fi
 
-if [[ -n ${KUBEFLOW_TRAINER_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(tas|trainjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+if [[ -n ${KUBEFLOW_TRAINER_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(tas|trainjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
     export KUBEFLOW_TRAINER_MANIFEST=${ROOT_DIR}/dep-crds/kf-trainer/manifests
     # Extract the Kubeflow Trainer controller manager image version tag (newTag) from the manifest.
     # This is necessary because the image version tag does not follow the usual package versioning convention.
@@ -210,12 +213,12 @@ if [[ -n ${KUBEFLOW_MPI_VERSION:-} ]]; then
     export KUBEFLOW_MPI_IMAGE=mpioperator/mpi-operator:${KUBEFLOW_MPI_VERSION/#v}
 fi
 
-if [[ -n ${KUBERAY_VERSION:-} && ("$GINKGO_ARGS" =~ feature:kuberay || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+if [[ -n ${KUBERAY_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_0 || "$GINKGO_ARGS" =~ feature:kuberay || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
     export KUBERAY_MANIFEST="${ROOT_DIR}/dep-crds/ray-operator/default/"
     export KUBERAY_IMAGE=quay.io/kuberay/operator:${KUBERAY_VERSION}
 fi
 
-if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_0 || "$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
     export LEADERWORKERSET_MANIFEST="https://github.com/kubernetes-sigs/lws/releases/download/${LEADERWORKERSET_VERSION}/manifests.yaml"
     export LEADERWORKERSET_IMAGE=registry.k8s.io/lws/lws:${LEADERWORKERSET_VERSION}
 fi
@@ -487,30 +490,30 @@ function prepare_docker_images {
     docker tag "$E2E_TEST_AGNHOST_IMAGE_OLD_WITH_SHA" "$E2E_TEST_AGNHOST_IMAGE_OLD"
     docker tag "$E2E_TEST_AGNHOST_IMAGE_WITH_SHA" "$E2E_TEST_AGNHOST_IMAGE"
 
-    if [[ -n ${APPWRAPPER_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(appwrapper|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${APPWRAPPER_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(appwrapper|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${APPWRAPPER_IMAGE}"
     fi
-    if [[ -n ${JOBSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(jobset|tas|trainjob|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${JOBSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_0 || "$GINKGO_ARGS" =~ feature:(jobset|tas|trainjob|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${JOBSET_IMAGE}"
     fi
-    if [[ -n ${KUBEFLOW_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(jaxjob|pytorchjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${KUBEFLOW_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(jaxjob|pytorchjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${KUBEFLOW_IMAGE}"
     fi
-    if [[ -n ${KUBEFLOW_TRAINER_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(tas|trainjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${KUBEFLOW_TRAINER_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(tas|trainjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${KF_TRAINER_IMAGE}"
     fi
 
     if [[ -n ${KUBEFLOW_MPI_VERSION:-} ]]; then
         e2e_docker_pull_if_needed "${KUBEFLOW_MPI_IMAGE}"
     fi
-    if [[ -n ${KUBERAY_VERSION:-} && ("$GINKGO_ARGS" =~ feature:kuberay || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${KUBERAY_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_0 || "$GINKGO_ARGS" =~ feature:kuberay || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${KUBERAY_IMAGE}"
         determine_kuberay_ray_image
         if [[ ${USE_RAY_FOR_TESTS:-} == "ray" ]]; then
             e2e_docker_pull_if_needed "${KUBERAY_RAY_IMAGE}"
         fi
     fi
-    if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_0 || "$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${LEADERWORKERSET_IMAGE}"
     fi
     if [[ -n ${KUEUE_UPGRADE_FROM_VERSION:-} ]]; then
@@ -554,30 +557,30 @@ function kind_load {
 
     cluster_kind_load "${e2e_cluster_name}"
 
-    if [[ -n ${APPWRAPPER_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(appwrapper|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${APPWRAPPER_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(appwrapper|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         install_appwrapper "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
-    if [[ -n ${JOBSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(jobset|tas|trainjob|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${JOBSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_0 || "$GINKGO_ARGS" =~ feature:(jobset|tas|trainjob|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         install_jobset "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
-    if [[ -n ${KUBEFLOW_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(jaxjob|pytorchjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${KUBEFLOW_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(jaxjob|pytorchjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         # In order for MPI-operator and Training-operator to work on the same cluster it is required that:
         # 1. 'kubeflow.org_mpijobs.yaml' is removed from base/crds/kustomization.yaml - https://github.com/kubeflow/training-operator/issues/1930
         # 2. Training-operator deployment is modified to enable all kubeflow jobs except for mpi -  https://github.com/kubeflow/training-operator/issues/1777
         install_kubeflow "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
 
-    if [[ -n ${KUBEFLOW_TRAINER_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(tas|trainjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${KUBEFLOW_TRAINER_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(tas|trainjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         install_kubeflow_trainer "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
 
     if [[ -n ${KUBEFLOW_MPI_VERSION:-} ]]; then
         install_mpi "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
-    if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_0 || "$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         install_lws "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
-    if [[ -n ${KUBERAY_VERSION:-} && ("$GINKGO_ARGS" =~ feature:kuberay || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${KUBERAY_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_0 || "$GINKGO_ARGS" =~ feature:kuberay || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         install_kuberay "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
     if [[ -n ${SPARKOPERATOR_VERSION:-} && ("$GINKGO_ARGS" =~ feature:spark || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then

--- a/test/e2e/singlecluster/extended/appwrapper_test.go
+++ b/test/e2e/singlecluster/extended/appwrapper_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("AppWrapper", ginkgo.Label("area:singlecluster", "feature:appwrapper"), func() {
+var _ = ginkgo.Describe("AppWrapper", ginkgo.Label(util.Shard1, "area:singlecluster", "feature:appwrapper"), func() {
 	var (
 		ns                 *corev1.Namespace
 		rf                 *kueue.ResourceFlavor

--- a/test/e2e/singlecluster/extended/jaxjob_test.go
+++ b/test/e2e/singlecluster/extended/jaxjob_test.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("JAX integration", ginkgo.Label("area:singlecluster", "feature:jaxjob"), func() {
+var _ = ginkgo.Describe("JAX integration", ginkgo.Label(util.Shard1, "area:singlecluster", "feature:jaxjob"), func() {
 	var (
 		ns                 *corev1.Namespace
 		rf                 *kueue.ResourceFlavor

--- a/test/e2e/singlecluster/extended/jobset_test.go
+++ b/test/e2e/singlecluster/extended/jobset_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("JobSet", ginkgo.Label("area:singlecluster", "feature:jobset"), func() {
+var _ = ginkgo.Describe("JobSet", ginkgo.Label(util.Shard0, "area:singlecluster", "feature:jobset"), func() {
 	var ns *corev1.Namespace
 
 	ginkgo.BeforeEach(func() {

--- a/test/e2e/singlecluster/extended/kuberay_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_test.go
@@ -73,7 +73,7 @@ const (
 	objectStoreMemory = "100000000"
 )
 
-var _ = ginkgo.Describe("Kuberay", ginkgo.Label("area:singlecluster", "feature:kuberay"), func() {
+var _ = ginkgo.Describe("Kuberay", ginkgo.Label(util.Shard0, "area:singlecluster", "feature:kuberay"), func() {
 	var (
 		ns                 *corev1.Namespace
 		rf                 *kueue.ResourceFlavor

--- a/test/e2e/singlecluster/extended/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/extended/leaderworkerset_test.go
@@ -42,7 +42,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:singlecluster", "feature:leaderworkerset"), func() {
+var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label(util.Shard0, "area:singlecluster", "feature:leaderworkerset"), func() {
 	var (
 		ns                 *corev1.Namespace
 		rf                 *kueue.ResourceFlavor

--- a/test/e2e/singlecluster/extended/pytorchjob_test.go
+++ b/test/e2e/singlecluster/extended/pytorchjob_test.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("PyTorch integration", ginkgo.Label("area:singlecluster", "feature:pytorchjob"), func() {
+var _ = ginkgo.Describe("PyTorch integration", ginkgo.Label(util.Shard1, "area:singlecluster", "feature:pytorchjob"), func() {
 	var (
 		ns                 *corev1.Namespace
 		rf                 *kueue.ResourceFlavor

--- a/test/e2e/singlecluster/extended/suite_test.go
+++ b/test/e2e/singlecluster/extended/suite_test.go
@@ -54,22 +54,22 @@ var _ = ginkgo.BeforeSuite(func() {
 	waitForAvailableStart := time.Now()
 	util.WaitForKueueAvailability(ctx, k8sClient)
 	labelFilter := ginkgo.GinkgoLabelFilter()
-	if ginkgo.Label("feature:jobset", "feature:tas", "feature:trainjob").MatchesLabelFilter(labelFilter) {
+	if ginkgo.Label(util.Shard0, "feature:jobset", "feature:trainjob").MatchesLabelFilter(labelFilter) {
 		util.WaitForJobSetAvailability(ctx, k8sClient)
 	}
-	if ginkgo.Label("feature:leaderworkerset").MatchesLabelFilter(labelFilter) {
+	if ginkgo.Label(util.Shard0, "feature:leaderworkerset").MatchesLabelFilter(labelFilter) {
 		util.WaitForLeaderWorkerSetAvailability(ctx, k8sClient)
 	}
-	if ginkgo.Label("feature:appwrapper").MatchesLabelFilter(labelFilter) {
+	if ginkgo.Label(util.Shard1, "feature:appwrapper").MatchesLabelFilter(labelFilter) {
 		util.WaitForAppWrapperAvailability(ctx, k8sClient)
 	}
-	if ginkgo.Label("feature:jaxjob", "feature:pytorchjob").MatchesLabelFilter(labelFilter) {
+	if ginkgo.Label(util.Shard1, "feature:jaxjob", "feature:pytorchjob").MatchesLabelFilter(labelFilter) {
 		util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sClient)
 	}
-	if ginkgo.Label("feature:kuberay").MatchesLabelFilter(labelFilter) {
+	if ginkgo.Label(util.Shard0, "feature:kuberay").MatchesLabelFilter(labelFilter) {
 		util.WaitForKubeRayOperatorAvailability(ctx, k8sClient)
 	}
-	if ginkgo.Label("feature:tas", "feature:trainjob").MatchesLabelFilter(labelFilter) {
+	if ginkgo.Label(util.Shard1, "feature:trainjob").MatchesLabelFilter(labelFilter) {
 		util.WaitForKubeFlowTrainnerControllerManagerAvailability(ctx, k8sClient)
 	}
 	ginkgo.GinkgoLogr.Info(

--- a/test/e2e/singlecluster/extended/trainjob_test.go
+++ b/test/e2e/singlecluster/extended/trainjob_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TrainJob", ginkgo.Label("area:singlecluster", "feature:trainjob"), func() {
+var _ = ginkgo.Describe("TrainJob", ginkgo.Label(util.Shard1, "area:singlecluster", "feature:trainjob"), func() {
 	var ns *corev1.Namespace
 
 	ginkgo.BeforeEach(func() {


### PR DESCRIPTION
Cherry pick of #11893 on release-0.17.

#11893: Optimize the "singlecluster/extended" e2e test suites by sharding

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```