### PR TITLE
Retry network-dependent install steps in kueueviz e2e frontend script…

### DIFF
--- a/hack/testing/e2e-kueueviz-frontend.sh
+++ b/hack/testing/e2e-kueueviz-frontend.sh
@@ -22,8 +22,13 @@ if [ -n "${CI}" ] && [ -n "${PROW_JOB_ID}" ]; then
   echo "Running in prow: Disabling color to have readable logs: NO_COLOR=${NO_COLOR}"
 fi
 
+# Retry network-dependent install steps to tolerate transient registry/network
+# failures (e.g. ECONNRESET) that would otherwise flake the e2e job.
+RETRY="${PROJECT_DIR}/hack/testing/retry.sh"
+
 # Install missing dependencies
-apt-get update && apt-get install -y curl make xdg-utils
+"${RETRY}" --attempts 5 --delay 5 --stream --exponential -- apt-get update
+"${RETRY}" --attempts 5 --delay 5 --stream --exponential -- apt-get install -y curl make xdg-utils
 
 # Function to clean up background processes
 cleanup() {
@@ -33,7 +38,7 @@ cleanup() {
 
 # Run frontend unit tests before starting the app
 cd "${PROJECT_DIR}/cmd/kueueviz/frontend"
-npm install
+"${RETRY}" --attempts 5 --delay 5 --stream --exponential -- npm install
 npm test
 
 # Start kueueviz frontend
@@ -41,8 +46,8 @@ npm start & FRONTEND_PID=$!
 
 # Run Cypress tests for kueueviz frontend
 cd "${PROJECT_DIR}/test/e2e/kueueviz"
-npm install
-npx cypress install
+"${RETRY}" --attempts 5 --delay 5 --stream --exponential -- npm install
+"${RETRY}" --attempts 5 --delay 5 --stream --exponential -- npx cypress install
 npm run cypress:run --headless --config-file cypress.config.js
 
 # The trap will handle cleanup 

--- a/hack/testing/retry.sh
+++ b/hack/testing/retry.sh
@@ -17,13 +17,21 @@
 # echoes it; stderr passes through. Designed to be invoked from Make $(shell ...)
 # where the captured stdout becomes the variable value.
 #
+# By default stdout is captured and echoed only on success, so failed-attempt
+# output never pollutes a $(shell ...) caller that captures the result. Use
+# --stream when you instead want the command's stdout/stderr forwarded live
+# (e.g. for installs whose progress should be visible); --stream forwards output
+# from every attempt and returns nothing to capture, so do not combine it with a
+# $(shell ...) consumer.
+#
 # Advanced features:
 #   --exponential:       Double the delay after each failed attempt.
+#   --stream:            Forward stdout/stderr live instead of capturing stdout.
 #   --continue-if "CMD": Evaluates CMD upon failure. If it fails, retries are aborted immediately (fail-fast).
 #   --cleanup "CMD": Evaluates CMD before starting the next retry attempt.
 #
 # Usage:
-#   retry.sh [--attempts N] [--delay SECONDS] [--exponential] [--continue-if "CMD"] [--cleanup "CMD"] -- <command> [args...]
+#   retry.sh [--attempts N] [--delay SECONDS] [--exponential] [--stream] [--continue-if "CMD"] [--cleanup "CMD"] -- <command> [args...]
 #
 # Defaults: --attempts 4, --delay 5 (no exponential backoff)
 # Exit:     0 on first success, 1 if all attempts fail, 2 on usage error.
@@ -33,6 +41,7 @@ set -u
 attempts=4
 delay=5
 exponential=false
+stream=false
 continue_if=""
 cleanup=""
 
@@ -41,6 +50,7 @@ while [ $# -gt 0 ]; do
         --attempts)        attempts=$2; shift 2 ;;
         --delay)           delay=$2;    shift 2 ;;
         --exponential)     exponential=true; shift ;;
+        --stream)          stream=true; shift ;;
         --continue-if)     continue_if=$2; shift 2 ;;
         --cleanup)         cleanup=$2; shift 2 ;;
         --)                shift; break ;;
@@ -56,7 +66,14 @@ fi
 
 for i in $(seq 1 "$attempts"); do
     echo "retry [$i/$attempts]: $*" 1>&2
-    if out=$("$@"); then
+    if [ "$stream" = "true" ]; then
+        # Forward stdout/stderr live; nothing is captured or echoed.
+        if "$@"; then
+            exit 0
+        fi
+    elif out=$("$@"); then
+        # Capture stdout and echo it only on success, so failed-attempt output
+        # never pollutes a $(shell ...) caller that captures the result.
         printf '%s' "$out"
         exit 0
     fi


### PR DESCRIPTION
… to tolerate transient npm/apt failures

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11984

#### Special notes for your reviewer:
```
$ make kind-image-build test-e2e-kueueviz
<...>
retry [1/5]: bash -c npx cypress install 1>&2
[STARTED] [12:36:59]  Downloading Cypress    
[FAILED] [12:36:59] getaddrinfo EAI_AGAIN download.cypress.io
getaddrinfo EAI_AGAIN download.cypress.io
retry [1/5] failed, retrying in 5s...
retry [2/5]: bash -c npx cypress install 1>&2
[STARTED] [12:37:04]  Downloading Cypress    
[FAILED] [12:37:04] getaddrinfo EAI_AGAIN download.cypress.io
getaddrinfo EAI_AGAIN download.cypress.io
retry [2/5] failed, retrying in 10s...
retry [3/5]: bash -c npx cypress install 1>&2
[STARTED] [12:37:14]  Downloading Cypress    
[FAILED] [12:37:14] getaddrinfo EAI_AGAIN download.cypress.io
getaddrinfo EAI_AGAIN download.cypress.io
retry [3/5] failed, retrying in 20s...
retry [4/5]: bash -c npx cypress install 1>&2
[STARTED] [12:37:34]  Downloading Cypress    
[FAILED] [12:37:34] getaddrinfo EAI_AGAIN download.cypress.io
getaddrinfo EAI_AGAIN download.cypress.io
retry [4/5] failed, retrying in 40s...
retry [5/5]: bash -c npx cypress install 1>&2
[STARTED] [12:38:15]  Downloading Cypress    
[FAILED] [12:38:15] getaddrinfo EAI_AGAIN download.cypress.io
getaddrinfo EAI_AGAIN download.cypress.io
retry [5/5] failed
<...>
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added retry logic with exponential backoff to network- and registry-dependent installation steps in the e2e test setup for improved resilience.
  * Routed all install commands through the retry wrapper so dependency installs are retried automatically (5 attempts, backoff).
  * Note: successful command stdout is no longer re-printed by the retry wrapper.
  * Test execution order (start frontend, run tests) is unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->