### PR TITLE
Revert "Use fixed-rate requeue for DRA RCT processing errors (#11943)"

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -73,10 +73,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
-const (
-	draRequeueDelay = time.Second
-)
-
 var (
 	realClock = clock.RealClock{}
 )
@@ -355,7 +351,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			if updateErr != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update workload status for DRA error: %w", updateErr)
 			}
-			return ctrl.Result{RequeueAfter: draRequeueDelay}, nil
+			return ctrl.Result{}, err
 		}
 
 		// Process Extended Resources backed by DRA (new path)
@@ -377,7 +373,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				if updateErr != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to update workload status for DRA extended resources error: %w", updateErr)
 				}
-				return ctrl.Result{RequeueAfter: draRequeueDelay}, nil
+				return ctrl.Result{}, err
 			}
 		}
 
@@ -412,7 +408,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				if updateErr != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to update workload status for DRA counter resources error: %w", updateErr)
 				}
-				return ctrl.Result{RequeueAfter: draRequeueDelay}, nil
+				return ctrl.Result{}, err
 			}
 			for podSetName, resources := range counterResources {
 				if existing, ok := draResources[podSetName]; ok {

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -669,10 +669,10 @@ func TestReconcile(t *testing.T) {
 				}
 				return wl
 			}(),
-			wantResult: reconcile.Result{RequeueAfter: draRequeueDelay},
-			wantEvents: nil,
+			wantErrorMsg: "not mapped in DRA configuration",
+			wantEvents:   nil,
 		},
-		"reconcile DRA ResourceClaimTemplate not found should requeue and mark inadmissible": {
+		"reconcile DRA ResourceClaimTemplate not found should return error": {
 			featureGates: map[featuregate.Feature]bool{
 				features.KueueDRAIntegration:              true,
 				features.MultiKueueOrchestratedPreemption: false,
@@ -707,8 +707,8 @@ func TestReconcile(t *testing.T) {
 					Message: `spec.podSets[0].template.spec.resourceClaims[0]: Internal error: failed to get claim spec for ResourceClaimTemplate missing-template in podset main: resourceclaimtemplates.resource.k8s.io "missing-template" not found`,
 				}).
 				Obj(),
-			wantResult: reconcile.Result{RequeueAfter: draRequeueDelay},
-			wantEvents: nil,
+			wantErrorMsg: "failed to get claim spec",
+			wantEvents:   nil,
 		},
 		"assign Admission Checks from ClusterQueue.spec.AdmissionCheckStrategy": {
 			workload: utiltestingapi.MakeWorkload("wl", "ns").


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
This reverts commit 1bb0707176bbb997b73f135cf659e6b9b414eb20.
Here's the follow up issue: https://github.com/kubernetes-sigs/kueue/issues/11994

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in the workload reconciliation process. DRA configuration-related errors are now returned immediately instead of being silently retried with a delay, enabling faster feedback when configuration issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->