### PR TITLE
Fix kueueviz e2e flake by waiting for the Kueue webhook to be reachab…

### DIFF
--- a/hack/testing/e2e-kueueviz-backend.sh
+++ b/hack/testing/e2e-kueueviz-backend.sh
@@ -34,7 +34,9 @@ fi
 # Function to clean up background processes
 cleanup() {
   echo "Cleaning up kueueviz processes"
-  kill "${BACKEND_PID}"
+  # BACKEND_PID may be unset if we exit before the backend starts (e.g. while
+  # waiting for the Kueue webhook), so guard against an empty kill argument.
+  [ -n "${BACKEND_PID:-}" ] && kill "${BACKEND_PID}"
   cluster_collect_artifacts "${KIND_CLUSTER_NAME}" ""
   cluster_cleanup "${KIND_CLUSTER_NAME}"
 }
@@ -50,7 +52,11 @@ cluster_kind_load "${KIND_CLUSTER_NAME}"
 kueue_deploy
 kubectl wait deploy/kueue-controller-manager -n"$KUEUE_NAMESPACE" --for=condition=available --timeout=5m
 
-# Deploy KueueViz resources
+# Wait for the Kueue webhook to be up before creating resources, otherwise the
+# creates can fail with "connection refused". A server-side dry-run probes the
+# webhook without persisting anything, so it is safe to retry.
+"${ROOT_DIR}/hack/testing/retry.sh" --attempts 10 --delay 3 --stream -- \
+  kubectl create --dry-run=server -f "${ROOT_DIR}/cmd/kueueviz/examples/00-resource-flavor.yaml"
 kubectl create -f "${ROOT_DIR}/cmd/kueueviz/examples/"
 
 # Start KueueViz backend

--- a/hack/testing/e2e-kueueviz-local.sh
+++ b/hack/testing/e2e-kueueviz-local.sh
@@ -26,7 +26,10 @@ mkdir -p "${ARTIFACTS}"
 # Function to clean up background processes
 cleanup() {
   echo "Cleaning up kueueviz processes"
-  kill $BACKEND_PID $FRONTEND_PID
+  # The PIDs may be unset if we exit before the processes start (e.g. while
+  # waiting for the Kueue webhook), so guard against empty kill arguments.
+  [ -n "${BACKEND_PID:-}" ] && kill "${BACKEND_PID}"
+  [ -n "${FRONTEND_PID:-}" ] && kill "${FRONTEND_PID}"
   cluster_collect_artifacts "$KIND_CLUSTER_NAME" ""
   cluster_cleanup "$KIND_CLUSTER_NAME"
 }
@@ -41,7 +44,11 @@ cluster_kind_load "${KIND_CLUSTER_NAME}"
 kueue_deploy
 kubectl wait deploy/kueue-controller-manager -n"$KUEUE_NAMESPACE" --for=condition=available --timeout=5m
 
-# Deploy kueueviz resources
+# Wait for the Kueue webhook to be up before creating resources, otherwise the
+# creates can fail with "connection refused". A server-side dry-run probes the
+# webhook without persisting anything, so it is safe to retry.
+"${ROOT_DIR}/hack/testing/retry.sh" --attempts 10 --delay 3 --stream -- \
+  kubectl create --dry-run=server -f "${ROOT_DIR}/cmd/kueueviz/examples/00-resource-flavor.yaml"
 kubectl create -f "${ROOT_DIR}/cmd/kueueviz/examples/"
 
 # Start kueueviz backend


### PR DESCRIPTION
…le before creating example resources

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Fix kueueviz e2e flake by waiting for the Kueue webhook to be reachable before creating example resources
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12008 

#### Special notes for your reviewer:
The webhook couldn't be up and ready sometimes, that is why we have this issue. The fix is to have dry run that tries to create yaml, and it tries until success which in turn means that webhook is up and running and we can create yaml objects now
```
$ make kind-image-build test-e2e-kueueviz 
<...>
retry [1/10]: kubectl create --dry-run=server -f /home/user1/Projects/kueue/hack/testing/../../cmd/kueueviz/examples/00-resource-flavor.yaml
Error from server (InternalError): error when creating "/home/user1/Projects/kueue/hack/testing/../../cmd/kueueviz/examples/00-resource-flavor.yaml": Internal error occurred: failed calling webhook "mresourceflavor.kb.io": failed to call webhook: Post "https://kueue-webhook-service.kueue-system.svc:443/mutate-kueue-x-k8s-io-v1beta2-resourceflavor?timeout=10s": dial tcp 10.96.104.137:443: connect: connection refused
Error from server (InternalError): error when creating "/home/user1/Projects/kueue/hack/testing/../../cmd/kueueviz/examples/00-resource-flavor.yaml": Internal error occurred: failed calling webhook "mresourceflavor.kb.io": failed to call webhook: Post "https://kueue-webhook-service.kueue-system.svc:443/mutate-kueue-x-k8s-io-v1beta2-resourceflavor?timeout=10s": dial tcp 10.96.104.137:443: connect: connection refused
Error from server (InternalError): error when creating "/home/user1/Projects/kueue/hack/testing/../../cmd/kueueviz/examples/00-resource-flavor.yaml": Internal error occurred: failed calling webhook "mresourceflavor.kb.io": failed to call webhook: Post "https://kueue-webhook-service.kueue-system.svc:443/mutate-kueue-x-k8s-io-v1beta2-resourceflavor?timeout=10s": dial tcp 10.96.104.137:443: connect: connection refused
retry [1/10] failed, retrying in 3s...
retry [2/10]: kubectl create --dry-run=server -f /home/user1/Projects/kueue/hack/testing/../../cmd/kueueviz/examples/00-resource-flavor.yaml
resourceflavor.kueue.x-k8s.io/default-flavor created (server dry run)
<...>
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test script reliability by adding conditional process cleanup to prevent errors during early exits.
  * Enhanced test setup to wait for webhook availability before creating resources, reducing transient failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->