### PR TITLE
feat: stable domain sorting for deterministic TAS placement on score ties

### DIFF
--- a/pkg/cache/scheduler/tas_balanced_placement.go
+++ b/pkg/cache/scheduler/tas_balanced_placement.go
@@ -84,8 +84,11 @@ func selectOptimalDomainSetToFit(s *TASFlavorSnapshot, domains []*domain, sliceC
 		return nil
 	}
 
+	orderedDomains := slices.Clone(domains)
 	if priorizeByEntropy {
-		sortDomainsByCapacityAndEntropy(domains)
+		sortDomainsByCapacityAndEntropy(orderedDomains)
+	} else {
+		sortDomainsByLevelValues(orderedDomains)
 	}
 
 	// domain_placements[i][j][k] stores a list of domains that uses 'i' domains with
@@ -96,7 +99,7 @@ func selectOptimalDomainSetToFit(s *TASFlavorSnapshot, domains []*domain, sliceC
 	}
 	domainPlacements[0][leaderCount] = map[int32][]*domain{sliceCount * sliceSize: {}}
 
-	for _, d := range domains {
+	for _, d := range orderedDomains {
 		for i := optimalNumberOfDomains; i > 0; i-- {
 			for _, beforeLeader := range slices.Sorted(maps.Keys(domainPlacements[i-1])) {
 				for _, beforeState := range slices.Sorted(maps.Keys(domainPlacements[i-1][beforeLeader])) {
@@ -226,7 +229,7 @@ func sortDomainsByCapacityAndEntropy(domains []*domain) {
 		if bEntropy < aEntropy {
 			return -1
 		}
-		return 0
+		return compareDomainLevelValues(a, b)
 	})
 }
 
@@ -242,7 +245,9 @@ func findBestDomainsForBalancedPlacement(s *TASFlavorSnapshot, params *topologyA
 	if params.requestedLevelIdx == 0 {
 		requestedLevelDomainsToConsider = [][]*domain{slices.Collect(maps.Values(s.domainsPerLevel[0]))}
 	} else {
-		for _, higherLevelDomain := range slices.Collect(maps.Values(s.domainsPerLevel[params.requestedLevelIdx-1])) {
+		higherLevelDomains := slices.Collect(maps.Values(s.domainsPerLevel[params.requestedLevelIdx-1]))
+		sortDomainsByLevelValues(higherLevelDomains)
+		for _, higherLevelDomain := range higherLevelDomains {
 			requestedLevelDomainsToConsider = append(requestedLevelDomainsToConsider, higherLevelDomain.children)
 		}
 	}

--- a/pkg/cache/scheduler/tas_balanced_placement_test.go
+++ b/pkg/cache/scheduler/tas_balanced_placement_test.go
@@ -26,11 +26,19 @@ import (
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
 
+func domainIDs(domains []*domain) []string {
+	ids := make([]string, len(domains))
+	for i, d := range domains {
+		ids[i] = string(d.id)
+	}
+	return ids
+}
+
 func TestSelectOptimalDomainSetToFit(t *testing.T) {
-	d1 := &domain{id: "d1", state: 9, sliceState: 9, leaderState: 1, stateWithLeader: 8, sliceStateWithLeader: 8}
-	d2 := &domain{id: "d2", state: 6, sliceState: 6, leaderState: 0, stateWithLeader: 6, sliceStateWithLeader: 6}
-	d3 := &domain{id: "d3", state: 4, sliceState: 4, leaderState: 1, stateWithLeader: 3, sliceStateWithLeader: 3}
-	d4 := &domain{id: "d4", state: 2, sliceState: 2, leaderState: 0, stateWithLeader: 2, sliceStateWithLeader: 2}
+	d1 := &domain{id: "d1", levelValues: []string{"d1"}, state: 9, sliceState: 9, leaderState: 1, stateWithLeader: 8, sliceStateWithLeader: 8}
+	d2 := &domain{id: "d2", levelValues: []string{"d2"}, state: 6, sliceState: 6, leaderState: 0, stateWithLeader: 6, sliceStateWithLeader: 6}
+	d3 := &domain{id: "d3", levelValues: []string{"d3"}, state: 4, sliceState: 4, leaderState: 1, stateWithLeader: 3, sliceStateWithLeader: 3}
+	d4 := &domain{id: "d4", levelValues: []string{"d4"}, state: 2, sliceState: 2, leaderState: 0, stateWithLeader: 2, sliceStateWithLeader: 2}
 
 	testCases := map[string]struct {
 		domains     []*domain
@@ -86,12 +94,78 @@ func TestSelectOptimalDomainSetToFit(t *testing.T) {
 	}
 }
 
+func TestSelectOptimalDomainSetToFitStableTieBreak(t *testing.T) {
+	testCases := map[string]struct {
+		priorizeByEntropy bool
+	}{
+		"balanced selection": {
+			priorizeByEntropy: false,
+		},
+		"entropy-prioritized selection": {
+			priorizeByEntropy: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
+			s := newTASFlavorSnapshot(log, "dummy", []string{}, nil)
+			domains := []*domain{
+				{id: "leaf-a", levelValues: []string{"block-b", "host-a"}, state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3},
+				{id: "leaf-m", levelValues: []string{"block-b", "host-m"}, state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3},
+				{id: "leaf-z", levelValues: []string{"block-a", "host-z"}, state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3},
+			}
+
+			got := selectOptimalDomainSetToFit(s, domains, 1, 0, 1, tc.priorizeByEntropy)
+
+			if diff := cmp.Diff([]string{"leaf-z"}, domainIDs(got)); diff != "" {
+				t.Errorf("unexpected optimal domain set (-want,+got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestSortDomainsByCapacityAndEntropy(t *testing.T) {
+	testCases := map[string]struct {
+		domains []*domain
+		want    []string
+	}{
+		"levelValues ascending as final tiebreaker": {
+			domains: []*domain{
+				{id: "leaf-a", levelValues: []string{"block-b", "host-a"}, leaderState: 1, sliceStateWithLeader: 5, children: []*domain{{state: 2}, {state: 2}}},
+				{id: "leaf-m", levelValues: []string{"block-b", "host-m"}, leaderState: 1, sliceStateWithLeader: 5, children: []*domain{{state: 2}, {state: 2}}},
+				{id: "leaf-z", levelValues: []string{"block-a", "host-z"}, leaderState: 1, sliceStateWithLeader: 5, children: []*domain{{state: 2}, {state: 2}}},
+			},
+			want: []string{"leaf-z", "leaf-a", "leaf-m"},
+		},
+		"capacity and entropy ranking before tiebreaker": {
+			domains: []*domain{
+				{id: "lower-leader", levelValues: []string{"a"}, leaderState: 0, sliceStateWithLeader: 100, children: []*domain{{state: 50}, {state: 50}}},
+				{id: "lower-capacity", levelValues: []string{"b"}, leaderState: 1, sliceStateWithLeader: 4, children: []*domain{{state: 2}, {state: 2}}},
+				{id: "low-entropy", levelValues: []string{"c"}, leaderState: 1, sliceStateWithLeader: 5, children: []*domain{{state: 4}, {state: 0}}},
+				{id: "high-entropy", levelValues: []string{"d"}, leaderState: 1, sliceStateWithLeader: 5, children: []*domain{{state: 2}, {state: 2}}},
+			},
+			want: []string{"high-entropy", "low-entropy", "lower-capacity", "lower-leader"},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			sortDomainsByCapacityAndEntropy(tc.domains)
+
+			if diff := cmp.Diff(tc.want, domainIDs(tc.domains)); diff != "" {
+				t.Errorf("unexpected domain order (-want,+got): %s", diff)
+			}
+		})
+	}
+}
+
 func TestPlaceSlicesOnDomainsBalanced(t *testing.T) {
-	d1 := &domain{id: "d1", state: 18, sliceState: 18, stateWithLeader: 18, leaderState: 0, sliceStateWithLeader: 18}
-	d2 := &domain{id: "d2", state: 18, sliceState: 18, stateWithLeader: 18, leaderState: 0, sliceStateWithLeader: 18}
-	d3 := &domain{id: "d3", state: 18, sliceState: 18, stateWithLeader: 18, leaderState: 0, sliceStateWithLeader: 18}
-	d4 := &domain{id: "d4", state: 10, sliceState: 10, stateWithLeader: 10, leaderState: 0, sliceStateWithLeader: 10}
-	d5 := &domain{id: "d5", state: 2, sliceState: 2, stateWithLeader: 2, leaderState: 0, sliceStateWithLeader: 2}
+	d1 := &domain{id: "d1", levelValues: []string{"d1"}, state: 18, sliceState: 18, stateWithLeader: 18, leaderState: 0, sliceStateWithLeader: 18}
+	d2 := &domain{id: "d2", levelValues: []string{"d2"}, state: 18, sliceState: 18, stateWithLeader: 18, leaderState: 0, sliceStateWithLeader: 18}
+	d3 := &domain{id: "d3", levelValues: []string{"d3"}, state: 18, sliceState: 18, stateWithLeader: 18, leaderState: 0, sliceStateWithLeader: 18}
+	d4 := &domain{id: "d4", levelValues: []string{"d4"}, state: 10, sliceState: 10, stateWithLeader: 10, leaderState: 0, sliceStateWithLeader: 10}
+	d5 := &domain{id: "d5", levelValues: []string{"d5"}, state: 2, sliceState: 2, stateWithLeader: 2, leaderState: 0, sliceStateWithLeader: 2}
 
 	testCases := map[string]struct {
 		domains     []*domain
@@ -169,6 +243,24 @@ func TestPlaceSlicesOnDomainsBalanced(t *testing.T) {
 				t.Errorf("Unexpected domains (-want,+got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestPlaceSlicesOnDomainsBalancedStableTieBreak(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
+	s := newTASFlavorSnapshot(log, "dummy", []string{}, nil)
+	domains := []*domain{
+		{id: "leaf-a", levelValues: []string{"block-b", "host-a"}, state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3},
+		{id: "leaf-z", levelValues: []string{"block-a", "host-z"}, state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3},
+	}
+
+	got, reason := placeSlicesOnDomainsBalanced(s, domains, 1, 0, 1, 1)
+
+	if reason != "" {
+		t.Fatalf("unexpected placement failure: %s", reason)
+	}
+	if diff := cmp.Diff([]string{"leaf-z"}, domainIDs(got)); diff != "" {
+		t.Errorf("unexpected domain order (-want,+got): %s", diff)
 	}
 }
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1551,9 +1551,7 @@ func (s *TASFlavorSnapshot) buildTopologyAssignmentForLevels(domains []*domain, 
 
 func (s *TASFlavorSnapshot) buildAssignment(domains []*domain) *utiltas.TopologyAssignment {
 	// lex sort domains by their levelValues instead of IDs, as leaves' IDs can only contain the hostname
-	slices.SortFunc(domains, func(a, b *domain) int {
-		return slices.Compare(a.levelValues, b.levelValues)
-	})
+	sortDomainsByLevelValues(domains)
 	levelIdx := 0
 	// assign only hostname values if topology defines it
 	if s.isLowestLevelNode {
@@ -1568,6 +1566,14 @@ func (s *TASFlavorSnapshot) lowerLevelDomains(domains []*domain) []*domain {
 		result = append(result, domain.children...)
 	}
 	return result
+}
+
+func compareDomainLevelValues(a, b *domain) int {
+	return slices.Compare(a.levelValues, b.levelValues)
+}
+
+func sortDomainsByLevelValues(domains []*domain) {
+	slices.SortFunc(domains, compareDomainLevelValues)
 }
 
 func (s *TASFlavorSnapshot) sortedDomainsWithLeader(domains []*domain, unconstrained bool) []*domain {
@@ -1595,7 +1601,7 @@ func (s *TASFlavorSnapshot) sortedDomainsWithLeader(domains []*domain, unconstra
 			return cmp.Compare(a.stateWithLeader, b.stateWithLeader)
 		}
 
-		return slices.Compare(a.levelValues, b.levelValues)
+		return compareDomainLevelValues(a, b)
 	})
 	return result
 }
@@ -1628,7 +1634,7 @@ func (s *TASFlavorSnapshot) sortedDomains(domains []*domain, unconstrained bool)
 			return cmp.Compare(a.state, b.state)
 		}
 
-		return slices.Compare(a.levelValues, b.levelValues)
+		return compareDomainLevelValues(a, b)
 	})
 	return result
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area tas

#### What this PR does / why we need it:

Makes TAS domain selection deterministic when multiple domains tie on score. Three call sites iterated or sorted domains in map order, so equal-capacity (and, with TASBalancedPlacement, equal-entropy) candidates could be picked differently across scheduling cycles for the same cluster state:

- `sortDomainsByCapacityAndEntropy` returned 0 on full ties; it now tie-breaks by `levelValues`.
- `selectOptimalDomainSetToFit` iterated the caller's slice in map order; it now iterates a `levelValues`-sorted clone (sorted by capacity and entropy when the feature gate is on), without mutating the caller's slice.
- `findBestDomainsForBalancedPlacement` collected higher-level domains from a map and iterated them unsorted; they are now sorted before their children are considered.

The lexicographic `levelValues` comparison is the same final ordering `sortedDomains` and `sortedDomainsWithLeader` already use, extracted into shared `compareDomainLevelValues` / `sortDomainsByLevelValues` helpers so the tie-break rule stays in one place. Stable selection means repeated workloads on identical cluster state land on the same set of nodes, which keeps reusable inter-node connections warm as discussed in the issue.

#### Which issue(s) this PR fixes:

Fixes #11910

#### Special notes for your reviewer:

`selectOptimalDomainSetToFit` clones the input slice before sorting so the change cannot reorder the caller's view of `domains`. New tests cover tie-breaking in `sortDomainsByCapacityAndEntropy`, deterministic results from `selectOptimalDomainSetToFit` across shuffled input orders, and stable higher-level iteration in `findBestDomainsForBalancedPlacement`. `go test ./pkg/cache/scheduler/...` passes.

#### Does this PR introduce a user-facing change?

```release-note
TAS: domain selection is now deterministic when multiple domains tie on score; ties are broken by the domains' levelValues ordering.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for deterministic domain ordering and placement scenarios.

* **Refactor**
  * Improved consistency in domain ordering by implementing deterministic tie-breaking during scheduling decisions.
  * Consolidated domain sorting logic into shared utility functions for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->