### PR TITLE
Automated cherry pick of #12241: Improve CI runtime for KubeRay by short grace termination of pods

### DIFF
--- a/pkg/util/testingjobs/rayjob/wrappers.go
+++ b/pkg/util/testingjobs/rayjob/wrappers.go
@@ -327,7 +327,7 @@ func (j *JobWrapper) VolumeMounts(rayType rayv1.RayNodeType, volumeMounts []core
 	return j
 }
 
-func (j *JobWrapper) TerminationGracePeriodSeconds(seconds int64) *JobWrapper {
+func (j *JobWrapper) TerminationGracePeriod(seconds int64) *JobWrapper {
 	j.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.TerminationGracePeriodSeconds = ptr.To(seconds)
 	for i := range len(j.Spec.RayClusterSpec.WorkerGroupSpecs) {
 		j.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.TerminationGracePeriodSeconds = ptr.To(seconds)

--- a/pkg/util/testingjobs/rayservice/wrappers.go
+++ b/pkg/util/testingjobs/rayservice/wrappers.go
@@ -241,6 +241,14 @@ func (j *ServiceWrapper) WorkloadPriorityClass(wpc string) *ServiceWrapper {
 	return j
 }
 
+func (j *ServiceWrapper) TerminationGracePeriod(seconds int64) *ServiceWrapper {
+	j.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.TerminationGracePeriodSeconds = ptr.To(seconds)
+	for i := range len(j.Spec.RayClusterSpec.WorkerGroupSpecs) {
+		j.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.TerminationGracePeriodSeconds = ptr.To(seconds)
+	}
+	return j
+}
+
 // WithWorkerGroups sets the worker groups.
 func (j *ServiceWrapper) WithWorkerGroups(workers ...rayv1.WorkerGroupSpec) *ServiceWrapper {
 	j.Spec.RayClusterSpec.WorkerGroupSpecs = workers

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -1119,6 +1119,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 					RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "0.5").
 					Image(rayv1.HeadNode, kuberayTestImage).
 					Image(rayv1.WorkerNode, kuberayTestImage).
+					TerminationGracePeriod(1).
 					Obj()
 
 				ginkgo.By("Creating the RayJob", func() {
@@ -1260,6 +1261,7 @@ app = HelloWorld.bind()`,
 					Volumes(rayv1.WorkerNode, volumes).
 					VolumeMounts(rayv1.HeadNode, volumeMounts).
 					VolumeMounts(rayv1.WorkerNode, volumeMounts).
+					TerminationGracePeriod(1).
 					Obj()
 
 				rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName = "small-group"

--- a/test/e2e/singlecluster/extended/kuberay_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_test.go
@@ -171,6 +171,7 @@ var _ = ginkgo.Describe("Kuberay", ginkgo.Label("area:singlecluster", "feature:k
 					RestartPolicy: corev1.RestartPolicyOnFailure,
 				},
 			}).
+			TerminationGracePeriod(1).
 			Image(rayv1.HeadNode, kuberayTestImage).
 			Image(rayv1.WorkerNode, kuberayTestImage).Obj()
 
@@ -303,7 +304,7 @@ print(ray.get([my_task.remote(i, 60) for i in range(3)]))`,
 			Image(rayv1.WorkerNode, kuberayTestImage).
 			Volumes(rayv1.HeadNode, volumes).
 			VolumeMounts(rayv1.HeadNode, volumeMounts).
-			TerminationGracePeriodSeconds(int64(1)).
+			TerminationGracePeriod(1).
 			Obj()
 
 		ginkgo.By("Creating the ConfigMap", func() {
@@ -501,7 +502,7 @@ print([ray.get(my_task.remote(i, 1)) for i in range(64)])`,
 			Image(rayv1.WorkerNode, kuberayTestImage).
 			Volumes(rayv1.HeadNode, volumes).
 			VolumeMounts(rayv1.HeadNode, volumeMounts).
-			TerminationGracePeriodSeconds(int64(1)).
+			TerminationGracePeriod(1).
 			Obj()
 
 		ginkgo.By("Creating the ConfigMap", func() {
@@ -737,6 +738,7 @@ app = HelloWorld.bind()`,
 			Volumes(rayv1.WorkerNode, volumes).
 			VolumeMounts(rayv1.HeadNode, volumeMounts).
 			VolumeMounts(rayv1.WorkerNode, volumeMounts).
+			TerminationGracePeriod(1).
 			Obj()
 
 		ginkgo.By("Creating the ConfigMap", func() {
@@ -883,6 +885,7 @@ app = HelloWorld.bind()`,
 			Volumes(rayv1.WorkerNode, volumes).
 			VolumeMounts(rayv1.HeadNode, volumeMounts).
 			VolumeMounts(rayv1.WorkerNode, volumeMounts).
+			TerminationGracePeriod(1).
 			Obj()
 
 		ginkgo.By("Creating the ConfigMap", func() {

--- a/test/e2e/tas/extended/rayjob_test.go
+++ b/test/e2e/tas/extended/rayjob_test.go
@@ -178,6 +178,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for RayJob", ginkgo.Ordered, fu
 				}).
 				Image(rayv1.HeadNode, kuberayTestImage).
 				Image(rayv1.WorkerNode, kuberayTestImage).
+				TerminationGracePeriod(1).
 				Obj()
 
 			util.MustCreate(ctx, k8sClient, rayjob)


### PR DESCRIPTION
Cherry pick of #12241 on release-0.17.

#12241: Improve CI runtime for KubeRay by short grace termination of pods

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```