### PR TITLE
test/e2e: wait for Kubeflow Trainer webhook endpoints

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -129,6 +129,39 @@ function e2e_wait_for_operator_in_install {
     -n "${ns}" --for=condition=available --timeout=5m
 }
 
+function e2e_wait_for_deployment_webhook_endpoints {
+    local kubeconfig=$1
+    local ns=$2
+    local deployment_name=$3
+    local service_name=$4
+    local -a kubectl_args=()
+    if [[ -n "${kubeconfig}" ]]; then
+        kubectl_args+=(--kubeconfig="${kubeconfig}")
+    fi
+
+    kubectl "${kubectl_args[@]}" wait deploy/"${deployment_name}" \
+        -n "${ns}" --for=condition=available --timeout=5m
+
+    local deadline=$((SECONDS + 300))
+    local ready_endpoint_ips=""
+    while [[ "${SECONDS}" -lt "${deadline}" ]]; do
+        ready_endpoint_ips=$(kubectl "${kubectl_args[@]}" -n "${ns}" get endpointslices \
+            -l "kubernetes.io/service-name=${service_name}" \
+            -o go-template='{{range .items}}{{range .endpoints}}{{if ne .conditions.ready false}}{{range .addresses}}{{println .}}{{end}}{{end}}{{end}}{{end}}' 2>/dev/null || true)
+        if [[ -n "${ready_endpoint_ips}" ]]; then
+            echo "Webhook endpoints for service/${service_name} are ready:"
+            echo "${ready_endpoint_ips}"
+            return 0
+        fi
+        sleep 2
+    done
+
+    echo "ERROR: Timed out waiting for ready webhook endpoints for service/${service_name} in namespace ${ns}." >&2
+    kubectl "${kubectl_args[@]}" -n "${ns}" get endpointslices \
+        -l "kubernetes.io/service-name=${service_name}" -o wide >&2 || true
+    return 1
+}
+
 function e2e_deployment_exists {
     local kubeconfig=${1:-}
     local ns=$2
@@ -934,8 +967,9 @@ function install_kubeflow_trainer {
         fi
         kubectl apply --kubeconfig="${kubeconfig}" --server-side -k "$manifests_temp_dir/overlays/manager"
     )
-    # In order to install the training runtimes we need to wait for the ClusterTrainingRuntime webhook to be ready
-    kubectl wait --kubeconfig="${kubeconfig}" deploy/"${deployment_name}" -n "${ns}" --for=condition=available --timeout=5m
+    # Installing runtimes creates ClusterTrainingRuntime objects, so wait until
+    # the webhook service has ready endpoints, not just an Available deployment.
+    e2e_wait_for_deployment_webhook_endpoints "${kubeconfig}" "${ns}" "${deployment_name}" "${deployment_name}"
     kubectl apply --kubeconfig="${kubeconfig}" --server-side -k "${KUBEFLOW_TRAINER_MANIFEST}/overlays/runtimes"
 }
 

--- a/hack/testing/e2e-common_test.sh
+++ b/hack/testing/e2e-common_test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "${test_dir}"' EXIT
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+export ROOT_DIR
+export SOURCE_DIR="${ROOT_DIR}/hack/testing"
+export GINKGO_ARGS="--label-filter=feature:trainjob"
+export E2E_KIND_VERSION="kindest/node:v1.36.1"
+export PATH="${test_dir}:$PATH"
+
+cat >"${test_dir}/kubectl" <<'EOF'
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+state_file="${KUBECTL_FAKE_STATE:?}"
+printf '%s\n' "$*" >>"${KUBECTL_FAKE_LOG:?}"
+
+case "$*" in
+  *" wait deploy/kubeflow-trainer-controller-manager "*)
+    exit 0
+    ;;
+  *" get deployment kubeflow-trainer-controller-manager "*)
+    printf '10.0.0.1\n'
+    exit 0
+    ;;
+  *" get endpointslices "*)
+    attempts=$(cat "${state_file}")
+    attempts=$((attempts + 1))
+    printf '%s' "${attempts}" >"${state_file}"
+    if [[ "${attempts}" -lt 2 ]]; then
+      printf '\n'
+    else
+      printf '10.0.0.1\n'
+    fi
+    exit 0
+    ;;
+esac
+
+printf 'unexpected kubectl call: %s\n' "$*" >&2
+exit 1
+EOF
+chmod +x "${test_dir}/kubectl"
+
+# shellcheck source=hack/testing/e2e-common.sh
+source "${ROOT_DIR}/hack/testing/e2e-common.sh"
+
+KUBECTL_FAKE_STATE="${test_dir}/kubectl-state"
+KUBECTL_FAKE_LOG="${test_dir}/kubectl.log"
+export KUBECTL_FAKE_STATE KUBECTL_FAKE_LOG
+printf '0' >"${KUBECTL_FAKE_STATE}"
+: >"${KUBECTL_FAKE_LOG}"
+
+e2e_wait_for_deployment_webhook_endpoints "test.kubeconfig" "kubeflow-system" \
+  "kubeflow-trainer-controller-manager" "kubeflow-trainer-controller-manager"
+
+endpoint_attempts=$(cat "${KUBECTL_FAKE_STATE}")
+if [[ "${endpoint_attempts}" != "2" ]]; then
+  echo "expected EndpointSlice polling to continue until ready endpoint appears; got ${endpoint_attempts} attempt(s)" >&2
+  exit 1
+fi
+
+echo "e2e-common tests passed"


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test
/kind flake
/kind regression

/area testing

#### What this PR does / why we need it:

In `hack/testing/e2e-common.sh`, wait for the Kubeflow Trainer controller deployment to become Available and for the webhook service EndpointSlices to have ready endpoints before applying the training runtime manifests. Creating `ClusterTrainingRuntime` objects triggers the validating webhook, and there can be a short propagation window after the deployment is Available but before the service endpoints are ready.

This PR was rebased on latest `main` to drop the MultiKueue TAS timeout changes that were merged separately in #11998.

#### Which issue(s) this PR fixes:

Fixes #11985

#### Does this PR introduce a user-facing change?

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the Kubeflow Trainer runtime installation process to more reliably wait for webhook endpoints to be ready before proceeding, enhancing deployment stability.
  * Enhanced internal testing infrastructure with additional validation checks for endpoint readiness during the installation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->