### PR TITLE
Prevent Cluster Autoscaler in MultiKueue manager cluster from scaling up nodes for Pod workloads

### DIFF
--- a/pkg/controller/jobs/pod/pod_multikueue_adapter.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter.go
@@ -162,7 +162,27 @@ func syncLocalPodWithRemote(
 
 		// Patch the status of the local pod to match the remote pod
 		return clientutil.PatchStatus(ctx, localClient, localPod, func() (bool, error) {
+			// While the local (management-cluster) Pod is gated it can never be
+			// scheduled here: MultiKueue runs it on the worker cluster. The local
+			// pod keeps its PodScheduled condition at False/SchedulingGated,
+			// which the cluster-autoscaler correctly ignores. Copying the remote
+			// PodScheduled=False/Unschedulable condition verbatim would make the
+			// management cluster's autoscaler treat the gated Pod as a regular
+			// unschedulable Pod and trigger a spurious scale-up. Preserve the local
+			// condition while gated; everything else (phase, container statuses, IPs)
+			// is still synced for visibility.
+			//
+			// The cluster-autoscaler classifies a Pod as Unschedulable (a scale-up
+			// candidate) purely from PodScheduled=False/reason=Unschedulable, and
+			// handles reason=SchedulingGated separately (ignored). It never consults
+			// spec.schedulingGates, so the synced reason is what matters. See
+			// ArrangePodsBySchedulability / isSchedulingGated in cluster-autoscaler:
+			// https://github.com/kubernetes/autoscaler/blob/94dcda068/cluster-autoscaler/utils/kubernetes/listers.go#L180-L236
+			localScheduled := findPodCondition(localPod.Status.Conditions, corev1.PodScheduled)
 			localPod.Status = remotePod.Status
+			if isGated(localPod) && localScheduled != nil {
+				setPodCondition(&localPod.Status, *localScheduled)
+			}
 			return true, nil
 		})
 	}
@@ -182,4 +202,27 @@ func syncLocalPodWithRemote(
 	}
 
 	return nil
+}
+
+// findPodCondition returns a pointer to the condition of the given type, or nil
+// if the Pod has no such condition.
+func findPodCondition(conditions []corev1.PodCondition, condType corev1.PodConditionType) *corev1.PodCondition {
+	for i := range conditions {
+		if conditions[i].Type == condType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+// setPodCondition replaces the condition of the same type in the status, or
+// appends it if no condition of that type is present.
+func setPodCondition(status *corev1.PodStatus, condition corev1.PodCondition) {
+	for i := range status.Conditions {
+		if status.Conditions[i].Type == condition.Type {
+			status.Conditions[i] = condition
+			return
+		}
+	}
+	status.Conditions = append(status.Conditions, condition)
 }

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter_test.go
@@ -133,6 +133,120 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
+		"keeps SchedulingGated condition on gated manager pod (avoids spurious autoscaler scale-up)": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*basePodBuilder.Clone().
+					KueueSchedulingGate().
+					StatusConditions(corev1.PodCondition{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionFalse,
+						Reason: corev1.PodReasonSchedulingGated,
+					}).
+					Obj(),
+			},
+			workerPods: []corev1.Pod{
+				*basePodBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					StatusPhase(corev1.PodPending).
+					StatusConditions(corev1.PodCondition{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionFalse,
+						Reason: corev1.PodReasonUnschedulable,
+					}).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: basePodName, Namespace: TestNamespace}, "wl1", "origin1")
+			},
+
+			// The remote PodScheduled=False/Unschedulable condition must not overwrite
+			// the local SchedulingGated one, otherwise the management cluster's
+			// cluster-autoscaler treats the gated Pod as unschedulable and scales up.
+			// Other status (the phase here) is still synced from the worker.
+			wantManagersPods: []corev1.Pod{
+				*basePodBuilder.Clone().
+					KueueSchedulingGate().
+					StatusPhase(corev1.PodPending).
+					StatusConditions(corev1.PodCondition{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionFalse,
+						Reason: corev1.PodReasonSchedulingGated,
+					}).
+					Obj(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*basePodBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					StatusPhase(corev1.PodPending).
+					StatusConditions(corev1.PodCondition{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionFalse,
+						Reason: corev1.PodReasonUnschedulable,
+					}).
+					Obj(),
+			},
+		},
+		"keeps SchedulingGated condition even when remote pod is scheduled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			// The management-cluster Pod stays gated for its whole lifetime, so its
+			// PodScheduled condition is locally owned (SchedulingGated) and is never
+			// overwritten - not even by the worker's PodScheduled=True, which would be
+			// untrue locally (the manager Pod has no NodeName) and would fight the
+			// local scheduler. Other status (phase, Ready) is still synced.
+			managersPods: []corev1.Pod{
+				*basePodBuilder.Clone().
+					KueueSchedulingGate().
+					StatusConditions(corev1.PodCondition{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionFalse,
+						Reason: corev1.PodReasonSchedulingGated,
+					}).
+					Obj(),
+			},
+			workerPods: []corev1.Pod{
+				*basePodBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					StatusPhase(corev1.PodRunning).
+					StatusConditions(
+						corev1.PodCondition{Type: corev1.PodScheduled, Status: corev1.ConditionTrue},
+						corev1.PodCondition{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+					).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: basePodName, Namespace: TestNamespace}, "wl1", "origin1")
+			},
+
+			wantManagersPods: []corev1.Pod{
+				*basePodBuilder.Clone().
+					KueueSchedulingGate().
+					StatusPhase(corev1.PodRunning).
+					StatusConditions(
+						corev1.PodCondition{
+							Type:   corev1.PodScheduled,
+							Status: corev1.ConditionFalse,
+							Reason: corev1.PodReasonSchedulingGated,
+						},
+						corev1.PodCondition{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+					).
+					Obj(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*basePodBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					StatusPhase(corev1.PodRunning).
+					StatusConditions(
+						corev1.PodCondition{Type: corev1.PodScheduled, Status: corev1.ConditionTrue},
+						corev1.PodCondition{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+					).
+					Obj(),
+			},
+		},
 		"remote pod is deleted": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			workerPods: []corev1.Pod{

--- a/test/e2e/multikueue/baseline/e2e_test.go
+++ b/test/e2e/multikueue/baseline/e2e_test.go
@@ -303,9 +303,14 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 					Reason: finishReason,
 				},
 				{
+					// The manager-cluster Pod stays scheduling-gated for its whole
+					// lifetime, so its locally-owned PodScheduled condition is
+					// preserved (SchedulingGated) rather than overwritten by the
+					// worker's PodScheduled=True. This keeps the Pod invisible to the
+					// manager cluster's cluster-autoscaler.
 					Type:   corev1.PodScheduled,
-					Status: corev1.ConditionTrue,
-					Reason: "",
+					Status: corev1.ConditionFalse,
+					Reason: corev1.PodReasonSchedulingGated,
 				},
 			}
 			ginkgo.By("Waiting for the pod to get status updates", func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area multikueue

#### What this PR does / why we need it:

When a pod workload is admitted in a MultiKueue worker cluster, the cluster autoscaler *in the management cluster* triggers a scale up even though the pod will never run in the management cluster due to the scheduling gates. This PR prevents this.


#### Which issue(s) this PR fixes:

When a pod workload is created in the management cluster, the following is added to its spec and status:

```yaml
  schedulingGates:
  - name: kueue.x-k8s.io/admission
  - name: kueue.x-k8s.io/topology
```

```yaml
  conditions:
  - lastProbeTime: null
    lastTransitionTime: '...'
    message: Scheduling is blocked due to non-empty scheduling gates
    reason: SchedulingGated
    status: 'False'
    type: PodScheduled
```

Such a pod is not considered a scale up candidate by the cluster autoscaler.

However, once the pod is admitted in the worker cluster, the `PodScheduled` condition is currently overwritten with:

```yaml
    conditions:
    - lastProbeTime: null
      lastTransitionTime: "..."
      message: '0/4 nodes are available: ...'
      observedGeneration: 2
      reason: Unschedulable
      status: "False"
      type: PodScheduled
```

The cluster autoscaler considers such a pod a scale up candidate *despite the scheduling gates*. Accordingly, I see a scale up event in the management cluster:

```console
Pod triggered scale-up: [{https://... 0->1 (max: 1000)}]
```

This scale up in the management cluster doesn't make any sense as the workload will never run there. To prevent it, we must preserve the `reason: SchedulingGated` for the `type: PodScheduled` condition in the management cluster.


#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: Fixed a bug where admitted Pod workloads could trigger unnecessary Cluster Autoscaler scale-ups
in the manager cluster. Kueue now preserves the scheduling-gated PodScheduled condition for manager-cluster
Pods, since they are intended to run only in worker clusters.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Pod status synchronization to preserve the local `PodScheduled` condition when a Pod is scheduling-gated, while still keeping other status details in sync with the remote Pod.

* **Tests**
  * Added coverage to ensure scheduling-gated manager Pod `PodScheduled` remains unchanged during job status synchronization.

* **E2E**
  * Updated the multikueue end-to-end expectations to reflect the manager Pod staying scheduling-gated for its lifetime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->