### PR TITLE
Drop the deprecated `DynamicResourceAllocation` feature gate

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -197,7 +197,7 @@ const (
 	// owner: @kannon92
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2941-DRA
 	//
-	// Reject workloads that use DRA resources when the DynamicResourceAllocation feature gate is disabled.
+	// Reject workloads that use DRA resources when the KueueDRAIntegration feature gate is disabled.
 	KueueDRARejectWorkloadsWhenDRADisabled featuregate.Feature = "KueueDRARejectWorkloadsWhenDRADisabled"
 
 	// owner: @PannagaRao

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -178,9 +178,6 @@ const (
 	// Enable quota accounting for Dynamic Resource Allocation (DRA) devices in workloads.
 	KueueDRAIntegration featuregate.Feature = "KueueDRAIntegration"
 
-	// Deprecated: planned to be removed in 0.19. Use KueueDRAIntegration instead.
-	DynamicResourceAllocation featuregate.Feature = "DynamicResourceAllocation"
-
 	// owner: @sohankunkerkar
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2941-DRA
 	//
@@ -545,10 +542,6 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	KueueDRAIntegration: {
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
-	},
-	DynamicResourceAllocation: {
-		{Version: version.MustParse("0.14"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Deprecated, LockToDefault: true}, // remove in 0.19
 	},
 	KueueDRAIntegrationExtendedResource: {
 		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -45,16 +45,6 @@
     lockToDefault: true
     preRelease: Deprecated
     version: "0.18"
-- name: DynamicResourceAllocation
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: "0.14"
-  - default: false
-    lockToDefault: true
-    preRelease: Deprecated
-    version: "0.18"
 - name: ElasticJobsViaWorkloadSlices
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -45,16 +45,6 @@
     lockToDefault: true
     preRelease: Deprecated
     version: "0.18"
-- name: DynamicResourceAllocation
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: "0.14"
-  - default: false
-    lockToDefault: true
-    preRelease: Deprecated
-    version: "0.18"
 - name: ElasticJobsViaWorkloadSlices
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind deprecation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
Required for https://github.com/kubernetes-sigs/kueue/pull/12256.

#### Does this PR introduce a user-facing change?
```release-note
DRA: Remove the deprecated `DynamicResourceAllocation` feature gate. Use `KueueDRAIntegration` instead.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the `DynamicResourceAllocation` feature gate from the versioned feature lists.
  * Updated `KueueDRAIntegration` to use the 0.18 Beta default behavior (enabled by default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->