### PR TITLE
test: shorten e2e Prometheus scrape interval

### DIFF
--- a/test/e2e/config/prometheus/prometheus-setup.yaml
+++ b/test/e2e/config/prometheus/prometheus-setup.yaml
@@ -61,6 +61,7 @@ metadata:
   namespace: monitoring
 spec:
   serviceAccountName: prometheus-k8s
+  scrapeInterval: 2s
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
 ---


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:
The flake happens when Prometheus picks up the Kueue ServiceMonitor too late and the target stays `unknown` until its first scrape; shrinking the scrape interval from 30s to 5s makes that scrape happen faster so the test doesn't time out. 
#### Which issue(s) this PR fixes:
Fixes #12239

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Prometheus configuration to set the metric scrape interval to **2 seconds**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->