### PR TITLE
Automated cherry pick of #12068: Bump secretreader images used in ClusterProfile e2e tests

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -68,6 +68,12 @@ function e2e_is_truthy {
     esac
 }
 
+# Returns success when the kind node Kubernetes version supports image volumes,
+# which are Beta and enabled by default from v1.35.
+function e2e_supports_image_volume {
+    [[ "$(printf '%s\n' "1.35.0" "${KIND_VERSION#v}" | sort -V | head -n1)" == "1.35.0" ]]
+}
+
 # $1 image reference
 function e2e_docker_pull_if_needed {
     local image="$1"
@@ -243,7 +249,15 @@ fi
 
 if [[ -n "${CLUSTERPROFILE_VERSION:-}" ]]; then
     export CLUSTERPROFILE_CRD=${ROOT_DIR}/dep-crds/clusterprofile/multicluster.x-k8s.io_clusterprofiles.yaml
-    export CLUSTERPROFILE_PLUGIN_IMAGE=us-central1-docker.pkg.dev/k8s-staging-images/kueue/secretreader-plugin:${CLUSTERPROFILE_PLUGIN_IMAGE_VERSION}
+    # Only one secretreader image is ever needed per suite. From k8s 1.35 image volumes are
+    # enabled by default, so the official image can be mounted directly; on older versions we
+    # use the self-built image whose binary an init container copies into a shared volume,
+    # because the official image does not ship a "cp" command.
+    if e2e_supports_image_volume; then
+        export CLUSTERPROFILE_PLUGIN_IMAGE=registry.k8s.io/cluster-inventory-api/secretreader:${CLUSTERPROFILE_VERSION}
+    else
+        export CLUSTERPROFILE_PLUGIN_IMAGE=us-central1-docker.pkg.dev/k8s-staging-images/kueue/secretreader-plugin:${CLUSTERPROFILE_PLUGIN_IMAGE_VERSION}
+    fi
 fi
 
 if [[ -n "${PROMETHEUS_OPERATOR_VERSION:-}" ]]; then
@@ -584,6 +598,9 @@ function prepare_docker_images {
     if [[ -n ${PROMETHEUS_OPERATOR_VERSION:-} && ("$GINKGO_ARGS" =~ feature:prometheus || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${PROMETHEUS_OPERATOR_IMAGE}"
         e2e_docker_pull_if_needed "${PROMETHEUS_CONFIG_RELOADER_IMAGE}"
+    fi
+    if [[ -n ${CLUSTERPROFILE_VERSION:-} ]]; then
+        e2e_docker_pull_if_needed "${CLUSTERPROFILE_PLUGIN_IMAGE}"
     fi
 }
 

--- a/hack/testing/secretreader/Dockerfile
+++ b/hack/testing/secretreader/Dockerfile
@@ -5,4 +5,6 @@ RUN go install sigs.k8s.io/cluster-inventory-api/plugins/secretreader/cmd/plugin
 # Final image
 FROM alpine:3.23.3
 USER 65534:65534
-COPY --from=builder /go/bin/plugin /secretreader-plugin
+# Place the binary at /bin to mirror the official secretreader image layout, so the
+# init-container fallback and the image-volume mount expose it at the same path.
+COPY --from=builder /go/bin/plugin /bin/secretreader-plugin

--- a/test/e2e/multikueue/sequential/e2e_test.go
+++ b/test/e2e/multikueue/sequential/e2e_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
-	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/tools/clientcmd/api"
 	apiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	"k8s.io/utils/ptr"
@@ -485,10 +484,15 @@ var _ = ginkgo.Describe("MultiKueue Sequential", func() {
 
 	ginkgo.Describe("Connection via ClusterProfile with plugins", ginkgo.Label(util.Shard0), ginkgo.Ordered, func() {
 		const (
-			secretReaderPath    = "/plugins/secretreader-plugin"
 			volumeName          = "plugins"
 			volumeMountPath     = "/plugins"
 			pluginContainerName = "secretreader-plugin-init"
+			// secretReaderPath is the plugin executable path inside the shared volume. Both the
+			// official and self-built images ship the binary at /bin/secretreader-plugin, so when
+			// the image is mounted as an image volume at /plugins (k8s >= 1.35) the binary is at
+			// /plugins/bin/secretreader-plugin; the init-container fallback copies it to the same
+			// path, keeping the exec command independent of the k8s version.
+			secretReaderPath = "/plugins/bin/secretreader-plugin"
 		)
 		var (
 			defaultManagerKueueCfg  *kueueconfig.Configuration
@@ -502,6 +506,13 @@ var _ = ginkgo.Describe("MultiKueue Sequential", func() {
 		)
 
 		ginkgo.BeforeAll(func() {
+			// Image volumes are Beta and enabled by default from k8s 1.35, so the official secretreader
+			// image can be mounted directly. On older versions we keep the init container that copies the
+			// binary from the self-built image, because the official image does not ship a "cp" command.
+			serverVersion, err := versionutil.ParseGeneric(util.GetKubernetesVersion(managerCfg))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			useImageVolume := serverVersion.AtLeast(versionutil.MustParseGeneric("v1.35.0"))
+
 			ginkgo.By("Creating Role and RoleBinding for secretreader-plugin", func() {
 				secretReaderRole = utiltesting.MakeRole("secretreader", kueueNS).
 					Rule([]string{""}, []string{"secrets"}, []string{"get", "list", "watch"}).
@@ -533,14 +544,12 @@ var _ = ginkgo.Describe("MultiKueue Sequential", func() {
 						}
 					}
 
-					kubeVer := util.GetKubernetesVersion(managerCfg)
-					if version.CompareKubeAwareVersionStrings(kubeVer, versionutil.MustParseGeneric("v1.35.0").String()) >= 0 {
+					if useImageVolume {
 						updatedDeployment.Spec.Template.Spec.Volumes = append(
 							updatedDeployment.Spec.Template.Spec.Volumes,
 							corev1.Volume{
 								Name: volumeName,
 								VolumeSource: corev1.VolumeSource{
-									EmptyDir: &corev1.EmptyDirVolumeSource{},
 									Image: &corev1.ImageVolumeSource{
 										Reference:  util.GetClusterProfilePluginImage(),
 										PullPolicy: corev1.PullIfNotPresent,
@@ -554,7 +563,7 @@ var _ = ginkgo.Describe("MultiKueue Sequential", func() {
 								Name(pluginContainerName).
 								Image(util.GetClusterProfilePluginImage()).
 								ImagePullPolicy(corev1.PullIfNotPresent).
-								Command("cp", "/secretreader-plugin", secretReaderPath).
+								Command("sh", "-c", fmt.Sprintf("mkdir -p %s/bin && cp /bin/secretreader-plugin %s", volumeMountPath, secretReaderPath)).
 								VolumeMount(volumeName, volumeMountPath).
 								Obj(),
 						}

--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -664,6 +664,7 @@ func GetKuberayTestImage() string {
 }
 
 func GetClusterProfilePluginImage() string {
+	ginkgo.GinkgoHelper()
 	clusterProfilePluginImage, found := os.LookupEnv("CLUSTERPROFILE_PLUGIN_IMAGE")
 	gomega.Expect(found).To(gomega.BeTrue())
 	return clusterProfilePluginImage


### PR DESCRIPTION
Cherry pick of #12068 on release-0.17.

#12068: Bump secretreader images used in ClusterProfile e2e tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup

```release-note
NONE
```