### PR TITLE
Automated cherry pick of #12113: Push ray-project-mini image to staging storage.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -504,6 +504,10 @@ ray-project-mini-image-build:
 		$(IMAGE_BUILD_EXTRA_OPTS) \
 		-f ./hack/testing/ray-mini/Dockerfile ./ \
 
+.PHONY: ray-project-mini-image-build-push
+ray-project-mini-image-build-push: PUSH=--push
+ray-project-mini-image-build-push: ray-project-mini-image-build
+
 # The step is required for local e2e test run
 .PHONY: kind-ray-project-mini-image-build
 kind-ray-project-mini-image-build: PLATFORMS=$(HOST_IMAGE_PLATFORM)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,6 +13,7 @@ steps:
       - helm-chart-push
       - kueueviz-image-push
       - kueue-populator-image-push
+      - ray-project-mini-image-build-push
     env:
       - DOCKER_BUILDX_CMD=/buildx-entrypoint
       - GOTOOLCHAIN=auto


### PR DESCRIPTION
Cherry pick of #12113 on release-0.17.

#12113: Push ray-project-mini image to staging storage.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```