### PR TITLE
Reject sources in deviceClassMappings when KueueDRAIntegrationPartitionableDevices is disabled

### DIFF
--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -506,39 +506,45 @@ func validateDeviceClassMappings(c *configapi.Configuration) field.ErrorList {
 			}
 		}
 
-		if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) && len(mapping.Sources) > 0 {
-			if len(mapping.Sources) > 1 {
-				allErrs = append(allErrs, field.TooMany(mappingPath.Child("sources"), len(mapping.Sources), 1))
-			}
-			celCache := dracel.NewCache(len(mapping.Sources), dracel.Features{})
-			for sIdx, source := range mapping.Sources {
-				sourcePath := mappingPath.Child("sources").Index(sIdx)
-				if source.Counter == nil {
-					allErrs = append(allErrs, field.Required(sourcePath.Child("counter"), "exactly one source type must be set"))
-					continue
+		if len(mapping.Sources) > 0 {
+			sourcesPath := mappingPath.Child("sources")
+			if !features.Enabled(features.KueueDRAIntegrationPartitionableDevices) {
+				allErrs = append(allErrs, field.Invalid(sourcesPath, len(mapping.Sources),
+					"sources require KueueDRAIntegrationPartitionableDevices to be enabled"))
+			} else {
+				if len(mapping.Sources) > 1 {
+					allErrs = append(allErrs, field.TooMany(sourcesPath, len(mapping.Sources), 1))
 				}
-				counterPath := sourcePath.Child("counter")
-				if source.Counter.Name == "" {
-					allErrs = append(allErrs, field.Required(counterPath.Child("name"), ""))
-				} else if len(source.Counter.Name) > 63 {
-					allErrs = append(allErrs, field.Invalid(counterPath.Child("name"), source.Counter.Name, "must not exceed 63 characters"))
-				}
-				if source.Counter.Driver == "" {
-					allErrs = append(allErrs, field.Required(counterPath.Child("driver"), ""))
-				} else if len(source.Counter.Driver) > 253 {
-					allErrs = append(allErrs, field.Invalid(counterPath.Child("driver"), source.Counter.Driver, "must not exceed 253 characters"))
-				}
-				selectorPath := counterPath.Child("deviceSelector", "cel", "expression")
-				if source.Counter.DeviceSelector.CEL == nil || source.Counter.DeviceSelector.CEL.Expression == "" {
-					allErrs = append(allErrs, field.Required(selectorPath, ""))
-				} else {
-					result := celCache.GetOrCompile(source.Counter.DeviceSelector.CEL.Expression)
-					if result.Error != nil {
-						allErrs = append(allErrs, field.Invalid(
-							selectorPath,
-							source.Counter.DeviceSelector.CEL.Expression,
-							fmt.Sprintf("CEL compilation failed: %v", result.Error),
-						))
+				celCache := dracel.NewCache(len(mapping.Sources), dracel.Features{})
+				for sIdx, source := range mapping.Sources {
+					sourcePath := sourcesPath.Index(sIdx)
+					if source.Counter == nil {
+						allErrs = append(allErrs, field.Required(sourcePath.Child("counter"), "exactly one source type must be set"))
+						continue
+					}
+					counterPath := sourcePath.Child("counter")
+					if source.Counter.Name == "" {
+						allErrs = append(allErrs, field.Required(counterPath.Child("name"), ""))
+					} else if len(source.Counter.Name) > 63 {
+						allErrs = append(allErrs, field.Invalid(counterPath.Child("name"), source.Counter.Name, "must not exceed 63 characters"))
+					}
+					if source.Counter.Driver == "" {
+						allErrs = append(allErrs, field.Required(counterPath.Child("driver"), ""))
+					} else if len(source.Counter.Driver) > 253 {
+						allErrs = append(allErrs, field.Invalid(counterPath.Child("driver"), source.Counter.Driver, "must not exceed 253 characters"))
+					}
+					selectorPath := counterPath.Child("deviceSelector", "cel", "expression")
+					if source.Counter.DeviceSelector.CEL == nil || source.Counter.DeviceSelector.CEL.Expression == "" {
+						allErrs = append(allErrs, field.Required(selectorPath, ""))
+					} else {
+						result := celCache.GetOrCompile(source.Counter.DeviceSelector.CEL.Expression)
+						if result.Error != nil {
+							allErrs = append(allErrs, field.Invalid(
+								selectorPath,
+								source.Counter.DeviceSelector.CEL.Expression,
+								fmt.Sprintf("CEL compilation failed: %v", result.Error),
+							))
+						}
 					}
 				}
 			}

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1126,6 +1126,34 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
+		"sources configured but KueueDRAIntegrationPartitionableDevices disabled": {
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "gpu.memory",
+							DeviceClassNames: []corev1.ResourceName{"mig.nvidia.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Counter: &configapi.DeviceClassCounterSource{
+									Name:   "memory",
+									Driver: "gpu.nvidia.com",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.nvidia.com'"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.deviceClassMappings[0].sources",
+				},
+			},
+		},
 		"sources: missing driver": {
 			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegrationPartitionableDevices: true},
 			cfg: &configapi.Configuration{


### PR DESCRIPTION
  
  
  <!--  Thanks for sending a pull request!  Here are some tips for you:
  
  1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
  2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
  3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
  4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
  5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
  -->
  
  #### What type of PR is this?
  /kind bug

  
  #### What this PR does / why we need it:
This adds config validation to reject `sources` when the PD gate is off, matching the KEP requirement at keps/2941-DRA/README.md.
  
  #### Which issue(s) this PR fixes:
  <!--
  *Automatically closes linked issue when PR is merged.
  Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
  _If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
  -->
  Fixes #
  
  #### Special notes for your reviewer:
Found this bug downstream: https://redhat.atlassian.net/browse/OCPBUGS-88341
  
  #### Does this PR introduce a user-facing change?
  <!--
  If no, just write "NONE" in the release-note block below.
  If yes, a release note is required:
  Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
  -->
  ```release-note
DRA: Fixed configuration validation to reject `deviceClassMappings[].sources` when the `KueueDRAIntegrationPartitionableDevices` feature gate is disabled, preventing unsupported partitionable-device configuration from being accepted.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation to enforce device class mapping constraints when feature gates are disabled, preventing invalid configuration scenarios.

* **Tests**
  * Added validation test coverage for device class mapping constraints with disabled feature gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->