### PR TITLE
Optimize the sequential/extended e2e test suites by sharding

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -266,12 +266,32 @@ test-e2e-sequential-baseline-shard-1: test-e2e-sequential-baseline
 test-e2e-sequential-baseline-helm: E2E_USE_HELM=true
 test-e2e-sequential-baseline-helm: test-e2e-sequential-baseline
 
+# Assign Shard 0 variables to the shard-0 target
+TEST_E2E_SEQUENTIAL_EXTENDED_SHARD_0_TARGETS := test-e2e-sequential-extended-shard-0
+$(TEST_E2E_SEQUENTIAL_EXTENDED_SHARD_0_TARGETS): export JOBSET_VERSION := $(JOBSET_VERSION)
+$(TEST_E2E_SEQUENTIAL_EXTENDED_SHARD_0_TARGETS): export APPWRAPPER_VERSION := $(APPWRAPPER_VERSION)
+$(TEST_E2E_SEQUENTIAL_EXTENDED_SHARD_0_TARGETS): export LEADERWORKERSET_VERSION := $(LEADERWORKERSET_VERSION)
+
+# Assign Shard 1 variables to the shard-1 target
+TEST_E2E_SEQUENTIAL_EXTENDED_SHARD_1_TARGETS := test-e2e-sequential-extended-shard-1
+$(TEST_E2E_SEQUENTIAL_EXTENDED_SHARD_1_TARGETS): export SPARKOPERATOR_VERSION := $(SPARKOPERATOR_VERSION)
+
 ## Label Taxonomy:
-##   Features: managejobswithoutqueuename, spark
+##   Features: managejobswithoutqueuename, workloadidentifierannotations, spark
 ## Examples:
 ##   Run only Spark Integration tests: GINKGO_ARGS="--label-filter=feature:spark" make test-e2e-sequential-extended
 .PHONY: test-e2e-sequential-extended
-test-e2e-sequential-extended: setup-e2e-env run-test-e2e-sequential-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
+test-e2e-sequential-extended:
+	$(MAKE) test-e2e-sequential-extended-shard-0 E2E_USE_HELM=$(E2E_USE_HELM)
+	$(MAKE) test-e2e-sequential-extended-shard-1 E2E_USE_HELM=$(E2E_USE_HELM)
+
+.PHONY: test-e2e-sequential-extended-shard-0
+test-e2e-sequential-extended-shard-0: GINKGO_ARGS=--label-filter=feature:managejobswithoutqueuename,feature:workloadidentifierannotations
+test-e2e-sequential-extended-shard-0: setup-e2e-env run-test-e2e-sequential-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
+
+.PHONY: test-e2e-sequential-extended-shard-1
+test-e2e-sequential-extended-shard-1: GINKGO_ARGS=--label-filter=feature:spark
+test-e2e-sequential-extended-shard-1: setup-e2e-env run-test-e2e-sequential-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-e2e-sequential-extended-helm
 test-e2e-sequential-extended-helm: E2E_USE_HELM=true
@@ -404,9 +424,6 @@ run-test-e2e-sequential-extended-%:
 	E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
 	E2E_ENFORCE_OPERATOR_UPDATE=$(E2E_ENFORCE_OPERATOR_UPDATE) \
 	KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="sequential/extended" \
-	JOBSET_VERSION=$(JOBSET_VERSION) APPWRAPPER_VERSION=$(APPWRAPPER_VERSION) \
-	LEADERWORKERSET_VERSION=$(LEADERWORKERSET_VERSION) \
-	SPARKOPERATOR_VERSION=$(SPARKOPERATOR_VERSION) \
 	TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
 	E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 	E2E_USE_HELM=$(E2E_USE_HELM) \

--- a/test/e2e/sequential/extended/managejobswithoutqueuename_test.go
+++ b/test/e2e/sequential/extended/managejobswithoutqueuename_test.go
@@ -946,7 +946,7 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Label("feature:mana
 	})
 })
 
-var _ = ginkgo.Describe("ManageJobsWithoutQueueName with ManagedJobsNamespaceSelectorAlwaysRespected=false", func() {
+var _ = ginkgo.Describe("ManageJobsWithoutQueueName with ManagedJobsNamespaceSelectorAlwaysRespected=false", ginkgo.Label("feature:managejobswithoutqueuename"), func() {
 	var (
 		ns           *corev1.Namespace
 		defaultRf    *kueue.ResourceFlavor
@@ -1050,7 +1050,7 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName with ManagedJobsNamespaceSel
 	})
 })
 
-var _ = ginkgo.Describe("ManageJobsWithoutQueueName without JobSet integration", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("ManageJobsWithoutQueueName without JobSet integration", ginkgo.Label("feature:managejobswithoutqueuename"), ginkgo.Ordered, func() {
 	var (
 		ns           *corev1.Namespace
 		defaultRf    *kueue.ResourceFlavor


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/area testing

#### What this PR does / why we need it:

Shards the `sequential/extended` e2e suite so the heavy Spark setup is isolated, following the same feature-label sharding approach as the `singlecluster/extended` suite (#11964). The suite is split into two shards:
  
- shard-0 (`feature:managejobswithoutqueuename`, `feature:workloadidentifierannotations`): 9 specs; installs jobset/lws/appwrapper.
- shard-1 (`feature:spark`): 2 specs; installs only the Spark operator + image.
  
Current pre-shard runtimes (`hack/tools/prow-runtimes`, last 6 successful runs):

| Job | Avg |
|---|---:|
| `periodic-kueue-test-e2e-sequential-extended-main` | 18:27 |
| `pull-kueue-test-e2e-sequential-extended-main` | 21:12 |
 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #11990

#### Special notes for your reviewer:

- Verified spec allocation with `ginkgo --dry-run`: shard-0 = 19, shard-1 = 2, total = 21 (no specs dropped or duplicated).
- Two pieces remain: (1) the paired test-infra PR and (2) release-0.17/0.18 backports. How would you prefer to sequence these: test-infra `main` right after this, or bundle everything (including release) into one test-infra PR?
    


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Split the extended end-to-end suite into two shard targets so related test groups run separately with shard-specific label filters (managejobs/workload identifiers vs. spark).
  * Assign shard-scoped operator versions and add feature labels to targeted e2e suites to ensure each shard runs with the appropriate configuration for consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->