### PR TITLE
[Flake][release-0.16] Increase Multikueue lost-worker pending retry assertion

### DIFF
--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -1519,11 +1519,11 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				createdWorkload := &kueue.Workload{}
 				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 				acs := admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
-				g.Expect(acs).To(gomega.BeComparableTo(&kueue.AdmissionCheckState{
-					Name:       kueue.AdmissionCheckReference(multiKueueAC.Name),
-					State:      kueue.CheckStatePending,
-					RetryCount: ptr.To(int32(1)),
-				}, cmpopts.IgnoreFields(kueue.AdmissionCheckState{}, "LastTransitionTime", "Message")))
+				g.Expect(acs).ToNot(gomega.BeNil())
+				g.Expect(acs.Name).To(gomega.Equal(kueue.AdmissionCheckReference(multiKueueAC.Name)))
+				g.Expect(acs.State).To(gomega.Equal(kueue.CheckStatePending))
+				g.Expect(acs.RetryCount).ToNot(gomega.BeNil())
+				g.Expect(*acs.RetryCount).To(gomega.BeNumerically(">", 0))
 
 				g.Expect(createdWorkload.Status.Conditions).ToNot(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
@@ -2501,11 +2501,11 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 					createdWorkload := &kueue.Workload{}
 					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 					acs := admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
-					g.Expect(acs).To(gomega.BeComparableTo(&kueue.AdmissionCheckState{
-						Name:       kueue.AdmissionCheckReference(multiKueueAC.Name),
-						State:      kueue.CheckStatePending,
-						RetryCount: ptr.To(int32(1)),
-					}, cmpopts.IgnoreFields(kueue.AdmissionCheckState{}, "LastTransitionTime", "Message")))
+					g.Expect(acs).ToNot(gomega.BeNil())
+					g.Expect(acs.Name).To(gomega.Equal(kueue.AdmissionCheckReference(multiKueueAC.Name)))
+					g.Expect(acs.State).To(gomega.Equal(kueue.CheckStatePending))
+					g.Expect(acs.RetryCount).ToNot(gomega.BeNil())
+					g.Expect(*acs.RetryCount).To(gomega.BeNumerically(">", 0))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/area multikueue

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Expecting the admission check to have exactly RetryCount = 1 is weak. 
If the controller runs one extra reconciliation, the retry count can become 2 and the test fails even though the system is behaving correctly.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11346 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
