### PR TITLE
Automated cherry pick of #11919: Optimize the "tas/extended" e2e test suites by sharding
#11928: Reorganize singlecluster/extended e2e tests shards.

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -226,7 +226,24 @@ test-e2e-baseline: setup-e2e-env kueuectl run-test-e2e-baseline-$(E2E_KIND_VERSI
 test-tas-e2e-baseline: setup-e2e-env run-test-tas-e2e-baseline-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-tas-e2e-extended
-test-tas-e2e-extended: setup-e2e-env kind-ray-project-mini-image-build run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
+test-tas-e2e-extended: test-tas-e2e-extended-shard-0 test-tas-e2e-extended-shard-1
+
+.PHONY: test-tas-e2e-extended-shard-0
+test-tas-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=shard-0
+test-tas-e2e-extended-shard-0: export JOBSET_VERSION := $(JOBSET_VERSION)
+test-tas-e2e-extended-shard-0: export LEADERWORKERSET_VERSION := $(LEADERWORKERSET_VERSION)
+test-tas-e2e-extended-shard-0: export KUBERAY_VERSION := $(KUBERAY_VERSION)
+test-tas-e2e-extended-shard-0: export RAY_VERSION := $(RAY_VERSION)
+test-tas-e2e-extended-shard-0: export RAYMINI_VERSION := $(RAYMINI_VERSION)
+test-tas-e2e-extended-shard-0: setup-e2e-env kind-ray-project-mini-image-build run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
+
+.PHONY: test-tas-e2e-extended-shard-1
+test-tas-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=shard-1
+test-tas-e2e-extended-shard-1: export APPWRAPPER_VERSION := $(APPWRAPPER_VERSION)
+test-tas-e2e-extended-shard-1: export KUBEFLOW_VERSION := $(KUBEFLOW_VERSION)
+test-tas-e2e-extended-shard-1: export KUBEFLOW_MPI_VERSION := $(KUBEFLOW_MPI_VERSION)
+test-tas-e2e-extended-shard-1: export KUBEFLOW_TRAINER_VERSION := $(KUBEFLOW_TRAINER_VERSION)
+test-tas-e2e-extended-shard-1: setup-e2e-env run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-tas-e2e-baseline-helm
 test-tas-e2e-baseline-helm: E2E_USE_HELM=true
@@ -370,11 +387,7 @@ run-test-tas-e2e-extended-%:
 		E2E_MODE=$(E2E_MODE) \
 		E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
 		E2E_ENFORCE_OPERATOR_UPDATE=$(E2E_ENFORCE_OPERATOR_UPDATE) \
-		JOBSET_VERSION=$(JOBSET_VERSION) KUBEFLOW_VERSION=$(KUBEFLOW_VERSION) KUBEFLOW_MPI_VERSION=$(KUBEFLOW_MPI_VERSION) \
-		APPWRAPPER_VERSION=$(APPWRAPPER_VERSION) \
-		LEADERWORKERSET_VERSION=$(LEADERWORKERSET_VERSION) \
-		KUBERAY_VERSION=$(KUBERAY_VERSION) RAY_VERSION=$(RAY_VERSION) RAYMINI_VERSION=$(RAYMINI_VERSION) USE_RAY_FOR_TESTS=$(USE_RAY_FOR_TESTS) \
-		KUBEFLOW_TRAINER_VERSION=$(KUBEFLOW_TRAINER_VERSION) \
+		USE_RAY_FOR_TESTS=$(USE_RAY_FOR_TESTS) \
 		KIND_CLUSTER_FILE="kind-cluster-tas.yaml" E2E_TARGET_FOLDER="tas/extended" \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
 		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -186,28 +186,28 @@ test-multikueue-e2e-helm: test-multikueue-e2e
 test-e2e-extended: test-e2e-extended-shard-0 test-e2e-extended-shard-1
 
 ## Label Taxonomy:
-##   Features: jobset,kuberay,leaderworkerset
+##   Features: kuberay
 ##
 ## Examples:
-##   Run only LeaderWorkerSet tests: GINKGO_ARGS="--label-filter=feature:leaderworkerset" make test-e2e-extended-shard-0
+##   Run only kuberay tests: GINKGO_ARGS="--label-filter=feature:kuberay" make test-e2e-extended-shard-0
 .PHONY: test-e2e-extended-shard-0
 test-e2e-extended-shard-0: E2E_NPROCS := 4
 test-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=shard-0
-test-e2e-extended-shard-0: export JOBSET_VERSION := $(JOBSET_VERSION)
-test-e2e-extended-shard-0: export LEADERWORKERSET_VERSION := $(LEADERWORKERSET_VERSION)
 test-e2e-extended-shard-0: export KUBERAY_VERSION := $(KUBERAY_VERSION)
 test-e2e-extended-shard-0: export RAY_VERSION := $(RAY_VERSION)
 test-e2e-extended-shard-0: export RAYMINI_VERSION := $(RAYMINI_VERSION)
 test-e2e-extended-shard-0: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 ## Label Taxonomy:
-##   Features: appwrapper,jaxjob,pytorchjob,trainjob
+##   Features: jobset,leaderworkerset,appwrapper,jaxjob,pytorchjob,trainjob
 ##
 ## Examples:
 ##   Run only AppWrapper tests: GINKGO_ARGS="--label-filter=feature:appwrapper" make test-e2e-extended-shard-1
 .PHONY: test-e2e-extended-shard-1
 test-e2e-extended-shard-1: E2E_NPROCS := 4
 test-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=shard-1
+test-e2e-extended-shard-1: export JOBSET_VERSION := $(JOBSET_VERSION)
+test-e2e-extended-shard-1: export LEADERWORKERSET_VERSION := $(LEADERWORKERSET_VERSION)
 test-e2e-extended-shard-1: export APPWRAPPER_VERSION := $(APPWRAPPER_VERSION)
 test-e2e-extended-shard-1: export KUBEFLOW_VERSION := $(KUBEFLOW_VERSION)
 test-e2e-extended-shard-1: export KUBEFLOW_TRAINER_VERSION := $(KUBEFLOW_TRAINER_VERSION)
@@ -230,8 +230,6 @@ test-tas-e2e-extended: test-tas-e2e-extended-shard-0 test-tas-e2e-extended-shard
 
 .PHONY: test-tas-e2e-extended-shard-0
 test-tas-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=shard-0
-test-tas-e2e-extended-shard-0: export JOBSET_VERSION := $(JOBSET_VERSION)
-test-tas-e2e-extended-shard-0: export LEADERWORKERSET_VERSION := $(LEADERWORKERSET_VERSION)
 test-tas-e2e-extended-shard-0: export KUBERAY_VERSION := $(KUBERAY_VERSION)
 test-tas-e2e-extended-shard-0: export RAY_VERSION := $(RAY_VERSION)
 test-tas-e2e-extended-shard-0: export RAYMINI_VERSION := $(RAYMINI_VERSION)
@@ -239,6 +237,8 @@ test-tas-e2e-extended-shard-0: setup-e2e-env kind-ray-project-mini-image-build r
 
 .PHONY: test-tas-e2e-extended-shard-1
 test-tas-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=shard-1
+test-tas-e2e-extended-shard-1: export JOBSET_VERSION := $(JOBSET_VERSION)
+test-tas-e2e-extended-shard-1: export LEADERWORKERSET_VERSION := $(LEADERWORKERSET_VERSION)
 test-tas-e2e-extended-shard-1: export APPWRAPPER_VERSION := $(APPWRAPPER_VERSION)
 test-tas-e2e-extended-shard-1: export KUBEFLOW_VERSION := $(KUBEFLOW_VERSION)
 test-tas-e2e-extended-shard-1: export KUBEFLOW_MPI_VERSION := $(KUBEFLOW_MPI_VERSION)

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -180,7 +180,7 @@ if [[ -n ${APPWRAPPER_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS
     export APPWRAPPER_IMAGE=quay.io/ibm/appwrapper:${APPWRAPPER_VERSION}
 fi
 
-if [[ -n ${JOBSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_0 || "$GINKGO_ARGS" =~ feature:(jobset|tas|trainjob|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+if [[ -n ${JOBSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(jobset|tas|trainjob|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
     export JOBSET_MANIFEST="https://github.com/kubernetes-sigs/jobset/releases/download/${JOBSET_VERSION}/manifests.yaml"
     export JOBSET_IMAGE=registry.k8s.io/jobset/jobset:${JOBSET_VERSION}
     export JOBSET_CRDS=${ROOT_DIR}/dep-crds/jobset-operator/
@@ -218,7 +218,7 @@ if [[ -n ${KUBERAY_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_0 || "$GINKGO_ARGS" =
     export KUBERAY_IMAGE=quay.io/kuberay/operator:${KUBERAY_VERSION}
 fi
 
-if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_0 || "$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
     export LEADERWORKERSET_MANIFEST="https://github.com/kubernetes-sigs/lws/releases/download/${LEADERWORKERSET_VERSION}/manifests.yaml"
     export LEADERWORKERSET_IMAGE=registry.k8s.io/lws/lws:${LEADERWORKERSET_VERSION}
 fi
@@ -493,7 +493,7 @@ function prepare_docker_images {
     if [[ -n ${APPWRAPPER_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(appwrapper|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${APPWRAPPER_IMAGE}"
     fi
-    if [[ -n ${JOBSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_0 || "$GINKGO_ARGS" =~ feature:(jobset|tas|trainjob|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${JOBSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(jobset|tas|trainjob|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${JOBSET_IMAGE}"
     fi
     if [[ -n ${KUBEFLOW_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(jaxjob|pytorchjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
@@ -513,7 +513,7 @@ function prepare_docker_images {
             e2e_docker_pull_if_needed "${KUBERAY_RAY_IMAGE}"
         fi
     fi
-    if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_0 || "$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${LEADERWORKERSET_IMAGE}"
     fi
     if [[ -n ${KUEUE_UPGRADE_FROM_VERSION:-} ]]; then
@@ -560,7 +560,7 @@ function kind_load {
     if [[ -n ${APPWRAPPER_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(appwrapper|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         install_appwrapper "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
-    if [[ -n ${JOBSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_0 || "$GINKGO_ARGS" =~ feature:(jobset|tas|trainjob|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${JOBSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(jobset|tas|trainjob|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         install_jobset "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
     if [[ -n ${KUBEFLOW_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(jaxjob|pytorchjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
@@ -577,7 +577,7 @@ function kind_load {
     if [[ -n ${KUBEFLOW_MPI_VERSION:-} ]]; then
         install_mpi "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
-    if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_0 || "$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         install_lws "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
     if [[ -n ${KUBERAY_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_0 || "$GINKGO_ARGS" =~ feature:kuberay || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then

--- a/test/e2e/singlecluster/extended/jobset_test.go
+++ b/test/e2e/singlecluster/extended/jobset_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("JobSet", ginkgo.Label(util.Shard0, "area:singlecluster", "feature:jobset"), func() {
+var _ = ginkgo.Describe("JobSet", ginkgo.Label(util.Shard1, "area:singlecluster", "feature:jobset"), func() {
 	var ns *corev1.Namespace
 
 	ginkgo.BeforeEach(func() {

--- a/test/e2e/singlecluster/extended/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/extended/leaderworkerset_test.go
@@ -42,7 +42,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label(util.Shard0, "area:singlecluster", "feature:leaderworkerset"), func() {
+var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label(util.Shard1, "area:singlecluster", "feature:leaderworkerset"), func() {
 	var (
 		ns                 *corev1.Namespace
 		rf                 *kueue.ResourceFlavor

--- a/test/e2e/singlecluster/extended/suite_test.go
+++ b/test/e2e/singlecluster/extended/suite_test.go
@@ -54,10 +54,10 @@ var _ = ginkgo.BeforeSuite(func() {
 	waitForAvailableStart := time.Now()
 	util.WaitForKueueAvailability(ctx, k8sClient)
 	labelFilter := ginkgo.GinkgoLabelFilter()
-	if ginkgo.Label(util.Shard0, "feature:jobset", "feature:trainjob").MatchesLabelFilter(labelFilter) {
+	if ginkgo.Label(util.Shard1, "feature:jobset", "feature:trainjob").MatchesLabelFilter(labelFilter) {
 		util.WaitForJobSetAvailability(ctx, k8sClient)
 	}
-	if ginkgo.Label(util.Shard0, "feature:leaderworkerset").MatchesLabelFilter(labelFilter) {
+	if ginkgo.Label(util.Shard1, "feature:leaderworkerset").MatchesLabelFilter(labelFilter) {
 		util.WaitForLeaderWorkerSetAvailability(ctx, k8sClient)
 	}
 	if ginkgo.Label(util.Shard1, "feature:appwrapper").MatchesLabelFilter(labelFilter) {

--- a/test/e2e/tas/extended/appwrapper_test.go
+++ b/test/e2e/tas/extended/appwrapper_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", ginkgo.Label(util.Shard1), func() {
 	var (
 		ns           *corev1.Namespace
 		topology     *kueue.Topology

--- a/test/e2e/tas/extended/jobset_test.go
+++ b/test/e2e/tas/extended/jobset_test.go
@@ -38,7 +38,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for JobSet", func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for JobSet", ginkgo.Label(util.Shard0), func() {
 	var ns *corev1.Namespace
 	ginkgo.BeforeEach(func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-tas-jobset-")

--- a/test/e2e/tas/extended/jobset_test.go
+++ b/test/e2e/tas/extended/jobset_test.go
@@ -38,7 +38,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for JobSet", ginkgo.Label(util.Shard0), func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for JobSet", ginkgo.Label(util.Shard1), func() {
 	var ns *corev1.Namespace
 	ginkgo.BeforeEach(func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-tas-jobset-")

--- a/test/e2e/tas/extended/leaderworkerset_test.go
+++ b/test/e2e/tas/extended/leaderworkerset_test.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for LeaderWorkerSet", ginkgo.Label(util.Shard0), func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for LeaderWorkerSet", ginkgo.Label(util.Shard1), func() {
 	var (
 		ns           *corev1.Namespace
 		topology     *kueue.Topology

--- a/test/e2e/tas/extended/leaderworkerset_test.go
+++ b/test/e2e/tas/extended/leaderworkerset_test.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for LeaderWorkerSet", func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for LeaderWorkerSet", ginkgo.Label(util.Shard0), func() {
 	var (
 		ns           *corev1.Namespace
 		topology     *kueue.Topology

--- a/test/e2e/tas/extended/mpijob_test.go
+++ b/test/e2e/tas/extended/mpijob_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for MPIJob", func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for MPIJob", ginkgo.Label(util.Shard1), func() {
 	var (
 		ns           *corev1.Namespace
 		topology     *kueue.Topology

--- a/test/e2e/tas/extended/pytorch_test.go
+++ b/test/e2e/tas/extended/pytorch_test.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for PyTorchJob", func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for PyTorchJob", ginkgo.Label(util.Shard1), func() {
 	var (
 		ns           *corev1.Namespace
 		topology     *kueue.Topology

--- a/test/e2e/tas/extended/rayjob_test.go
+++ b/test/e2e/tas/extended/rayjob_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for RayJob", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for RayJob", ginkgo.Ordered, ginkgo.Label(util.Shard0), func() {
 	var (
 		ns           *corev1.Namespace
 		topology     *kueue.Topology

--- a/test/e2e/tas/extended/suite_test.go
+++ b/test/e2e/tas/extended/suite_test.go
@@ -50,12 +50,17 @@ var _ = ginkgo.BeforeSuite(func() {
 
 	waitForAvailableStart := time.Now()
 	util.WaitForKueueAvailability(ctx, k8sClient)
-	util.WaitForJobSetAvailability(ctx, k8sClient)
-	util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sClient)
-	util.WaitForKubeFlowMPIOperatorAvailability(ctx, k8sClient)
-	util.WaitForAppWrapperAvailability(ctx, k8sClient)
-	util.WaitForLeaderWorkerSetAvailability(ctx, k8sClient)
-	util.WaitForKubeRayOperatorAvailability(ctx, k8sClient)
+	labelFilter := ginkgo.GinkgoLabelFilter()
+	if ginkgo.Label(util.Shard0).MatchesLabelFilter(labelFilter) {
+		util.WaitForJobSetAvailability(ctx, k8sClient)
+		util.WaitForLeaderWorkerSetAvailability(ctx, k8sClient)
+		util.WaitForKubeRayOperatorAvailability(ctx, k8sClient)
+	}
+	if ginkgo.Label(util.Shard1).MatchesLabelFilter(labelFilter) {
+		util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sClient)
+		util.WaitForKubeFlowMPIOperatorAvailability(ctx, k8sClient)
+		util.WaitForAppWrapperAvailability(ctx, k8sClient)
+	}
 	ginkgo.GinkgoLogr.Info(
 		"Kueue and all required operators are available in the cluster",
 		"waitingTime", time.Since(waitForAvailableStart),

--- a/test/e2e/tas/extended/suite_test.go
+++ b/test/e2e/tas/extended/suite_test.go
@@ -52,11 +52,11 @@ var _ = ginkgo.BeforeSuite(func() {
 	util.WaitForKueueAvailability(ctx, k8sClient)
 	labelFilter := ginkgo.GinkgoLabelFilter()
 	if ginkgo.Label(util.Shard0).MatchesLabelFilter(labelFilter) {
-		util.WaitForJobSetAvailability(ctx, k8sClient)
-		util.WaitForLeaderWorkerSetAvailability(ctx, k8sClient)
 		util.WaitForKubeRayOperatorAvailability(ctx, k8sClient)
 	}
 	if ginkgo.Label(util.Shard1).MatchesLabelFilter(labelFilter) {
+		util.WaitForJobSetAvailability(ctx, k8sClient)
+		util.WaitForLeaderWorkerSetAvailability(ctx, k8sClient)
 		util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sClient)
 		util.WaitForKubeFlowMPIOperatorAvailability(ctx, k8sClient)
 		util.WaitForAppWrapperAvailability(ctx, k8sClient)

--- a/test/e2e/tas/extended/trainjob_test.go
+++ b/test/e2e/tas/extended/trainjob_test.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for TrainJob", func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for TrainJob", ginkgo.Label(util.Shard1), func() {
 	var ns *corev1.Namespace
 	ginkgo.BeforeEach(func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-tas-jobset-")


### PR DESCRIPTION
Cherry pick of #11919 #11928 on release-0.17.

#11919: Optimize the "tas/extended" e2e test suites by sharding
#11928: Reorganize singlecluster/extended e2e tests shards.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```