### PR TITLE
fix typo in admission fair sharing docs

### DIFF
--- a/site/content/en/docs/concepts/admission_fair_sharing.md
+++ b/site/content/en/docs/concepts/admission_fair_sharing.md
@@ -43,7 +43,7 @@ For example, if Tenant A has low historical usage and Tenant B has high usage, b
 
 The following parameters can be configured in Kueue's configuration `.admissionFairSharing`:
 
-- `usageHalfLifeDecayTime`: Controls how quickly historical usage decays
+- `usageHalfLifeTime`: Controls how quickly historical usage decays
 - `usageSamplingInterval`: How frequently usage is sampled
 - `resourceWeights`: Relative importance of different resource types
 

--- a/site/content/zh-CN/docs/concepts/admission_fair_sharing.md
+++ b/site/content/zh-CN/docs/concepts/admission_fair_sharing.md
@@ -36,7 +36,7 @@ description: >
 
 可以在 Kueue 的配置文件中通过 `.admissionFairSharing` 配置以下参数：
 
-- `usageHalfLifeDecayTime`：控制历史使用量衰减的速度
+- `usageHalfLifeTime`：控制历史使用量衰减的速度
 - `usageSamplingInterval`：资源使用量采样的频率
 - `resourceWeights`：不同资源类型的重要性权重
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
/area website
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Fix typo in admission fair sharing.

```
type AdmissionFairSharing struct {
        // usageHalfLifeTime indicates the time after which the current usage will decay by a half
        // If set to 0, usage will be reset to 0 immediately.
        UsageHalfLifeTime metav1.Duration `json:"usageHalfLifeTime"`

        // usageSamplingInterval indicates how often Kueue updates consumedResources in FairSharingStatus
        // Defaults to 5min.
        UsageSamplingInterval metav1.Duration `json:"usageSamplingInterval"`

        // resourceWeights assigns weights to resources which then are used to calculate LocalQueue's
        // resource usage and order Workloads.
        // Defaults to 1.
        ResourceWeights map[corev1.ResourceName]float64 `json:"resourceWeights,omitempty"`
}
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Admission Fair Sharing configuration documentation with clarified parameter naming.
  * Fixed formatting in Observability example output to display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->