### PR TITLE
Changes for Graduation of TASMultiLayerTopology to Beta

### DIFF
--- a/apis/kueue/v1beta2/topology_types.go
+++ b/apis/kueue/v1beta2/topology_types.go
@@ -65,7 +65,7 @@ const (
 	// is mutually exclusive with PodSetSliceRequiredTopologyAnnotation and
 	// PodSetSliceSizeAnnotation.
 	//
-	// This annotation is alpha-level for the TASMultiLayerTopology feature gate.
+	// This annotation is beta-level for the TASMultiLayerTopology feature gate.
 	PodSetSliceRequiredTopologyConstraintsAnnotation = "kueue.x-k8s.io/podset-slice-required-topology-constraints"
 
 	// TopologySchedulingGate is used to delay scheduling of a Pod until the

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -891,7 +891,7 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	}
 	state.sliceSizeAtLevel = sliceSizeAtLevel
 
-	if features.Enabled(features.TASMultiLayerTopology) && len(sliceSizeAtLevel) > 0 {
+	if len(sliceSizeAtLevel) > 0 {
 		state.multiLayerConstraints = workersTasPodSetRequests.PodSet.TopologyRequest.PodsetSliceRequiredTopologyConstraints
 	}
 
@@ -1044,16 +1044,13 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 //  3. Fills all intermediate levels between the previous and current layer with
 //     this layer's size, ensuring that intermediate levels also distribute in
 //     multiples of the inner layer's size.
-//
-// TODO: once TASMultiLayerTopology graduates to beta, use this function to unify logic for both
-// 1-layer (kueue.x-k8s.io/podset-slice-size) and multi-layer topology constraints.
 func (s *TASFlavorSnapshot) buildSliceSizeAtLevel(
 	workersTasPodSetRequests TASPodSetRequests,
 	sliceSize int32,
 	sliceLevelIdx int,
 ) (map[int]int32, string) {
 	sliceSizeAtLevel := make(map[int]int32)
-	if !features.Enabled(features.TASMultiLayerTopology) || workersTasPodSetRequests.PodSet.TopologyRequest == nil {
+	if workersTasPodSetRequests.PodSet.TopologyRequest == nil {
 		return sliceSizeAtLevel, ""
 	}
 
@@ -1110,7 +1107,7 @@ func (s *TASFlavorSnapshot) HasLevel(r *kueue.PodSetTopologyRequest) bool {
 	}
 
 	// Also check multi-level topology constraints.
-	if features.Enabled(features.TASMultiLayerTopology) && r != nil {
+	if r != nil {
 		for _, layer := range r.PodsetSliceRequiredTopologyConstraints {
 			if _, found := s.resolveLevelIdx(layer.Topology); !found {
 				return false

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1720,6 +1720,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASFailedNodeReplacementFailFast): true,
 				string(features.TASReplaceNodeOnPodTermination):   false,
 				string(features.TASReplaceNodeOnNodeTaints):       false,
+				string(features.TASMultiLayerTopology):            false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:          true,
@@ -1729,6 +1730,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				features.TASFailedNodeReplacementFailFast: true,
 				features.TASReplaceNodeOnPodTermination:   true,
 				features.TASReplaceNodeOnNodeTaints:       true,
+				features.TASMultiLayerTopology:            true,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1752,7 +1754,6 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASFailedNodeReplacementFailFast): false,
 				string(features.TASReplaceNodeOnPodTermination):   true,
 				string(features.TASReplaceNodeOnNodeTaints):       false,
-				string(features.TASMultiLayerTopology):            false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:          true,
@@ -1762,7 +1763,6 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				features.TASFailedNodeReplacementFailFast: true,
 				features.TASReplaceNodeOnPodTermination:   true,
 				features.TASReplaceNodeOnNodeTaints:       true,
-				features.TASMultiLayerTopology:            true,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1327,6 +1327,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASFailedNodeReplacementFailFast): false,
 				string(features.TASReplaceNodeOnPodTermination):   false,
 				string(features.TASReplaceNodeOnNodeTaints):       false,
+				string(features.TASMultiLayerTopology):            false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TASProfileMixed:                  false,
@@ -1335,6 +1336,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				features.TASFailedNodeReplacementFailFast: true,
 				features.TASReplaceNodeOnPodTermination:   true,
 				features.TASReplaceNodeOnNodeTaints:       true,
+				features.TASMultiLayerTopology:            true,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1376,6 +1378,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASFailedNodeReplacementFailFast):    false,
 				string(features.TASReplaceNodeOnPodTermination):      false,
 				string(features.TASReplaceNodeOnNodeTaints):          false,
+				string(features.TASMultiLayerTopology):               false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.ElasticJobsViaWorkloadSlicesWithTAS: false,
@@ -1386,6 +1389,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				features.TASFailedNodeReplacementFailFast:    true,
 				features.TASReplaceNodeOnPodTermination:      true,
 				features.TASReplaceNodeOnNodeTaints:          true,
+				features.TASMultiLayerTopology:               true,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1420,6 +1424,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASFailedNodeReplacementFailFast):    false,
 				string(features.TASReplaceNodeOnPodTermination):      false,
 				string(features.TASReplaceNodeOnNodeTaints):          false,
+				string(features.TASMultiLayerTopology):               false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TASProfileMixed:                     false,
@@ -1431,6 +1436,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				features.TASFailedNodeReplacementFailFast:    true,
 				features.TASReplaceNodeOnPodTermination:      true,
 				features.TASReplaceNodeOnNodeTaints:          true,
+				features.TASMultiLayerTopology:               true,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1481,6 +1487,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASFailedNodeReplacementFailFast): false,
 				string(features.TASReplaceNodeOnPodTermination):   false,
 				string(features.TASReplaceNodeOnNodeTaints):       false,
+				string(features.TASMultiLayerTopology):            false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TASHandleOverlappingFlavors:      true,
@@ -1490,6 +1497,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				features.TASFailedNodeReplacementFailFast: true,
 				features.TASReplaceNodeOnPodTermination:   true,
 				features.TASReplaceNodeOnNodeTaints:       true,
+				features.TASMultiLayerTopology:            true,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1519,6 +1527,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASFailedNodeReplacementFailFast): false,
 				string(features.TASReplaceNodeOnPodTermination):   false,
 				string(features.TASReplaceNodeOnNodeTaints):       false,
+				string(features.TASMultiLayerTopology):            false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:          true,
@@ -1528,6 +1537,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				features.TASFailedNodeReplacementFailFast: true,
 				features.TASReplaceNodeOnPodTermination:   true,
 				features.TASReplaceNodeOnNodeTaints:       true,
+				features.TASMultiLayerTopology:            true,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1547,6 +1557,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASReplaceNodeOnPodTermination):   false,
 				string(features.TASReplaceNodeOnNodeTaints):       false,
 				string(features.TASBalancedPlacement):             true,
+				string(features.TASMultiLayerTopology):            false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:          true,
@@ -1557,6 +1568,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				features.TASReplaceNodeOnPodTermination:   true,
 				features.TASReplaceNodeOnNodeTaints:       true,
 				features.TASBalancedPlacement:             false,
+				features.TASMultiLayerTopology:            true,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1575,6 +1587,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASFailedNodeReplacementFailFast): false,
 				string(features.TASReplaceNodeOnPodTermination):   false,
 				string(features.TASReplaceNodeOnNodeTaints):       true,
+				string(features.TASMultiLayerTopology):            false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:          true,
@@ -1584,6 +1597,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				features.TASFailedNodeReplacementFailFast: true,
 				features.TASReplaceNodeOnPodTermination:   true,
 				features.TASReplaceNodeOnNodeTaints:       true,
+				features.TASMultiLayerTopology:            true,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1632,6 +1646,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASReplaceNodeOnPodTermination):   false,
 				string(features.TASReplaceNodeOnNodeTaints):       false,
 				string(features.TASRespectNodeAffinityPreferred):  true,
+				string(features.TASMultiLayerTopology):            false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:          true,
@@ -1642,6 +1657,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				features.TASReplaceNodeOnPodTermination:   true,
 				features.TASReplaceNodeOnNodeTaints:       true,
 				features.TASRespectNodeAffinityPreferred:  false,
+				features.TASMultiLayerTopology:            true,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1657,12 +1673,14 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASFailedNodeReplacement):         false,
 				string(features.TASFailedNodeReplacementFailFast): true,
 				string(features.TASReplaceNodeOnPodTermination):   false,
+				string(features.TASMultiLayerTopology):            false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:          true,
 				features.TASFailedNodeReplacement:         true,
 				features.TASFailedNodeReplacementFailFast: true,
 				features.TASReplaceNodeOnPodTermination:   true,
+				features.TASMultiLayerTopology:            true,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1734,6 +1752,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASFailedNodeReplacementFailFast): false,
 				string(features.TASReplaceNodeOnPodTermination):   true,
 				string(features.TASReplaceNodeOnNodeTaints):       false,
+				string(features.TASMultiLayerTopology):            false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:          true,
@@ -1743,6 +1762,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				features.TASFailedNodeReplacementFailFast: true,
 				features.TASReplaceNodeOnPodTermination:   true,
 				features.TASReplaceNodeOnNodeTaints:       true,
+				features.TASMultiLayerTopology:            true,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1754,6 +1754,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASFailedNodeReplacementFailFast): false,
 				string(features.TASReplaceNodeOnPodTermination):   true,
 				string(features.TASReplaceNodeOnNodeTaints):       false,
+				string(features.TASMultiLayerTopology):            false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:          true,
@@ -1763,6 +1764,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				features.TASFailedNodeReplacementFailFast: true,
 				features.TASReplaceNodeOnPodTermination:   true,
 				features.TASReplaceNodeOnNodeTaints:       true,
+				features.TASMultiLayerTopology:            true,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{

--- a/pkg/controller/jobframework/tas_validation_test.go
+++ b/pkg/controller/jobframework/tas_validation_test.go
@@ -119,6 +119,9 @@ func TestValidateSliceRequiredTopologyConstraintsAnnotation(t *testing.T) {
 			wantErrNum: 1, // podset-group-name forbidden with constraints
 		},
 		"invalid: feature gate disabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASMultiLayerTopology: false, // explicitly disable since it's now Beta (enabled by default)
+			},
 			annotations: map[string]string{
 				kueue.PodSetRequiredTopologyAnnotation:                 "cloud.com/block",
 				kueue.PodSetSliceRequiredTopologyConstraintsAnnotation: `[{"topology":"cloud.com/rack","size":16}]`,

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -614,6 +614,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	TASMultiLayerTopology: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
 	},
 	SchedulingEquivalenceHashing: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Beta},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -614,7 +614,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	TASMultiLayerTopology: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
 	},
 	SchedulingEquivalenceHashing: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Beta},

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -337,7 +337,7 @@ minimized. However, if the Job would not fit within a single domain **one level 
 Kueue will not perform the balanced placement and will fallback to the standard TAS algorithm.
 
 #### Multi-Layer Topology
-{{< feature-state state="beta" for_version="v0.18" >}}
+{{< feature-state state="beta" for_version="v0.19" >}}
 {{% alert title="Note" color="primary" %}}
 `TASMultiLayerTopology` is currently an beta feature and is disabled by default.
 

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -337,9 +337,9 @@ minimized. However, if the Job would not fit within a single domain **one level 
 Kueue will not perform the balanced placement and will fallback to the standard TAS algorithm.
 
 #### Multi-Layer Topology
-{{< feature-state state="alpha" for_version="v0.17" >}}
+{{< feature-state state="beta" for_version="v0.18" >}}
 {{% alert title="Note" color="primary" %}}
-`TASMultiLayerTopology` is currently an alpha feature and is disabled by default.
+`TASMultiLayerTopology` is currently an beta feature and is disabled by default.
 
 You can enable it by editing the `TASMultiLayerTopology` feature gate. Refer to the
 [Installation guide](/docs/installation/#change-the-feature-gates-configuration)

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -339,9 +339,9 @@ Kueue will not perform the balanced placement and will fallback to the standard 
 #### Multi-Layer Topology
 {{< feature-state state="beta" for_version="v0.19" >}}
 {{% alert title="Note" color="primary" %}}
-`TASMultiLayerTopology` is currently an beta feature and is disabled by default.
+`TASMultiLayerTopology` is currently an beta feature and is enabled by default.
 
-You can enable it by editing the `TASMultiLayerTopology` feature gate. Refer to the
+You can disable it by editing the `TASMultiLayerTopology` feature gate. Refer to the
 [Installation guide](/docs/installation/#change-the-feature-gates-configuration)
 for instructions on configuring feature gates.
 {{% /alert %}}

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -439,6 +439,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.17"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.18"
 - name: TASProfileMixed
   versionedSpecs:
   - default: false

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -442,7 +442,7 @@
   - default: true
     lockToDefault: false
     preRelease: Beta
-    version: "0.18"
+    version: "0.19"
 - name: TASProfileMixed
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/kind feature

#### What this PR does / why we need it:
This Pr changes TASMultiLayerTopology to Beta

#### Which issue(s) this PR fixes:

Fixes #11991


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
TAS: Graduated `TASMultiLayerTopology` to Beta and enabled it by default which 
allows to configure multi-layer slice topology constraints per workload.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The Topology Aware Scheduling multi-layer topology feature gate is now **beta** and **enabled by default** starting with version **0.19** (alpha behavior for **0.17** remains supported).
* **Documentation**
  * Updated topology-aware scheduling docs to reflect the gate’s **beta** status and **v0.19**.
* **Tests**
  * Updated feature gate validation and TAS-related tests to explicitly handle the gate’s new **beta/default** behavior, including correct disable/restore expectations.
* **Chores**
  * Updated the versioned feature gate listing to include the **0.19 beta** default entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->