### PR TITLE
Graduate AdmissionGatedBy feature gate to beta

### DIFF
--- a/keps/6915-scheduling-gated-by-annotation/README.md
+++ b/keps/6915-scheduling-gated-by-annotation/README.md
@@ -228,7 +228,7 @@ Validation enforces:
 - For each controller name, the characters before the first "/" must be a
   valid subdomain as defined by RFC 1123 and all characters trailing the
   first "/" must follow RFC 3986.
-- Feature gate: `AdmissionGatedBy` (Alpha, default off)
+- Feature gate: `AdmissionGatedBy` (Beta, default on)
 
 ### Implementation Overview
 

--- a/keps/6915-scheduling-gated-by-annotation/kep.yaml
+++ b/keps/6915-scheduling-gated-by-annotation/kep.yaml
@@ -20,16 +20,17 @@ see-also: []
 replaces: []
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.17"
+latest-milestone: "v0.19"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v0.17"
+  beta: "v0.19"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -74,7 +74,7 @@ const (
 	// until the annotation is removed. The value is a comma-separated list of
 	// controller names (e.g., "example.com/controller1,example.com/controller2").
 	//
-	// This annotation is alpha-level and requires the AdmissionGatedBy feature gate, disabled by default.
+	// This annotation is beta-level and requires the AdmissionGatedBy feature gate, enabled by default.
 	AdmissionGatedByAnnotation = "kueue.x-k8s.io/admission-gated-by"
 
 	// ElasticJobAnnotation is an annotation set on the Job to indicate that it is an elastic job.

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -488,7 +488,7 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"statefulset with AdmissionGatedBy annotation but feature gate disabled should not propagate": {
-			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false, features.AdmissionGatedBy: false},
 			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
 			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				UID("sts-uid").

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -646,6 +646,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	AdmissionGatedBy: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
 	},
 	ShortWorkloadNames: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha},

--- a/site/content/en/docs/concepts/admission.md
+++ b/site/content/en/docs/concepts/admission.md
@@ -7,7 +7,7 @@ description: >
 ---
 
 Kueue's admission process determines whether a Workload can begin execution.
-Admission may also be subject to the [admission gate mechanism](/docs/reference/labels-and-annotations/#kueuex-k8sioadmission-gated-by) which is currently in alpha.
+Admission may also be subject to the [admission gate mechanism](/docs/reference/labels-and-annotations/#kueuex-k8sioadmission-gated-by) which is in beta and enabled by default.
 
 It involves verifying:
 - logical resource availability via quota reservation

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -17,6 +17,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.17"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
 - name: AssignQueueLabelsForPods
   versionedSpecs:
   - default: true

--- a/site/data/labels_and_annotations.yaml
+++ b/site/data/labels_and_annotations.yaml
@@ -4,7 +4,7 @@
   used_on: |
     Kueue-managed Jobs.
   description: |
-    This annotation requires the `AdmissionGatedBy` feature that is disabled by default.
+    This annotation requires the `AdmissionGatedBy` feature that is enabled by default.
     
     When it contains a value, the annotation prevents the Job from entering the Quota Reservation
     phase of Kueue's Admission Flow.

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -17,6 +17,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.17"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
 - name: AssignQueueLabelsForPods
   versionedSpecs:
   - default: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind kep

#### What this PR does / why we need it:

Graduates `AdmissionGatedBy` to Beta for v0.19 (enabled by default). The feature has been in Alpha since v0.17 with no bugs reported and adoption growing (see slack thread in #12042). This flips the default, updates the KEP/docs, and fixes one test that was relying on the old default.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12042

#### Special notes for your reviewer:

The only test change is in `statefulset_reconciler_test.go`: the test case "statefulset with AdmissionGatedBy annotation but feature gate disabled should not propagate" previously relied on the Alpha default (off) without explicitly setting `AdmissionGatedBy: false`. With the Beta default (on), this needed to be pinned explicitly. All other disabled-behavior tests across the codebase already set the gate explicitly.

AI usage disclosure: this PR was prepared with AI assistance; all changes have been reviewed and verified.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Graduate the AdmissionGatedBy feature gate to Beta, enabled by default. Users who previously had to manually enable this gate no longer need to. Users who do not use the `kueue.x-k8s.io/admission-gated-by` annotation are unaffected.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated admission-gating mechanism documentation to reflect beta status and default-enabled configuration.

* **Chores**
  * Progressed AdmissionGatedBy feature gate from alpha to beta, now enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->