### PR TITLE
Automated cherry pick of #12266: test: increase preemption event assertion timeout

### DIFF
--- a/test/integration/singlecluster/scheduler/preemption_test.go
+++ b/test/integration/singlecluster/scheduler/preemption_test.go
@@ -316,7 +316,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 					for _, event := range events {
 						g.Expect(event.Count).To(gomega.Equal(int32(1)))
 					}
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Finishing the first high priority workload")


### PR DESCRIPTION
Cherry pick of #12266 on release-0.17.

#12266: test: increase preemption event assertion timeout

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind flake


```release-note
NONE
```