### PR TITLE
fix: lq metrics clear race condition

### DIFF
--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -321,9 +321,7 @@ func (r *LocalQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.LocalQueue
 		r.queues.DeleteLocalQueue(log, e.ObjectOld)
 	}
 
-	// Reconcile LocalQueue metrics only after the queueing system and cache have been
-	// updated above, so the Manager already sees the new labels. Clearing before that
-	// update races with concurrent metric reports
+	// Clear after manager update to avoid race with concurrent metric reports.
 	if r.lqMetrics.ShouldExposeLocalQueueMetrics(e.ObjectNew.GetLabels()) && !customLabelsChanged {
 		r.updateLocalQueueResourceMetrics(log, e.ObjectNew)
 	} else if r.lqMetrics.ShouldExposeLocalQueueMetrics(e.ObjectOld.GetLabels()) {

--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -292,12 +292,6 @@ func (r *LocalQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.LocalQueue
 		)
 	}
 
-	if r.lqMetrics.ShouldExposeLocalQueueMetrics(e.ObjectNew.GetLabels()) && !customLabelsChanged {
-		r.updateLocalQueueResourceMetrics(log, e.ObjectNew)
-	} else if r.lqMetrics.ShouldExposeLocalQueueMetrics(e.ObjectOld.GetLabels()) {
-		clearLocalQueueMetrics(e.ObjectOld)
-	}
-
 	oldStopPolicy := ptr.Deref(e.ObjectOld.Spec.StopPolicy, kueue.None)
 	newStopPolicy := ptr.Deref(e.ObjectNew.Spec.StopPolicy, kueue.None)
 	clusterQueueChanged := e.ObjectOld.Spec.ClusterQueue != e.ObjectNew.Spec.ClusterQueue
@@ -325,6 +319,15 @@ func (r *LocalQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.LocalQueue
 		}
 	default:
 		r.queues.DeleteLocalQueue(log, e.ObjectOld)
+	}
+
+	// Reconcile LocalQueue metrics only after the queueing system and cache have been
+	// updated above, so the Manager already sees the new labels. Clearing before that
+	// update races with concurrent metric reports
+	if r.lqMetrics.ShouldExposeLocalQueueMetrics(e.ObjectNew.GetLabels()) && !customLabelsChanged {
+		r.updateLocalQueueResourceMetrics(log, e.ObjectNew)
+	} else if r.lqMetrics.ShouldExposeLocalQueueMetrics(e.ObjectOld.GetLabels()) {
+		clearLocalQueueMetrics(e.ObjectOld)
 	}
 
 	if customLabelsChanged && !stoppingQueue {

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -38,8 +40,11 @@ import (
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	queueafs "sigs.k8s.io/kueue/pkg/cache/queue/afs"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/metrics"
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	testingmetrics "sigs.k8s.io/kueue/pkg/util/testing/metrics"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/test/util"
 )
@@ -637,6 +642,101 @@ func TestLocalQueueReconcile(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.wantLocalQueue, gotLocalQueue, cmpOpts...); diff != "" {
 				t.Errorf("Workloads after reconcile (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestLocalQueueUpdateClearsMetricsOnLabelChange covers the behavior fixed for #12164:
+// when a LocalQueue's labels change so it no longer matches the metrics selector, the
+// Update handler must clear its per-queue metrics; when it still matches (or the feature
+// gate is off) the metrics must be left in place. This is single-threaded behavioral
+// coverage of the clear-on-label-change path — the concurrency race itself is exercised by
+// the integration spec (validated in CI).
+func TestLocalQueueUpdateClearsMetricsOnLabelChange(t *testing.T) {
+	matching := map[string]string{"metrics-test": "true"}
+	nonMatching := map[string]string{"metrics-test": "false"}
+	lqMetrics := metrics.NewLocalQueueMetricsConfig(&config.LocalQueueMetrics{
+		Enable:             true,
+		LocalQueueSelector: &metav1.LabelSelector{MatchLabels: matching},
+	})
+
+	cases := map[string]struct {
+		gateEnabled bool
+		oldLabels   map[string]string
+		newLabels   map[string]string
+		wantCleared bool
+	}{
+		"matching to non-matching clears metrics": {
+			gateEnabled: true,
+			oldLabels:   matching,
+			newLabels:   nonMatching,
+			wantCleared: true,
+		},
+		"matching to matching keeps metrics": {
+			gateEnabled: true,
+			oldLabels:   matching,
+			newLabels:   matching,
+			wantCleared: false,
+		},
+		"feature gate off is a no-op": {
+			gateEnabled: false,
+			oldLabels:   matching,
+			newLabels:   nonMatching,
+			wantCleared: false,
+		},
+	}
+
+	idx := 0
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.LocalQueueMetrics, tc.gateEnabled)
+
+			// Unique names so Prometheus series do not leak across subtests.
+			idx++
+			nsName := fmt.Sprintf("ns-%d", idx)
+			lqName := fmt.Sprintf("lq-%d", idx)
+
+			cq := utiltestingapi.MakeClusterQueue("cq-" + lqName).Obj()
+			oldLQ := utiltestingapi.MakeLocalQueue(lqName, nsName).ClusterQueue(cq.Name).Obj()
+			oldLQ.Labels = tc.oldLabels
+			newLQ := oldLQ.DeepCopy()
+			newLQ.Labels = tc.newLabels
+
+			cl := utiltesting.NewClientBuilder().
+				WithObjects(cq, oldLQ).
+				WithStatusSubresource(cq, oldLQ).
+				Build()
+
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cqCache := schdcache.New(cl)
+			if err := cqCache.AddClusterQueue(ctx, cq); err != nil {
+				t.Fatalf("AddClusterQueue (scheduler cache): %v", err)
+			}
+			_ = cqCache.AddLocalQueue(oldLQ)
+			qManager := qcache.NewManagerForUnitTests(cl, cqCache)
+			if err := qManager.AddClusterQueue(ctx, cq); err != nil {
+				t.Fatalf("AddClusterQueue (queue manager): %v", err)
+			}
+			_ = qManager.AddLocalQueue(ctx, oldLQ)
+
+			reconciler := NewLocalQueueReconciler(cl, qManager, cqCache, WithLocalQueueMetrics(lqMetrics))
+
+			// Simulate a previously reported pending-workloads series for this LocalQueue.
+			lqRef := metrics.LocalQueueReference{Name: kueue.LocalQueueName(lqName), Namespace: nsName}
+			metrics.ReportLocalQueuePendingWorkloads(lqRef, 1, 0, nil, nil)
+			defer metrics.ClearLocalQueueMetrics(lqRef)
+
+			filter := map[string]string{"name": lqName, "namespace": nsName}
+			if got := testingmetrics.CollectFilteredGaugeVec(metrics.LocalQueuePendingWorkloads, filter); len(got) == 0 {
+				t.Fatalf("precondition failed: pending_workloads series should exist before the update")
+			}
+
+			reconciler.Update(event.TypedUpdateEvent[*kueue.LocalQueue]{ObjectOld: oldLQ, ObjectNew: newLQ})
+
+			got := testingmetrics.CollectFilteredGaugeVec(metrics.LocalQueuePendingWorkloads, filter)
+			if cleared := len(got) == 0; cleared != tc.wantCleared {
+				t.Errorf("after update: cleared=%v, want %v (remaining series=%+v)", cleared, tc.wantCleared, got)
 			}
 		})
 	}

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -18,7 +18,6 @@ package core
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -32,7 +31,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -40,11 +38,8 @@ import (
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	queueafs "sigs.k8s.io/kueue/pkg/cache/queue/afs"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
-	"sigs.k8s.io/kueue/pkg/features"
-	"sigs.k8s.io/kueue/pkg/metrics"
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
-	testingmetrics "sigs.k8s.io/kueue/pkg/util/testing/metrics"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/test/util"
 )
@@ -642,97 +637,6 @@ func TestLocalQueueReconcile(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.wantLocalQueue, gotLocalQueue, cmpOpts...); diff != "" {
 				t.Errorf("Workloads after reconcile (-want,+got):\n%s", diff)
-			}
-		})
-	}
-}
-
-// TestLocalQueueUpdateClearsMetricsOnLabelChange verifies the #12164 fix: an Update that
-// makes a LocalQueue stop matching the metrics selector clears its per-queue metrics.
-func TestLocalQueueUpdateClearsMetricsOnLabelChange(t *testing.T) {
-	matching := map[string]string{"metrics-test": "true"}
-	nonMatching := map[string]string{"metrics-test": "false"}
-	lqMetrics := metrics.NewLocalQueueMetricsConfig(&config.LocalQueueMetrics{
-		Enable:             true,
-		LocalQueueSelector: &metav1.LabelSelector{MatchLabels: matching},
-	})
-
-	cases := map[string]struct {
-		gateEnabled bool
-		oldLabels   map[string]string
-		newLabels   map[string]string
-		wantCleared bool
-	}{
-		"matching to non-matching clears metrics": {
-			gateEnabled: true,
-			oldLabels:   matching,
-			newLabels:   nonMatching,
-			wantCleared: true,
-		},
-		"matching to matching keeps metrics": {
-			gateEnabled: true,
-			oldLabels:   matching,
-			newLabels:   matching,
-			wantCleared: false,
-		},
-		"feature gate off is a no-op": {
-			gateEnabled: false,
-			oldLabels:   matching,
-			newLabels:   nonMatching,
-			wantCleared: false,
-		},
-	}
-
-	idx := 0
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.LocalQueueMetrics, tc.gateEnabled)
-
-			// Unique names so Prometheus series do not leak across subtests.
-			idx++
-			nsName := fmt.Sprintf("ns-%d", idx)
-			lqName := fmt.Sprintf("lq-%d", idx)
-
-			cq := utiltestingapi.MakeClusterQueue("cq-" + lqName).Obj()
-			oldLQ := utiltestingapi.MakeLocalQueue(lqName, nsName).ClusterQueue(cq.Name).Obj()
-			oldLQ.Labels = tc.oldLabels
-			newLQ := oldLQ.DeepCopy()
-			newLQ.Labels = tc.newLabels
-
-			cl := utiltesting.NewClientBuilder().
-				WithObjects(cq, oldLQ).
-				WithStatusSubresource(cq, oldLQ).
-				Build()
-
-			ctx, _ := utiltesting.ContextWithLog(t)
-			cqCache := schdcache.New(cl)
-			if err := cqCache.AddClusterQueue(ctx, cq); err != nil {
-				t.Fatalf("AddClusterQueue (scheduler cache): %v", err)
-			}
-			_ = cqCache.AddLocalQueue(oldLQ)
-			qManager := qcache.NewManagerForUnitTests(cl, cqCache)
-			if err := qManager.AddClusterQueue(ctx, cq); err != nil {
-				t.Fatalf("AddClusterQueue (queue manager): %v", err)
-			}
-			_ = qManager.AddLocalQueue(ctx, oldLQ)
-
-			reconciler := NewLocalQueueReconciler(cl, qManager, cqCache, WithLocalQueueMetrics(lqMetrics))
-
-			// Simulate a previously reported pending-workloads series for this LocalQueue.
-			lqRef := metrics.LocalQueueReference{Name: kueue.LocalQueueName(lqName), Namespace: nsName}
-			metrics.ReportLocalQueuePendingWorkloads(lqRef, 1, 0, nil, nil)
-			defer metrics.ClearLocalQueueMetrics(lqRef)
-
-			filter := map[string]string{"name": lqName, "namespace": nsName}
-			if got := testingmetrics.CollectFilteredGaugeVec(metrics.LocalQueuePendingWorkloads, filter); len(got) == 0 {
-				t.Fatalf("precondition failed: pending_workloads series should exist before the update")
-			}
-
-			reconciler.Update(event.TypedUpdateEvent[*kueue.LocalQueue]{ObjectOld: oldLQ, ObjectNew: newLQ})
-
-			got := testingmetrics.CollectFilteredGaugeVec(metrics.LocalQueuePendingWorkloads, filter)
-			if cleared := len(got) == 0; cleared != tc.wantCleared {
-				t.Errorf("after update: cleared=%v, want %v (remaining series=%+v)", cleared, tc.wantCleared, got)
 			}
 		})
 	}

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -647,12 +647,8 @@ func TestLocalQueueReconcile(t *testing.T) {
 	}
 }
 
-// TestLocalQueueUpdateClearsMetricsOnLabelChange covers the behavior fixed for #12164:
-// when a LocalQueue's labels change so it no longer matches the metrics selector, the
-// Update handler must clear its per-queue metrics; when it still matches (or the feature
-// gate is off) the metrics must be left in place. This is single-threaded behavioral
-// coverage of the clear-on-label-change path — the concurrency race itself is exercised by
-// the integration spec (validated in CI).
+// TestLocalQueueUpdateClearsMetricsOnLabelChange verifies the #12164 fix: an Update that
+// makes a LocalQueue stop matching the metrics selector clears its per-queue metrics.
 func TestLocalQueueUpdateClearsMetricsOnLabelChange(t *testing.T) {
 	matching := map[string]string{"metrics-test": "true"}
 	nonMatching := map[string]string{"metrics-test": "false"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Fix lq metrics clear race condition 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12164 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Observability: Fixed a race condition that could leave stale LocalQueue metrics after a label change caused the LocalQueue to stop matching the metrics selector.
```
---

> AI Assistance Disclosure: This pull request was created with the assistance of AI (Claude Code by Anthropic).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized metrics reconciliation timing during local queue updates to prevent race conditions.

* **Tests**
  * Added test coverage for metric clearing behavior when local queue labels change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->