### PR TITLE
Invalidate representative mode cache on psAssignment error

### DIFF
--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -241,6 +241,11 @@ func (a *Assignment) TotalRequestsFor(log logr.Logger, wl *workload.Info) resour
 	return usage
 }
 
+func (a *Assignment) psError(psAssignment *PodSetAssignment, err error) {
+	psAssignment.error(err)
+	a.representativeMode = nil
+}
+
 func IgnoreUndeclaredResources(quotaCheckStrategy configapi.QuotaCheckStrategy) bool {
 	return features.Enabled(features.QuotaCheckStrategy) && quotaCheckStrategy == configapi.QuotaCheckIgnoreUndeclared
 }

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -43,11 +43,11 @@ import (
 
 var (
 	statusComparer = cmp.Comparer(func(a, b Status) bool {
+		if a.err != nil && b.err != nil {
+			return errors.Is(a.err, b.err) || strings.HasPrefix(a.err.Error(), b.err.Error()) || strings.HasPrefix(b.err.Error(), a.err.Error())
+		}
 		if a.err != nil || b.err != nil {
-			if a.err == nil || b.err == nil {
-				return false
-			}
-			return a.err.Error() == b.err.Error()
+			return false
 		}
 		return cmp.Equal(a.reasons, b.reasons, cmpopts.SortSlices(func(x, y string) bool {
 			return x < y
@@ -3315,6 +3315,58 @@ func TestAssignFlavors(t *testing.T) {
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{}},
 			},
 		},
+		"multiple TAS flavors assigned to different resources in the same PodSet leads to NoFit": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling: true,
+			},
+			topologies: []*kueue.Topology{
+				utiltestingapi.MakeTopology("tas-topo-a").Levels(corev1.LabelHostname).Obj(),
+				utiltestingapi.MakeTopology("tas-topo-b").Levels(corev1.LabelHostname).Obj(),
+			},
+			wlPods: []kueue.PodSet{
+				*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					Request(corev1.ResourceCPU, "1").
+					Request(corev1.ResourceMemory, "1Mi").
+					RequiredTopologyRequest(corev1.LabelHostname).
+					Obj(),
+			},
+			clusterQueue: *utiltestingapi.MakeClusterQueue("test-clusterqueue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("tas-a").
+						Resource(corev1.ResourceCPU, "10").
+						Obj(),
+				).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("tas-b").
+						Resource(corev1.ResourceMemory, "10Mi").
+						Obj(),
+				).
+				Obj(),
+			wantRepMode: NoFit,
+			wantAssignment: Assignment{
+				PodSets: []PodSetAssignment{
+					{
+						Name: kueue.DefaultPodSetName,
+						Flavors: ResourceAssignment{
+							corev1.ResourceCPU:    {Name: "tas-a", Mode: Fit, TriedFlavorIdx: -1},
+							corev1.ResourceMemory: {Name: "tas-b", Mode: Fit, TriedFlavorIdx: -1},
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("1Mi"),
+						},
+						Count: 1,
+						Status: Status{
+							err: errors.New("more than one TAS flavor assigned"),
+						},
+					},
+				},
+				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+					{Flavor: "tas-a", Resource: corev1.ResourceCPU}:    resources.NewAmount(1_000),
+					{Flavor: "tas-b", Resource: corev1.ResourceMemory}: resources.NewAmount(utiltesting.Mi),
+				}},
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -3342,6 +3394,11 @@ func TestAssignFlavors(t *testing.T) {
 			}
 			for _, rf := range resourceFlavors {
 				cache.AddOrUpdateResourceFlavor(log, rf)
+			}
+			if tc.topologies != nil {
+				for _, topology := range tc.topologies {
+					cache.AddOrUpdateTopology(log, topology)
+				}
 			}
 
 			if err := cache.AddOrUpdateCohort(utiltestingapi.MakeCohort(tc.clusterQueue.Spec.CohortName).Obj()); err != nil {
@@ -4057,7 +4114,6 @@ func TestWorkloadsTopologyRequests_ErrorBranches(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			tc.assignment.representativeMode = new(Fit)
 			tasReqs := tc.assignment.WorkloadsTopologyRequests(testr.New(t), &tc.workload, &tc.cq)
 			if len(tasReqs) != 0 {
 				t.Errorf("expected no TAS requests, got: %+v", tasReqs)
@@ -4201,7 +4257,6 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			tc.assignment.representativeMode = new(Fit)
 			tasReqs := tc.assignment.WorkloadsTopologyRequests(testr.New(t), &tc.workload, &tc.cq)
 			if tc.wantErr != "" {
 				if len(tasReqs) != 0 {

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4159,6 +4159,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					Count:  2,
 					Status: *NewStatus(),
 				}},
+				representativeMode: new(Fit),
 				replaceWorkloadSlice: workload.NewInfo(&kueue.Workload{
 					Status: kueue.WorkloadStatus{
 						Admission: &kueue.Admission{
@@ -4195,6 +4196,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					Count:  2,
 					Status: *NewStatus(),
 				}},
+				representativeMode: new(Fit),
 				replaceWorkloadSlice: workload.NewInfo(&kueue.Workload{
 					Status: kueue.WorkloadStatus{
 						Admission: &kueue.Admission{

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -44,7 +44,10 @@ import (
 var (
 	statusComparer = cmp.Comparer(func(a, b Status) bool {
 		if a.err != nil || b.err != nil {
-			return errors.Is(a.err, b.err)
+			if a.err == nil || b.err == nil {
+				return false
+			}
+			return a.err.Error() == b.err.Error()
 		}
 		return cmp.Equal(a.reasons, b.reasons, cmpopts.SortSlices(func(x, y string) bool {
 			return x < y
@@ -195,6 +198,8 @@ func TestAssignFlavors(t *testing.T) {
 				Effect:   corev1.TaintEffectNoSchedule,
 			}).
 			Obj(),
+		"tas-a": utiltestingapi.MakeResourceFlavor("tas-a").TopologyName("tas-topo-a").Obj(),
+		"tas-b": utiltestingapi.MakeResourceFlavor("tas-b").TopologyName("tas-topo-b").Obj(),
 	}
 
 	cases := map[string]struct {
@@ -210,6 +215,7 @@ func TestAssignFlavors(t *testing.T) {
 		simulationResult           map[resources.FlavorResource]simulationResultForFlavor
 		preemptWorkloadSlice       *workload.Info
 		featureGates               map[featuregate.Feature]bool
+		topologies                 []*kueue.Topology
 	}{
 		"single flavor, fits": {
 			wlPods: []kueue.PodSet{
@@ -4051,7 +4057,7 @@ func TestWorkloadsTopologyRequests_ErrorBranches(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			tc.assignment.representativeMode = ptr.To(Fit)
+			tc.assignment.representativeMode = new(Fit)
 			tasReqs := tc.assignment.WorkloadsTopologyRequests(testr.New(t), &tc.workload, &tc.cq)
 			if len(tasReqs) != 0 {
 				t.Errorf("expected no TAS requests, got: %+v", tasReqs)
@@ -4195,7 +4201,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			tc.assignment.representativeMode = ptr.To(Fit)
+			tc.assignment.representativeMode = new(Fit)
 			tasReqs := tc.assignment.WorkloadsTopologyRequests(testr.New(t), &tc.workload, &tc.cq)
 			if tc.wantErr != "" {
 				if len(tasReqs) != 0 {

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4051,6 +4051,7 @@ func TestWorkloadsTopologyRequests_ErrorBranches(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			tc.assignment.representativeMode = ptr.To(Fit)
 			tasReqs := tc.assignment.WorkloadsTopologyRequests(testr.New(t), &tc.workload, &tc.cq)
 			if len(tasReqs) != 0 {
 				t.Errorf("expected no TAS requests, got: %+v", tasReqs)
@@ -4194,6 +4195,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			tc.assignment.representativeMode = ptr.To(Fit)
 			tasReqs := tc.assignment.WorkloadsTopologyRequests(testr.New(t), &tc.workload, &tc.cq)
 			if tc.wantErr != "" {
 				if len(tasReqs) != 0 {
@@ -4204,8 +4206,16 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 				} else if diff := cmp.Diff(tc.wantErr, tc.assignment.PodSets[0].Status.err.Error()); diff != "" {
 					t.Errorf("Error mismatch (-want +got):\n%s", diff)
 				}
-			} else if tc.assignment.PodSets[0].Status.err != nil {
-				t.Errorf("expected no error, got: %v", tc.assignment.PodSets[0].Status.err)
+				if got := tc.assignment.RepresentativeMode(); got != NoFit {
+					t.Errorf("RepresentativeMode() = %v, want NoFit (workload must not be admitted when elastic job validation fails)", got)
+				}
+			} else {
+				if tc.assignment.PodSets[0].Status.err != nil {
+					t.Errorf("expected no error, got: %v", tc.assignment.PodSets[0].Status.err)
+				}
+				if got := tc.assignment.RepresentativeMode(); got != Fit {
+					t.Errorf("RepresentativeMode() = %v, want Fit", got)
+				}
 			}
 		})
 	}

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -63,10 +63,12 @@ func (a *Assignment) WorkloadsTopologyRequests(log logr.Logger, wl *workload.Inf
 			if features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
 				if podSet.TopologyRequest != nil && podSet.TopologyRequest.Required != nil {
 					psAssignment.error(errors.New("required topology is not supported with ElasticJobsViaWorkloadSlices"))
+					a.representativeMode = nil
 					continue
 				}
 				if podSet.TopologyRequest != nil && podSet.TopologyRequest.Preferred != nil {
 					psAssignment.error(errors.New("preferred topology is not supported with ElasticJobsViaWorkloadSlices"))
+					a.representativeMode = nil
 					continue
 				}
 				previousAssignment = getPreviousTopologyAssignment(a.replaceWorkloadSlice, podSet.Name)
@@ -75,6 +77,7 @@ func (a *Assignment) WorkloadsTopologyRequests(log logr.Logger, wl *workload.Inf
 			psTASRequest, err := podSetTopologyRequest(psAssignment, wl, cq, isTASImplied, i, previousAssignment)
 			if err != nil {
 				psAssignment.error(err)
+				a.representativeMode = nil
 			} else if psTASRequest != nil {
 				tasRequests[psTASRequest.Flavor] = append(tasRequests[psTASRequest.Flavor], *psTASRequest)
 			}

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -62,13 +62,11 @@ func (a *Assignment) WorkloadsTopologyRequests(log logr.Logger, wl *workload.Inf
 			var previousAssignment *kueue.TopologyAssignment
 			if features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
 				if podSet.TopologyRequest != nil && podSet.TopologyRequest.Required != nil {
-					psAssignment.error(errors.New("required topology is not supported with ElasticJobsViaWorkloadSlices"))
-					a.representativeMode = nil
+					a.psError(psAssignment, errors.New("required topology is not supported with ElasticJobsViaWorkloadSlices"))
 					continue
 				}
 				if podSet.TopologyRequest != nil && podSet.TopologyRequest.Preferred != nil {
-					psAssignment.error(errors.New("preferred topology is not supported with ElasticJobsViaWorkloadSlices"))
-					a.representativeMode = nil
+					a.psError(psAssignment, errors.New("preferred topology is not supported with ElasticJobsViaWorkloadSlices"))
 					continue
 				}
 				previousAssignment = getPreviousTopologyAssignment(a.replaceWorkloadSlice, podSet.Name)
@@ -76,8 +74,8 @@ func (a *Assignment) WorkloadsTopologyRequests(log logr.Logger, wl *workload.Inf
 
 			psTASRequest, err := podSetTopologyRequest(psAssignment, wl, cq, isTASImplied, i, previousAssignment)
 			if err != nil {
-				psAssignment.error(err)
-				a.representativeMode = nil
+				a.psError(psAssignment, err)
+				continue
 			} else if psTASRequest != nil {
 				tasRequests[psTASRequest.Flavor] = append(tasRequests[psTASRequest.Flavor], *psTASRequest)
 			}

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -2134,7 +2134,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 		ginkgo.It("Should not admit new created workloads", func() {
 			ginkgo.By("Create clusterQueue")
 			cq = utiltestingapi.MakeClusterQueue("cluster-queue").
-			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj()).Obj()
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj()).Obj()
 			util.MustCreate(ctx, k8sClient, cq)
 			queue = utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue(cq.Name).Obj()
 			util.MustCreate(ctx, k8sClient, queue)

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -2133,7 +2133,8 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 		ginkgo.It("Should not admit new created workloads", func() {
 			ginkgo.By("Create clusterQueue")
-			cq = utiltestingapi.MakeClusterQueue("cluster-queue").Obj()
+			cq = utiltestingapi.MakeClusterQueue("cluster-queue").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj()).Obj()
 			util.MustCreate(ctx, k8sClient, cq)
 			queue = utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue(cq.Name).Obj()
 			util.MustCreate(ctx, k8sClient, queue)


### PR DESCRIPTION
#### What type of PR is this?
AI assisted

/kind bug
/area tas

#### What this PR does / why we need it:
If onlyTASFlavor() return error the psAssigment has error. In this case the assignment mode should be NoFit (https://github.com/kubernetes-sigs/kueue/blob/main/pkg/scheduler/flavorassigner/flavorassigner.go#L307) but if the previous a.assignmentMode is Fit, RepresentativeMode() will persist to return Fit mode because the cache is not invalidated, which will result in a wrong scheduler results (quota reservation).

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
TAS: Fixed error handling for TAS topology assignments so Workloads are not considered
`Fit` when topology assignment fails. Kueue now treats such assignment errors as `NoFit`
instead of allowing the Workload to reserve quota.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure topology-request validation updates representative mode reliably for elastic-job/TAS scenarios; clear representative mode when recording TAS-related errors and report conflicts when multiple TAS flavors are assigned.
  * Improve error comparison in test assertions to tolerate additional error suffixes or compatible wrapped errors.

* **Tests**
  * Strengthened tests for multi-TAS conflict behavior and explicit representative-mode initialization/assertions; adjusted an integration test to use an explicit resource group for on-demand flavor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->