### PR TITLE
fix(kueueviz): fix Vitest compatibility with @mui/material 9.1.1

### DIFF
--- a/cmd/kueueviz/frontend/package-lock.json
+++ b/cmd/kueueviz/frontend/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@mui/icons-material": "^9.0.1",
-        "@mui/material": "^9.0.0",
+        "@mui/icons-material": "^9.1.1",
+        "@mui/material": "^9.1.1",
         "ace-builds": "^1.44.0",
         "react": "^19.2.6",
         "react-ace": "^14.0.1",
@@ -383,9 +383,9 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.0.1.tgz",
-      "integrity": "sha512-GzamIIhZ1bH77dq7eKaeyRgJdkypsxin4jBFq2EMs4lBWRR0LFO1CSVMsoebn/VvjcNrnrOrjy48MkrkQUK2iw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.1.1.tgz",
+      "integrity": "sha512-AupmMICbdJHqAh6FfOMaaiiIr7dfEgZJn5DFfiPuGNrbs+ZZy9cD1APwO0TSVBz5j08MJEEY6n7iC76/2wjMEA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -393,9 +393,9 @@
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-9.0.1.tgz",
-      "integrity": "sha512-5PRpQjVLTNLyV/2J9J53Yz4R0tVbodG0BQDN2zQI1QBG1OPYM25ar+4N20eyFOfJT6zKglLzsnU70+zdVLaTkw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-9.1.1.tgz",
+      "integrity": "sha512-OXhm9DajemStb58AumM06DuPhHTa3XD36TFD4yf6WtJyNRO5DfEZbbnHlBg/US2Y2oOXwM/XurMTBOD6L/YYZw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2"
@@ -408,7 +408,7 @@
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@mui/material": "^9.0.1",
+        "@mui/material": "^9.1.1",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -419,22 +419,22 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.0.1.tgz",
-      "integrity": "sha512-voyCpeUxcSWLN7KPZuq0pGCIt726T9K6kiVM3XUcywZDAlZSarLHaUxJVQpospbjjOzN53hwyjo8s6KoWl6utw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.1.1.tgz",
+      "integrity": "sha512-Wv+gInjrpf99l1Q0oHe0eOWGTnlbkzs5nowClX65KCT/2fyPMwcbFEEkUsOHdpcHhB5UAbz/d7jlwt5ajWVvlA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
-        "@mui/core-downloads-tracker": "^9.0.1",
-        "@mui/system": "^9.0.1",
-        "@mui/types": "^9.0.0",
-        "@mui/utils": "^9.0.1",
+        "@mui/core-downloads-tracker": "^9.1.1",
+        "@mui/system": "^9.1.1",
+        "@mui/types": "^9.1.1",
+        "@mui/utils": "^9.1.1",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
         "csstype": "^3.2.3",
         "prop-types": "^15.8.1",
-        "react-is": "^19.2.4",
+        "react-is": "^19.2.6",
         "react-transition-group": "^4.4.5"
       },
       "engines": {
@@ -447,7 +447,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^9.0.1",
+        "@mui/material-pigment-css": "^9.1.1",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -468,13 +468,13 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.0.1.tgz",
-      "integrity": "sha512-pSIGq4Yw749KHEwlkYZWVERgHgwJELP6ODtBNUfV8V4oIb5H+h7IQDFXuk/b2oQccODK1enJAtiEzlgLZmq+8g==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.1.1.tgz",
+      "integrity": "sha512-oH6c+d6sJ1CZT0Vg2/fHdUQ5zvo9Pn+f+WWk0tlQliHqqIRdN32DZ7UxjalW3LUj4OkHbdWR31biWuLxK9i7Cg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
-        "@mui/utils": "^9.0.1",
+        "@mui/utils": "^9.1.1",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -495,9 +495,9 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.0.0.tgz",
-      "integrity": "sha512-9RLGdX4Jg0aQPRuvqh/OLzYSPlgd5zyEw5/1HIRfdavSiOd03WtUaGZH9/w1RoTYuRKwpgy0hpIFaMHIqPVIWg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.1.1.tgz",
+      "integrity": "sha512-neaYKdJfvEG54q8efHLJR7swpHG/gfSv9xGqW5iTSMsubD7yPCPFrhVBt284j1DOF3uZaaDJSHQL7gz6jGF21Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
@@ -529,16 +529,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.0.1.tgz",
-      "integrity": "sha512-WvlioaLxk6ewUIOfh0StxUvOPDS1mCfzaulcudsL1brZNXuh0N9FMk7RpH7ImJKjEz412SEy/V/yvqmtxbqxCQ==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.1.1.tgz",
+      "integrity": "sha512-q+aqNa58QZUwmmyUvJKKrStrej+4BcWFw4M0Ug+zRylPIQgR64cqvBnE3QTfLZm4OXulydp8Hl3zwKxMayrdsA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
-        "@mui/private-theming": "^9.0.1",
-        "@mui/styled-engine": "^9.0.0",
-        "@mui/types": "^9.0.0",
-        "@mui/utils": "^9.0.1",
+        "@mui/private-theming": "^9.1.1",
+        "@mui/styled-engine": "^9.1.1",
+        "@mui/types": "^9.1.1",
+        "@mui/utils": "^9.1.1",
         "clsx": "^2.1.1",
         "csstype": "^3.2.3",
         "prop-types": "^15.8.1"
@@ -569,9 +569,9 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.0.0.tgz",
-      "integrity": "sha512-i1cuFCAWN44b3AJWO7mh7tuh1sqbQSeVr/94oG0TX5uXivac8XalgE4/6fQZcmGZigzbQ35IXxj/4jLpRIBYZg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.1.1.tgz",
+      "integrity": "sha512-Zjt7u8wNvDg40rPTGoL+TnfkpuSKjwubsNSFRH1KAVZLcaV4I3AFNHIFbvH7p4F3alEibSbdd90xAgn5Rnfndg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2"
@@ -586,17 +586,17 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.0.1.tgz",
-      "integrity": "sha512-f3UO3jNN1pYg5zxqXC81Bvv8hx5ACcYc0387382ZI7M5ono1heIwHYLrKsz85myguWdeVKPRZGmDdynWUBjK2g==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.1.1.tgz",
+      "integrity": "sha512-qSNfnkzZMptaaWFFklpDf4NPJztgwsMDVfM/sSDt+wq4ssYSBhLYwwjuB6eS/+p2IUYbeRzHluzXbw0Zn7aI4A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
-        "@mui/types": "^9.0.0",
+        "@mui/types": "^9.1.1",
         "@types/prop-types": "^15.7.15",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^19.2.4"
+        "react-is": "^19.2.6"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -981,9 +981,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3345,9 +3345,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
-      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "license": "MIT"
     },
     "node_modules/react-router": {

--- a/cmd/kueueviz/frontend/package.json
+++ b/cmd/kueueviz/frontend/package.json
@@ -17,8 +17,8 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
-    "@mui/icons-material": "^9.0.1",
-    "@mui/material": "^9.0.0",
+    "@mui/icons-material": "^9.1.1",
+    "@mui/material": "^9.1.1",
     "ace-builds": "^1.44.0",
     "react": "^19.2.6",
     "react-ace": "^14.0.1",

--- a/cmd/kueueviz/frontend/vite.config.js
+++ b/cmd/kueueviz/frontend/vite.config.js
@@ -13,10 +13,24 @@ export default defineConfig({
   },
   resolve: {
     extensions: ['.js', '.jsx', '.json'],
+    alias: {
+      // MUI 9.1.1 imports react-transition-group as a directory which is not
+      // supported in ES modules. Redirect to the CJS version for Vitest compatibility.
+      'react-transition-group/TransitionGroupContext':
+        'react-transition-group/cjs/TransitionGroupContext.js',
+    },
   },
   publicDir: 'public',
   envPrefix: ['VITE_', 'REACT_APP_'], // Support both VITE_ and REACT_APP_ prefixes
   test: {
     environment: 'node',
+    server: {
+      deps: {
+        // @mui/material 9.1.1 imports react-transition-group using a directory path
+        // which is not supported in ES modules. Inlining both packages forces Vitest
+        // to transform them rather than passing them to Node's native ESM resolver.
+        inline: ['@mui/material', 'react-transition-group'],
+      },
+    },
   },
 }); 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup
/area dashboard

#### What this PR does / why we need it:
Bumping `@mui/material` to 9.1.1 broke the Vitest unit test suite. The new version imports `react-transition-group/TransitionGroupContext` as a directory path inside `@mui/material/internal/Transition.mjs`, which is not supported by Node's ES module resolver, causing `UsageBar.test.js` and `ErrorMessage.test.js` to fail before running any tests.

The fix adds `@mui/material` and `react-transition-group` to `server.deps.inline` in `cmd/kueueviz/frontend/vite.config.js`, so Vitest transforms these packages internally instead of passing them to the native ESM resolver, unblocking the MUI upgrade from #12180.

#### Which issue(s) this PR fixes:
Fixes #12202

#### Special notes for your reviewer:
None.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated Material-UI dependencies to version 9.1.1
* Enhanced build configuration for improved module compatibility and testing stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->