### PR TITLE
Push ray-project-mini image to staging storage.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -544,6 +544,10 @@ ray-project-mini-image-build:
 		$(IMAGE_BUILD_EXTRA_OPTS) \
 		-f ./hack/testing/ray-mini/Dockerfile ./ \
 
+.PHONY: ray-project-mini-image-build-push
+ray-project-mini-image-build-push: PUSH=--push
+ray-project-mini-image-build-push: ray-project-mini-image-build
+
 # The step is required for local e2e test run
 .PHONY: kind-ray-project-mini-image-build
 kind-ray-project-mini-image-build: PLATFORMS=$(HOST_IMAGE_PLATFORM)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,6 +14,7 @@ steps:
       - kueueviz-image-push
       - kueue-populator-image-push
       - kueue-priority-booster-image-push
+      - ray-project-mini-image-build-push
     env:
       - DOCKER_BUILDX_CMD=/buildx-entrypoint
       - GOTOOLCHAIN=auto


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Push image to staging storage.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #12103

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a dedicated image push step that separately invokes the image build with explicit push behavior, making image publication an explicit single-step operation.
  * Simplified an end-to-end test target so it now performs only the image push step (removing prior environment setup and extended test run), streamlining test invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->