### PR TITLE
Fix limit for LocalQueue FlavorsReservation and FlavorsUsage

### DIFF
--- a/apis/kueue/v1beta1/localqueue_types.go
+++ b/apis/kueue/v1beta1/localqueue_types.go
@@ -65,7 +65,7 @@ type LocalQueueFlavorStatus struct {
 
 	// resources used in the flavor.
 	// +listType=set
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	// +optional
 	Resources []corev1.ResourceName `json:"resources,omitempty"`
 
@@ -138,7 +138,7 @@ type LocalQueueStatus struct {
 	// workloads assigned to this LocalQueue.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	// +optional
 	FlavorsReservation []LocalQueueFlavorUsage `json:"flavorsReservation"`
 
@@ -146,14 +146,14 @@ type LocalQueueStatus struct {
 	// workloads assigned to this LocalQueue.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	// +optional
 	FlavorUsage []LocalQueueFlavorUsage `json:"flavorUsage"`
 
 	// flavors lists all currently available ResourceFlavors in specified ClusterQueue.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	// +optional
 	//
 	// Deprecated: Flavors is deprecated and marked for removal in v1beta2.
@@ -177,7 +177,7 @@ type LocalQueueFlavorUsage struct {
 	// resources lists the quota usage for the resources in this flavor.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	Resources []LocalQueueResourceUsage `json:"resources"`
 }
 

--- a/apis/kueue/v1beta2/localqueue_types.go
+++ b/apis/kueue/v1beta2/localqueue_types.go
@@ -104,7 +104,7 @@ type LocalQueueStatus struct {
 	// workloads assigned to this LocalQueue.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	// +optional
 	FlavorsReservation []LocalQueueFlavorUsage `json:"flavorsReservation,omitempty"`
 
@@ -112,7 +112,7 @@ type LocalQueueStatus struct {
 	// workloads assigned to this LocalQueue.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	// +optional
 	FlavorsUsage []LocalQueueFlavorUsage `json:"flavorsUsage,omitempty"`
 
@@ -164,7 +164,7 @@ type LocalQueueFlavorUsage struct {
 	// resources lists the quota usage for the resources in this flavor.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	// +required
 	Resources []LocalQueueResourceUsage `json:"resources,omitempty"`
 }

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_localqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_localqueues.yaml
@@ -279,7 +279,7 @@ spec:
                           required:
                             - name
                           type: object
-                        maxItems: 16
+                        maxItems: 64
                         type: array
                         x-kubernetes-list-map-keys:
                           - name
@@ -288,7 +288,7 @@ spec:
                       - name
                       - resources
                     type: object
-                  maxItems: 16
+                  maxItems: 64
                   type: array
                   x-kubernetes-list-map-keys:
                     - name
@@ -352,7 +352,7 @@ spec:
                         items:
                           description: ResourceName is the name identifying various resources in a ResourceList.
                           type: string
-                        maxItems: 16
+                        maxItems: 64
                         type: array
                         x-kubernetes-list-type: set
                       topology:
@@ -382,7 +382,7 @@ spec:
                     required:
                       - name
                     type: object
-                  maxItems: 16
+                  maxItems: 64
                   type: array
                   x-kubernetes-list-map-keys:
                     - name
@@ -415,7 +415,7 @@ spec:
                           required:
                             - name
                           type: object
-                        maxItems: 16
+                        maxItems: 64
                         type: array
                         x-kubernetes-list-map-keys:
                           - name
@@ -424,7 +424,7 @@ spec:
                       - name
                       - resources
                     type: object
-                  maxItems: 16
+                  maxItems: 64
                   type: array
                   x-kubernetes-list-map-keys:
                     - name
@@ -674,7 +674,7 @@ spec:
                           required:
                             - name
                           type: object
-                        maxItems: 16
+                        maxItems: 64
                         type: array
                         x-kubernetes-list-map-keys:
                           - name
@@ -683,7 +683,7 @@ spec:
                       - name
                       - resources
                     type: object
-                  maxItems: 16
+                  maxItems: 64
                   type: array
                   x-kubernetes-list-map-keys:
                     - name
@@ -716,7 +716,7 @@ spec:
                           required:
                             - name
                           type: object
-                        maxItems: 16
+                        maxItems: 64
                         type: array
                         x-kubernetes-list-map-keys:
                           - name
@@ -725,7 +725,7 @@ spec:
                       - name
                       - resources
                     type: object
-                  maxItems: 16
+                  maxItems: 64
                   type: array
                   x-kubernetes-list-map-keys:
                     - name

--- a/config/components/crd/bases/kueue.x-k8s.io_localqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_localqueues.yaml
@@ -253,7 +253,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 16
+                      maxItems: 64
                       type: array
                       x-kubernetes-list-map-keys:
                       - name
@@ -262,7 +262,7 @@ spec:
                   - name
                   - resources
                   type: object
-                maxItems: 16
+                maxItems: 64
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -331,7 +331,7 @@ spec:
                         description: ResourceName is the name identifying various
                           resources in a ResourceList.
                         type: string
-                      maxItems: 16
+                      maxItems: 64
                       type: array
                       x-kubernetes-list-type: set
                     topology:
@@ -361,7 +361,7 @@ spec:
                   required:
                   - name
                   type: object
-                maxItems: 16
+                maxItems: 64
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -395,7 +395,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 16
+                      maxItems: 64
                       type: array
                       x-kubernetes-list-map-keys:
                       - name
@@ -404,7 +404,7 @@ spec:
                   - name
                   - resources
                   type: object
-                maxItems: 16
+                maxItems: 64
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -661,7 +661,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 16
+                      maxItems: 64
                       type: array
                       x-kubernetes-list-map-keys:
                       - name
@@ -670,7 +670,7 @@ spec:
                   - name
                   - resources
                   type: object
-                maxItems: 16
+                maxItems: 64
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -704,7 +704,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 16
+                      maxItems: 64
                       type: array
                       x-kubernetes-list-map-keys:
                       - name
@@ -713,7 +713,7 @@ spec:
                   - name
                   - resources
                   type: object
-                maxItems: 16
+                maxItems: 64
                 type: array
                 x-kubernetes-list-map-keys:
                 - name

--- a/test/integration/singlecluster/webhook/core/localqueue_test.go
+++ b/test/integration/singlecluster/webhook/core/localqueue_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package core
 
 import (
+	"fmt"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -58,4 +61,59 @@ var _ = ginkgo.Describe("Queue validating webhook", func() {
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
+	ginkgo.When("Updating the status of a Queue", func() {
+		ginkgo.It("Should allow flavors quantity up to the limit in flavorsReservation and flavorsUsage", func() {
+			ginkgo.By("Creating a new Queue")
+			obj := utiltestingapi.MakeLocalQueue(queueName, ns.Name).ClusterQueue("foo").Obj()
+			util.MustCreate(ctx, k8sClient, obj)
+
+			ginkgo.By("Updating the Queue status")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedQ kueue.LocalQueue
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(obj), &updatedQ)).Should(gomega.Succeed())
+				updatedQ.Status.FlavorsReservation = makeLocalQueueFlavorUsage(flavorsMaxItems)
+				updatedQ.Status.FlavorsUsage = makeLocalQueueFlavorUsage(flavorsMaxItems)
+				g.Expect(k8sClient.Status().Update(ctx, &updatedQ)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+		ginkgo.It("Should reject flavors quantity over the limit in flavorsReservation", func() {
+			ginkgo.By("Creating a new Queue")
+			obj := utiltestingapi.MakeLocalQueue(queueName, ns.Name).ClusterQueue("foo").Obj()
+			util.MustCreate(ctx, k8sClient, obj)
+
+			ginkgo.By("Updating the Queue status")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedQ kueue.LocalQueue
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(obj), &updatedQ)).Should(gomega.Succeed())
+				updatedQ.Status.FlavorsReservation = makeLocalQueueFlavorUsage(flavorsMaxItems + 1)
+				g.Expect(k8sClient.Status().Update(ctx, &updatedQ)).Should(utiltesting.BeInvalidError())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+		ginkgo.It("Should reject flavors quantity over the limit in flavorsUsage", func() {
+			ginkgo.By("Creating a new Queue")
+			obj := utiltestingapi.MakeLocalQueue(queueName, ns.Name).ClusterQueue("foo").Obj()
+			util.MustCreate(ctx, k8sClient, obj)
+
+			ginkgo.By("Updating the Queue status")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedQ kueue.LocalQueue
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(obj), &updatedQ)).Should(gomega.Succeed())
+				updatedQ.Status.FlavorsUsage = makeLocalQueueFlavorUsage(flavorsMaxItems + 1)
+				g.Expect(k8sClient.Status().Update(ctx, &updatedQ)).Should(utiltesting.BeInvalidError())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
 })
+
+func makeLocalQueueFlavorUsage(quantity int) []kueue.LocalQueueFlavorUsage {
+	usage := make([]kueue.LocalQueueFlavorUsage, quantity)
+	for i := range usage {
+		usage[i] = kueue.LocalQueueFlavorUsage{
+			Name: kueue.ResourceFlavorReference(fmt.Sprintf("f%d", i)),
+			Resources: []kueue.LocalQueueResourceUsage{{
+				Name: corev1.ResourceCPU,
+			}},
+		}
+	}
+	return usage
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

In PR https://github.com/kubernetes-sigs/kueue/pull/6906, the ClusterQueue coveredResources and flavors limits were increased to 64, and https://github.com/kubernetes-sigs/kueue/pull/7064 increased the matching limits on Resources under FlavorQuotas and on FlavorsReservation and FlavorsUsage under ClusterQueueStatus. However, the corresponding LocalQueue **status** fields still use the old limit of 16: `flavorsReservation`, `flavorUsage` (`flavorsUsage` in v1beta2), their per-flavor `resources` lists, and the deprecated v1beta1 `flavors` field.

As a result, a LocalQueue referencing a ClusterQueue with more than 16 flavors (valid since #6906) gets every status update rejected once workloads reserve quota in more than 16 flavors:

```
LocalQueue.kueue.x-k8s.io "..." is invalid: status.flavorsReservation: Too many: 23: must have at most 16 items
```

Since the whole status update fails, the LocalQueue also stops receiving updates to its `Active` condition and its pending/reserving/admitted workload counts. This PR increases those limits to 64 to make them consistent with the ClusterQueue limits.

#### Which issue(s) this PR fixes:
Fixes #12079

#### Special notes for your reviewer:

- The deprecated v1beta1 `status.flavors` field (and its nested `resources` list) is included in the bump for consistency, since it is populated from the same set of ClusterQueue flavors — happy to drop that part if you would rather leave the deprecated field untouched.
- Per the [AI tool usage policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance): this PR was written in part with the assistance of generative AI; I have reviewed and verified all changes.

#### Does this PR introduce a user-facing change?

```release-note
LocalQueues: Fixed a bug that caused LocalQueue status updates to be rejected
when quota reservation or usage included more than 16 ResourceFlavors, leaving
the LocalQueue condition and workload counts stale. LocalQueue status now
supports up to 64 ResourceFlavors, matching the ClusterQueue limits.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced LocalQueue capacity by increasing the maximum item limits for flavor resource lists from 16 to 64 items per list across all API versions, enabling support for more resource configurations.

* **Tests**
  * Added comprehensive validation tests for LocalQueue status updates to ensure the expanded capacity limits function correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->