### PR TITLE
docs: document TASReplaceNodeOnNodeTaints

### DIFF
--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -199,6 +199,52 @@ for instructions on configuring feature gates.
 
 By default, Kueue tries to find a replacement for a failed node until it succeeds or until the workload is evicted (for example, by `waitForPodsReady.recoveryTimeout`). To prevent Kueue from retrying indefinitely, you can enable the `TASFailedNodeReplacementFailFast` feature gate. When enabled, Kueue will only attempt to find a replacement node once. If it fails, it will not try again, and the workload will get evicted and requeued.
 
+#### Replace Node on Node Taints
+{{< feature-state state="beta" for_version="v0.17" >}}
+{{% alert title="Note" color="primary" %}}
+`TASReplaceNodeOnNodeTaints` is currently a beta feature and is enabled by default.
+
+You can disable it by editing the `TASReplaceNodeOnNodeTaints` feature gate. Refer to the
+[Installation guide](/docs/installation/#change-the-feature-gates-configuration)
+for instructions on configuring feature gates.
+{{% /alert %}}
+
+Nodes are sometimes tainted to take them out of service, for example to drain them for
+maintenance or to reserve them for a higher-priority workload. When this happens, the
+Kubernetes core [taint eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
+controller may delete the Pods of a running TAS workload, but Kueue's TAS cache still
+accounts for the workload on that node. As a result the freed capacity is not reusable until
+the workload is eventually evicted (for example by `waitForPodsReady.recoveryTimeout`), which
+can take several minutes.
+
+With the `TASReplaceNodeOnNodeTaints` feature gate enabled, Kueue treats a node as failed when
+it carries a scheduling taint (`NoExecute` or `NoSchedule`) that the workload does not tolerate,
+and handles it through the same hot swap flow described above. This lets Kueue release the stale
+capacity quickly instead of waiting for the workload to time out.
+
+Only the `NoExecute` and `NoSchedule` taint effects are considered; nodes with other taint
+effects (such as `PreferNoSchedule`) are not treated as failed. Whether a taint is tolerated is
+evaluated against the effective tolerations of the workload's Pods for that node, including any
+tolerations added by admission checks.
+
+When the workload does not tolerate the taint, the node becomes a candidate for replacement.
+With `TASReplaceNodeOnPodTermination` enabled (the default), Kueue waits until the workload's
+Pods are no longer running on the node (they are terminating, terminated, or were never
+scheduled there) before treating it as failed; with `TASReplaceNodeOnPodTermination` disabled,
+the node is treated as failed as soon as the untolerated taint is observed. The two scheduling
+taint effects differ in how the Pods stop running:
+
+- **`NoExecute`**: The Kubernetes taint eviction controller terminates Pods that do not tolerate
+  the taint, so they stop running on their own. If a Pod tolerates the taint with a
+  `tolerationSeconds` value, the taint eviction controller keeps that Pod for the given duration
+  before evicting it, so the node is treated as failed only after that Pod stops running.
+- **`NoSchedule`**: A `NoSchedule` taint does not evict already-running Pods, so a workload whose
+  Pods keep running on the tainted node is left undisturbed. Kueue triggers recovery only after
+  those Pods stop running there, for example after they are drained manually.
+
+In all cases, Kueue replaces the failed node when `TASFailedNodeReplacement` is enabled, or
+evicts the workload if no replacement is possible.
+
 #### Usage Scenarios
 
 Here are a few scenarios that can happen when both `TASReplaceNodeOnPodTermination` and `TASFailedNodeReplacementFailFast` are enabled:
@@ -229,7 +275,7 @@ Here are a few scenarios that can happen when both `TASReplaceNodeOnPodTerminati
 
 ##### Feature Gate Interaction Matrix
 
-The following table summarizes the behavior based on the combination of the feature gates. If `TASFailedNodeReplacement` is `false`, the other two gates have no effect.
+The following table summarizes the behavior based on the combination of the feature gates. If `TASFailedNodeReplacement` is `false`, the other gates have no effect.
 
 **Feature Gate Legend:**
 - **FNR**: `TASFailedNodeReplacement`
@@ -244,9 +290,21 @@ The following table summarizes the behavior based on the combination of the feat
 | `true` | `false` | `true` | **Fast Hot Swap**<ul><li>**Trigger**: Node is `NotReady` for > 30 seconds.</li><li>**Behavior**: Attempts replacement **only once**. Evicts the workload if it fails.</li></ul> |
 | `true` | `true` | `true` | **Fast Hot Swap with Pod Termination Trigger**<ul><li>**Trigger**: Node is `NotReady`, AND a workload pod is terminating.</li><li>**Behavior**: Attempts replacement **only once**. Evicts the workload if it fails.</li></ul> |
 
+{{% alert title="Note" color="primary" %}}
+`TASReplaceNodeOnNodeTaints` adds taints as an additional failure signal on top of the
+combinations above. When it is enabled (and `TASFailedNodeReplacement` is `true`), an
+untolerated `NoExecute` or `NoSchedule` taint also marks a node as failed, in addition to the
+not-ready and pod-termination triggers in the table. As with the not-ready trigger, when the
+node is treated as failed depends on `TASReplaceNodeOnPodTermination`: with it enabled (the
+default) Kueue waits until the workload's Pods stop running on the node, and with it disabled the
+node is treated as failed as soon as the untolerated taint is observed. The workload then follows
+the same retry behavior shown for the active combination (controlled by `TASFailedNodeReplacementFailFast`).
+See [Replace Node on Node Taints](#replace-node-on-node-taints) for the per-taint details.
+{{% /alert %}}
+
 **Recommended configuration**
 
-We recommend keeping all three feature gates enabled to ensure the fastest feedback loop for workloads affected by node failures.
+We recommend keeping all four feature gates enabled to ensure the fastest feedback loop for workloads affected by node failures or tainted nodes.
 
 #### Balanced Placement
 {{< feature-state state="alpha" for_version="v0.15" >}}

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -217,10 +217,11 @@ accounts for the workload on that node. As a result the freed capacity is not re
 the workload is eventually evicted (for example by `waitForPodsReady.recoveryTimeout`), which
 can take several minutes.
 
-With the `TASReplaceNodeOnNodeTaints` feature gate enabled, Kueue treats a node as failed when
-it carries a scheduling taint (`NoExecute` or `NoSchedule`) that the workload does not tolerate,
-and handles it through the same hot swap flow described above. This lets Kueue release the stale
-capacity quickly instead of waiting for the workload to time out.
+With the `TASReplaceNodeOnNodeTaints` feature gate enabled, a scheduling taint (`NoExecute` or
+`NoSchedule`) that the workload does not tolerate can cause Kueue to treat the node as failed and
+handle it through the same hot swap flow described above, releasing the stale capacity quickly
+instead of waiting for the workload to time out. When the node is treated as failed depends on the
+taint effect and whether the workload's Pods are still running on it, as described below.
 
 Only the `NoExecute` and `NoSchedule` taint effects are considered; nodes with other taint
 effects (such as `PreferNoSchedule`) are not treated as failed. Whether a taint is tolerated is
@@ -238,9 +239,10 @@ taint effects differ in how the Pods stop running:
   the taint, so they stop running on their own. If a Pod tolerates the taint with a
   `tolerationSeconds` value, the taint eviction controller keeps that Pod for the given duration
   before evicting it, so the node is treated as failed only after that Pod stops running.
-- **`NoSchedule`**: A `NoSchedule` taint does not evict already-running Pods, so a workload whose
-  Pods keep running on the tainted node is left undisturbed. Kueue triggers recovery only after
-  those Pods stop running there, for example after they are drained manually.
+- **`NoSchedule`**: A `NoSchedule` taint does not evict already-running Pods, so under the default
+  `TASReplaceNodeOnPodTermination` behavior a workload whose Pods keep running on the tainted node
+  is left undisturbed, and Kueue triggers recovery only after those Pods stop running there, for
+  example after they are drained manually.
 
 In all cases, Kueue replaces the failed node when `TASFailedNodeReplacement` is enabled, or
 evicts the workload if no replacement is possible.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation
/area website

#### What this PR does / why we need it:

This PR adds documentation for the `TASReplaceNodeOnNodeTaints` feature gate to the Topology Aware Scheduling concepts page. It documents how untolerated `NoExecute` and `NoSchedule` taints participate in the existing TAS replacement flow.

The existing feature-gate interaction matrix is intentionally left unchanged, with an additional note clarifying that `TASReplaceNodeOnNodeTaints` acts as an orthogonal trigger.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11896

#### AI assistance disclosure (per the project AI contribution policy): 
I used an AI assistant to help draft and phrase the prose. I reviewed the result myself and verified  the documented behavior against the controller (`pkg/controller/tas/node_controller.go`); and the KEP was used for framing.

#### Special notes for your reviewer:

I considered extending the existing feature-gate interaction matrix to explicitly model `TASReplaceNodeOnNodeTaints`, but opted to keep the current structure unchanged and document it as an additional orthogonal trigger instead. I felt this kept the change smaller and aligned better with the current organization of the page, but I'm happy to adjust the presentation if reviewers would prefer the matrix to be expanded :)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added beta guidance for the Replace Node on Node Taints feature (TASReplaceNodeOnNodeTaints).
  * Clarified TASReplaceNodeOnPodTermination’s effect on when taints cause recovery vs. waiting for Pod termination.
  * Explained per-taint behavior: NoExecute interacts with tolerationSeconds; NoSchedule waits for Pods to stop.
  * Noted taints as an independent failure signal and broadened feature-gate interaction guidance.
  * Recommended keeping four related gates enabled for fastest feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->