### PR TITLE
Fix stale DRA resource requests on requeue after DeviceClass deletion

### DIFF
--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -693,7 +693,11 @@ func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reas
 	}
 	log := ctrl.LoggerFrom(ctx)
 	workload.AdjustResources(ctx, m.client, &w)
-	info.Update(log, &w)
+	if dra.NeedsDRAReconcile(&w, m.draBackedResources) {
+		info.Update(log, &w, workload.WithPreserveTotalRequests())
+	} else {
+		info.Update(log, &w, m.workloadInfoOptions...)
+	}
 	m.addWorkload(info, q)
 
 	cq := m.hm.ClusterQueue(q.ClusterQueue)

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -127,6 +127,7 @@ type dra struct {
 type InfoOptions struct {
 	excludedResourcePrefixes []string
 	resourceTransformations  map[corev1.ResourceName]*config.ResourceTransformation
+	preserveTotalRequests    bool
 	dra
 }
 
@@ -145,6 +146,15 @@ func WithExcludedResourcePrefixes(n []string) InfoOption {
 func WithResourceTransformations(transforms []config.ResourceTransformation) InfoOption {
 	return func(o *InfoOptions) {
 		o.resourceTransformations = utilslices.ToRefMap(transforms, func(e *config.ResourceTransformation) corev1.ResourceName { return e.Input })
+	}
+}
+
+// WithPreserveTotalRequests prevents Update from rebuilding TotalRequests.
+// Used when requeuing DRA-backed workloads whose TotalRequests were
+// preprocessed by the workload controller and must survive the requeue.
+func WithPreserveTotalRequests() InfoOption {
+	return func(o *InfoOptions) {
+		o.preserveTotalRequests = true
 	}
 }
 
@@ -289,34 +299,47 @@ func (p *PodSetResources) ScaledTo(newCount int32) *PodSetResources {
 }
 
 func NewInfo(w *kueue.Workload, opts ...InfoOption) *Info {
-	options := defaultOptions
-	for _, opt := range opts {
-		opt(&options)
-	}
-	info := &Info{
-		Obj: w,
-	}
-	if w.Status.Admission != nil {
-		info.ClusterQueue = w.Status.Admission.ClusterQueue
-		info.TotalRequests = totalRequestsFromAdmission(w)
-	} else {
-		info.TotalRequests = totalRequestsFromPodSets(w, &options)
-	}
+	info := &Info{}
+	info.Update(klog.Background(), w, opts...)
 	return info
 }
 
 // UpdateSchedulingHash computes and sets the scheduling hash using the
-// provided contextual logger. Call this after NewInfo in production code.
+// provided contextual logger. Called internally by Update.
 func (i *Info) UpdateSchedulingHash(log logr.Logger) {
 	i.SchedulingHash = computeSchedulingHash(log, i.Obj, i.TotalRequests)
 }
 
-// Update refreshes the object reference and recomputes the scheduling hash
-// to reflect any changes (e.g., priority updates).
-func (i *Info) Update(log logr.Logger, wl *kueue.Workload) {
-	log.V(5).Info("Workload info updated", "workload", klog.KObj(wl))
+// Update refreshes the object reference, rebuilds TotalRequests, and
+// recomputes the scheduling hash. Pass WithPreserveTotalRequests to skip
+// the TotalRequests rebuild (e.g., to retain DRA preprocessing on requeue).
+func (i *Info) Update(log logr.Logger, wl *kueue.Workload, opts ...InfoOption) {
 	i.Obj = wl
+	i.rebuildTotalRequests(opts...)
 	i.UpdateSchedulingHash(log)
+}
+
+// rebuildTotalRequests refreshes ClusterQueue and recomputes TotalRequests
+// from the current workload state. When WithPreserveTotalRequests is set,
+// only TotalRequests recomputation is skipped.
+func (i *Info) rebuildTotalRequests(opts ...InfoOption) {
+	options := defaultOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+	admitted := i.Obj.Status.Admission != nil
+	if admitted {
+		i.ClusterQueue = i.Obj.Status.Admission.ClusterQueue
+	} else {
+		i.ClusterQueue = ""
+	}
+	if !options.preserveTotalRequests {
+		if admitted {
+			i.TotalRequests = totalRequestsFromAdmission(i.Obj)
+		} else {
+			i.TotalRequests = totalRequestsFromPodSets(i.Obj, &options)
+		}
+	}
 }
 
 // computeSchedulingHash returns a deterministic hash of the workload's

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -621,6 +621,107 @@ func TestNewInfo(t *testing.T) {
 	}
 }
 
+func TestUpdateWithRebuild(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	cases := map[string]struct {
+		initial        *kueue.Workload
+		initialOptions []InfoOption
+		updated        *kueue.Workload
+		updateOptions  []InfoOption
+		wantRequests   []PodSetResources
+	}{
+		"pending workload with changed requests": {
+			initial: utiltestingapi.MakeWorkload("wl", "ns").
+				Request(corev1.ResourceCPU, "100m").Obj(),
+			updated: utiltestingapi.MakeWorkload("wl", "ns").
+				Request(corev1.ResourceCPU, "200m").Obj(),
+			wantRequests: []PodSetResources{{
+				Name:     kueue.DefaultPodSetName,
+				Requests: resources.Requests{corev1.ResourceCPU: 200},
+				Count:    1,
+			}},
+		},
+		"stale DRA TotalRequests cleared on rebuild": {
+			initial: utiltestingapi.MakeWorkload("wl", "ns").
+				Request("example.com/gpu", "1").Obj(),
+			initialOptions: []InfoOption{
+				WithPreprocessedDRAResources(
+					map[kueue.PodSetReference]corev1.ResourceList{
+						kueue.DefaultPodSetName: {
+							"gpu": resource.MustParse("1"),
+						},
+					},
+					map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{
+						kueue.DefaultPodSetName: sets.New[corev1.ResourceName]("example.com/gpu"),
+					},
+				),
+			},
+			updated: utiltestingapi.MakeWorkload("wl", "ns").
+				Request("example.com/gpu", "1").Obj(),
+			wantRequests: []PodSetResources{{
+				Name:     kueue.DefaultPodSetName,
+				Requests: resources.Requests{"example.com/gpu": 1},
+				Count:    1,
+			}},
+		},
+		"admitted workload recomputes from admission": {
+			initial: utiltestingapi.MakeWorkload("wl", "ns").
+				Request(corev1.ResourceCPU, "100m").Obj(),
+			updated: utiltestingapi.MakeWorkload("wl", "ns").
+				Request(corev1.ResourceCPU, "100m").
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").
+					PodSets(kueue.PodSetAssignment{
+						Name:          kueue.DefaultPodSetName,
+						ResourceUsage: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+						Count:         ptr.To[int32](1),
+					}).Obj(), now).
+				Obj(),
+			wantRequests: []PodSetResources{{
+				Name:     kueue.DefaultPodSetName,
+				Requests: resources.Requests{corev1.ResourceCPU: 200},
+				Count:    1,
+			}},
+		},
+		"WithPreserveTotalRequests keeps DRA-translated requests": {
+			initial: utiltestingapi.MakeWorkload("wl", "ns").
+				Request("example.com/gpu", "1").Obj(),
+			initialOptions: []InfoOption{
+				WithPreprocessedDRAResources(
+					map[kueue.PodSetReference]corev1.ResourceList{
+						kueue.DefaultPodSetName: {"gpu": resource.MustParse("1")},
+					},
+					map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{
+						kueue.DefaultPodSetName: sets.New[corev1.ResourceName]("example.com/gpu"),
+					},
+				),
+			},
+			updated: utiltestingapi.MakeWorkload("wl", "ns").
+				Request("example.com/gpu", "1").Obj(),
+			updateOptions: []InfoOption{WithPreserveTotalRequests()},
+			wantRequests: []PodSetResources{{
+				Name:     kueue.DefaultPodSetName,
+				Requests: resources.Requests{"gpu": 1},
+				Count:    1,
+			}},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			info := NewInfo(tc.initial, tc.initialOptions...)
+			if len(tc.updateOptions) == 0 {
+				if diff := cmp.Diff(tc.wantRequests, info.TotalRequests, cmpopts.IgnoreFields(PodSetResources{}, "Flavors")); diff == "" {
+					t.Fatal("precondition failed: initial TotalRequests should differ from expected post-rebuild state")
+				}
+			}
+			info.Update(logr.Discard(), tc.updated, tc.updateOptions...)
+			if diff := cmp.Diff(tc.wantRequests, info.TotalRequests,
+				cmpopts.IgnoreFields(PodSetResources{}, "Flavors")); diff != "" {
+				t.Errorf("TotalRequests after Update (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestSetConditionAndUpdate(t *testing.T) {
 	now := time.Now()
 	fakeClock := testingclock.NewFakeClock(now)

--- a/test/integration/singlecluster/controller/dra/dra_test.go
+++ b/test/integration/singlecluster/controller/dra/dra_test.go
@@ -1444,6 +1444,50 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
+		ginkgo.It("Should clear stale DRA TotalRequests when admitted workload is requeued after DeviceClass deletion", func() {
+			ginkgo.By("Creating DeviceClass")
+			deviceClass := &resourcev1.DeviceClass{
+				ObjectMeta: metav1.ObjectMeta{Name: deviceClassName},
+				Spec: resourcev1.DeviceClassSpec{
+					ExtendedResourceName: ptr.To(extendedResourceName),
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, deviceClass)).To(gomega.Succeed())
+
+			ginkgo.By("Creating workload and verifying it is admitted with DRA-translated quota key")
+			wl := utiltestingapi.MakeWorkload("stale-dra-wl", ns.Name).
+				Queue("dc-tracking-lq").
+				Request(corev1.ResourceName(extendedResourceName), "2").
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeTrue())
+				assignment := updatedWl.Status.Admission.PodSetAssignments[0]
+				g.Expect(assignment.ResourceUsage).To(gomega.HaveKey(corev1.ResourceName(logicalName)),
+					"workload should be admitted with DRA-translated logical name %q", logicalName)
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Deleting DeviceClass so workload is no longer DRA-backed")
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, deviceClass, true)
+
+			ginkgo.By("Evicting admitted workload to trigger requeue with stale TotalRequests")
+			util.SetQuotaReservation(ctx, k8sClient, client.ObjectKeyFromObject(wl), nil)
+
+			ginkgo.By("Verifying requeued workload uses raw ER name, not stale DRA translation")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeFalse())
+				cond := apimeta.FindStatusCondition(updatedWl.Status.Conditions, kueue.WorkloadQuotaReserved)
+				g.Expect(cond).NotTo(gomega.BeNil())
+				g.Expect(cond.Message).To(gomega.ContainSubstring(string(extendedResourceName)),
+					"requeued workload should reference raw ER %q, not stale DRA logical name", extendedResourceName)
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
 		ginkgo.It("Should requeue inadmissible workload when DeviceClass extendedResourceName is updated", func() {
 			const newExtendedResourceName = "example.com/tpu"
 

--- a/test/integration/singlecluster/controller/dra/suite_test.go
+++ b/test/integration/singlecluster/controller/dra/suite_test.go
@@ -126,7 +126,11 @@ func managerSetup(modifyConfig func(*config.Configuration)) framework.ManagerSet
 
 		cCache := schdcache.New(mgr.GetClient())
 		preemptionExpectations := preemptexpectations.New()
-		queueOptions := []qcache.Option{qcache.WithPreemptionExpectations(preemptionExpectations)}
+		draBackedResources := dra.NewExtendedResourceCache()
+		queueOptions := []qcache.Option{
+			qcache.WithPreemptionExpectations(preemptionExpectations),
+			qcache.WithDRABackedResources(draBackedResources),
+		}
 		queues := util.NewManagerForIntegrationTests(ctx, mgr.GetClient(), cCache, queueOptions...)
 
 		// Core controllers
@@ -135,7 +139,7 @@ func managerSetup(modifyConfig func(*config.Configuration)) framework.ManagerSet
 			queues,
 			cCache,
 			controllersCfg,
-			core.SetupControllersOpts{PreemptionExpectations: preemptionExpectations, DRAMapper: draMapper, DRABackedResources: dra.NewExtendedResourceCache()},
+			core.SetupControllersOpts{PreemptionExpectations: preemptionExpectations, DRAMapper: draMapper, DRABackedResources: draBackedResources},
 		)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
When a workload is requeued after a DeviceClass deletion, Info.Update keeps the old DRA-translated `TotalRequests` even though the resource is no longer DRA-backed. Rebuild TotalRequests from the raw spec in that case.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
DRA: Fix workloads retaining DRA-mapped resource names after their DeviceClass is deleted.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved workload update flow: updates to total-request recomputation now support a conditional preserve mode to retain preprocessed DRA totals when requeuing workloads.

* **Tests**
  * Added unit tests verifying rebuild vs. preservation of total resource requests.
  * Updated integration test setup to use a shared DRA-backed resource cache for consistent reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->