### PR TITLE
Fix webhook server silently dropping TLS parse errors

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -204,7 +204,10 @@ func main() {
 		metricsServerOptions.TLSOpts = append(metricsServerOptions.TLSOpts, tlsOpts...)
 	}
 
-	config.AddWebhookSettingsTo(&options, &cfg)
+	if err := config.AddWebhookSettingsTo(&options, &cfg); err != nil {
+		setupLog.Error(err, "Unable to configure webhook server")
+		os.Exit(1)
+	}
 
 	var metricsCertWatcher *certwatcher.CertWatcher
 	if cfg.InternalCertManagement == nil || !*cfg.InternalCertManagement.Enable {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ package config
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -41,6 +42,9 @@ import (
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/tlsconfig"
 )
+
+// ErrWebhookTLSParse is returned when TLS options for the webhook server cannot be parsed.
+var ErrWebhookTLSParse = errors.New("unable to parse TLS options for webhook server")
 
 var (
 	objectKeySecret         = new(corev1.Secret)
@@ -164,7 +168,7 @@ func addLeaderElectionTo(o *ctrl.Options, cfg *configapi.Configuration) {
 
 // AddWebhookSettingsTo is used to add settings to the webhook
 // This is separated to a exported function as we need to call this function after the feature gates are parsed.
-func AddWebhookSettingsTo(o *ctrl.Options, cfg *configapi.Configuration) {
+func AddWebhookSettingsTo(o *ctrl.Options, cfg *configapi.Configuration) error {
 	if o.WebhookServer == nil && cfg.Webhook.Port != nil {
 		wo := webhook.Options{}
 		if cfg.Webhook.Port != nil {
@@ -182,14 +186,16 @@ func AddWebhookSettingsTo(o *ctrl.Options, cfg *configapi.Configuration) {
 		if features.Enabled(features.TLSOptions) {
 			if cfg.TLS != nil {
 				tlsOpts, err := tlsconfig.ParseTLSOptions(cfg.TLS)
-				if err == nil {
-					tlsOpts := tlsconfig.BuildTLSOptions(tlsOpts)
-					wo.TLSOpts = append(wo.TLSOpts, tlsOpts...)
+				if err != nil {
+					return fmt.Errorf("%w: %w", ErrWebhookTLSParse, err)
 				}
+				builtOpts := tlsconfig.BuildTLSOptions(tlsOpts)
+				wo.TLSOpts = append(wo.TLSOpts, builtOpts...)
 			}
 		}
 		o.WebhookServer = webhook.NewServer(wo)
 	}
+	return nil
 }
 
 func Encode(scheme *runtime.Scheme, cfg *configapi.Configuration) (string, error) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -913,12 +913,25 @@ webhook:
 		t.Fatal(err)
 	}
 
+	tlsConfigInvalid := filepath.Join(tmpDir, "tls-invalid.yaml")
+	if err := os.WriteFile(tlsConfigInvalid, []byte(`apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+namespace: kueue-system
+tls:
+  minVersion: InvalidVersion
+webhook:
+  port: 9443
+`), os.FileMode(0600)); err != nil {
+		t.Fatal(err)
+	}
+
 	testcases := []struct {
 		name              string
 		configFile        string
 		featureGates      map[featuregate.Feature]bool
 		wantConfiguration configapi.Configuration
 		verifyTLSApplied  bool
+		wantError         error
 	}{
 		{
 			name:         "TLS config applied when feature gate enabled",
@@ -1067,6 +1080,58 @@ webhook:
 			verifyTLSApplied: true,
 		},
 		{
+			name:         "invalid TLS config returns error when feature gate enabled",
+			configFile:   tlsConfigInvalid,
+			featureGates: map[featuregate.Feature]bool{features.TLSOptions: true},
+			wantError:    ErrWebhookTLSParse,
+		},
+		{
+			name:         "invalid TLS config ignored when feature gate disabled",
+			configFile:   tlsConfigInvalid,
+			featureGates: map[featuregate.Feature]bool{features.TLSOptions: false},
+			wantConfiguration: configapi.Configuration{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: configapi.GroupVersion.String(),
+					Kind:       "Configuration",
+				},
+				Namespace:                  ptr.To(configapi.DefaultNamespace),
+				ManageJobsWithoutQueueName: false,
+				InternalCertManagement: &configapi.InternalCertManagement{
+					Enable:             new(true),
+					WebhookServiceName: ptr.To(configapi.DefaultWebhookServiceName),
+					WebhookSecretName:  ptr.To(configapi.DefaultWebhookSecretName),
+				},
+				ClientConnection: &configapi.ClientConnection{
+					QPS:   ptr.To(configapi.DefaultClientConnectionQPS),
+					Burst: ptr.To(configapi.DefaultClientConnectionBurst),
+				},
+				Integrations: &configapi.Integrations{
+					Frameworks: []string{job.FrameworkName},
+				},
+				MultiKueue: &configapi.MultiKueue{
+					GCInterval:        &metav1.Duration{Duration: configapi.DefaultMultiKueueGCInterval},
+					Origin:            ptr.To(configapi.DefaultMultiKueueOrigin),
+					WorkerLostTimeout: &metav1.Duration{Duration: configapi.DefaultMultiKueueWorkerLostTimeout},
+					DispatcherName:    ptr.To(configapi.MultiKueueDispatcherModeAllAtOnce),
+				},
+				ManagedJobsNamespaceSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      corev1.LabelMetadataName,
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   []string{"kube-system", "kueue-system"},
+						},
+					},
+				},
+				ControllerManager: configapi.ControllerManager{
+					TLS: &configapi.TLSOptions{
+						MinVersion: "InvalidVersion",
+					},
+				},
+			},
+			verifyTLSApplied: false,
+		},
+		{
 			name:         "TLS 1.3 config NOT applied when feature gate disabled",
 			configFile:   tlsConfigTLS13,
 			featureGates: map[featuregate.Feature]bool{features.TLSOptions: false},
@@ -1125,7 +1190,16 @@ webhook:
 			}
 
 			// Call AddWebhookSettingsTo to configure webhook server with TLS options
-			AddWebhookSettingsTo(&options, &cfg)
+			err = AddWebhookSettingsTo(&options, &cfg)
+			if tc.wantError != nil {
+				if !errors.Is(err, tc.wantError) {
+					t.Errorf("AddWebhookSettingsTo() error = %v, wantErr %v", err, tc.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error from AddWebhookSettingsTo: %v", err)
+			}
 
 			// Compare the loaded configuration
 			configCmpOpts := cmp.Options{

--- a/pkg/util/tlsconfig/tlsconfig.go
+++ b/pkg/util/tlsconfig/tlsconfig.go
@@ -28,6 +28,13 @@ import (
 
 const TLS12 = tls.VersionTLS12
 
+var (
+	// ErrInvalidMinVersion is returned when the TLS minimum version is invalid.
+	ErrInvalidMinVersion = errors.New("invalid minVersion")
+	// ErrInvalidCipherSuites is returned when cipher suites are invalid.
+	ErrInvalidCipherSuites = errors.New("invalid cipher suites")
+)
+
 type TLS struct {
 	MinVersion   uint16
 	CipherSuites []uint16
@@ -83,11 +90,11 @@ func convertTLSMinVersion(tlsMinVersion string) (uint16, error) {
 		return TLS12, nil
 	}
 	if tlsMinVersion == "VersionTLS11" || tlsMinVersion == "VersionTLS10" {
-		return 0, errors.New("invalid minVersion. Please use VersionTLS12 or VersionTLS13")
+		return 0, fmt.Errorf("%w. Please use VersionTLS12 or VersionTLS13", ErrInvalidMinVersion)
 	}
 	version, err := cliflag.TLSVersion(tlsMinVersion)
 	if err != nil {
-		return 0, fmt.Errorf("invalid minVersion: %w. Please use VersionTLS12 or VersionTLS13", err)
+		return 0, fmt.Errorf("%w: %v. Please use VersionTLS12 or VersionTLS13", ErrInvalidMinVersion, err)
 	}
 	return version, nil
 }
@@ -100,7 +107,7 @@ func convertCipherSuites(cipherSuites []string) ([]uint16, error) {
 	}
 	suites, err := cliflag.TLSCipherSuites(cipherSuites)
 	if err != nil {
-		return nil, fmt.Errorf("invalid cipher suites: %w. Please use the secure cipher names: %v", err, cliflag.PreferredTLSCipherNames())
+		return nil, fmt.Errorf("%w: %v. Please use the secure cipher names: %v", ErrInvalidCipherSuites, err, cliflag.PreferredTLSCipherNames())
 	}
 	return suites, nil
 }

--- a/pkg/util/tlsconfig/tlsconfig_test.go
+++ b/pkg/util/tlsconfig/tlsconfig_test.go
@@ -19,34 +19,11 @@ package tlsconfig
 import (
 	"crypto/tls"
 	"errors"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
-)
-
-// compareAllErrors checks that every error in wantErrs is present in got.
-func compareAllErrors(wantErrs []error, got error) bool {
-	if len(wantErrs) == 0 && got == nil {
-		return true
-	}
-	if len(wantErrs) == 0 || got == nil {
-		return false
-	}
-	for _, want := range wantErrs {
-		if !strings.Contains(got.Error(), want.Error()) {
-			return false
-		}
-	}
-	return true
-}
-
-var (
-	errInvalidMinVersionTLS10or11 = errors.New("invalid minVersion. Please use VersionTLS12 or VersionTLS13")
-	errInvalidCipherSuite         = errors.New("cipher suite")        // Partial match for cipher suite errors
-	errInvalidVersion             = errors.New("unknown tls version") // From cliflag.TLSVersion for invalid versions
 )
 
 func TestParseTLSOptions(t *testing.T) {
@@ -176,7 +153,7 @@ func TestParseTLSOptions(t *testing.T) {
 					"TLS_AES_256_GCM_SHA384",
 				},
 			},
-			wantErrs: []error{errInvalidMinVersionTLS10or11},
+			wantErrs: []error{ErrInvalidMinVersion},
 		},
 		{
 			name: "tls 1.2 with invalid cipher suites",
@@ -186,7 +163,7 @@ func TestParseTLSOptions(t *testing.T) {
 					"DUMMY",
 				},
 			},
-			wantErrs: []error{errInvalidCipherSuite},
+			wantErrs: []error{ErrInvalidCipherSuites},
 		},
 		{
 			name: "tls 1.0 with invalid cipher suites returns both errors",
@@ -196,19 +173,23 @@ func TestParseTLSOptions(t *testing.T) {
 					"DUMMY",
 				},
 			},
-			wantErrs: []error{errInvalidMinVersionTLS10or11, errInvalidCipherSuite},
+			wantErrs: []error{ErrInvalidMinVersion, ErrInvalidCipherSuites},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tlsOpts, err := ParseTLSOptions(tt.cfg)
-			if !compareAllErrors(tt.wantErrs, err) {
-				t.Errorf("ParseTLSOptions() error = %v, wantErrs %v", err, tt.wantErrs)
+			if len(tt.wantErrs) > 0 {
+				for _, wantErr := range tt.wantErrs {
+					if !errors.Is(err, wantErr) {
+						t.Errorf("ParseTLSOptions() error = %v, want to contain %v", err, wantErr)
+					}
+				}
 				return
 			}
-
 			if err != nil {
+				t.Errorf("ParseTLSOptions() unexpected error = %v", err)
 				return
 			}
 
@@ -231,7 +212,7 @@ func TestConvertCipherSuites(t *testing.T) {
 		name     string
 		input    []string
 		expected []uint16
-		wantErrs []error
+		wantErr  error
 	}{
 		{
 			name:     "empty input",
@@ -259,19 +240,21 @@ func TestConvertCipherSuites(t *testing.T) {
 			input: []string{
 				"INVALID_CIPHER_SUITE",
 			},
-			wantErrs: []error{errInvalidCipherSuite},
+			wantErr: ErrInvalidCipherSuites,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := convertCipherSuites(tt.input)
-			if !compareAllErrors(tt.wantErrs, err) {
-				t.Errorf("convertCipherSuites() error = %v, wantErrs %v", err, tt.wantErrs)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("convertCipherSuites() error = %v, wantErr %v", err, tt.wantErr)
+				}
 				return
 			}
-
 			if err != nil {
+				t.Errorf("convertCipherSuites() unexpected error = %v", err)
 				return
 			}
 
@@ -308,31 +291,35 @@ func TestConvertTLSMinVersion(t *testing.T) {
 			name:     "invalid version returns error",
 			input:    "InvalidVersion",
 			expected: 0,
-			wantErrs: []error{errInvalidVersion},
+			wantErrs: []error{ErrInvalidMinVersion},
 		},
 		{
 			name:     "tls version 1.1 returns error",
 			input:    "VersionTLS11",
 			expected: 0,
-			wantErrs: []error{errInvalidMinVersionTLS10or11},
+			wantErrs: []error{ErrInvalidMinVersion},
 		},
 		{
 			name:     "tls version 1.0 returns error",
 			input:    "VersionTLS10",
 			expected: 0,
-			wantErrs: []error{errInvalidMinVersionTLS10or11},
+			wantErrs: []error{ErrInvalidMinVersion},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := convertTLSMinVersion(tt.input)
-			if !compareAllErrors(tt.wantErrs, err) {
-				t.Errorf("convertTLSMinVersion() error = %v, wantErrs %v", err, tt.wantErrs)
+			if len(tt.wantErrs) > 0 {
+				for _, wantErr := range tt.wantErrs {
+					if !errors.Is(err, wantErr) {
+						t.Errorf("convertTLSMinVersion() error = %v, want to contain %v", err, wantErr)
+					}
+				}
 				return
 			}
-
 			if err != nil {
+				t.Errorf("convertTLSMinVersion() unexpected error = %v", err)
 				return
 			}
 


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

`AddWebhookSettingsTo` silently ignored `ParseTLSOptions` errors (`if err == nil`), causing the webhook server to start with Go TLS defaults on invalid config. This is inconsistent with `main.go` which calls `os.Exit(1)` on the same error for the metrics server.

This changes `AddWebhookSettingsTo` to return an error, and the call site in `main.go` now exits with a clear error message, matching the metrics server behavior.

Found by @sohankunkerkar during review of #11832.

#### Which issue(s) this PR fixes:

Partial #10698

#### Special notes for your reviewer:

AI was used to help create this PR.

#### Does this PR introduce a user-facing change?

```release-note
ConfigAPI: TLS: Fixed a bug where invalid webhook server TLS settings could be silently ignored,
causing the webhook server to start with Go TLS defaults. Kueue now fails startup with a
clear configuration error, matching metrics server TLS validation behavior.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook server startup validation by treating webhook settings application as fallible, surfacing TLS parsing errors when the TLS options feature gate is enabled.
  * Startup now fails fast with a clear error message if webhook settings cannot be configured, preventing silent misconfiguration.
* **Tests**
  * Expanded TLS feature-gate coverage with a new invalid TLS fixture and updated assertions to verify error behavior differs correctly between enabled vs. disabled modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->