### PR TITLE
secure path to avoid path traversal issues

### DIFF
--- a/keps/693-multikueue/README.md
+++ b/keps/693-multikueue/README.md
@@ -152,6 +152,23 @@ deployments with very high job throughput (above 1M jobs per day).
     learning the state of the world from the worker clusters (not covered
     by this KEP).
 
+* **Arbitrary file read via `locationType=Path`**: When `KubeConfig.LocationType`
+  is set to `Path`, the controller reads the file at the user-supplied location
+  using `os.ReadFile`. Without path restrictions, any principal with
+  `create`/`update` access to `MultiKueueCluster` resources could read arbitrary
+  files from the controller pod's filesystem (e.g. the projected service account
+  token). This is mitigated by:
+  * Gating safe path validation behind the `MultiKueueKubeConfigPathValidation` feature
+    gate (Alpha, default disabled). When the gate is on, only
+    paths under the hardcoded prefix `/etc/multikueue/kubeconfigs/` are
+    accepted. When disabled, the controller falls back to the legacy
+    behavior of allowing any path.
+  * Canonicalizing and validating the path: the controller cleans the path,
+    rejects `..` segments, resolves symlinks, and requires the resolved absolute
+    path to reside under the prefix directory.
+  * Recommended deployment practice is to use `locationType=Secret` or
+    `ClusterProfile` instead of `Path` in production environments.
+
 ## Design Details
 MultiKueue will be enabled on a cluster queue using the admission check fields.
 Just like ProvisioningRequest, MultiKueue will have its own configuration, 

--- a/pkg/controller/admissionchecks/multikueue/clusterqueue_test.go
+++ b/pkg/controller/admissionchecks/multikueue/clusterqueue_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -454,7 +455,7 @@ func TestCQReconcile(t *testing.T) {
 				Build()
 
 			adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
-			cRec := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil)
+			cRec := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, record.NewFakeRecorder(10))
 			cRec.rootContext = ctx
 			for worker, wState := range tc.workers {
 				workerClient := NewNeverCachingClient(utiltesting.NewClientBuilder().

--- a/pkg/controller/admissionchecks/multikueue/controllers.go
+++ b/pkg/controller/admissionchecks/multikueue/controllers.go
@@ -152,7 +152,11 @@ func SetupControllers(mgr ctrl.Manager, namespace string, opts ...SetupOption) e
 		cpAccessProvider = &NoOpClusterProfileAccessProvider{}
 	}
 
-	cRec := newClustersReconciler(mgr.GetClient(), namespace, options.gcInterval, options.origin, fsWatcher, options.adapters, cpAccessProvider, options.roleTracker)
+	cRec := newClustersReconciler(
+		mgr.GetClient(), namespace, options.gcInterval, options.origin, fsWatcher,
+		options.adapters, cpAccessProvider, options.roleTracker,
+		mgr.GetEventRecorderFor("multikueue-cluster"),
+	)
 	err = cRec.setupWithManager(mgr)
 	if err != nil {
 		return err

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -45,6 +46,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
@@ -574,9 +576,16 @@ func (rc *remoteClient) runGC(ctx context.Context) {
 
 // clustersReconciler implements the reconciler for all MultiKueueClusters.
 // Its main task being to maintain the list of remote clients associated to each MultiKueueCluster.
+// defaultKubeConfigPathPrefix is the hardcoded directory under which
+// kubeconfig files must reside when the MultiKueueKubeConfigPathValidation feature
+// gate is enabled (the default).
+const defaultKubeConfigPathPrefix = "/etc/multikueue/kubeconfigs"
+
 type clustersReconciler struct {
-	localClient     client.Client
-	configNamespace string
+	localClient          client.Client
+	configNamespace      string
+	kubeConfigPathPrefix string
+	recorder             record.EventRecorder
 
 	lock sync.RWMutex
 	// The list of remote remoteClients, indexed by the cluster name.
@@ -710,6 +719,15 @@ func (c *clustersReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 
 	log := ctrl.LoggerFrom(ctx)
 	log.V(2).Info("Reconcile MultiKueueCluster")
+
+	// Warn about deprecated Path usage when the validation feature gate is off.
+	if cluster.Spec.ClusterSource.KubeConfig != nil &&
+		cluster.Spec.ClusterSource.KubeConfig.LocationType == kueue.PathLocationType &&
+		!features.Enabled(features.MultiKueueKubeConfigPathValidation) {
+		c.recorder.Event(cluster, corev1.EventTypeWarning, "DeprecatedPathUsage",
+			"Using locationType=Path without MultiKueueKubeConfigPathValidation feature gate is deprecated and will be removed in a future release. "+
+				"Enable the MultiKueueKubeConfigPathValidation feature gate and place kubeconfig files under /etc/multikueue/kubeconfigs/.")
+	}
 
 	if err != nil || !cluster.DeletionTimestamp.IsZero() {
 		c.stopAndRemoveCluster(req.Name)
@@ -901,8 +919,70 @@ func (c *clustersReconciler) getKubeConfigFromSecret(ctx context.Context, secret
 	return kconfigBytes, nil
 }
 
-func (c *clustersReconciler) getKubeConfigFromPath(path string) ([]byte, error) {
-	return os.ReadFile(path)
+// errPathNotAllowed is returned when the resolved kubeconfig path escapes the
+// configured allowed prefix directory.
+var errPathNotAllowed = errors.New("kubeconfig path is not under the allowed prefix")
+
+// validateKubeConfigPath resolves symlinks and ensures the resulting absolute
+// path is located under allowedPrefix when the MultiKueueKubeConfigPathValidation
+// feature gate is enabled (the default). When the gate is disabled, any
+// path is accepted (legacy unsafe behavior).
+func validateKubeConfigPath(ctx context.Context, rawPath, allowedPrefix string) (string, error) {
+	if !features.Enabled(features.MultiKueueKubeConfigPathValidation) {
+		// Legacy unsafe behavior: accept any path.
+		log := ctrl.LoggerFrom(ctx)
+		log.V(2).Info("Legacy unsafe behavior detected: this will be deprecated in the future.")
+		return rawPath, nil
+	}
+	if rawPath == "" {
+		return "", errors.New("kubeconfig path must not be empty")
+	}
+
+	cleaned := filepath.Clean(rawPath)
+
+	// Reject paths where any component is exactly ".." after cleaning.
+	if slices.Contains(strings.Split(cleaned, string(filepath.Separator)), "..") {
+		return "", fmt.Errorf("%w: path contains \"..\"", errPathNotAllowed)
+	}
+
+	// Require an absolute path.
+	if !filepath.IsAbs(cleaned) {
+		return "", fmt.Errorf("%w: path must be absolute", errPathNotAllowed)
+	}
+
+	// Resolve symlinks and get the absolute path of the allowed prefix.
+	// If the prefix directory does not exist, no kubeconfig can be under it.
+	resolvedPrefix, err := filepath.EvalSymlinks(allowedPrefix)
+	if err != nil {
+		return "", fmt.Errorf("%w: %q is not under %q", errPathNotAllowed, cleaned, filepath.Clean(allowedPrefix))
+	}
+	allowedAbs, err := filepath.Abs(resolvedPrefix)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve allowed prefix: %w", err)
+	}
+
+	// Resolve symlinks so an attacker cannot use a symlink to escape.
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve kubeconfig path symlinks: %w", err)
+	}
+
+	// Ensure the prefix directory boundary is respected.
+	// Add a trailing separator so "/etc/kueue" does not match "/etc/kueue-other".
+	prefixWithSep := allowedAbs + string(filepath.Separator)
+	if !strings.HasPrefix(resolved+string(filepath.Separator), prefixWithSep) {
+		return "", fmt.Errorf("%w: %q is not under %q", errPathNotAllowed, resolved, allowedAbs)
+	}
+
+	return resolved, nil
+}
+
+func (c *clustersReconciler) getKubeConfigFromPath(rawPath string) ([]byte, error) {
+	validated, err := validateKubeConfigPath(c.rootContext, rawPath, c.kubeConfigPathPrefix)
+	if err != nil {
+		return nil, err
+	}
+	return os.ReadFile(validated)
 }
 
 func (c *clustersReconciler) updateStatus(ctx context.Context, cluster *kueue.MultiKueueCluster, active bool, reason, message string) error {
@@ -967,10 +1047,13 @@ func newClustersReconciler(
 	adapters map[string]jobframework.MultiKueueAdapter,
 	cpAccessProvider clusterProfileAccessProvider,
 	roleTracker *roletracker.RoleTracker,
+	recorder record.EventRecorder,
 ) *clustersReconciler {
 	return &clustersReconciler{
 		localClient:                  c,
 		configNamespace:              namespace,
+		kubeConfigPathPrefix:         defaultKubeConfigPathPrefix,
+		recorder:                     recorder,
 		remoteClients:                make(map[string]*remoteClient),
 		wlUpdateCh:                   make(chan event.GenericEvent, eventChBufferSize),
 		watchEndedCh:                 make(chan event.GenericEvent, eventChBufferSize),
@@ -1043,8 +1126,9 @@ func (c *clustersReconciler) Create(e event.CreateEvent) bool {
 		log := c.logger().WithValues("multiKueueCluster", klog.KObj(cluster))
 		log.V(5).Info("MultiKueueCluster create event")
 		if cluster.Spec.ClusterSource.KubeConfig != nil && cluster.Spec.ClusterSource.KubeConfig.LocationType == kueue.PathLocationType {
-			err := c.fsWatcher.AddOrUpdate(cluster.Name, cluster.Spec.ClusterSource.KubeConfig.Location)
-			if err != nil {
+			if validated, err := validateKubeConfigPath(c.rootContext, cluster.Spec.ClusterSource.KubeConfig.Location, c.kubeConfigPathPrefix); err != nil {
+				log.Error(err, "Rejecting FS watch for invalid path")
+			} else if err := c.fsWatcher.AddOrUpdate(cluster.Name, validated); err != nil {
 				log.Error(err, "AddOrUpdate FS watch")
 			}
 		}
@@ -1071,8 +1155,9 @@ func (c *clustersReconciler) Update(e event.UpdateEvent) bool {
 	}
 
 	if clusterNewHasKubeConfigPath {
-		err := c.fsWatcher.AddOrUpdate(clusterNew.Name, clusterNew.Spec.ClusterSource.KubeConfig.Location)
-		if err != nil {
+		if validated, err := validateKubeConfigPath(c.rootContext, clusterNew.Spec.ClusterSource.KubeConfig.Location, c.kubeConfigPathPrefix); err != nil {
+			log.Error(err, "Rejecting FS watch for invalid path")
+		} else if err := c.fsWatcher.AddOrUpdate(clusterNew.Name, validated); err != nil {
 			log.Error(err, "AddOrUpdate FS watch")
 		}
 	}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
 	inventoryv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
@@ -191,11 +192,14 @@ func TestUpdateConfig(t *testing.T) {
 		clusterprofiles  []inventoryv1alpha1.ClusterProfile
 		cpAccessProvider clusterProfileAccessProvider
 
-		wantRemoteClients map[string]*remoteClient
-		wantClusters      []kueue.MultiKueueCluster
-		wantRequeueAfter  time.Duration
-		wantCancelCalled  int
-		wantErr           error
+		wantRemoteClients             map[string]*remoteClient
+		wantClusters                  []kueue.MultiKueueCluster
+		wantRequeueAfter              time.Duration
+		wantCancelCalled              int
+		wantErr                       error
+		wantEvent                     string
+		overrideKubeConfigPrefix      bool
+		multiKueueSafePathFeatureGate bool
 	}{
 		"new valid client is added": {
 			reconcileFor: "worker1",
@@ -270,7 +274,9 @@ func TestUpdateConfig(t *testing.T) {
 			wantRemoteClients: map[string]*remoteClient{
 				"worker1": newTestClient(ctx, []byte(testKubeconfig("worker1")), nil, nil),
 			},
-			wantCancelCalled: 1,
+			wantCancelCalled:              1,
+			overrideKubeConfigPrefix:      true,
+			multiKueueSafePathFeatureGate: true,
 		},
 		"update client with invalid secret config": {
 			reconcileFor: "worker1",
@@ -300,7 +306,8 @@ func TestUpdateConfig(t *testing.T) {
 			wantCancelCalled: 1,
 		},
 		"update client with invalid path config": {
-			reconcileFor: "worker1",
+			reconcileFor:                  "worker1",
+			multiKueueSafePathFeatureGate: true,
 			clusters: []kueue.MultiKueueCluster{
 				*utiltestingapi.MakeMultiKueueCluster("worker1").
 					KubeConfig(kueue.PathLocationType, "").
@@ -313,7 +320,7 @@ func TestUpdateConfig(t *testing.T) {
 			wantClusters: []kueue.MultiKueueCluster{
 				*utiltestingapi.MakeMultiKueueCluster("worker1").
 					KubeConfig(kueue.PathLocationType, "").
-					Active(metav1.ConditionFalse, "BadKubeConfig", "load client config failed: open : no such file or directory", 1).
+					Active(metav1.ConditionFalse, "BadKubeConfig", "load client config failed: kubeconfig path must not be empty", 1).
 					Generation(1).
 					Obj(),
 			},
@@ -321,7 +328,7 @@ func TestUpdateConfig(t *testing.T) {
 				"worker1": newTestClient(ctx, []byte("worker1 old kubeconfig"), nil, nil),
 			},
 			wantCancelCalled: 1,
-			wantErr:          fmt.Errorf("failed to load client config, reason: BadKubeConfig, error: %w", errors.New("open : no such file or directory")),
+			wantErr:          fmt.Errorf("failed to load client config, reason: BadKubeConfig, error: %w", errors.New("kubeconfig path must not be empty")),
 		},
 		"missing cluster is removed": {
 			reconcileFor: "worker2",
@@ -608,6 +615,27 @@ func TestUpdateConfig(t *testing.T) {
 			},
 			wantErr: fmt.Errorf("failed to load client config, reason: MultiKueueClusterProfileFeatureDisabled, error: %w", errors.New("MultiKueueClusterProfile feature gate is disabled")),
 		},
+		"path with feature gate off emits deprecation warning": {
+			reconcileFor: "worker1",
+			clusters: []kueue.MultiKueueCluster{
+				*utiltestingapi.MakeMultiKueueCluster("worker1").
+					KubeConfig(kueue.PathLocationType, validKubeconfigLocation).
+					Generation(1).
+					Obj(),
+			},
+			wantClusters: []kueue.MultiKueueCluster{
+				*utiltestingapi.MakeMultiKueueCluster("worker1").
+					KubeConfig(kueue.PathLocationType, validKubeconfigLocation).
+					Active(metav1.ConditionTrue, "Active", "Connected", 1).
+					Generation(1).
+					Obj(),
+			},
+			wantRemoteClients: map[string]*remoteClient{
+				"worker1": newTestClient(ctx, []byte(testKubeconfig("worker1")), nil, nil),
+			},
+			multiKueueSafePathFeatureGate: false,
+			wantEvent:                     "Warning DeprecatedPathUsage Using locationType=Path without MultiKueueKubeConfigPathValidation feature gate is deprecated and will be removed in a future release. Enable the MultiKueueKubeConfigPathValidation feature gate and place kubeconfig files under /etc/multikueue/kubeconfigs/.",
+		},
 		"invalid rest config from cluster profile": {
 			reconcileFor: "invalid",
 			clusters: []kueue.MultiKueueCluster{
@@ -647,7 +675,8 @@ func TestUpdateConfig(t *testing.T) {
 			c := builder.Build()
 
 			adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
-			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, tc.cpAccessProvider, nil)
+			fakeRecorder := record.NewFakeRecorder(10)
+			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, tc.cpAccessProvider, nil, fakeRecorder)
 
 			reconciler.rootContext = ctx
 
@@ -655,6 +684,13 @@ func TestUpdateConfig(t *testing.T) {
 				reconciler.remoteClients = tc.remoteClients
 			}
 			reconciler.builderOverride = fakeClientBuilder(ctx)
+
+			features.SetFeatureGateDuringTest(t, features.MultiKueueKubeConfigPathValidation, tc.multiKueueSafePathFeatureGate)
+
+			if tc.overrideKubeConfigPrefix {
+				// Override the hardcoded prefix for testing with temp dirs.
+				reconciler.kubeConfigPathPrefix = filepath.Dir(validKubeconfigLocation)
+			}
 
 			if len(tc.clusterprofiles) > 0 {
 				features.SetFeatureGateDuringTest(t, features.MultiKueueClusterProfile, true)
@@ -717,6 +753,25 @@ func TestUpdateConfig(t *testing.T) {
 					return true
 				})); diff != "" {
 				t.Errorf("unexpected controllers (-want/+got):\n%s", diff)
+			}
+
+			// Check for expected events.
+			if tc.wantEvent != "" {
+				select {
+				case gotEvent := <-fakeRecorder.Events:
+					if diff := cmp.Diff(tc.wantEvent, gotEvent); diff != "" {
+						t.Errorf("unexpected event (-want/+got):\n%s", diff)
+					}
+				default:
+					t.Error("expected a warning event but none was recorded")
+				}
+			} else {
+				select {
+				case gotEvent := <-fakeRecorder.Events:
+					t.Errorf("unexpected event recorded: %s", gotEvent)
+				default:
+					// No event expected, none received. Good.
+				}
 			}
 		})
 	}
@@ -794,7 +849,7 @@ func TestReconnectBackoff(t *testing.T) {
 			c := builder.Build()
 
 			adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
-			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileAccessProvider{}, nil)
+			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileAccessProvider{}, nil, record.NewFakeRecorder(10))
 			reconciler.rootContext = ctx
 
 			var buildCalls int
@@ -849,7 +904,7 @@ func TestDisconnectedClientReconnectsWithSameConfig(t *testing.T) {
 	c := builder.Build()
 
 	adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
-	reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileAccessProvider{}, nil)
+	reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileAccessProvider{}, nil, record.NewFakeRecorder(10))
 	reconciler.rootContext = ctx
 
 	var buildCalls int
@@ -1177,7 +1232,7 @@ func TestClustersReconcilerEventFilters(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
 			c := getClientBuilder(ctx).Build()
-			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, newKubeConfigFSWatcher(), nil, &NoOpClusterProfileAccessProvider{}, nil)
+			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, newKubeConfigFSWatcher(), nil, &NoOpClusterProfileAccessProvider{}, nil, record.NewFakeRecorder(10))
 			reconciler.rootContext = ctx
 
 			if got := tc.invoke(reconciler); got != tc.wantReconcile {
@@ -1343,7 +1398,7 @@ func TestSetRemoteClientConfigDoesNotBlockOtherClusters(t *testing.T) {
 		WithStatusSubresource(slowCluster, fastCluster).
 		Build()
 
-	reconciler := newClustersReconciler(localClient, TestNamespace, 0, defaultOrigin, nil, nil, &NoOpClusterProfileAccessProvider{}, nil)
+	reconciler := newClustersReconciler(localClient, TestNamespace, 0, defaultOrigin, nil, nil, &NoOpClusterProfileAccessProvider{}, nil, record.NewFakeRecorder(10))
 	reconciler.rootContext = ctx
 	reconciler.builderOverride = gatedBuilder
 
@@ -1379,5 +1434,110 @@ func TestSetRemoteClientConfigDoesNotBlockOtherClusters(t *testing.T) {
 	case <-slowDone:
 	case <-time.After(stuckWatchTimeout):
 		t.Fatal("slow goroutine did not exit after release")
+	}
+}
+
+func TestValidateKubeConfigPath(t *testing.T) {
+	allowedDir := t.TempDir()
+	// Create a real file under the allowed dir to test symlink resolution.
+	validFile := filepath.Join(allowedDir, "worker.kubeconfig")
+	if err := os.WriteFile(validFile, []byte("test"), 0644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	// Create a symlink inside allowedDir that points outside.
+	externalFile := filepath.Join(t.TempDir(), "external-secret")
+	if err := os.WriteFile(externalFile, []byte("token"), 0644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	symlink := filepath.Join(allowedDir, "escape-symlink")
+	if err := os.Symlink(externalFile, symlink); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	cases := map[string]struct {
+		path          string
+		allowedPrefix string
+		featureGate   bool
+		wantErr       bool
+		errContains   string
+	}{
+		"safe FG disabled allows any path (legacy)": {
+			path:          "/any/arbitrary/path",
+			allowedPrefix: allowedDir,
+			featureGate:   false,
+		},
+		"valid path under prefix": {
+			path:          validFile,
+			allowedPrefix: allowedDir,
+			featureGate:   true,
+		},
+		"empty path": {
+			path:          "",
+			allowedPrefix: allowedDir,
+			wantErr:       true,
+			errContains:   "must not be empty",
+			featureGate:   true,
+		},
+		"path with dot-dot traversal": {
+			path:          filepath.Join(allowedDir, "..", "etc", "passwd"),
+			allowedPrefix: allowedDir,
+			wantErr:       true,
+			errContains:   "cannot resolve kubeconfig path symlinks",
+			featureGate:   true,
+		},
+		"path outside prefix": {
+			path:          "/var/run/secrets/kubernetes.io/serviceaccount/token",
+			allowedPrefix: allowedDir,
+			wantErr:       true,
+			errContains:   "cannot resolve kubeconfig path symlinks",
+			featureGate:   true,
+		},
+		"relative path rejected": {
+			path:          "relative/path/file",
+			allowedPrefix: allowedDir,
+			wantErr:       true,
+			errContains:   "must be absolute",
+			featureGate:   true,
+		},
+		"symlink escape rejected": {
+			path:          symlink,
+			allowedPrefix: allowedDir,
+			wantErr:       true,
+			errContains:   "not under",
+			featureGate:   true,
+		},
+		"SA token path rejected": {
+			path:          "/var/run/secrets/kubernetes.io/serviceaccount/token",
+			allowedPrefix: "/etc/multikueue/kubeconfigs",
+			wantErr:       true,
+			errContains:   "not under",
+			featureGate:   true,
+		},
+		"prefix name collision": {
+			// /etc/kueue-other should not match prefix /etc/kueue
+			path:          "/etc/kueue-other/file",
+			allowedPrefix: "/etc/kueue",
+			wantErr:       true,
+			errContains:   "not under",
+			featureGate:   true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.MultiKueueKubeConfigPathValidation, tc.featureGate)
+			_, err := validateKubeConfigPath(t.Context(), tc.path, tc.allowedPrefix)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.errContains)
+				}
+				if !strings.Contains(err.Error(), tc.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.errContains)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
 	}
 }

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
@@ -1629,7 +1630,7 @@ func TestWlReconcile(t *testing.T) {
 
 				managerClient := managerBuilder.Build()
 				adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
-				cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil)
+				cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, record.NewFakeRecorder(10))
 
 				worker1Client := NewNeverCachingClient(getClientBuilder(ctx).
 					WithLists(&kueue.WorkloadList{Items: tc.worker1Workloads}, &batchv1.JobList{Items: tc.worker1Jobs}).

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -217,6 +217,15 @@ const (
 	// Deprecated: locked to its default value (false) in 0.19; planned to be removed in 0.20.
 	MultiKueueAllowInsecureKubeconfigs featuregate.Feature = "MultiKueueAllowInsecureKubeconfigs"
 
+	// owner: @kannon92
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/12144
+	//
+	// Enforce safe path validation for locationType=Path MultiKueueCluster
+	// kubeconfig references. When enabled (the default), only paths under
+	// /etc/multikueue/kubeconfigs/ are accepted. When disabled, the
+	// controller falls back to the legacy behavior of allowing any path.
+	MultiKueueKubeConfigPathValidation featuregate.Feature = "MultiKueueKubeConfigPathValidation"
+
 	// owner: @pbundyra
 	//
 	// Enables reclaimable pods counting towards quota.
@@ -557,6 +566,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.15"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Deprecated},
 		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Deprecated, LockToDefault: true}, // remove in 0.20
+	},
+
+	MultiKueueKubeConfigPathValidation: {
+		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	ReclaimablePods: {
 		{Version: version.MustParse("0.15"), Default: true, PreRelease: featuregate.Beta},

--- a/site/content/en/docs/concepts/multikueue.md
+++ b/site/content/en/docs/concepts/multikueue.md
@@ -151,6 +151,31 @@ Kueue handles delegation to the appropriate worker cluster without requiring any
 - [Set up a MultiKueue environment](/docs/tasks/manage/setup_multikueue/)
 - [Run Jobs in a MultiKueue environment](/docs/tasks/run/multikueue)
 
+## Security Considerations
+
+### KubeConfig Location Types
+
+MultiKueueCluster supports three sources for cluster credentials:
+
+| Source | Recommended | Notes |
+|---|---|---|
+| `ClusterProfile` | ✅ Production | Federated credential discovery via the ClusterProfile API. |
+| `Secret` | ✅ Production | Kubeconfig stored in a Kubernetes Secret. |
+| `Path` | ⚠️ Development only | File path on the controller pod's filesystem. |
+
+**`locationType=Path` validation is available as an alpha feature.**
+The `MultiKueueKubeConfigPathValidation` feature gate (disabled by default)
+restricts kubeconfig file paths to the hardcoded prefix
+`/etc/multikueue/kubeconfigs/`. When enabled, the controller rejects paths
+containing `..`, relative paths, and symlinks that resolve outside the prefix.
+To enable this validation, set the feature gate:
+`--feature-gates=MultiKueueKubeConfigPathValidation=true`.
+
+For production deployments, use `ClusterProfile` or `Secret` instead of `Path`.
+
+See [Setup a MultiKueue environment](/docs/tasks/manage/setup_multikueue/) for
+configuration details.
+
 ## Limitations
 
 - We do not currently support running the manager cluster as one of the workers for itself.

--- a/site/content/en/docs/tasks/manage/setup_multikueue.md
+++ b/site/content/en/docs/tasks/manage/setup_multikueue.md
@@ -84,6 +84,42 @@ For the next example, having the `worker1` cluster Kubeconfig stored in a file c
 
 Check the [worker](#multikueue-specific-kubeconfig) section for details on Kubeconfig generation.
 
+### (Optional) Enable `locationType=Path` for kubeconfig files
+
+{{% alert title="Security Notice" color="warning" %}}
+`locationType=Path` path validation is an **alpha feature** (disabled by default).
+In production, use `locationType=Secret` or `ClusterProfile` instead.
+{{% /alert %}}
+
+The `MultiKueueKubeConfigPathValidation` feature gate (alpha, disabled by default)
+restricts kubeconfig file paths to the hardcoded prefix
+`/etc/multikueue/kubeconfigs/`. When enabled, the controller will:
+
+- Reject empty or relative paths.
+- Reject paths containing `..` segments after cleaning.
+- Resolve symlinks and reject any path that resolves outside the prefix.
+
+To enable this validation, set the feature gate:
+
+```
+--feature-gates=MultiKueueKubeConfigPathValidation=true
+```
+
+To use a path-based kubeconfig, mount the file into the controller pod under
+`/etc/multikueue/kubeconfigs/` and reference it in the `MultiKueueCluster`:
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: MultiKueueCluster
+metadata:
+  name: worker1
+spec:
+  clusterSource:
+    kubeConfig:
+      locationType: Path
+      location: /etc/multikueue/kubeconfigs/worker1.kubeconfig
+```
+
 ### Create a sample setup
 
 Apply the following to create a sample setup in which the Jobs submitted in the ClusterQueue `cluster-queue` are delegated to a worker `worker1`

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -231,6 +231,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: MultiKueueKubeConfigPathValidation
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.19"
 - name: MultiKueueManagerQuotaAutomation
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -231,6 +231,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: MultiKueueKubeConfigPathValidation
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.19"
 - name: MultiKueueManagerQuotaAutomation
   versionedSpecs:
   - default: false

--- a/test/integration/multikueue/setup_test.go
+++ b/test/integration/multikueue/setup_test.go
@@ -283,6 +283,8 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should properly manage the active condition of AdmissionChecks and MultiKueueClusters, kubeconfig provided by file", func() {
+		// Disable path validation since this test uses temp dirs outside the hardcoded prefix.
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueKubeConfigPathValidation, false)
 		ac := utiltestingapi.MakeAdmissionCheck("testing-ac").
 			ControllerName(kueue.MultiKueueControllerName).
 			Parameters(kueue.GroupVersion.Group, "MultiKueueConfig", "testing-config").
@@ -512,6 +514,8 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should properly detect insecure kubeconfig of MultiKueueClusters, kubeconfig provided by file", func() {
+		// Disable path validation since this test uses temp dirs outside the hardcoded prefix.
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueKubeConfigPathValidation, false)
 		var w1KubeconfigInvalidBytes []byte
 		ginkgo.By("Create a kubeconfig with disallowed tokenFile", func() {
 			cfg, err := worker1TestCluster.kubeConfigBytes()
@@ -612,6 +616,79 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 					}, util.IgnoreConditionTimestampsAndObservedGeneration)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
+		})
+	})
+
+	ginkgo.It("Should reject kubeconfig path outside allowed prefix when MultiKueueKubeConfigPathValidation is enabled", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueKubeConfigPathValidation, true)
+		ac := utiltestingapi.MakeAdmissionCheck("testing-ac").
+			ControllerName(kueue.MultiKueueControllerName).
+			Parameters(kueue.GroupVersion.Group, "MultiKueueConfig", "testing-config").
+			Obj()
+		ginkgo.By("creating the admission check", func() {
+			gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, ac)).Should(gomega.Succeed())
+			ginkgo.DeferCleanup(func() error { return managerTestCluster.client.Delete(managerTestCluster.ctx, ac) })
+		})
+
+		mkConfig := utiltestingapi.MakeMultiKueueConfig("testing-config").Clusters("testing-cluster", "testing-cluster-relative", "testing-cluster-traversal").Obj()
+		ginkgo.By("creating the config", func() {
+			gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, mkConfig)).Should(gomega.Succeed())
+			ginkgo.DeferCleanup(func() error { return managerTestCluster.client.Delete(managerTestCluster.ctx, mkConfig) })
+		})
+
+		ginkgo.By("creating a cluster with path outside allowed prefix, the cluster is rejected", func() {
+			tempDir := ginkgo.GinkgoT().TempDir()
+			fsKubeConfig := filepath.Join(tempDir, "testing.kubeconfig")
+			gomega.Expect(os.WriteFile(fsKubeConfig, []byte("test"), 0666)).Should(gomega.Succeed())
+
+			cluster := utiltestingapi.MakeMultiKueueCluster("testing-cluster").KubeConfig(kueue.PathLocationType, fsKubeConfig).Obj()
+			gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, cluster)).Should(gomega.Succeed())
+			ginkgo.DeferCleanup(func() error { return managerTestCluster.client.Delete(managerTestCluster.ctx, cluster) })
+
+			updatedCluster := kueue.MultiKueueCluster{}
+			clusterKey := client.ObjectKeyFromObject(cluster)
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, clusterKey, &updatedCluster)).To(gomega.Succeed())
+				cond := apimeta.FindStatusCondition(updatedCluster.Status.Conditions, kueue.MultiKueueClusterActive)
+				g.Expect(cond).NotTo(gomega.BeNil())
+				g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(gomega.Equal("BadKubeConfig"))
+				g.Expect(cond.Message).To(gomega.ContainSubstring("kubeconfig path is not under the allowed prefix"))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("creating a cluster with relative path, the cluster is rejected", func() {
+			cluster := utiltestingapi.MakeMultiKueueCluster("testing-cluster-relative").KubeConfig(kueue.PathLocationType, "relative/path/file").Obj()
+			gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, cluster)).Should(gomega.Succeed())
+			ginkgo.DeferCleanup(func() error { return managerTestCluster.client.Delete(managerTestCluster.ctx, cluster) })
+
+			updatedCluster := kueue.MultiKueueCluster{}
+			clusterKey := client.ObjectKeyFromObject(cluster)
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, clusterKey, &updatedCluster)).To(gomega.Succeed())
+				cond := apimeta.FindStatusCondition(updatedCluster.Status.Conditions, kueue.MultiKueueClusterActive)
+				g.Expect(cond).NotTo(gomega.BeNil())
+				g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(gomega.Equal("BadKubeConfig"))
+				g.Expect(cond.Message).To(gomega.ContainSubstring("path must be absolute"))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("creating a cluster with dot-dot traversal path, the cluster is rejected", func() {
+			cluster := utiltestingapi.MakeMultiKueueCluster("testing-cluster-traversal").KubeConfig(kueue.PathLocationType, "/etc/multikueue/kubeconfigs/../../etc/passwd").Obj()
+			gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, cluster)).Should(gomega.Succeed())
+			ginkgo.DeferCleanup(func() error { return managerTestCluster.client.Delete(managerTestCluster.ctx, cluster) })
+
+			updatedCluster := kueue.MultiKueueCluster{}
+			clusterKey := client.ObjectKeyFromObject(cluster)
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, clusterKey, &updatedCluster)).To(gomega.Succeed())
+				cond := apimeta.FindStatusCondition(updatedCluster.Status.Conditions, kueue.MultiKueueClusterActive)
+				g.Expect(cond).NotTo(gomega.BeNil())
+				g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(gomega.Equal("BadKubeConfig"))
+				g.Expect(cond.Message).To(gomega.ContainSubstring("kubeconfig path is not under the allowed prefix"))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/area multikueue
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12144 

#### Special notes for your reviewer:

https://owasp.org/www-community/attacks/Path_Traversal

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MultiKueue: Fixed a security vulnerability in `locationType=Path` kubeconfig handling
that could allow users with `MultiKueueCluster` create or update access to make the
controller read arbitrary files. Kueue now validates path-based kubeconfigs to stay under
`/etc/multikueue/kubeconfigs`.

ACTION REQUIRED: If you use `locationType=Path`, plan to move kubeconfig files under
`/etc/multikueue/kubeconfigs`, or switch to `locationType=Secret` or `ClusterProfile`.
This prepares your setup for future releases where `MultiKueueKubeConfigPathValidation`
is expected to be enabled by default.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `SafeMultiKueueConfigPath` feature gate (enabled by default) to enforce safe `locationType=Path` kubeconfig handling: rejects empty/relative/`..` paths, blocks symlink escapes, confines reads to `/etc/multikueue/kubeconfigs/`, and avoids filesystem watcher registration for invalid paths. Disable the gate to restore legacy behavior.
* **Documentation**
  * Added security considerations and setup guidance for using `Path` kubeconfigs, including recommended `Secret`/`ClusterProfile` alternatives.
* **Tests**
  * Added kubeconfig path validation coverage and updated integration setup for test-specific path prefixing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->