### PR TITLE
Automated cherry pick of #11951: fix: preload Spark image into kind for SparkApplication tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,12 +49,13 @@ updates:
       - "/hack/releasing/krew-release-bot"
       - "/hack/testing/agnhost"
       - "/hack/testing/cypress"
-      - "/hack/testing/linkchecker"
       - "/hack/testing/depcheck"
+      - "/hack/testing/linkchecker"
       - "/hack/testing/ray"
       - "/hack/testing/ray-mini"
       - "/hack/testing/secretreader"
       - "/hack/testing/shellcheck"
+      - "/hack/testing/spark"
     schedule:
       interval: "weekly"
     labels:

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -259,6 +259,10 @@ export E2E_TEST_AGNHOST_IMAGE_OLD=${E2E_TEST_AGNHOST_IMAGE_OLD_WITH_SHA%%@*}
 E2E_TEST_AGNHOST_IMAGE_WITH_SHA=$(grep '^FROM' "${SOURCE_DIR}/agnhost/Dockerfile" | awk '{print $2}')
 export E2E_TEST_AGNHOST_IMAGE=${E2E_TEST_AGNHOST_IMAGE_WITH_SHA%%@*}
 
+if [ -z "${E2E_TEST_SPARK_IMAGE:-}" ]; then
+  E2E_TEST_SPARK_IMAGE=$(grep '^FROM' "${ROOT_DIR}/hack/testing/spark/Dockerfile" | awk '{print $2}')
+  export E2E_TEST_SPARK_IMAGE=${E2E_TEST_SPARK_IMAGE%%@*}
+fi
 
 # $1 cluster name
 function cluster_cleanup {
@@ -521,6 +525,7 @@ function prepare_docker_images {
     fi
     if [[ -n ${SPARKOPERATOR_VERSION:-} && ("$GINKGO_ARGS" =~ feature:spark || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${SPARKOPERATOR_IMAGE}"
+        e2e_docker_pull_if_needed "${E2E_TEST_SPARK_IMAGE}"
     fi
     if [[ -n ${PROMETHEUS_OPERATOR_VERSION:-} && ("$GINKGO_ARGS" =~ feature:prometheus || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${PROMETHEUS_OPERATOR_IMAGE}"
@@ -1073,6 +1078,7 @@ function install_sparkoperator {
     expected_version="${expected_version#v}"
     local install_cmd="install"
     cluster_kind_load_image "${cluster_name}" "${SPARKOPERATOR_IMAGE}"
+    cluster_kind_load_image "${cluster_name}" "${E2E_TEST_SPARK_IMAGE}"
 
     ${HELM} repo add --force-update spark-operator https://kubeflow.github.io/spark-operator
 

--- a/hack/testing/spark/Dockerfile
+++ b/hack/testing/spark/Dockerfile
@@ -1,0 +1,1 @@
+FROM apache/spark:4.0.0

--- a/pkg/util/testingjobs/sparkapplication/wrappers_sparkapplication.go
+++ b/pkg/util/testingjobs/sparkapplication/wrappers_sparkapplication.go
@@ -38,8 +38,6 @@ func MakeSparkApplication(name, ns string) *SparkApplicationWrapper {
 		Spec: sparkappv1beta2.SparkApplicationSpec{
 			Type:                sparkappv1beta2.SparkApplicationTypeScala,
 			Mode:                sparkappv1beta2.DeployModeCluster,
-			SparkVersion:        "4.0.0",
-			Image:               ptr.To("spark:4.0.0"),
 			MainApplicationFile: ptr.To("local:///opt/spark/examples/jars/spark-examples.jar"),
 			MainClass:           ptr.To("org.apache.spark.examples.SparkPi"),
 			Arguments:           []string{"1000"},
@@ -67,6 +65,18 @@ func MakeSparkApplication(name, ns string) *SparkApplicationWrapper {
 func (w *SparkApplicationWrapper) Clone() *SparkApplicationWrapper {
 	clone := w.DeepCopy()
 	return &SparkApplicationWrapper{*clone}
+}
+
+// Image sets the container image for the SparkApplication.
+func (w *SparkApplicationWrapper) Image(image string) *SparkApplicationWrapper {
+	w.Spec.Image = ptr.To(image)
+	return w
+}
+
+// SparkVersion sets the spark version of the SparkApplication.
+func (w *SparkApplicationWrapper) SparkVersion(version string) *SparkApplicationWrapper {
+	w.Spec.SparkVersion = version
+	return w
 }
 
 // Suspend sets the suspend field of the SparkApplication.

--- a/test/e2e/sequential/extended/sparkapplication_test.go
+++ b/test/e2e/sequential/extended/sparkapplication_test.go
@@ -137,7 +137,10 @@ var _ = ginkgo.Describe("SparkApplication integration", ginkgo.Label("feature:sp
 		})
 
 		ginkgo.It("should run if admitted", func() {
+			sparkImage := util.GetSparkTestImage()
 			sparkApp := sparkapplicationtesting.MakeSparkApplication("sparkapplication-simple", ns.Name).
+				Image(sparkImage).
+				SparkVersion(util.VersionFromImage(sparkImage)).
 				DriverServiceAccount(sa.Name).
 				DriverCoreRequest("0.1").
 				DriverMemoryRequest("512m"). // 512MB
@@ -234,7 +237,10 @@ var _ = ginkgo.Describe("SparkApplication integration", ginkgo.Label("feature:sp
 		})
 
 		ginkgo.It("should admit a SparkApplication via TAS", func() {
+			sparkImage := util.GetSparkTestImage()
 			sparkApp := sparkapplicationtesting.MakeSparkApplication("test-sparkapplication-tas", ns.Name).
+				Image(sparkImage).
+				SparkVersion(util.VersionFromImage(sparkImage)).
 				DriverAnnotation(
 					kueue.PodSetRequiredTopologyAnnotation, corev1.LabelHostname,
 				).

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -99,4 +100,9 @@ const (
 const (
 	Shard0 = "shard-0"
 	Shard1 = "shard-1"
+)
+
+var (
+	sparkTestImageOnce sync.Once
+	sparkTestImage     string
 )

--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -111,6 +111,36 @@ func GetAgnHostImage() string {
 	return agnhostImage
 }
 
+func GetSparkTestImage() string {
+	sparkTestImageOnce.Do(func() {
+		if image := os.Getenv("E2E_TEST_SPARK_IMAGE"); image != "" {
+			sparkTestImage = image
+			return
+		}
+
+		sparkDockerfilePath := filepath.Join(ProjectBaseDir, "hack", "testing", "spark", "Dockerfile")
+		sparkImage, err := getDockerImageFromDockerfile(sparkDockerfilePath)
+		if err != nil {
+			panic(fmt.Errorf("failed to get spark image: %v", err))
+		}
+
+		sparkTestImage = sparkImage
+	})
+	return sparkTestImage
+}
+
+// VersionFromImage extracts the version tag from an image reference,
+func VersionFromImage(image string) string {
+	if at := strings.IndexByte(image, '@'); at != -1 {
+		image = image[:at]
+	}
+
+	if colon := strings.LastIndexByte(image, ':'); colon > strings.LastIndexByte(image, '/') {
+		return image[colon+1:]
+	}
+	return ""
+}
+
 func getDockerImageFromDockerfile(filePath string) (string, error) {
 	// Open the Dockerfile
 	file, err := os.Open(filePath)


### PR DESCRIPTION
Cherry pick of #11951 on release-0.17.

#11951: fix: preload Spark image into kind for SparkApplication tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind flake


```release-note
NONE
```