### PR TITLE
docs: document late DeviceClass creation behavior for extended resources

### DIFF
--- a/site/content/en/docs/tasks/manage/setup_dra.md
+++ b/site/content/en/docs/tasks/manage/setup_dra.md
@@ -159,6 +159,25 @@ The `coveredResources` must include the extended resource name that matches
 kubectl apply -f https://kueue.sigs.k8s.io/examples/dra/sample-dra-queues.yaml
 ```
 
+### Late DeviceClass creation
+
+Kueue watches `DeviceClass` objects for create, update, and delete events.
+When a `DeviceClass` is created or its `extendedResourceName` changes, Kueue
+requeues pending workloads that request the affected extended resource so they
+are re-evaluated through the DRA path.
+
+If the `DeviceClass` does not exist when a workload is submitted, Kueue
+processes the extended resource through the normal (non-DRA) quota path. The
+workload is admitted if the ClusterQueue covers the extended resource name,
+but the pod stays Pending because the Kubernetes scheduler cannot create a
+ResourceClaim without a DeviceClass. Once the DeviceClass is created, the
+Kubernetes scheduler creates a ResourceClaim and the pod runs.
+
+Alternatively, configure a `deviceClassMappings` entry and use the mapped
+logical name in the ClusterQueue. Without a DeviceClass, Kueue skips DRA
+resolution and the raw extended resource name does not match the logical
+name in the ClusterQueue, so the workload stays inadmissible.
+
 ### Why this path exists
 
 Without the `KueueDRAIntegrationExtendedResource` feature gate, Kueue charges quota for both


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

 #### How late DeviceClass creation works with extended resources

  **Default (CQ covers `nvidia.com/gpu`, no deviceClassMappings):**

  1. Workload submitted with `nvidia.com/gpu: 1`
  2. No DeviceClass → Kueue admits as regular ER → quota consumed
  3. Pod Pending (no ResourceClaim without DeviceClass)
  4. DeviceClass created → k8s scheduler creates ResourceClaim → pod runs
  
  → Quota is consumed at step 2 even though the pod can't run yet.
  
  **With deviceClassMappings (CQ covers `gpu`):**

  1. Workload submitted with `nvidia.com/gpu: 1`
  2. No DeviceClass → `nvidia.com/gpu` not in CQ → inadmissible, no quota consumed
  3. DeviceClass created → Kueue requeues → DRA resolves `nvidia.com/gpu` → `gpu`
  4. CQ has `gpu` → admitted → ResourceClaim created → pod runs
  
  → No quota wasted. Workload waits until DeviceClass exists.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for Late DeviceClass creation behavior in DRA setup, covering event monitoring, workload requeuing mechanics, and admission processes when DeviceClass is created after workload submission with or without deviceClassMappings configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->