### PR TITLE
Fix ParseTLSOptions dropping earlier errors in errors.Join

### DIFF
--- a/pkg/util/tlsconfig/tlsconfig.go
+++ b/pkg/util/tlsconfig/tlsconfig.go
@@ -42,7 +42,7 @@ func ParseTLSOptions(cfg *config.TLSOptions) (*TLS, error) {
 	}
 	version, err := convertTLSMinVersion(cfg.MinVersion)
 	if err != nil {
-		errRet = errors.Join(err)
+		errRet = err
 	}
 	ret.MinVersion = version
 
@@ -50,7 +50,7 @@ func ParseTLSOptions(cfg *config.TLSOptions) (*TLS, error) {
 	if len(cfg.CipherSuites) > 0 {
 		cipherSuites, err := convertCipherSuites(cfg.CipherSuites)
 		if err != nil {
-			errRet = errors.Join(err)
+			errRet = errors.Join(errRet, err)
 		}
 		if err == nil && len(cipherSuites) > 0 {
 			ret.CipherSuites = cipherSuites

--- a/pkg/util/tlsconfig/tlsconfig_test.go
+++ b/pkg/util/tlsconfig/tlsconfig_test.go
@@ -27,16 +27,20 @@ import (
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 )
 
-// compareErrors compares errors by their string representation
-func compareErrors(want, got error) bool {
-	if want == nil && got == nil {
+// compareAllErrors checks that every error in wantErrs is present in got.
+func compareAllErrors(wantErrs []error, got error) bool {
+	if len(wantErrs) == 0 && got == nil {
 		return true
 	}
-	if want == nil || got == nil {
+	if len(wantErrs) == 0 || got == nil {
 		return false
 	}
-	// Compare error strings, handling wrapped errors
-	return strings.Contains(got.Error(), want.Error())
+	for _, want := range wantErrs {
+		if !strings.Contains(got.Error(), want.Error()) {
+			return false
+		}
+	}
+	return true
 }
 
 var (
@@ -50,7 +54,7 @@ func TestParseTLSOptions(t *testing.T) {
 		name       string
 		cfg        *config.TLSOptions
 		expectNil  bool
-		wantErr    error
+		wantErrs   []error
 		validateFn func(*testing.T, *TLS)
 	}{
 		{
@@ -172,7 +176,7 @@ func TestParseTLSOptions(t *testing.T) {
 					"TLS_AES_256_GCM_SHA384",
 				},
 			},
-			wantErr: errInvalidMinVersionTLS10or11,
+			wantErrs: []error{errInvalidMinVersionTLS10or11},
 		},
 		{
 			name: "tls 1.2 with invalid cipher suites",
@@ -182,25 +186,25 @@ func TestParseTLSOptions(t *testing.T) {
 					"DUMMY",
 				},
 			},
-			wantErr: errInvalidCipherSuite,
+			wantErrs: []error{errInvalidCipherSuite},
 		},
 		{
-			name: "tls 1.0 with invalid cipher suites",
+			name: "tls 1.0 with invalid cipher suites returns both errors",
 			cfg: &config.TLSOptions{
 				MinVersion: "VersionTLS10",
 				CipherSuites: []string{
 					"DUMMY",
 				},
 			},
-			wantErr: errInvalidCipherSuite, // Both TLS version and cipher suite are invalid, but cipher suite error is returned last
+			wantErrs: []error{errInvalidMinVersionTLS10or11, errInvalidCipherSuite},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tlsOpts, err := ParseTLSOptions(tt.cfg)
-			if !compareErrors(tt.wantErr, err) {
-				t.Errorf("ParseTLSOptions() error = %v, wantErr %v", err, tt.wantErr)
+			if !compareAllErrors(tt.wantErrs, err) {
+				t.Errorf("ParseTLSOptions() error = %v, wantErrs %v", err, tt.wantErrs)
 				return
 			}
 
@@ -227,7 +231,7 @@ func TestConvertCipherSuites(t *testing.T) {
 		name     string
 		input    []string
 		expected []uint16
-		wantErr  error
+		wantErrs []error
 	}{
 		{
 			name:     "empty input",
@@ -255,15 +259,15 @@ func TestConvertCipherSuites(t *testing.T) {
 			input: []string{
 				"INVALID_CIPHER_SUITE",
 			},
-			wantErr: errInvalidCipherSuite,
+			wantErrs: []error{errInvalidCipherSuite},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := convertCipherSuites(tt.input)
-			if !compareErrors(tt.wantErr, err) {
-				t.Errorf("convertCipherSuites() error = %v, wantErr %v", err, tt.wantErr)
+			if !compareAllErrors(tt.wantErrs, err) {
+				t.Errorf("convertCipherSuites() error = %v, wantErrs %v", err, tt.wantErrs)
 				return
 			}
 
@@ -283,7 +287,7 @@ func TestConvertTLSMinVersion(t *testing.T) {
 		name     string
 		input    string
 		expected uint16
-		wantErr  error
+		wantErrs []error
 	}{
 		{
 			name:     "TLS 1.2",
@@ -304,27 +308,27 @@ func TestConvertTLSMinVersion(t *testing.T) {
 			name:     "invalid version returns error",
 			input:    "InvalidVersion",
 			expected: 0,
-			wantErr:  errInvalidVersion,
+			wantErrs: []error{errInvalidVersion},
 		},
 		{
 			name:     "tls version 1.1 returns error",
 			input:    "VersionTLS11",
 			expected: 0,
-			wantErr:  errInvalidMinVersionTLS10or11,
+			wantErrs: []error{errInvalidMinVersionTLS10or11},
 		},
 		{
 			name:     "tls version 1.0 returns error",
 			input:    "VersionTLS10",
 			expected: 0,
-			wantErr:  errInvalidMinVersionTLS10or11,
+			wantErrs: []error{errInvalidMinVersionTLS10or11},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := convertTLSMinVersion(tt.input)
-			if !compareErrors(tt.wantErr, err) {
-				t.Errorf("convertTLSMinVersion() error = %v, wantErr %v", err, tt.wantErr)
+			if !compareAllErrors(tt.wantErrs, err) {
+				t.Errorf("convertTLSMinVersion() error = %v, wantErrs %v", err, tt.wantErrs)
 				return
 			}
 


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Fixes a bug in `ParseTLSOptions` where `errors.Join(err)` was used instead of `errors.Join(errRet, err)`. This silently dropped any previously accumulated errors. For example, if both the TLS min version and cipher suites were invalid, only the cipher suite error was returned — the TLS version error was lost.

The test case name is updated to reflect it now validates both errors are returned.

This was split out from #11832 per reviewer feedback.

#### Which issue(s) this PR fixes:

Fixes #10698 (partially)

#### Special notes for your reviewer:

AI was used to help create this PR.

#### Does this PR introduce a user-facing change?

```release-note
ConfigAPI: Fixed TLS configuration validation to report all detected option errors instead of only the last one.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Fixed TLS options validation to consistently return all relevant errors when multiple inputs are invalid (for example, when both the minimum TLS version and cipher suites are wrong).

## Tests
- Enhanced TLS config tests to validate multi-error outputs by checking that every expected error is present, updating table-driven cases accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->