### PR TITLE
test: Shard for Kuberay jobs to reduce CI time

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -211,7 +211,7 @@ test-e2e-extended-shard-0: GINKGO_ARGS=--label-filter="feature:kuberay && shard:
 test-e2e-extended-shard-0: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-e2e-extended-shard-1
-test-e2e-extended-shard-0: E2E_NPROCS := 4
+test-e2e-extended-shard-1: E2E_NPROCS := 4
 test-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=feature:appwrapper,feature:jaxjob,feature:jobset,feature:leaderworkerset,feature:pytorchjob,feature:trainjob
 test-e2e-extended-shard-1: setup-e2e-env run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%) test-e2e-extended-shard-2
 

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -211,12 +211,12 @@ test-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=feature:kuberay,shard:kube
 test-e2e-extended-shard-0: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-e2e-extended-shard-1
-test-e2e-extended-shard-0: E2E_NPROCS := 4
+test-e2e-extended-shard-1: E2E_NPROCS := 4
 test-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=feature:appwrapper,feature:jaxjob,feature:jobset,feature:leaderworkerset,feature:pytorchjob,feature:trainjob
-test-e2e-extended-shard-1: setup-e2e-env run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
+test-e2e-extended-shard-1: setup-e2e-env run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%) test-e2e-extended-shard-2
 
 .PHONY: test-e2e-extended-shard-2
-test-e2e-extended-shard-0: E2E_NPROCS := 4
+test-e2e-extended-shard-2: E2E_NPROCS := 4
 test-e2e-extended-shard-2: GINKGO_ARGS=--label-filter=feature:kuberay,shard:kuberay-b
 test-e2e-extended-shard-2: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -182,19 +182,19 @@ $(TEST_E2E_SHARD_0_TARGETS): export RAY_VERSION := $(RAY_VERSION)
 $(TEST_E2E_SHARD_0_TARGETS): export RAYMINI_VERSION := $(RAYMINI_VERSION)
 
 # Assign Shard 1 variables to all parent suites AND all shard-1 targets
-TEST_E2E_SHARD_1_TARGETS := test-e2e-extended test-e2e-extended-shard-1
-$(TEST_E2E_SHARD_1_TARGETS): export KUBERAY_VERSION := $(KUBERAY_VERSION)
-$(TEST_E2E_SHARD_1_TARGETS): export RAY_VERSION := $(RAY_VERSION)
-$(TEST_E2E_SHARD_1_TARGETS): export RAYMINI_VERSION := $(RAYMINI_VERSION)
+TEST_E2E_SHARD_1_TARGETS := test-e2e-extended test-e2e-extended-shard-1 test-tas-e2e-extended test-tas-e2e-extended-shard-1
+$(TEST_E2E_SHARD_1_TARGETS): export JOBSET_VERSION := $(JOBSET_VERSION)
+$(TEST_E2E_SHARD_1_TARGETS): export LEADERWORKERSET_VERSION := $(LEADERWORKERSET_VERSION)
+$(TEST_E2E_SHARD_1_TARGETS): export APPWRAPPER_VERSION := $(APPWRAPPER_VERSION)
+$(TEST_E2E_SHARD_1_TARGETS): export KUBEFLOW_VERSION := $(KUBEFLOW_VERSION)
+$(TEST_E2E_SHARD_1_TARGETS): export KUBEFLOW_MPI_VERSION := $(KUBEFLOW_MPI_VERSION)
+$(TEST_E2E_SHARD_1_TARGETS): export KUBEFLOW_TRAINER_VERSION := $(KUBEFLOW_TRAINER_VERSION)
 
 # Assign Shard 2 variables to all parent suites AND all shard-2 targets
 TEST_E2E_SHARD_2_TARGETS := test-e2e-extended test-e2e-extended-shard-2
-$(TEST_E2E_SHARD_2_TARGETS): export JOBSET_VERSION := $(JOBSET_VERSION)
-$(TEST_E2E_SHARD_2_TARGETS): export LEADERWORKERSET_VERSION := $(LEADERWORKERSET_VERSION)
-$(TEST_E2E_SHARD_2_TARGETS): export APPWRAPPER_VERSION := $(APPWRAPPER_VERSION)
-$(TEST_E2E_SHARD_2_TARGETS): export KUBEFLOW_VERSION := $(KUBEFLOW_VERSION)
-$(TEST_E2E_SHARD_2_TARGETS): export KUBEFLOW_MPI_VERSION := $(KUBEFLOW_MPI_VERSION)
-$(TEST_E2E_SHARD_2_TARGETS): export KUBEFLOW_TRAINER_VERSION := $(KUBEFLOW_TRAINER_VERSION)
+$(TEST_E2E_SHARD_2_TARGETS): export KUBERAY_VERSION := $(KUBERAY_VERSION)
+$(TEST_E2E_SHARD_2_TARGETS): export RAY_VERSION := $(RAY_VERSION)
+$(TEST_E2E_SHARD_2_TARGETS): export RAYMINI_VERSION := $(RAYMINI_VERSION)
 
 ## Label Taxonomy:
 ##   Features: appwrapper,jaxjob,jobset,kuberay,leaderworkerset,pytorchjob,trainjob
@@ -211,14 +211,14 @@ test-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=feature:kuberay,shard:kube
 test-e2e-extended-shard-0: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-e2e-extended-shard-1
-test-e2e-extended-shard-1: E2E_NPROCS := 4
-test-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=feature:kuberay,shard:kuberay-b
-test-e2e-extended-shard-1: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
+test-e2e-extended-shard-0: E2E_NPROCS := 4
+test-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=feature:appwrapper,feature:jaxjob,feature:jobset,feature:leaderworkerset,feature:pytorchjob,feature:trainjob
+test-e2e-extended-shard-1: setup-e2e-env run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-e2e-extended-shard-2
-test-e2e-extended-shard-2: E2E_NPROCS := 4
-test-e2e-extended-shard-2: GINKGO_ARGS=--label-filter=feature:appwrapper,feature:jaxjob,feature:jobset,feature:leaderworkerset,feature:pytorchjob,feature:trainjob
-test-e2e-extended-shard-2: setup-e2e-env run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
+test-e2e-extended-shard-0: E2E_NPROCS := 4
+test-e2e-extended-shard-2: GINKGO_ARGS=--label-filter=feature:kuberay,shard:kuberay-b
+test-e2e-extended-shard-2: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 ## Label Taxonomy:
 ##   Features: certs,deployment,job,fairsharing,kueuectl,metrics,pod,statefulset,visibility,e2e_v1beta1,ha

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -208,7 +208,7 @@ test-e2e-extended: run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 .PHONY: test-e2e-extended-shard-0
 test-e2e-extended-shard-0: E2E_NPROCS := 4
 test-e2e-extended-shard-0: GINKGO_ARGS=--label-filter='feature:kuberay && shard:kuberay-a'
-test-e2e-extended-shard-0: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
+test-e2e-extended-shard-0: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%) test-e2e-extended-shard-2
 
 .PHONY: test-e2e-extended-shard-1
 test-e2e-extended-shard-1: E2E_NPROCS := 4

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -183,12 +183,18 @@ $(TEST_E2E_SHARD_0_TARGETS): export RAYMINI_VERSION := $(RAYMINI_VERSION)
 
 # Assign Shard 1 variables to all parent suites AND all shard-1 targets
 TEST_E2E_SHARD_1_TARGETS := test-e2e-extended test-e2e-extended-shard-1 test-tas-e2e-extended test-tas-e2e-extended-shard-1
-$(TEST_E2E_SHARD_1_TARGETS): export JOBSET_VERSION := $(JOBSET_VERSION)
-$(TEST_E2E_SHARD_1_TARGETS): export LEADERWORKERSET_VERSION := $(LEADERWORKERSET_VERSION)
-$(TEST_E2E_SHARD_1_TARGETS): export APPWRAPPER_VERSION := $(APPWRAPPER_VERSION)
-$(TEST_E2E_SHARD_1_TARGETS): export KUBEFLOW_VERSION := $(KUBEFLOW_VERSION)
-$(TEST_E2E_SHARD_1_TARGETS): export KUBEFLOW_MPI_VERSION := $(KUBEFLOW_MPI_VERSION)
-$(TEST_E2E_SHARD_1_TARGETS): export KUBEFLOW_TRAINER_VERSION := $(KUBEFLOW_TRAINER_VERSION)
+$(TEST_E2E_SHARD_1_TARGETS): export KUBERAY_VERSION := $(KUBERAY_VERSION)
+$(TEST_E2E_SHARD_1_TARGETS): export RAY_VERSION := $(RAY_VERSION)
+$(TEST_E2E_SHARD_1_TARGETS): export RAYMINI_VERSION := $(RAYMINI_VERSION)
+
+# Assign Shard 2 variables to all parent suites AND all shard-2 targets
+TEST_E2E_SHARD_2_TARGETS := test-e2e-extended test-e2e-extended-shard-2 test-tas-e2e-extended test-tas-e2e-extended-shard-2
+$(TEST_E2E_SHARD_2_TARGETS): export JOBSET_VERSION := $(JOBSET_VERSION)
+$(TEST_E2E_SHARD_2_TARGETS): export LEADERWORKERSET_VERSION := $(LEADERWORKERSET_VERSION)
+$(TEST_E2E_SHARD_2_TARGETS): export APPWRAPPER_VERSION := $(APPWRAPPER_VERSION)
+$(TEST_E2E_SHARD_2_TARGETS): export KUBEFLOW_VERSION := $(KUBEFLOW_VERSION)
+$(TEST_E2E_SHARD_2_TARGETS): export KUBEFLOW_MPI_VERSION := $(KUBEFLOW_MPI_VERSION)
+$(TEST_E2E_SHARD_2_TARGETS): export KUBEFLOW_TRAINER_VERSION := $(KUBEFLOW_TRAINER_VERSION)
 
 ## Label Taxonomy:
 ##   Features: appwrapper,jaxjob,jobset,kuberay,leaderworkerset,pytorchjob,trainjob
@@ -201,13 +207,18 @@ test-e2e-extended: run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-e2e-extended-shard-0
 test-e2e-extended-shard-0: E2E_NPROCS := 4
-test-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=feature:kuberay
+test-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=feature:kuberay && shard:kuberay-a
 test-e2e-extended-shard-0: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-e2e-extended-shard-1
 test-e2e-extended-shard-1: E2E_NPROCS := 4
-test-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=feature:appwrapper,feature:jaxjob,feature:jobset,feature:leaderworkerset,feature:pytorchjob,feature:trainjob
-test-e2e-extended-shard-1: setup-e2e-env run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
+test-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=feature:kuberay && shard:kuberay-b
+test-e2e-extended-shard-1: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
+
+.PHONY: test-e2e-extended-shard-2
+test-e2e-extended-shard-2: E2E_NPROCS := 4
+test-e2e-extended-shard-2: GINKGO_ARGS=--label-filter=feature:appwrapper,feature:jaxjob,feature:jobset,feature:leaderworkerset,feature:pytorchjob,feature:trainjob
+test-e2e-extended-shard-2: setup-e2e-env run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 ## Label Taxonomy:
 ##   Features: certs,deployment,job,fairsharing,kueuectl,metrics,pod,statefulset,visibility,e2e_v1beta1,ha
@@ -225,12 +236,16 @@ test-tas-e2e-baseline: setup-e2e-env run-test-tas-e2e-baseline-$(E2E_KIND_VERSIO
 test-tas-e2e-extended: run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-tas-e2e-extended-shard-0
-test-tas-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=feature:kuberay
+test-tas-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=feature:kuberay && shard:kuberay-a
 test-tas-e2e-extended-shard-0: setup-e2e-env kind-ray-project-mini-image-build run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-tas-e2e-extended-shard-1
-test-tas-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=feature:appwrapper,feature:jobset,feature:leaderworkerset,feature:pytorchjob,feature:trainjob,feature:mpijob
-test-tas-e2e-extended-shard-1: setup-e2e-env run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
+test-tas-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=feature:kuberay && shard:kuberay-b
+test-tas-e2e-extended-shard-1: setup-e2e-env kind-ray-project-mini-image-build run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
+
+.PHONY: test-tas-e2e-extended-shard-2
+test-tas-e2e-extended-shard-2: GINKGO_ARGS=--label-filter=feature:appwrapper,feature:jobset,feature:leaderworkerset,feature:pytorchjob,feature:trainjob,feature:mpijob
+test-tas-e2e-extended-shard-2: setup-e2e-env run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-tas-e2e-baseline-helm
 test-tas-e2e-baseline-helm: E2E_USE_HELM=true

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -207,7 +207,7 @@ test-e2e-extended: run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-e2e-extended-shard-0
 test-e2e-extended-shard-0: E2E_NPROCS := 4
-test-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=feature:kuberay,shard:kuberay-a
+test-e2e-extended-shard-0: GINKGO_ARGS=--label-filter="feature:kuberay && shard:kuberay-a"
 test-e2e-extended-shard-0: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-e2e-extended-shard-1
@@ -217,7 +217,7 @@ test-e2e-extended-shard-1: setup-e2e-env run-test-e2e-extended-$(E2E_KIND_VERSIO
 
 .PHONY: test-e2e-extended-shard-2
 test-e2e-extended-shard-2: E2E_NPROCS := 4
-test-e2e-extended-shard-2: GINKGO_ARGS=--label-filter=feature:kuberay,shard:kuberay-b
+test-e2e-extended-shard-2: GINKGO_ARGS=--label-filter="feature:kuberay && shard:kuberay-b"
 test-e2e-extended-shard-2: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 ## Label Taxonomy:

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -182,13 +182,13 @@ $(TEST_E2E_SHARD_0_TARGETS): export RAY_VERSION := $(RAY_VERSION)
 $(TEST_E2E_SHARD_0_TARGETS): export RAYMINI_VERSION := $(RAYMINI_VERSION)
 
 # Assign Shard 1 variables to all parent suites AND all shard-1 targets
-TEST_E2E_SHARD_1_TARGETS := test-e2e-extended test-e2e-extended-shard-1 test-tas-e2e-extended test-tas-e2e-extended-shard-1
+TEST_E2E_SHARD_1_TARGETS := test-e2e-extended test-e2e-extended-shard-1
 $(TEST_E2E_SHARD_1_TARGETS): export KUBERAY_VERSION := $(KUBERAY_VERSION)
 $(TEST_E2E_SHARD_1_TARGETS): export RAY_VERSION := $(RAY_VERSION)
 $(TEST_E2E_SHARD_1_TARGETS): export RAYMINI_VERSION := $(RAYMINI_VERSION)
 
 # Assign Shard 2 variables to all parent suites AND all shard-2 targets
-TEST_E2E_SHARD_2_TARGETS := test-e2e-extended test-e2e-extended-shard-2 test-tas-e2e-extended test-tas-e2e-extended-shard-2
+TEST_E2E_SHARD_2_TARGETS := test-e2e-extended test-e2e-extended-shard-2
 $(TEST_E2E_SHARD_2_TARGETS): export JOBSET_VERSION := $(JOBSET_VERSION)
 $(TEST_E2E_SHARD_2_TARGETS): export LEADERWORKERSET_VERSION := $(LEADERWORKERSET_VERSION)
 $(TEST_E2E_SHARD_2_TARGETS): export APPWRAPPER_VERSION := $(APPWRAPPER_VERSION)
@@ -207,12 +207,12 @@ test-e2e-extended: run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-e2e-extended-shard-0
 test-e2e-extended-shard-0: E2E_NPROCS := 4
-test-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=feature:kuberay && shard:kuberay-a
+test-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=feature:kuberay,shard:kuberay-a
 test-e2e-extended-shard-0: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-e2e-extended-shard-1
 test-e2e-extended-shard-1: E2E_NPROCS := 4
-test-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=feature:kuberay && shard:kuberay-b
+test-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=feature:kuberay,shard:kuberay-b
 test-e2e-extended-shard-1: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-e2e-extended-shard-2
@@ -236,16 +236,12 @@ test-tas-e2e-baseline: setup-e2e-env run-test-tas-e2e-baseline-$(E2E_KIND_VERSIO
 test-tas-e2e-extended: run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-tas-e2e-extended-shard-0
-test-tas-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=feature:kuberay && shard:kuberay-a
+test-tas-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=feature:kuberay
 test-tas-e2e-extended-shard-0: setup-e2e-env kind-ray-project-mini-image-build run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-tas-e2e-extended-shard-1
-test-tas-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=feature:kuberay && shard:kuberay-b
-test-tas-e2e-extended-shard-1: setup-e2e-env kind-ray-project-mini-image-build run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
-
-.PHONY: test-tas-e2e-extended-shard-2
-test-tas-e2e-extended-shard-2: GINKGO_ARGS=--label-filter=feature:appwrapper,feature:jobset,feature:leaderworkerset,feature:pytorchjob,feature:trainjob,feature:mpijob
-test-tas-e2e-extended-shard-2: setup-e2e-env run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
+test-tas-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=feature:appwrapper,feature:jobset,feature:leaderworkerset,feature:pytorchjob,feature:trainjob,feature:mpijob
+test-tas-e2e-extended-shard-1: setup-e2e-env run-test-tas-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-tas-e2e-baseline-helm
 test-tas-e2e-baseline-helm: E2E_USE_HELM=true

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -207,7 +207,7 @@ test-e2e-extended: run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-e2e-extended-shard-0
 test-e2e-extended-shard-0: E2E_NPROCS := 4
-test-e2e-extended-shard-0: GINKGO_ARGS=--label-filter="feature:kuberay && shard:kuberay-a"
+test-e2e-extended-shard-0: GINKGO_ARGS=--label-filter='feature:kuberay && shard:kuberay-a'
 test-e2e-extended-shard-0: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-e2e-extended-shard-1
@@ -217,7 +217,7 @@ test-e2e-extended-shard-1: setup-e2e-env run-test-e2e-extended-$(E2E_KIND_VERSIO
 
 .PHONY: test-e2e-extended-shard-2
 test-e2e-extended-shard-2: E2E_NPROCS := 4
-test-e2e-extended-shard-2: GINKGO_ARGS=--label-filter="feature:kuberay && shard:kuberay-b"
+test-e2e-extended-shard-2: GINKGO_ARGS=--label-filter='feature:kuberay && shard:kuberay-b'
 test-e2e-extended-shard-2: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 ## Label Taxonomy:

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -211,7 +211,7 @@ test-e2e-extended-shard-0: GINKGO_ARGS=--label-filter="feature:kuberay && shard:
 test-e2e-extended-shard-0: setup-e2e-env kind-ray-project-mini-image-build run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-e2e-extended-shard-1
-test-e2e-extended-shard-1: E2E_NPROCS := 4
+test-e2e-extended-shard-0: E2E_NPROCS := 4
 test-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=feature:appwrapper,feature:jaxjob,feature:jobset,feature:leaderworkerset,feature:pytorchjob,feature:trainjob
 test-e2e-extended-shard-1: setup-e2e-env run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%) test-e2e-extended-shard-2
 

--- a/test/e2e/singlecluster/extended/kuberay_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_test.go
@@ -140,7 +140,7 @@ var _ = ginkgo.Describe("Kuberay", ginkgo.Label("area:singlecluster", "feature:k
 		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
 	})
 
-	ginkgo.It("Should run a rayjob if admitted", func() {
+	ginkgo.It("Should run a rayjob if admitted", ginkgo.Label("shard:kuberay-a"), func() {
 		kuberayTestImage := util.GetKuberayTestImage()
 
 		rayJob := testingrayjob.MakeJob("rayjob", ns.Name).
@@ -221,7 +221,7 @@ var _ = ginkgo.Describe("Kuberay", ginkgo.Label("area:singlecluster", "feature:k
 	})
 
 	// ginkgo.Serial prevents concurrent ray-head containers from competing for CPU, causing liveness probe failures and crash-loops
-	ginkgo.It("Should run a rayjob with InTreeAutoscaling", ginkgo.Serial, func() {
+	ginkgo.It("Should run a rayjob with InTreeAutoscaling", ginkgo.Serial, ginkgo.Label("shard:kuberay-b"), func() {
 		kuberayTestImage := util.GetKuberayTestImage()
 
 		// Create ConfigMap with Python script
@@ -407,7 +407,7 @@ print(ray.get([my_task.remote(i, 60) for i in range(3)]))`,
 		})
 	})
 
-	ginkgo.It("Should run a rayjob with multi scale-up steps", func() {
+	ginkgo.It("Should run a rayjob with multi scale-up steps", ginkgo.Label("shard:kuberay-a"), func() {
 		kuberayTestImage := util.GetKuberayTestImage()
 
 		// Create ConfigMap with Python script that triggers multiple scale-up phases
@@ -618,7 +618,7 @@ print([ray.get(my_task.remote(i, 1)) for i in range(32)])`,
 	})
 
 	// ginkgo.Serial prevents concurrent ray-head containers from competing for CPU, causing liveness probe failures and crash-loops
-	ginkgo.It("Should run a RayCluster on worker if admitted", ginkgo.Serial, func() {
+	ginkgo.It("Should run a RayCluster on worker if admitted", ginkgo.Serial, ginkgo.Label("shard:kuberay-b"), func() {
 		kuberayTestImage := util.GetKuberayTestImage()
 
 		raycluster := testingraycluster.MakeCluster("raycluster1", ns.Name).
@@ -659,7 +659,7 @@ print([ray.get(my_task.remote(i, 1)) for i in range(32)])`,
 		})
 	})
 
-	ginkgo.It("Should run a RayService if admitted", func() {
+	ginkgo.It("Should run a RayService if admitted", ginkgo.Label("shard:kuberay-a"), func() {
 		kuberayTestImage := util.GetKuberayTestImage()
 
 		// Create ConfigMap with a simple Ray Serve application
@@ -793,7 +793,7 @@ app = HelloWorld.bind()`,
 	})
 
 	// ginkgo.Serial prevents concurrent ray-head containers from competing for CPU, causing liveness probe failures and crash-loops
-	ginkgo.It("Should run a rayservice with InTreeAutoscaling", ginkgo.Serial, func() {
+	ginkgo.It("Should run a rayservice with InTreeAutoscaling", ginkgo.Serial, ginkgo.Label("shard:kuberay-b"), func() {
 		kuberayTestImage := util.GetKuberayTestImage()
 
 		// Create ConfigMap with a Ray Serve application that supports a delay parameter


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area testing

#### What this PR does / why we need it:
Split tests to shards.

#### Which issue(s) this PR fixes:

Fixes #11940

#### Special notes for your reviewer:
Shard for Kuberay jobs to reduce CI time
It is to be noted that labels are given as kuberay-a for shard-0 & kuberay-b for shard-1

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated extended end-to-end test sharding: kuberay shards now use shard-specific label filters (a/b).
  * Reassigned which version variables are exported between shard groups so kuberay/ray versions are with shard-1 and jobset/appwrapper/Kubeflow-related versions moved to shard-2.
  * Minor formatting tweak in an e2e command invocation.
* **Tests**
  * Assigned several extended tests explicit shard labels to improve parallelization and organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->