### PR TITLE
Prepare MultiKueue Kind dev setup to use CA-based kubeconfigs

### DIFF
--- a/site/content/en/docs/tasks/dev/setup_multikueue_development_environment.md
+++ b/site/content/en/docs/tasks/dev/setup_multikueue_development_environment.md
@@ -119,13 +119,9 @@ done
 
 ### Step 3: Configure Manager for Kind
 
-Enable the feature gate for insecure kubeconfigs and configure integrations:
+Configure integrations:
 
 ```bash
-# Enable feature gate (required for Kind clusters with insecure-skip-tls-verify)
-kubectl --context kind-manager patch deployment kueue-controller-manager -n kueue-system --type='json' \
-  -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--feature-gates=MultiKueueAllowInsecureKubeconfigs=true"}]'
-
 # Configure to use only batch/job integration
 cat > /tmp/kueue-integrations-patch.yaml <<'EOF'
 data:
@@ -225,13 +221,16 @@ EOF
   # be plaintext in kubeconfig
   TOKEN=$(kubectl --context "kind-${cluster}" get secret multikueue-sa-token -n kueue-system -o jsonpath='{.data.token}' | base64 --decode)
 
+  # Extract the Certificate Authority
+  CA_DATA=$(kubectl --context "kind-${cluster}" config view --minify --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
+
   # Create kubeconfig
   cat > ${cluster}.kubeconfig <<EOF
 apiVersion: v1
 kind: Config
 clusters:
 - cluster:
-    insecure-skip-tls-verify: true
+    certificate-authority-data: ${CA_DATA}
     server: https://${cluster}-control-plane:6443
   name: ${cluster}
 contexts:

--- a/site/static/examples/multikueue/dev/setup-kind-multikueue-tas.sh
+++ b/site/static/examples/multikueue/dev/setup-kind-multikueue-tas.sh
@@ -175,7 +175,7 @@ EOF
     # Extract the Certificate Authority
     CA_DATA=$(kubectl --context "kind-${cluster}" config view --minify --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
 
-    # Create kubeconfig with insecure-skip-tls-verify for Kind clusters
+    # Create kubeconfig with the cluster's certificate authority for Kind clusters
     cat > "${SCRIPT_DIR}/${cluster}.kubeconfig" <<EOF
 apiVersion: v1
 kind: Config


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is a preparatory PR for #12284.

The documented Kind-based MultiKueue development setup currently generates worker kubeconfigs with `insecure-skip-tls-verify: true` and relies on the deprecated `MultiKueueAllowInsecureKubeconfigs` feature gate.

This PR updates that dev setup to generate CA-based kubeconfigs using `certificate-authority-data` extracted from the Kind worker cluster, so the documented workflow no longer depends on insecure kubeconfigs.

It does not change the feature-gate lifecycle yet.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #12284

#### Special notes for your reviewer:

The `setup-kind-multikueue-tas.sh` change is only a stale-comment fix; the script already used `certificate-authority-data`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
