### PR TITLE
Add wait_for_kueue_controller_operator check that ensures the kueue c…

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -715,6 +715,38 @@ function deploy_with_certmanager() {
     printf "%s\n" "$default_backup" > "$default_kust"
 }
 
+# Wait for the Kueue deployment and webhook endpoint to be ready.
+# $1 kubeconfig path (pass "" to use the default kubeconfig)
+function wait_for_kueue_controller_operator {
+    local kubeconfig="${1:-}"
+
+    local -a kubectl_args=()
+    if [[ -n "${kubeconfig}" ]]; then
+        kubectl_args+=(--kubeconfig="${kubeconfig}")
+    fi
+
+    kubectl ${kubectl_args[@]+"${kubectl_args[@]}"} -n "${KUEUE_NAMESPACE}" wait deploy/"${KUEUE_DEPLOYMENT_NAME}" \
+        --for=condition=available --timeout=5m
+
+    # TODO(#11996): once the shared e2e_wait_for_deployment_webhook_endpoints helper
+    # lands, call it here for kueue-webhook-service to wait for ready webhook endpoints
+    # (generic deployment + webhook-endpoint readiness, reusable across operators).
+
+    # Dry run to make sure that at least one webhook correctly handles the new flavors.
+    local probe_manifest
+    probe_manifest=$(mktemp)
+    # shellcheck disable=SC2064 # Intentionally expand now to capture the temp file path
+    trap "rm -f '$probe_manifest'" RETURN
+    cat >"${probe_manifest}" <<'EOF'
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: webhook-probe
+EOF
+    "${ROOT_DIR}/hack/testing/retry.sh" --attempts 10 --delay 5 --stream -- \
+        kubectl ${kubectl_args[@]+"${kubectl_args[@]}"} create --dry-run=server -f "${probe_manifest}"
+}
+
 # $1 kubeconfig
 function cluster_kueue_deploy {
     # Handle upgrade test mode
@@ -748,6 +780,8 @@ function cluster_kueue_deploy {
     else
         build_and_apply_kueue_manifests "$1" "${ROOT_DIR}/test/e2e/config/${E2E_CONFIG_FOLDER:-default}"
     fi
+
+    wait_for_kueue_controller_operator "$1"
 }
 
 # $1 kubeconfig
@@ -1364,9 +1398,9 @@ function upgrade_test_flow {
       sed 's|imagePullPolicy: Always|imagePullPolicy: IfNotPresent|g' | \
       kubectl apply --server-side -f -
 
-    kubectl wait --for=condition=available --timeout=180s deployment/"${KUEUE_DEPLOYMENT_NAME}" -n kueue-system
+    wait_for_kueue_controller_operator "$1"
     echo "✓ $old_version ready"
-    
+
     # Step 2: Create test resources
     echo "Creating test resources..."
     
@@ -1428,7 +1462,7 @@ EOF
     
     # Wait for the rolling update to complete.
     echo "Waiting for rolling update to complete..."
-    kubectl wait --for=condition=available --timeout=300s deployment/"${KUEUE_DEPLOYMENT_NAME}" -n "${KUEUE_NAMESPACE}"
+    wait_for_kueue_controller_operator "$1"
     echo "Upgrade complete (rolling update finished)"
     echo "========================================="
 }

--- a/hack/testing/e2e-kueueviz-backend.sh
+++ b/hack/testing/e2e-kueueviz-backend.sh
@@ -50,13 +50,6 @@ echo Waiting for kind cluster "${KIND_CLUSTER_NAME}" to start...
 prepare_docker_images
 cluster_kind_load "${KIND_CLUSTER_NAME}"
 kueue_deploy
-kubectl wait deploy/kueue-controller-manager -n"$KUEUE_NAMESPACE" --for=condition=available --timeout=5m
-
-# Wait for the Kueue webhook to be up before creating resources, otherwise the
-# creates can fail with "connection refused". A server-side dry-run probes the
-# webhook without persisting anything, so it is safe to retry.
-"${ROOT_DIR}/hack/testing/retry.sh" --attempts 10 --delay 3 --stream -- \
-  kubectl create --dry-run=server -f "${ROOT_DIR}/cmd/kueueviz/examples/00-resource-flavor.yaml"
 kubectl create -f "${ROOT_DIR}/cmd/kueueviz/examples/"
 
 # Start KueueViz backend

--- a/hack/testing/e2e-kueueviz-local.sh
+++ b/hack/testing/e2e-kueueviz-local.sh
@@ -42,13 +42,6 @@ echo Waiting for kind cluster "${KIND_CLUSTER_NAME}" to start...
 prepare_docker_images
 cluster_kind_load "${KIND_CLUSTER_NAME}"
 kueue_deploy
-kubectl wait deploy/kueue-controller-manager -n"$KUEUE_NAMESPACE" --for=condition=available --timeout=5m
-
-# Wait for the Kueue webhook to be up before creating resources, otherwise the
-# creates can fail with "connection refused". A server-side dry-run probes the
-# webhook without persisting anything, so it is safe to retry.
-"${ROOT_DIR}/hack/testing/retry.sh" --attempts 10 --delay 3 --stream -- \
-  kubectl create --dry-run=server -f "${ROOT_DIR}/cmd/kueueviz/examples/00-resource-flavor.yaml"
 kubectl create -f "${ROOT_DIR}/cmd/kueueviz/examples/"
 
 # Start kueueviz backend


### PR DESCRIPTION
…ontroller operator is ready

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug 
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Add wait_for_kueue_controller_operator check that ensures the kueue controller operator is ready
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12022 

#### Special notes for your reviewer:
```
Skipping install-time wait for deployment/kueue-controller-manager in kueue-system; BeforeSuite will verify readiness.
retry [1/10]: bash -c 
        kubectl  create --dry-run=server -f - <<'EOF'
apiVersion: kueue.x-k8s.io/v1beta2
kind: ResourceFlavor
metadata:
  name: webhook-probe
EOF

Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "mresourceflavor.kb.io": failed to call webhook: Post "https://kueue-webhook-service.kueue-system.svc:443/mutate-kueue-x-k8s-io-v1beta2-resourceflavor?timeout=10s": dial tcp 10.96.40.123:443: connect: connection refused
retry [1/10] failed, retrying in 3s...
retry [2/10]: bash -c 
        kubectl  create --dry-run=server -f - <<'EOF'
apiVersion: kueue.x-k8s.io/v1beta2
kind: ResourceFlavor
metadata:
  name: webhook-probe
EOF

Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "mresourceflavor.kb.io": failed to call webhook: Post "https://kueue-webhook-service.kueue-system.svc:443/mutate-kueue-x-k8s-io-v1beta2-resourceflavor?timeout=10s": dial tcp 10.96.40.123:443: connect: connection refused
retry [2/10] failed, retrying in 3s...
retry [3/10]: bash -c 
        kubectl  create --dry-run=server -f - <<'EOF'
apiVersion: kueue.x-k8s.io/v1beta2
kind: ResourceFlavor
metadata:
  name: webhook-probe
EOF

Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "mresourceflavor.kb.io": failed to call webhook: Post "https://kueue-webhook-service.kueue-system.svc:443/mutate-kueue-x-k8s-io-v1beta2-resourceflavor?timeout=10s": dial tcp 10.96.40.123:443: connect: connection refused
retry [3/10] failed, retrying in 3s...
retry [4/10]: bash -c 
        kubectl  create --dry-run=server -f - <<'EOF'
apiVersion: kueue.x-k8s.io/v1beta2
kind: ResourceFlavor
metadata:
  name: webhook-probe
EOF
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added readiness checks that wait for controller availability and webhook handling before creating test resources during deploy and upgrade flows.
  * Run readiness checks both before and after rolling upgrades for more reliable initialization and validation.
  * Simplified local/example test flows to create example resources immediately, removing the prior webhook warm‑up wait.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->