### PR TITLE
Automated cherry pick of #12006: TAS: Use PodSpec resources for node capacity tracking

### DIFF
--- a/pkg/scheduler/fair_sharing_iterator.go
+++ b/pkg/scheduler/fair_sharing_iterator.go
@@ -225,7 +225,11 @@ func (e *entryComparer) computeDRS(rootCohort *schdcache.CohortSnapshot, cqToEnt
 		if !ok {
 			continue
 		}
-		usage := entry.assignmentUsage()
+		log := e.log.WithValues(
+			"workload", klog.KObj(entry.Obj),
+			"clusterQueue", klog.KRef("", string(cq.Name)),
+		)
+		usage := entry.assignmentUsage(log)
 		// We add workload's usage to CQ, so that all
 		// subsequent DRS include the admission of workload.
 		revert := cq.SimulateUsageAddition(usage)

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -75,7 +75,7 @@ type Assignment struct {
 }
 
 // UpdateForTASResult updates the Assignment with the TAS result
-func (a *Assignment) UpdateForTASResult(cq *schdcache.ClusterQueueSnapshot, wl *workload.Info, result schdcache.TASAssignmentsResult) {
+func (a *Assignment) UpdateForTASResult(log logr.Logger, cq *schdcache.ClusterQueueSnapshot, wl *workload.Info, result schdcache.TASAssignmentsResult) {
 	for psName, psResult := range result {
 		psAssignment := a.podSetAssignmentByName(psName)
 		psAssignment.TopologyAssignment = psResult.TopologyAssignment
@@ -83,11 +83,11 @@ func (a *Assignment) UpdateForTASResult(cq *schdcache.ClusterQueueSnapshot, wl *
 			psAssignment.DelayedTopologyRequest = ptr.To(kueue.DelayedTopologyRequestStateReady)
 		}
 	}
-	a.Usage.TAS = a.ComputeTASNetUsage(cq, wl, nil)
+	a.Usage.TAS = a.ComputeTASNetUsage(log, cq, wl, nil)
 }
 
 // ComputeTASNetUsage computes the net TAS usage for the assignment
-func (a *Assignment) ComputeTASNetUsage(cq *schdcache.ClusterQueueSnapshot, wl *workload.Info, prevAdmission *kueue.Admission) workload.TASUsage {
+func (a *Assignment) ComputeTASNetUsage(log logr.Logger, cq *schdcache.ClusterQueueSnapshot, wl *workload.Info, prevAdmission *kueue.Admission) workload.TASUsage {
 	result := make(workload.TASUsage)
 	for i, psa := range a.PodSets {
 		if psa.TopologyAssignment != nil {
@@ -96,10 +96,12 @@ func (a *Assignment) ComputeTASNetUsage(cq *schdcache.ClusterQueueSnapshot, wl *
 			}
 			podSet := podset.FindPodSetByName(wl.Obj.Spec.PodSets, psa.Name)
 			if podSet == nil {
+				log.Error(nil, "PodSet not found while computing TAS net usage", "podSet", psa.Name)
 				continue
 			}
 			tasFlavor, err := onlyTASFlavor(psa.Flavors, cq.TASFlavors)
 			if err != nil {
+				log.Error(err, "Failed to find TAS flavor while computing TAS net usage", "podSet", psa.Name)
 				continue
 			}
 			singlePodRequests := resources.NewRequestsFromPodSpec(&podSet.Template.Spec)
@@ -695,7 +697,7 @@ func (a *FlavorAssigner) assignFlavors(log logr.Logger, counts []int32) Assignme
 				assignment.representativeMode = ptr.To(Preempt)
 			} else {
 				// All PodSets fit, we just update the TopologyAssignments
-				assignment.UpdateForTASResult(a.cq, a.wl, result)
+				assignment.UpdateForTASResult(log, a.cq, a.wl, result)
 			}
 		}
 		if assignment.RepresentativeMode() == Preempt && !workload.HasUnhealthyNodes(a.wl.Obj) {

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -41,6 +41,7 @@ import (
 	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
 	utilmath "sigs.k8s.io/kueue/pkg/util/math"
 	"sigs.k8s.io/kueue/pkg/util/orderedgroups"
+	"sigs.k8s.io/kueue/pkg/util/podset"
 	"sigs.k8s.io/kueue/pkg/util/tas"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -74,7 +75,7 @@ type Assignment struct {
 }
 
 // UpdateForTASResult updates the Assignment with the TAS result
-func (a *Assignment) UpdateForTASResult(cq *schdcache.ClusterQueueSnapshot, result schdcache.TASAssignmentsResult) {
+func (a *Assignment) UpdateForTASResult(cq *schdcache.ClusterQueueSnapshot, wl *workload.Info, result schdcache.TASAssignmentsResult) {
 	for psName, psResult := range result {
 		psAssignment := a.podSetAssignmentByName(psName)
 		psAssignment.TopologyAssignment = psResult.TopologyAssignment
@@ -82,42 +83,35 @@ func (a *Assignment) UpdateForTASResult(cq *schdcache.ClusterQueueSnapshot, resu
 			psAssignment.DelayedTopologyRequest = ptr.To(kueue.DelayedTopologyRequestStateReady)
 		}
 	}
-	a.Usage.TAS = a.ComputeTASNetUsage(cq, nil)
+	a.Usage.TAS = a.ComputeTASNetUsage(cq, wl, nil)
 }
 
 // ComputeTASNetUsage computes the net TAS usage for the assignment
-func (a *Assignment) ComputeTASNetUsage(cq *schdcache.ClusterQueueSnapshot, prevAdmission *kueue.Admission) workload.TASUsage {
+func (a *Assignment) ComputeTASNetUsage(cq *schdcache.ClusterQueueSnapshot, wl *workload.Info, prevAdmission *kueue.Admission) workload.TASUsage {
 	result := make(workload.TASUsage)
 	for i, psa := range a.PodSets {
 		if psa.TopologyAssignment != nil {
 			if prevAdmission != nil && prevAdmission.PodSetAssignments[i].TopologyAssignment != nil {
 				continue
 			}
-			tasRequests := make(corev1.ResourceList, len(psa.Requests))
-			for resourceName, quantity := range psa.Requests {
-				flv := psa.Flavors[resourceName]
-				if flv == nil || cq.TASFlavors[flv.Name] == nil {
-					// This is the quota-only resources, skip when computing TAS usage.
-					continue
-				}
-				tasRequests[resourceName] = quantity
+			podSet := podset.FindPodSetByName(wl.Obj.Spec.PodSets, psa.Name)
+			if podSet == nil {
+				continue
 			}
-			singlePodRequests := resources.NewRequests(tasRequests).ScaledDown(int64(psa.Count))
-			for _, flv := range psa.Flavors {
-				if cq.TASFlavors[flv.Name] == nil {
-					// This is a quota-only flavor, skip when computing TAS usage.
-					continue
-				}
-				if _, ok := result[flv.Name]; !ok {
-					result[flv.Name] = make(workload.TASFlavorUsage, 0)
-				}
-				for _, domain := range psa.TopologyAssignment.Domains {
-					result[flv.Name] = append(result[flv.Name], workload.TopologyDomainRequests{
-						Values:            domain.Values,
-						SinglePodRequests: singlePodRequests.Clone(),
-						Count:             domain.Count,
-					})
-				}
+			tasFlavor, err := onlyTASFlavor(psa.Flavors, cq.TASFlavors)
+			if err != nil {
+				continue
+			}
+			singlePodRequests := resources.NewRequestsFromPodSpec(&podSet.Template.Spec)
+			if _, ok := result[*tasFlavor]; !ok {
+				result[*tasFlavor] = make(workload.TASFlavorUsage, 0)
+			}
+			for _, domain := range psa.TopologyAssignment.Domains {
+				result[*tasFlavor] = append(result[*tasFlavor], workload.TopologyDomainRequests{
+					Values:            domain.Values,
+					SinglePodRequests: singlePodRequests.Clone(),
+					Count:             domain.Count,
+				})
 			}
 		}
 	}
@@ -701,7 +695,7 @@ func (a *FlavorAssigner) assignFlavors(log logr.Logger, counts []int32) Assignme
 				assignment.representativeMode = ptr.To(Preempt)
 			} else {
 				// All PodSets fit, we just update the TopologyAssignments
-				assignment.UpdateForTASResult(a.cq, result)
+				assignment.UpdateForTASResult(a.cq, a.wl, result)
 			}
 		}
 		if assignment.RepresentativeMode() == Preempt && !workload.HasUnhealthyNodes(a.wl.Obj) {

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4531,7 +4531,7 @@ func TestAssignment_ComputeTASNetUsage(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := tt.assignment.ComputeTASNetUsage(tt.cq, tt.wl, tt.prevAdmission)
+			got := tt.assignment.ComputeTASNetUsage(testr.New(t), tt.cq, tt.wl, tt.prevAdmission)
 
 			if diff := cmp.Diff(tt.want, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Unexpected TAS usage (-want,+got):\n%s", diff)

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
 	preemptioncommon "sigs.k8s.io/kueue/pkg/scheduler/preemption/common"
+	"sigs.k8s.io/kueue/pkg/util/tas"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -4412,6 +4413,128 @@ func TestAssignment_TotalRequestsFor(t *testing.T) {
 			got := a.TotalRequestsFor(tt.args.wl)
 			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("TotalRequestsFor() (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAssignment_ComputeTASNetUsage(t *testing.T) {
+	tests := map[string]struct {
+		assignment    Assignment
+		wl            *workload.Info
+		cq            *schdcache.ClusterQueueSnapshot
+		prevAdmission *kueue.Admission
+		want          workload.TASUsage
+	}{
+		"records actual pod requests when assignment requests differ": {
+			assignment: Assignment{
+				PodSets: []PodSetAssignment{{
+					Name: kueue.DefaultPodSetName,
+					Flavors: ResourceAssignment{
+						corev1.ResourceCPU:        {Name: "tas"},
+						corev1.ResourceMemory:     {Name: "tas"},
+						"example.com/logical-gpu": {Name: "quota"},
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:        resource.MustParse("2"),
+						corev1.ResourceMemory:     resource.MustParse("2Gi"),
+						"example.com/logical-gpu": resource.MustParse("2"),
+					},
+					Count: 2,
+					TopologyAssignment: &tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{{
+							Values: []string{"node-a"},
+							Count:  2,
+						}},
+					},
+				}},
+			},
+			wl: workload.NewInfo(&kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
+							// In assignment requests, example.com/gpu is transformed to
+							// example.com/logical-gpu and networking.example.com/vpc is excluded.
+							Request(corev1.ResourceCPU, "1").
+							Request(corev1.ResourceMemory, "1Gi").
+							Request("example.com/gpu", "1").
+							Request("networking.example.com/vpc", "1").
+							RequiredTopologyRequest(corev1.LabelHostname).
+							Obj(),
+					},
+				},
+			}),
+			cq: &schdcache.ClusterQueueSnapshot{
+				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{
+					"tas": {},
+				},
+			},
+			want: workload.TASUsage{
+				"tas": []workload.TopologyDomainRequests{{
+					Values: []string{"node-a"},
+					SinglePodRequests: resources.NewRequests(corev1.ResourceList{
+						corev1.ResourceCPU:           resource.MustParse("1"),
+						corev1.ResourceMemory:        resource.MustParse("1Gi"),
+						"example.com/gpu":            resource.MustParse("1"),
+						"networking.example.com/vpc": resource.MustParse("1"),
+					}),
+					Count: 2,
+				}},
+			},
+		},
+		"skips usage already present in previous admission": {
+			assignment: Assignment{
+				PodSets: []PodSetAssignment{{
+					Name: kueue.DefaultPodSetName,
+					Flavors: ResourceAssignment{
+						corev1.ResourceCPU:    {Name: "tas"},
+						corev1.ResourceMemory: {Name: "tas"},
+						"example.com/gpu":     {Name: "quota"},
+					},
+					Count: 2,
+					TopologyAssignment: &tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{{
+							Values: []string{"node-a"},
+							Count:  2,
+						}},
+					},
+				}},
+			},
+			wl: workload.NewInfo(&kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
+							Request(corev1.ResourceCPU, "1").
+							Request(corev1.ResourceMemory, "1Gi").
+							Request("example.com/gpu", "1").
+							RequiredTopologyRequest(corev1.LabelHostname).
+							Obj(),
+					},
+				},
+			}),
+			cq: &schdcache.ClusterQueueSnapshot{
+				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{
+					"tas": {},
+				},
+			},
+			prevAdmission: &kueue.Admission{
+				PodSetAssignments: []kueue.PodSetAssignment{{
+					Name:               kueue.DefaultPodSetName,
+					TopologyAssignment: &kueue.TopologyAssignment{},
+				}},
+			},
+			want: workload.TASUsage{},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tt.assignment.ComputeTASNetUsage(tt.cq, tt.wl, tt.prevAdmission)
+
+			if diff := cmp.Diff(tt.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Unexpected TAS usage (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -546,7 +546,7 @@ func resourcesToReserve(e *entry, cq *schdcache.ClusterQueueSnapshot) workload.U
 func netUsage(e *entry, netQuota resources.FlavorResourceQuantities) workload.Usage {
 	result := workload.Usage{}
 	if features.Enabled(features.TopologyAwareScheduling) {
-		result.TAS = e.assignment.ComputeTASNetUsage(e.clusterQueueSnapshot, e.Obj.Status.Admission)
+		result.TAS = e.assignment.ComputeTASNetUsage(e.clusterQueueSnapshot, &e.Info, e.Obj.Status.Admission)
 	}
 	if !workload.HasQuotaReservation(e.Obj) {
 		result.Quota = netQuota
@@ -688,7 +688,7 @@ func updateAssignmentForTAS(log logr.Logger, snapshot *schdcache.Snapshot, cq *s
 			// assuming the cluster is empty.
 			tasResult = cq.FindTopologyAssignmentsForWorkload(tasRequests, schdcache.WithSimulateEmpty(true))
 		}
-		assignment.UpdateForTASResult(cq, tasResult)
+		assignment.UpdateForTASResult(cq, wl, tasResult)
 	}
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -340,7 +340,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 					// borrowing limit, so that
 					// lower-priority workloads in another
 					// Cohort cannot admit before us.
-					cq.AddUsage(resourcesToReserve(e, cq))
+					cq.AddUsage(resourcesToReserve(log, e, cq))
 				}
 				continue
 			}
@@ -360,7 +360,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 			continue
 		}
 
-		usage := e.assignmentUsage()
+		usage := e.assignmentUsage(log)
 		if !fits(snapshot, cq, &usage, preemptedWorkloads, e.preemptionTargets) {
 			setSkipped(e, "Workload no longer fits after processing another workload")
 			if mode == flavorassigner.Preempt {
@@ -481,8 +481,8 @@ type entry struct {
 	clusterQueueSnapshot *schdcache.ClusterQueueSnapshot
 }
 
-func (e *entry) assignmentUsage() workload.Usage {
-	return netUsage(e, e.assignment.Usage.Quota)
+func (e *entry) assignmentUsage(log logr.Logger) workload.Usage {
+	return netUsage(log, e, e.assignment.Usage.Quota)
 }
 
 // nominate returns the workloads with their requirements (resource flavors, borrowing) if
@@ -538,15 +538,15 @@ func fits(snapshot *schdcache.Snapshot, cq *schdcache.ClusterQueueSnapshot, usag
 }
 
 // resourcesToReserve calculates how much of the available resources in cq/cohort assignment should be reserved.
-func resourcesToReserve(e *entry, cq *schdcache.ClusterQueueSnapshot) workload.Usage {
-	return netUsage(e, quotaResourcesToReserve(e, cq))
+func resourcesToReserve(log logr.Logger, e *entry, cq *schdcache.ClusterQueueSnapshot) workload.Usage {
+	return netUsage(log, e, quotaResourcesToReserve(e, cq))
 }
 
 // netUsage calculates the net usage for quota and TAS to reserve
-func netUsage(e *entry, netQuota resources.FlavorResourceQuantities) workload.Usage {
+func netUsage(log logr.Logger, e *entry, netQuota resources.FlavorResourceQuantities) workload.Usage {
 	result := workload.Usage{}
 	if features.Enabled(features.TopologyAwareScheduling) {
-		result.TAS = e.assignment.ComputeTASNetUsage(e.clusterQueueSnapshot, &e.Info, e.Obj.Status.Admission)
+		result.TAS = e.assignment.ComputeTASNetUsage(log, e.clusterQueueSnapshot, &e.Info, e.Obj.Status.Admission)
 	}
 	if !workload.HasQuotaReservation(e.Obj) {
 		result.Quota = netQuota
@@ -688,7 +688,7 @@ func updateAssignmentForTAS(log logr.Logger, snapshot *schdcache.Snapshot, cq *s
 			// assuming the cluster is empty.
 			tasResult = cq.FindTopologyAssignmentsForWorkload(tasRequests, schdcache.WithSimulateEmpty(true))
 		}
-		assignment.UpdateForTASResult(cq, wl, tasResult)
+		assignment.UpdateForTASResult(log, cq, wl, tasResult)
 	}
 }
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
@@ -7709,7 +7710,7 @@ func TestResourcesToReserve(t *testing.T) {
 			}
 			cqSnapshot := snapshot.ClusterQueue("cq")
 
-			got := resourcesToReserve(e, cqSnapshot)
+			got := resourcesToReserve(logr.Discard(), e, cqSnapshot)
 			if !reflect.DeepEqual(tc.wantReserved, got.Quota) {
 				t.Errorf("%s failed\n: Want reservedMem: %v, got: %v", tc.name, tc.wantReserved, got)
 			}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -636,10 +636,14 @@ func totalRequestsFromAdmission(wl *kueue.Workload) []PodSetResources {
 			setRes.TopologyRequest = &TopologyRequest{
 				Levels: psa.TopologyAssignment.Levels,
 			}
+			singlePodRequests := setRes.SinglePodRequests()
+			if ps := podset.FindPodSetByName(wl.Spec.PodSets, psa.Name); ps != nil {
+				singlePodRequests = resources.NewRequestsFromPodSpec(&ps.Template.Spec)
+			}
 			for req := range tas.InternalSeqFrom(psa.TopologyAssignment) {
 				setRes.TopologyRequest.DomainRequests = append(setRes.TopologyRequest.DomainRequests, TopologyDomainRequests{
 					Values:            req.Values,
-					SinglePodRequests: setRes.SinglePodRequests(),
+					SinglePodRequests: singlePodRequests,
 					Count:             req.Count,
 				})
 			}

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -211,6 +211,66 @@ func TestNewInfo(t *testing.T) {
 				},
 			},
 		},
+		"admitted with TAS and transformed resources": {
+			workload: *utiltestingapi.MakeWorkload("tas", "").
+				PodSets(
+					*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
+						// The admitted usage below transforms example.com/gpu to
+						// example.com/logical-gpu and excludes networking.example.com/vpc.
+						Request(corev1.ResourceCPU, "1").
+						Request(corev1.ResourceMemory, "1Gi").
+						Request("example.com/gpu", "1").
+						Request("networking.example.com/vpc", "1").
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Obj(),
+				).
+				ReserveQuotaAt(
+					utiltestingapi.MakeAdmission("tas-cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "tas", "2").
+							Assignment(corev1.ResourceMemory, "tas", "2Gi").
+							Assignment("example.com/logical-gpu", "quota", "2").
+							Count(2).
+							TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(utiltestingapi.MakeDefaultOneLevelTopology("default"))).
+								Domains(utiltestingapi.MakeTopologyDomainAssignment([]string{"node-a"}, 2).Obj()).
+								Obj()).
+							Obj()).
+						Obj(), now,
+				).
+				Obj(),
+			wantInfo: Info{
+				ClusterQueue: "tas-cq",
+				TotalRequests: []PodSetResources{
+					{
+						Name: kueue.DefaultPodSetName,
+						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+							corev1.ResourceCPU:        "tas",
+							corev1.ResourceMemory:     "tas",
+							"example.com/logical-gpu": "quota",
+						},
+						Requests: resources.Requests{
+							corev1.ResourceCPU:        2000,
+							corev1.ResourceMemory:     2 * 1024 * 1024 * 1024,
+							"example.com/logical-gpu": 2,
+						},
+						Count: 2,
+						TopologyRequest: &TopologyRequest{
+							Levels: []string{corev1.LabelHostname},
+							DomainRequests: []TopologyDomainRequests{{
+								Values: []string{"node-a"},
+								SinglePodRequests: resources.Requests{
+									corev1.ResourceCPU:           1000,
+									corev1.ResourceMemory:        1024 * 1024 * 1024,
+									"example.com/gpu":            1,
+									"networking.example.com/vpc": 1,
+								},
+								Count: 2,
+							}},
+						},
+					},
+				},
+			},
+		},
 		"admitted with reclaim; reclaimablePods on": {
 			workload: *utiltestingapi.MakeWorkload("", "").
 				PodSets(

--- a/test/integration/singlecluster/scheduler/excluderesources/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/excluderesources/scheduler_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package excluderesources
 
 import (
+	"fmt"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -323,6 +325,52 @@ var _ = ginkgo.Describe("TAS with ExcludeResourcePrefixes", ginkgo.Ordered, gink
 			resourceUsage := wl.Status.Admission.PodSetAssignments[0].ResourceUsage
 			gomega.Expect(resourceUsage).To(gomega.HaveKey(corev1.ResourceCPU))
 			gomega.Expect(resourceUsage).NotTo(gomega.HaveKey(corev1.ResourceName("example.com/test-resource")))
+		})
+	})
+
+	ginkgo.It("should account for excluded PodSpec resources in TAS placement across workloads", func() {
+		wls := []*kueue.Workload{}
+		for i := range 4 {
+			wl := utiltestingapi.MakeWorkload(fmt.Sprintf("wl-%d", i), ns.Name).
+				Queue(kueue.LocalQueueName(lq.Name)).
+				PodSets(*utiltestingapi.MakePodSet("main", 1).
+					PreferredTopologyRequest(corev1.LabelHostname).
+					Request(corev1.ResourceCPU, "100m").
+					Request("example.com/test-resource", "1").
+					Obj()).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+			wls = append(wls, wl)
+		}
+
+		ginkgo.By("verifying workloads are placed within excluded resource capacity", func() {
+			assignedPodsByNode := map[string]int32{}
+			for _, wl := range wls {
+				gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: wl.Name, Namespace: ns.Name}, wl)).To(gomega.Succeed())
+				topologyAssignment := wl.Status.Admission.PodSetAssignments[0].TopologyAssignment
+				gomega.Expect(topologyAssignment).NotTo(gomega.BeNil())
+
+				domains := utiltas.InternalFrom(topologyAssignment).Domains
+				gomega.Expect(domains).To(gomega.HaveLen(1))
+				for _, domain := range domains {
+					gomega.Expect(domain.Count).To(gomega.Equal(int32(1)))
+					assignedPodsByNode[domain.Values[0]] += domain.Count
+				}
+			}
+
+			for _, node := range nodes {
+				allocatable := node.Status.Allocatable[corev1.ResourceName("example.com/test-resource")]
+				gomega.Expect(assignedPodsByNode[node.Name]).To(gomega.BeNumerically("<=", allocatable.Value()))
+			}
+		})
+
+		ginkgo.By("verifying excluded resource is not included in quota usage", func() {
+			for _, wl := range wls {
+				resourceUsage := wl.Status.Admission.PodSetAssignments[0].ResourceUsage
+				gomega.Expect(resourceUsage).To(gomega.HaveKey(corev1.ResourceCPU))
+				gomega.Expect(resourceUsage).NotTo(gomega.HaveKey(corev1.ResourceName("example.com/test-resource")))
+			}
 		})
 	})
 })


### PR DESCRIPTION
Cherry pick of #12006 on release-0.17.

#12006: TAS: Use PodSpec resources for node capacity tracking

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
TAS: Fix a bug where TAS ignores excluded or transformed resources in node capacity tracking.
```