### PR TITLE
Automated cherry pick of #11998: test: relax MultiKueue TAS completion waits

### DIFF
--- a/test/e2e/multikueue/baseline/e2e_test.go
+++ b/test/e2e/multikueue/baseline/e2e_test.go
@@ -1238,8 +1238,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			})
 
 			ginkgo.By("Waiting for both jobs to complete", func() {
-				util.ExpectJobToBeCompleted(ctx, k8sManagerClient, jobMk)
-				util.ExpectJobToBeCompleted(ctx, k8sManagerClient, jobRegular)
+				util.ExpectJobToBeCompletedWithTimeout(ctx, k8sManagerClient, jobMk, util.LongTimeout)
+				util.ExpectJobToBeCompletedWithTimeout(ctx, k8sManagerClient, jobRegular, util.LongTimeout)
 			})
 		})
 	})

--- a/test/e2e/multikueue/baseline/tas_test.go
+++ b/test/e2e/multikueue/baseline/tas_test.go
@@ -573,7 +573,7 @@ var _ = ginkgo.Describe("MultiKueue TAS with asymmetric quotas", func() {
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 			g.Expect(createdWorkload.Status.Conditions).To(utiltesting.HaveConditionStatusTrueAndReason(kueue.WorkloadFinished, kueue.WorkloadFinishedReasonSucceeded))
-		}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+		}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 
 		ginkgo.By("Checking no objects are left in worker clusters and job is completed")
 		util.ExpectObjectToBeDeletedOnClusters(ctx, createdWorkload, k8sWorker1Client, k8sWorker2Client)
@@ -644,7 +644,7 @@ var _ = ginkgo.Describe("MultiKueue TAS with asymmetric quotas", func() {
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 			g.Expect(createdWorkload.Status.Conditions).To(utiltesting.HaveConditionStatusTrueAndReason(kueue.WorkloadFinished, kueue.WorkloadFinishedReasonSucceeded))
-		}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+		}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 
 		ginkgo.By("Checking cleanup on worker clusters")
 		util.ExpectObjectToBeDeletedOnClusters(ctx, createdWorkload, k8sWorker1Client, k8sWorker2Client)

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1433,7 +1433,7 @@ func ExpectJobToBeRunning(ctx context.Context, c client.Client, job *batchv1.Job
 	}, MediumTimeout, Interval).Should(gomega.Succeed(), AssertMsg("Job is not running", createdJob))
 }
 
-func ExpectJobToBeCompleted(ctx context.Context, c client.Client, job *batchv1.Job) {
+func ExpectJobToBeCompletedWithTimeout(ctx context.Context, c client.Client, job *batchv1.Job, timeout time.Duration) {
 	ginkgo.GinkgoHelper()
 	createdJob := &batchv1.Job{}
 	gomega.Eventually(func(g gomega.Gomega) {
@@ -1444,7 +1444,12 @@ func ExpectJobToBeCompleted(ctx context.Context, c client.Client, job *batchv1.J
 				Status: corev1.ConditionTrue,
 			},
 			cmpopts.IgnoreFields(batchv1.JobCondition{}, "LastTransitionTime", "LastProbeTime", "Reason", "Message"))))
-	}, MediumTimeout, Interval).Should(gomega.Succeed(), AssertMsg("Job did not complete", createdJob))
+	}, timeout, Interval).Should(gomega.Succeed(), AssertMsg("Job did not complete", createdJob))
+}
+
+func ExpectJobToBeCompleted(ctx context.Context, c client.Client, job *batchv1.Job) {
+	ginkgo.GinkgoHelper()
+	ExpectJobToBeCompletedWithTimeout(ctx, c, job, MediumTimeout)
 }
 
 func UpdateReclaimablePods(ctx context.Context, c client.Client, wl *kueue.Workload, reclaimablePods []kueue.ReclaimablePod) {


### PR DESCRIPTION
Cherry pick of #11998 on release-0.17.

#11998: test: relax MultiKueue TAS completion waits

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?

/kind failing-test
/kind flake
/area testing

#### What this PR does / why we need it:

Backports #11998 to relax MultiKueue TAS completion waits on release-0.17.

During conflict resolution, the `test/e2e/sequential/baseline/quota_check_strategy_test.go` hunk from main was intentionally not applied because that file is not present on release-0.17.

#### Which issue(s) this PR fixes:

Related to #11982

#### Special notes for your reviewer:

AI usage disclosure: this cherry-pick PR was prepared with AI assistance from OpenAI Codex.

Local verification:
- `go test ./test/util ./test/e2e/multikueue/baseline -run '^$'`
- `go test ./test/e2e/... -run '^$'`

#### Does this PR introduce a user-facing change?

```release-note
None
```