### PR TITLE
test/e2e: probe webhook data path after kueue rolling restart

### DIFF
--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -498,6 +498,16 @@ func waitForKueueControllerReadyWithWebhookEndpoints(ctx context.Context, k8sCli
 		g.Expect(endpointIPs).To(gomega.Equal(readyPodIPs))
 	}, LongTimeout, Interval).Should(gomega.Succeed())
 
+	// EndpointSlice readiness does not guarantee that the apiserver has dropped
+	// stale webhook connections, so verify the webhook path itself.
+	ginkgo.By(fmt.Sprintf("Probing the webhook data path: %q", key))
+	gomega.Eventually(func(g gomega.Gomega) {
+		probeRF := &kueue.ResourceFlavor{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "webhook-probe-"},
+		}
+		g.Expect(k8sClient.Create(ctx, probeRF, client.DryRunAll)).To(gomega.Succeed())
+	}, LongTimeout, Interval).Should(gomega.Succeed())
+
 	ginkgo.GinkgoLogr.Info("Ready pods and webhook endpoints verified", "deployment", key, "waitingTime", time.Since(waitStart))
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind flake
/area testing

#### What this PR does / why we need it:

Post-restart readiness currently verifies Deployment, EndpointSlice, and leader-election state, but it does not guarantee that the apiserver can successfully call the webhook.

This PR adds an active webhook data-path probe after the webhook endpoints are ready. It retries a server-side dry-run `ResourceFlavor` create until it succeeds, so tests continue only after the apiserver-to-webhook path is usable.

The dry-run probe leaves no objects behind and avoids exposing tests to the first stale webhook connection after a rolling update.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12075

#### Special notes for your reviewer:
- Each failed probe attempt can consume one webhook timeout (10s). The probe is wrapped in LongTimeout, so it can absorb the stale first call and still retry. When the webhook path is already healthy, it adds only a single dry-run round trip.
- This may also help the same class of post-restart webhook flakes, such as #12084. #12041 is possibly related

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced webhook readiness verification for Kueue controller by adding a probing check that validates the webhook data path is responding correctly during health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->