### PR TITLE
Optimize the multikueue/extended e2e test suite by sharding

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -178,11 +178,13 @@ test-multikueue-e2e-extended:
 .PHONY: test-multikueue-e2e-extended-shard-0
 test-multikueue-e2e-extended-shard-0: E2E_NPROCS := 5
 test-multikueue-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=feature:leaderworkerset,feature:jobset,feature:appwrapper,feature:pytorchjob,feature:mpijob,feature:trainjob
+test-multikueue-e2e-extended-shard-0: E2E_CONFIG_FOLDER=multikueue/extended-shard-0
 test-multikueue-e2e-extended-shard-0: setup-e2e-env run-test-multikueue-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-multikueue-e2e-extended-shard-1
 test-multikueue-e2e-extended-shard-1: E2E_NPROCS := 5
 test-multikueue-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=feature:kuberay
+test-multikueue-e2e-extended-shard-1: E2E_CONFIG_FOLDER=multikueue/extended-shard-1
 test-multikueue-e2e-extended-shard-1: setup-e2e-env run-test-multikueue-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-multikueue-e2e-sequential
@@ -396,6 +398,7 @@ run-test-multikueue-e2e-extended-%:
 		E2E_ENFORCE_OPERATOR_UPDATE=$(E2E_ENFORCE_OPERATOR_UPDATE) \
 		USE_RAY_FOR_TESTS=$(USE_RAY_FOR_TESTS) \
 		E2E_TARGET_FOLDER="multikueue/extended" \
+		E2E_CONFIG_FOLDER=$(E2E_CONFIG_FOLDER) \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
 		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		E2E_USE_HELM=$(E2E_USE_HELM) \

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -155,8 +155,35 @@ test-e2e-extended-helm: test-e2e-extended
 test-multikueue-e2e-baseline: E2E_NPROCS := 5
 test-multikueue-e2e-baseline: setup-e2e-env run-test-multikueue-e2e-baseline-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
-test-multikueue-e2e-extended: E2E_NPROCS := 5
-test-multikueue-e2e-extended: setup-e2e-env run-test-multikueue-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
+# Assign shard-0 operator versions (all operators except KubeRay) to the shard-0 target
+TEST_MULTIKUEUE_E2E_EXTENDED_SHARD_0_TARGETS := test-multikueue-e2e-extended-shard-0
+$(TEST_MULTIKUEUE_E2E_EXTENDED_SHARD_0_TARGETS): export JOBSET_VERSION := $(JOBSET_VERSION)
+$(TEST_MULTIKUEUE_E2E_EXTENDED_SHARD_0_TARGETS): export LEADERWORKERSET_VERSION := $(LEADERWORKERSET_VERSION)
+$(TEST_MULTIKUEUE_E2E_EXTENDED_SHARD_0_TARGETS): export APPWRAPPER_VERSION := $(APPWRAPPER_VERSION)
+$(TEST_MULTIKUEUE_E2E_EXTENDED_SHARD_0_TARGETS): export KUBEFLOW_VERSION := $(KUBEFLOW_VERSION)
+$(TEST_MULTIKUEUE_E2E_EXTENDED_SHARD_0_TARGETS): export KUBEFLOW_MPI_VERSION := $(KUBEFLOW_MPI_VERSION)
+$(TEST_MULTIKUEUE_E2E_EXTENDED_SHARD_0_TARGETS): export KUBEFLOW_TRAINER_VERSION := $(KUBEFLOW_TRAINER_VERSION)
+
+# Assign shard-1 operator versions (KubeRay + Ray) to the shard-1 target
+TEST_MULTIKUEUE_E2E_EXTENDED_SHARD_1_TARGETS := test-multikueue-e2e-extended-shard-1
+$(TEST_MULTIKUEUE_E2E_EXTENDED_SHARD_1_TARGETS): export KUBERAY_VERSION := $(KUBERAY_VERSION)
+$(TEST_MULTIKUEUE_E2E_EXTENDED_SHARD_1_TARGETS): export RAY_VERSION := $(RAY_VERSION)
+$(TEST_MULTIKUEUE_E2E_EXTENDED_SHARD_1_TARGETS): export RAYMINI_VERSION := $(RAYMINI_VERSION)
+
+.PHONY: test-multikueue-e2e-extended
+test-multikueue-e2e-extended:
+	$(MAKE) test-multikueue-e2e-extended-shard-0
+	$(MAKE) test-multikueue-e2e-extended-shard-1
+
+.PHONY: test-multikueue-e2e-extended-shard-0
+test-multikueue-e2e-extended-shard-0: E2E_NPROCS := 5
+test-multikueue-e2e-extended-shard-0: GINKGO_ARGS=--label-filter=feature:leaderworkerset,feature:jobset,feature:appwrapper,feature:pytorchjob,feature:mpijob,feature:trainjob
+test-multikueue-e2e-extended-shard-0: setup-e2e-env run-test-multikueue-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
+
+.PHONY: test-multikueue-e2e-extended-shard-1
+test-multikueue-e2e-extended-shard-1: E2E_NPROCS := 5
+test-multikueue-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=feature:kuberay
+test-multikueue-e2e-extended-shard-1: setup-e2e-env run-test-multikueue-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-multikueue-e2e-sequential
 test-multikueue-e2e-sequential: setup-e2e-env kind-secretreader-plugin-image-build run-test-e2e-multikueue-sequential-$(E2E_KIND_VERSION:kindest/node:v%=%)
@@ -367,12 +394,7 @@ run-test-multikueue-e2e-extended-%:
 		E2E_MODE=$(E2E_MODE) \
 		E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
 		E2E_ENFORCE_OPERATOR_UPDATE=$(E2E_ENFORCE_OPERATOR_UPDATE) \
-		APPWRAPPER_VERSION=$(APPWRAPPER_VERSION) \
-		JOBSET_VERSION=$(JOBSET_VERSION) KUBEFLOW_VERSION=$(KUBEFLOW_VERSION) \
-		KUBEFLOW_MPI_VERSION=$(KUBEFLOW_MPI_VERSION) \
-		KUBERAY_VERSION=$(KUBERAY_VERSION) RAY_VERSION=$(RAY_VERSION) RAYMINI_VERSION=$(RAYMINI_VERSION) USE_RAY_FOR_TESTS=$(USE_RAY_FOR_TESTS) \
-		KUBEFLOW_TRAINER_VERSION=$(KUBEFLOW_TRAINER_VERSION) \
-		LEADERWORKERSET_VERSION=$(LEADERWORKERSET_VERSION) \
+		USE_RAY_FOR_TESTS=$(USE_RAY_FOR_TESTS) \
 		E2E_TARGET_FOLDER="multikueue/extended" \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
 		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -243,7 +243,7 @@ if [[ -n ${KUBEFLOW_TRAINER_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(tas|trainj
     export KF_TRAINER_IMAGE=ghcr.io/kubeflow/trainer/trainer-controller-manager:${KF_TRAINER_IMAGE_VERSION}
 fi
 
-if [[ -n ${KUBEFLOW_MPI_VERSION:-} ]]; then
+if [[ -n ${KUBEFLOW_MPI_VERSION:-} && ("$GINKGO_ARGS" =~ feature:mpijob || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
     export KUBEFLOW_MPI_MANIFEST="https://raw.githubusercontent.com/kubeflow/mpi-operator/${KUBEFLOW_MPI_VERSION}/deploy/v2beta1/mpi-operator.yaml"
     export KUBEFLOW_MPI_IMAGE=mpioperator/mpi-operator:${KUBEFLOW_MPI_VERSION/#v}
 fi
@@ -551,7 +551,7 @@ function prepare_docker_images {
         e2e_docker_pull_if_needed "${KF_TRAINER_IMAGE}"
     fi
 
-    if [[ -n ${KUBEFLOW_MPI_VERSION:-} ]]; then
+    if [[ -n ${KUBEFLOW_MPI_VERSION:-} && ("$GINKGO_ARGS" =~ feature:mpijob || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${KUBEFLOW_MPI_IMAGE}"
     fi
     if [[ -n ${KUBERAY_VERSION:-} && ("$GINKGO_ARGS" =~ feature:kuberay || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
@@ -621,7 +621,7 @@ function kind_load {
         install_kubeflow_trainer "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
 
-    if [[ -n ${KUBEFLOW_MPI_VERSION:-} ]]; then
+    if [[ -n ${KUBEFLOW_MPI_VERSION:-} && ("$GINKGO_ARGS" =~ feature:mpijob || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         install_mpi "${e2e_cluster_name}" "${e2e_kubeconfig}"
     fi
     if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then

--- a/test/e2e/config/multikueue/extended-shard-0/controller_manager_config.yaml
+++ b/test/e2e/config/multikueue/extended-shard-0/controller_manager_config.yaml
@@ -1,0 +1,54 @@
+apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+metrics:
+  enableClusterQueueResources: true
+leaderElection:
+  leaderElect: true
+controller:
+  groupKindConcurrency:
+    Job.batch: 5
+    Pod: 5
+    Workload.kueue.x-k8s.io: 5
+    LocalQueue.kueue.x-k8s.io: 1
+    ClusterQueue.kueue.x-k8s.io: 1
+    ResourceFlavor.kueue.x-k8s.io: 1
+fairSharing:
+  preemptionStrategies: ["LessThanOrEqualToFinalShare", "LessThanInitialShare"]
+clientConnection:
+  qps: 50
+  burst: 100
+# The MultiKueue remote client requires every enabled framework to have its
+# CRDs installed on every worker cluster, so each shard must only enable the
+# integrations whose operators it installs. This shard installs all extended
+# operators except KubeRay, hence no ray.io/* frameworks here.
+integrations:
+  frameworks:
+  - "batch/job"
+  - "kubeflow.org/mpijob"
+  - "jobset.x-k8s.io/jobset"
+  - "kubeflow.org/paddlejob"
+  - "kubeflow.org/pytorchjob"
+  - "kubeflow.org/tfjob"
+  - "kubeflow.org/xgboostjob"
+  - "kubeflow.org/jaxjob"
+  - "trainer.kubeflow.org/trainjob"
+  - "workload.codeflare.dev/appwrapper"
+  - "pod"
+  - "deployment"
+  - "statefulset"
+  - "leaderworkerset.x-k8s.io/leaderworkerset"
+featureGates:
+  LocalQueueMetrics: true
+  ElasticJobsViaWorkloadSlices: true
+  ConcurrentAdmission: true
+  MultiKueueManagerQuotaAutomation: true
+tls:
+  minVersion: "VersionTLS12"
+  # this is the default ciphersuite for golang 1.25
+  cipherSuites:
+    - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+    - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+    - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+    - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384

--- a/test/e2e/config/multikueue/extended-shard-0/kustomization.yaml
+++ b/test/e2e/config/multikueue/extended-shard-0/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../default
+
+configMapGenerator:
+- behavior: merge
+  files:
+  - controller_manager_config.yaml
+  name: kueue-manager-config
+  namespace: kueue-system

--- a/test/e2e/config/multikueue/extended-shard-1/controller_manager_config.yaml
+++ b/test/e2e/config/multikueue/extended-shard-1/controller_manager_config.yaml
@@ -1,0 +1,47 @@
+apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+metrics:
+  enableClusterQueueResources: true
+leaderElection:
+  leaderElect: true
+controller:
+  groupKindConcurrency:
+    Job.batch: 5
+    Pod: 5
+    Workload.kueue.x-k8s.io: 5
+    LocalQueue.kueue.x-k8s.io: 1
+    ClusterQueue.kueue.x-k8s.io: 1
+    ResourceFlavor.kueue.x-k8s.io: 1
+fairSharing:
+  preemptionStrategies: ["LessThanOrEqualToFinalShare", "LessThanInitialShare"]
+clientConnection:
+  qps: 50
+  burst: 100
+# The MultiKueue remote client requires every enabled framework to have its
+# CRDs installed on every worker cluster, so each shard must only enable the
+# integrations whose operators it installs. This shard only installs KubeRay,
+# hence only the base and ray.io/* frameworks here.
+integrations:
+  frameworks:
+  - "batch/job"
+  - "ray.io/rayjob"
+  - "ray.io/raycluster"
+  - "ray.io/rayservice"
+  - "pod"
+  - "deployment"
+  - "statefulset"
+featureGates:
+  LocalQueueMetrics: true
+  ElasticJobsViaWorkloadSlices: true
+  ConcurrentAdmission: true
+  MultiKueueManagerQuotaAutomation: true
+tls:
+  minVersion: "VersionTLS12"
+  # this is the default ciphersuite for golang 1.25
+  cipherSuites:
+    - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+    - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+    - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+    - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384

--- a/test/e2e/config/multikueue/extended-shard-1/kustomization.yaml
+++ b/test/e2e/config/multikueue/extended-shard-1/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../default
+
+configMapGenerator:
+- behavior: merge
+  files:
+  - controller_manager_config.yaml
+  name: kueue-manager-config
+  namespace: kueue-system

--- a/test/e2e/multikueue/extended/e2e_test.go
+++ b/test/e2e/multikueue/extended/e2e_test.go
@@ -239,10 +239,10 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 		gomega.Expect(client.IgnoreNotFound(k8sWorker1Client.Delete(ctx, rayServiceConfigMap.DeepCopy()))).To(gomega.Succeed())
 		gomega.Expect(client.IgnoreNotFound(k8sWorker2Client.Delete(ctx, rayServiceConfigMap.DeepCopy()))).To(gomega.Succeed())
 
-		rayService := &rayv1.RayService{ObjectMeta: metav1.ObjectMeta{Name: "rayservice1", Namespace: managerNs.Name}}
-		gomega.Expect(client.IgnoreNotFound(k8sManagerClient.Delete(ctx, rayService))).To(gomega.Succeed())
-		gomega.Expect(client.IgnoreNotFound(k8sWorker1Client.Delete(ctx, rayService.DeepCopy()))).To(gomega.Succeed())
-		gomega.Expect(client.IgnoreNotFound(k8sWorker2Client.Delete(ctx, rayService.DeepCopy()))).To(gomega.Succeed())
+		// Use the CRD-tolerant helper: shards without KubeRay have no RayService CRD installed.
+		gomega.Expect(util.DeleteAllRayServicesInNamespace(ctx, k8sManagerClient, managerNs)).To(gomega.Succeed())
+		gomega.Expect(util.DeleteAllRayServicesInNamespace(ctx, k8sWorker1Client, worker1Ns)).To(gomega.Succeed())
+		gomega.Expect(util.DeleteAllRayServicesInNamespace(ctx, k8sWorker2Client, worker2Ns)).To(gomega.Succeed())
 
 		gomega.Expect(util.DeleteNamespace(ctx, k8sManagerClient, managerNs)).To(gomega.Succeed())
 		gomega.Expect(util.DeleteNamespace(ctx, k8sWorker1Client, worker1Ns)).To(gomega.Succeed())

--- a/test/e2e/multikueue/extended/e2e_test.go
+++ b/test/e2e/multikueue/extended/e2e_test.go
@@ -273,7 +273,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 	})
 
 	ginkgo.When("Creating a multikueue integration workload", func() {
-		ginkgo.It("Should sync a LeaderWorkerSet and run replicas on worker cluster", func() {
+		ginkgo.It("Should sync a LeaderWorkerSet and run replicas on worker cluster", ginkgo.Label("feature:leaderworkerset"), func() {
 			lws := testingleaderworkerset.MakeLeaderWorkerSet("leaderworkerset", managerNs.Name).
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				Replicas(2).
@@ -357,7 +357,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			})
 		})
 
-		ginkgo.It("Should dispatch all LeaderWorkerSet workloads to the same worker", func() {
+		ginkgo.It("Should dispatch all LeaderWorkerSet workloads to the same worker", ginkgo.Label("feature:leaderworkerset"), func() {
 			const lwsReplicas = 3
 			lws := testingleaderworkerset.MakeLeaderWorkerSet("leaderworkerset", managerNs.Name).
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
@@ -440,7 +440,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			})
 		})
 
-		ginkgo.It("Should run a jobSet on worker if admitted", func() {
+		ginkgo.It("Should run a jobSet on worker if admitted", ginkgo.Label("feature:jobset"), func() {
 			jobSet := testingjobset.MakeJobSet("job-set", managerNs.Name).
 				Queue(managerLq.Name).
 				ReplicatedJobs(
@@ -520,7 +520,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			})
 		})
 
-		ginkgo.It("Should run an appwrapper containing a job on worker if admitted", func() {
+		ginkgo.It("Should run an appwrapper containing a job on worker if admitted", ginkgo.Label("feature:appwrapper"), func() {
 			jobName := "job-1"
 			aw := testingaw.MakeAppWrapper("aw", managerNs.Name).
 				Queue(managerLq.Name).
@@ -576,7 +576,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			})
 		})
 
-		ginkgo.It("Should run a kubeflow PyTorchJob on worker if admitted", func() {
+		ginkgo.It("Should run a kubeflow PyTorchJob on worker if admitted", ginkgo.Label("feature:pytorchjob"), func() {
 			pyTorchJob := testingpytorchjob.MakePyTorchJob("pytorchjob1", managerNs.Name).
 				ManagedBy(kueue.MultiKueueControllerName).
 				Queue(managerLq.Name).
@@ -634,7 +634,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			})
 		})
 
-		ginkgo.It("Should run a MPIJob on worker if admitted", func() {
+		ginkgo.It("Should run a MPIJob on worker if admitted", ginkgo.Label("feature:mpijob"), func() {
 			mpijob := testingmpijob.MakeMPIJob("mpijob1", managerNs.Name).
 				Queue(managerLq.Name).
 				ManagedBy(kueue.MultiKueueControllerName).
@@ -695,7 +695,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			})
 		})
 
-		ginkgo.It("Should run a TrainJob on worker if admitted", func() {
+		ginkgo.It("Should run a TrainJob on worker if admitted", ginkgo.Label("feature:trainjob"), func() {
 			trainjob := testingtrainjob.MakeTrainJob("trainjob-test", managerNs.Name).
 				RuntimeRefName("torch-distributed").
 				Queue(managerLq.Name).
@@ -723,7 +723,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			})
 		})
 
-		ginkgo.When("Ray integration tests", ginkgo.Ordered, func() {
+		ginkgo.When("Ray integration tests", ginkgo.Ordered, ginkgo.Label("feature:kuberay"), func() {
 			ginkgo.It("Should run a RayJob on worker if admitted", func() {
 				kuberayTestImage := util.GetKuberayTestImage()
 				rayjob := testingrayjob.MakeJob("rayjob1", managerNs.Name).

--- a/test/e2e/multikueue/extended/suite_test.go
+++ b/test/e2e/multikueue/extended/suite_test.go
@@ -80,28 +80,42 @@ var _ = ginkgo.SynchronizedBeforeSuite(
 		util.WaitForKueueAvailability(ctx, k8sWorker1Client)
 		util.WaitForKueueAvailability(ctx, k8sWorker2Client)
 
-		util.WaitForJobSetAvailability(ctx, k8sManagerClient)
-		util.WaitForJobSetAvailability(ctx, k8sWorker1Client)
-		util.WaitForJobSetAvailability(ctx, k8sWorker2Client)
+		labelFilter := ginkgo.GinkgoLabelFilter()
 
-		util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sManagerClient)
-		util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sWorker1Client)
-		util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sWorker2Client)
+		if ginkgo.Label("feature:jobset", "feature:trainjob").MatchesLabelFilter(labelFilter) {
+			util.WaitForJobSetAvailability(ctx, k8sManagerClient)
+			util.WaitForJobSetAvailability(ctx, k8sWorker1Client)
+			util.WaitForJobSetAvailability(ctx, k8sWorker2Client)
+		}
 
-		util.WaitForKubeFlowMPIOperatorAvailability(ctx, k8sWorker1Client)
-		util.WaitForKubeFlowMPIOperatorAvailability(ctx, k8sWorker2Client)
+		if ginkgo.Label("feature:pytorchjob").MatchesLabelFilter(labelFilter) {
+			util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sManagerClient)
+			util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sWorker1Client)
+			util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sWorker2Client)
+		}
 
-		util.WaitForAppWrapperAvailability(ctx, k8sManagerClient)
-		util.WaitForAppWrapperAvailability(ctx, k8sWorker1Client)
-		util.WaitForAppWrapperAvailability(ctx, k8sWorker2Client)
+		if ginkgo.Label("feature:mpijob").MatchesLabelFilter(labelFilter) {
+			util.WaitForKubeFlowMPIOperatorAvailability(ctx, k8sWorker1Client)
+			util.WaitForKubeFlowMPIOperatorAvailability(ctx, k8sWorker2Client)
+		}
 
-		util.WaitForKubeRayOperatorAvailability(ctx, k8sManagerClient)
-		util.WaitForKubeRayOperatorAvailability(ctx, k8sWorker1Client)
-		util.WaitForKubeRayOperatorAvailability(ctx, k8sWorker2Client)
+		if ginkgo.Label("feature:appwrapper").MatchesLabelFilter(labelFilter) {
+			util.WaitForAppWrapperAvailability(ctx, k8sManagerClient)
+			util.WaitForAppWrapperAvailability(ctx, k8sWorker1Client)
+			util.WaitForAppWrapperAvailability(ctx, k8sWorker2Client)
+		}
 
-		util.WaitForLeaderWorkerSetAvailability(ctx, k8sManagerClient)
-		util.WaitForLeaderWorkerSetAvailability(ctx, k8sWorker1Client)
-		util.WaitForLeaderWorkerSetAvailability(ctx, k8sWorker2Client)
+		if ginkgo.Label("feature:kuberay").MatchesLabelFilter(labelFilter) {
+			util.WaitForKubeRayOperatorAvailability(ctx, k8sManagerClient)
+			util.WaitForKubeRayOperatorAvailability(ctx, k8sWorker1Client)
+			util.WaitForKubeRayOperatorAvailability(ctx, k8sWorker2Client)
+		}
+
+		if ginkgo.Label("feature:leaderworkerset").MatchesLabelFilter(labelFilter) {
+			util.WaitForLeaderWorkerSetAvailability(ctx, k8sManagerClient)
+			util.WaitForLeaderWorkerSetAvailability(ctx, k8sWorker1Client)
+			util.WaitForLeaderWorkerSetAvailability(ctx, k8sWorker2Client)
+		}
 
 		ginkgo.GinkgoLogr.Info(
 			"Kueue and all required operators are available in all the clusters",

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -322,6 +322,10 @@ func DeleteAllRayJobsInNamespace(ctx context.Context, c client.Client, ns *corev
 	return deleteAllObjectsInNamespace(ctx, c, ns, &rayv1.RayJob{})
 }
 
+func DeleteAllRayServicesInNamespace(ctx context.Context, c client.Client, ns *corev1.Namespace) error {
+	return deleteAllObjectsInNamespace(ctx, c, ns, &rayv1.RayService{})
+}
+
 func DeleteAllSparkApplicationsInNamespace(ctx context.Context, c client.Client, ns *corev1.Namespace) error {
 	return deleteAllObjectsInNamespace(ctx, c, ns, &sparkv1beta2.SparkApplication{})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/area testing

#### What this PR does / why we need it:

Shards the `multikueue/extended` e2e suite to isolate the KubeRay setup into its own shard.
Split into two shards:

  - shard-0 (`feature:leaderworkerset,jobset,appwrapper,pytorchjob,mpijob,trainjob`): 7 specs; installs JobSet, LeaderWorkerSet, AppWrapper, Kubeflow Training-Operator, Kubeflow MPI and Kubeflow Trainer.
  - shard-1 (`feature:kuberay`): 3 specs; installs only KubeRay + the Ray image.



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #11988

#### Special notes for your reviewer:

- This PR also gates the MPI operator install on the `feature:mpijob` label (in `e2e-common.sh`), aligning it with the other operators so sharding is self-consistent; a side effect is that `test-e2e-extended-shard-1` no longer installs an unused MPI operator.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * E2E extended suite split into two sharded subtargets for balanced parallel execution and focused feature filtering.
  * Tests labeled by feature so each shard runs only relevant scenarios; suite setup only waits for optional operators when selected.
  * Ray cleanup now removes all RayService resources across namespaces.

* **Chores**
  * Test env wiring refined to separate Ray-related settings from other operator-version settings.

* **Infrastructure**
  * Added per-shard controller-manager configurations and kustomize overlays to tailor integrations and feature gates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->