### PR TITLE
fix: Resolve RBAC Forbidden for Controller-Runtime events.k8s.io API

### DIFF
--- a/cmd/experimental/kueue-populator/charts/kueue-populator/templates/manager.yaml
+++ b/cmd/experimental/kueue-populator/charts/kueue-populator/templates/manager.yaml
@@ -32,6 +32,7 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:

--- a/cmd/experimental/kueue-populator/config/rbac/role.yaml
+++ b/cmd/experimental/kueue-populator/config/rbac/role.yaml
@@ -7,18 +7,19 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - namespaces
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - kueue.x-k8s.io
   resources:

--- a/cmd/experimental/kueue-populator/pkg/controller/controller.go
+++ b/cmd/experimental/kueue-populator/pkg/controller/controller.go
@@ -100,6 +100,7 @@ func NewKueuePopulatorReconciler(
 
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=clusterqueues,verbs=get;list;watch
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=localqueues,verbs=get;list;watch;create
 


### PR DESCRIPTION
 
#### What type of PR is this?

 
/kind bug
 
#### What this PR does / why we need it:

Issue  Root Cause
Controller manager uses new  events.k8s.io  client via  mgr.GetEventRecorder .
However, manager.yaml and role.yaml only list empty core API group  ""  for  events  resource.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Kueue-populator: Fixed `events.k8s.io` RBAC permissions for event recording.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated role-based access control (RBAC) permissions for the kueue-populator to properly handle events through the `events.k8s.io` API group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->