### PR TITLE
[release-0.17] Classify DRA reconcile errors as transient vs deterministic

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -75,6 +75,20 @@ var (
 	realClock = clock.RealClock{}
 )
 
+// hasInternalError reports whether the field error list contains an internal
+// error. DRA resolution reports retryable failures, such as API errors, as
+// internal errors, so the reconciler retries them with controller-runtime
+// backoff; deterministic spec or configuration errors use other field error
+// types and are left inadmissible without requeue.
+func hasInternalError(errs field.ErrorList) bool {
+	for _, e := range errs {
+		if e.Type == field.ErrorTypeInternal {
+			return true
+		}
+	}
+	return false
+}
+
 type waitForPodsReadyConfig struct {
 	timeout                     time.Duration
 	recoveryTimeout             *time.Duration
@@ -304,7 +318,10 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			if updateErr != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update workload status for DRA error: %w", updateErr)
 			}
-			return ctrl.Result{}, err
+			if hasInternalError(fieldErrs) {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
 		}
 
 		// Process Extended Resources backed by DRA (new path)
@@ -326,7 +343,10 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				if updateErr != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to update workload status for DRA extended resources error: %w", updateErr)
 				}
-				return ctrl.Result{}, err
+				if hasInternalError(extFieldErrs) {
+					return ctrl.Result{}, err
+				}
+				return ctrl.Result{}, nil
 			}
 		}
 

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -593,8 +593,9 @@ func TestReconcile(t *testing.T) {
 				}
 				return wl
 			}(),
-			wantErrorMsg: "not mapped in DRA configuration",
-			wantEvents:   nil,
+			// An unmapped DeviceClass is a deterministic configuration error, so the
+			// workload is left inadmissible without requeue (no reconcile error).
+			wantEvents: nil,
 		},
 		"reconcile DRA ResourceClaimTemplate not found should return error": {
 			featureGates: map[featuregate.Feature]bool{


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Manual cherry-pick of #12002 to `release-0.17`, requested by @mimowo (the
automated cherry-pick could not apply cleanly).

`release-0.17` predates the DRA counter (partitionable devices) and CEL-selector
paths, so those parts of the original change do not exist here and are omitted.
This backport applies the same classification to the two DRA error paths that do
exist on `release-0.17`:

- A new `hasInternalError` helper inspects the field error type.
- Internal/API failures (e.g. fetching a ResourceClaimTemplate or listing
  DeviceClasses) keep the controller-runtime backoff so the workload still
  recovers once the cluster changes.
- Deterministic spec/configuration errors (unsupported DRA features, unmapped
  device classes, non-integer extended resources) leave the workload inadmissible
  and return without requeue, instead of being retried pointlessly.

#### Which issue(s) this PR fixes:
Cherry-pick of #12002 (Fixes #11994).

#### Special notes for your reviewer:
- Adapted backport: the counter/partitionable-devices path and the CEL
  device-shortage reclassification from #12002 are not present on `release-0.17`,
  so this change only touches the claims (RCT) and extended-resource paths.
- The existing "unmapped device class" reconciler test is updated to expect no
  requeue (deterministic error); the transient "failed to get claim spec" test
  continues to assert backoff.
- Verified on `release-0.17`: pkg/controller/core and pkg/dra unit tests, the DRA
  controller integration suite, gofmt, and go vet.
- AI tools were used to assist in preparing this change.

#### Does this PR introduce a user-facing change?
```release-note
DRA: Fixed hot reconcile loops for inadmissible Workloads with deterministic DRA resolution
failures. Kueue now avoids requeueing permanent DRA spec or configuration errors while still
retrying transient failures with backoff.
```
