### PR TITLE
fix: Support Kubernetes events.k8s.io Event API in priority booster

### DIFF
--- a/cmd/experimental/kueue-priority-booster/charts/kueue-priority-booster/templates/manager.yaml
+++ b/cmd/experimental/kueue-priority-booster/charts/kueue-priority-booster/templates/manager.yaml
@@ -11,6 +11,7 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:

--- a/cmd/experimental/kueue-priority-booster/config/rbac/role.yaml
+++ b/cmd/experimental/kueue-priority-booster/config/rbac/role.yaml
@@ -6,6 +6,7 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:
@@ -18,5 +19,5 @@ rules:
   verbs:
   - get
   - list
-  - watch
   - patch
+  - watch

--- a/cmd/experimental/kueue-priority-booster/pkg/controller/controller.go
+++ b/cmd/experimental/kueue-priority-booster/pkg/controller/controller.go
@@ -112,7 +112,9 @@ func NewPriorityBoostReconciler(c client.Client, recorder events.EventRecorder, 
 }
 
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads,verbs=get;list;watch;patch
+
 func (r *PriorityBoostReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Support Kubernetes events.k8s.io Event API in priority booster

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11954 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
PriorityBooster: Fix a bug that events.k8s.io Events operation permission errors.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated event permission configuration for the experimental priority booster controller to include the newer events API group, ensuring it can create and patch events as intended.
  * Minor RBAC rule ordering cleaned up to align permissions across deployment manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->