### PR TITLE
Classify DRA reconcile errors as transient vs deterministic

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -77,6 +77,21 @@ var (
 	realClock = clock.RealClock{}
 )
 
+// hasInternalError reports whether the field error list contains an internal
+// error. DRA resolution reports retryable failures — API errors and cluster-state
+// shortages that clear once ResourceSlices change — as internal errors, so the
+// reconciler retries them with controller-runtime backoff; deterministic spec or
+// configuration errors use other field error types and are left inadmissible
+// without requeue.
+func hasInternalError(errs field.ErrorList) bool {
+	for _, e := range errs {
+		if e.Type == field.ErrorTypeInternal {
+			return true
+		}
+	}
+	return false
+}
+
 type waitForPodsReadyConfig struct {
 	timeout                     time.Duration
 	recoveryTimeout             *time.Duration
@@ -351,7 +366,10 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			if updateErr != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update workload status for DRA error: %w", updateErr)
 			}
-			return ctrl.Result{}, err
+			if hasInternalError(fieldErrs) {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
 		}
 
 		// Process Extended Resources backed by DRA (new path)
@@ -373,7 +391,10 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				if updateErr != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to update workload status for DRA extended resources error: %w", updateErr)
 				}
-				return ctrl.Result{}, err
+				if hasInternalError(extFieldErrs) {
+					return ctrl.Result{}, err
+				}
+				return ctrl.Result{}, nil
 			}
 		}
 
@@ -408,7 +429,10 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				if updateErr != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to update workload status for DRA counter resources error: %w", updateErr)
 				}
-				return ctrl.Result{}, err
+				if hasInternalError(counterFieldErrs) {
+					return ctrl.Result{}, err
+				}
+				return ctrl.Result{}, nil
 			}
 			for podSetName, resources := range counterResources {
 				if existing, ok := draResources[podSetName]; ok {

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -416,6 +416,7 @@ func TestReconcile(t *testing.T) {
 		resourceClaims            []*resourcev1.ResourceClaim
 		resourceClaimTemplates    []*resourcev1.ResourceClaimTemplate
 		patchErr                  error
+		listErr                   error
 		wantDRAResourceTotal      *int64
 		wantWorkloadsInQueue      *int
 		wantWorkload              *kueue.Workload
@@ -669,8 +670,7 @@ func TestReconcile(t *testing.T) {
 				}
 				return wl
 			}(),
-			wantErrorMsg: "not mapped in DRA configuration",
-			wantEvents:   nil,
+			wantEvents: nil,
 		},
 		"reconcile DRA ResourceClaimTemplate not found should return error": {
 			featureGates: map[featuregate.Feature]bool{
@@ -708,6 +708,33 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 			wantErrorMsg: "failed to get claim spec",
+			wantEvents:   nil,
+		},
+		"reconcile DRA transient ResourceSlice list failure should back off": {
+			featureGates: map[featuregate.Feature]bool{
+				features.KueueDRAIntegration:              true,
+				features.MultiKueueOrchestratedPreemption: false,
+			},
+			listErr: errTest,
+			workload: utiltestingapi.MakeWorkload("wlListErrDRA", "ns").
+				Queue("lq").
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					ResourceClaimTemplate("gpu", "gpu-template").
+					Obj()).
+				Obj(),
+			resourceClaimTemplates: []*resourcev1.ResourceClaimTemplate{
+				utiltesting.MakeResourceClaimTemplate("gpu-template", "ns").
+					DeviceRequest("gpu-request", "gpu.example.com", 1).
+					WithCELSelectors("device.driver == \"test-driver\"").
+					Obj(),
+			},
+			cq: utiltestingapi.MakeClusterQueue("cq").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("flavor1").
+						Resource("gpu", "2").Obj(),
+				).Obj(),
+			lq:           utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			wantErrorMsg: "failed to list ResourceSlices",
 			wantEvents:   nil,
 		},
 		"assign Admission Checks from ClusterQueue.spec.AdmissionCheckStrategy": {
@@ -3430,6 +3457,14 @@ func TestReconcile(t *testing.T) {
 								return tc.patchErr
 							}
 							return utiltesting.TreatSSAAsStrategicMerge(ctx, client, subResourceName, obj, patch, opts...)
+						},
+						List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+							if tc.listErr != nil {
+								if _, ok := list.(*resourcev1.ResourceSliceList); ok {
+									return tc.listErr
+								}
+							}
+							return c.List(ctx, list, opts...)
 						},
 					})
 				cl := clientBuilder.Build()

--- a/pkg/dra/claims.go
+++ b/pkg/dra/claims.go
@@ -461,10 +461,10 @@ func validateCELSelectorsAgainstDevices(ctx context.Context, cl client.Client, c
 		}
 
 		if matchCount < cr.count {
-			allErrs = append(allErrs, field.Invalid(
+			// Cluster-state shortage: retryable until matching ResourceSlices are published.
+			allErrs = append(allErrs, field.InternalError(
 				basePath.Child("devices", "requests").Index(cr.index).Child("exactly", "selectors"),
-				nil,
-				fmt.Sprintf("insufficient matching devices for CEL selector in DeviceClass %s: %d device(s) match in the cluster but %d requested",
+				fmt.Errorf("insufficient matching devices for CEL selector in DeviceClass %s: %d device(s) match in the cluster but %d requested",
 					cr.deviceClassName, matchCount, cr.count),
 			))
 		}

--- a/pkg/dra/claims_test.go
+++ b/pkg/dra/claims_test.go
@@ -359,10 +359,9 @@ func Test_GetResourceRequests(t *testing.T) {
 			},
 			lookup: defaultLookup,
 			wantErr: field.ErrorList{
-				field.Invalid(
+				field.InternalError(
 					field.NewPath("spec", "podSets").Index(0).Child("template", "spec", "resourceClaims").Index(0).Child("devices", "requests").Index(0).Child("exactly", "selectors"),
-					"",
-					"",
+					errors.New(""),
 				),
 			},
 		},
@@ -395,10 +394,9 @@ func Test_GetResourceRequests(t *testing.T) {
 			},
 			lookup: defaultLookup,
 			wantErr: field.ErrorList{
-				field.Invalid(
+				field.InternalError(
 					field.NewPath("spec", "podSets").Index(0).Child("template", "spec", "resourceClaims").Index(0).Child("devices", "requests").Index(0).Child("exactly", "selectors"),
-					"",
-					"",
+					errors.New(""),
 				),
 			},
 		},
@@ -460,10 +458,9 @@ func Test_GetResourceRequests(t *testing.T) {
 			},
 			lookup: defaultLookup,
 			wantErr: field.ErrorList{
-				field.Invalid(
+				field.InternalError(
 					field.NewPath("spec", "podSets").Index(0).Child("template", "spec", "resourceClaims").Index(0).Child("devices", "requests").Index(1).Child("exactly", "selectors"),
-					"",
-					"",
+					errors.New(""),
 				),
 			},
 		},

--- a/pkg/dra/counters.go
+++ b/pkg/dra/counters.go
@@ -150,10 +150,10 @@ func processCounterCharge(
 	log.V(4).Info("Matched devices for counter charge", "deviceClass", deviceClassName, "matched", len(matched), "requested", count)
 
 	if int64(len(matched)) < count {
-		return nil, field.ErrorList{field.Invalid(
+		// Cluster-state shortage: retryable until matching ResourceSlices appear.
+		return nil, field.ErrorList{field.InternalError(
 			reqPath,
-			nil,
-			fmt.Sprintf("insufficient matching devices for counter driver: %d device(s) match but %d requested",
+			fmt.Errorf("insufficient matching devices for counter driver: %d device(s) match but %d requested",
 				len(matched), count),
 		)}
 	}
@@ -163,10 +163,11 @@ func processCounterCharge(
 		return charges, nil
 	}
 
-	return nil, field.ErrorList{field.Invalid(
+	// No consumesCounters yet on the matched devices: another cluster-state
+	// condition that can clear as ResourceSlices are updated, so retry with backoff.
+	return nil, field.ErrorList{field.InternalError(
 		reqPath,
-		nil,
-		fmt.Sprintf("matched devices have no consumesCounters entry for counter %q", counterConfig.counterName),
+		fmt.Errorf("matched devices have no consumesCounters entry for counter %q", counterConfig.counterName),
 	)}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
DRA resolution errors in the workload reconciler were all returned as reconcile
errors, so permanent failures (unsupported DRA features, unmapped device classes,
non-integer extended resources) were retried with controller-runtime backoff even
though retrying cannot change the outcome.

The three DRA helpers now report whether their errors warrant a retry:
- Internal/API failures and cluster-state shortages ("too few matching devices")
  keep the controller-runtime backoff, so the workload still recovers once the
  cluster or its ResourceSlices change.
- Permanent spec/configuration errors leave the workload inadmissible and return
  without requeue.

This supersedes the reverted #11943 (fixed-rate requeue) by distinguishing the
error categories instead of applying one policy to all of them.

#### Which issue(s) this PR fixes:
Fixes #11994

#### Special notes for your reviewer:
- Device-shortage errors intentionally stay on backoff: the integration test
  "Should requeue inadmissible workload when ResourceSlice is created" relies on
  that recovery, and there is no ResourceSlice->workload informer yet (KEP-2941
  lists event-driven ResourceSlice requeuing as an alpha graduation item).
- Verified: pkg/dra and pkg/controller/core unit tests, the DRA controller
  integration suite, gofmt, go vet, and golangci-lint.
- AI tools were used to assist in preparing this change.

#### Does this PR introduce a user-facing change?
```release-note
DRA: Fixed hot reconcile loops for inadmissible Workloads with deterministic DRA resolution
failures. Kueue now avoids requeueing permanent DRA spec or configuration errors while still
retrying transient failures with backoff.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in device resource allocation operations to properly identify and process transient failures
  * Device resource validation failures now correctly classified as recoverable errors
  
* **Tests**
  * Added test coverage for transient failures in resource discovery operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->