### PR TITLE
Remove unused StartWorkloadSlicePods function

### DIFF
--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"slices"
 
-	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -37,9 +36,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/scheduler/preemption"
-	clientutil "sigs.k8s.io/kueue/pkg/util/client"
 	cmputil "sigs.k8s.io/kueue/pkg/util/cmp"
-	"sigs.k8s.io/kueue/pkg/util/pod"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
@@ -317,39 +314,6 @@ func normalizeActiveSlices(
 	}
 
 	return selectedWorkload, nil
-}
-
-// StartWorkloadSlicePods identifies pods associated with the provided workload
-// that are gated by the ElasticJobSchedulingGate scheduling gate and removes this gate,
-// allowing them to be considered for scheduling.
-//
-// This function performs the following steps:
-//  1. Lists all pods in the same namespace with the WorkloadSliceNameAnnotation matching
-//     the workload slice name.
-//  2. For each pod, removes the ElasticJobSchedulingGate scheduling gate if present.
-//
-// Returns:
-// - An error if any of the operations fail; otherwise, nil.
-func StartWorkloadSlicePods(ctx context.Context, clnt client.Client, wl *kueue.Workload) error {
-	log := ctrl.LoggerFrom(ctx)
-	list := &corev1.PodList{}
-	sliceName := SliceName(wl)
-
-	// First try annotation-based lookup (supports JobSet and other workloads where pods
-	// are not immediate children of the job).
-	if err := clnt.List(ctx, list, client.InNamespace(wl.Namespace), client.MatchingFields{indexer.WorkloadSliceNameKey: sliceName}); err != nil {
-		return fmt.Errorf("failed to list workload slice pods: %w", err)
-	}
-
-	for i := range list.Items {
-		log.V(4).Info("Patching pod to remove elastic job scheduling gate", "podName", list.Items[i].Name, "workloadSliceName", sliceName)
-		if err := clientutil.Patch(ctx, clnt, &list.Items[i], func() (bool, error) {
-			return pod.Ungate(&list.Items[i], kueue.ElasticJobSchedulingGate), nil
-		}); err != nil {
-			return fmt.Errorf("failed to patch pod: %w", err)
-		}
-	}
-	return nil
 }
 
 // ReplacedWorkloadSlice returns the replacement workload slice for the given workload `wl`

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1141,130 +1140,6 @@ func TestNormalizeActiveSlices(t *testing.T) {
 				if !kept && !workload.IsFinished(wl) {
 					t.Errorf("workload %q should be finished but is not", wl.Name)
 				}
-			}
-		})
-	}
-}
-
-func Test_StartWorkloadSlicePods(t *testing.T) {
-	clientBuilder := func() *fake.ClientBuilder {
-		return fake.NewClientBuilder().WithScheme(scheme.Scheme).
-			WithIndex(&corev1.Pod{}, indexer.WorkloadSliceNameKey, indexer.IndexPodWorkloadSliceName)
-	}
-	testPod := func(name, resourceVersion, sliceName string, schedulingGates ...corev1.PodSchedulingGate) corev1.Pod {
-		return corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            name,
-				Namespace:       "default",
-				ResourceVersion: resourceVersion,
-				Annotations: map[string]string{
-					kueue.WorkloadSliceNameAnnotation: sliceName,
-				},
-			},
-			Spec: corev1.PodSpec{
-				SchedulingGates: schedulingGates,
-			},
-		}
-	}
-	testWorkload := &kueue.Workload{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-workload",
-			Namespace: "default",
-			Annotations: map[string]string{
-				kueue.WorkloadSliceNameAnnotation: "test-slice",
-			},
-		},
-	}
-
-	type args struct {
-		clnt client.Client
-		wl   *kueue.Workload
-	}
-	tests := map[string]struct {
-		args     args
-		wantErr  bool
-		wantPods *corev1.PodList
-	}{
-		"FailureToListPods": {
-			args: args{
-				clnt: clientBuilder().WithInterceptorFuncs(interceptor.Funcs{
-					List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
-						return errors.New("test-list-pods-error")
-					},
-				}).Build(),
-				wl: testWorkload,
-			},
-			wantErr: true,
-		},
-		"NoPods": {
-			args: args{
-				clnt: clientBuilder().Build(),
-				wl:   testWorkload,
-			},
-		},
-		"ProcessPods": {
-			args: args{
-				clnt: clientBuilder().WithLists(&corev1.PodList{
-					Items: []corev1.Pod{
-						// Un-gated pod should remain un-gated, i.e., no change.
-						testPod("test-one", "100", "test-slice"),
-						// Gated pod - gate should be removed.
-						testPod("test-two", "200", "test-slice", corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}),
-						// Gated with some other gate -
-						testPod("test-three", "300", "test-slice", corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}, corev1.PodSchedulingGate{Name: kueue.TopologySchedulingGate}),
-						// Other gated pod (not for this workload slice)
-						testPod("other-pod", "400", "other-slice", corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}),
-					},
-				}).Build(),
-				wl: testWorkload,
-			},
-			wantPods: &corev1.PodList{
-				Items: []corev1.Pod{
-					testPod("test-one", "100", "test-slice"),
-					// Gated pod - gate removed (resource version increase).
-					testPod("test-two", "201", "test-slice"),
-					// Gated with some other gate - other gate remains (resource version increased).
-					testPod("test-three", "301", "test-slice", corev1.PodSchedulingGate{Name: kueue.TopologySchedulingGate}),
-					// Other gated pod (not for this workload slice) - no change.
-					testPod("other-pod", "400", "other-slice", corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}),
-				},
-			},
-		},
-		"FailureUpdatingPod": {
-			args: args{
-				clnt: clientBuilder().WithLists(&corev1.PodList{
-					Items: []corev1.Pod{
-						testPod("test", "100", "test-slice", corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}),
-					},
-				}).WithInterceptorFuncs(interceptor.Funcs{
-					Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
-						return errors.New("test-pod-patch-error")
-					},
-				}).
-					Build(),
-				wl: testWorkload,
-			},
-			wantErr: true,
-		},
-	}
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			ctx, _ := utiltesting.ContextWithLog(t)
-			if err := StartWorkloadSlicePods(ctx, tt.args.clnt, tt.args.wl); (err != nil) != tt.wantErr {
-				t.Errorf("StartWorkloadSlicePods() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if tt.wantPods == nil {
-				return
-			}
-
-			pods := &corev1.PodList{}
-			if err := tt.args.clnt.List(ctx, pods); err != nil {
-				t.Errorf("unexpected list error: %v", err)
-			}
-			if diff := cmp.Diff(pods.Items, tt.wantPods.Items, cmpopts.SortSlices(func(a, b corev1.Pod) bool {
-				return a.Name < b.Name
-			})); diff != "" {
-				t.Errorf("StartWorkloadSlicePods() pod-validaion: got(-),want(+): %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
StartWorkloadSlicePods became dead code after #10272 moved pod ungating to the dedicated ElasticJobUngater controller. Remove the function, its test, and the imports that were only needed by it.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes the unused StartWorkloadSlicePods function, its unit test, and the imports that were only needed by it (corev1, clientutil, pod in the main file; scheme in the test file). This function became dead code after #10272 moved pod ungating to the dedicated ElasticJobUngater controller. It was intentionally left behind in that PR to keep the diff minimal, and issue #12036 was filed to track its removal.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12036

#### Special notes for your reviewer:

AI usage disclosure: this PR was prepared with AI assistance; all changes have been reviewed and verified.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused internal workload processing function and associated test coverage.
  * Cleaned up unnecessary dependencies from the workload slicing package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->