### PR TITLE
test/e2e: deflake Prometheus target discovery

### DIFF
--- a/test/e2e/certmanager/metrics_test.go
+++ b/test/e2e/certmanager/metrics_test.go
@@ -201,7 +201,7 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Ordered, func() {
 					}
 				}
 				g.Expect(hasKueueTarget).To(gomega.BeTrue(), "Kueue target not found. Active targets: %v", result.Active)
-			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("Verifying admission metric is available via PromQL")
 			gomega.Eventually(func(g gomega.Gomega) {


### PR DESCRIPTION

#### What type of PR is this?
/kind bug
/kind flake

#### What this PR does / why we need it:
Switches to `LongTimeout` due to slow Prometheus target discovery.

The slow propagation of ServiceMonitor/config reload events could be the reason for the flake, so having a bit extra time seems reasonable.
#### Which issue(s) this PR fixes:
Fixes #12091

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased timeout duration for Prometheus metrics target discovery verification in end-to-end tests to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->