### PR TITLE
TAS: Clean up second-pass queue follow-ups

### DIFF
--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -901,10 +901,11 @@ func (m *Manager) DeleteSecondPassWithoutLock(wlKey workload.Reference) {
 // delay.
 func (m *Manager) QueueSecondPassIfNeeded(ctx context.Context, w *kueue.Workload, iteration int) bool {
 	log := ctrl.LoggerFrom(ctx)
+	wlKey := workload.Key(w)
 	if workload.NeedsSecondPass(w) {
 		iteration++
 		delay := m.secondPassQueue.nextDelay(iteration)
-		log.V(3).Info("Workload pre-queued for second pass (with backoff)", "workload", workload.Key(w), "delay", delay)
+		log.V(3).Info("Workload pre-queued for second pass (with backoff)", "workload", wlKey, "delay", delay)
 		m.secondPassQueue.prequeue(w)
 		m.clock.AfterFunc(delay, func() {
 			m.queueSecondPass(ctx, w, iteration)
@@ -913,9 +914,9 @@ func (m *Manager) QueueSecondPassIfNeeded(ctx context.Context, w *kueue.Workload
 	} else if iteration > 0 {
 		// Remove the workload from the second-pass queue only after at least one
 		// retry iteration, to avoid canceling the initial backoff window.
-		// See #8357.
-		log.V(3).Info("Workload removed from second pass queue", "workload", workload.Key(w))
-		m.secondPassQueue.deleteByKey(workload.Key(w))
+		// See https://github.com/kubernetes-sigs/kueue/issues/8357.
+		log.V(3).Info("Workload removed from second pass queue", "workload", wlKey)
+		m.secondPassQueue.deleteByKey(wlKey)
 	}
 	return false
 }

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -2087,10 +2087,10 @@ func TestQueueSecondPassIfNeeded(t *testing.T) {
 	baseWorkloadNotNeedingSecondPass := baseWorkloadBuilder.Clone()
 
 	cases := map[string]struct {
-		workloads []*kueue.Workload
-		update    func(*kueue.Workload)
-		passTime  time.Duration
-		wantReady sets.Set[workload.Reference]
+		workloads      []*kueue.Workload
+		updateWorkload *kueue.Workload
+		passTime       time.Duration
+		wantReady      sets.Set[workload.Reference]
 	}{
 		"single queued workload checked immediately": {
 			workloads: []*kueue.Workload{
@@ -2105,24 +2105,25 @@ func TestQueueSecondPassIfNeeded(t *testing.T) {
 			passTime:  time.Second,
 			wantReady: sets.New(workload.Key(baseWorkloadNeedingSecondPass.Obj())),
 		},
-		"workload stops needing second pass after being queued": {
+		"workload is evicted after being queued": {
 			workloads: []*kueue.Workload{
 				baseWorkloadNeedingSecondPass.DeepCopy(),
 			},
-			update: func(wl *kueue.Workload) {
-				wl.Status.Admission = nil
-			},
+			updateWorkload: baseWorkloadNeedingSecondPass.Clone().
+				EvictedAt(now).
+				Obj(),
 			passTime:  time.Second,
 			wantReady: nil,
 		},
-		"two queued workloads, one updated to no longer need second pass": {
+		"two queued workloads, one evicted before second pass": {
 			workloads: []*kueue.Workload{
 				baseWorkloadNeedingSecondPass.Clone().Name("first").Obj(),
 				baseWorkloadNeedingSecondPass.Clone().Name("second").Obj(),
 			},
-			update: func(wl *kueue.Workload) {
-				wl.Status.Admission = nil
-			},
+			updateWorkload: baseWorkloadNeedingSecondPass.Clone().
+				Name("first").
+				EvictedAt(now).
+				Obj(),
 			passTime:  time.Second,
 			wantReady: sets.New(workload.NewReference("default", "second")),
 		},
@@ -2143,10 +2144,8 @@ func TestQueueSecondPassIfNeeded(t *testing.T) {
 				manager.QueueSecondPassIfNeeded(ctx, wl, 0)
 			}
 
-			if tc.update != nil {
-				wl := tc.workloads[0]
-				tc.update(wl)
-				manager.QueueSecondPassIfNeeded(ctx, wl, 1)
+			if tc.updateWorkload != nil {
+				manager.QueueSecondPassIfNeeded(ctx, tc.updateWorkload, 1)
 			}
 
 			fakeClock.Step(tc.passTime)


### PR DESCRIPTION
 
#### What type of PR is this?
 
/kind cleanup

#### What this PR does / why we need it:
Addresses TAS cleanup comments from https://github.com/kubernetes-sigs/kueue/pull/8431
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8682
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized queue management code for improved maintainability through streamlined variable management and reduced redundant operations.

* **Tests**
  * Enhanced test coverage with new eviction-focused scenarios validating workload readiness outcomes and queuing behavior when workloads are evicted during queue processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->