### PR TITLE
Document MultiKueue migration to ClusterProfile accessProviders

### DIFF
--- a/keps/693-multikueue/README.md
+++ b/keps/693-multikueue/README.md
@@ -276,8 +276,8 @@ type ClusterProfile struct {
 
 	// CredentialsProviders defines a list of providers to obtain credentials of worker clusters
 	// using the ClusterProfile API.
-	// Deprecated: Use AccessProviders instead. If both AccessProviders and CredentialsProviders are provided,
-	// both are used. In case they specify a provider with the same name, the one in AccessProviders is preferred.
+	// Deprecated: Use AccessProviders instead. AccessProviders and CredentialsProviders
+	// are mutually exclusive.
 	CredentialsProviders []ClusterProfileCredentialsProvider `json:"credentialsProviders,omitempty"`
 }
 
@@ -294,7 +294,7 @@ type ClusterProfileAccessProvider struct {
 type ClusterProfileCredentialsProvider = ClusterProfileAccessProvider
 ```
 
-  The `credentialsProviders` field remains accepted for backwards compatibility. If both `accessProviders` and `credentialsProviders` are specified, the controller uses providers from both fields. When both fields specify a provider with the same name, the provider in `accessProviders` takes precedence.
+  The `credentialsProviders` field remains accepted for backwards compatibility when `accessProviders` is not configured. The `accessProviders` and `credentialsProviders` fields are mutually exclusive, so users should migrate existing `credentialsProviders` entries to `accessProviders`. The deprecated `credentialsProviders` field and `ClusterProfileCredentialsProvider` alias will be removed in the `v1beta3` Configuration API.
 
   On the ClusterProfile API side, Kueue uses `status.accessProviders` as the preferred source of cluster access information. The deprecated `status.credentialProviders` field remains supported by the ClusterProfile API compatibility layer.
 

--- a/keps/693-multikueue/README.md
+++ b/keps/693-multikueue/README.md
@@ -258,7 +258,7 @@ The controller obtains cluster credentials based on the `MultiKueueCluster` spec
 
   The authentication flow is as follows:
   1. The controller reads the `ClusterProfile` object referenced by the `MultiKueueCluster`. The `ClusterProfile` contains a list of access providers.
-  2. The controller uses this configuration to match the access provider with the credentials provider and invoke the credential plugin binary. The list of credentials providers is configured in the `CredentialsProviders` section under `ClusterProfile` in the `MultiKueue` in the Configuration API.
+  2. The controller uses this configuration to match the cluster access provider with a configured access provider and invoke the credential plugin binary. The list of access providers is configured in the `accessProviders` section under `clusterProfile` in the `MultiKueue` Configuration API.
 
 ```go
 type MultiKueue struct {
@@ -270,19 +270,32 @@ type MultiKueue struct {
 
 // ClusterProfile defines configuration for using the ClusterProfile API in MultiKueue.
 type ClusterProfile struct {
+	// AccessProviders defines a list of providers to obtain access to worker clusters
+	// using the ClusterProfile API.
+	AccessProviders []ClusterProfileAccessProvider `json:"accessProviders,omitempty"`
+
 	// CredentialsProviders defines a list of providers to obtain credentials of worker clusters
 	// using the ClusterProfile API.
-	CredentialsProviders []ClusterProfileCredentialsProvider `json:"credentialsProviders,omitempty"`
+	// Deprecated: Use AccessProviders instead.
+	CredentialsProviders []ClusterProfileAccessProvider `json:"credentialsProviders,omitempty"`
+}
+
+// ClusterProfileAccessProvider defines an access provider in the ClusterProfile API.
+type ClusterProfileAccessProvider struct {
+	// Name is the name of the provider.
+	Name string `json:"name"`
+	// ExecConfig is the exec configuration to obtain credentials.
+	ExecConfig clientcmdapi.ExecConfig `json:"execConfig"`
 }
 
 // ClusterProfileCredentialsProvider defines a credentials provider in the ClusterProfile API.
-type ClusterProfileCredentialsProvider struct {
-	// Name is the name of the provider.
-	Name string `json:"name"`
-	//  ExecConfig is the exec configuration to obtain credentials.
-	ExecConfig clientcmdapi.ExecConfig `json:"execConfig"`
-}
+// Deprecated: Use ClusterProfileAccessProvider instead.
+type ClusterProfileCredentialsProvider = ClusterProfileAccessProvider
 ```
+
+  The `credentialsProviders` field remains accepted for backwards compatibility. If both `accessProviders` and `credentialsProviders` are specified, the controller uses providers from both fields. When both fields specify a provider with the same name, the provider in `accessProviders` takes precedence.
+
+  On the ClusterProfile API side, Kueue uses `status.accessProviders` as the preferred source of cluster access information. The deprecated `status.credentialProviders` field remains supported by the ClusterProfile API compatibility layer.
 
   3. The plugin is responsible for the actual authentication process. This might involve calling an external HTTP endpoint (e.g., a cloud provider's metadata service or an OIDC provider) to generate a short-lived authentication token. The details of this process are specific to the plugin and are opaque to Kueue. It returns the credentials, including the token, to the controller.
   4. The controller uses these credentials to configure a Kubernetes client for the worker cluster.
@@ -525,6 +538,7 @@ Graduation to beta criteria:
 * Roadmap for missing features is defined.
 
 ## Implementation History
+* 2026-06-09 Add ClusterProfile accessProviders configuration and deprecate credentialsProviders.
 * 2023-11-28 Initial KEP.
 
 ## Drawbacks
@@ -538,4 +552,3 @@ MultiKueue has some drawbacks.
 ## Alternatives
 * Use Armada or Multi Cluster App Dispatcher.
 * Use multicluster-specific Job APIs.
-

--- a/keps/693-multikueue/README.md
+++ b/keps/693-multikueue/README.md
@@ -276,8 +276,9 @@ type ClusterProfile struct {
 
 	// CredentialsProviders defines a list of providers to obtain credentials of worker clusters
 	// using the ClusterProfile API.
-	// Deprecated: Use AccessProviders instead.
-	CredentialsProviders []ClusterProfileAccessProvider `json:"credentialsProviders,omitempty"`
+	// Deprecated: Use AccessProviders instead. If both AccessProviders and CredentialsProviders are provided,
+	// both are used. In case they specify a provider with the same name, the one in AccessProviders is preferred.
+	CredentialsProviders []ClusterProfileCredentialsProvider `json:"credentialsProviders,omitempty"`
 }
 
 // ClusterProfileAccessProvider defines an access provider in the ClusterProfile API.


### PR DESCRIPTION
#### What type of PR is this?

/kind kep
/area multikueue

#### What this PR does / why we need it:

Updates KEP-693 to document MultiKueue's migration from ClusterProfile `credentialsProviders` to `accessProviders`.

The Cluster Inventory API renamed the provider concept because the old `credentialProviders` field actually carries cluster access information rather than credential material. The new `accessProviders` field is now the preferred API, and `credentialProviders` is deprecated:

- kubernetes-sigs/cluster-inventory-api#23 introduced the rename direction.
- kubernetes-sigs/cluster-inventory-api#52 propagated the rename from credentials to access in the Cluster Inventory API code.

The Cluster Inventory API still keeps compatibility for the deprecated field today, but that compatibility is expected to be removed in the future:

- kubernetes-sigs/cluster-inventory-api#65 tracks removal of credential provider compatibility.

Because MultiKueue consumes ClusterProfile access information, this KEP update records the intent to migrate before the deprecated Cluster Inventory API field is removed. The KEP now describes `multiKueue.clusterProfile.accessProviders` as the preferred MultiKueue configuration field, keeps `credentialsProviders` as a deprecated compatibility field, and records the precedence rule when both fields define the same provider name.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This is a KEP-only follow-up for the API shape being implemented in #12011.

AI disclosure: This PR was written in part with the assistance of generative AI.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the MultiKueue KEP-693 ClusterProfile API/config examples to use a configured `accessProviders` list for cluster access provisioning.
  * Added `accessProviders` (`ClusterProfileAccessProvider` with `Name` and `ExecConfig`) and retained `credentialsProviders` as a deprecated compatibility option; `ClusterProfileCredentialsProvider` is now an alias.
  * Clarified precedence and status fields: `accessProviders` is preferred over `credentialsProviders`, and `status.accessProviders` is preferred while `status.credentialProviders` remains supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->