### PR TITLE
Automated cherry pick of #11964: Use feature labels for shards.

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -203,12 +203,12 @@ test-e2e-extended: run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-e2e-extended-shard-0
 test-e2e-extended-shard-0: E2E_NPROCS := 4
-test-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=shard-0
+test-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=feature:kuberay
 test-e2e-extended-shard-0: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-e2e-extended-shard-1
 test-e2e-extended-shard-1: E2E_NPROCS := 4
-test-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=shard-1
+test-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=feature:appwrapper,feature:jaxjob,feature:jobset,feature:leaderworkerset,feature:pytorchjob,feature:trainjob
 test-e2e-extended-shard-1: setup-e2e-env run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 ## Label Taxonomy:
@@ -227,11 +227,11 @@ test-tas-e2e-baseline: setup-e2e-env run-test-tas-e2e-baseline-$(E2E_KIND_VERSIO
 test-tas-e2e-extended: run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-tas-e2e-extended-shard-0
-test-tas-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=shard-0
+test-tas-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=feature:kuberay
 test-tas-e2e-extended-shard-0: setup-e2e-env kind-ray-project-mini-image-build run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-tas-e2e-extended-shard-1
-test-tas-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=shard-1
+test-tas-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=feature:appwrapper,feature:jobset,feature:leaderworkerset,feature:pytorchjob,feature:trainjob,feature:mpijob
 test-tas-e2e-extended-shard-1: setup-e2e-env run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-tas-e2e-baseline-helm

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -14,9 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-declare -r SHARD_0="shard-0"
-declare -r SHARD_1="shard-1"
-
 export KUSTOMIZE="$ROOT_DIR"/bin/kustomize
 export GINKGO="$ROOT_DIR"/bin/ginkgo
 export KIND="$ROOT_DIR"/bin/kind
@@ -175,18 +172,18 @@ function e2e_crd_exists {
     kubectl ${kubectl_args[@]+"${kubectl_args[@]}"} get crd "${crd}" >/dev/null 2>&1
 }
 
-if [[ -n ${APPWRAPPER_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(appwrapper|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+if [[ -n ${APPWRAPPER_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(appwrapper|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
     export APPWRAPPER_MANIFEST=${ROOT_DIR}/dep-crds/appwrapper/config/default
     export APPWRAPPER_IMAGE=quay.io/ibm/appwrapper:${APPWRAPPER_VERSION}
 fi
 
-if [[ -n ${JOBSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(jobset|tas|trainjob|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+if [[ -n ${JOBSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(jobset|tas|trainjob|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
     export JOBSET_MANIFEST="https://github.com/kubernetes-sigs/jobset/releases/download/${JOBSET_VERSION}/manifests.yaml"
     export JOBSET_IMAGE=registry.k8s.io/jobset/jobset:${JOBSET_VERSION}
     export JOBSET_CRDS=${ROOT_DIR}/dep-crds/jobset-operator/
 fi
 
-if [[ -n ${KUBEFLOW_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(jaxjob|pytorchjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+if [[ -n ${KUBEFLOW_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(jaxjob|pytorchjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
     export KUBEFLOW_MANIFEST_ORIG=${ROOT_DIR}/dep-crds/training-operator/manifests/overlays/standalone/kustomization.yaml
     export KUBEFLOW_MANIFEST_PATCHED=${ROOT_DIR}/test/e2e/config/multikueue/kubeflow-manifest-patch
     # Extract the Kubeflow Training Operator image name and version tag from the manifest.
@@ -199,7 +196,7 @@ if [[ -n ${KUBEFLOW_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" 
     export KUBEFLOW_IMAGE=${KUBEFLOW_IMAGE_NAME}:${KUBEFLOW_IMAGE_VERSION}
 fi
 
-if [[ -n ${KUBEFLOW_TRAINER_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(tas|trainjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+if [[ -n ${KUBEFLOW_TRAINER_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(tas|trainjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
     export KUBEFLOW_TRAINER_MANIFEST=${ROOT_DIR}/dep-crds/kf-trainer/manifests
     # Extract the Kubeflow Trainer controller manager image version tag (newTag) from the manifest.
     # This is necessary because the image version tag does not follow the usual package versioning convention.
@@ -213,12 +210,12 @@ if [[ -n ${KUBEFLOW_MPI_VERSION:-} ]]; then
     export KUBEFLOW_MPI_IMAGE=mpioperator/mpi-operator:${KUBEFLOW_MPI_VERSION/#v}
 fi
 
-if [[ -n ${KUBERAY_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_0 || "$GINKGO_ARGS" =~ feature:kuberay || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+if [[ -n ${KUBERAY_VERSION:-} && ("$GINKGO_ARGS" =~ feature:kuberay || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
     export KUBERAY_MANIFEST="${ROOT_DIR}/dep-crds/ray-operator/default/"
     export KUBERAY_IMAGE=quay.io/kuberay/operator:${KUBERAY_VERSION}
 fi
 
-if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
     export LEADERWORKERSET_MANIFEST="https://github.com/kubernetes-sigs/lws/releases/download/${LEADERWORKERSET_VERSION}/manifests.yaml"
     export LEADERWORKERSET_IMAGE=registry.k8s.io/lws/lws:${LEADERWORKERSET_VERSION}
 fi
@@ -494,30 +491,30 @@ function prepare_docker_images {
     docker tag "$E2E_TEST_AGNHOST_IMAGE_OLD_WITH_SHA" "$E2E_TEST_AGNHOST_IMAGE_OLD"
     docker tag "$E2E_TEST_AGNHOST_IMAGE_WITH_SHA" "$E2E_TEST_AGNHOST_IMAGE"
 
-    if [[ -n ${APPWRAPPER_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(appwrapper|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${APPWRAPPER_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(appwrapper|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${APPWRAPPER_IMAGE}"
     fi
-    if [[ -n ${JOBSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(jobset|tas|trainjob|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${JOBSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(jobset|tas|trainjob|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${JOBSET_IMAGE}"
     fi
-    if [[ -n ${KUBEFLOW_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(jaxjob|pytorchjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${KUBEFLOW_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(jaxjob|pytorchjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${KUBEFLOW_IMAGE}"
     fi
-    if [[ -n ${KUBEFLOW_TRAINER_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(tas|trainjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${KUBEFLOW_TRAINER_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(tas|trainjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${KF_TRAINER_IMAGE}"
     fi
 
     if [[ -n ${KUBEFLOW_MPI_VERSION:-} ]]; then
         e2e_docker_pull_if_needed "${KUBEFLOW_MPI_IMAGE}"
     fi
-    if [[ -n ${KUBERAY_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_0 || "$GINKGO_ARGS" =~ feature:kuberay || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${KUBERAY_VERSION:-} && ("$GINKGO_ARGS" =~ feature:kuberay || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${KUBERAY_IMAGE}"
         determine_kuberay_ray_image
         if [[ ${USE_RAY_FOR_TESTS:-} == "ray" ]]; then
             e2e_docker_pull_if_needed "${KUBERAY_RAY_IMAGE}"
         fi
     fi
-    if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${LEADERWORKERSET_IMAGE}"
     fi
     if [[ -n ${KUEUE_UPGRADE_FROM_VERSION:-} ]]; then
@@ -562,30 +559,30 @@ function kind_load {
 
     cluster_kind_load "${e2e_cluster_name}"
 
-    if [[ -n ${APPWRAPPER_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(appwrapper|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${APPWRAPPER_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(appwrapper|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         install_appwrapper "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
-    if [[ -n ${JOBSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(jobset|tas|trainjob|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${JOBSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(jobset|tas|trainjob|managejobswithoutqueuename) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         install_jobset "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
-    if [[ -n ${KUBEFLOW_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(jaxjob|pytorchjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${KUBEFLOW_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(jaxjob|pytorchjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         # In order for MPI-operator and Training-operator to work on the same cluster it is required that:
         # 1. 'kubeflow.org_mpijobs.yaml' is removed from base/crds/kustomization.yaml - https://github.com/kubeflow/training-operator/issues/1930
         # 2. Training-operator deployment is modified to enable all kubeflow jobs except for mpi -  https://github.com/kubeflow/training-operator/issues/1777
         install_kubeflow "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
 
-    if [[ -n ${KUBEFLOW_TRAINER_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(tas|trainjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${KUBEFLOW_TRAINER_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(tas|trainjob) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         install_kubeflow_trainer "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
 
     if [[ -n ${KUBEFLOW_MPI_VERSION:-} ]]; then
         install_mpi "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
-    if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_1 || "$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         install_lws "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
-    if [[ -n ${KUBERAY_VERSION:-} && ("$GINKGO_ARGS" =~ $SHARD_0 || "$GINKGO_ARGS" =~ feature:kuberay || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
+    if [[ -n ${KUBERAY_VERSION:-} && ("$GINKGO_ARGS" =~ feature:kuberay || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         install_kuberay "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
     if [[ -n ${SPARKOPERATOR_VERSION:-} && ("$GINKGO_ARGS" =~ feature:spark || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then

--- a/test/e2e/singlecluster/extended/appwrapper_test.go
+++ b/test/e2e/singlecluster/extended/appwrapper_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("AppWrapper", ginkgo.Label(util.Shard1, "area:singlecluster", "feature:appwrapper"), func() {
+var _ = ginkgo.Describe("AppWrapper", ginkgo.Label("area:singlecluster", "feature:appwrapper"), func() {
 	var (
 		ns                 *corev1.Namespace
 		rf                 *kueue.ResourceFlavor

--- a/test/e2e/singlecluster/extended/jaxjob_test.go
+++ b/test/e2e/singlecluster/extended/jaxjob_test.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("JAX integration", ginkgo.Label(util.Shard1, "area:singlecluster", "feature:jaxjob"), func() {
+var _ = ginkgo.Describe("JAX integration", ginkgo.Label("area:singlecluster", "feature:jaxjob"), func() {
 	var (
 		ns                 *corev1.Namespace
 		rf                 *kueue.ResourceFlavor

--- a/test/e2e/singlecluster/extended/jobset_test.go
+++ b/test/e2e/singlecluster/extended/jobset_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("JobSet", ginkgo.Label(util.Shard1, "area:singlecluster", "feature:jobset"), func() {
+var _ = ginkgo.Describe("JobSet", ginkgo.Label("area:singlecluster", "feature:jobset"), func() {
 	var ns *corev1.Namespace
 
 	ginkgo.BeforeEach(func() {

--- a/test/e2e/singlecluster/extended/kuberay_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_test.go
@@ -73,7 +73,7 @@ const (
 	objectStoreMemory = "100000000"
 )
 
-var _ = ginkgo.Describe("Kuberay", ginkgo.Label(util.Shard0, "area:singlecluster", "feature:kuberay"), func() {
+var _ = ginkgo.Describe("Kuberay", ginkgo.Label("area:singlecluster", "feature:kuberay"), func() {
 	var (
 		ns                 *corev1.Namespace
 		rf                 *kueue.ResourceFlavor

--- a/test/e2e/singlecluster/extended/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/extended/leaderworkerset_test.go
@@ -42,7 +42,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label(util.Shard1, "area:singlecluster", "feature:leaderworkerset"), func() {
+var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:singlecluster", "feature:leaderworkerset"), func() {
 	var (
 		ns                 *corev1.Namespace
 		rf                 *kueue.ResourceFlavor

--- a/test/e2e/singlecluster/extended/pytorchjob_test.go
+++ b/test/e2e/singlecluster/extended/pytorchjob_test.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("PyTorch integration", ginkgo.Label(util.Shard1, "area:singlecluster", "feature:pytorchjob"), func() {
+var _ = ginkgo.Describe("PyTorch integration", ginkgo.Label("area:singlecluster", "feature:pytorchjob"), func() {
 	var (
 		ns                 *corev1.Namespace
 		rf                 *kueue.ResourceFlavor

--- a/test/e2e/singlecluster/extended/suite_test.go
+++ b/test/e2e/singlecluster/extended/suite_test.go
@@ -54,22 +54,22 @@ var _ = ginkgo.BeforeSuite(func() {
 	waitForAvailableStart := time.Now()
 	util.WaitForKueueAvailability(ctx, k8sClient)
 	labelFilter := ginkgo.GinkgoLabelFilter()
-	if ginkgo.Label(util.Shard1, "feature:jobset", "feature:trainjob").MatchesLabelFilter(labelFilter) {
+	if ginkgo.Label("feature:jobset", "feature:trainjob").MatchesLabelFilter(labelFilter) {
 		util.WaitForJobSetAvailability(ctx, k8sClient)
 	}
-	if ginkgo.Label(util.Shard1, "feature:leaderworkerset").MatchesLabelFilter(labelFilter) {
+	if ginkgo.Label("feature:leaderworkerset").MatchesLabelFilter(labelFilter) {
 		util.WaitForLeaderWorkerSetAvailability(ctx, k8sClient)
 	}
-	if ginkgo.Label(util.Shard1, "feature:appwrapper").MatchesLabelFilter(labelFilter) {
+	if ginkgo.Label("feature:appwrapper").MatchesLabelFilter(labelFilter) {
 		util.WaitForAppWrapperAvailability(ctx, k8sClient)
 	}
-	if ginkgo.Label(util.Shard1, "feature:jaxjob", "feature:pytorchjob").MatchesLabelFilter(labelFilter) {
+	if ginkgo.Label("feature:jaxjob", "feature:pytorchjob").MatchesLabelFilter(labelFilter) {
 		util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sClient)
 	}
-	if ginkgo.Label(util.Shard0, "feature:kuberay").MatchesLabelFilter(labelFilter) {
+	if ginkgo.Label("feature:kuberay").MatchesLabelFilter(labelFilter) {
 		util.WaitForKubeRayOperatorAvailability(ctx, k8sClient)
 	}
-	if ginkgo.Label(util.Shard1, "feature:trainjob").MatchesLabelFilter(labelFilter) {
+	if ginkgo.Label("feature:trainjob").MatchesLabelFilter(labelFilter) {
 		util.WaitForKubeFlowTrainnerControllerManagerAvailability(ctx, k8sClient)
 	}
 	ginkgo.GinkgoLogr.Info(

--- a/test/e2e/singlecluster/extended/trainjob_test.go
+++ b/test/e2e/singlecluster/extended/trainjob_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TrainJob", ginkgo.Label(util.Shard1, "area:singlecluster", "feature:trainjob"), func() {
+var _ = ginkgo.Describe("TrainJob", ginkgo.Label("area:singlecluster", "feature:trainjob"), func() {
 	var ns *corev1.Namespace
 
 	ginkgo.BeforeEach(func() {

--- a/test/e2e/tas/extended/appwrapper_test.go
+++ b/test/e2e/tas/extended/appwrapper_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", ginkgo.Label(util.Shard1, "area:tas", "feature:appwrapper"), func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", ginkgo.Label("area:tas", "feature:appwrapper"), func() {
 	var (
 		ns           *corev1.Namespace
 		topology     *kueue.Topology

--- a/test/e2e/tas/extended/jobset_test.go
+++ b/test/e2e/tas/extended/jobset_test.go
@@ -38,7 +38,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for JobSet", ginkgo.Label(util.Shard1, "area:tas", "feature:jobset"), func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for JobSet", ginkgo.Label("area:tas", "feature:jobset"), func() {
 	var ns *corev1.Namespace
 	ginkgo.BeforeEach(func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-tas-jobset-")

--- a/test/e2e/tas/extended/leaderworkerset_test.go
+++ b/test/e2e/tas/extended/leaderworkerset_test.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for LeaderWorkerSet", ginkgo.Label(util.Shard1, "area:tas", "feature:leaderworkerset"), func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for LeaderWorkerSet", ginkgo.Label("area:tas", "feature:leaderworkerset"), func() {
 	var (
 		ns           *corev1.Namespace
 		topology     *kueue.Topology

--- a/test/e2e/tas/extended/mpijob_test.go
+++ b/test/e2e/tas/extended/mpijob_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for MPIJob", ginkgo.Label(util.Shard1, "area:tas", "feature:mpijob"), func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for MPIJob", ginkgo.Label("area:tas", "feature:mpijob"), func() {
 	var (
 		ns           *corev1.Namespace
 		topology     *kueue.Topology

--- a/test/e2e/tas/extended/pytorch_test.go
+++ b/test/e2e/tas/extended/pytorch_test.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for PyTorchJob", ginkgo.Label(util.Shard1, "area:tas", "feature:pytorchjob"), func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for PyTorchJob", ginkgo.Label("area:tas", "feature:pytorchjob"), func() {
 	var (
 		ns           *corev1.Namespace
 		topology     *kueue.Topology

--- a/test/e2e/tas/extended/rayjob_test.go
+++ b/test/e2e/tas/extended/rayjob_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for RayJob", ginkgo.Ordered, ginkgo.Label(util.Shard0, "area:tas", "feature:kuberay"), func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for RayJob", ginkgo.Ordered, ginkgo.Label("area:tas", "feature:kuberay"), func() {
 	var (
 		ns           *corev1.Namespace
 		topology     *kueue.Topology

--- a/test/e2e/tas/extended/suite_test.go
+++ b/test/e2e/tas/extended/suite_test.go
@@ -51,15 +51,23 @@ var _ = ginkgo.BeforeSuite(func() {
 	waitForAvailableStart := time.Now()
 	util.WaitForKueueAvailability(ctx, k8sClient)
 	labelFilter := ginkgo.GinkgoLabelFilter()
-	if ginkgo.Label(util.Shard0).MatchesLabelFilter(labelFilter) {
+	if ginkgo.Label("feature:jobset", "feature:trainjob").MatchesLabelFilter(labelFilter) {
+		util.WaitForJobSetAvailability(ctx, k8sClient)
+	}
+	if ginkgo.Label("feature:leaderworkerset").MatchesLabelFilter(labelFilter) {
+		util.WaitForLeaderWorkerSetAvailability(ctx, k8sClient)
+	}
+	if ginkgo.Label("feature:appwrapper").MatchesLabelFilter(labelFilter) {
+		util.WaitForAppWrapperAvailability(ctx, k8sClient)
+	}
+	if ginkgo.Label("feature:kuberay").MatchesLabelFilter(labelFilter) {
 		util.WaitForKubeRayOperatorAvailability(ctx, k8sClient)
 	}
-	if ginkgo.Label(util.Shard1).MatchesLabelFilter(labelFilter) {
-		util.WaitForJobSetAvailability(ctx, k8sClient)
-		util.WaitForLeaderWorkerSetAvailability(ctx, k8sClient)
-		util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sClient)
+	if ginkgo.Label("feature:trainjob").MatchesLabelFilter(labelFilter) {
+		util.WaitForKubeFlowTrainnerControllerManagerAvailability(ctx, k8sClient)
+	}
+	if ginkgo.Label("feature:mpijob").MatchesLabelFilter(labelFilter) {
 		util.WaitForKubeFlowMPIOperatorAvailability(ctx, k8sClient)
-		util.WaitForAppWrapperAvailability(ctx, k8sClient)
 	}
 	ginkgo.GinkgoLogr.Info(
 		"Kueue and all required operators are available in the cluster",

--- a/test/e2e/tas/extended/suite_test.go
+++ b/test/e2e/tas/extended/suite_test.go
@@ -60,6 +60,9 @@ var _ = ginkgo.BeforeSuite(func() {
 	if ginkgo.Label("feature:appwrapper").MatchesLabelFilter(labelFilter) {
 		util.WaitForAppWrapperAvailability(ctx, k8sClient)
 	}
+	if ginkgo.Label("feature:pytorchjob").MatchesLabelFilter(labelFilter) {
+		util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sClient)
+	}
 	if ginkgo.Label("feature:kuberay").MatchesLabelFilter(labelFilter) {
 		util.WaitForKubeRayOperatorAvailability(ctx, k8sClient)
 	}

--- a/test/e2e/tas/extended/trainjob_test.go
+++ b/test/e2e/tas/extended/trainjob_test.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("TopologyAwareScheduling for TrainJob", ginkgo.Label(util.Shard1, "area:tas", "feature:trainjob"), func() {
+var _ = ginkgo.Describe("TopologyAwareScheduling for TrainJob", ginkgo.Label("area:tas", "feature:trainjob"), func() {
 	var ns *corev1.Namespace
 	ginkgo.BeforeEach(func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-tas-jobset-")


### PR DESCRIPTION
Cherry pick of #11964 on release-0.17.

#11964: Use feature labels for shards.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```