### PR TITLE
test/e2e: deflake baseline Prometheus checks

### DIFF
--- a/test/e2e/singlecluster/baseline/prometheus_test.go
+++ b/test/e2e/singlecluster/baseline/prometheus_test.go
@@ -52,7 +52,7 @@ var _ = ginkgo.Describe("Prometheus", ginkgo.Label("area:prometheus", "feature:p
 				}
 			}
 			g.Expect(hasKueueTarget).To(gomega.BeTrue(), "Kueue target not found. Active targets: %v", result.Active)
-		}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+		}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 	})
 
 	ginkgo.It("should scrape kueue_build_info metric via PromQL", func() {
@@ -64,7 +64,7 @@ var _ = ginkgo.Describe("Prometheus", ginkgo.Label("area:prometheus", "feature:p
 			g.Expect(ok).To(gomega.BeTrue())
 			g.Expect(vector).NotTo(gomega.BeEmpty())
 			g.Expect(string(vector[0].Metric[model.MetricNameLabel])).To(gomega.Equal(kueueBuildInfoMetric))
-		}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+		}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 	})
 
 	ginkgo.It("should report workload admission metrics via PromQL", func() {
@@ -123,6 +123,6 @@ var _ = ginkgo.Describe("Prometheus", ginkgo.Label("area:prometheus", "feature:p
 			vector, ok := result.(model.Vector)
 			g.Expect(ok).To(gomega.BeTrue())
 			g.Expect(vector).NotTo(gomega.BeEmpty())
-		}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+		}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 	})
 })


### PR DESCRIPTION

#### What type of PR is this?
/kind bug
/kind flake


#### What this PR does / why we need it:
Increases baseline Prometheus e2e waits to `LongTimeout` to account for slow ServiceMonitor/config propagation.

xref: https://github.com/kubernetes-sigs/kueue/issues/12123#issuecomment-4689642265
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12123

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Prometheus monitoring test timeouts for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->