### PR TITLE
test: fix WorkloadRequestUseMergePatch feature gate always set to true in provisioning controller test

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -1664,7 +1664,7 @@ func TestReconcile(t *testing.T) {
 	for name, tc := range cases {
 		for _, useMergePatch := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", name, useMergePatch), func(t *testing.T) {
-				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, true)
+				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, useMergePatch)
 
 				interceptorFuncs := interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}
 				if tc.interceptorFuncsCreate != nil {


### PR DESCRIPTION
## What this PR does / why we need it

In `TestReconcile` (`pkg/controller/admissionchecks/provisioning/controller_test.go`), the test loops over `[]bool{false, true}` to run sub-tests with the `WorkloadRequestUseMergePatch` feature gate both enabled and disabled. However, `SetFeatureGateDuringTest` was hardcoded to `true` in both iterations, so the disabled path was never actually tested.

**Before:**
```go
for _, useMergePatch := range []bool{false, true} {
    features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, true) // always true
```

**After:**
```go
for _, useMergePatch := range []bool{false, true} {
    features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, useMergePatch) // uses loop variable
```

## Which issue(s) this PR fixes

None — this is a test-only fix.

## Does this PR introduce a user-facing change?

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)