### PR TITLE
bump kubeadm from v1beta3 to v1beta4

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -367,18 +367,23 @@ function patch_kind_config_for_dra {
     $YQ -i '.featureGates.DRAExtendedResource = true' "$patched_config"
     $YQ -i '.containerdConfigPatches += ["[plugins.\"io.containerd.grpc.v1.cri\"]\n  enable_cdi = true"]' "$patched_config"
     $YQ -i '(.nodes[] | select(.role == "control-plane")).kubeadmConfigPatches[0] = "kind: ClusterConfiguration
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 scheduler:
   extraArgs:
-    v: \"3\"
+  - name: v
+    value: \"3\"
 controllerManager:
   extraArgs:
-    v: \"3\"
+  - name: v
+    value: \"3\"
 apiServer:
   extraArgs:
-    enable-aggregator-routing: \"true\"
-    runtime-config: \"resource.k8s.io/v1=true\"
-    v: \"3\"
+  - name: enable-aggregator-routing
+    value: \"true\"
+  - name: runtime-config
+    value: \"resource.k8s.io/v1=true\"
+  - name: v
+    value: \"3\"
 "' "$patched_config"
 
     echo "$patched_config"
@@ -393,18 +398,23 @@ function patch_kind_config_for_was {
     $YQ -i '.featureGates.GenericWorkload = true' "$patched_config"
     $YQ -i '.featureGates.GangScheduling = true' "$patched_config"
     $YQ -i '(.nodes[] | select(.role == "control-plane")).kubeadmConfigPatches[0] = "kind: ClusterConfiguration
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 scheduler:
   extraArgs:
-    v: \"3\"
+  - name: v
+    value: \"3\"
 controllerManager:
   extraArgs:
-    v: \"3\"
+  - name: v
+    value: \"3\"
 apiServer:
   extraArgs:
-    enable-aggregator-routing: \"true\"
-    runtime-config: \"scheduling.k8s.io/v1alpha3=true\"
-    v: \"3\"
+  - name: enable-aggregator-routing
+    value: \"true\"
+  - name: runtime-config
+    value: \"scheduling.k8s.io/v1alpha3=true\"
+  - name: v
+    value: \"3\"
 "' "$patched_config"
 
     echo "$patched_config"

--- a/hack/testing/kind-cluster-tas.yaml
+++ b/hack/testing/kind-cluster-tas.yaml
@@ -6,22 +6,28 @@ nodes:
     kubeadmConfigPatches:
       - |
         kind: ClusterConfiguration
-        apiVersion: kubeadm.k8s.io/v1beta3
+        apiVersion: kubeadm.k8s.io/v1beta4
         scheduler:
           extraArgs:
-            v: "3"
+          - name: v
+            value: "3"
         controllerManager:
           extraArgs:
-            v: "3"
+          - name: v
+            value: "3"
         apiServer:
           extraArgs:
-            enable-aggregator-routing: "true"
-            v: "3"
+          - name: enable-aggregator-routing
+            value: "true"
+          - name: v
+            value: "3"
       - |
         kind: InitConfiguration
+        apiVersion: kubeadm.k8s.io/v1beta4
         nodeRegistration:
           kubeletExtraArgs:
-            v: "3"
+          - name: v
+            value: "3"
   - role: worker
     labels:
       cloud.provider.com/node-group: tas-group
@@ -66,6 +72,8 @@ nodes:
 kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"

--- a/hack/testing/kind-cluster.yaml
+++ b/hack/testing/kind-cluster.yaml
@@ -5,22 +5,28 @@ nodes:
   kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration
-    apiVersion: kubeadm.k8s.io/v1beta3
+    apiVersion: kubeadm.k8s.io/v1beta4
     scheduler:
       extraArgs:
-        v: "3"
+      - name: v
+        value: "3"
     controllerManager:
       extraArgs:
-        v: "3"
+      - name: v
+        value: "3"
     apiServer:
       extraArgs:
-        enable-aggregator-routing: "true"
-        v: "3"
+      - name: enable-aggregator-routing
+        value: "true"
+      - name: v
+        value: "3"
   - |
     kind: InitConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"
 - role: worker
   labels:
     instance-type: on-demand
@@ -31,6 +37,8 @@ nodes:
 kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"

--- a/hack/testing/multikueue/manager-cluster.kind.yaml
+++ b/hack/testing/multikueue/manager-cluster.kind.yaml
@@ -5,22 +5,28 @@ nodes:
   kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration
-    apiVersion: kubeadm.k8s.io/v1beta3
+    apiVersion: kubeadm.k8s.io/v1beta4
     scheduler:
       extraArgs:
-        v: "3"
+      - name: v
+        value: "3"
     controllerManager:
       extraArgs:
-        v: "3"
+      - name: v
+        value: "3"
     apiServer:
       extraArgs:
-        enable-aggregator-routing: "true"
-        v: "3"
+      - name: enable-aggregator-routing
+        value: "true"
+      - name: v
+        value: "3"
   - |
     kind: InitConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"
 - role: worker
   labels:
     instance-type: on-demand
@@ -29,6 +35,8 @@ nodes:
 kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"

--- a/hack/testing/multikueue/worker-cluster.kind.yaml
+++ b/hack/testing/multikueue/worker-cluster.kind.yaml
@@ -5,23 +5,30 @@ nodes:
   kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration
-    apiVersion: kubeadm.k8s.io/v1beta3
+    apiVersion: kubeadm.k8s.io/v1beta4
     scheduler:
       extraArgs:
-        v: "3"
+      - name: v
+        value: "3"
     controllerManager:
       extraArgs:
-        v: "3"
+      - name: v
+        value: "3"
     apiServer:
       extraArgs:
-        enable-aggregator-routing: "true"
-        v: "3"
-        service-account-max-token-expiration: "168h"
+      - name: enable-aggregator-routing
+        value: "true"
+      - name: v
+        value: "3"
+      - name: service-account-max-token-expiration
+        value: "168h"
   - |
     kind: InitConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"
 - role: worker
   labels:
     instance-type: on-demand
@@ -30,6 +37,8 @@ nodes:
 kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test
/area testing


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #11979

#### Special notes for your reviewer:

See https://github.com/kubernetes/kubernetes/pull/136016 and https://github.com/kubernetes-sigs/kind/issues/3847

https://github.com/kubernetes/kubeadm/issues/2890 is all about kubeadm v1beta4 

#### Does this PR introduce a user-facing change?

```release-note
bump kubeadm v1beta4 API as kubernetes 1.37 dropped kubeadm v1beta3 API support
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated KIND test cluster kubeadm patches to apiVersion kubeadm.k8s.io/v1beta4.
  * Converted component extraArgs and kubeletExtraArgs from map-style to ordered name/value lists across control-plane and worker join patches.
  * Preserved runtime flags (e.g., v=3) and enable-aggregator-routing by representing them in the new list format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->