### PR TITLE
Generalize TAS PodSet groups beyond leader-worker (required, alpha)

### DIFF
--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -60,6 +60,10 @@
     - [Example](#example-2)
   - [Cross-PodSet Topology Aware scheduling](#cross-podset-topology-aware-scheduling)
     - [Ensure leader and workers end up on the same flavor](#ensure-leader-and-workers-end-up-on-the-same-flavor)
+    - [Generalizing PodSet Groups beyond leader-worker (N PodSets, no single-replica leader)](#generalizing-podset-groups-beyond-leader-worker-n-podsets-no-single-replica-leader)
+      - [Out of scope (future work)](#out-of-scope-future-work)
+      - [Alternatives considered](#alternatives-considered)
+      - [Scalability and limitations](#scalability-and-limitations)
   - [Enforcing the assignment](#enforcing-the-assignment)
   - [Support for Elastic Workloads](#support-for-elastic-workloads)
   - [Balanced placement](#balanced-placement)
@@ -1667,6 +1671,228 @@ assignment unit to `PodSet Group`.
 User can influence the value of `PodSetGroup` by setting `kueue.x-k8s.io/podset-group-name`
 annotation.
 
+#### Generalizing PodSet Groups beyond leader-worker (N PodSets, no single-replica leader)
+
+**Use case.** The initial `PodSet Group` implementation (motivated by LeaderWorkerSet, see
+[Story 6](#story-6)) supports exactly **two** PodSets where at least one has `count == 1`
+(the "leader"). This cannot express reinforcement-learning workloads where the
+*inference/rollout* and *training* pods — distinct PodSets, each with multiple replicas and
+no singleton leader — must share a spine so weight-sync collectives do not cross the
+high-bandwidth fabric (see [#11953](https://github.com/kubernetes-sigs/kueue/issues/11953)).
+
+**What we expand.** For the **required** topology case, a group may now contain `N >= 2`
+PodSets, each with `count > 1` (no required single-replica leader). The semantics are
+unchanged: all PodSets sharing a `podset-group-name` are co-located within a single domain
+at the requested level.
+
+The routing is simple: the new generalized path (validation, scheduling, and ungating) is
+taken when the `TASPodSetGroupGeneralization` feature gate is enabled, the group requests
+required topology, **and** the group is not the legacy leader-worker shape (exactly two
+PodSets, one with a single replica). Everything else — the gate disabled, a group
+requesting preferred topology, or a legacy leader-worker group — uses the existing
+leader-worker path unchanged. Leader-worker groups are kept on the legacy path because
+their pods are not interchangeable and rely on the merged leader/worker rank layout. The
+gate is alpha and off by default.
+
+**Placement.** Each PodSet keeps its real per-pod footprint, and its pods are placed only on
+nodes that PodSet is allowed to run on — the packer applies the same per-PodSet node
+filtering as the single-PodSet path (taints vs. tolerations, node selector, required node
+affinity, with `PodSetUpdates` and flavor tolerations merged in), via the shared
+`leafNodeEligibility` / `podSetNodeRequirements` helpers. The group's pods are packed into
+the leaves of one required-level domain. Since the PodSets have different footprints,
+fitting a group into a domain is a **multi-dimensional (vector) bin-packing** problem rather
+than a single "how many pods fit" count. The exact problem is NP-hard (and has no APTAS for
+two or more resource dimensions, Woeginger 1997), so we use a near-optimal heuristic: a
+single **best-fit First-Fit-Decreasing** pass (per the vector-bin-packing literature,
+Panigrahy et al., "Heuristics for Vector Bin Packing", ESA 2011; Grandl et al., "Tetris",
+SIGCOMM 2014). Placing each pod (largest first) on the eligible leaf that leaves the least
+scarcity-weighted residual capacity keeps roomier leaves free for larger pods, consistent
+with the domain-level BestFit and the single-PodSet fit behavior. This is the same
+fragmentation concern tracked for the single-PodSet case in
+[#10574](https://github.com/kubernetes-sigs/kueue/issues/10574); the existing
+balanced-placement pseudo-polynomial DP solves *multi-domain selection over homogeneous
+slice counts* and does not apply to single-domain heterogeneous packing, hence the
+vector-bin-packing heuristic here.
+
+**Algorithm.**
+
+```
+1. Group all PodSets sharing a podset-group-name; sum their per-pod requests to
+   determine the flavor (unchanged from today).
+2. Compute the group's real aggregate demand D_total = sum_i(count_i * footprint_i),
+   plus the total pod count.
+3. Pre-filter required-level domains whose aggregate free capacity (over leaves, minus
+   TAS and assumed usage) is >= D_total. If none qualify, the group does not fit and the
+   workload is not admitted (no fallback to coarser levels -- that is preferred behavior,
+   out of scope here). Rank the survivors tightest-fit first.
+4. For each surviving domain in order, run one greedy best-fit pass: place pods
+   largest-first (FFD) on the eligible leaf (one the PodSet may run on) that leaves the
+   least scarcity-weighted residual capacity. Return the first domain whose pass places
+   all pods. The pass is O(pods * leaves * resources); it is near-optimal but NOT exact, so
+   a fragmented-but-packable group may be reported as not fitting (a conservative
+   false-negative; pods are never mis-placed).
+5. Emit one TopologyAssignment per PodSet from the placement.
+```
+
+**Pseudo-algorithm.**
+
+```
+FindGroupAssignment(group, assumedUsage):
+    # group is the list of PodSets sharing a podset-group-name, in PodSet order.
+
+    # 1. Real aggregate demand (per-resource sum + one Pod slot per pod).
+    Dtotal <- {}
+    totalCount <- 0
+    for ps in group:
+        Dtotal <- Dtotal + ps.count * ps.footprint
+        totalCount <- totalCount + ps.count
+    Dtotal[pods] <- Dtotal[pods] + totalCount
+
+    level <- requiredLevel(group)           # shared required level (validated)
+
+    # 2. Best-fit search over domains at the required level.
+    best <- none ; bestSlack <- +inf
+    for domain in sortedDomains(level):     # deterministic order
+        leaves <- leavesUnder(domain)
+        free   <- [ leaf.capacity - tasUsage(leaf) - assumedUsage(leaf)
+                    for leaf in leaves ]
+        agg    <- sum(free)
+
+        slack <- howManyTimesFits(Dtotal, agg)   # CountIn: necessary pre-filter
+        if slack < 1:        continue            # domain can never hold the group
+        if best != none and slack >= bestSlack:  continue   # cannot beat current best
+
+        placement <- PackGroupOntoLeaves(group, leaves, free)
+        if placement != none:
+            best <- placement ; bestSlack <- slack
+
+    if best == none:
+        return NotFit("no domain at <level> fits the group")
+    return PerPodSetAssignments(best)            # one TopologyAssignment per PodSet
+
+
+PackGroupOntoLeaves(group, leaves, free):
+    # Near-optimal vector bin packing: a single greedy best-fit FFD pass.
+    # Returns a leaf per pod, or none if some pod cannot be placed.
+    pods <- [ (psIndex, ps.footprint + {pods:1}) for ps in group, repeated ps.count times ]
+    sort pods by footprint descending          # FFD (dominant-resource order)
+    totalCap <- sum(free)                       # for scarcity weights
+
+    remaining <- copy(free)
+    for i in 0..len(pods):
+        bestLeaf <- none ; bestScore <- +inf
+        for leaf in leaves:
+            if not eligible(pods[i].podSet, leaf):        continue   # taints / selector / affinity
+            if not fits(pods[i].need, remaining[leaf]):   continue
+            # scarcity-weighted leftover capacity AFTER placing the pod (lower = tighter)
+            score <- sum over r (sorted) of max(0, remaining[leaf][r] - pods[i].need[r]) / totalCap[r]
+            if score < bestScore:   bestLeaf <- leaf ; bestScore <- score
+        if bestLeaf == none:   return none      # group does not fit this domain
+        remaining[bestLeaf] <- remaining[bestLeaf] - pods[i].need
+        assign pods[i] -> bestLeaf
+
+    return assignment            # pods grouped back per PodSet, counted per leaf
+```
+
+**Other changes.**
+
+- *Ungating.* The scheduler emits one `TopologyAssignment` per PodSet (today at most two).
+  The `TopologyUngater` is generalized so that, instead of the `smaller == leader` /
+  `larger == workers` rank-merging heuristic (which only handles exactly two PodSets), each
+  PodSet in a generalized required group gets its own rank space: its pods carry
+  PodSet-local indices (`0..count-1`) and are ungated within the group's co-located domain.
+  Because required-topology pods within a PodSet are interchangeable, no cross-PodSet global
+  rank ordering is imposed. The `kueue.x-k8s.io/podset-group-name` annotation remains the
+  only source of group membership; no new user-facing API is added.
+- *Validation.* For gate-enabled required groups that are not the legacy leader-worker
+  shape, `ValidatePodSetGroupingTopology` is relaxed to allow more than two PodSets and to
+  drop the "at least one PodSet has `count == 1`" requirement, keeping the invariant that
+  every PodSet in the group requests the same required topology at the same level. Preferred
+  groups, legacy leader-worker groups, and all groups when the gate is off keep the original
+  two-PodSet/single-leader validation.
+
+##### Out of scope (future work)
+
+- **Preferred topology for generalized groups.** When the group requests `preferred`
+  rather than `required`, the desired degradation behavior (climb to coarser levels, then
+  best-effort spread across multiple domains) and, crucially, *whether the PodSets of a
+  group degrade in lockstep or may be split across domains independently*, is undesigned
+  upstream. The current two-PodSet code treats the group as one summed unit when it falls
+  back, but this has never been specified for groups. Generalized `preferred` groups are
+  therefore left to a follow-up KEP update; since preferred groups stay on the legacy path,
+  a preferred group with more than two PodSets (or without a single-replica leader) is
+  rejected by the existing leader-worker validation.
+- **Per-PodSet topology levels within a group.** Today (since
+  [#6242](https://github.com/kubernetes-sigs/kueue/issues/6242) /
+  [#7061](https://github.com/kubernetes-sigs/kueue/pull/7061)) all PodSets in a group must
+  request the same level. Allowing, e.g., the trainer to require `rack` while the inference
+  fleet requires `block` is a larger design change (the placement algorithm assumes a
+  single shared required level for the whole group) and is explicitly out of scope.
+- **Balanced placement across the group's domains.** Spreading pods evenly across the
+  chosen domains for a generalized group (the `TASBalancedPlacement` interaction) is part
+  of the preferred work above and is out of scope for the required-only alpha.
+
+##### Alternatives considered
+
+- **Generalize `stateWithLeader` into a `state(d, k)` dynamic program** (the direction
+  suggested on [#11953](https://github.com/kubernetes-sigs/kueue/issues/11953), and related
+  to the optimal-bin-packing DP in
+  [#10574](https://github.com/kubernetes-sigs/kueue/issues/10574)). This is a clean
+  generalization when the group has a single distinguished "leader" footprint whose
+  per-domain count `k` ranges `0..K`: the existing balanced-placement DP already indexes its
+  table by a leader dimension. We did **not** adopt it as the core algorithm because the
+  motivating use case has `N` PodSets with *distinct* footprints across *multiple* resources.
+  Exactly fitting them requires a per-domain count vector `(k_1, ..., k_N)` per resource
+  dimension, so the DP state is pseudo-polynomial in each resource's capacity *and*
+  exponential in the number of distinct footprints — it loses the polynomial guarantee
+  precisely in the regime we care about (this is the NP-hardness / no-APTAS result for
+  vector bin packing in ≥2 dimensions, Woeginger 1997). The `state(d, k)` DP remains the
+  right tool for the homogeneous / single-leader case, which the legacy path already
+  handles; for the heterogeneous group we use the vector-bin-packing heuristic above. The
+  existing balanced-placement DP is also a *multi-domain* selector over homogeneous slice
+  counts, whereas the required group is a *single-domain* heterogeneous packing — a
+  different problem shape.
+- **Exact / backtracking packing.** Rejected for simplicity: exact bin packing is
+  worst-case exponential and does not scale to large groups (hundreds of pods). We use a
+  single greedy best-fit pass and accept conservative false-negatives (see below) rather
+  than carrying a bounded-backtracking fallback.
+
+##### Scalability and limitations
+
+**Cost.** Let `P` be the total pods in the group, `N` the number of PodSets, `L` the leaves
+under a candidate domain, `D` the candidate domains at the required level, and `R` the
+resource dimensions (small constant, e.g. CPU/memory/GPU). Per candidate domain the work is:
+
+- per-PodSet node eligibility precompute: `O(N × L × R)` (taints/selector/affinity per
+  leaf, reusing the same filter as the single-PodSet path);
+- one greedy best-fit pass: `O(P × L × R)` (each pod scans the eligible leaves, scoring `R`
+  resources).
+
+Domains are aggregate-pre-filtered (`O(D × L × R)`) and sorted tightest-fit first
+(`O(D log D)`); the packer then runs on candidate domains in order and stops at the first
+that places all pods. In the common case (the tightest domain packs) only one domain is
+packed, so the dominant term is `O((P + N) × L × R)` — polynomial and suitable for the
+scheduling hot path even for large groups (hundreds of pods). The worst case, where every
+candidate domain passes the aggregate pre-filter but fails to pack, runs the greedy pass on
+all of them: `O(D × (P + N) × L × R)`. There is no exponential path.
+
+**Not exact.** The single greedy pass is near-optimal but **not** exact: a
+fragmented-but-packable group can be reported as not fitting. Consequences, stated honestly:
+
+- A greedy strand makes the workload **pend** (a false-negative) even if a packing
+  technically exists. It is never mis-placed, and never placed on an ineligible node.
+- Best-fit FFD (largest pods first, onto the tightest eligible leaf) recovers most realistic
+  fragmentation cases, which is why a single greedy pass is acceptable for the alpha.
+- This is a deliberate simplicity vs. placement-completeness tradeoff. Possible future
+  improvements (still polynomial): additional greedy orderings, a local-search swap phase,
+  or an exact search bounded to small groups.
+
+**Determinism.** Placement is reproducible across scheduling cycles: leaves under a domain
+are iterated in a stable `levelValues` order, candidate domains are sorted by slack then
+domain ID, the best-fit score iterates resources in sorted order (float addition is not
+associative), and FFD uses a stable sort. Identical input therefore yields identical
+assignments.
+
 ### Enforcing the assignment
 
 When the workload has the PodSet assignments and is about to start we modify the
@@ -1896,6 +2122,19 @@ well covered. In particular, the following scenarios need coverage:
 - un-gate pods by with the "topology" scheduling gate
 - the Workload can be suspended and unsuspended
 
+For the generalized PodSet groups feature (`TASPodSetGroupGeneralization`), additional
+coverage:
+- validation routing: a required group of `N > 2` PodSets (and a two-PodSet group with no
+  single-replica leader) is accepted with the gate on and rejected with it off; a
+  `preferred` generalized group is rejected via the legacy path; mismatched levels within a
+  group are rejected
+- scheduler packing: heterogeneous-footprint groups that fit / do not fit a domain;
+  per-PodSet node eligibility (a capacity-sufficient leaf excluded by a taint or by a
+  node-selector/affinity mismatch); best-fit domain selection (tightest fitting domain
+  chosen, larger domains left free); deterministic placement across repeated calls
+  with tied leaves; a group spanning multiple leaves within a required domain
+- ungating: each PodSet in a generalized group is ungated within the co-located domain
+
 ### Graduation Criteria
 
 #### Alpha:
@@ -1904,6 +2143,12 @@ well covered. In particular, the following scenarios need coverage:
 - support multi-level hierarchy
 - support TAS with minimal cross to other features (no cohorts, no preemption,
   no reclaimable pods)
+- generalized PodSet groups (`TASPodSetGroupGeneralization`, alpha, off by default):
+  required-topology groups of `N >= 2` heterogeneous PodSets (excluding the legacy
+  leader-worker shape) co-located in a single domain, with the vector-bin-packing placement
+  described above. Graduation to beta requires revisiting the greedy-only false-negative
+  behavior on fragmented large groups and deciding whether `preferred` groups and per-PodSet
+  levels are in scope.
 
 The new validations which are for MVP, but likely will be relaxed in the future:
 - ClusterQueue is marked inactive if it contains a TAS ResourceFlavor and

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -578,6 +578,27 @@ func (s *TASFlavorSnapshot) FindTopologyAssignmentsForFlavor(flavorTASRequests F
 				addAssumedUsage(assumedUsage, replacementAssignment, &tr)
 			}
 		} else {
+			// Generalized PodSet group path: when the feature gate is enabled
+			// and the group requests required topology, place the whole group
+			// within a single co-located domain using the generalized
+			// bin-packer. Everything else (gate disabled, or preferred
+			// topology) uses the legacy leader-worker path below. See the
+			// "Generalizing PodSet Groups beyond leader-worker" section in
+			// keps/2724-topology-aware-scheduling.
+			if features.Enabled(features.TASPodSetGroupGeneralization) && isRequiredPodSetGroup(trs) {
+				groupAssignments, reason := s.findGeneralizedGroupAssignment(trs, assumedUsage, opts.simulateEmpty)
+				for _, tr := range trs {
+					result[tr.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: groupAssignments[tr.PodSet.Name], FailureReason: reason}
+				}
+				if reason != "" {
+					return result
+				}
+				for _, tr := range trs {
+					addAssumedUsage(assumedUsage, groupAssignments[tr.PodSet.Name], &tr)
+				}
+				continue
+			}
+
 			leader, workers := findLeaderAndWorkers(trs)
 
 			// Handle elastic workloads with delta-only placement
@@ -624,6 +645,344 @@ func findLeaderAndWorkers(trs FlavorTASRequests) (*TASPodSetRequests, TASPodSetR
 		}
 	}
 	return leader, workers
+}
+
+// isRequiredPodSetGroup reports whether a PodSet group should be handled by the
+// generalized N-PodSet placement path. With the TASPodSetGroupGeneralization
+// feature gate enabled, the new path handles required-topology groups EXCEPT the
+// legacy leader-worker shape (exactly two PodSets, one with a single replica),
+// which stays on the legacy path to preserve its merged leader/worker rank
+// layout (its pods are not interchangeable). Preferred groups also use the
+// legacy path.
+func isRequiredPodSetGroup(trs FlavorTASRequests) bool {
+	if len(trs) < 2 || !isRequired(trs[0].PodSet.TopologyRequest) {
+		return false
+	}
+	return !isLegacyLeaderWorkerShape(len(trs), func(i int) int32 { return trs[i].Count })
+}
+
+// isLegacyLeaderWorkerShape reports whether a group is the legacy leader-worker
+// shape: exactly two PodSets where at least one has a single replica.
+func isLegacyLeaderWorkerShape(numPodSets int, count func(i int) int32) bool {
+	return numPodSets == 2 && (count(0) == 1 || count(1) == 1)
+}
+
+// findGeneralizedGroupAssignment co-locates all PodSets sharing a
+// podset-group-name within a single required-level topology domain and returns
+// a per-PodSet TopologyAssignment.
+//
+// Required topology only. Each PodSet keeps its real per-pod footprint. The
+// algorithm:
+//
+//  1. Compute the group's real aggregate demand and, as a fast pre-filter,
+//     restrict to required-level domains whose aggregate free capacity can hold
+//     it (a domain that fails this can never pack the group).
+//  2. Among the surviving domains (tightest fit first), run a single greedy
+//     best-fit pass that places all the group's pods (each with its own
+//     footprint, on nodes its PodSet is allowed to run on) onto the domain's
+//     leaves. This is near-optimal but NOT exact: a fragmented-but-packable
+//     group may be reported as not fitting (a conservative false-negative).
+//  3. Build one TopologyAssignment per PodSet from the placement.
+func (s *TASFlavorSnapshot) findGeneralizedGroupAssignment(
+	trs FlavorTASRequests,
+	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
+	simulateEmpty bool,
+) (map[kueue.PodSetReference]*utiltas.TopologyAssignment, string) {
+	// Compute the group's real aggregate demand: sum of count_i * footprint_i
+	// across all PodSets, plus one Pods resource per pod.
+	groupDemand := resources.Requests{}
+	var totalCount int32
+	for i := range trs {
+		groupDemand.Add(trs[i].SinglePodRequests.ScaledUp(int64(trs[i].Count)))
+		totalCount += trs[i].Count
+	}
+	groupDemand.Add(resources.Requests{corev1.ResourcePods: int64(totalCount)})
+
+	// Build each PodSet's node-scheduling constraints (tolerations, selector,
+	// required affinity, merged with PodSetUpdates and flavor tolerations) so
+	// the packer only places a PodSet's pods on nodes that PodSet can run on.
+	constraints := make([]podSetNodeConstraints, len(trs))
+	for i := range trs {
+		c, reason := s.podSetNodeRequirements(&trs[i])
+		if reason != "" {
+			return nil, reason
+		}
+		constraints[i] = c
+	}
+
+	// Resolve the required level shared by all PodSets in the group (validation
+	// guarantees they request the same required topology).
+	topologyKey := s.levelKeyWithImpliedFallback(&trs[0])
+	if topologyKey == nil {
+		return nil, "topology level not specified"
+	}
+	requiredLevelIdx, found := s.resolveLevelIdx(*topologyKey)
+	if !found {
+		return nil, fmt.Sprintf("no requested topology level: %s", *topologyKey)
+	}
+
+	// Try required-level domains, choosing the best-fit one (consistent with
+	// the single-PodSet BestFit algorithm: among domains that fit, prefer the
+	// one with the least remaining free capacity, keeping larger domains free).
+	// Required groups are never unconstrained, so BestFit always applies.
+	//
+	// We first cheaply pre-filter domains by aggregate free capacity (a
+	// necessary, not sufficient, condition) and rank the survivors tightest-fit
+	// first. Then we run the greedy packer in that order and return the first
+	// domain that admits a placement -- so we do the minimum work and naturally
+	// fall back to a looser domain if a tighter one cannot be packed.
+	type candidate struct {
+		domainID   utiltas.TopologyDomainID
+		leaves     []*leafDomain
+		capacities []resources.Requests
+		slack      int32
+	}
+	domainsByID := s.domainsPerLevel[requiredLevelIdx]
+	candidates := make([]candidate, 0, len(domainsByID))
+	for _, domainID := range slices.Sorted(maps.Keys(domainsByID)) {
+		leaves := s.leavesUnder(domainsByID[domainID])
+		capacities := make([]resources.Requests, len(leaves))
+		aggregate := resources.Requests{}
+		for i, leaf := range leaves {
+			capacity := leaf.freeCapacity.Clone()
+			if !simulateEmpty {
+				capacity.Sub(leaf.tasUsage)
+			}
+			if used, ok := assumedUsage[leaf.id]; ok {
+				capacity.Sub(used)
+			}
+			capacities[i] = capacity
+			aggregate.Add(capacity)
+		}
+		slack := groupDemand.CountIn(aggregate)
+		if slack < 1 {
+			// Domain cannot even aggregate-fit the group; skip it.
+			continue
+		}
+		candidates = append(candidates, candidate{
+			domainID:   domainID,
+			leaves:     leaves,
+			capacities: capacities,
+			slack:      slack,
+		})
+	}
+	// Tightest fit first; ties broken by domain ID for deterministic placement.
+	slices.SortFunc(candidates, func(a, b candidate) int {
+		if a.slack != b.slack {
+			return int(a.slack - b.slack)
+		}
+		return cmp.Compare(a.domainID, b.domainID)
+	})
+	for _, c := range candidates {
+		if result := s.packGroupOntoLeaves(trs, constraints, c.leaves, c.capacities); result != nil {
+			return result, ""
+		}
+	}
+	return nil, fmt.Sprintf("no topology domain at level %s can fit the pod set group", *topologyKey)
+}
+
+// packGroupOntoLeaves attempts to place every pod of every PodSet in trs onto
+// the given leaves (with the given remaining capacities) such that no leaf is
+// oversubscribed and every pod lands on a node its PodSet is allowed to run on
+// (per-PodSet node constraints). It returns one TopologyAssignment per PodSet,
+// or nil if the greedy pass could not place all pods.
+//
+// This is a single greedy best-fit First-Fit-Decreasing pass: pods are placed
+// largest-first, each on the eligible leaf that leaves the least
+// scarcity-weighted residual capacity. It is O(pods * leaves * resources) and
+// near-optimal, but not exact -- a fragmented-but-packable group may be reported
+// as not fitting (a conservative false-negative; pods are never mis-placed).
+func (s *TASFlavorSnapshot) packGroupOntoLeaves(
+	trs FlavorTASRequests,
+	constraints []podSetNodeConstraints,
+	leaves []*leafDomain,
+	capacities []resources.Requests,
+) map[kueue.PodSetReference]*utiltas.TopologyAssignment {
+	// Precompute, per PodSet, which leaves it may use (taints / selector /
+	// required affinity). Only meaningful when nodes are the lowest level.
+	eligible := make([][]bool, len(trs))
+	for i := range trs {
+		eligible[i] = make([]bool, len(leaves))
+		for j, leaf := range leaves {
+			if !s.isLowestLevelNode {
+				eligible[i][j] = true
+				continue
+			}
+			ok, _, _ := s.leafNodeEligibility(leaf, constraints[i].tolerations, constraints[i].selector, constraints[i].affinitySelector)
+			eligible[i][j] = ok
+		}
+	}
+
+	// Build the flat pod list: each entry records its PodSet and its footprint
+	// (real per-pod requests plus one Pod slot).
+	type pod struct {
+		psIdx int
+		need  resources.Requests
+	}
+	pods := make([]pod, 0)
+	for i := range trs {
+		need := trs[i].SinglePodRequests.Clone()
+		need.Add(resources.Requests{corev1.ResourcePods: 1})
+		for range int(trs[i].Count) {
+			pods = append(pods, pod{psIdx: i, need: need})
+		}
+	}
+	// First-Fit-Decreasing: place larger pods first (dominant-resource order).
+	slices.SortStableFunc(pods, func(a, b pod) int {
+		return compareFootprintDesc(a.need, b.need)
+	})
+
+	// Scarcity weights for the best-fit score: weigh each resource by the
+	// inverse of its total capacity across the domain, so leftover capacity is
+	// measured relative to how constrained that resource is (Panigrahy et al.,
+	// "Heuristics for Vector Bin Packing"; Tetris, SIGCOMM 2014).
+	totalCapacity := resources.Requests{}
+	for _, c := range capacities {
+		totalCapacity.Add(c)
+	}
+
+	remaining := make([]resources.Requests, len(capacities))
+	for i := range capacities {
+		remaining[i] = capacities[i].Clone()
+	}
+	placement := make([]int, len(pods))
+	for podIdx := range pods {
+		bestLeaf := -1
+		var bestScore float64
+		for leafIdx := range leaves {
+			if !eligible[pods[podIdx].psIdx][leafIdx] {
+				continue
+			}
+			if pods[podIdx].need.CountIn(remaining[leafIdx]) < 1 {
+				continue
+			}
+			score := bestFitScore(pods[podIdx].need, remaining[leafIdx], totalCapacity)
+			if bestLeaf == -1 || score < bestScore {
+				bestLeaf = leafIdx
+				bestScore = score
+			}
+		}
+		if bestLeaf == -1 {
+			return nil
+		}
+		remaining[bestLeaf].Sub(pods[podIdx].need)
+		placement[podIdx] = bestLeaf
+	}
+
+	// Build per-PodSet assignments: for each PodSet, count pods per leaf.
+	levelIdx := 0
+	if s.isLowestLevelNode {
+		levelIdx = len(s.levelKeys) - 1
+	}
+	// perPodSetLeafCounts[psIdx][leafIdx] = number of pods of that PodSet on the leaf.
+	perPodSetLeafCounts := make([]map[int]int32, len(trs))
+	for i := range perPodSetLeafCounts {
+		perPodSetLeafCounts[i] = make(map[int]int32)
+	}
+	for podIdx := range pods {
+		perPodSetLeafCounts[pods[podIdx].psIdx][placement[podIdx]]++
+	}
+
+	result := make(map[kueue.PodSetReference]*utiltas.TopologyAssignment, len(trs))
+	for i := range trs {
+		assignment := &utiltas.TopologyAssignment{
+			Levels:  s.levelKeys[levelIdx:],
+			Domains: make([]utiltas.TopologyDomainAssignment, 0, len(perPodSetLeafCounts[i])),
+		}
+		// Deterministic leaf ordering by levelValues.
+		leafIdxs := slices.Collect(maps.Keys(perPodSetLeafCounts[i]))
+		slices.SortFunc(leafIdxs, func(a, b int) int {
+			return slices.Compare(leaves[a].levelValues, leaves[b].levelValues)
+		})
+		for _, leafIdx := range leafIdxs {
+			assignment.Domains = append(assignment.Domains, utiltas.TopologyDomainAssignment{
+				Values: leaves[leafIdx].levelValues[levelIdx:],
+				Count:  perPodSetLeafCounts[i][leafIdx],
+			})
+		}
+		result[trs[i].PodSet.Name] = assignment
+	}
+	return result
+}
+
+// bestFitScore returns the scarcity-weighted leftover capacity a leaf would
+// have AFTER placing a pod of the given demand on it. A lower score is a tighter
+// fit, so picking the minimum-score feasible leaf keeps roomier leaves available
+// for larger pods and reduces fragmentation (best-fit). Each resource's leftover
+// is weighted by its scarcity (inverse of total capacity) so a scarce resource
+// such as GPUs dominates the decision over abundant ones such as CPU. Resources
+// are iterated in sorted order so the float sum is reproducible (float addition
+// is not associative; map iteration order is randomized).
+func bestFitScore(need, residual, totalCapacity resources.Requests) float64 {
+	var score float64
+	for _, name := range slices.Sorted(maps.Keys(residual)) {
+		total := totalCapacity[name]
+		if total <= 0 {
+			continue
+		}
+		leftover := max(residual[name]-need[name], 0)
+		score += float64(leftover) / float64(total)
+	}
+	return score
+}
+
+// compareFootprintDesc orders footprints from largest to smallest using a
+// dominant-resource style comparison (largest single resource value first, then
+// remaining resources for determinism).
+func compareFootprintDesc(a, b resources.Requests) int {
+	names := make(map[corev1.ResourceName]struct{}, len(a)+len(b))
+	for n := range a {
+		names[n] = struct{}{}
+	}
+	for n := range b {
+		names[n] = struct{}{}
+	}
+	sorted := slices.Sorted(maps.Keys(names))
+	// Compare by the largest resource value first.
+	var maxA, maxB int64
+	for _, n := range sorted {
+		maxA = max(maxA, a[n])
+		maxB = max(maxB, b[n])
+	}
+	if maxA != maxB {
+		return int(maxB - maxA)
+	}
+	// Tie-break deterministically by per-resource values.
+	for _, n := range sorted {
+		if a[n] != b[n] {
+			return int(b[n] - a[n])
+		}
+	}
+	return 0
+}
+
+// leavesUnder returns all leaf domains under the given domain (the domain
+// itself if it is already a leaf).
+func (s *TASFlavorSnapshot) leavesUnder(d *domain) []*leafDomain {
+	if leaf, ok := s.leaves[d.id]; ok && len(d.children) == 0 {
+		return []*leafDomain{leaf}
+	}
+	var result []*leafDomain
+	stack := []*domain{d}
+	for len(stack) > 0 {
+		cur := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if len(cur.children) == 0 {
+			if leaf, ok := s.leaves[cur.id]; ok {
+				result = append(result, leaf)
+			}
+			continue
+		}
+		stack = append(stack, cur.children...)
+	}
+	// Sort by levelValues for deterministic placement: the domain tree is built
+	// from map iteration, so child/leaf order is otherwise unstable across
+	// scheduling cycles. A stable order keeps best-fit tie-breaking (and thus
+	// the per-leaf pod distribution) reproducible.
+	slices.SortFunc(result, func(a, b *leafDomain) int {
+		return slices.Compare(a.levelValues, b.levelValues)
+	})
+	return result
 }
 
 // findReplacementAssignment finds the topology assignment for the replacement node
@@ -847,13 +1206,6 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 		state.leaderCount = 1
 	}
 
-	info := podset.FromPodSet(workersTasPodSetRequests.PodSet)
-	for _, podSetUpdate := range workersTasPodSetRequests.PodSetUpdates {
-		if err := info.Merge(podset.FromUpdate(podSetUpdate)); err != nil {
-			return nil, fmt.Sprintf("invalid podSetUpdate for PodSet %s, error: %s", workersTasPodSetRequests.PodSet.Name, err.Error())
-		}
-	}
-
 	// If slice topology is not requested then we can assume that slice is a single pod
 	sliceSize, reason := getSliceSizeWithSinglePodAsDefault(workersTasPodSetRequests.PodSet.TopologyRequest)
 	if len(reason) > 0 {
@@ -895,37 +1247,17 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 		state.multiLayerConstraints = workersTasPodSetRequests.PodSet.TopologyRequest.PodsetSliceRequiredTopologyConstraints
 	}
 
-	requirements.tolerations = append(info.Tolerations, s.tolerations...)
-
-	if s.isLowestLevelNode {
-		sel, err := labels.ValidatedSelectorFromSet(info.NodeSelector)
-		if err != nil {
-			return nil, fmt.Sprintf("invalid node selectors: %s, reason: %s", info.NodeSelector, err)
-		}
-		requirements.selector = sel
-	} else {
-		requirements.selector = labels.Everything()
+	// Build the per-PodSet node-scheduling constraints (tolerations, selector,
+	// required/preferred affinity, merged with PodSetUpdates and flavor
+	// tolerations). Shared with the generalized group packer.
+	nodeReqs, reason := s.podSetNodeRequirements(&workersTasPodSetRequests)
+	if reason != "" {
+		return nil, reason
 	}
-
-	if info.Affinity != nil && info.Affinity.NodeAffinity != nil {
-		if requiredAffinity := info.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution; requiredAffinity != nil {
-			affinitySelector, err := nodeaffinity.NewNodeSelector(requiredAffinity)
-			if err != nil {
-				return nil, fmt.Sprintf("invalid affinity node selectors: %s, reason: %s", requiredAffinity, err)
-			}
-			requirements.affinitySelector = affinitySelector
-		}
-		if features.Enabled(features.TASRespectNodeAffinityPreferred) {
-			preferredAffinity := info.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
-			if len(preferredAffinity) > 0 {
-				prefTerms, err := nodeaffinity.NewPreferredSchedulingTerms(preferredAffinity)
-				if err != nil {
-					return nil, fmt.Sprintf("invalid preferred node affinity terms: %v, reason: %s", preferredAffinity, err)
-				}
-				requirements.preferredSchedulingTerms = prefTerms
-			}
-		}
-	}
+	requirements.tolerations = nodeReqs.tolerations
+	requirements.selector = nodeReqs.selector
+	requirements.affinitySelector = nodeReqs.affinitySelector
+	requirements.preferredSchedulingTerms = nodeReqs.preferredSchedulingTerms
 
 	// phase 1 - determine the number of pods and slices which can fit in each topology domain
 	s.fillInCounts(requirements, state)
@@ -1633,6 +1965,110 @@ func (s *TASFlavorSnapshot) sortedDomains(domains []*domain, unconstrained bool)
 	return result
 }
 
+// podSetNodeConstraints holds a single PodSet's node-scheduling constraints,
+// derived from its PodSet (merged with PodSetUpdates) and the flavor tolerations.
+type podSetNodeConstraints struct {
+	tolerations              []corev1.Toleration
+	selector                 labels.Selector
+	affinitySelector         *nodeaffinity.NodeSelector
+	preferredSchedulingTerms *nodeaffinity.PreferredSchedulingTerms
+}
+
+// podSetNodeRequirements builds the node-scheduling constraints for a single
+// PodSet: tolerations (PodSet + flavor), the node-label selector, required node
+// affinity, and (when TASRespectNodeAffinityPreferred is enabled) the preferred
+// scheduling terms. It is the single source of truth for per-PodSet node
+// requirements, used by both findTopologyAssignment (legacy path) and the
+// generalized group packer.
+func (s *TASFlavorSnapshot) podSetNodeRequirements(tr *TASPodSetRequests) (podSetNodeConstraints, string) {
+	var c podSetNodeConstraints
+	info := podset.FromPodSet(tr.PodSet)
+	for _, podSetUpdate := range tr.PodSetUpdates {
+		if err := info.Merge(podset.FromUpdate(podSetUpdate)); err != nil {
+			return c, fmt.Sprintf("invalid podSetUpdate for PodSet %s, error: %s", tr.PodSet.Name, err.Error())
+		}
+	}
+
+	c.tolerations = append(info.Tolerations, s.tolerations...)
+
+	if s.isLowestLevelNode {
+		sel, err := labels.ValidatedSelectorFromSet(info.NodeSelector)
+		if err != nil {
+			return c, fmt.Sprintf("invalid node selectors: %s, reason: %s", info.NodeSelector, err)
+		}
+		c.selector = sel
+	} else {
+		c.selector = labels.Everything()
+	}
+
+	if info.Affinity != nil && info.Affinity.NodeAffinity != nil {
+		if requiredAffinity := info.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution; requiredAffinity != nil {
+			affinitySelector, err := nodeaffinity.NewNodeSelector(requiredAffinity)
+			if err != nil {
+				return c, fmt.Sprintf("invalid affinity node selectors: %s, reason: %s", requiredAffinity, err)
+			}
+			c.affinitySelector = affinitySelector
+		}
+		if features.Enabled(features.TASRespectNodeAffinityPreferred) {
+			preferredAffinity := info.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+			if len(preferredAffinity) > 0 {
+				prefTerms, err := nodeaffinity.NewPreferredSchedulingTerms(preferredAffinity)
+				if err != nil {
+					return c, fmt.Sprintf("invalid preferred node affinity terms: %v, reason: %s", preferredAffinity, err)
+				}
+				c.preferredSchedulingTerms = prefTerms
+			}
+		}
+	}
+	return c, ""
+}
+
+// nodeIneligibleReason explains why a leaf node was excluded for a PodSet.
+type nodeIneligibleReason int
+
+const (
+	nodeEligible nodeIneligibleReason = iota
+	nodeIneligibleTaint
+	nodeIneligibleSelector
+	nodeIneligibleAffinity
+)
+
+// leafNodeEligibility reports whether a leaf node satisfies a PodSet's
+// scheduling constraints: tolerations vs. node taints, node labels vs. selector,
+// and required node affinity. On exclusion it returns the reason and (for the
+// taint case) the offending taint string. This is the shared predicate used by
+// both the single-PodSet path (fillInCounts) and the generalized group packer,
+// so that generalized groups respect the same node constraints.
+func (s *TASFlavorSnapshot) leafNodeEligibility(
+	leaf *leafDomain,
+	tolerations []corev1.Toleration,
+	selector labels.Selector,
+	affinitySelector *nodeaffinity.NodeSelector,
+) (bool, nodeIneligibleReason, string) {
+	// 1. Tolerations vs node taints.
+	taint, untolerated := corev1helpers.FindMatchingUntoleratedTaint(s.log, leaf.node.Taints, tolerations, func(t *corev1.Taint) bool {
+		return t.Effect == corev1.TaintEffectNoSchedule || t.Effect == corev1.TaintEffectNoExecute
+	}, true)
+	if untolerated {
+		return false, nodeIneligibleTaint, taint.ToString()
+	}
+
+	// 2. Node labels vs compiled selector.
+	var nodeLabelSet labels.Set
+	if nodeLabels := leaf.node.Labels; nodeLabels != nil {
+		nodeLabelSet = nodeLabels
+	}
+	if selector != nil && !selector.Matches(nodeLabelSet) {
+		return false, nodeIneligibleSelector, ""
+	}
+
+	// 3. Required node affinity.
+	if affinitySelector != nil && !affinitySelector.Match(leaf.node.toNode()) {
+		return false, nodeIneligibleAffinity, ""
+	}
+	return true, nodeEligible, ""
+}
+
 // fillInCounts computes per-domain pod, slice, and leader capacities from the
 // pod requirements, then rolls those capacities up the topology tree.
 func (s *TASFlavorSnapshot) fillInCounts(requirements *topologyAssignmentPodRequirements, state *findTopologyAssignmentState) {
@@ -1651,40 +2087,25 @@ func (s *TASFlavorSnapshot) fillInCounts(requirements *topologyAssignmentPodRequ
 		state.stats.TotalNodes++
 		// Gather node level information only when the node is the lowest level of the topology
 		if s.isLowestLevelNode {
-			// 1. Check Tolerations against Node Taints
-			nodeTaints := leaf.node.Taints
-			taint, untolerated := corev1helpers.FindMatchingUntoleratedTaint(s.log, nodeTaints, requirements.tolerations, func(t *corev1.Taint) bool {
-				return t.Effect == corev1.TaintEffectNoSchedule || t.Effect == corev1.TaintEffectNoExecute
-			}, true)
-			if untolerated {
-				s.log.V(5).Info("excluding node with untolerated taint", "domainID", leaf.id, "taint", taint)
-				state.stats.Taints[taint.ToString()]++
+			eligible, reason, taint := s.leafNodeEligibility(leaf, requirements.tolerations, requirements.selector, requirements.affinitySelector)
+			if !eligible {
+				switch reason {
+				case nodeIneligibleTaint:
+					s.log.V(5).Info("excluding node with untolerated taint", "domainID", leaf.id, "taint", taint)
+					state.stats.Taints[taint]++
+				case nodeIneligibleSelector:
+					s.log.V(5).Info("excluding node that doesn't match nodeSelectors", "domainID", leaf.id, "nodeLabels", leaf.node.Labels)
+					state.stats.NodeSelector++
+				case nodeIneligibleAffinity:
+					s.log.V(5).Info("excluding node that doesn't match requiredDuringSchedulingIgnoredDuringExecution affinity", "domainID", leaf.id)
+					state.stats.Affinity++
+				}
 				continue
 			}
 
-			// 2. Check Node Labels against Compiled Selector
-			var nodeLabelSet labels.Set
-			if nodeLabels := leaf.node.Labels; nodeLabels != nil {
-				nodeLabelSet = nodeLabels
-			}
-
-			if !requirements.selector.Matches(nodeLabelSet) {
-				s.log.V(5).Info("excluding node that doesn't match nodeSelectors", "domainID", leaf.id, "nodeLabels", nodeLabelSet)
-				state.stats.NodeSelector++
-				continue
-			}
-
-			// 3. Check Node against Affinity Node Selector
-			nodeObj := leaf.node.toNode()
-			if requirements.affinitySelector != nil && !requirements.affinitySelector.Match(nodeObj) {
-				s.log.V(5).Info("excluding node that doesn't match requiredDuringSchedulingIgnoredDuringExecution affinity", "domainID", leaf.id)
-				state.stats.Affinity++
-				continue
-			}
-
-			// 4. Calculate Affinity Score
+			// Calculate Affinity Score
 			if features.Enabled(features.TASRespectNodeAffinityPreferred) && requirements.preferredSchedulingTerms != nil {
-				leaf.affinityScore += requirements.preferredSchedulingTerms.Score(nodeObj)
+				leaf.affinityScore += requirements.preferredSchedulingTerms.Score(leaf.node.toNode())
 			}
 		}
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package scheduler
 
 import (
+	"maps"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -938,5 +940,397 @@ func TestTruncateAssignment(t *testing.T) {
 				t.Errorf("TruncateAssignment() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestPackGroupOntoLeaves(t *testing.T) {
+	gpu := corev1.ResourceName("nvidia.com/gpu")
+	// Helper to build a TASPodSetRequests with a name, count, and GPU footprint.
+	ps := func(name string, count int32, gpus int64) TASPodSetRequests {
+		return TASPodSetRequests{
+			PodSet:            &kueue.PodSet{Name: kueue.PodSetReference(name)},
+			Count:             count,
+			SinglePodRequests: resources.Requests{gpu: gpus},
+		}
+	}
+	// Helper to build a leaf with a hostname value and GPU capacity (plus pod slots).
+	leaf := func(host string, gpus, pods int64) *leafDomain {
+		return &leafDomain{
+			domain: domain{
+				id:          tas.TopologyDomainID(host),
+				levelValues: []string{"b1", host},
+			},
+			freeCapacity: resources.Requests{gpu: gpus, corev1.ResourcePods: pods},
+			node:         &nodeInfo{Name: host, Labels: map[string]string{corev1.LabelHostname: host}},
+		}
+	}
+
+	newSnapshot := func() *TASFlavorSnapshot {
+		return &TASFlavorSnapshot{
+			levelKeys:         []string{"cloud.com/block", corev1.LabelHostname},
+			isLowestLevelNode: true,
+		}
+	}
+
+	// defaultConstraints builds permissive per-PodSet node constraints (match
+	// any node) for the given PodSets, so the packer's eligibility filter is a
+	// no-op in tests that aren't exercising taints/selectors/affinity.
+	defaultConstraints := func(trs FlavorTASRequests) []podSetNodeConstraints {
+		c := make([]podSetNodeConstraints, len(trs))
+		for i := range c {
+			c[i] = podSetNodeConstraints{selector: labels.Everything()}
+		}
+		return c
+	}
+
+	totalCount := func(res map[kueue.PodSetReference]*tas.TopologyAssignment, name string) int32 {
+		var n int32
+		for _, d := range res[kueue.PodSetReference(name)].Domains {
+			n += d.Count
+		}
+		return n
+	}
+
+	t.Run("heterogeneous group fits across leaves", func(t *testing.T) {
+		s := newSnapshot()
+		// training: 4 pods x 8 GPU, inference: 6 pods x 1 GPU => 38 GPU total.
+		trs := FlavorTASRequests{ps("training", 4, 8), ps("inference", 6, 1)}
+		// Two leaves of 24 GPU each (48 total) -- fits 38.
+		leaves := []*leafDomain{leaf("n1", 24, 24), leaf("n2", 24, 24)}
+		caps := []resources.Requests{leaves[0].freeCapacity.Clone(), leaves[1].freeCapacity.Clone()}
+		res := s.packGroupOntoLeaves(trs, defaultConstraints(trs), leaves, caps)
+		if res == nil {
+			t.Fatal("expected a packing, got nil")
+		}
+		if got := totalCount(res, "training"); got != 4 {
+			t.Errorf("training placed %d pods, want 4", got)
+		}
+		if got := totalCount(res, "inference"); got != 6 {
+			t.Errorf("inference placed %d pods, want 6", got)
+		}
+	})
+
+	t.Run("does not fit when aggregate capacity is insufficient", func(t *testing.T) {
+		s := newSnapshot()
+		trs := FlavorTASRequests{ps("training", 4, 8), ps("inference", 6, 1)} // 38 GPU
+		leaves := []*leafDomain{leaf("n1", 16, 16), leaf("n2", 16, 16)}       // 32 GPU
+		caps := []resources.Requests{leaves[0].freeCapacity.Clone(), leaves[1].freeCapacity.Clone()}
+		if res := s.packGroupOntoLeaves(trs, defaultConstraints(trs), leaves, caps); res != nil {
+			t.Errorf("expected nil (group does not fit), got %v", res)
+		}
+	})
+
+	t.Run("greedy best-fit packs complementary big/small pods", func(t *testing.T) {
+		s := newSnapshot()
+		// Two big pods (5 GPU each) and two small pods (3 GPU each) onto two
+		// leaves of 8 GPU. The valid packing is one big + one small per leaf
+		// (5+3=8); greedy best-fit FFD (largest first, tightest leaf) finds it.
+		trs := FlavorTASRequests{ps("big", 2, 5), ps("small", 2, 3)}
+		leaves := []*leafDomain{leaf("n1", 8, 8), leaf("n2", 8, 8)}
+		caps := []resources.Requests{leaves[0].freeCapacity.Clone(), leaves[1].freeCapacity.Clone()}
+		res := s.packGroupOntoLeaves(trs, defaultConstraints(trs), leaves, caps)
+		if res == nil {
+			t.Fatal("expected a packing, got nil")
+		}
+		if got := totalCount(res, "big"); got != 2 {
+			t.Errorf("big placed %d pods, want 2", got)
+		}
+		if got := totalCount(res, "small"); got != 2 {
+			t.Errorf("small placed %d pods, want 2", got)
+		}
+	})
+
+	t.Run("exact fit on a single leaf", func(t *testing.T) {
+		s := newSnapshot()
+		trs := FlavorTASRequests{ps("a", 2, 2), ps("b", 1, 4)} // 8 GPU
+		leaves := []*leafDomain{leaf("n1", 8, 8)}
+		caps := []resources.Requests{leaves[0].freeCapacity.Clone()}
+		res := s.packGroupOntoLeaves(trs, defaultConstraints(trs), leaves, caps)
+		if res == nil {
+			t.Fatal("expected a packing, got nil")
+		}
+		if got := totalCount(res, "a"); got != 2 {
+			t.Errorf("a placed %d pods, want 2", got)
+		}
+		if got := totalCount(res, "b"); got != 1 {
+			t.Errorf("b placed %d pods, want 1", got)
+		}
+	})
+
+	t.Run("multi-resource group placed by best-fit greedy without fallback", func(t *testing.T) {
+		// Two leaves with complementary scarcity: n-cpu is CPU-heavy, n-gpu is
+		// GPU-heavy. The CPU-heavy pods only fit n-cpu and the GPU-heavy pods
+		// only fit n-gpu, so the greedy best-fit pass places them correctly.
+		s := newSnapshot()
+		cpu := corev1.ResourceCPU
+		mkPS := func(name string, count int32, cpus, gpus int64) TASPodSetRequests {
+			return TASPodSetRequests{
+				PodSet:            &kueue.PodSet{Name: kueue.PodSetReference(name)},
+				Count:             count,
+				SinglePodRequests: resources.Requests{cpu: cpus, gpu: gpus},
+			}
+		}
+		mkLeaf := func(host string, cpus, gpus int64) *leafDomain {
+			return &leafDomain{
+				domain:       domain{id: tas.TopologyDomainID(host), levelValues: []string{"b1", host}},
+				freeCapacity: resources.Requests{cpu: cpus, gpu: gpus, corev1.ResourcePods: 100},
+				node:         &nodeInfo{Name: host, Labels: map[string]string{corev1.LabelHostname: host}},
+			}
+		}
+		trs := FlavorTASRequests{mkPS("cpuheavy", 2, 8, 1), mkPS("gpuheavy", 2, 1, 8)}
+		leaves := []*leafDomain{mkLeaf("n-cpu", 18, 4), mkLeaf("n-gpu", 4, 18)}
+		caps := []resources.Requests{leaves[0].freeCapacity.Clone(), leaves[1].freeCapacity.Clone()}
+		res := s.packGroupOntoLeaves(trs, defaultConstraints(trs), leaves, caps)
+		if res == nil {
+			t.Fatal("expected a packing, got nil")
+		}
+		if got := totalCount(res, "cpuheavy"); got != 2 {
+			t.Errorf("cpuheavy placed %d pods, want 2", got)
+		}
+		if got := totalCount(res, "gpuheavy"); got != 2 {
+			t.Errorf("gpuheavy placed %d pods, want 2", got)
+		}
+	})
+
+	t.Run("best-fit places a pod on the tighter leaf, keeping the larger free", func(t *testing.T) {
+		// One PodSet of a single 2-GPU pod, two leaves: n-small=2 GPU, n-big=4
+		// GPU. Best-fit must place it on n-small (exact fit), leaving n-big's 4
+		// GPUs intact for a future larger workload.
+		s := newSnapshot()
+		trs := FlavorTASRequests{ps("a", 1, 2)}
+		leaves := []*leafDomain{leaf("n-small", 2, 10), leaf("n-big", 4, 10)}
+		caps := []resources.Requests{leaves[0].freeCapacity.Clone(), leaves[1].freeCapacity.Clone()}
+		res := s.packGroupOntoLeaves(trs, defaultConstraints(trs), leaves, caps)
+		if res == nil {
+			t.Fatal("expected a packing, got nil")
+		}
+		ta := res[kueue.PodSetReference("a")]
+		if len(ta.Domains) != 1 {
+			t.Fatalf("expected placement on a single leaf, got %d", len(ta.Domains))
+		}
+		if host := ta.Domains[0].Values[len(ta.Domains[0].Values)-1]; host != "n-small" {
+			t.Errorf("placed on %q, want best-fit leaf n-small (keeps n-big free)", host)
+		}
+	})
+
+	t.Run("placement is deterministic across repeated calls with tied leaves", func(t *testing.T) {
+		// Three identical leaves and a group of identical pods: every leaf ties
+		// on the best-fit score, so the distribution must be decided by a stable
+		// leaf order, not map iteration. Repeated calls must produce identical
+		// per-leaf counts.
+		s := newSnapshot()
+		trs := FlavorTASRequests{ps("a", 6, 1)}
+		newLeaves := func() []*leafDomain {
+			return []*leafDomain{leaf("n1", 4, 10), leaf("n2", 4, 10), leaf("n3", 4, 10)}
+		}
+		var first map[string]int32
+		for iter := range 10 {
+			leaves := newLeaves()
+			caps := []resources.Requests{
+				leaves[0].freeCapacity.Clone(),
+				leaves[1].freeCapacity.Clone(),
+				leaves[2].freeCapacity.Clone(),
+			}
+			res := s.packGroupOntoLeaves(trs, defaultConstraints(trs), leaves, caps)
+			if res == nil {
+				t.Fatal("expected a packing, got nil")
+			}
+			got := map[string]int32{}
+			for _, d := range res[kueue.PodSetReference("a")].Domains {
+				got[d.Values[len(d.Values)-1]] += d.Count
+			}
+			if first == nil {
+				first = got
+				continue
+			}
+			if !maps.Equal(first, got) {
+				t.Fatalf("non-deterministic placement: iter %d got %v, want %v", iter, got, first)
+			}
+		}
+	})
+}
+
+func TestBestFitScore(t *testing.T) {
+	gpu := corev1.ResourceName("nvidia.com/gpu")
+	cpu := corev1.ResourceCPU
+	total := resources.Requests{cpu: 10, gpu: 10}
+
+	// Best-fit: a tighter leaf (less leftover after placement) must score LOWER.
+	// A 2-GPU pod leaves 0 on a 2-GPU leaf vs 2 on a 4-GPU leaf, so the 2-GPU
+	// leaf is preferred (keeps the larger leaf free).
+	need := resources.Requests{gpu: 2}
+	tight := resources.Requests{gpu: 2}
+	roomy := resources.Requests{gpu: 4}
+	if bestFitScore(need, tight, total) >= bestFitScore(need, roomy, total) {
+		t.Errorf("expected the tighter-fitting leaf to score lower (best-fit)")
+	}
+
+	// Multi-resource: the leaf left with the least scarcity-weighted leftover wins.
+	mixedNeed := resources.Requests{cpu: 8, gpu: 1}
+	cpuRich := resources.Requests{cpu: 9, gpu: 1}    // leftover (1,0)
+	cpuExcess := resources.Requests{cpu: 18, gpu: 1} // leftover (10,0) -- much roomier
+	if bestFitScore(mixedNeed, cpuRich, total) >= bestFitScore(mixedNeed, cpuExcess, total) {
+		t.Errorf("expected the tighter CPU leaf to score lower")
+	}
+
+	// Zero total capacity for a resource must not panic or contribute.
+	if got := bestFitScore(resources.Requests{gpu: 1}, resources.Requests{gpu: 1}, resources.Requests{}); got != 0 {
+		t.Errorf("expected 0 score when total capacity is empty, got %v", got)
+	}
+}
+
+func TestPackGroupOntoLeavesNodeEligibility(t *testing.T) {
+	gpu := corev1.ResourceName("nvidia.com/gpu")
+	s := &TASFlavorSnapshot{
+		levelKeys:         []string{"cloud.com/block", corev1.LabelHostname},
+		isLowestLevelNode: true,
+	}
+	ps := func(name string, count int32, gpus int64) TASPodSetRequests {
+		return TASPodSetRequests{
+			PodSet:            &kueue.PodSet{Name: kueue.PodSetReference(name)},
+			Count:             count,
+			SinglePodRequests: resources.Requests{gpu: gpus},
+		}
+	}
+	// leaf with optional taint and a "pool" label.
+	mkLeaf := func(host, pool string, gpus int64, taints []corev1.Taint) *leafDomain {
+		return &leafDomain{
+			domain:       domain{id: tas.TopologyDomainID(host), levelValues: []string{"b1", host}},
+			freeCapacity: resources.Requests{gpu: gpus, corev1.ResourcePods: 100},
+			node: &nodeInfo{
+				Name:   host,
+				Labels: map[string]string{corev1.LabelHostname: host, "pool": pool},
+				Taints: taints,
+			},
+		}
+	}
+	totalCount := func(res map[kueue.PodSetReference]*tas.TopologyAssignment, name string) int32 {
+		var n int32
+		for _, d := range res[kueue.PodSetReference(name)].Domains {
+			n += d.Count
+		}
+		return n
+	}
+
+	t.Run("excludes a capacity-sufficient leaf with an untolerated taint", func(t *testing.T) {
+		// n-bad has plenty of GPU but a NoSchedule taint the PodSet doesn't
+		// tolerate; n-good (exact fit) must be used instead.
+		trs := FlavorTASRequests{ps("a", 2, 1)}
+		constraints := []podSetNodeConstraints{{selector: labels.Everything()}} // no tolerations
+		taint := []corev1.Taint{{Key: "dedicated", Value: "other", Effect: corev1.TaintEffectNoSchedule}}
+		leaves := []*leafDomain{mkLeaf("n-bad", "p", 100, taint), mkLeaf("n-good", "p", 2, nil)}
+		caps := []resources.Requests{leaves[0].freeCapacity.Clone(), leaves[1].freeCapacity.Clone()}
+		res := s.packGroupOntoLeaves(trs, constraints, leaves, caps)
+		if res == nil {
+			t.Fatal("expected a packing on the untainted leaf, got nil")
+		}
+		for _, d := range res[kueue.PodSetReference("a")].Domains {
+			if host := d.Values[len(d.Values)-1]; host != "n-good" {
+				t.Errorf("placed on tainted node %q, want n-good", host)
+			}
+		}
+		if totalCount(res, "a") != 2 {
+			t.Errorf("placed %d pods, want 2", totalCount(res, "a"))
+		}
+	})
+
+	t.Run("excludes a capacity-sufficient leaf that fails the node selector", func(t *testing.T) {
+		// PodSet requires pool=gpu; n-big is pool=cpu (mismatch) despite ample
+		// capacity, so the group must land on n-small (pool=gpu).
+		trs := FlavorTASRequests{ps("a", 2, 1)}
+		sel, err := labels.ValidatedSelectorFromSet(map[string]string{"pool": "gpu"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		constraints := []podSetNodeConstraints{{selector: sel}}
+		leaves := []*leafDomain{mkLeaf("n-big", "cpu", 100, nil), mkLeaf("n-small", "gpu", 2, nil)}
+		caps := []resources.Requests{leaves[0].freeCapacity.Clone(), leaves[1].freeCapacity.Clone()}
+		res := s.packGroupOntoLeaves(trs, constraints, leaves, caps)
+		if res == nil {
+			t.Fatal("expected a packing on the matching leaf, got nil")
+		}
+		for _, d := range res[kueue.PodSetReference("a")].Domains {
+			if host := d.Values[len(d.Values)-1]; host != "n-small" {
+				t.Errorf("placed on label-mismatched node %q, want n-small", host)
+			}
+		}
+	})
+
+	t.Run("not fit when the only capacity-sufficient leaf is ineligible", func(t *testing.T) {
+		// Single leaf has capacity but a taint the PodSet can't tolerate.
+		trs := FlavorTASRequests{ps("a", 2, 1)}
+		constraints := []podSetNodeConstraints{{selector: labels.Everything()}}
+		taint := []corev1.Taint{{Key: "dedicated", Value: "other", Effect: corev1.TaintEffectNoSchedule}}
+		leaves := []*leafDomain{mkLeaf("n-bad", "p", 100, taint)}
+		caps := []resources.Requests{leaves[0].freeCapacity.Clone()}
+		if res := s.packGroupOntoLeaves(trs, constraints, leaves, caps); res != nil {
+			t.Errorf("expected nil (only leaf is ineligible), got %v", res)
+		}
+	})
+}
+
+func TestFindGeneralizedGroupAssignmentBestFit(t *testing.T) {
+	gpu := corev1.ResourceName("nvidia.com/gpu")
+	block := "cloud.com/block"
+	host := corev1.LabelHostname
+
+	// Build a snapshot with two block-level domains, each with a single leaf
+	// (host). "tight" has just enough capacity for the group; "roomy" has much
+	// more. BestFit should choose "tight" to keep "roomy" free.
+	newLeaf := func(blockVal, hostVal string, gpus int64) *leafDomain {
+		return &leafDomain{
+			domain: domain{
+				id:          tas.TopologyDomainID(hostVal),
+				levelValues: []string{blockVal, hostVal},
+			},
+			freeCapacity: resources.Requests{gpu: gpus, corev1.ResourcePods: 100},
+			node:         &nodeInfo{Name: hostVal, Labels: map[string]string{corev1.LabelHostname: hostVal}},
+		}
+	}
+	tightLeaf := newLeaf("b-tight", "n-tight", 8)
+	roomyLeaf := newLeaf("b-roomy", "n-roomy", 64)
+
+	tightBlock := &domain{id: "b-tight", levelValues: []string{"b-tight"}, children: []*domain{&tightLeaf.domain}}
+	roomyBlock := &domain{id: "b-roomy", levelValues: []string{"b-roomy"}, children: []*domain{&roomyLeaf.domain}}
+
+	s := &TASFlavorSnapshot{
+		levelKeys:         []string{block, host},
+		isLowestLevelNode: true,
+		leaves: leafDomainByID{
+			tightLeaf.id: tightLeaf,
+			roomyLeaf.id: roomyLeaf,
+		},
+		domainsPerLevel: []domainByID{
+			{tightBlock.id: tightBlock, roomyBlock.id: roomyBlock}, // level 0: block
+			{tightLeaf.id: &tightLeaf.domain, roomyLeaf.id: &roomyLeaf.domain},
+		},
+	}
+
+	// Group: 2 PodSets x 2 GPU pods x 2 = 8 GPU total, requiring block topology.
+	mkPS := func(name string, count int32, gpus int64) TASPodSetRequests {
+		return TASPodSetRequests{
+			PodSet: &kueue.PodSet{
+				Name: kueue.PodSetReference(name),
+				TopologyRequest: &kueue.PodSetTopologyRequest{
+					Required: &block,
+				},
+			},
+			Count:             count,
+			SinglePodRequests: resources.Requests{gpu: gpus},
+		}
+	}
+	trs := FlavorTASRequests{mkPS("a", 2, 2), mkPS("b", 2, 2)} // 8 GPU
+
+	result, reason := s.findGeneralizedGroupAssignment(trs, map[tas.TopologyDomainID]resources.Requests{}, false)
+	if reason != "" {
+		t.Fatalf("unexpected failure: %s", reason)
+	}
+	// All assignments must land in the tight block (host n-tight), not roomy.
+	for name, ta := range result {
+		for _, d := range ta.Domains {
+			if got := d.Values[len(d.Values)-1]; got != "n-tight" {
+				t.Errorf("pod set %s placed on %q, want best-fit domain n-tight", name, got)
+			}
+		}
 	}
 }

--- a/pkg/controller/jobframework/tas_validation.go
+++ b/pkg/controller/jobframework/tas_validation.go
@@ -224,6 +224,17 @@ func ValidatePodSetGroupingTopology(podSets []kueue.PodSet, podSetAnnotationsByN
 	var allErrs field.ErrorList
 
 	for groupName, podSets := range podSetGroups.InOrder {
+		// When the generalization gate is enabled and the group requests
+		// required topology, apply the relaxed validation (more than two
+		// PodSets, no single-replica leader needed). Everything else (gate
+		// disabled, or preferred topology) keeps going through the original
+		// validation below, so existing LWS/MPI behavior is unchanged and
+		// preferred groups remain restricted to the legacy leader-worker shape.
+		if features.Enabled(features.TASPodSetGroupGeneralization) && isRequiredPodSetGroup(podSets) {
+			allErrs = append(allErrs, validateGeneralizedPodSetGroup(groupName, podSets, podSetAnnotationsByName)...)
+			continue
+		}
+
 		if groupSize := len(podSets); groupSize != 2 {
 			for _, podSet := range podSets {
 				allErrs = append(
@@ -283,6 +294,68 @@ func ValidatePodSetGroupingTopology(podSets []kueue.PodSet, podSetAnnotationsByN
 					fmt.Sprintf(errorMessageTemplate, annotationsPath1),
 				),
 			)
+		}
+	}
+
+	return allErrs
+}
+
+// isRequiredPodSetGroup reports whether a PodSet group should use the
+// generalized validation path: it requests required topology (checked on the
+// first PodSet; topology consistency is validated separately) and is NOT the
+// legacy leader-worker shape (exactly two PodSets, one with a single replica),
+// which stays on the legacy two-PodSet/single-leader validation. The
+// generalized path is used only when the TASPodSetGroupGeneralization gate is
+// enabled.
+func isRequiredPodSetGroup(podSets []kueue.PodSet) bool {
+	if len(podSets) < 2 {
+		return false
+	}
+	tr := podSets[0].TopologyRequest
+	if tr == nil || tr.Required == nil {
+		return false
+	}
+	// Legacy leader-worker shape stays on the legacy path.
+	if len(podSets) == 2 && (podSets[0].Count == 1 || podSets[1].Count == 1) {
+		return false
+	}
+	return true
+}
+
+// validateGeneralizedPodSetGroup validates a required-topology PodSet group when
+// the TASPodSetGroupGeneralization feature gate is enabled. Compared to the
+// legacy two-PodSet/leader-worker validation, it:
+//   - allows groups with more than two PodSets, and
+//   - drops the "at least one PodSet has count == 1" requirement.
+//
+// It keeps the invariant that every PodSet in the group requests the same
+// required topology at the same level.
+func validateGeneralizedPodSetGroup(
+	groupName string,
+	podSets []kueue.PodSet,
+	podSetAnnotationsByName map[kueue.PodSetReference]*field.Path,
+) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if len(podSets) < 2 {
+		// A group of a single PodSet is a no-op grouping; nothing to co-locate.
+		return allErrs
+	}
+
+	// All PodSets in the group must request the same topology, consistent with
+	// the first PodSet in the group.
+	reference := podSets[0].TopologyRequest
+	for _, podSet := range podSets {
+		annotationsPath := podSetAnnotationsByName[podSet.Name]
+		if !topologyRequestsValid(reference, podSet.TopologyRequest) {
+			allErrs = append(allErrs, field.Invalid(
+				annotationsPath,
+				field.OmitValueType{},
+				fmt.Sprintf("must specify '%s' topology consistent across all pod sets in group '%s'",
+					kueue.PodSetRequiredTopologyAnnotation,
+					groupName,
+				),
+			))
 		}
 	}
 

--- a/pkg/controller/jobs/jobset/jobset_webhook_test.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook_test.go
@@ -312,6 +312,161 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
+		{
+			name: "valid generalized PodSet grouping - three required PodSets, all count>1, gate enabled",
+			job: testingutil.MakeJobSet("jobset", "default").
+				ReplicatedJobs(
+					testingutil.ReplicatedJobRequirements{
+						Name: "job1", Replicas: 2, Parallelism: 1, Completions: 1, PodAnnotations: map[string]string{
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                  "groupname",
+						},
+					},
+					testingutil.ReplicatedJobRequirements{
+						Name: "job2", Replicas: 3, Parallelism: 1, Completions: 1, PodAnnotations: map[string]string{
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                  "groupname",
+						},
+					},
+					testingutil.ReplicatedJobRequirements{
+						Name: "job3", Replicas: 4, Parallelism: 1, Completions: 1, PodAnnotations: map[string]string{
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                  "groupname",
+						},
+					},
+				).
+				Obj(),
+			wantErr: nil,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:      true,
+				features.TASPodSetGroupGeneralization: true,
+			},
+		},
+		{
+			name: "valid generalized PodSet grouping - two required PodSets, no single-replica leader, gate enabled",
+			job: testingutil.MakeJobSet("jobset", "default").
+				ReplicatedJobs(
+					testingutil.ReplicatedJobRequirements{
+						Name: "job1", Replicas: 2, Parallelism: 1, Completions: 1, PodAnnotations: map[string]string{
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                  "groupname",
+						},
+					},
+					testingutil.ReplicatedJobRequirements{
+						Name: "job2", Replicas: 3, Parallelism: 1, Completions: 1, PodAnnotations: map[string]string{
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                  "groupname",
+						},
+					},
+				).
+				Obj(),
+			wantErr: nil,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:      true,
+				features.TASPodSetGroupGeneralization: true,
+			},
+		},
+		{
+			name: "invalid generalized PodSet grouping - preferred group of three rejected via legacy path even with gate enabled",
+			job: testingutil.MakeJobSet("jobset", "default").
+				ReplicatedJobs(
+					testingutil.ReplicatedJobRequirements{
+						Name: "job1", Replicas: 1, Parallelism: 1, Completions: 1, PodAnnotations: map[string]string{
+							kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                   "3podsets",
+						},
+					},
+					testingutil.ReplicatedJobRequirements{
+						Name: "job2", Replicas: 2, Parallelism: 1, Completions: 1, PodAnnotations: map[string]string{
+							kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                   "3podsets",
+						},
+					},
+					testingutil.ReplicatedJobRequirements{
+						Name: "job3", Replicas: 2, Parallelism: 1, Completions: 1, PodAnnotations: map[string]string{
+							kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                   "3podsets",
+						},
+					},
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("spec.replicatedJobs[0].template.spec.template.metadata.annotations").
+					Key("kueue.x-k8s.io/podset-group-name"), "3podsets", "can only define groups of exactly 2 pod sets, got: 3 pod set(s)"),
+				field.Invalid(field.NewPath("spec.replicatedJobs[1].template.spec.template.metadata.annotations").
+					Key("kueue.x-k8s.io/podset-group-name"), "3podsets", "can only define groups of exactly 2 pod sets, got: 3 pod set(s)"),
+				field.Invalid(field.NewPath("spec.replicatedJobs[2].template.spec.template.metadata.annotations").
+					Key("kueue.x-k8s.io/podset-group-name"), "3podsets", "can only define groups of exactly 2 pod sets, got: 3 pod set(s)"),
+			}.ToAggregate(),
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:      true,
+				features.TASPodSetGroupGeneralization: true,
+			},
+		},
+		{
+			name: "invalid generalized PodSet grouping - required group of three rejected when gate disabled",
+			job: testingutil.MakeJobSet("jobset", "default").
+				ReplicatedJobs(
+					testingutil.ReplicatedJobRequirements{
+						Name: "job1", Replicas: 2, Parallelism: 1, Completions: 1, PodAnnotations: map[string]string{
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                  "3podsets",
+						},
+					},
+					testingutil.ReplicatedJobRequirements{
+						Name: "job2", Replicas: 2, Parallelism: 1, Completions: 1, PodAnnotations: map[string]string{
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                  "3podsets",
+						},
+					},
+					testingutil.ReplicatedJobRequirements{
+						Name: "job3", Replicas: 2, Parallelism: 1, Completions: 1, PodAnnotations: map[string]string{
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                  "3podsets",
+						},
+					},
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("spec.replicatedJobs[0].template.spec.template.metadata.annotations").
+					Key("kueue.x-k8s.io/podset-group-name"), "3podsets", "can only define groups of exactly 2 pod sets, got: 3 pod set(s)"),
+				field.Invalid(field.NewPath("spec.replicatedJobs[1].template.spec.template.metadata.annotations").
+					Key("kueue.x-k8s.io/podset-group-name"), "3podsets", "can only define groups of exactly 2 pod sets, got: 3 pod set(s)"),
+				field.Invalid(field.NewPath("spec.replicatedJobs[2].template.spec.template.metadata.annotations").
+					Key("kueue.x-k8s.io/podset-group-name"), "3podsets", "can only define groups of exactly 2 pod sets, got: 3 pod set(s)"),
+			}.ToAggregate(),
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+		},
+		{
+			name: "invalid generalized PodSet grouping - mismatched required levels within group, gate enabled",
+			job: testingutil.MakeJobSet("jobset", "default").
+				ReplicatedJobs(
+					testingutil.ReplicatedJobRequirements{
+						Name: "job1", Replicas: 2, Parallelism: 1, Completions: 1, PodAnnotations: map[string]string{
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/rack",
+							kueue.PodSetGroupName:                  "groupname",
+						},
+					},
+					testingutil.ReplicatedJobRequirements{
+						Name: "job2", Replicas: 3, Parallelism: 1, Completions: 1, PodAnnotations: map[string]string{
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodSetGroupName:                  "groupname",
+						},
+					},
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec.replicatedJobs[1].template.spec.template.metadata.annotations"),
+					field.OmitValueType{},
+					"must specify 'kueue.x-k8s.io/podset-required-topology' topology consistent across all pod sets in group 'groupname'",
+				),
+			}.ToAggregate(),
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:      true,
+				features.TASPodSetGroupGeneralization: true,
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/controller/tas/topology_ungater.go
+++ b/pkg/controller/tas/topology_ungater.go
@@ -157,6 +157,26 @@ func (h *podHandler) queueReconcileForPod(ctx context.Context, object client.Obj
 	}
 }
 
+// isRequiredGroup reports whether a PodSet group should use the generalized
+// N-PodSet rank assignment. It mirrors the scheduler routing: a required-topology
+// group of two or more PodSets, EXCEPT the legacy leader-worker shape (exactly
+// two PodSets, one with a single replica), which keeps the legacy merged
+// leader/worker rank layout. Preferred groups also keep the legacy layout.
+func isRequiredGroup(psas []*kueue.PodSetAssignment, psNameToTopologyRequest map[kueue.PodSetReference]*kueue.PodSetTopologyRequest) bool {
+	if len(psas) < 2 {
+		return false
+	}
+	tr := psNameToTopologyRequest[psas[0].Name]
+	if tr == nil || tr.Required == nil {
+		return false
+	}
+	// Legacy leader-worker shape stays on the legacy rank layout.
+	if len(psas) == 2 && (*psas[0].Count == 1 || *psas[1].Count == 1) {
+		return false
+	}
+	return true
+}
+
 func (r *topologyUngater) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(2).Info("Reconcile Topology Ungater")
@@ -199,6 +219,18 @@ func (r *topologyUngater) Reconcile(ctx context.Context, req reconcile.Request) 
 	maxRank := make(map[kueue.PodSetReference]int32)
 
 	for _, psas := range groupedPodSetAssignments {
+		if features.Enabled(features.TASPodSetGroupGeneralization) && isRequiredGroup(psas, psNameToTopologyRequest) {
+			// Generalized PodSet group (gate on + required topology): each
+			// PodSet's pods are interchangeable within the co-location domain
+			// and carry PodSet-local indices (0..count-1), so give every PodSet
+			// its own rank space. (The legacy leader-worker rank-merging below
+			// only handles exactly two PodSets and must not be applied here.)
+			for _, psa := range psas {
+				rankOffsets[psa.Name] = 0
+				maxRank[psa.Name] = *psa.Count
+			}
+			continue
+		}
 		if len(psas) > 1 {
 			// In case of LeaderWorkerSet, in each Workload there will be
 			// 1 leader and N workers. Leader will get rank 0 and workers

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/constants"
 	coreindexer "sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/tas/indexer"
+	"sigs.k8s.io/kueue/pkg/features"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	"sigs.k8s.io/kueue/pkg/util/tas"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -120,6 +121,7 @@ func TestReconcile(t *testing.T) {
 		wantPods               []corev1.Pod
 		wantCounts             []counts
 		wantErr                error
+		enableGeneralization   bool
 	}{
 		"ungate single pod": {
 			workloads: []kueue.Workload{
@@ -1129,6 +1131,167 @@ func TestReconcile(t *testing.T) {
 						tasRackLabel:  "r2",
 					},
 					Count: 1,
+				},
+				{
+					NodeSelector: map[string]string{
+						tasBlockLabel: "b2",
+						tasRackLabel:  "r1",
+					},
+					Count: 2,
+				},
+			},
+		},
+		"ranks: ungate pods for a generalized required group of three PodSets - gate enabled": {
+			enableGeneralization: true,
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet("a", 2).
+							Request(corev1.ResourceCPU, "1").
+							PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
+							RequiredTopologyRequest(tasRackLabel).
+							PodSetGroup("group").
+							Obj(),
+						*utiltestingapi.MakePodSet("b", 2).
+							Request(corev1.ResourceCPU, "1").
+							PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
+							RequiredTopologyRequest(tasRackLabel).
+							PodSetGroup("group").
+							Obj(),
+						*utiltestingapi.MakePodSet("c", 2).
+							Request(corev1.ResourceCPU, "1").
+							PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
+							RequiredTopologyRequest(tasRackLabel).
+							PodSetGroup("group").
+							Obj(),
+					).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(
+								utiltestingapi.MakePodSetAssignment("a").
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
+									Count(2).
+									TopologyAssignment(utiltestingapi.MakeTopologyAssignment(defaultTestLevels).
+										Domains(utiltestingapi.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj()).
+										Obj()).
+									Obj(),
+								utiltestingapi.MakePodSetAssignment("b").
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
+									Count(2).
+									TopologyAssignment(utiltestingapi.MakeTopologyAssignment(defaultTestLevels).
+										Domains(utiltestingapi.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 2).Obj()).
+										Obj()).
+									Obj(),
+								utiltestingapi.MakePodSetAssignment("c").
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
+									Count(2).
+									TopologyAssignment(utiltestingapi.MakeTopologyAssignment(defaultTestLevels).
+										Domains(utiltestingapi.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 2).Obj()).
+										Obj()).
+									Obj(),
+							).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("a0", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(batchv1.JobCompletionIndexAnnotation, "0").
+					Label(constants.PodSetLabel, "a").
+					TopologySchedulingGate().
+					Obj(),
+				*testingpod.MakePod("a1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(batchv1.JobCompletionIndexAnnotation, "1").
+					Label(constants.PodSetLabel, "a").
+					TopologySchedulingGate().
+					Obj(),
+				*testingpod.MakePod("b0", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(batchv1.JobCompletionIndexAnnotation, "0").
+					Label(constants.PodSetLabel, "b").
+					TopologySchedulingGate().
+					Obj(),
+				*testingpod.MakePod("b1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(batchv1.JobCompletionIndexAnnotation, "1").
+					Label(constants.PodSetLabel, "b").
+					TopologySchedulingGate().
+					Obj(),
+				*testingpod.MakePod("c0", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(batchv1.JobCompletionIndexAnnotation, "0").
+					Label(constants.PodSetLabel, "c").
+					TopologySchedulingGate().
+					Obj(),
+				*testingpod.MakePod("c1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(batchv1.JobCompletionIndexAnnotation, "1").
+					Label(constants.PodSetLabel, "c").
+					TopologySchedulingGate().
+					Obj(),
+			},
+			nodeSelectorAssertMode: nodeSelectorAssertExact,
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("a0", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(batchv1.JobCompletionIndexAnnotation, "0").
+					Label(constants.PodSetLabel, "a").
+					NodeSelector(tasBlockLabel, "b1").
+					NodeSelector(tasRackLabel, "r1").
+					Obj(),
+				*testingpod.MakePod("a1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(batchv1.JobCompletionIndexAnnotation, "1").
+					Label(constants.PodSetLabel, "a").
+					NodeSelector(tasBlockLabel, "b1").
+					NodeSelector(tasRackLabel, "r1").
+					Obj(),
+				*testingpod.MakePod("b0", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(batchv1.JobCompletionIndexAnnotation, "0").
+					Label(constants.PodSetLabel, "b").
+					NodeSelector(tasBlockLabel, "b1").
+					NodeSelector(tasRackLabel, "r2").
+					Obj(),
+				*testingpod.MakePod("b1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(batchv1.JobCompletionIndexAnnotation, "1").
+					Label(constants.PodSetLabel, "b").
+					NodeSelector(tasBlockLabel, "b1").
+					NodeSelector(tasRackLabel, "r2").
+					Obj(),
+				*testingpod.MakePod("c0", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(batchv1.JobCompletionIndexAnnotation, "0").
+					Label(constants.PodSetLabel, "c").
+					NodeSelector(tasBlockLabel, "b2").
+					NodeSelector(tasRackLabel, "r1").
+					Obj(),
+				*testingpod.MakePod("c1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(batchv1.JobCompletionIndexAnnotation, "1").
+					Label(constants.PodSetLabel, "c").
+					NodeSelector(tasBlockLabel, "b2").
+					NodeSelector(tasRackLabel, "r1").
+					Obj(),
+			},
+			wantCounts: []counts{
+				{
+					NodeSelector: map[string]string{
+						tasBlockLabel: "b1",
+						tasRackLabel:  "r1",
+					},
+					Count: 2,
+				},
+				{
+					NodeSelector: map[string]string{
+						tasBlockLabel: "b1",
+						tasRackLabel:  "r2",
+					},
+					Count: 2,
 				},
 				{
 					NodeSelector: map[string]string{
@@ -2602,6 +2765,9 @@ func TestReconcile(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			if tc.enableGeneralization {
+				features.SetFeatureGateDuringTest(t, features.TASPodSetGroupGeneralization, true)
+			}
 			ctx, log := utiltesting.ContextWithLog(t)
 			clientBuilder := utiltesting.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 			if err := indexer.SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder)); err != nil {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -310,6 +310,14 @@ const (
 	// placement across deep topology hierarchies.
 	TASMultiLayerTopology featuregate.Feature = "TASMultiLayerTopology"
 
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-scheduling
+	//
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/11953
+	// Generalize TAS PodSet groups beyond the leader-worker pair: allow groups
+	// with more than two PodSets and without the single-replica leader
+	// constraint, for the required topology case.
+	TASPodSetGroupGeneralization featuregate.Feature = "TASPodSetGroupGeneralization"
+
 	// owner: @sohankunkerkar
 	//
 	// issue: https://github.com/kubernetes-sigs/kueue/issues/9694
@@ -621,6 +629,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	TASMultiLayerTopology: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	TASPodSetGroupGeneralization: {
+		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	SchedulingEquivalenceHashing: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Beta},

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -445,6 +445,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.17"
+- name: TASPodSetGroupGeneralization
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.18"
 - name: TASProfileMixed
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -445,6 +445,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.17"
+- name: TASPodSetGroupGeneralization
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.18"
 - name: TASProfileMixed
   versionedSpecs:
   - default: false

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -3076,6 +3076,537 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				})
 			})
 		})
+		ginkgo.When("TASPodSetGroupGeneralization is enabled", func() {
+			var (
+				nodes []corev1.Node
+			)
+			// gpuNode builds a TAS node in block b1 / rack r1 with the given
+			// hostname and GPU capacity (CPU/mem/pods are generous so GPU is the
+			// only constraint).
+			gpuNode := func(host string, gpus int64) corev1.Node {
+				return *testingnode.MakeNode(host).
+					Label("node-group", "tas").
+					Label(utiltesting.DefaultBlockTopologyLevel, "b1").
+					Label(utiltesting.DefaultRackTopologyLevel, "r1").
+					Label(corev1.LabelHostname, host).
+					StatusAllocatable(corev1.ResourceList{
+						"nvidia.com/gpu":      *resource.NewQuantity(gpus, resource.DecimalSI),
+						corev1.ResourceCPU:    resource.MustParse("100"),
+						corev1.ResourceMemory: resource.MustParse("100Gi"),
+						corev1.ResourcePods:   resource.MustParse("100"),
+					}).
+					Ready().
+					Obj()
+			}
+
+			ginkgo.BeforeEach(func() {
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.TASPodSetGroupGeneralization, true)
+			})
+
+			ginkgo.JustBeforeEach(func() {
+				util.CreateNodesWithStatus(ctx, k8sClient, nodes)
+
+				topology = utiltestingapi.MakeDefaultThreeLevelTopology("default")
+				util.MustCreate(ctx, k8sClient, topology)
+
+				tasFlavor = utiltestingapi.MakeResourceFlavor("tas-flavor").
+					NodeLabel("node-group", "tas").
+					TopologyName("default").Obj()
+				util.MustCreate(ctx, k8sClient, tasFlavor)
+
+				clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas(tasFlavor.Name).Resource("nvidia.com/gpu", "1000").Obj()).
+					Obj()
+				util.MustCreate(ctx, k8sClient, clusterQueue)
+				util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
+
+				localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+				util.MustCreate(ctx, k8sClient, localQueue)
+			})
+
+			ginkgo.AfterEach(func() {
+				gomega.Expect(util.DeleteAllJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+				gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+				gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+				for i := range nodes {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, &nodes[i], true)
+				}
+			})
+
+			// gpusInAssignment returns, per block value, the total GPU pods
+			// assigned across all PodSets, and the set of block values used.
+			countPerHost := func(wl *kueue.Workload) map[string]int32 {
+				perHost := map[string]int32{}
+				for _, psa := range wl.Status.Admission.PodSetAssignments {
+					if psa.TopologyAssignment == nil {
+						continue
+					}
+					ta := utiltas.InternalFrom(psa.TopologyAssignment)
+					for _, d := range ta.Domains {
+						perHost[d.Values[len(d.Values)-1]] += d.Count
+					}
+				}
+				return perHost
+			}
+
+			ginkgo.When("there are two GPU nodes in the same block", func() {
+				ginkgo.BeforeEach(func() {
+					// b1 / r1 / {x1:8, x2:8}
+					nodes = []corev1.Node{gpuNode("x1", 8), gpuNode("x2", 8)}
+				})
+
+				ginkgo.It("co-locates a group of three PodSets (all count>1) within the block", func() {
+					var wl *kueue.Workload
+					ginkgo.By("creating a workload with three grouped PodSets", func() {
+						wl = utiltestingapi.MakeWorkload("wl", ns.Name).
+							PodSets(
+								*utiltestingapi.MakePodSet("a", 4).
+									PodSetGroup("group").
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "1").Obj(),
+								*utiltestingapi.MakePodSet("b", 4).
+									PodSetGroup("group").
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "1").Obj(),
+								*utiltestingapi.MakePodSet("c", 4).
+									PodSetGroup("group").
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "1").Obj(),
+							).
+							Queue(kueue.LocalQueueName(localQueue.Name)).Obj()
+						util.MustCreate(ctx, k8sClient, wl)
+					})
+
+					ginkgo.By("verifying the workload is admitted and all 12 GPU pods are placed on the two block nodes", func() {
+						util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+						gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+						perHost := countPerHost(wl)
+						var total int32
+						for host, c := range perHost {
+							gomega.Expect(host).To(gomega.BeElementOf("x1", "x2"))
+							total += c
+						}
+						gomega.Expect(total).To(gomega.Equal(int32(12)))
+						gomega.Expect(wl.Status.Admission.PodSetAssignments).To(gomega.HaveLen(3))
+					})
+				})
+
+				ginkgo.It("co-locates a group with heterogeneous footprints", func() {
+					var wl *kueue.Workload
+					ginkgo.By("creating a group of a large-footprint and a small-footprint PodSet", func() {
+						// training: 2 pods x 4 GPU = 8; inference: 4 pods x 1 GPU = 4; total 12 over 16 capacity.
+						wl = utiltestingapi.MakeWorkload("wl", ns.Name).
+							PodSets(
+								*utiltestingapi.MakePodSet("training", 2).
+									PodSetGroup("group").
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "4").Obj(),
+								*utiltestingapi.MakePodSet("inference", 4).
+									PodSetGroup("group").
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "1").Obj(),
+							).
+							Queue(kueue.LocalQueueName(localQueue.Name)).Obj()
+						util.MustCreate(ctx, k8sClient, wl)
+					})
+
+					ginkgo.By("verifying admission with correct per-PodSet counts", func() {
+						util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+						gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+						psaCount := func(name string) int32 {
+							var n int32
+							for _, psa := range wl.Status.Admission.PodSetAssignments {
+								if string(psa.Name) == name && psa.TopologyAssignment != nil {
+									for _, d := range utiltas.InternalFrom(psa.TopologyAssignment).Domains {
+										n += d.Count
+									}
+								}
+							}
+							return n
+						}
+						gomega.Expect(psaCount("training")).To(gomega.Equal(int32(2)))
+						gomega.Expect(psaCount("inference")).To(gomega.Equal(int32(4)))
+					})
+				})
+
+				ginkgo.It("does not admit a group that exceeds the block capacity", func() {
+					var wl *kueue.Workload
+					ginkgo.By("creating a group demanding 18 GPU into a 16-GPU block", func() {
+						wl = utiltestingapi.MakeWorkload("wl", ns.Name).
+							PodSets(
+								*utiltestingapi.MakePodSet("a", 9).
+									PodSetGroup("group").
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "1").Obj(),
+								*utiltestingapi.MakePodSet("b", 9).
+									PodSetGroup("group").
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "1").Obj(),
+							).
+							Queue(kueue.LocalQueueName(localQueue.Name)).Obj()
+						util.MustCreate(ctx, k8sClient, wl)
+					})
+
+					ginkgo.By("verifying the workload stays pending", func() {
+						util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
+					})
+				})
+
+				ginkgo.It("admits a pending group once a blocking workload frees capacity", func() {
+					var blocker, grp *kueue.Workload
+					ginkgo.By("admitting a blocker that consumes most of the block", func() {
+						blocker = utiltestingapi.MakeWorkload("blocker", ns.Name).
+							PodSets(*utiltestingapi.MakePodSet("w", 14).
+								RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+								Request("nvidia.com/gpu", "1").Obj()).
+							Queue(kueue.LocalQueueName(localQueue.Name)).Obj()
+						util.MustCreate(ctx, k8sClient, blocker)
+						util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, blocker)
+					})
+
+					ginkgo.By("creating a group that needs 4 GPU but only 2 are free", func() {
+						grp = utiltestingapi.MakeWorkload("grp", ns.Name).
+							PodSets(
+								*utiltestingapi.MakePodSet("a", 2).
+									PodSetGroup("group").
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "1").Obj(),
+								*utiltestingapi.MakePodSet("b", 2).
+									PodSetGroup("group").
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "1").Obj(),
+							).
+							Queue(kueue.LocalQueueName(localQueue.Name)).Obj()
+						util.MustCreate(ctx, k8sClient, grp)
+						util.ExpectWorkloadsToBePending(ctx, k8sClient, grp)
+					})
+
+					ginkgo.By("deleting the blocker and verifying the group is then admitted", func() {
+						gomega.Expect(util.DeleteObject(ctx, k8sClient, blocker)).To(gomega.Succeed())
+						util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, grp)
+					})
+				})
+
+				ginkgo.It("places a group that only fits via non-greedy packing", func() {
+					var wl *kueue.Workload
+					ginkgo.By("creating a group whose only feasible packing splits big and small pods across nodes", func() {
+						// Two nodes of 8 GPU each. big: 2 x 5 GPU, small: 2 x 3 GPU.
+						// The only valid packing is one big + one small per node (5+3=8).
+						wl = utiltestingapi.MakeWorkload("wl", ns.Name).
+							PodSets(
+								*utiltestingapi.MakePodSet("big", 2).
+									PodSetGroup("group").
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "5").Obj(),
+								*utiltestingapi.MakePodSet("small", 2).
+									PodSetGroup("group").
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "3").Obj(),
+							).
+							Queue(kueue.LocalQueueName(localQueue.Name)).Obj()
+						util.MustCreate(ctx, k8sClient, wl)
+					})
+
+					ginkgo.By("verifying admission", func() {
+						util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+						gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+						perHost := countPerHost(wl)
+						gomega.Expect(perHost).To(gomega.HaveLen(2), "pods should span both nodes")
+					})
+				})
+
+				ginkgo.It("still co-locates a legacy leader-worker required group via the legacy path with the gate on", func() {
+					var wl *kueue.Workload
+					ginkgo.By("creating a 1-leader + multi-worker group", func() {
+						wl = utiltestingapi.MakeWorkload("wl", ns.Name).
+							PodSets(
+								*utiltestingapi.MakePodSet("leader", 1).
+									PodSetGroup("group").
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "1").Obj(),
+								*utiltestingapi.MakePodSet("worker", 6).
+									PodSetGroup("group").
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "1").Obj(),
+							).
+							Queue(kueue.LocalQueueName(localQueue.Name)).Obj()
+						util.MustCreate(ctx, k8sClient, wl)
+					})
+
+					ginkgo.By("verifying admission and co-location", func() {
+						util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+						gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+						perHost := countPerHost(wl)
+						var total int32
+						for host, c := range perHost {
+							gomega.Expect(host).To(gomega.BeElementOf("x1", "x2"))
+							total += c
+						}
+						gomega.Expect(total).To(gomega.Equal(int32(7)))
+					})
+				})
+			})
+
+			ginkgo.When("there are two blocks of different free capacity", func() {
+				ginkgo.BeforeEach(func() {
+					// Tight block b-tight (8 GPU) and roomy block b-roomy (64 GPU).
+					tight := *testingnode.MakeNode("n-tight").
+						Label("node-group", "tas").
+						Label(utiltesting.DefaultBlockTopologyLevel, "b-tight").
+						Label(utiltesting.DefaultRackTopologyLevel, "r-tight").
+						Label(corev1.LabelHostname, "n-tight").
+						StatusAllocatable(corev1.ResourceList{
+							"nvidia.com/gpu":      *resource.NewQuantity(8, resource.DecimalSI),
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("100Gi"),
+							corev1.ResourcePods:   resource.MustParse("100"),
+						}).
+						Ready().
+						Obj()
+					roomy := *testingnode.MakeNode("n-roomy").
+						Label("node-group", "tas").
+						Label(utiltesting.DefaultBlockTopologyLevel, "b-roomy").
+						Label(utiltesting.DefaultRackTopologyLevel, "r-roomy").
+						Label(corev1.LabelHostname, "n-roomy").
+						StatusAllocatable(corev1.ResourceList{
+							"nvidia.com/gpu":      *resource.NewQuantity(64, resource.DecimalSI),
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("100Gi"),
+							corev1.ResourcePods:   resource.MustParse("100"),
+						}).
+						Ready().
+						Obj()
+					nodes = []corev1.Node{tight, roomy}
+				})
+
+				ginkgo.It("selects the best-fit (tightest) block, keeping the roomy block free", func() {
+					var wl *kueue.Workload
+					ginkgo.By("creating a group needing exactly 8 GPU", func() {
+						wl = utiltestingapi.MakeWorkload("wl", ns.Name).
+							PodSets(
+								*utiltestingapi.MakePodSet("a", 4).
+									PodSetGroup("group").
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "1").Obj(),
+								*utiltestingapi.MakePodSet("b", 4).
+									PodSetGroup("group").
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "1").Obj(),
+							).
+							Queue(kueue.LocalQueueName(localQueue.Name)).Obj()
+						util.MustCreate(ctx, k8sClient, wl)
+					})
+
+					ginkgo.By("verifying the group lands on the tight block node", func() {
+						util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+						gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+						perHost := countPerHost(wl)
+						gomega.Expect(perHost).To(gomega.HaveKey("n-tight"))
+						gomega.Expect(perHost).ToNot(gomega.HaveKey("n-roomy"))
+					})
+				})
+			})
+
+			ginkgo.When("a required block spans multiple racks", func() {
+				// rackNode builds a TAS node in block b1 on the given rack/host.
+				rackNode := func(rack, host string, gpus int64) corev1.Node {
+					return *testingnode.MakeNode(host).
+						Label("node-group", "tas").
+						Label(utiltesting.DefaultBlockTopologyLevel, "b1").
+						Label(utiltesting.DefaultRackTopologyLevel, rack).
+						Label(corev1.LabelHostname, host).
+						StatusAllocatable(corev1.ResourceList{
+							"nvidia.com/gpu":      *resource.NewQuantity(gpus, resource.DecimalSI),
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("100Gi"),
+							corev1.ResourcePods:   resource.MustParse("100"),
+						}).
+						Ready().
+						Obj()
+				}
+				ginkgo.BeforeEach(func() {
+					// b1 / {r1: x1=4, x2=4 ; r2: x3=4} -- single block, three
+					// hosts across two racks.
+					nodes = []corev1.Node{
+						rackNode("r1", "x1", 4),
+						rackNode("r1", "x2", 4),
+						rackNode("r2", "x3", 4),
+					}
+				})
+
+				ginkgo.It("co-locates the group within the block while spreading across racks/hosts", func() {
+					var wl *kueue.Workload
+					ginkgo.By("creating a group of 10 GPU pods requiring the block", func() {
+						wl = utiltestingapi.MakeWorkload("wl", ns.Name).
+							PodSets(
+								*utiltestingapi.MakePodSet("a", 6).
+									PodSetGroup("group").
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "1").Obj(),
+								*utiltestingapi.MakePodSet("b", 4).
+									PodSetGroup("group").
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "1").Obj(),
+							).
+							Queue(kueue.LocalQueueName(localQueue.Name)).Obj()
+						util.MustCreate(ctx, k8sClient, wl)
+					})
+
+					ginkgo.By("verifying admission with all 10 pods placed within block b1 across multiple hosts", func() {
+						util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+						gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+						perHost := countPerHost(wl)
+						var total int32
+						for host, c := range perHost {
+							gomega.Expect(host).To(gomega.BeElementOf("x1", "x2", "x3"))
+							total += c
+						}
+						gomega.Expect(total).To(gomega.Equal(int32(10)))
+						// 10 pods cannot fit on fewer than 3 hosts of 4 GPU each,
+						// so the group must span multiple hosts within the block.
+						gomega.Expect(len(perHost)).To(gomega.BeNumerically(">=", 3))
+					})
+				})
+			})
+
+			ginkgo.When("a capacity-sufficient node is excluded by a taint", func() {
+				ginkgo.BeforeEach(func() {
+					// b1: x-tainted (large, but NoSchedule taint) and x-clean
+					// (exact fit). The group must avoid the tainted node.
+					nodes = []corev1.Node{
+						*testingnode.MakeNode("x-tainted").
+							Label("node-group", "tas").
+							Label(utiltesting.DefaultBlockTopologyLevel, "b1").
+							Label(utiltesting.DefaultRackTopologyLevel, "r1").
+							Label(corev1.LabelHostname, "x-tainted").
+							Taints(corev1.Taint{Key: "dedicated", Value: "other", Effect: corev1.TaintEffectNoSchedule}).
+							StatusAllocatable(corev1.ResourceList{
+								"nvidia.com/gpu":      *resource.NewQuantity(100, resource.DecimalSI),
+								corev1.ResourceCPU:    resource.MustParse("100"),
+								corev1.ResourceMemory: resource.MustParse("100Gi"),
+								corev1.ResourcePods:   resource.MustParse("100"),
+							}).
+							Ready().
+							Obj(),
+						gpuNode("x-clean", 8),
+					}
+				})
+
+				ginkgo.It("places the group on the untainted node despite the tainted node having more capacity", func() {
+					var wl *kueue.Workload
+					ginkgo.By("creating a group of 8 GPU pods that fits only the untainted node", func() {
+						wl = utiltestingapi.MakeWorkload("wl", ns.Name).
+							PodSets(
+								*utiltestingapi.MakePodSet("a", 4).
+									PodSetGroup("group").
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "1").Obj(),
+								*utiltestingapi.MakePodSet("b", 4).
+									PodSetGroup("group").
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "1").Obj(),
+							).
+							Queue(kueue.LocalQueueName(localQueue.Name)).Obj()
+						util.MustCreate(ctx, k8sClient, wl)
+					})
+
+					ginkgo.By("verifying admission with all pods on the untainted node", func() {
+						util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+						gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+						perHost := countPerHost(wl)
+						gomega.Expect(perHost).To(gomega.HaveKey("x-clean"))
+						gomega.Expect(perHost).ToNot(gomega.HaveKey("x-tainted"))
+					})
+				})
+			})
+
+			ginkgo.When("there are two GPU nodes in the same block for ungating", func() {
+				ginkgo.BeforeEach(func() {
+					nodes = []corev1.Node{gpuNode("x1", 8), gpuNode("x2", 8)}
+				})
+
+				ginkgo.It("ungates each PodSet of a generalized group within its co-located domain", func() {
+					var wl *kueue.Workload
+					ginkgo.By("creating and admitting a two-PodSet group (both count>1)", func() {
+						wl = utiltestingapi.MakeWorkload("wl-ungate", ns.Name).
+							PodSets(
+								*utiltestingapi.MakePodSet("trainer", 2).
+									PodSetGroup("group").
+									PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "1").Obj(),
+								*utiltestingapi.MakePodSet("inference", 2).
+									PodSetGroup("group").
+									PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
+									RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+									Request("nvidia.com/gpu", "1").Obj(),
+							).
+							Queue(kueue.LocalQueueName(localQueue.Name)).Obj()
+						util.MustCreate(ctx, k8sClient, wl)
+						util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+					})
+
+					ginkgo.By("verifying each PodSet received a topology assignment", func() {
+						gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+						gomega.Expect(wl.Status.Admission.PodSetAssignments).To(gomega.HaveLen(2))
+						for _, psa := range wl.Status.Admission.PodSetAssignments {
+							gomega.Expect(psa.TopologyAssignment).ToNot(gomega.BeNil(),
+								"PodSet %s should have a topology assignment", psa.Name)
+						}
+					})
+
+					// Build the set of hosts the group was assigned to (all must be
+					// in the single required block).
+					assignedHosts := func() map[string]bool {
+						hosts := map[string]bool{}
+						for _, psa := range wl.Status.Admission.PodSetAssignments {
+							for _, d := range utiltas.InternalFrom(psa.TopologyAssignment).Domains {
+								hosts[d.Values[len(d.Values)-1]] = true
+							}
+						}
+						return hosts
+					}
+
+					ginkgo.By("creating gated pods for each PodSet and verifying the ungater places them in the co-located domain", func() {
+						mkPod := func(name, podSet, idx string) *corev1.Pod {
+							return testingpod.MakePod(name, ns.Name).
+								Annotation(kueue.WorkloadAnnotation, wl.Name).
+								Annotation(kueue.PodSetRequiredTopologyAnnotation, utiltesting.DefaultBlockTopologyLevel).
+								Label(batchv1.JobCompletionIndexAnnotation, idx).
+								Label(constants.PodSetLabel, podSet).
+								TopologySchedulingGate().
+								Obj()
+						}
+						pods := []*corev1.Pod{
+							mkPod("trainer-0", "trainer", "0"),
+							mkPod("trainer-1", "trainer", "1"),
+							mkPod("inference-0", "inference", "0"),
+							mkPod("inference-1", "inference", "1"),
+						}
+						for _, p := range pods {
+							util.MustCreate(ctx, k8sClient, p)
+						}
+
+						hosts := assignedHosts()
+						gomega.Eventually(func(g gomega.Gomega) {
+							for _, p := range pods {
+								pod := &corev1.Pod{}
+								g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(p), pod)).To(gomega.Succeed())
+								g.Expect(pod.Spec.SchedulingGates).To(gomega.BeEmpty(),
+									"pod %s should be ungated", p.Name)
+								host := pod.Spec.NodeSelector[corev1.LabelHostname]
+								g.Expect(host).ToNot(gomega.BeEmpty(), "pod %s should have a hostname nodeSelector", p.Name)
+								g.Expect(hosts).To(gomega.HaveKey(host),
+									"pod %s ungated to host %s outside the group's assigned domain", p.Name, host)
+							}
+						}, util.Timeout, util.Interval).Should(gomega.Succeed())
+					})
+				})
+			})
+		})
 		ginkgo.When("Preemption is enabled within ClusterQueue", func() {
 			var (
 				nodes []corev1.Node


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind kep
/area tas

#### What this PR does / why we need it:

Generalizes TAS PodSet groups beyond the leader-worker pair so that, for the
**required** topology case, a group may contain `N >= 2` PodSets, each with
`count > 1` and no single-replica leader, co-located within a single topology
domain.

The motivating use case is reinforcement learning, where distinct
multi-replica roles (e.g. training and inference/rollout) must share a spine so
that weight-sync collectives over the high-bandwidth fabric do not cross
spines. The existing PodSet-group support requires exactly two PodSets with at
least one single-replica leader, which cannot express this.

The change is split into two commits:

1. **KEP-2724 update** — documents the generalization (required-only): routing,
   placement model (vector bin packing), per-PodSet node eligibility, ungating,
   validation changes, alternatives considered (including why the suggested
   `state(d, k)` DP is not adopted for the heterogeneous multi-resource case),
   scalability limits, and the test plan.
2. **Alpha prototype** behind a new `TASPodSetGroupGeneralization` feature gate
   (off by default):
   - **Routing**: the generalized path (validation, scheduling, ungating) is
     used when the gate is enabled, the group requests required topology, and it
     is **not** the legacy leader-worker shape (which keeps the existing path and
     merged leader/worker rank layout).
   - **Scheduler**: best-fit selection of a single required-level domain, then a
     greedy best-fit First-Fit-Decreasing pass that packs each PodSet's pods
     (with their real per-pod footprints) onto eligible leaves, honoring
     per-PodSet node constraints (taints, node selector, required/preferred
     affinity) via helpers shared with the single-PodSet path.
   - **Validation**: relaxes the two-PodSet/single-leader rules for gate-enabled
     required groups while keeping topology-consistency invariants.
   - **Ungater**: assigns each PodSet in a generalized group its own
     PodSet-local rank space.

This is intended as a prototype to align on the implementation approach for the
"Cross-PodSet Topology Aware scheduling" section of the TAS KEP, per the
discussion on the issue. Feedback on the algorithm and scope is very welcome.

#### Which issue(s) this PR fixes:

Fixes #11953

#### Special notes for your reviewer:

- The feature gate `TASPodSetGroupGeneralization` is alpha and disabled by
  default; with it off, behavior is unchanged.
- Placement uses a single greedy best-fit pass (near-optimal, not exact). A
  fragmented-but-packable group may be conservatively reported as not fitting
  (false-negative pend); it is never mis-placed. Rationale and complexity are
  documented in the KEP's "Scalability and limitations" and "Alternatives
  considered" sections, including why the existing balanced-placement DP and the
  `state(d, k)` formulation do not apply to single-domain heterogeneous packing.
- The intersection with elastic workload slices (`ElasticJobsViaWorkloadSlices`)
  is out of scope: that path supports only unconstrained topology, and a group
  is identified by `podSetGroupName`, which elastic worker groups do not use.
- Manually validated on a cluster: co-location within a required domain,
  best-fit domain selection, node packing, and node-eligibility (a tainted node
  is excluded → workload pends → untaint → schedules).

AI assistance disclosure: this change was developed with the assistance of an
AI coding tool. All code, tests, and KEP content were reviewed by the author.

#### Does this PR introduce a user-facing change?

```release-note
TAS: added an alpha `TASPodSetGroupGeneralization` feature gate (disabled by default) that generalizes PodSet groups for the required-topology case to support groups of two or more PodSets, each with multiple replicas and no single-replica leader, co-located within a single topology domain.
```
