### PR TITLE
Automated cherry pick of #12165: Bump kubeadm from v1beta3 to v1beta4

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -418,6 +418,21 @@ apiServer:
   - name: v
     value: \"3\"
 "' "$patched_config"
+    # v1beta3 variant for k8s <=1.35, where kind ignores the v1beta4 patch above.
+    $YQ -i '(.nodes[] | select(.role == "control-plane")).kubeadmConfigPatches += ["kind: ClusterConfiguration
+apiVersion: kubeadm.k8s.io/v1beta3
+scheduler:
+  extraArgs:
+    v: \"3\"
+controllerManager:
+  extraArgs:
+    v: \"3\"
+apiServer:
+  extraArgs:
+    enable-aggregator-routing: \"true\"
+    runtime-config: \"resource.k8s.io/v1=true\"
+    v: \"3\"
+"]' "$patched_config"
 
     echo "$patched_config"
 }
@@ -455,6 +470,21 @@ apiServer:
     value: \"3\"
 >>>>>>> bump kubeadm from v1beta3 to v1beta4
 "' "$patched_config"
+    # v1beta3 variant for k8s <=1.35, where kind ignores the v1beta4 patch above (#12022).
+    $YQ -i '(.nodes[] | select(.role == "control-plane")).kubeadmConfigPatches += ["kind: ClusterConfiguration
+apiVersion: kubeadm.k8s.io/v1beta3
+scheduler:
+  extraArgs:
+    v: \"3\"
+controllerManager:
+  extraArgs:
+    v: \"3\"
+apiServer:
+  extraArgs:
+    enable-aggregator-routing: \"true\"
+    runtime-config: \"scheduling.k8s.io/v1alpha3=true\"
+    v: \"3\"
+"]' "$patched_config"
 
     echo "$patched_config"
 }

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -400,18 +400,23 @@ function patch_kind_config_for_dra {
     $YQ -i '.featureGates.DRAExtendedResource = true' "$patched_config"
     $YQ -i '.containerdConfigPatches += ["[plugins.\"io.containerd.grpc.v1.cri\"]\n  enable_cdi = true"]' "$patched_config"
     $YQ -i '(.nodes[] | select(.role == "control-plane")).kubeadmConfigPatches[0] = "kind: ClusterConfiguration
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 scheduler:
   extraArgs:
-    v: \"3\"
+  - name: v
+    value: \"3\"
 controllerManager:
   extraArgs:
-    v: \"3\"
+  - name: v
+    value: \"3\"
 apiServer:
   extraArgs:
-    enable-aggregator-routing: \"true\"
-    runtime-config: \"resource.k8s.io/v1=true\"
-    v: \"3\"
+  - name: enable-aggregator-routing
+    value: \"true\"
+  - name: runtime-config
+    value: \"resource.k8s.io/v1=true\"
+  - name: v
+    value: \"3\"
 "' "$patched_config"
 
     echo "$patched_config"
@@ -426,18 +431,29 @@ function patch_kind_config_for_was {
     $YQ -i '.featureGates.GenericWorkload = true' "$patched_config"
     $YQ -i '.featureGates.GangScheduling = true' "$patched_config"
     $YQ -i '(.nodes[] | select(.role == "control-plane")).kubeadmConfigPatches[0] = "kind: ClusterConfiguration
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 scheduler:
   extraArgs:
-    v: \"3\"
+  - name: v
+    value: \"3\"
 controllerManager:
   extraArgs:
-    v: \"3\"
+  - name: v
+    value: \"3\"
 apiServer:
   extraArgs:
+<<<<<<< HEAD
     enable-aggregator-routing: \"true\"
     runtime-config: \"scheduling.k8s.io/v1alpha2=true\"
     v: \"3\"
+=======
+  - name: enable-aggregator-routing
+    value: \"true\"
+  - name: runtime-config
+    value: \"scheduling.k8s.io/v1alpha3=true\"
+  - name: v
+    value: \"3\"
+>>>>>>> bump kubeadm from v1beta3 to v1beta4
 "' "$patched_config"
 
     echo "$patched_config"

--- a/hack/testing/kind-cluster-tas.yaml
+++ b/hack/testing/kind-cluster-tas.yaml
@@ -22,12 +22,31 @@ nodes:
           - name: v
             value: "3"
       - |
+        kind: ClusterConfiguration
+        apiVersion: kubeadm.k8s.io/v1beta3
+        scheduler:
+          extraArgs:
+            v: "3"
+        controllerManager:
+          extraArgs:
+            v: "3"
+        apiServer:
+          extraArgs:
+            enable-aggregator-routing: "true"
+            v: "3"
+      - |
         kind: InitConfiguration
         apiVersion: kubeadm.k8s.io/v1beta4
         nodeRegistration:
           kubeletExtraArgs:
           - name: v
             value: "3"
+      - |
+        kind: InitConfiguration
+        apiVersion: kubeadm.k8s.io/v1beta3
+        nodeRegistration:
+          kubeletExtraArgs:
+            v: "3"
   - role: worker
     labels:
       cloud.provider.com/node-group: tas-group
@@ -77,3 +96,9 @@ kubeadmConfigPatches:
       kubeletExtraArgs:
       - name: v
         value: "3"
+  - |
+    kind: JoinConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta3
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "3"

--- a/hack/testing/kind-cluster-tas.yaml
+++ b/hack/testing/kind-cluster-tas.yaml
@@ -6,22 +6,28 @@ nodes:
     kubeadmConfigPatches:
       - |
         kind: ClusterConfiguration
-        apiVersion: kubeadm.k8s.io/v1beta3
+        apiVersion: kubeadm.k8s.io/v1beta4
         scheduler:
           extraArgs:
-            v: "3"
+          - name: v
+            value: "3"
         controllerManager:
           extraArgs:
-            v: "3"
+          - name: v
+            value: "3"
         apiServer:
           extraArgs:
-            enable-aggregator-routing: "true"
-            v: "3"
+          - name: enable-aggregator-routing
+            value: "true"
+          - name: v
+            value: "3"
       - |
         kind: InitConfiguration
+        apiVersion: kubeadm.k8s.io/v1beta4
         nodeRegistration:
           kubeletExtraArgs:
-            v: "3"
+          - name: v
+            value: "3"
   - role: worker
     labels:
       cloud.provider.com/node-group: tas-group
@@ -66,6 +72,8 @@ nodes:
 kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"

--- a/hack/testing/kind-cluster.yaml
+++ b/hack/testing/kind-cluster.yaml
@@ -21,12 +21,31 @@ nodes:
       - name: v
         value: "3"
   - |
+    kind: ClusterConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta3
+    scheduler:
+      extraArgs:
+        v: "3"
+    controllerManager:
+      extraArgs:
+        v: "3"
+    apiServer:
+      extraArgs:
+        enable-aggregator-routing: "true"
+        v: "3"
+  - |
     kind: InitConfiguration
     apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
       - name: v
         value: "3"
+  - |
+    kind: InitConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta3
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "3"
 - role: worker
   labels:
     instance-type: on-demand
@@ -42,3 +61,9 @@ kubeadmConfigPatches:
       kubeletExtraArgs:
       - name: v
         value: "3"
+  - |
+    kind: JoinConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta3
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "3"

--- a/hack/testing/kind-cluster.yaml
+++ b/hack/testing/kind-cluster.yaml
@@ -5,22 +5,28 @@ nodes:
   kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration
-    apiVersion: kubeadm.k8s.io/v1beta3
+    apiVersion: kubeadm.k8s.io/v1beta4
     scheduler:
       extraArgs:
-        v: "3"
+      - name: v
+        value: "3"
     controllerManager:
       extraArgs:
-        v: "3"
+      - name: v
+        value: "3"
     apiServer:
       extraArgs:
-        enable-aggregator-routing: "true"
-        v: "3"
+      - name: enable-aggregator-routing
+        value: "true"
+      - name: v
+        value: "3"
   - |
     kind: InitConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"
 - role: worker
   labels:
     instance-type: on-demand
@@ -31,6 +37,8 @@ nodes:
 kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"

--- a/hack/testing/multikueue/manager-cluster.kind.yaml
+++ b/hack/testing/multikueue/manager-cluster.kind.yaml
@@ -5,22 +5,28 @@ nodes:
   kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration
-    apiVersion: kubeadm.k8s.io/v1beta3
+    apiVersion: kubeadm.k8s.io/v1beta4
     scheduler:
       extraArgs:
-        v: "3"
+      - name: v
+        value: "3"
     controllerManager:
       extraArgs:
-        v: "3"
+      - name: v
+        value: "3"
     apiServer:
       extraArgs:
-        enable-aggregator-routing: "true"
-        v: "3"
+      - name: enable-aggregator-routing
+        value: "true"
+      - name: v
+        value: "3"
   - |
     kind: InitConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"
 - role: worker
   labels:
     instance-type: on-demand
@@ -29,6 +35,8 @@ nodes:
 kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"

--- a/hack/testing/multikueue/manager-cluster.kind.yaml
+++ b/hack/testing/multikueue/manager-cluster.kind.yaml
@@ -21,12 +21,31 @@ nodes:
       - name: v
         value: "3"
   - |
+    kind: ClusterConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta3
+    scheduler:
+      extraArgs:
+        v: "3"
+    controllerManager:
+      extraArgs:
+        v: "3"
+    apiServer:
+      extraArgs:
+        enable-aggregator-routing: "true"
+        v: "3"
+  - |
     kind: InitConfiguration
     apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
       - name: v
         value: "3"
+  - |
+    kind: InitConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta3
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "3"
 - role: worker
   labels:
     instance-type: on-demand
@@ -40,3 +59,9 @@ kubeadmConfigPatches:
       kubeletExtraArgs:
       - name: v
         value: "3"
+  - |
+    kind: JoinConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta3
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "3"

--- a/hack/testing/multikueue/worker-cluster.kind.yaml
+++ b/hack/testing/multikueue/worker-cluster.kind.yaml
@@ -23,12 +23,32 @@ nodes:
       - name: service-account-max-token-expiration
         value: "168h"
   - |
+    kind: ClusterConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta3
+    scheduler:
+      extraArgs:
+        v: "3"
+    controllerManager:
+      extraArgs:
+        v: "3"
+    apiServer:
+      extraArgs:
+        enable-aggregator-routing: "true"
+        v: "3"
+        service-account-max-token-expiration: "168h"
+  - |
     kind: InitConfiguration
     apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
       - name: v
         value: "3"
+  - |
+    kind: InitConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta3
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "3"
 - role: worker
   labels:
     instance-type: on-demand
@@ -42,3 +62,9 @@ kubeadmConfigPatches:
       kubeletExtraArgs:
       - name: v
         value: "3"
+  - |
+    kind: JoinConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta3
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "3"

--- a/hack/testing/multikueue/worker-cluster.kind.yaml
+++ b/hack/testing/multikueue/worker-cluster.kind.yaml
@@ -5,23 +5,30 @@ nodes:
   kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration
-    apiVersion: kubeadm.k8s.io/v1beta3
+    apiVersion: kubeadm.k8s.io/v1beta4
     scheduler:
       extraArgs:
-        v: "3"
+      - name: v
+        value: "3"
     controllerManager:
       extraArgs:
-        v: "3"
+      - name: v
+        value: "3"
     apiServer:
       extraArgs:
-        enable-aggregator-routing: "true"
-        v: "3"
-        service-account-max-token-expiration: "168h"
+      - name: enable-aggregator-routing
+        value: "true"
+      - name: v
+        value: "3"
+      - name: service-account-max-token-expiration
+        value: "168h"
   - |
     kind: InitConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"
 - role: worker
   labels:
     instance-type: on-demand
@@ -30,6 +37,8 @@ nodes:
 kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
     nodeRegistration:
       kubeletExtraArgs:
-        v: "3"
+      - name: v
+        value: "3"


### PR DESCRIPTION
Cherry pick of #12165 on release-0.17.

#12165: Bump kubeadm from v1beta3 to v1beta4

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```