### PR TITLE
Skip AfterSuite Kueue config resets outside dev mode

### DIFF
--- a/test/e2e/sequential/baseline/suite_test.go
+++ b/test/e2e/sequential/baseline/suite_test.go
@@ -64,5 +64,7 @@ var _ = ginkgo.BeforeSuite(func() {
 })
 
 var _ = ginkgo.AfterSuite(func() {
-	util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
+	if util.IsE2EModeDev() {
+		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
+	}
 })

--- a/test/e2e/sequential/extended/suite_test.go
+++ b/test/e2e/sequential/extended/suite_test.go
@@ -70,5 +70,7 @@ var _ = ginkgo.BeforeSuite(func() {
 })
 
 var _ = ginkgo.AfterSuite(func() {
-	util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
+	if util.IsE2EModeDev() {
+		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
+	}
 })

--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -83,6 +83,14 @@ const (
 	DefaultMetricsServiceName = "kueue-controller-manager-metrics-service"
 )
 
+// IsE2EModeDev returns true when E2E_MODE is set to "dev".
+// Use this to skip teardown steps that only make sense when the cluster
+// is kept around after the test run (local development), but are
+// unnecessary in CI where the cluster is ephemeral.
+func IsE2EModeDev() bool {
+	return os.Getenv("E2E_MODE") == "dev"
+}
+
 func GetKueueNamespace() string {
 	if ns := os.Getenv("KUEUE_NAMESPACE"); ns != "" {
 		return ns


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind cleanup
/area testing

#### What this PR does / why we need it:

The sequential baseline and extended e2e suites reset the Kueue
configuration to the default in AfterSuite, which restarts the
controller manager and waits for it to become available (~25s each).
The reset exists only to leave a locally kept cluster in a clean state.
In CI the cluster is deleted right after the run, so the restart is
wasted time.

This PR adds `util.IsE2EModeDev()` and gates both AfterSuite resets on
it, as suggested in
https://github.com/kubernetes-sigs/kueue/issues/12124#issuecomment-4683845695.
Local runs with `E2E_MODE=dev` keep the current behavior.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #12124, contributes to #11606.

#### Special notes for your reviewer:

The multikueue AfterSuites are untouched: they clean up shared secrets,
not configuration, so there is nothing to skip.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @mimowo 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Optimized end-to-end test teardown behavior to conditionally skip cluster restart steps during local development, reducing test cycle time while maintaining full cleanup in CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->