### PR TITLE
Add check for ElasticWorkloads in TAS topology request

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -76,4 +76,6 @@ const (
 	//
 	// This annotation is alpha-level and requires the AdmissionGatedBy feature gate, disabled by default.
 	AdmissionGatedByAnnotation = "kueue.x-k8s.io/admission-gated-by"
+
+	ElasticJobAnnotation = "kueue.x-k8s.io/elastic-job"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -77,5 +77,6 @@ const (
 	// This annotation is alpha-level and requires the AdmissionGatedBy feature gate, disabled by default.
 	AdmissionGatedByAnnotation = "kueue.x-k8s.io/admission-gated-by"
 
+	// ElasticJobAnnotation is an annotation set on the Job to indicate that it is an elastic job.
 	ElasticJobAnnotation = "kueue.x-k8s.io/elastic-job"
 )

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
@@ -4108,6 +4109,11 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 				}),
 			},
 			workload: *workload.NewInfo(&kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"kueue.x-k8s.io/elastic-job": "true",
+					},
+				},
 				Spec: kueue.WorkloadSpec{
 					PodSets: []kueue.PodSet{
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
@@ -4144,6 +4150,42 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 				}),
 			},
 			workload: *workload.NewInfo(&kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"kueue.x-k8s.io/elastic-job": "true",
+					},
+				},
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
+							Request(corev1.ResourceCPU, "1").
+							PreferredTopologyRequest(corev1.LabelHostname).
+							Obj(),
+					},
+				},
+			}),
+			wantErr: "preferred topology is not supported with ElasticJobsViaWorkloadSlices",
+		},
+		"preferred topology is rejected for new elastic workload": {
+			cq: schdcache.ClusterQueueSnapshot{
+				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{"tas": tasFlavor},
+			},
+			assignment: Assignment{
+				PodSets: []PodSetAssignment{{
+					Name: kueue.DefaultPodSetName,
+					Flavors: ResourceAssignment{
+						corev1.ResourceCPU: {Name: "tas", Mode: Fit, TriedFlavorIdx: -1},
+					},
+					Count:  2,
+					Status: *NewStatus(),
+				}},
+			},
+			workload: *workload.NewInfo(&kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"kueue.x-k8s.io/elastic-job": "true",
+					},
+				},
 				Spec: kueue.WorkloadSpec{
 					PodSets: []kueue.PodSet{
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
@@ -4180,11 +4222,66 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 				}),
 			},
 			workload: *workload.NewInfo(&kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"kueue.x-k8s.io/elastic-job": "true",
+					},
+				},
 				Spec: kueue.WorkloadSpec{
 					PodSets: []kueue.PodSet{
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
 							Request(corev1.ResourceCPU, "1").
 							UnconstrainedTopologyRequest().
+							Obj(),
+					},
+				},
+			}),
+		},
+		"required topology is accepted for regular jobs with ElasticJobsViaWorkloadSlicesWithTAS": {
+			cq: schdcache.ClusterQueueSnapshot{
+				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{"tas": tasFlavor},
+			},
+			assignment: Assignment{
+				PodSets: []PodSetAssignment{{
+					Name: kueue.DefaultPodSetName,
+					Flavors: ResourceAssignment{
+						corev1.ResourceCPU: {Name: "tas", Mode: Fit, TriedFlavorIdx: -1},
+					},
+					Count:  2,
+					Status: *NewStatus(),
+				}},
+			},
+			workload: *workload.NewInfo(&kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
+							Request(corev1.ResourceCPU, "1").
+							RequiredTopologyRequest(corev1.LabelHostname).
+							Obj(),
+					},
+				},
+			}),
+		},
+		"preferred topology is accepted for regular jobs with ElasticJobsViaWorkloadSlicesWithTAS": {
+			cq: schdcache.ClusterQueueSnapshot{
+				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{"tas": tasFlavor},
+			},
+			assignment: Assignment{
+				PodSets: []PodSetAssignment{{
+					Name: kueue.DefaultPodSetName,
+					Flavors: ResourceAssignment{
+						corev1.ResourceCPU: {Name: "tas", Mode: Fit, TriedFlavorIdx: -1},
+					},
+					Count:  2,
+					Status: *NewStatus(),
+				}},
+			},
+			workload: *workload.NewInfo(&kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
+							Request(corev1.ResourceCPU, "1").
+							PreferredTopologyRequest(corev1.LabelHostname).
 							Obj(),
 					},
 				},

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -61,11 +61,7 @@ func (a *Assignment) WorkloadsTopologyRequests(log logr.Logger, wl *workload.Inf
 			var previousAssignment *kueue.TopologyAssignment
 
 			// Only unconstrained topology is supported with elastic workload slices.
-			if workload.IsElasticWorkload(wl.Obj) {
-				if !features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
-					psAssignment.error(errors.New("ElasticJobsViaWorkloadSlicesWithTAS feature gate is not enabled"))
-					continue
-				}
+			if workload.IsElasticWorkload(wl.Obj) && features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
 				if podSet.TopologyRequest != nil && podSet.TopologyRequest.Required != nil {
 					psAssignment.error(errors.New("required topology is not supported with ElasticJobsViaWorkloadSlices"))
 					continue

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -58,9 +58,14 @@ func (a *Assignment) WorkloadsTopologyRequests(log logr.Logger, wl *workload.Inf
 			}
 			isTASImplied := isTASImplied(&podSet, cq)
 
-			// Only unconstrained topology is supported with elastic workload slices.
 			var previousAssignment *kueue.TopologyAssignment
-			if features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
+
+			// Only unconstrained topology is supported with elastic workload slices.
+			if workload.IsElasticWorkload(wl.Obj) {
+				if !features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
+					psAssignment.error(errors.New("ElasticJobsViaWorkloadSlicesWithTAS feature gate is not enabled"))
+					continue
+				}
 				if podSet.TopologyRequest != nil && podSet.TopologyRequest.Required != nil {
 					psAssignment.error(errors.New("required topology is not supported with ElasticJobsViaWorkloadSlices"))
 					continue

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -1977,3 +1977,12 @@ func TASAssignedNodeNames(wl *kueue.Workload) []string {
 	}
 	return nodesSet.UnsortedList()
 }
+
+// IsElasticWorkload returns true if ElasticJobsViaWorkloadSlices feature gate is enabled
+// and the given Workload is marked as elastic.
+func IsElasticWorkload(wl *kueue.Workload) bool {
+	if wl == nil {
+		return false
+	}
+	return features.Enabled(features.ElasticJobsViaWorkloadSlices) && wl.GetAnnotations()[constants.ElasticJobAnnotation] == "true"
+}

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -33,6 +33,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/scheduler/preemption"
@@ -51,7 +52,7 @@ import (
 const (
 	// EnabledAnnotationKey refers to the annotation key present on Job's that support
 	// workload slicing.
-	EnabledAnnotationKey = "kueue.x-k8s.io/elastic-job"
+	EnabledAnnotationKey = constants.ElasticJobAnnotation
 	// EnabledAnnotationValue refers to the annotation value. To enable
 	// workload slicing for a given job, we match both annotation key and value.
 	EnabledAnnotationValue = "true"


### PR DESCRIPTION
#### What type of PR is this?
AI-assisted

/kind bug

/area tas
/area elasticworkloads

#### What this PR does / why we need it:
Scheduler guard is not scoped to elastic jobs, but should be: keps/77-dynamically-sized-jobs/README.md:289-291

#### Which issue(s) this PR fixes:
Fixes # 

#### Does this PR introduce a user-facing change?
```release-note
ElasticJobsViaWorkloadSlices: Fix the bug that regular (non-elastic) workloads with the required/preferred topology
were rejected when the feature ElasticJobsViaWorkloadSlicesWithTAS is enabled.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of elastic jobs for topology-aware scheduling, gated by feature flags and the elastic-job annotation.

* **Tests**
  * Added validation tests for topology requests covering elastic and non-elastic workloads with multiple sub-cases.

* **Chores**
  * Centralized the elastic-job annotation key across the codebase and introduced a workload-level check for elastic jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->