### PR TITLE
Automated cherry pick of #12249: Retry go mod download on transient proxy errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder
 WORKDIR /workspace
 # fetch dependencies first, for iterative development
 COPY go.mod go.sum ./
-RUN go mod download
+COPY hack/testing/retry.sh /usr/local/bin/retry.sh
+RUN retry.sh --attempts 7 --delay 2 --exponential --stream -- go mod download
 # copy the rest of the sources and build
 COPY . .
 ARG GIT_TAG GIT_COMMIT TARGETARCH CGO_ENABLED=0

--- a/Makefile
+++ b/Makefile
@@ -176,12 +176,12 @@ fmt: ## Run go fmt against code.
 .PHONY: gomod-download
 gomod-download: ## Download Go module dependencies (main)
 	@echo "→ Downloading main dependencies..."
-	$(GO_CMD) mod download
+	$(NETWORK_INSTALL_RETRY) $(GO_CMD) mod download
 
 .PHONY: gomod-download-tools
 gomod-download-tools: ## Download Go module dependencies (tools)
 	@echo "→ Downloading tools dependencies..."
-	cd $(TOOLS_DIR) && $(GO_CMD) mod download
+	cd $(TOOLS_DIR) && $(NETWORK_INSTALL_RETRY) $(GO_CMD) mod download
 
 .PHONY: toc-update
 toc-update: mdtoc
@@ -423,7 +423,7 @@ kueueviz-image-build:
 		--build-arg CGO_ENABLED=$(CGO_ENABLED) \
 		$(PUSH) \
 		$(IMAGE_BUILD_EXTRA_OPTS) \
-		-f ./cmd/kueueviz/backend/Dockerfile ./cmd/kueueviz/backend
+		-f ./cmd/kueueviz/backend/Dockerfile .
 	$(IMAGE_BUILD_CMD) \
 		-t $(IMAGE_TAG_KUEUEVIZ_FRONTEND) \
 		-t $(IMAGE_REPO_KUEUEVIZ_FRONTEND):$(RELEASE_BRANCH) \

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -696,7 +696,7 @@ run-tas-performance-scheduler-in-cluster: envtest performance-scheduler-runner
 
 .PHONY: ginkgo-top
 ginkgo-top:
-	cd $(TOOLS_DIR) && go mod download && \
+	cd $(TOOLS_DIR) && $(NETWORK_INSTALL_RETRY) $(GO_CMD) mod download && \
 	$(GO_BUILD_ENV) $(GO_CMD) build -ldflags="$(LD_FLAGS)" -o $(BIN_DIR)/ginkgo-top ./ginkgo-top
 
 .PHONY: setup-e2e-env

--- a/cmd/experimental/kueue-populator/Dockerfile
+++ b/cmd/experimental/kueue-populator/Dockerfile
@@ -16,7 +16,8 @@ COPY . .
 
 WORKDIR /workspace/cmd/experimental/kueue-populator
 
-RUN go mod download
+COPY hack/testing/retry.sh /usr/local/bin/retry.sh
+RUN retry.sh --attempts 7 --delay 2 --exponential --stream -- go mod download
 RUN make build GO_BUILD_ENV='CGO_ENABLED=${CGO_ENABLED} GOOS=linux GOARCH=${TARGETARCH}'
 
 FROM ${BASE_IMAGE}

--- a/cmd/kueueviz/backend/Dockerfile
+++ b/cmd/kueueviz/backend/Dockerfile
@@ -3,12 +3,12 @@ ARG BUILDER_IMAGE=golang:1.25
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder
 
-# Copy Go modules manifests and download dependencies
-COPY go.mod go.sum ./
-RUN go mod download
+COPY cmd/kueueviz/backend/go.mod cmd/kueueviz/backend/go.sum ./
+COPY hack/testing/retry.sh /usr/local/bin/retry.sh
+RUN retry.sh --attempts 7 --delay 2 --exponential --stream -- go mod download
 
 # Copy the application source code
-COPY . .
+COPY cmd/kueueviz/backend/ .
 
 # Build the application
 ARG TARGETARCH
@@ -28,5 +28,3 @@ EXPOSE 8080
 
 # Command to run the application
 ENTRYPOINT ["/kueueviz"]
-
-


### PR DESCRIPTION
Cherry pick of #12249 on release-0.17.

#12249: Retry go mod download on transient proxy errors

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind flake


```release-note
NONE
```