### PR TITLE
Install Spark operator Helm chart from OCI registry with retries

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -1080,13 +1080,12 @@ function install_sparkoperator {
     local kubeconfig=${2:-}
     local ns="${SPARKOPERATOR_NAMESPACE:-spark-operator}"
     local helm_release_name="${SPARKOPERATOR_HELM_RELEASE_NAME:-spark-operator}"
+    local helm_chart="${SPARKOPERATOR_HELM_CHART:-oci://ghcr.io/kubeflow/helm-charts/spark-operator}"
     local expected_version="${SPARKOPERATOR_VERSION:-}"
     expected_version="${expected_version#v}"
     local install_cmd="install"
     cluster_kind_load_image "${cluster_name}" "${SPARKOPERATOR_IMAGE}"
     cluster_kind_load_image "${cluster_name}" "${E2E_TEST_SPARK_IMAGE}"
-
-    ${HELM} repo add --force-update spark-operator https://kubeflow.github.io/spark-operator
 
     if [[ "${E2E_MODE}" == "dev" ]] && ! e2e_is_truthy "${E2E_ENFORCE_OPERATOR_UPDATE}"; then
         if helm list --namespace "${ns}" | grep -q "${helm_release_name}"; then
@@ -1107,14 +1106,18 @@ function install_sparkoperator {
         fi
     fi
 
-    ${HELM} --kubeconfig="${kubeconfig}" \
-    ${install_cmd} "${helm_release_name}" spark-operator/spark-operator \
-    --version "${expected_version}" \
-    --namespace "${ns}" \
-    --create-namespace \
-    --wait \
-    --set image.tag="${expected_version}" \
-    --set 'spark.jobNamespaces[0]='
+    local install_args=(
+        --kubeconfig="${kubeconfig}"
+        "${install_cmd}" "${helm_release_name}" "${helm_chart}"
+        --version "${expected_version}"
+        --namespace "${ns}"
+        --create-namespace
+        --wait
+        --set image.tag="${expected_version}"
+        --set 'spark.jobNamespaces[0]='
+    )
+    "${ROOT_DIR}/hack/testing/retry.sh" --attempts 7 --delay 2 --exponential --stream -- \
+        "${HELM}" "${install_args[@]}"
 }
 
 # $1 kubeconfig option


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
before any test ran.
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
To mitigate transient GitHub errors, the Spark operator chart is pulled not from `kubeflow.github.io` but over OCI from `oci://ghcr.io/kubeflow/helm-charts/spark-operator`, and the install is wrapped in a retry.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11987

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Spark Operator deployment reliability with configurable Helm chart references and automatic retry logic with exponential backoff for more robust installation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->