### PR TITLE
test: test/e2e/sequential/baseline /default_config_test.go should use defaultKueueCfg only once

### DIFF
--- a/test/e2e/sequential/baseline/default_config_test.go
+++ b/test/e2e/sequential/baseline/default_config_test.go
@@ -45,11 +45,10 @@ const (
 )
 
 var _ = ginkgo.Describe("Default configuration tests", ginkgo.Label(util.Shard0), ginkgo.Ordered, func() {
-
 	ginkgo.BeforeAll(func() {
 		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
 	})
-	
+
 	ginkgo.Context("Certs", func() {
 		var (
 			ns             *corev1.Namespace

--- a/test/e2e/sequential/baseline/default_config_test.go
+++ b/test/e2e/sequential/baseline/default_config_test.go
@@ -45,6 +45,11 @@ const (
 )
 
 var _ = ginkgo.Describe("Default configuration tests", ginkgo.Label(util.Shard0), ginkgo.Ordered, func() {
+
+	ginkgo.BeforeAll(func() {
+		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
+	})
+	
 	ginkgo.Context("Certs", func() {
 		var (
 			ns             *corev1.Namespace
@@ -258,10 +263,6 @@ var _ = ginkgo.Describe("Default configuration tests", ginkgo.Label(util.Shard0)
 			cq *kueue.ClusterQueue
 			lq *kueue.LocalQueue
 		)
-
-		ginkgo.BeforeEach(func() {
-			util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
-		})
 
 		ginkgo.BeforeEach(func() {
 			ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "ha-failover-")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area testing


#### What this PR does / why we need it:
The idea for test/e2e/sequential/baseline /default_config_test.go was to use util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName) only once, for all tests in the file.

#### Which issue(s) this PR fixes:

Fixes #12083

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Moved configuration update and controller restart into a global test setup so they run once before the suite.
  * Removed redundant context-specific setup for HA failover, reducing duplication and making test initialization more streamlined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->