### PR TITLE
cleanup: share image-resolution logic for e2e test images

### DIFF
--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -105,4 +105,7 @@ const (
 var (
 	sparkTestImageOnce sync.Once
 	sparkTestImage     string
+
+	agnHostImageOnce sync.Once
+	agnHostImage     string
 )

--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -27,6 +27,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -98,35 +99,32 @@ func GetAgnHostImageOld() string {
 }
 
 func GetAgnHostImage() string {
-	if image := os.Getenv("E2E_TEST_AGNHOST_IMAGE"); image != "" {
-		return image
-	}
-
-	agnhostDockerfilePath := filepath.Join(ProjectBaseDir, "hack", "testing", "agnhost", "Dockerfile")
-	agnhostImage, err := getDockerImageFromDockerfile(agnhostDockerfilePath)
-	if err != nil {
-		panic(fmt.Errorf("failed to get agnhost image: %v", err))
-	}
-
-	return agnhostImage
+	return getCachedDockerImage(&agnHostImageOnce, &agnHostImage, "E2E_TEST_AGNHOST_IMAGE", "agnhost")
 }
 
 func GetSparkTestImage() string {
-	sparkTestImageOnce.Do(func() {
-		if image := os.Getenv("E2E_TEST_SPARK_IMAGE"); image != "" {
-			sparkTestImage = image
+	return getCachedDockerImage(&sparkTestImageOnce, &sparkTestImage, "E2E_TEST_SPARK_IMAGE", "spark")
+}
+
+// getCachedDockerImage resolves a test image exactly once via the supplied sync.Once,
+// caching the result in *cache. It returns the value of envVar if set, otherwise the
+// image parsed from hack/testing/<dir>/Dockerfile.
+func getCachedDockerImage(once *sync.Once, cache *string, envVar, dir string) string {
+	once.Do(func() {
+		if image := os.Getenv(envVar); image != "" {
+			*cache = image
 			return
 		}
 
-		sparkDockerfilePath := filepath.Join(ProjectBaseDir, "hack", "testing", "spark", "Dockerfile")
-		sparkImage, err := getDockerImageFromDockerfile(sparkDockerfilePath)
+		dockerfilePath := filepath.Join(ProjectBaseDir, "hack", "testing", dir, "Dockerfile")
+		image, err := getDockerImageFromDockerfile(dockerfilePath)
 		if err != nil {
-			panic(fmt.Errorf("failed to get spark image: %v", err))
+			panic(fmt.Errorf("failed to get %s image: %w", dir, err))
 		}
 
-		sparkTestImage = sparkImage
+		*cache = image
 	})
-	return sparkTestImage
+	return *cache
 }
 
 // VersionFromImage extracts the version tag from an image reference,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->
/area testing
#### What this PR does / why we need it:
Optimize GetAgnHostImage func used in e2e tests by following the pattern established in GetSparkTestImage func.

#### Which issue(s) this PR fixes:
GetAgnHostImage opens and parses the agnhost Dockerfile from disk on every call, whereas GetSparkTestImage already wraps the equivalent lookup in a sync.Once so the image is resolved only once and cached for reuse. Aligning GetAgnHostImage with that pattern avoids repeated file I/O and parsing across e2e test runs and keeps the two image-resolution helpers consistent and easier to maintain.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12066

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized Docker image resolution for tests with caching to improve performance.

* **Chores**
  * Added support for environment variable overrides in test image configuration, with fallback to Dockerfile parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->