### PR TITLE
Update partial admission kep to support ElasticJobs

### DIFF
--- a/keps/420-partial-admission/README.md
+++ b/keps/420-partial-admission/README.md
@@ -79,7 +79,8 @@ type PodSet struct {
 
 In case the workload proposed for the current scheduling cycle, does not fit, with or without preemption, in the current available quota and any of its PodSets allow partial admission, try to find to find a lower counts combination that fits the available quota with or without borrowing.
 
-The search should be priority based assuming that PodSets are listed accordinly to priorities.
+The search could be priority based or proportianaly. It's a job-level setting, that is set by adding 'kueue.x-k8s.io/partial-admission-policy=priority-based' or 'kueue.x-k8s.io/partial-admission-policy=proportional' annotation. If the value is not set, the proportional policy is used. 
+The priority based policy assume that the PodSets are listed in descending order of priorities.
 
 The accepted number of pods in each PodSet are recorded in `workload.Status.Admission.PodSetAssignments[*].ResourceUsage.Count`
 
@@ -145,7 +146,7 @@ Additional research is needed into the potential usage of multiple variable coun
 
 ### RayJob/RayService/RayCluster controller
 
-The RayCluster with 'kueue.x-k8s.io/partial-preemption=true' annotation are eligible for partial preemption. The
+The RayCluster with 'kueue.x-k8s.io/partial-admission=true' annotation are eligible for partial admission. The
 RayCluster.workerGroupSpec[i].minReplicas will be translated to the PodSet.MinCount for the Worker PodSet.
 There will be no update on RayCluster object. If the number of admitted pods less than requested count, the leftover pods should remain scheduling gated. In order to achieve that the same mechanism as for elastic workloads will be applied – the podTemplate will be initially gated and then the correct amount of pods will be ungated.
 
@@ -176,5 +177,3 @@ The `scheduler` and `controllers/job` should be extended to cover the new capabi
 
 
 ## Alternatives
-
-Using proportional algorithm instead of priority based one, i.e each PodSet should be shrinked proportionaly.

--- a/keps/420-partial-admission/README.md
+++ b/keps/420-partial-admission/README.md
@@ -10,6 +10,8 @@
 - [Design Details](#design-details)
   - [Workload API](#workload-api)
   - [Scheduler / Flavorassignment](#scheduler--flavorassignment)
+    - [Priority-Based Policy (<code>priority-based</code>)](#priority-based-policy-priority-based)
+    - [Proportional Policy (<code>proportional</code> - default)](#proportional-policy-proportional---default)
   - [Jobframework](#jobframework)
   - [batch/Job controller](#batchjob-controller)
   - [kubeflow/MPIJob controller](#kubeflowmpijob-controller)
@@ -80,33 +82,102 @@ type PodSet struct {
 
 In case the workload proposed for the current scheduling cycle does not fit, with or without preemption, in the current available quota and any of its PodSets allow partial admission, try to find a lower counts combination that fits the available quota with or without borrowing.
 
-The search could be priority-based or proportionally. It's a job-level setting, that is set by adding 'kueue.x-k8s.io/partial-admission-policy=priority-based' or 'kueue.x-k8s.io/partial-admission-policy=proportional' annotation. If the value is not set, the proportional policy is used. 
-The priority-based policy assumes that the PodSets are listed in descending order of priorities.
+The policy for shrinking PodSet counts is configured via the `kueue.x-k8s.io/partial-admission-policy` annotation on the Job. The supported policies are:
+- **`proportional` (default)**: Shrinks the counts of all variable PodSets proportionally to their allowable reduction ranges.
+- **`priority-based`**: Shrinks the counts of the PodSets sequentially, assuming they are listed in descending order of priority (i.e., the first PodSet has the highest priority and the last PodSet has the lowest priority).
 
-The accepted number of pods in each PodSet is recorded in `workload.Status.Admission.PodSetAssignments[*].ResourceUsage.Count`
+#### Priority-Based Policy (`priority-based`)
 
-In order to evaluate the potential success of the preemption, the preemption process should be split into:
-- Target selection, which should select the workloads within cohort that will need to be evicted, if the list is empty the assignment will be treated as `NoFit`. This step will take place during nomination.
-- Preemption issuing, will do the actual eviction of the targets previously selected.
+Under the `priority-based` policy, Kueue assumes that the PodSets are listed in descending order of priority. To preserve the counts of higher-priority PodSets, Kueue shrinks the PodSets starting from the end (lowest priority) and moving towards the beginning (highest priority) as needed.
 
-**Partial admission with multiple variable PodSets count**
+Specifically, if multiple PodSets have variable counts, Kueue iterates over them in the order they are defined in the Workload spec, starting from the last one. It decreases the count of the current PodSet down to its `minCount` until the workload fits the available quota. If shrinking the last PodSet to its `minCount` is still not enough to fit, Kueue keeps it at its `minCount` and moves to the second-to-last PodSet, decreasing its count down to its `minCount`, and so on.
 
-If multiple PodSets within a workload have variable counts, Kueue will iterate over the PodSets in the order they are defined in the Workload spec, starting from the end, and will try to decrease their counts until a fit is found. If shrinking the last PodSet still results in a NoFit, Kueue will try to decrease the next PodSet while keeping the last one at its minimum count, and so on.
+**Example:**
+Consider a Job with three PodSets:
+- `ps0` (highest priority): `count: 1`, no `minCount` (cannot be shrunk).
+- `ps1` (medium priority): `count: 4`, `minCount: 2` (can be reduced by up to 2 pods).
+- `ps2` (lowest priority): `count: 20`, `minCount: 10` (can be reduced by up to 10 pods).
+
+Total requested pods: `1 + 4 + 20 = 25` pods.
+
+- **Scenario A: Available quota is 19 pods** (requires a reduction of 6 pods).
+  1. Kueue targets the lowest priority PodSet, `ps2`, and decreases its count by 6 (from 20 to 14).
+  2. The resulting counts are: `ps0: 1`, `ps1: 4`, `ps2: 14` (total 19 pods, fits the quota).
+  3. Admitted counts: `ps0: 1`, `ps1: 4`, `ps2: 14`.
+
+- **Scenario B: Available quota is 13 pods** (requires a reduction of 12 pods).
+  1. Kueue targets the lowest priority PodSet, `ps2`, and decreases its count to its minimum: `10` (reduction of 10 pods). The current total count is now `1 + 4 + 10 = 15`.
+  2. Since it still does not fit the quota of 13, Kueue keeps `ps2` at `10` and moves to the next lowest priority PodSet, `ps1`.
+  3. Kueue decreases `ps1` by the remaining 2 pods (from 4 to 2). The resulting total count is `1 + 2 + 10 = 13` pods.
+  4. Admitted counts: `ps0: 1`, `ps1: 2`, `ps2: 10`.
+
+- **Scenario C: Available quota is 10 pods** (requires a reduction of 15 pods).
+  1. Kueue targets the lowest priority PodSet, `ps2`, and decreases its count to its minimum: `10` (reduction of 10 pods). The current total count is now `1 + 4 + 10 = 15`.
+  2. Since it does not fit the quota of 10, Kueue keeps `ps2` at `10` and moves to the next lowest priority PodSet, `ps1`.
+  3. Kueue decreases `ps1` to its minimum: `2` (reduction of 2 pods). The current total count is now `1 + 2 + 10 = 13`.
+  4. Since it still does not fit the quota of 10, and the remaining PodSet `ps0` does not allow partial admission (has no `minCount`), the search fails.
+  5. The job remains unadmitted.
+
+#### Proportional Policy (`proportional` - default)
+
+Under the `proportional` policy, Kueue reduces the counts of all variable PodSets proportionally to their maximum allowable reduction range (i.e., `count - minCount`).
+
+For each PodSet $j$ that allows partial admission, let:
+- $C_j$ be the maximum requested count.
+- $M_j$ be the minimum acceptable count (`minCount`).
+- $D_j = C_j - M_j$ be the maximum reduction delta for PodSet $j$.
+- $T_D = \sum D_j$ be the sum of all maximum reduction deltas.
+
+To find the optimal fit, Kueue performs a binary search on a scaling index $i$ in the range $[0, T_D]$. For a given index $i$, the count for PodSet $j$ is computed as:
+$$currentCount_j = C_j - \lfloor \frac{D_j \times i}{T_D} \rfloor$$
+
+Kueue finds the smallest index $i$ (corresponding to the minimal reduction) for which the resulting counts fit the available quota.
+
+**Example:**
+Consider a Job with three PodSets:
+- `ps0`: `count: 1`, no `minCount` ($D_0 = 0$).
+- `ps1`: `count: 4`, `minCount: 2` ($D_1 = 2$).
+- `ps2`: `count: 20`, `minCount: 10` ($D_2 = 10$).
+
+Total requested pods: `1 + 4 + 20 = 25` pods.
+Total reduction delta: $T_D = 0 + 2 + 10 = 12$ pods.
+
+- **Scenario A: Available quota is 19 pods** (requires a reduction of at least 6 pods).
+  - For $i = 6$:
+    - `ps0` count: $1 - \lfloor \frac{0 \times 6}{12} \rfloor = 1 - 0 = 1$
+    - `ps1` count: $4 - \lfloor \frac{2 \times 6}{12} \rfloor = 4 - 1 = 3$
+    - `ps2` count: $20 - \lfloor \frac{10 \times 6}{12} \rfloor = 20 - 5 = 15$
+    - Total count: `1 + 3 + 15 = 19` pods. This fits the 19-pod quota.
+  - For $i = 5$:
+    - `ps0` count: $1 - \lfloor \frac{0 \times 5}{12} \rfloor = 1 - 0 = 1$
+    - `ps1` count: $4 - \lfloor \frac{2 \times 5}{12} \rfloor = 4 - 0 = 4$
+    - `ps2` count: $20 - \lfloor \frac{10 \times 5}{12} \rfloor = 20 - 4 = 16$
+    - Total count: `1 + 4 + 16 = 21` pods. This does not fit the 19-pod quota.
+  - Thus, the binary search selects $i = 6$.
+  - Admitted counts: `ps0: 1`, `ps1: 3`, `ps2: 15` (total 19 pods).
+
+- **Scenario B: Available quota is 13 pods** (requires a reduction of at least 12 pods).
+  - For $i = 12$:
+    - `ps0` count: $1 - \lfloor \frac{0 \times 12}{12} \rfloor = 1 - 0 = 1$
+    - `ps1` count: $4 - \lfloor \frac{2 \times 12}{12} \rfloor = 4 - 2 = 2$
+    - `ps2` count: $20 - \lfloor \frac{10 \times 12}{12} \rfloor = 20 - 10 = 10$
+    - Total count: `1 + 2 + 10 = 13` pods. This fits the 13-pod quota.
+  - For $i = 11$:
+    - `ps0` count: $1 - \lfloor \frac{0 \times 11}{12} \rfloor = 1 - 0 = 1$
+    - `ps1` count: $4 - \lfloor \frac{2 \times 11}{12} \rfloor = 4 - 1 = 3$
+    - `ps2` count: $20 - \lfloor \frac{10 \times 11}{12} \rfloor = 20 - 9 = 11$
+    - Total count: `1 + 3 + 11 = 15` pods. This does not fit the 13-pod quota.
+  - Thus, the binary search selects $i = 12$.
+  - Admitted counts: `ps0: 1`, `ps1: 2`, `ps2: 10` (total 13 pods).
+
+- **Scenario C: Available quota is 10 pods** (requires a reduction of at least 15 pods).
+  - Even with the maximum possible index $i = 12$ (maximum reduction), the total count is `1 + 2 + 10 = 13` pods, which does not fit in 10 pods.
+  - Thus, the binary search fails, and the job remains unadmitted.
 
 As an optimization, we will introduce an increased step: when a workload finds a combination that fits the available quota, Kueue could try to find the combination that can be reached with minimum pod loss by checking if any of the PodSets with count == min count can be increased up to the original count. 
 The increased step is not necessary for elastic workloads, but the non-elastic workloads will benefit from it.
 
-Starting with the PodSets:
-
-```go
-[]podSet { {Count: 1} , {Count: 4, MinCount: 2}, {Count: 20, MinCount: 10}}
-```
-
-And only being able to admit 19 pods, it should end up with
-
-```go
-[]podSet { {Count: 1} , {Count: 4}, {Count: 14}}
-```
+The accepted number of pods in each PodSet is recorded in `workload.Status.Admission.PodSetAssignments[*].ResourceUsage.Count`.
 
 ### Jobframework
 

--- a/keps/420-partial-admission/README.md
+++ b/keps/420-partial-admission/README.md
@@ -79,7 +79,7 @@ type PodSet struct {
 
 In case the workload proposed for the current scheduling cycle, does not fit, with or without preemption, in the current available quota and any of its PodSets allow partial admission, try to find to find a lower counts combination that fits the available quota with or without borrowing.
 
-The search should be optimized (binary search) and preserve the proportion of pods lost across the variable count PodSets.
+The search should be priority based assuming that PodSets are listed accordinly to priorities.
 
 The accepted number of pods in each PodSet are recorded in `workload.Status.Admission.PodSetAssignments[*].ResourceUsage.Count`
 
@@ -91,7 +91,8 @@ In order to evaluate the potential success of the preemption, the preemption pro
 
 If multiple PodSets within a workload have variable counts, Kueue will iterate over the PodSets in the order they are defined in the Workload spec, starting from the end, and will try to decrease their counts until a fit is found. If shrinking the last PodSet still results in a NoFit, Kueue will try to decrease the next PodSet while keeping the last one at its minimum count, and so on.
 
-When a workload finds a combination that fits the available quota, it tries to find the combination that can be reached with minimum pod loss by checking if any of the PodSets with count == min count can be increased up to the original count.
+As an optimisation we will introdce an increased step: when a workload finds a combination that fits the available quota, Kueue could try to find the combination that can be reached with minimum pod loss by checking if any of the PodSets with count == min count can be increased up to the original count. 
+The increased step is not nessesary for elastic workloads, but it the non-elastic workloads will benefit from it.
 
 Starting with the PodSets:
 
@@ -104,8 +105,6 @@ And only being able to admit 19 pods, it should end up with
 ```go
 []podSet { {Count: 1} , {Count: 4}, {Count: 14}}
 ```
-
-If the priority based partial admission is not sufficient, the "proportional" partial admission will be introduced.
 
 ### Jobframework
 
@@ -148,7 +147,7 @@ Additional research is needed into the potential usage of multiple variable coun
 
 The RayCluster with 'kueue.x-k8s.io/partial-preemption=true' annotation are eligible for partial preemption. The
 RayCluster.workerGroupSpec[i].minReplicas will be translated to the PodSet.MinCount for the Worker PodSet.
-There will be no update on RayCluster object. If the number of admitted pods less than requested count, the leftover pods should remain scheduling gated. In order to achive that the same mechanism as for elastic workloads will be applied – the podTemplate will be initially gated and then the correct amount of pods will be ungated.
+There will be no update on RayCluster object. If the number of admitted pods less than requested count, the leftover pods should remain scheduling gated. In order to achieve that the same mechanism as for elastic workloads will be applied – the podTemplate will be initially gated and then the correct amount of pods will be ungated.
 
 ### Test Plan
 
@@ -178,3 +177,4 @@ The `scheduler` and `controllers/job` should be extended to cover the new capabi
 
 ## Alternatives
 
+Using proportional algorithm instead of priority based one, i.e each PodSet should be shrinked proportionaly.

--- a/keps/420-partial-admission/README.md
+++ b/keps/420-partial-admission/README.md
@@ -17,6 +17,7 @@
   - [Test Plan](#test-plan)
     - [Unit Tests](#unit-tests)
     - [Integration tests](#integration-tests)
+    - [E2E tests](#e2e-tests)
   - [Graduation Criteria](#graduation-criteria)
 - [Implementation History](#implementation-history)
 - [Drawbacks](#drawbacks)
@@ -31,7 +32,7 @@ Add an optional way of allowing the partial admission of a workload if the full 
 
 In practice, not all Workloads require the parallel execution of all the `count` of a `PodSet`, for such cases having a way to partially reserve the quota in order to prevent starvation.
 
-For example if a batch/Job has parallelism is x and there is only quota available for y < x then the job could still be admitted if it can work with a lower parallelism.
+For example, if a batch/Job has parallelism x and there is only quota available for y < x, then the job could still be admitted if it can work with a lower parallelism.
 
 ### Goals
 
@@ -45,7 +46,7 @@ Kueue will not take any measure to ensure that the parent job respects the assig
 
 ## Proposal
 
-Change the way the flavor assigner work to support decrementing the pods count in order to find a better fit for the current workload.
+Change the way the flavor assigner works to support decrementing the pods count in order to find a better fit for the current workload.
 In case a partial fit is chosen, the jobframework reconciler should provide the admitted pod counts to the parent job before unsuspending it, in a similar fashion as the node selectors are provided. In case the job gets suspended, the original pod counts should be restored in order to allow a potential future admission with its original pod counts.
 
 ### User Stories
@@ -77,14 +78,14 @@ type PodSet struct {
 
 ### Scheduler / Flavorassignment
 
-In case the workload proposed for the current scheduling cycle, does not fit, with or without preemption, in the current available quota and any of its PodSets allow partial admission, try to find to find a lower counts combination that fits the available quota with or without borrowing.
+In case the workload proposed for the current scheduling cycle does not fit, with or without preemption, in the current available quota and any of its PodSets allow partial admission, try to find a lower counts combination that fits the available quota with or without borrowing.
 
-The search could be priority based or proportianaly. It's a job-level setting, that is set by adding 'kueue.x-k8s.io/partial-admission-policy=priority-based' or 'kueue.x-k8s.io/partial-admission-policy=proportional' annotation. If the value is not set, the proportional policy is used. 
-The priority based policy assume that the PodSets are listed in descending order of priorities.
+The search could be priority-based or proportionally. It's a job-level setting, that is set by adding 'kueue.x-k8s.io/partial-admission-policy=priority-based' or 'kueue.x-k8s.io/partial-admission-policy=proportional' annotation. If the value is not set, the proportional policy is used. 
+The priority-based policy assumes that the PodSets are listed in descending order of priorities.
 
-The accepted number of pods in each PodSet are recorded in `workload.Status.Admission.PodSetAssignments[*].ResourceUsage.Count`
+The accepted number of pods in each PodSet is recorded in `workload.Status.Admission.PodSetAssignments[*].ResourceUsage.Count`
 
-In order to evaluate the potential success of the preemption, the preemption process should be split in:
+In order to evaluate the potential success of the preemption, the preemption process should be split into:
 - Target selection, which should select the workloads within cohort that will need to be evicted, if the list is empty the assignment will be treated as `NoFit`. This step will take place during nomination.
 - Preemption issuing, will do the actual eviction of the targets previously selected.
 
@@ -92,8 +93,8 @@ In order to evaluate the potential success of the preemption, the preemption pro
 
 If multiple PodSets within a workload have variable counts, Kueue will iterate over the PodSets in the order they are defined in the Workload spec, starting from the end, and will try to decrease their counts until a fit is found. If shrinking the last PodSet still results in a NoFit, Kueue will try to decrease the next PodSet while keeping the last one at its minimum count, and so on.
 
-As an optimisation we will introdce an increased step: when a workload finds a combination that fits the available quota, Kueue could try to find the combination that can be reached with minimum pod loss by checking if any of the PodSets with count == min count can be increased up to the original count. 
-The increased step is not nessesary for elastic workloads, but it the non-elastic workloads will benefit from it.
+As an optimization, we will introduce an increased step: when a workload finds a combination that fits the available quota, Kueue could try to find the combination that can be reached with minimum pod loss by checking if any of the PodSets with count == min count can be increased up to the original count. 
+The increased step is not necessary for elastic workloads, but the non-elastic workloads will benefit from it.
 
 Starting with the PodSets:
 
@@ -115,7 +116,7 @@ type GenericJob interface {
 
 	
 -    // RunWithNodeAffinity will inject the node affinity extracting from workload to job and unsuspend the job.
-+    // RunWithPodSetsInfo will inject the node affinity and podsSet counts extracted from workload to the job and unsuspend the job.
++    // RunWithPodSetsInfo will inject the node affinity and podSet counts extracted from workload to the job and unsuspend the job.
 -    RunWithNodeAffinity(nodeSelectors []PodSetNodeSelector)
 +    RunWithPodSetsInfo(nodeSelectors []PodSetNodeSelector, podSetCounts []int32)
 -    // RestoreNodeAffinity will restore the original node affinity of job.
@@ -133,8 +134,8 @@ type GenericJob interface {
 Besides adapting `RunWithPodSetsInfo` and `RestorePodSetsInfo` it should also:
 
 - rework `PodSets()` to populate `MinCount` if the job is marked to support partial admission.
-  * jobs supporting partial admission should have a dedicated annotation. eg. `kueue.x-k8s.io/job-min-parallelism`, indicating the minimum `parallelism` acceptable by the job in case of partial admission.
-  * jobs which need the `completions` count kept in sync with `parallelism` should indicate this in a second annotation `kueue.x-k8s.io/job-completions-equal-parallelism`
+  * jobs supporting partial admission should have a dedicated annotation, e.g., `kueue.x-k8s.io/job-min-parallelism`, indicating the minimum `parallelism` acceptable by the job in case of partial admission.
+  * jobs which need the `completions` count kept in sync with `parallelism` should indicate this in a second annotation, `kueue.x-k8s.io/job-completions-equal-parallelism`
 - rework `EquivalentToWorkload` to account for potential differences in `PodSets` spec `Parallelism`.
 
 ### kubeflow/MPIJob controller
@@ -146,13 +147,13 @@ Additional research is needed into the potential usage of multiple variable coun
 
 ### RayJob/RayService/RayCluster controller
 
-The RayCluster with 'kueue.x-k8s.io/partial-admission=true' annotation are eligible for partial admission. The
+RayClusters with 'kueue.x-k8s.io/partial-admission=true' annotation are eligible for partial admission. The
 RayCluster.workerGroupSpec[i].minReplicas will be translated to the PodSet.MinCount for the Worker PodSet.
-There will be no update on RayCluster object. If the number of admitted pods less than requested count, the leftover pods should remain scheduling gated. In order to achieve that the same mechanism as for elastic workloads will be applied – the podTemplate will be initially gated and then the correct amount of pods will be ungated.
+There will be no update on RayCluster object. If the number of admitted pods is less than requested count, the leftover pods should remain scheduling gated. In order to achieve that, the same mechanism as for elastic workloads will be applied – the podTemplate will be initially gated and then the correct amount of pods will be ungated.
 
 ### Test Plan
 
-No regressions in the current test should be observed.
+No regressions in the current tests should be observed.
 
 [X] I/we understand the owners of the involved components may require updates to
 existing tests to make this code solid enough prior to committing the changes necessary
@@ -160,11 +161,41 @@ to implement this enhancement.
 
 #### Unit Tests
 
-The changes in the flavorassignment should be covered by unit tests
+- **Scheduler/Flavor Assignment**:
+  - `pkg/scheduler/scheduler_test.go`:
+    - `partial admission single variable pod set`: verifies flavor assignment with a single variable count PodSet.
+    - `partial admission single variable pod set, preempt first`: verifies preemption behavior when a workload can be admitted using partial admission.
+    - `partial admission single variable pod set, preempt with partial admission`: verifies that preemption triggers when partial admission alone is not enough.
+    - `partial admission multiple variable pod sets, proportional policy`: verifies shrinking order and flavor assignment when multiple variable count PodSets are defined using the default proportional policy.
+    - `partial admission multiple variable pod sets, priority-based policy`: verifies shrinking order when the priority-based policy is set, starting from the last PodSet.
+    - `partial admission disabled, multiple variable pod sets`: verifies that no partial admission is performed if features/annotations are not active.
+  - `pkg/scheduler/scheduler_tas_test.go`:
+    - `TAS workload gets scheduled as trimmed by partial admission`: verifies that Topology Aware Scheduling is compatible with partial admission.
+    - `reclaim within cohort; preempting with partial admission`: verifies that reclaiming quota within a cohort works alongside preemption and partial admission.
+
+- **Webhooks**:
+  - `pkg/webhooks/workload_webhook_test.go`: validates that `minCount` cannot be negative or larger than the base `count`.
+
+- **Controllers**:
+  - `pkg/controller/jobs/job/job_controller_test.go`: verifies job controller's `RunWithPodSetsInfo` and `RestorePodSetsInfo` logic, updating/restoring parallelism correctly when job is unsuspended or suspended.
 
 #### Integration tests
 
-The `scheduler` and `controllers/job` should be extended to cover the new capabilities.
+- **Controllers & Scheduler**:
+  - `test/integration/singlecluster/controller/jobs/job/job_controller_test.go`:
+    - `Should schedule jobs with partial admission`: verifies a complete integration flow where a Job with `kueue.x-k8s.io/job-min-parallelism` is suspended, partially admitted with reduced parallelism, and its original parallelism is restored when the workload is stopped.
+  - `test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go`:
+    - `Should schedule RayClusters with partial admission priority policy`: verifies a complete integration flow where a RayCluster with partial admission annotation is admitted with reduced worker count according to priority policy.
+- **Workload Webhook**:
+  - `test/integration/singlecluster/webhook/core/workload_test.go`:
+    - `invalid podSet minCount (negative)`: verifies negative minCount values are rejected.
+    - `invalid podSet minCount (too big)`: verifies minCount larger than count is rejected.
+    - `too many variable count podSets`: verifies that workloads with multiple variable count PodSets are rejected.
+
+#### E2E tests
+
+- `test/e2e/singlecluster/baseline/job_test.go`:
+  - `Should partially admit the Job if configured and not fully fits`: verifies that a real Job is successfully admitted with a reduced parallelism count matching the available cluster resources.
 
 ### Graduation Criteria
 

--- a/keps/420-partial-admission/README.md
+++ b/keps/420-partial-admission/README.md
@@ -13,6 +13,7 @@
   - [Jobframework](#jobframework)
   - [batch/Job controller](#batchjob-controller)
   - [kubeflow/MPIJob controller](#kubeflowmpijob-controller)
+  - [RayJob/RayService/RayCluster controller](#rayjobrayserviceraycluster-controller)
   - [Test Plan](#test-plan)
     - [Unit Tests](#unit-tests)
     - [Integration tests](#integration-tests)
@@ -88,7 +89,9 @@ In order to evaluate the potential success of the preemption, the preemption pro
 
 **Partial admission with multiple variable PodSets count**
 
-If multiple PodSets within a workload have variable counts the way the counts should be decrease is highly dependent on the job framework needs, currently the following is proposed:
+If multiple PodSets within a workload have variable counts, Kueue will iterate over the PodSets in the order they are defined in the Workload spec, starting from the end, and will try to decrease their counts until a fit is found. If shrinking the last PodSet still results in a NoFit, Kueue will try to decrease the next PodSet while keeping the last one at its minimum count, and so on.
+
+When a workload finds a combination that fits the available quota, it tries to find the combination that can be reached with minimum pod loss by checking if any of the PodSets with count == min count can be increased up to the original count.
 
 Starting with the PodSets:
 
@@ -98,14 +101,11 @@ Starting with the PodSets:
 
 And only being able to admit 19 pods, it should end up with
 
-
 ```go
-[]podSet { {Count: 1} , {Count: 3}, {Count: 15}}
+[]podSet { {Count: 1} , {Count: 4}, {Count: 14}}
 ```
 
-With both pods that accept partial admission losing 50% of their range.
-
-The presented solution is not taking into account which of the variable count PodSets is causing the "NoFit" status and can potentially decrease the count of PodSets that will otherwise fit. If this behaviour is not suitable for a specific job framework, the integration layer of the framework can take into account limiting the variable count PodSets to 1.
+If the priority based partial admission is not sufficient, the "proportional" partial admission will be introduced.
 
 ### Jobframework
 
@@ -144,6 +144,12 @@ In case of MPIJob `j.Spec.RunPolicy.SchedulingPolicy.MinAvailable` can be used t
 Whether an MPIJob supports partial admission or not can be deduced based on `MinAvailable` without the need of a dedicated annotation.
 Additional research is needed into the potential usage of multiple variable count PodSets.
 
+### RayJob/RayService/RayCluster controller
+
+The RayCluster with 'kueue.x-k8s.io/partial-preemption=true' annotation are eligible for partial preemption. The
+RayCluster.workerGroupSpec[i].minReplicas will be translated to the PodSet.MinCount for the Worker PodSet.
+There will be no update on RayCluster object. If the number of admitted pods less than requested count, the leftover pods should remain scheduling gated. In order to achive that the same mechanism as for elastic workloads will be applied – the podTemplate will be initially gated and then the correct amount of pods will be ungated.
+
 ### Test Plan
 
 No regressions in the current test should be observed.
@@ -164,6 +170,7 @@ The `scheduler` and `controllers/job` should be extended to cover the new capabi
 
 
 ## Implementation History
+- 07/07/2023 - Partial admission for batch.job was added that support only 1 podSet with minCount value.
 
 
 ## Drawbacks

--- a/keps/420-partial-admission/README.md
+++ b/keps/420-partial-admission/README.md
@@ -10,7 +10,7 @@
 - [Design Details](#design-details)
   - [Workload API](#workload-api)
   - [Scheduler / Flavorassignment](#scheduler--flavorassignment)
-    - [Priority-Based Policy (<code>priority-based</code>)](#priority-based-policy-priority-based)
+    - [Order-Based Policy (<code>order-based</code>)](#order-based-policy-order-based)
     - [Proportional Policy (<code>proportional</code> - default)](#proportional-policy-proportional---default)
   - [Jobframework](#jobframework)
   - [batch/Job controller](#batchjob-controller)
@@ -84,15 +84,17 @@ In case the workload proposed for the current scheduling cycle does not fit, wit
 
 The policy for shrinking PodSet counts is configured via the `kueue.x-k8s.io/partial-admission-policy` annotation on the Job. The supported policies are:
 - **`proportional` (default)**: Shrinks the counts of all variable PodSets proportionally to their allowable reduction ranges.
-- **`priority-based`**: Shrinks the counts of the PodSets sequentially, assuming they are listed in descending order of priority (i.e., the first PodSet has the highest priority and the last PodSet has the lowest priority).
+- **`order-based`**: Shrinks the counts of the PodSets sequentially starting from the last one (suits for the cases when the podsets are ordered by priority). The Workload PodSet order is usually the same as the order of the PodSet in the Job spec. For the RayCluster the Workload PodSets starting from Head PodSet and following by WorkerGroupPodSets in the same order as in RayCluster.
 
-#### Priority-Based Policy (`priority-based`)
+#### Order-Based Policy (`order-based`)
 
-Under the `priority-based` policy, Kueue assumes that the PodSets are listed in descending order of priority. To preserve the counts of higher-priority PodSets, Kueue shrinks the PodSets starting from the end (lowest priority) and moving towards the beginning (highest priority) as needed.
-
+Under the `order-based` policy, Kueue shrinks the PodSets starting from the last one and moving towards the beginning as needed.
 Specifically, if multiple PodSets have variable counts, Kueue iterates over them in the order they are defined in the Workload spec, starting from the last one. It decreases the count of the current PodSet down to its `minCount` until the workload fits the available quota. If shrinking the last PodSet to its `minCount` is still not enough to fit, Kueue keeps it at its `minCount` and moves to the second-to-last PodSet, decreasing its count down to its `minCount`, and so on.
+As an optimization, we will introduce a second phase (similar to the preemption algorithm): when a workload finds a combination that fits the available quota, Kueue tries to gradually put the reduced counts back. In this phase, Kueue iterates over all PodSets from the first to the last one. For each PodSet that was reduced, Kueue tries to increase its count back to the original count. If that fits, Kueue keeps it. Otherwise, Kueue performs a binary search on the PodSet's count between the current count and the original count to find the maximum count that fits.
 
-**Example:**
+One example when order-based policy is used, is when the RayCluster has identical WorkerGroupPodSets, that have different node selectors that are tight to different node group capacity — for example, reservation/on-demand/spot. In this case, it is preferable to keep workers to run on reservation nodes than on-demand/spot nodes.
+
+**Examples:**
 Consider a Job with three PodSets:
 - `ps0` (highest priority): `count: 1`, no `minCount` (cannot be shrunk).
 - `ps1` (medium priority): `count: 4`, `minCount: 2` (can be reduced by up to 2 pods).
@@ -238,7 +240,7 @@ to implement this enhancement.
     - `partial admission single variable pod set, preempt first`: verifies preemption behavior when a workload can be admitted using partial admission.
     - `partial admission single variable pod set, preempt with partial admission`: verifies that preemption triggers when partial admission alone is not enough.
     - `partial admission multiple variable pod sets, proportional policy`: verifies shrinking order and flavor assignment when multiple variable count PodSets are defined using the default proportional policy.
-    - `partial admission multiple variable pod sets, priority-based policy`: verifies shrinking order when the priority-based policy is set, starting from the last PodSet.
+    - `partial admission multiple variable pod sets, order-based policy`: verifies shrinking order when the order-based policy is set, starting from the last PodSet.
     - `partial admission disabled, multiple variable pod sets`: verifies that no partial admission is performed if features/annotations are not active.
   - `pkg/scheduler/scheduler_tas_test.go`:
     - `TAS workload gets scheduled as trimmed by partial admission`: verifies that Topology Aware Scheduling is compatible with partial admission.
@@ -256,7 +258,7 @@ to implement this enhancement.
   - `test/integration/singlecluster/controller/jobs/job/job_controller_test.go`:
     - `Should schedule jobs with partial admission`: verifies a complete integration flow where a Job with `kueue.x-k8s.io/job-min-parallelism` is suspended, partially admitted with reduced parallelism, and its original parallelism is restored when the workload is stopped.
   - `test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go`:
-    - `Should schedule RayClusters with partial admission priority policy`: verifies a complete integration flow where a RayCluster with partial admission annotation is admitted with reduced worker count according to priority policy.
+    - `Should schedule RayClusters with partial admission order policy`: verifies a complete integration flow where a RayCluster with partial admission annotation is admitted with reduced worker count according to the order.
 - **Workload Webhook**:
   - `test/integration/singlecluster/webhook/core/workload_test.go`:
     - `invalid podSet minCount (negative)`: verifies negative minCount values are rejected.

--- a/keps/420-partial-admission/README.md
+++ b/keps/420-partial-admission/README.md
@@ -46,6 +46,8 @@ Since this is an opt-in feature, the parent job should accept the partial admiss
 
 Kueue will not take any measure to ensure that the parent job respects the assigned quota.
 
+Partial admission is not allowed for concurrent admission in order to not increase the complexity. The webhook will reject workloads that support partial admission to be created for a cluster queue with concurrent admission policy. 
+
 ## Proposal
 
 Change the way the flavor assigner works to support decrementing the pods count in order to find a better fit for the current workload.
@@ -120,6 +122,18 @@ Total requested pods: `1 + 4 + 20 = 25` pods.
   4. Since it still does not fit the quota of 10, and the remaining PodSet `ps0` does not allow partial admission (has no `minCount`), the search fails.
   5. The job remains unadmitted.
 
+- **Scenario D: Multiple resource flavors (illustrates the second phase)**
+  Assume `ps1` and `ps2` are tied to different resource flavors, `rf1` and `rf2`, respectively.
+  The available quota for `rf1` is 2 pods (requires a reduction of at least 2 pods for `ps1`), and the available quota for `rf2` is 20 pods (full capacity for `ps2`).
+  1. In the first phase, Kueue targets the lowest priority PodSet, `ps2` (tied to `rf2`), and decreases its count to its minimum `10` (reduction of 10 pods) in search of a fit. The intermediate total count is `1 + 4 + 10 = 15` pods.
+  2. Since the workload still does not fit because of the constraint on `rf1` (which only allows 2 pods for `ps1` but it requests 4), Kueue keeps `ps2` at `10` and moves to the next lowest priority PodSet, `ps1`.
+  3. Kueue decreases `ps1` by 2 pods (from 4 to 2) to fit the available quota of `rf1`. The resulting total count is `1 + 2 + 10 = 13` pods.
+  4. The first phase successfully finds a combination (`ps0: 1`, `ps1: 2`, `ps2: 10`) that fits the available quotas.
+  5. In the second phase (optimization), Kueue iterates over all PodSets from the first to the last (`ps0`, `ps1`, `ps2`) and tries to restore the reduced counts.
+     - `ps1` was reduced to 2. Kueue tries to increase its count back to 4, but this fails since `rf1` only has a quota of 2. `ps1` remains at 2.
+     - `ps2` was reduced to 10. Kueue tries to increase its count back to 20. This succeeds since `rf2` has 20 available quota.
+  6. Admitted counts: `ps0: 1`, `ps1: 2`, `ps2: 20`.
+
 #### Proportional Policy (`proportional` - default)
 
 Under the `proportional` policy, Kueue reduces the counts of all variable PodSets proportionally to their maximum allowable reduction range (i.e., `count - minCount`).
@@ -175,9 +189,6 @@ Total reduction delta: $T_D = 0 + 2 + 10 = 12$ pods.
 - **Scenario C: Available quota is 10 pods** (requires a reduction of at least 15 pods).
   - Even with the maximum possible index $i = 12$ (maximum reduction), the total count is `1 + 2 + 10 = 13` pods, which does not fit in 10 pods.
   - Thus, the binary search fails, and the job remains unadmitted.
-
-As an optimization, we will introduce an increased step: when a workload finds a combination that fits the available quota, Kueue could try to find the combination that can be reached with minimum pod loss by checking if any of the PodSets with count == min count can be increased up to the original count. 
-The increased step is not necessary for elastic workloads, but the non-elastic workloads will benefit from it.
 
 The accepted number of pods in each PodSet is recorded in `workload.Status.Admission.PodSetAssignments[*].ResourceUsage.Count`.
 

--- a/keps/420-partial-admission/README.md
+++ b/keps/420-partial-admission/README.md
@@ -30,7 +30,6 @@
       - [Step 2: Scale Up to 12 (Quota Constraint: 7), scale up isn't admitted](#step-2-scale-up-to-12-quota-constraint-7-scale-up-isnt-admitted)
       - [Step 3: Quota increases to 12, opportunistic scale up when capacity is freed](#step-3-quota-increases-to-12-opportunistic-scale-up-when-capacity-is-freed)
   - [batch/Job controller](#batchjob-controller)
-  - [kubeflow/MPIJob controller](#kubeflowmpijob-controller)
   - [RayJob/RayService/RayCluster controller](#rayjobrayserviceraycluster-controller)
   - [Limitations](#limitations)
   - [Test Plan](#test-plan)
@@ -165,6 +164,11 @@ type PodSetAssignment struct {
 }
 ```
 
+### Validation
+
+- `.spec.podSets.minCount <= .spec.podSets.count`
+- `.spec.podSets.minCount >= 0`
+
 ### Scheduler / Flavorassignment
 
 In case the workload proposed for the current scheduling cycle does not fit, with or without preemption, in the current available quota and any of its PodSets allow partial admission, Kueue will try to find a lower counts combination that fits the available quota with or without borrowing.
@@ -176,7 +180,6 @@ The search for appropriate count value is done using binary search algorithm.
 #### Partial Admission for multiple PodSets
 
 There are multiple ways how to approach multiple podsets shrinking in case of insufficient quota. For simplicity reasons we'll start with the order-based one and will expand options if needed in future.
-Another approach that was considered is proportional. However it was discarded because of insufficiency for some use cases.
 
 - **`order-based` (default)**: Shrinks the counts of the PodSets sequentially starting from the last one (suits for the cases when the podsets are ordered by priority). The Workload PodSet order is usually the same as the order of the PodSet in the Job spec. For the RayCluster the Workload PodSets starting from Head PodSet and followed by WorkerGroupPodSets in the same order as in RayCluster.
 
@@ -259,6 +262,7 @@ Also, a new Workload representing the full job will be created and added to the 
 #### Opportunistic scale up when capacity is freed
 
 In order to schedule remaining pods after partial admission, workload controller will create a new workload representing the full job and add it to the queue. The scheduler will admit new workload and replace the old workload via workload slice mechanism as the capacity becomes available.
+The newly created workload for opportunistic scale up should have a different name from the admitted workload.
 
 #### Example: Two-Step Scale Up under Quota Constraints (with Partial Admission)
 
@@ -337,13 +341,6 @@ Besides adapting `RunWithPodSetsInfo` and `RestorePodSetsInfo` it should also:
   * jobs which need the `completions` count kept in sync with `parallelism` should indicate this in a second annotation, `kueue.x-k8s.io/job-completions-equal-parallelism`
 - rework `EquivalentToWorkload` to account for potential differences in `PodSets` spec `Parallelism`.
 
-### kubeflow/MPIJob controller
-
-In case of MPIJob `j.Spec.RunPolicy.SchedulingPolicy.MinAvailable` can be used to provide a `minimumCount` for the `Worker` PodSets while updating `j.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeWorker].Replicas` before unsuspending the job and after suspending it.
-
-Whether an MPIJob supports partial admission or not can be deduced based on `MinAvailable` without the need of a dedicated annotation.
-Additional research is needed into the potential usage of multiple variable count PodSets.
-
 ### RayJob/RayService/RayCluster controller
 
 The RayCluster.workerGroupSpec[i].replicas * numOfHosts will be translated to the PodSet.Count, and minReplicas * numOfHosts will be translated to the PodSet.MinCount for the Worker PodSet.
@@ -367,7 +364,6 @@ to implement this enhancement.
     - `partial admission single variable pod set`: verifies flavor assignment with a single variable count PodSet.
     - `partial admission single variable pod set, preempt first`: verifies preemption behavior when a workload can be admitted using partial admission.
     - `partial admission single variable pod set, preempt with partial admission`: verifies that preemption triggers when partial admission alone is not enough.
-    - `partial admission multiple variable pod sets, proportional policy`: verifies shrinking order and flavor assignment when multiple variable count PodSets are defined using the default proportional policy.
     - `partial admission multiple variable pod sets, order-based policy`: verifies shrinking order when the order-based policy is set, starting from the last PodSet.
     - `partial admission disabled, multiple variable pod sets`: verifies that no partial admission is performed if features/annotations are not active.
   - `pkg/scheduler/scheduler_tas_test.go`:
@@ -422,3 +418,5 @@ major outstanding bugs.
 
 
 ## Alternatives
+
+For partial admission of multiple PodSets, another approach that was considered is proportional shrinking. However it was discarded because of insufficiency for some use cases. For example, when shrinking two PodSets from initial counts of (2, 2) down to 3 pods, a proportional approach might result in (1, 1) due to rounding, rather than an optimal (2, 1) or (1, 2).

--- a/keps/420-partial-admission/README.md
+++ b/keps/420-partial-admission/README.md
@@ -7,7 +7,15 @@
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
   - [User Stories](#user-stories)
+    - [Story 1 (partial admission)](#story-1-partial-admission)
+    - [Story 2 (graceful scale up handling)](#story-2-graceful-scale-up-handling)
+    - [Story 3 (opportunistic scale up)](#story-3-opportunistic-scale-up)
+    - [Story 4 (multi-podset RayJob)](#story-4-multi-podset-rayjob)
 - [Design Details](#design-details)
+  - [Enablement](#enablement)
+    - [Features](#features)
+    - [Partial Admission Annotation](#partial-admission-annotation)
+    - [Scenario Summary](#scenario-summary)
   - [Workload API](#workload-api)
   - [Scheduler / Flavorassignment](#scheduler--flavorassignment)
     - [Partial Admission for one PodSets](#partial-admission-for-one-podsets)
@@ -15,11 +23,12 @@
     - [Order-Based policy (<code>order-based</code>)](#order-based-policy-order-based)
   - [Jobframework](#jobframework)
   - [ElasticJob](#elasticjob)
+    - [Opportunistic scale up when capacity is freed](#opportunistic-scale-up-when-capacity-is-freed)
     - [Example: Two-Step Scale Up under Quota Constraints (with Partial Admission)](#example-two-step-scale-up-under-quota-constraints-with-partial-admission)
       - [Step 0: Job Creation (Initial Size: 5)](#step-0-job-creation-initial-size-5)
-      - [Step 1: Scale Up from 5 to 10](#step-1-scale-up-from-5-to-10)
-      - [Step 2: Scale Up to 12 (Quota Constraint: 7)](#step-2-scale-up-to-12-quota-constraint-7)
-      - [Step 3: Quota increases to 12](#step-3-quota-increases-to-12)
+      - [Step 1: Scale Up from 5 to 10 (Quota Constraint: 7), partial admission of scale up](#step-1-scale-up-from-5-to-10-quota-constraint-7-partial-admission-of-scale-up)
+      - [Step 2: Scale Up to 12 (Quota Constraint: 7), scale up isn't admitted](#step-2-scale-up-to-12-quota-constraint-7-scale-up-isnt-admitted)
+      - [Step 3: Quota increases to 12, opportunistic scale up when capacity is freed](#step-3-quota-increases-to-12-opportunistic-scale-up-when-capacity-is-freed)
   - [batch/Job controller](#batchjob-controller)
   - [kubeflow/MPIJob controller](#kubeflowmpijob-controller)
   - [RayJob/RayService/RayCluster controller](#rayjobrayserviceraycluster-controller)
@@ -29,6 +38,9 @@
     - [Integration tests](#integration-tests)
     - [E2E tests](#e2e-tests)
   - [Graduation Criteria](#graduation-criteria)
+    - [Alpha](#alpha)
+    - [Beta](#beta)
+    - [Stable(GA)](#stablega)
 - [Implementation History](#implementation-history)
 - [Drawbacks](#drawbacks)
 - [Alternatives](#alternatives)
@@ -63,63 +75,92 @@ In case a partial fit is chosen, the jobframework reconciler should provide the 
 
 Kueue issue [420](https://github.com/kubernetes-sigs/kueue/issues/420) provides details on the initial feature details and its applicability for `batch/Job`.
 
-Autoscaled RayJob is running and scaled up from 1000 to 5000 pods, but only capacity for 2000 more pod is available. With partial admission, the Kueue admits a 2000 out of 4000 pods to the cluster instead of rejecting the scale up.
+#### Story 1 (partial admission)
+
+As a user submitting a regular batch Job (e.g., `batch/v1.Job`), I want the Job to start running even if there are not enough resources in the cluster to satisfy its full requested parallelism. If the Job can work with a lower parallelism (as long as it meets a specified minimum), Kueue should admit it with the available capacity, allowing the Job to proceed instead of waiting in the queue indefinitely.
+
+#### Story 2 (graceful scale up handling)
+
+As a user running an autoscaled job (like a RayJob), when my job requests to scale up (e.g. from 1000 to 5000 pods) but the cluster only has capacity for a fraction of the scale-up request (e.g., 2000 more pods), I want Kueue to gracefully admit the scale-up up to the available capacity (admitting 2000 additional pods) rather than rejecting the scale-up request entirely.
+
+#### Story 3 (opportunistic scale up)
+
+As a user running an elastic job (like a RayJob), when my job is admitted with partial capacity due to resource constraints, I want the job to dynamically scale up to its full requested capacity as soon as other workloads complete and resources become available in the cluster, maximizing resource utilization and reducing the job's overall completion time.
+
+#### Story 4 (multi-podset RayJob)
+
+As a user of a multi-podset RayJob (which defines a head pod and multiple worker groups, potentially targeting different resource flavors or node groups like reservation, on-demand, or spot), I want to enable partial admission such that Kueue reduces the worker groups sequentially starting from the least critical (e.g., spot or low-priority worker groups defined last in the spec) while preserving the capacity of the more critical worker groups.
 
 ## Design Details
 
-Jobs with `kueue.x-k8s.io/partial-admission=true` annotation are eligible for partial admission.
+### Enablement
+
+PartialAdmission in Kueue is enabled through a combination of a Kubernetes feature gate and an opt-in annotation on individual Workload objects. At the cluster level, the PartialAdmission feature (enabled by default) and PartialAdmissionForElasticJobs feature for ElasticJobs, must be enabled via the corresponding Kueue feature gate.
+
+Once the feature gate is enabled, individual Job objects can opt into partial admission by including the ``kueue.x-k8s.io/partial-admission="true"` annotation. 
+When both conditions are met, Kueue treats the Workload as eligible for partial admission. 
+
+#### Features
+```go
+	// Enables partial admission for non-elastic jobs.
+	PartialAdmission featuregate.Feature = "PartialAdmission"
+
+	// Enables partial admission for elastic jobs.
+	PartialAdmissionForElasticJobs featuregate.Feature = "PartialAdmissionForElasticJobs"
+```
+
+#### Partial Admission Annotation
+```go
+const (
+  // EnabledAnnotationKey refers to the annotation key present on Job's that support
+  // workload slicing.
+  // This annotation is alpha-level.
+  EnabledPartialAdmission = "kueue.x-k8s.io/partial-admission"
+)
+```
+
+#### Scenario Summary
+
+The table below summarizes the scheduling and admission behaviors for different combinations of the `kueue.x-k8s.io/partial-admission` and `kueue.x-k8s.io/elastic-job` annotations for `batch/v1.Job` and KubeRay (`RayJob` / `RayCluster`) objects:
+
+| Framework | `partial-admission` | `elastic-job` | Scheduling & Admission Behavior |
+| --- | --- | --- | --- |
+| **batch/Job** | `true` | `true` | **Partial Admission + Workload Slicing**: Kueue can shrink the Job's podset down to its `job-min-parallelism`. The Job's spec (`.spec.parallelism`) remains unmodified. Kueue uses scheduling gates to ungate only the admitted pod count. A pending workload slice is created to dynamically scale up (opportunistic scale up) when more quota becomes available. |
+| **batch/Job** | `true` | `false`/not present | **Partial Admission (Traditional)**: Kueue shrinks the Job's podset down to its `job-min-parallelism`. Upon admission, Kueue modifies the Job's spec (`.spec.parallelism`) directly to match the admitted count. No scheduling gates are used, and no future scale-up occurs for this workload. |
+| **batch/Job** | `false`/not present | `true` | **Workload Slicing Only**: Kueue cannot shrink the Job's podset during initial scheduling; the job must fit its full requested capacity to be admitted. If admitted, scheduling gates are used. If the user manually scales up the Job, Kueue creates a new workload slice for the scale-up request, but this scale-up will only be admitted if it can be fully satisfied (no partial admission of the scale-up). |
+| **KubeRay** | `true` | `true` | **Partial Admission + Workload Slicing**: Kueue can shrink the worker groups down to their `minReplicas` (defined in the worker spec). The Ray object's spec remains unmodified. Admission is managed via scheduling gates. A pending workload slice is created to allow KubeRay to scale up (opportunistic scale up) worker pods as more quota becomes available. |
+| **KubeRay** | `true` | `false`/not present | **Not supported / Out of scope**: Kueue does not support partial admission for non-autoscaled KubeRay jobs at this time. |
+| **KubeRay** | `false`/not present | `true` | **Workload Slicing Only**: Kueue cannot shrink the worker groups; they must fit their full requested replicas to be admitted. Once admitted, scheduling gates are used. If the autoscaler scales up the worker groups, Kueue creates a workload slice representing the scale-up request, but this scale-up is only admitted if there is enough quota to satisfy the full scale-up request. |
 
 ### Workload API
 
 ```go
 type PodSet struct {
-    // .......
+  // .......
 
-    // // count is the number of pods requested by the Job.
-    // +kubebuilder:validation:Minimum=0
-    Count int32 `json:"count"`
+  // // count is the number of pods requested by the Job.
+  // +kubebuilder:validation:Minimum=0
+  Count int32 `json:"count"`
 
-    // minCount is the minimum number of pods acceptable for admission in case of partial admission.
-    //
-    // If not provided, partial admission for the current PodSet is not
-    // enabled.
-    // +optional
-    MinCount *int32 `json:"minCount,omitempty"`
-}
-
-type WorkloadStatus struct {
-    // ........
-
-    // admission holds the parameters of the admission of the workload by a
-    // ClusterQueue. admission can be set back to null, but its fields cannot be
-    // changed once set.
-    // +optional
-    Admission *Admission `json:"admission,omitempty"`
-    
-    // ........
-}
-
-type Admission struct {
-    // .........
-
-    // podSetAssignments hold the admission results for each of the .spec.podSets entries.
-    // +listType=map
-    // +listMapKey=name
-    // +kubebuilder:validation:MaxItems=10
-    PodSetAssignments []PodSetAssignment `json:"podSetAssignments"`
+  // minCount is the minimum number of pods acceptable for admission in case of partial admission.
+  //
+  // If not provided, partial admission for the current PodSet is not
+  // enabled.
+  // +optional
+  MinCount *int32 `json:"minCount,omitempty"`
 }
 
 type PodSetAssignment struct {
-    // ........
+  // ........
 
-    // count is the number of pods taken into account at admission time.
-    // This field will not change in case of quota reclaim.
-    // Value could be missing for Workloads created before this field was added,
-    // in that case spec.podSets[*].count value will be used.
-    //
-    // +optional
-    // +kubebuilder:validation:Minimum=0
-    Count *int32 `json:"count,omitempty"`
+  // count is the number of pods taken into account at admission time.
+  // This field will not change in case of quota reclaim.
+  // Value could be missing for Workloads created before this field was added,
+  // in that case spec.podSets[*].count value will be used.
+  //
+  // +optional
+  // +kubebuilder:validation:Minimum=0
+  Count *int32 `json:"count,omitempty"`
 }
 ```
 
@@ -140,7 +181,7 @@ Another approch that was considered is proportional. However it was disgarded be
 
 #### Order-Based policy (`order-based`)
 
-Under the `order-based` policy, Kueue shrinks the PodSets starting from the last one and moving towards the beginning as needed.
+Under the `order-based` policy, Kueue shrinks the PodSets starting from the last one in the list and moving towards the beginning as needed.
 Specifically, if multiple PodSets have variable counts, Kueue iterates over them in the order they are defined in the Workload spec, starting from the last one. It decreases the count of the current PodSet down to its `minCount` until the workload fits the available quota. If shrinking the last PodSet to its `minCount` is still not enough to fit, Kueue keeps it at its `minCount` and moves to the second-to-last PodSet, decreasing its count down to its `minCount`, and so on.
 As an optimization, we will introduce a second phase (similar to the preemption algorithm): when a workload finds a combination that fits the available quota, Kueue tries to gradually put the reduced counts back. In this phase, Kueue iterates over all PodSets from the first to the last one. For each PodSet that was reduced, Kueue tries to increase its count back to the original count. If that fits, Kueue keeps it. Otherwise, Kueue performs a binary search on the PodSet's count between the current count and the original count to find the maximum count that fits.
 
@@ -214,6 +255,10 @@ To avoid this, the `podSets` count won't be updated in `RunWithPodSetsInfo` for 
 The `minCount` value for an ElasticJob workload will represent the currently admitted value + 1.
 Also, a new Workload representing the full job will be created and added to the queue, to admit the remaining capacity once it becomes available.
 
+#### Opportunistic scale up when capacity is freed
+
+In order to schedule remaining pods after partial admission, workload controller will create a new workload representing the full job and add it to the queue. The scheduler will admit new workload and replace the old workload via workload slice mechanism as the capacity becomes available.
+
 #### Example: Two-Step Scale Up under Quota Constraints (with Partial Admission)
 
 Consider a scenario where:
@@ -236,16 +281,16 @@ Consider a scenario where:
   5. **Kube-scheduler**: Schedules the 5 ungated pods, which transition to the Running state.
 * **Quota usage**: 5/7 (2 available).
 
-##### Step 1: Scale Up from 5 to 10
+##### Step 1: Scale Up from 5 to 10 (Quota Constraint: 7), partial admission of scale up
 * **Job spec.parallelism**: 10
 * **Workloads**:
   * `wl-A` (Finished - aggregated/replaced by `wl-B`)
   * `wl-B` (Admitted - Partially):
-    * `spec.podSets.count` = 7 (originally requested 10, but updated to 7 during partial admission)
+    * `spec.podSets.count` = 10
     * `spec.podSets.minCount` = 6 (the current running count 5 + 1)
     * `status.admission.count` = 7
   * `wl-C` (Pending, since there is no capacity for 10 pods)
-    * `spec.podSets.count` = 10 (representing the job count)
+    * `spec.podSets.count` = 10
     * `spec.podSets.minCount` = 8 (the current running count 7 + 1)
 * **Controller Actions**:
   1. **Job Controller**: Detects the parallelism increase and creates 5 new Pods (total 10 pods: 5 running, 5 gated). The new pods are created with the `kueue.x-k8s.io/elastic-job` scheduling gate.
@@ -255,7 +300,7 @@ Consider a scenario where:
   5. **ElasticJobUngater Controller**: Detects that `wl-B` is admitted with count 7. It removes the scheduling gate from 2 of the new pods (bringing running pods to 7). The other 3 new pods remain gated.
 * **Quota usage**: 7/7 (0 available).
 
-##### Step 2: Scale Up to 12 (Quota Constraint: 7)
+##### Step 2: Scale Up to 12 (Quota Constraint: 7), scale up isn't admitted
 * **Job spec.parallelism**: 12
 * **Workloads**:
   * `wl-B` (Admitted)
@@ -267,7 +312,7 @@ Consider a scenario where:
   2. **Workload Controller**: Detects the update. Since the Job's parallelism is updated to 12, Kueue updates the pending workload `wl-C` with `spec.podSets.count = 12`.
   3. **Kueue Scheduler**: Evaluates `wl-C`. The demand is `12 - 7 = 5`. The available quota is 0, so the scheduler puts `wl-C` in the queue.
 
-##### Step 3: Quota increases to 12
+##### Step 3: Quota increases to 12, opportunistic scale up when capacity is freed
 If the available quota in the ClusterQueue increases to 12 (or more) in the future:
 * **Workloads**:
   * `wl-B` (Finished)
@@ -277,6 +322,7 @@ If the available quota in the ClusterQueue increases to 12 (or more) in the futu
     * `status.admission.count` = 12
 
 In the next scheduler loop, the Kueue scheduler will evaluate and admit `wl-C`. It will also update its `spec.podSets.minCount` to match the job's minCount.
+
 
 ### batch/Job controller
 
@@ -296,7 +342,7 @@ Additional research is needed into the potential usage of multiple variable coun
 
 ### RayJob/RayService/RayCluster controller
 
-The RayCluster.workerGroupSpec[i].minReplicas will be translated to the PodSet.MinCount for the Worker PodSet.
+The RayCluster.workerGroupSpec[i].replicas * numOfHosts will be translated to the PodSet.Count, and minReplicas * numOfHosts will be translated to the PodSet.MinCount for the Worker PodSet.
 
 ### Limitations
 
@@ -349,6 +395,19 @@ to implement this enhancement.
   - `Should partially admit the Job if configured and not fully fits`: verifies that a real Job is successfully admitted with a reduced parallelism count matching the available cluster resources.
 
 ### Graduation Criteria
+
+#### Alpha
+Partial admission for elastic workloads is implemented behind the
+`PartialAdmissionForElasticJobs` feature gate, with basic functionality (such as RayCluster
+and RayJob support) covered by integration tests and documentation.
+
+#### Beta
+Positive feedback from Alpha, broader test coverage (handling scale up/down race conditions),
+and any documented follow-ups addressed.
+
+#### Stable(GA)
+The feature has spent at least one release cycle in beta with no
+major outstanding bugs.
 
 
 ## Implementation History

--- a/keps/420-partial-admission/README.md
+++ b/keps/420-partial-admission/README.md
@@ -18,7 +18,7 @@
     - [Scenario Summary](#scenario-summary)
   - [Workload API](#workload-api)
   - [Scheduler / Flavorassignment](#scheduler--flavorassignment)
-    - [Partial Admission for one PodSets](#partial-admission-for-one-podsets)
+    - [Partial Admission for one PodSet](#partial-admission-for-one-podset)
     - [Partial Admission for multiple PodSets](#partial-admission-for-multiple-podsets)
     - [Order-Based policy (<code>order-based</code>)](#order-based-policy-order-based)
   - [Jobframework](#jobframework)
@@ -112,8 +112,8 @@ When both conditions are met, Kueue treats the Workload as eligible for partial 
 #### Partial Admission Annotation
 ```go
 const (
-  // EnabledAnnotationKey refers to the annotation key present on Job's that support
-  // workload slicing.
+  // EnabledAnnotationKey refers to the annotation key present on Jobs that support
+  // partial admission.
   // This annotation is alpha-level.
   EnabledPartialAdmission = "kueue.x-k8s.io/partial-admission"
 )
@@ -167,18 +167,18 @@ type PodSetAssignment struct {
 
 ### Scheduler / Flavorassignment
 
-In case the workload proposed for the current scheduling cycle does not fit, with or without preemption, in the current available quota and any of its PodSets allow partial admission, kueue will try to find a lower counts combination that fits the available quota with or without borrowing.
+In case the workload proposed for the current scheduling cycle does not fit, with or without preemption, in the current available quota and any of its PodSets allow partial admission, Kueue will try to find a lower counts combination that fits the available quota with or without borrowing.
 
-#### Partial Admission for one PodSets
+#### Partial Admission for one PodSet
 
-The search for appopriate count value is done using binary search algorithm.
+The search for appropriate count value is done using binary search algorithm.
 
 #### Partial Admission for multiple PodSets
 
-The are multiple ways how to approach multiple podsets shrinking in case of insufficient quota. For simplisity reason we'll start with the order-based one and will expand option if needed in future.
-Another approch that was considered is proportional. However it was disgarded because of insufficiency for some use cases.
+There are multiple ways how to approach multiple podsets shrinking in case of insufficient quota. For simplicity reasons we'll start with the order-based one and will expand options if needed in future.
+Another approach that was considered is proportional. However it was discarded because of insufficiency for some use cases.
 
-- **`order-based` (default)**: Shrinks the counts of the PodSets sequentially starting from the last one (suits for the cases when the podsets are ordered by priority). The Workload PodSet order is usually the same as the order of the PodSet in the Job spec. For the RayCluster the Workload PodSets starting from Head PodSet and following by WorkerGroupPodSets in the same order as in RayCluster.
+- **`order-based` (default)**: Shrinks the counts of the PodSets sequentially starting from the last one (suits for the cases when the podsets are ordered by priority). The Workload PodSet order is usually the same as the order of the PodSet in the Job spec. For the RayCluster the Workload PodSets starting from Head PodSet and followed by WorkerGroupPodSets in the same order as in RayCluster.
 
 #### Order-Based policy (`order-based`)
 
@@ -186,7 +186,7 @@ Under the `order-based` policy, Kueue shrinks the PodSets starting from the last
 Specifically, if multiple PodSets have variable counts, Kueue iterates over them in the order they are defined in the Workload spec, starting from the last one. It decreases the count of the current PodSet down to its `minCount` until the workload fits the available quota. If shrinking the last PodSet to its `minCount` is still not enough to fit, Kueue keeps it at its `minCount` and moves to the second-to-last PodSet, decreasing its count down to its `minCount`, and so on.
 As an optimization, we will introduce a second phase (similar to the preemption algorithm): when a workload finds a combination that fits the available quota, Kueue tries to gradually put the reduced counts back. In this phase, Kueue iterates over all PodSets from the first to the last one. For each PodSet that was reduced, Kueue tries to increase its count back to the original count. If that fits, Kueue keeps it. Otherwise, Kueue performs a binary search on the PodSet's count between the current count and the original count to find the maximum count that fits.
 
-One example when order-based policy is used, is when the RayCluster has identical WorkerGroupPodSets, that have different node selectors that are tight to different node group capacity — for example, reservation/on-demand/spot. In this case, it is preferable to keep workers to run on reservation nodes than on-demand/spot nodes.
+One example when order-based policy is used, is when the RayCluster has identical WorkerGroupPodSets, that have different node selectors that are tied to different node group capacity — for example, reservation/on-demand/spot. In this case, it is preferable to keep workers to run on reservation nodes than on-demand/spot nodes.
 
 **Examples:**
 Consider a Job with three PodSets:
@@ -251,9 +251,9 @@ type GenericJob interface {
 
 ### ElasticJob
 
-For ElasticJobs, updating `job.spec.parallelism` or `job.spec.count` could cause race conditions between partial admission and scaling up/down activity. 
-To avoid this, the `podSets` count won't be updated in `RunWithPodSetsInfo` for elastic jobs. Instead, the workload controller will use the `workload.Status.Admission.PodSetAssignments[*].Count` value to calculate the number of pods from which Kueue should remove scheduling gates. 
-The `minCount` value for an ElasticJob workload will represent the currently admitted value + 1.
+For ElasticJobs, updating `job.spec.parallelism` could cause race conditions between partial admission and scaling up/down activity. 
+To avoid this, the `job.spec.parallelism` won't be updated in `RunWithPodSetsInfo` for elastic jobs. Instead, the workload controller will use the `workload.Status.Admission.PodSetAssignments[*].Count` value to calculate the number of pods from which Kueue should remove scheduling gates. 
+The `Workload.Spec.PodSets[].MinCount` for an ElasticJob workload will represent the currently admitted value + 1.
 Also, a new Workload representing the full job will be created and added to the queue, to admit the remaining capacity once it becomes available.
 
 #### Opportunistic scale up when capacity is freed
@@ -269,6 +269,7 @@ Consider a scenario where:
 
 ##### Step 0: Job Creation (Initial Size: 5)
 * **Job spec.parallelism**: 5
+* **Job spec.minParallelism**: 2
 * **Workloads**:
   * `wl-A` (Admitted):
     * `spec.podSets.count` = 5
@@ -284,6 +285,7 @@ Consider a scenario where:
 
 ##### Step 1: Scale Up from 5 to 10 (Quota Constraint: 7), partial admission of scale up
 * **Job spec.parallelism**: 10
+* **Job spec.minParallelism**: 2
 * **Workloads**:
   * `wl-A` (Finished - aggregated/replaced by `wl-B`)
   * `wl-B` (Admitted - Partially):
@@ -303,6 +305,7 @@ Consider a scenario where:
 
 ##### Step 2: Scale Up to 12 (Quota Constraint: 7), scale up isn't admitted
 * **Job spec.parallelism**: 12
+* **Job spec.minParallelism**: 2
 * **Workloads**:
   * `wl-B` (Admitted)
   * `wl-C` (Updated, keep pending):
@@ -412,7 +415,7 @@ major outstanding bugs.
 
 
 ## Implementation History
-- 07/07/2023 - Partial admission for batch.job was added that support only 1 podSet with minCount value.
+- 07/07/2023 - Partial admission for batch/Job was added that supports only 1 podSet with minCount value.
 
 
 ## Drawbacks

--- a/keps/420-partial-admission/README.md
+++ b/keps/420-partial-admission/README.md
@@ -10,12 +10,20 @@
 - [Design Details](#design-details)
   - [Workload API](#workload-api)
   - [Scheduler / Flavorassignment](#scheduler--flavorassignment)
-    - [Order-Based Policy (<code>order-based</code>)](#order-based-policy-order-based)
-    - [Proportional Policy (<code>proportional</code> - default)](#proportional-policy-proportional---default)
+    - [Partial Admission for one PodSets](#partial-admission-for-one-podsets)
+    - [Partial Admission for multiple PodSets](#partial-admission-for-multiple-podsets)
+    - [Order-Based policy (<code>order-based</code>)](#order-based-policy-order-based)
   - [Jobframework](#jobframework)
+  - [ElasticJob](#elasticjob)
+    - [Example: Two-Step Scale Up under Quota Constraints (with Partial Admission)](#example-two-step-scale-up-under-quota-constraints-with-partial-admission)
+      - [Step 0: Job Creation (Initial Size: 5)](#step-0-job-creation-initial-size-5)
+      - [Step 1: Scale Up from 5 to 10](#step-1-scale-up-from-5-to-10)
+      - [Step 2: Scale Up to 12 (Quota Constraint: 7)](#step-2-scale-up-to-12-quota-constraint-7)
+      - [Step 3: Quota increases to 12](#step-3-quota-increases-to-12)
   - [batch/Job controller](#batchjob-controller)
   - [kubeflow/MPIJob controller](#kubeflowmpijob-controller)
   - [RayJob/RayService/RayCluster controller](#rayjobrayserviceraycluster-controller)
+  - [Limitations](#limitations)
   - [Test Plan](#test-plan)
     - [Unit Tests](#unit-tests)
     - [Integration tests](#integration-tests)
@@ -46,8 +54,6 @@ Since this is an opt-in feature, the parent job should accept the partial admiss
 
 Kueue will not take any measure to ensure that the parent job respects the assigned quota.
 
-Partial admission is not allowed for concurrent admission in order to not increase the complexity. The webhook will reject workloads that support partial admission to be created for a cluster queue with concurrent admission policy. 
-
 ## Proposal
 
 Change the way the flavor assigner works to support decrementing the pods count in order to find a better fit for the current workload.
@@ -57,7 +63,11 @@ In case a partial fit is chosen, the jobframework reconciler should provide the 
 
 Kueue issue [420](https://github.com/kubernetes-sigs/kueue/issues/420) provides details on the initial feature details and its applicability for `batch/Job`.
 
+Autoscaled RayJob is running and scaled up from 1000 to 5000 pods, but only capacity for 2000 more pod is available. With partial admission, the Kueue admits a 2000 out of 4000 pods to the cluster instead of rejecting the scale up.
+
 ## Design Details
+
+Jobs with `kueue.x-k8s.io/partial-admission=true` annotation are eligible for partial admission.
 
 ### Workload API
 
@@ -65,12 +75,11 @@ Kueue issue [420](https://github.com/kubernetes-sigs/kueue/issues/420) provides 
 type PodSet struct {
     // .......
 
-    // count is the number of pods for the spec.
-    // +kubebuilder:validation:Minimum=1
+    // // count is the number of pods requested by the Job.
+    // +kubebuilder:validation:Minimum=0
     Count int32 `json:"count"`
 
-    // minimumCount is the minimum number of pods for the spec acceptable
-    // in case of partial admission.
+    // minCount is the minimum number of pods acceptable for admission in case of partial admission.
     //
     // If not provided, partial admission for the current PodSet is not
     // enabled.
@@ -78,17 +87,58 @@ type PodSet struct {
     MinCount *int32 `json:"minCount,omitempty"`
 }
 
+type WorkloadStatus struct {
+    // ........
+
+    // admission holds the parameters of the admission of the workload by a
+    // ClusterQueue. admission can be set back to null, but its fields cannot be
+    // changed once set.
+    // +optional
+    Admission *Admission `json:"admission,omitempty"`
+    
+    // ........
+}
+
+type Admission struct {
+    // .........
+
+    // podSetAssignments hold the admission results for each of the .spec.podSets entries.
+    // +listType=map
+    // +listMapKey=name
+    // +kubebuilder:validation:MaxItems=10
+    PodSetAssignments []PodSetAssignment `json:"podSetAssignments"`
+}
+
+type PodSetAssignment struct {
+    // ........
+
+    // count is the number of pods taken into account at admission time.
+    // This field will not change in case of quota reclaim.
+    // Value could be missing for Workloads created before this field was added,
+    // in that case spec.podSets[*].count value will be used.
+    //
+    // +optional
+    // +kubebuilder:validation:Minimum=0
+    Count *int32 `json:"count,omitempty"`
+}
 ```
 
 ### Scheduler / Flavorassignment
 
-In case the workload proposed for the current scheduling cycle does not fit, with or without preemption, in the current available quota and any of its PodSets allow partial admission, try to find a lower counts combination that fits the available quota with or without borrowing.
+In case the workload proposed for the current scheduling cycle does not fit, with or without preemption, in the current available quota and any of its PodSets allow partial admission, kueue will try to find a lower counts combination that fits the available quota with or without borrowing.
 
-The policy for shrinking PodSet counts is configured via the `kueue.x-k8s.io/partial-admission-policy` annotation on the Job. The supported policies are:
-- **`proportional` (default)**: Shrinks the counts of all variable PodSets proportionally to their allowable reduction ranges.
-- **`order-based`**: Shrinks the counts of the PodSets sequentially starting from the last one (suits for the cases when the podsets are ordered by priority). The Workload PodSet order is usually the same as the order of the PodSet in the Job spec. For the RayCluster the Workload PodSets starting from Head PodSet and following by WorkerGroupPodSets in the same order as in RayCluster.
+#### Partial Admission for one PodSets
 
-#### Order-Based Policy (`order-based`)
+The search for appopriate count value is done using binary search algorithm.
+
+#### Partial Admission for multiple PodSets
+
+The are multiple ways how to approach multiple podsets shrinking in case of insufficient quota. For simplisity reason we'll start with the order-based one and will expand option if needed in future.
+Another approch that was considered is proportional. However it was disgarded because of insufficiency for some use cases.
+
+- **`order-based` (default)**: Shrinks the counts of the PodSets sequentially starting from the last one (suits for the cases when the podsets are ordered by priority). The Workload PodSet order is usually the same as the order of the PodSet in the Job spec. For the RayCluster the Workload PodSets starting from Head PodSet and following by WorkerGroupPodSets in the same order as in RayCluster.
+
+#### Order-Based policy (`order-based`)
 
 Under the `order-based` policy, Kueue shrinks the PodSets starting from the last one and moving towards the beginning as needed.
 Specifically, if multiple PodSets have variable counts, Kueue iterates over them in the order they are defined in the Workload spec, starting from the last one. It decreases the count of the current PodSet down to its `minCount` until the workload fits the available quota. If shrinking the last PodSet to its `minCount` is still not enough to fit, Kueue keeps it at its `minCount` and moves to the second-to-last PodSet, decreasing its count down to its `minCount`, and so on.
@@ -134,63 +184,7 @@ Total requested pods: `1 + 4 + 20 = 25` pods.
      - `ps2` was reduced to 10. Kueue tries to increase its count back to 20. This succeeds since `rf2` has 20 available quota.
   6. Admitted counts: `ps0: 1`, `ps1: 2`, `ps2: 20`.
 
-#### Proportional Policy (`proportional` - default)
-
-Under the `proportional` policy, Kueue reduces the counts of all variable PodSets proportionally to their maximum allowable reduction range (i.e., `count - minCount`).
-
-For each PodSet $j$ that allows partial admission, let:
-- $C_j$ be the maximum requested count.
-- $M_j$ be the minimum acceptable count (`minCount`).
-- $D_j = C_j - M_j$ be the maximum reduction delta for PodSet $j$.
-- $T_D = \sum D_j$ be the sum of all maximum reduction deltas.
-
-To find the optimal fit, Kueue performs a binary search on a scaling index $i$ in the range $[0, T_D]$. For a given index $i$, the count for PodSet $j$ is computed as:
-$$currentCount_j = C_j - \lfloor \frac{D_j \times i}{T_D} \rfloor$$
-
-Kueue finds the smallest index $i$ (corresponding to the minimal reduction) for which the resulting counts fit the available quota.
-
-**Example:**
-Consider a Job with three PodSets:
-- `ps0`: `count: 1`, no `minCount` ($D_0 = 0$).
-- `ps1`: `count: 4`, `minCount: 2` ($D_1 = 2$).
-- `ps2`: `count: 20`, `minCount: 10` ($D_2 = 10$).
-
-Total requested pods: `1 + 4 + 20 = 25` pods.
-Total reduction delta: $T_D = 0 + 2 + 10 = 12$ pods.
-
-- **Scenario A: Available quota is 19 pods** (requires a reduction of at least 6 pods).
-  - For $i = 6$:
-    - `ps0` count: $1 - \lfloor \frac{0 \times 6}{12} \rfloor = 1 - 0 = 1$
-    - `ps1` count: $4 - \lfloor \frac{2 \times 6}{12} \rfloor = 4 - 1 = 3$
-    - `ps2` count: $20 - \lfloor \frac{10 \times 6}{12} \rfloor = 20 - 5 = 15$
-    - Total count: `1 + 3 + 15 = 19` pods. This fits the 19-pod quota.
-  - For $i = 5$:
-    - `ps0` count: $1 - \lfloor \frac{0 \times 5}{12} \rfloor = 1 - 0 = 1$
-    - `ps1` count: $4 - \lfloor \frac{2 \times 5}{12} \rfloor = 4 - 0 = 4$
-    - `ps2` count: $20 - \lfloor \frac{10 \times 5}{12} \rfloor = 20 - 4 = 16$
-    - Total count: `1 + 4 + 16 = 21` pods. This does not fit the 19-pod quota.
-  - Thus, the binary search selects $i = 6$.
-  - Admitted counts: `ps0: 1`, `ps1: 3`, `ps2: 15` (total 19 pods).
-
-- **Scenario B: Available quota is 13 pods** (requires a reduction of at least 12 pods).
-  - For $i = 12$:
-    - `ps0` count: $1 - \lfloor \frac{0 \times 12}{12} \rfloor = 1 - 0 = 1$
-    - `ps1` count: $4 - \lfloor \frac{2 \times 12}{12} \rfloor = 4 - 2 = 2$
-    - `ps2` count: $20 - \lfloor \frac{10 \times 12}{12} \rfloor = 20 - 10 = 10$
-    - Total count: `1 + 2 + 10 = 13` pods. This fits the 13-pod quota.
-  - For $i = 11$:
-    - `ps0` count: $1 - \lfloor \frac{0 \times 11}{12} \rfloor = 1 - 0 = 1$
-    - `ps1` count: $4 - \lfloor \frac{2 \times 11}{12} \rfloor = 4 - 1 = 3$
-    - `ps2` count: $20 - \lfloor \frac{10 \times 11}{12} \rfloor = 20 - 9 = 11$
-    - Total count: `1 + 3 + 11 = 15` pods. This does not fit the 13-pod quota.
-  - Thus, the binary search selects $i = 12$.
-  - Admitted counts: `ps0: 1`, `ps1: 2`, `ps2: 10` (total 13 pods).
-
-- **Scenario C: Available quota is 10 pods** (requires a reduction of at least 15 pods).
-  - Even with the maximum possible index $i = 12$ (maximum reduction), the total count is `1 + 2 + 10 = 13` pods, which does not fit in 10 pods.
-  - Thus, the binary search fails, and the job remains unadmitted.
-
-The accepted number of pods in each PodSet is recorded in `workload.Status.Admission.PodSetAssignments[*].ResourceUsage.Count`.
+The accepted number of pods in each PodSet is recorded in `workload.Status.Admission.PodSetAssignments[*].Count`.
 
 ### Jobframework
 
@@ -213,6 +207,77 @@ type GenericJob interface {
 
 ```
 
+### ElasticJob
+
+For ElasticJobs, updating `job.spec.parallelism` or `job.spec.count` could cause race conditions between partial admission and scaling up/down activity. 
+To avoid this, the `podSets` count won't be updated in `RunWithPodSetsInfo` for elastic jobs. Instead, the workload controller will use the `workload.Status.Admission.PodSetAssignments[*].Count` value to calculate the number of pods from which Kueue should remove scheduling gates. 
+The `minCount` value for an ElasticJob workload will represent the currently admitted value + 1.
+Also, a new Workload representing the full job will be created and added to the queue, to admit the remaining capacity once it becomes available.
+
+#### Example: Two-Step Scale Up under Quota Constraints (with Partial Admission)
+
+Consider a scenario where:
+1. The ClusterQueue has a total quota of **7** for the requested resource flavor.
+2. The Job is configured for both `ElasticJobs` and `PartialAdmission`.
+3. The user performs a two-step scale up of the Job: starting at **5** replicas, scaling up to **10**, and then to **12**.
+
+##### Step 0: Job Creation (Initial Size: 5)
+* **Job spec.parallelism**: 5
+* **Workloads**:
+  * `wl-A` (Admitted):
+    * `spec.podSets.count` = 5
+    * `spec.podSets.minCount` = 2
+    * `status.admission.count` = 5
+* **Controller Actions**:
+  1. **Job Controller**: Detects the Job creation, sets `.spec.suspend = false`, and creates 5 Pods. Due to Kueue's webhook mutation, the Pods are created with the `kueue.x-k8s.io/elastic-job` scheduling gate.
+  2. **Kueue Job Framework / Workload Controller**: Detects the Job and creates `wl-A` with `spec.podSets.count = 5` and `spec.podSets.minCount = 2`.
+  3. **Kueue Scheduler**: Evaluates `wl-A`. Since the requested 5 pods fit within the available quota of 7, it admits `wl-A` (`status.admission.count = 5`), reserving 5 units of quota.
+  4. **ElasticJobUngater Controller**: Detects that `wl-A` is admitted and removes the scheduling gate from the 5 pods.
+  5. **Kube-scheduler**: Schedules the 5 ungated pods, which transition to the Running state.
+* **Quota usage**: 5/7 (2 available).
+
+##### Step 1: Scale Up from 5 to 10
+* **Job spec.parallelism**: 10
+* **Workloads**:
+  * `wl-A` (Finished - aggregated/replaced by `wl-B`)
+  * `wl-B` (Admitted - Partially):
+    * `spec.podSets.count` = 7 (originally requested 10, but updated to 7 during partial admission)
+    * `spec.podSets.minCount` = 6 (the current running count 5 + 1)
+    * `status.admission.count` = 7
+  * `wl-C` (Pending, since there is no capacity for 10 pods)
+    * `spec.podSets.count` = 10 (representing the job count)
+    * `spec.podSets.minCount` = 8 (the current running count 7 + 1)
+* **Controller Actions**:
+  1. **Job Controller**: Detects the parallelism increase and creates 5 new Pods (total 10 pods: 5 running, 5 gated). The new pods are created with the `kueue.x-k8s.io/elastic-job` scheduling gate.
+  2. **Workload Controller**: Observes the scale-up and creates a new Workload slice `wl-B` with `spec.podSets.count = 10` and `spec.podSets.minCount = 6` (inheriting/adjusting the minimum count based on the currently running/admitted count of 5 + 1 from `wl-A`). It is annotated as a replacement for `wl-A` via `kueue.x-k8s.io/workload-slice-replacement-for`.
+  3. **Kueue Scheduler**: Evaluates `wl-B`. Since it replaces `wl-A`, it calculates the demand: `10 (new request) - 5 (already admitted in wl-A) = 5`. The available quota is only 2. Since the Workload could not be fully admitted, the Kueue scheduler evaluates whether it can partially admit the workload with any count between 6 and 10. Given the available quota of 2, the scheduler admits `wl-B` with a count of `5 + 2 = 7` (`status.admission.count = 7`), reserving 2 more units of quota (total 7).
+  4. **WorkloadSlice Controller**: Creates another WorkloadSlice `wl-C` that represents the current state of the job with `.spec.podSets[0].count` = 10 and `spec.podSets.minCount` = 8. This workload is added to the queue to be evaluated when capacity becomes available, and it currently stays `Pending`. `wl-A` is marked as finished.
+  5. **ElasticJobUngater Controller**: Detects that `wl-B` is admitted with count 7. It removes the scheduling gate from 2 of the new pods (bringing running pods to 7). The other 3 new pods remain gated.
+* **Quota usage**: 7/7 (0 available).
+
+##### Step 2: Scale Up to 12 (Quota Constraint: 7)
+* **Job spec.parallelism**: 12
+* **Workloads**:
+  * `wl-B` (Admitted)
+  * `wl-C` (Updated, keep pending):
+    * `spec.podSets.count` = 12
+    * `spec.podSets.minCount` = 8 (7 + 1)
+* **Controller Actions**:
+  1. **Job Controller**: Detects the parallelism increase and creates 2 more Pods (total 12 pods: 7 running, 5 gated). The new pods are created with the `kueue.x-k8s.io/elastic-job` scheduling gate.
+  2. **Workload Controller**: Detects the update. Since the Job's parallelism is updated to 12, Kueue updates the pending workload `wl-C` with `spec.podSets.count = 12`.
+  3. **Kueue Scheduler**: Evaluates `wl-C`. The demand is `12 - 7 = 5`. The available quota is 0, so the scheduler puts `wl-C` in the queue.
+
+##### Step 3: Quota increases to 12
+If the available quota in the ClusterQueue increases to 12 (or more) in the future:
+* **Workloads**:
+  * `wl-B` (Finished)
+  * `wl-C` (Admitted):
+    * `spec.podSets.count` = 12
+    * `spec.podSets.minCount` = 8 (7 + 1)
+    * `status.admission.count` = 12
+
+In the next scheduler loop, the Kueue scheduler will evaluate and admit `wl-C`. It will also update its `spec.podSets.minCount` to match the job's minCount.
+
 ### batch/Job controller
 
 Besides adapting `RunWithPodSetsInfo` and `RestorePodSetsInfo` it should also:
@@ -231,9 +296,11 @@ Additional research is needed into the potential usage of multiple variable coun
 
 ### RayJob/RayService/RayCluster controller
 
-RayClusters with 'kueue.x-k8s.io/partial-admission=true' annotation are eligible for partial admission. The
-RayCluster.workerGroupSpec[i].minReplicas will be translated to the PodSet.MinCount for the Worker PodSet.
-There will be no update on RayCluster object. If the number of admitted pods is less than requested count, the leftover pods should remain scheduling gated. In order to achieve that, the same mechanism as for elastic workloads will be applied – the podTemplate will be initially gated and then the correct amount of pods will be ungated.
+The RayCluster.workerGroupSpec[i].minReplicas will be translated to the PodSet.MinCount for the Worker PodSet.
+
+### Limitations
+
+Partial admission is not supported for concurrent admission to avoid increasing complexity. The webhook will reject the creation of workloads that support partial admission for a ClusterQueue with a concurrent admission policy. 
 
 ### Test Plan
 

--- a/keps/420-partial-admission/README.md
+++ b/keps/420-partial-admission/README.md
@@ -135,6 +135,7 @@ The table below summarizes the scheduling and admission behaviors for different 
 ### Workload API
 
 ```go
+// +kubebuilder:validation:XValidation:rule="has(self.minCount) ? self.minCount <= self.count : true", message="minCount should be positive and less or equal to count"
 type PodSet struct {
   // .......
 

--- a/keps/420-partial-admission/kep.yaml
+++ b/keps/420-partial-admission/kep.yaml
@@ -19,7 +19,7 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.19"
+latest-milestone: "v0.20"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:

--- a/keps/420-partial-admission/kep.yaml
+++ b/keps/420-partial-admission/kep.yaml
@@ -2,6 +2,7 @@ title: Allow partial admission of jobs
 kep-number: 420
 authors:
   - "@trasc"
+  - "@yaroslava-serdiuk"
 status: implementable
 creation-date: 2023-05-10
 reviewers:
@@ -18,7 +19,7 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.5"
+latest-milestone: "v0.19"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:

--- a/keps/420-partial-admission/kep.yaml
+++ b/keps/420-partial-admission/kep.yaml
@@ -11,6 +11,11 @@ reviewers:
 approvers:
   - "@alculquicondor"
   - "@ahg-g"
+  - "@mimiwo"
+
+see-also:
+  - "/keps/77-dynamically-sized-jobs"
+  - "/keps/8691-concurrent-admission"
 
 
 # The target maturity stage in the current dev cycle for this KEP.
@@ -28,3 +33,4 @@ milestone:
 
 feature-gates:
   - name: PartialAdmission
+  - name: PartialAdmissionForElasticJobs

--- a/keps/420-partial-admission/kep.yaml
+++ b/keps/420-partial-admission/kep.yaml
@@ -11,7 +11,7 @@ reviewers:
 approvers:
   - "@alculquicondor"
   - "@ahg-g"
-  - "@mimiwo"
+  - "@mimowo"
 
 see-also:
   - "/keps/77-dynamically-sized-jobs"

--- a/keps/77-dynamically-sized-jobs/README.md
+++ b/keps/77-dynamically-sized-jobs/README.md
@@ -336,10 +336,6 @@ This section captures all known limitations and incompatibilities introduced by,
 
 #### PartialAdmission
 
-A given Job instance cannot have both `PartialAdmission` and `ElasticJob` enabled. This is a **per-Job limitation**, not a global feature-level conflict. It is entirely valid to have both features enabled in the system, just not simultaneously on the same Job.
-
-**Rationale**
-
 * `PartialAdmission` depends on the static nature of a workload. Specifically, it assumes, reasonably, given the current model, that workloads are immutable in terms of `podSets[].count`. Based on this assumption, it adjusts the Job’s spec to reflect the minimum allowed parallelism at scheduling time. This value is fixed and will not change, even if the ClusterQueue’s capacity increases later.
 
 * In practice, `PartialAdmission` takes ownership of `job.spec.parallelism`, and Kueue enforces this immutability through the admission webhook. For example:

--- a/keps/77-dynamically-sized-jobs/README.md
+++ b/keps/77-dynamically-sized-jobs/README.md
@@ -336,6 +336,10 @@ This section captures all known limitations and incompatibilities introduced by,
 
 #### PartialAdmission
 
+A given Job instance cannot have both `PartialAdmission` and `ElasticJob` enabled. This is a **per-Job limitation**, not a global feature-level conflict. It is entirely valid to have both features enabled in the system, just not simultaneously on the same Job.
+
+**Rationale**
+
 * `PartialAdmission` depends on the static nature of a workload. Specifically, it assumes, reasonably, given the current model, that workloads are immutable in terms of `podSets[].count`. Based on this assumption, it adjusts the Job’s spec to reflect the minimum allowed parallelism at scheduling time. This value is fixed and will not change, even if the ClusterQueue’s capacity increases later.
 
 * In practice, `PartialAdmission` takes ownership of `job.spec.parallelism`, and Kueue enforces this immutability through the admission webhook. For example:

--- a/keps/77-dynamically-sized-jobs/README.md
+++ b/keps/77-dynamically-sized-jobs/README.md
@@ -27,8 +27,6 @@
     - [Pod Identification Across Slices](#pod-identification-across-slices)
     - [Scale Up](#scale-up)
     - [Scale Down](#scale-down)
-  - [Limitations and Incompatibilities](#limitations-and-incompatibilities)
-    - [PartialAdmission](#partialadmission)
 - [Phases for MVP (alpha)](#phases-for-mvp-alpha)
   - [Phase 1 - batchv1/Job WorkloadSlices Support in Single-Cluster Configuration.](#phase-1---batchv1job-workloadslices-support-in-single-cluster-configuration)
     - [Scale Down](#scale-down-1)
@@ -329,34 +327,6 @@ pods), allowing scale-down to 2 replicas could result in only 1 active pod.
 **Note:** This blocking behavior is a tentative plan for Alpha and will be re-evaluated before Beta.
 
 See [KEP-2724: Topology Aware Scheduling](../2724-topology-aware-scheduling#support-for-elastic-workloads) for TAS details.
-
-### Limitations and Incompatibilities
-
-This section captures all known limitations and incompatibilities introduced by, or resulting from, enabling the ElasticJobs feature.
-
-#### PartialAdmission
-
-A given Job instance cannot have both `PartialAdmission` and `ElasticJob` enabled. This is a **per-Job limitation**, not a global feature-level conflict. It is entirely valid to have both features enabled in the system, just not simultaneously on the same Job.
-
-**Rationale**
-
-* `PartialAdmission` depends on the static nature of a workload. Specifically, it assumes, reasonably, given the current model, that workloads are immutable in terms of `podSets[].count`. Based on this assumption, it adjusts the Job’s spec to reflect the minimum allowed parallelism at scheduling time. This value is fixed and will not change, even if the ClusterQueue’s capacity increases later.
-
-* In practice, `PartialAdmission` takes ownership of `job.spec.parallelism`, and Kueue enforces this immutability through the admission webhook. For example:
-
-  ```text
-  admission webhook "vjob.kb.io" denied the request: spec.parallelism: Forbidden: cannot change when partial admission is enabled and the job is not suspended
-  ```
-
-**Validation**
-
-To avoid delayed or implicit validation errors, any Kueue-integrated Job that supports `ElasticJobs` should include admission validation logic to reject the following annotation combination:
-
-```yaml
-annotations:
-  kueue.x-k8s.io/dynamically-sized-job: "true"
-  kueue.x-k8s.io/job-min-parallelism: "1"
-```
 
 ## Phases for MVP (alpha)
 

--- a/keps/8691-concurrent-admission/README.md
+++ b/keps/8691-concurrent-admission/README.md
@@ -53,6 +53,7 @@ tags, and then generate with `hack/update-toc.sh`.
     - [StrictFIFO](#strictfifo)
   - [Risks and Mitigations](#risks-and-mitigations)
   - [FlavorFungibility Misinterpretation](#flavorfungibility-misinterpretation)
+  - [Limitations](#limitations)
   - [Misconfiguration](#misconfiguration)
   - [Test Plan](#test-plan)
       - [Prerequisite testing updates](#prerequisite-testing-updates)
@@ -608,6 +609,10 @@ At the same time if a single Variant can be scheduled onto multiple flavors due 
 the `FlavorFungibility` config.
 
 This may lead to confusion, so we need to address this use-case directly in the documentation.
+
+### Limitations
+
+- Partial admission is not supported for concurrent admission.
 
 ### Misconfiguration
 


### PR DESCRIPTION
#### What type of PR is this?
/kind kep

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Related to #12100 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated partial admission behavior for workloads with multiple PodSets, improving how pod loss is minimized when selecting a fitable combination.
  * Expanded Ray controller partial-preemption eligibility and clarified how worker replica minimums map to PodSet minimums, including scheduling-gated leftovers.

* **Documentation**
  * Revised the multi-PodSet partial admission procedure and worked example, with clearer guidance on the proportional fallback.
  * Updated KEP metadata (authors/latest milestone) and adjusted Ray controller section formatting/notes for implementation history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->