### PR TITLE
deflake: use waitForKueueControllerReadyWithWebhookEndpoints for KCM

### DIFF
--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -584,6 +584,9 @@ func ForceLeaderFailover(ctx context.Context, k8sClient client.Client) {
 		g.Expect(newHolder).NotTo(gomega.BeEmpty())
 		g.Expect(newHolder).NotTo(gomega.Equal(holderIdentity))
 	}, LongTimeout, Interval).Should(gomega.Succeed())
+
+	kcmKey := types.NamespacedName{Namespace: kueueNS, Name: "kueue-controller-manager"}
+	waitForKueueControllerReadyWithWebhookEndpoints(ctx, k8sClient, kcmKey)
 }
 
 // waitForLeaderElection waits for the kueue controller to acquire the leader lease


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Per https://github.com/kubernetes-sigs/kueue/pull/11981#discussion_r3379059990

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved leadership failover testing by adding post-failover synchronization verification. The test now waits for controller deployment readiness and webhook endpoint availability to ensure system stability after failover events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->