### PR TITLE
cleanup: use retry.sh in e2e_docker_pull_if_needed

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -76,32 +76,12 @@ function e2e_docker_pull_if_needed {
         return 0
     fi
 
-    local max_retries=7
-    local retry_delay=2
-    local attempt output
-    for attempt in $(seq 1 "$max_retries"); do
-        if output=$(docker pull "$image" 2>&1); then
-            echo "$output"
-            return 0
-        fi
-        echo "$output"
+    local non_retriable_errors="manifest (unknown|for .* not found)|repository does not exist|not found|pull access denied|unauthorized|denied: requested access|no space left on device"
 
-        if echo "$output" | grep -qiE 'manifest (unknown|for .* not found)|repository does not exist|not found|pull access denied|unauthorized|denied: requested access|no space left on device'; then
-            echo "ERROR: docker pull '$image' failed with a non-retriable error."
-            return 1
-        fi
-
-        if [ "$attempt" -eq "$max_retries" ]; then
-            break
-        fi
-
-        echo "WARNING: docker pull '$image' failed (attempt $attempt/$max_retries). Retrying in ${retry_delay}s..."
-        sleep "$retry_delay"
-        retry_delay=$((retry_delay * 2))
-    done
-
-    echo "ERROR: Failed to pull '$image' after $max_retries attempts."
-    return 1
+    "${ROOT_DIR}/hack/testing/retry.sh" \
+        --attempts 7 --delay 2 --exponential --stream \
+        --continue-if "! grep -qiE '${non_retriable_errors}' {output}" \
+        -- docker pull "$image"
 }
 
 function e2e_kubectl_apply_url {

--- a/hack/testing/retry.sh
+++ b/hack/testing/retry.sh
@@ -28,6 +28,9 @@
 #   --exponential:       Double the delay after each failed attempt.
 #   --stream:            Forward stdout/stderr live instead of capturing stdout.
 #   --continue-if "CMD": Evaluates CMD upon failure. If it fails, retries are aborted immediately (fail-fast).
+#                        When set, each attempt's combined output is captured to a temp file, and any '{output}'
+#                        token in CMD is replaced with that file's path (e.g. --continue-if '! grep -q FATAL {output}').
+#                        Captured output is not displayed; add --stream to forward it live.
 #   --cleanup "CMD": Evaluates CMD before starting the next retry attempt.
 #
 # Usage:
@@ -64,33 +67,56 @@ if [ $# -eq 0 ]; then
     exit 2
 fi
 
+# When a continue-if check is provided, capture each attempt's combined output to
+# a temp file so the check can inspect why the attempt failed (via the '{output}' token),
+# while still streaming the output live to stderr.
+out=""
+output_file=""
+if [ -n "$continue_if" ]; then
+    output_file=$(mktemp) || exit 2
+    trap 'rm -f "$output_file"' EXIT
+fi
+
 for i in $(seq 1 "$attempts"); do
     echo "retry [$i/$attempts]: $*" 1>&2
-    if [ "$stream" = "true" ]; then
-        # Forward stdout/stderr live; nothing is captured or echoed.
-        if "$@"; then
-            exit 0
+    if [ -n "$output_file" ]; then
+        # continue-if needs the output captured to the temp file so the check can
+        # inspect it via the '{output}' token. Stream it live too when --stream is set.
+        if [ "$stream" = "true" ]; then
+            "$@" 2>&1 | tee "$output_file" >&2
+            status=${PIPESTATUS[0]}
+        else
+            "$@" >"$output_file" 2>&1
+            status=$?
         fi
-    elif out=$("$@"); then
+    elif [ "$stream" = "true" ]; then
+        # Forward stdout/stderr live; nothing is captured or echoed.
+        "$@"
+        status=$?
+    else
         # Capture stdout and echo it only on success, so failed-attempt output
         # never pollutes a $(shell ...) caller that captures the result.
-        printf '%s' "$out"
+        out=$("$@")
+        status=$?
+    fi
+    if [ "$status" -eq 0 ]; then
+        # $out is only populated without --continue-if/--stream; echo it on success as the $(shell ...) value.
+        if [ -z "$output_file" ] && [ "$stream" != "true" ]; then
+            printf '%s' "$out"
+        fi
         exit 0
     fi
     if [ "$i" -lt "$attempts" ]; then
-        echo "retry [$i/$attempts] failed, retrying in ${delay}s..." 1>&2
-    else
-        echo "retry [$i/$attempts] failed" 1>&2
-    fi
-
-    if [ "$i" -lt "$attempts" ]; then
         if [ -n "$continue_if" ]; then
-            # Evaluate the fail-fast condition
-            if ! eval "$continue_if"; then
+            # Evaluate the fail-fast condition, replacing '{output}' with the output file path.
+            if ! eval "${continue_if//\{output\}/$output_file}"; then
+                echo "retry [$i/$attempts] failed" 1>&2
                 echo "retry: aborting early as continue-if condition failed (fail-fast)" 1>&2
                 exit 1
             fi
         fi
+
+        echo "retry [$i/$attempts] failed, retrying in ${delay}s..." 1>&2
 
         if [ -n "$cleanup" ]; then
             # Run the cleanup command before the next attempt
@@ -105,6 +131,8 @@ for i in $(seq 1 "$attempts"); do
         if [ "$exponential" = "true" ]; then
             delay=$((delay * 2))
         fi
+    else
+        echo "retry [$i/$attempts] failed" 1>&2
     fi
 done
 exit 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

Uses generalized `retry.sh` script in `e2e_docker_pull_if_needed`  func in `e2e-common.sh`.
To improve readability and consistency across all retries used in the scripts.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11887

#### Special notes for your reviewer:

Success
```bash
retry [1/7]: docker pull quay.io/prometheus-operator/prometheus-operator:v0.89.0
v0.89.0: Pulling from prometheus-operator/prometheus-operator
Digest: sha256:fea93ca9be807eee2f51f4d997b7a2bf073d4051d9012b45b3c84a7b9e8b3f25
Status: Image is up to date for quay.io/prometheus-operator/prometheus-operator:v0.89.0
quay.io/prometheus-operator/prometheus-operator:v0.89.0
```

Fail-fast
```bash
retry [1/7]: docker pull quay.io/prometheus-operator/prometheus-operator:v0.0.0-nonexistent
Error response from daemon: failed to resolve reference "quay.io/prometheus-operator/prometheus-operator:v0.0.0-nonexistent": quay.io/prometheus-operator/prometheus-operator:v0.0.0-nonexistent: not found
retry [1/7] failed
retry: aborting early as continue-if condition failed (fail-fast)
```

Recovered
```bash
retry [1/7]: docker pull quay.io/prometheus-operator/prometheus-operator:recover
Error response from daemon: net/http: TLS handshake timeout
retry [1/7] failed, retrying in 2s...
retry [2/7]: docker pull quay.io/prometheus-operator/prometheus-operator:recover
Error response from daemon: net/http: TLS handshake timeout
retry [2/7] failed, retrying in 4s...
retry [3/7]: docker pull quay.io/prometheus-operator/prometheus-operator:recover
Error response from daemon: net/http: TLS handshake timeout
retry [3/7] failed, retrying in 8s...
retry [4/7]: docker pull quay.io/prometheus-operator/prometheus-operator:recover
Status: Downloaded newer image for quay.io/prometheus-operator/prometheus-operator:recover
```

Eventually failed
```bash
retry [1/7]: docker pull quay.io/prometheus-operator/prometheus-operator:fail
Error response from daemon: net/http: TLS handshake timeout
retry [1/7] failed, retrying in 2s...
retry [2/7]: docker pull quay.io/prometheus-operator/prometheus-operator:fail
Error response from daemon: net/http: TLS handshake timeout
retry [2/7] failed, retrying in 4s...
retry [3/7]: docker pull quay.io/prometheus-operator/prometheus-operator:fail
Error response from daemon: net/http: TLS handshake timeout
retry [3/7] failed, retrying in 8s...
retry [4/7]: docker pull quay.io/prometheus-operator/prometheus-operator:fail
Error response from daemon: net/http: TLS handshake timeout
retry [4/7] failed, retrying in 16s...
retry [5/7]: docker pull quay.io/prometheus-operator/prometheus-operator:fail
Error response from daemon: net/http: TLS handshake timeout
retry [5/7] failed, retrying in 32s...
retry [6/7]: docker pull quay.io/prometheus-operator/prometheus-operator:fail
Error response from daemon: net/http: TLS handshake timeout
retry [6/7] failed, retrying in 64s...
retry [7/7]: docker pull quay.io/prometheus-operator/prometheus-operator:fail
Error response from daemon: net/http: TLS handshake timeout
retry [7/7] failed
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated and simplified image-pull retry behavior to use a shared retry utility with improved exit handling.

* **Tests**
  * More robust image download retries (up to 7 attempts, exponential backoff, streaming).
  * Added fail-fast checks to detect and stop on non-retriable pull errors and capture per-attempt output for diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->