### PR TITLE
docs: update secretreader plugin link

### DIFF
--- a/site/content/en/docs/tasks/manage/setup_multikueue.md
+++ b/site/content/en/docs/tasks/manage/setup_multikueue.md
@@ -248,7 +248,7 @@ The access provider defined in `ClusterProfile` depends upon an executable plugi
 Kueue controller manager pods running within the MultiKueue manager cluster.
 It's the responsibility of the Kueue administrator to make sure that the required command is available.
 
-An example plugin can be found [here](https://github.com/kubernetes-sigs/cluster-inventory-api/tree/445319b6307a88778b930e154ed3e2f38d85a689/cmd/secretreader-plugin) (secret reader) or [here](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke) (Google Cloud Platform).
+An example plugin can be found [here](https://github.com/kubernetes-sigs/cluster-inventory-api/tree/v0.1.3/plugins/secretreader) (secret reader) or [here](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke) (Google Cloud Platform).
 
 #### Mount the executable with `initContainers`
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/area website

#### What this PR does / why we need it:

Updates the MultiKueue setup docs to point the secretreader plugin example at the `v0.1.3` `plugins/secretreader` path in `cluster-inventory-api`.

This keeps the documentation link aligned with the current released plugin location and keeps the change small enough to cherry-pick to the `website` branch.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This is split out from kubernetes-sigs/kueue#12011 so the docs-only link update can be cherry-picked to the `website` branch independently.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
