### PR TITLE
Tune KubeRay e2e task durations for faster CI

### DIFF
--- a/test/e2e/singlecluster/extended/kuberay_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_test.go
@@ -242,10 +242,14 @@ def my_task(x, s):
     time.sleep(s)
     return x * x
 
-# 3 parallel tasks with 60s sleep: triggers scale-up to 2 workers
-# (1 task on head + 2 on workers) and keeps them alive through
-# pod replacement verification.
-print(ray.get([my_task.remote(i, 60) for i in range(3)]))`,
+# A queue of 20 short tasks (~200 task-seconds over at most 3 slots:
+# 1 on head + 1 per worker) triggers scale-up to 2 workers and keeps
+# both busy through pod replacement verification: pending tasks hold
+# the demand no matter how long scale-up or replacement takes, and the
+# job drains quickly once the queue is empty. With a few long tasks
+# instead, their expiry races the autoscaler's idle scale-down
+# (idleTimeoutSeconds=10) during verification.
+print(ray.get([my_task.remote(i, 10) for i in range(20)]))`,
 			},
 		}
 
@@ -443,8 +447,10 @@ print(ray.get([my_task.remote(i, 8) for i in range(4)]))
 # create workload slices, and schedule new workers.
 print(ray.get([my_task.remote(i, 8) for i in range(16)]))
 
-# run tasks in sequence to trigger scaling down
-print([ray.get(my_task.remote(i, 1)) for i in range(32)])`,
+# run tasks in sequence to trigger scaling down; 20 tasks (~25s with
+# scheduling overhead) keep the job alive through idle detection
+# (idleTimeoutSeconds=10) and the scale-down annotation update
+print([ray.get(my_task.remote(i, 1)) for i in range(20)])`,
 			},
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind cleanup
/area testing

#### What this PR does / why we need it:

Two specs dominate the kuberay CI shards, per the junit from the prow
run linked in #12176:

| Spec | Shard | CI duration |
|---|---|---|
| Should run a rayjob with InTreeAutoscaling | kuberay-b | 206s |
| Should run a rayjob with multi scale-up steps | kuberay-a | 179s |

**InTreeAutoscaling**: replace the 3 tasks of 60s with a queue of 20
tasks of 10s (the same ~200 task-seconds of work).

The long tasks make the job end late: the deleted worker's task
restarts on the replacement pod, adding ~85s after replacement is
verified. Shorter sleeps are unsafe: scale-up takes ~40s in CI, so
30s tasks finish before the second worker starts and the autoscaler
(idleTimeoutSeconds=10, minReplicas=1) scales the idle first worker
down under the "2 running workers" assertions. The queue avoids
both: pending tasks hold worker demand through verification, and the
job drains within ~10s once the queue empties.

**Multi scale-up**: cut the trailing keep-alive tasks from 32 to 20.
They only need to outlive scale-down verification (the 10s idle
timeout plus an annotation update); 20 tasks (~25s) do.

Local A/B runs on a kind cluster:

| Spec | main | this PR |
|---|---|---|
| multi scale-up | 120-123s | 107-110s |
| InTreeAutoscaling | 118-121s | 116-117s |

Locally the pod deletion lands early, so main's tail barely shows.
In CI it lands late (the ~85s tail in the 205.7s baseline); the
queue's tail stays bounded no matter when the deletion lands, so the
spec gets faster and more deterministic in CI.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #12176, contributes to #11606

#### Special notes for your reviewer:

The verification steps and timeouts are unchanged; only the Ray task
payloads are tuned.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
