### PR TITLE
test : Adding Labels for tests in 'tas'

### DIFF
--- a/test/e2e/tas/baseline/hotswap_test.go
+++ b/test/e2e/tas/baseline/hotswap_test.go
@@ -40,7 +40,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Label(util.Shard1, "area:tas", "feature:tas"), ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Label(util.Shard1, "area:tas", "feature:hotswap"), ginkgo.Ordered, func() {
 	var ns *corev1.Namespace
 	ginkgo.BeforeEach(func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-tas-hotswap-")

--- a/test/e2e/tas/baseline/hotswap_test.go
+++ b/test/e2e/tas/baseline/hotswap_test.go
@@ -40,7 +40,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Label(util.Shard1, "area:tas", "feature:tas"), ginkgo.Ordered, func() {
 	var ns *corev1.Namespace
 	ginkgo.BeforeEach(func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-tas-hotswap-")

--- a/test/e2e/tas/baseline/job_test.go
+++ b/test/e2e/tas/baseline/job_test.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for Job", func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for Job", ginkgo.Label(util.Shard1, "area:tas", "feature:job"), func() {
 	var ns *corev1.Namespace
 	ginkgo.BeforeEach(func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-tas-job-")

--- a/test/e2e/tas/baseline/pod_group_test.go
+++ b/test/e2e/tas/baseline/pod_group_test.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for Pod group", func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for Pod group", ginkgo.Label(util.Shard1, "area:tas", "feature:pod"), func() {
 	var ns *corev1.Namespace
 	ginkgo.BeforeEach(func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-tas-pod-group-")

--- a/test/e2e/tas/baseline/statefulset_test.go
+++ b/test/e2e/tas/baseline/statefulset_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for StatefulSet", func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for StatefulSet", ginkgo.Label(util.Shard1, "area:tas", "feature:statefulset"), func() {
 	var (
 		ns           *corev1.Namespace
 		topology     *kueue.Topology

--- a/test/e2e/tas/extended/appwrapper_test.go
+++ b/test/e2e/tas/extended/appwrapper_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", ginkgo.Label(util.Shard1), func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", ginkgo.Label(util.Shard1, "area:tas", "feature:appwrapper"), func() {
 	var (
 		ns           *corev1.Namespace
 		topology     *kueue.Topology

--- a/test/e2e/tas/extended/jobset_test.go
+++ b/test/e2e/tas/extended/jobset_test.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for JobSet", ginkgo.Label(util.Shard1), func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for JobSet", ginkgo.Label(util.Shard1, "area:tas", "feature:jobset"), func() {
 	var ns *corev1.Namespace
 	ginkgo.BeforeEach(func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-tas-jobset-")

--- a/test/e2e/tas/extended/leaderworkerset_test.go
+++ b/test/e2e/tas/extended/leaderworkerset_test.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for LeaderWorkerSet", ginkgo.Label(util.Shard1), func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for LeaderWorkerSet", ginkgo.Label(util.Shard1, "area:tas", "feature:leaderworkerset"), func() {
 	var (
 		ns           *corev1.Namespace
 		topology     *kueue.Topology

--- a/test/e2e/tas/extended/mpijob_test.go
+++ b/test/e2e/tas/extended/mpijob_test.go
@@ -38,7 +38,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for MPIJob", ginkgo.Label(util.Shard1), func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for MPIJob", ginkgo.Label(util.Shard1, "area:tas", "feature:mpijob"), func() {
 	var (
 		ns           *corev1.Namespace
 		topology     *kueue.Topology

--- a/test/e2e/tas/extended/pytorch_test.go
+++ b/test/e2e/tas/extended/pytorch_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for PyTorchJob", ginkgo.Label(util.Shard1), func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for PyTorchJob", ginkgo.Label(util.Shard1, "area:tas", "feature:pytorchjob"), func() {
 	var (
 		ns           *corev1.Namespace
 		topology     *kueue.Topology

--- a/test/e2e/tas/extended/rayjob_test.go
+++ b/test/e2e/tas/extended/rayjob_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for RayJob", ginkgo.Ordered, ginkgo.Label(util.Shard0), func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for RayJob", ginkgo.Ordered, ginkgo.Label(util.Shard0, "area:tas", "feature:kuberay"), func() {
 	var (
 		ns           *corev1.Namespace
 		topology     *kueue.Topology

--- a/test/e2e/tas/extended/trainjob_test.go
+++ b/test/e2e/tas/extended/trainjob_test.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for TrainJob", ginkgo.Label(util.Shard1), func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for TrainJob", ginkgo.Label(util.Shard1, "area:tas", "feature:trainjob"), func() {
 	var ns *corev1.Namespace
 	ginkgo.BeforeEach(func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-tas-jobset-")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area tas
/area testing


#### What this PR does / why we need it:
This PR adds tests labels to every test in the end-to-end tas category.

#### Which issue(s) this PR fixes:
Fixes #11941 

#### Special notes for your reviewer:
Label addition and area is set to tas

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced organization of e2e test infrastructure for Topology Aware Scheduling by adding comprehensive labels to test suite definitions. Test suites across both baseline and extended categories now include detailed area and feature-specific organizational identifiers, improving test filtering, selection, and categorization capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->