### PR TITLE
Restart worker Kueues in parallel in preemption E2E test

### DIFF
--- a/test/e2e/multikueue/sequential/e2e_test.go
+++ b/test/e2e/multikueue/sequential/e2e_test.go
@@ -19,6 +19,7 @@ package sequential
 import (
 	"fmt"
 	"os/exec"
+	"sync"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/onsi/ginkgo/v2"
@@ -48,6 +49,22 @@ import (
 	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/test/util"
 )
+
+// updateAndRestartConcurrently runs the given functions in parallel goroutines,
+// each guarded with GinkgoRecover so that gomega assertions propagate failures
+// back to the calling Ginkgo node.
+func updateAndRestartConcurrently(fns ...func()) {
+	var wg sync.WaitGroup
+	wg.Add(len(fns))
+	for _, fn := range fns {
+		go func() {
+			defer ginkgo.GinkgoRecover()
+			defer wg.Done()
+			fn()
+		}()
+	}
+	wg.Wait()
+}
 
 var _ = ginkgo.Describe("MultiKueue Sequential", func() {
 	var (
@@ -710,16 +727,34 @@ var _ = ginkgo.Describe("MultiKueue Sequential", func() {
 					cfg.FeatureGates[string(features.MultiKueueOrchestratedPreemption)] = true
 				}
 
+				// Restart the manager first: its new leader needs time to
+				// re-establish the MultiKueue remote clients, and a workload
+				// reconciled before any cluster is connected is not requeued
+				// when the clusters connect. The worker restarts below provide
+				// that warm-up window.
 				util.UpdateKueueConfigurationAndRestart(ctx, k8sManagerClient, defaultManagerKueueCfg.DeepCopy(), managerClusterName, updateCfg)
-				util.UpdateKueueConfigurationAndRestart(ctx, k8sWorker1Client, defaultWorker1KueueCfg.DeepCopy(), worker1ClusterName, updateCfg)
-				util.UpdateKueueConfigurationAndRestart(ctx, k8sWorker2Client, defaultWorker2KueueCfg.DeepCopy(), worker2ClusterName, updateCfg)
+				updateAndRestartConcurrently(
+					func() {
+						util.UpdateKueueConfigurationAndRestart(ctx, k8sWorker1Client, defaultWorker1KueueCfg.DeepCopy(), worker1ClusterName, updateCfg)
+					},
+					func() {
+						util.UpdateKueueConfigurationAndRestart(ctx, k8sWorker2Client, defaultWorker2KueueCfg.DeepCopy(), worker2ClusterName, updateCfg)
+					},
+				)
 			})
 		})
 		ginkgo.AfterAll(func() {
 			ginkgo.By("reverting the configuration", func() {
+				// Manager first, for the same reason as in BeforeAll.
 				util.UpdateKueueConfigurationAndRestart(ctx, k8sManagerClient, defaultManagerKueueCfg, managerClusterName)
-				util.UpdateKueueConfigurationAndRestart(ctx, k8sWorker1Client, defaultWorker1KueueCfg, worker1ClusterName)
-				util.UpdateKueueConfigurationAndRestart(ctx, k8sWorker2Client, defaultWorker2KueueCfg, worker2ClusterName)
+				updateAndRestartConcurrently(
+					func() {
+						util.UpdateKueueConfigurationAndRestart(ctx, k8sWorker1Client, defaultWorker1KueueCfg, worker1ClusterName)
+					},
+					func() {
+						util.UpdateKueueConfigurationAndRestart(ctx, k8sWorker2Client, defaultWorker2KueueCfg, worker2ClusterName)
+					},
+				)
 			})
 		})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind cleanup
/area testing
/area multikueue

#### What this PR does / why we need it:

The `MultiKueueOrchestratedPreemption is enabled` block restarts the
kueue-controller-manager on the manager and both worker clusters, one
after another, in both BeforeAll and AfterAll: ~150s of restarts per
run at ~25s each.

The two worker restarts are independent, so this PR runs them in
parallel goroutines (guarded with `ginkgo.GinkgoRecover()` so a failed
assertion still fails the calling Ginkgo node). Each block drops from
~75s to ~50s.

The manager restart stays first and synchronous on purpose. Right
after its rollout, the new leader is still acquiring the lease and
reconnecting the MultiKueue remote clients; a workload reconciled in
that window finds no connected clusters and is never requeued when
they connect, so the test times out (reproduced locally). The worker
restarts give the manager that warm-up window, as the old sequential
ordering did implicitly.

Verified with a focused local run: manager restart ~25s, the two
worker restarts overlapping at ~25s combined, spec passes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #12124, contributes to #11606

#### Special notes for your reviewer:

The BeforeAll closure only reads the feature-gate map and DeepCopies
the config before mutating, so the two goroutines share no mutable
state.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added concurrent execution for restart operations in e2e tests to improve performance while maintaining reliability.
  * Enhanced assertion error handling and recovery mechanisms for parallel test operations.
  * Optimized the setup and teardown sequence for MultiKueueOrchestratedPreemption testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->