### PR TITLE
Remove unused weightedShare from LocalQueueFairSharingStatus

### DIFF
--- a/apis/kueue/v1beta1/localqueue_conversion.go
+++ b/apis/kueue/v1beta1/localqueue_conversion.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"unsafe"
+
 	conversionapi "k8s.io/apimachinery/pkg/conversion"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -58,4 +60,15 @@ func Convert_v1beta1_LocalQueueStatus_To_v1beta2_LocalQueueStatus(in *LocalQueue
 		}
 	}
 	return autoConvert_v1beta1_LocalQueueStatus_To_v1beta2_LocalQueueStatus(in, out, s)
+}
+
+func Convert_v1beta1_FairSharingStatus_To_v1beta2_LocalQueueFairSharingStatus(in *FairSharingStatus, out *v1beta2.LocalQueueFairSharingStatus, s conversionapi.Scope) error {
+	out.AdmissionFairSharingStatus = (*v1beta2.LocalQueueAdmissionFairSharingStatus)(unsafe.Pointer(in.AdmissionFairSharingStatus))
+	return nil
+}
+
+func Convert_v1beta2_LocalQueueFairSharingStatus_To_v1beta1_FairSharingStatus(in *v1beta2.LocalQueueFairSharingStatus, out *FairSharingStatus, s conversionapi.Scope) error {
+	out.WeightedShare = 0
+	out.AdmissionFairSharingStatus = (*AdmissionFairSharingStatus)(unsafe.Pointer(in.AdmissionFairSharingStatus))
+	return nil
 }

--- a/apis/kueue/v1beta1/localqueue_conversion_test.go
+++ b/apis/kueue/v1beta1/localqueue_conversion_test.go
@@ -210,7 +210,6 @@ func TestLocalQueueConvertTo(t *testing.T) {
 				},
 				Status: v1beta2.LocalQueueStatus{
 					FairSharing: &v1beta2.LocalQueueFairSharingStatus{
-						WeightedShare: 100,
 						AdmissionFairSharingStatus: &v1beta2.LocalQueueAdmissionFairSharingStatus{
 							ConsumedResources: corev1.ResourceList{
 								corev1.ResourceCPU: resource.MustParse("10"),
@@ -260,6 +259,7 @@ func TestLocalQueueConvertFrom(t *testing.T) {
 		Name:      "test-localqueue",
 		Namespace: "default",
 	}
+	now := metav1.Now()
 
 	testCases := map[string]struct {
 		input    *v1beta2.LocalQueue
@@ -400,6 +400,14 @@ func TestLocalQueueConvertFrom(t *testing.T) {
 					ClusterQueue: "cluster-queue-1",
 				},
 				Status: v1beta2.LocalQueueStatus{
+					FairSharing: &v1beta2.LocalQueueFairSharingStatus{
+						AdmissionFairSharingStatus: &v1beta2.LocalQueueAdmissionFairSharingStatus{
+							ConsumedResources: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("10"),
+							},
+							LastUpdate: now,
+						},
+					},
 					Conditions: []metav1.Condition{
 						{
 							Type:   "Active",
@@ -427,6 +435,15 @@ func TestLocalQueueConvertFrom(t *testing.T) {
 					ClusterQueue: "cluster-queue-1",
 				},
 				Status: LocalQueueStatus{
+					FairSharing: &FairSharingStatus{
+						WeightedShare: 0,
+						AdmissionFairSharingStatus: &AdmissionFairSharingStatus{
+							ConsumedResources: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("10"),
+							},
+							LastUpdate: now,
+						},
+					},
 					Conditions: []metav1.Condition{
 						{
 							Type:   "Active",
@@ -465,8 +482,11 @@ func TestLocalQueueConvertFrom(t *testing.T) {
 }
 
 func TestLocalQueueConversion_RoundTrip(t *testing.T) {
+	now := metav1.Now()
+
 	testCases := map[string]struct {
 		v1beta1Obj *LocalQueue
+		expected   *LocalQueue
 	}{
 		"complete LocalQueue with multiple flavors": {
 			v1beta1Obj: &LocalQueue{
@@ -524,6 +544,48 @@ func TestLocalQueueConversion_RoundTrip(t *testing.T) {
 				},
 			},
 		},
+		"LocalQueue with FairSharing is lossy for WeightedShare": {
+			v1beta1Obj: &LocalQueue{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fairsharing-localqueue",
+					Namespace: "default",
+				},
+				Spec: LocalQueueSpec{
+					ClusterQueue: "main-cluster-queue",
+				},
+				Status: LocalQueueStatus{
+					FairSharing: &FairSharingStatus{
+						WeightedShare: 100,
+						AdmissionFairSharingStatus: &AdmissionFairSharingStatus{
+							ConsumedResources: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("10"),
+							},
+							LastUpdate: now,
+						},
+					},
+				},
+			},
+			expected: &LocalQueue{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fairsharing-localqueue",
+					Namespace: "default",
+				},
+				Spec: LocalQueueSpec{
+					ClusterQueue: "main-cluster-queue",
+				},
+				Status: LocalQueueStatus{
+					FairSharing: &FairSharingStatus{
+						WeightedShare: 0,
+						AdmissionFairSharingStatus: &AdmissionFairSharingStatus{
+							ConsumedResources: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("10"),
+							},
+							LastUpdate: now,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -541,8 +603,106 @@ func TestLocalQueueConversion_RoundTrip(t *testing.T) {
 			}
 
 			// Verify round-trip
-			if diff := cmp.Diff(tc.v1beta1Obj, roundTripped); diff != "" {
-				t.Errorf("round-trip conversion produced diff (-original +roundtripped):\n%s", diff)
+			want := tc.expected
+			if want == nil {
+				want = tc.v1beta1Obj
+			}
+			if diff := cmp.Diff(want, roundTripped); diff != "" {
+				t.Errorf("round-trip conversion produced diff (-want +roundtripped):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestConvert_v1beta1_FairSharingStatus_To_v1beta2_LocalQueueFairSharingStatus(t *testing.T) {
+	now := metav1.Now()
+
+	testCases := map[string]struct {
+		input    *FairSharingStatus
+		expected *v1beta2.LocalQueueFairSharingStatus
+	}{
+		"drops WeightedShare and copies AdmissionFairSharingStatus": {
+			input: &FairSharingStatus{
+				WeightedShare: 100,
+				AdmissionFairSharingStatus: &AdmissionFairSharingStatus{
+					ConsumedResources: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("5"),
+					},
+					LastUpdate: now,
+				},
+			},
+			expected: &v1beta2.LocalQueueFairSharingStatus{
+				AdmissionFairSharingStatus: &v1beta2.LocalQueueAdmissionFairSharingStatus{
+					ConsumedResources: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("5"),
+					},
+					LastUpdate: now,
+				},
+			},
+		},
+		"nil AdmissionFairSharingStatus": {
+			input: &FairSharingStatus{
+				WeightedShare: 50,
+			},
+			expected: &v1beta2.LocalQueueFairSharingStatus{},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			out := &v1beta2.LocalQueueFairSharingStatus{}
+			if err := Convert_v1beta1_FairSharingStatus_To_v1beta2_LocalQueueFairSharingStatus(tc.input, out, nil); err != nil {
+				t.Fatalf("conversion failed: %v", err)
+			}
+			if diff := cmp.Diff(tc.expected, out); diff != "" {
+				t.Errorf("unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestConvert_v1beta2_LocalQueueFairSharingStatus_To_v1beta1_FairSharingStatus(t *testing.T) {
+	now := metav1.Now()
+
+	testCases := map[string]struct {
+		input    *v1beta2.LocalQueueFairSharingStatus
+		expected *FairSharingStatus
+	}{
+		"sets WeightedShare to zero and copies AdmissionFairSharingStatus": {
+			input: &v1beta2.LocalQueueFairSharingStatus{
+				AdmissionFairSharingStatus: &v1beta2.LocalQueueAdmissionFairSharingStatus{
+					ConsumedResources: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("5"),
+					},
+					LastUpdate: now,
+				},
+			},
+			expected: &FairSharingStatus{
+				WeightedShare: 0,
+				AdmissionFairSharingStatus: &AdmissionFairSharingStatus{
+					ConsumedResources: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("5"),
+					},
+					LastUpdate: now,
+				},
+			},
+		},
+		"nil AdmissionFairSharingStatus": {
+			input: &v1beta2.LocalQueueFairSharingStatus{},
+			expected: &FairSharingStatus{
+				WeightedShare: 0,
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			out := &FairSharingStatus{}
+			if err := Convert_v1beta2_LocalQueueFairSharingStatus_To_v1beta1_FairSharingStatus(tc.input, out, nil); err != nil {
+				t.Fatalf("conversion failed: %v", err)
+			}
+			if diff := cmp.Diff(tc.expected, out); diff != "" {
+				t.Errorf("unexpected result (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/apis/kueue/v1beta1/zz_generated.conversion.go
+++ b/apis/kueue/v1beta1/zz_generated.conversion.go
@@ -714,6 +714,11 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
+	if err := s.AddConversionFunc((*FairSharingStatus)(nil), (*v1beta2.LocalQueueFairSharingStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta1_FairSharingStatus_To_v1beta2_LocalQueueFairSharingStatus(a.(*FairSharingStatus), b.(*v1beta2.LocalQueueFairSharingStatus), scope)
+	}); err != nil {
+		return err
+	}
 	if err := s.AddConversionFunc((*LocalQueueStatus)(nil), (*v1beta2.LocalQueueStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta1_LocalQueueStatus_To_v1beta2_LocalQueueStatus(a.(*LocalQueueStatus), b.(*v1beta2.LocalQueueStatus), scope)
 	}); err != nil {
@@ -741,6 +746,11 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}
 	if err := s.AddConversionFunc((*v1beta2.ClusterQueueSpec)(nil), (*ClusterQueueSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta2_ClusterQueueSpec_To_v1beta1_ClusterQueueSpec(a.(*v1beta2.ClusterQueueSpec), b.(*ClusterQueueSpec), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1beta2.LocalQueueFairSharingStatus)(nil), (*FairSharingStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta2_LocalQueueFairSharingStatus_To_v1beta1_FairSharingStatus(a.(*v1beta2.LocalQueueFairSharingStatus), b.(*FairSharingStatus), scope)
 	}); err != nil {
 		return err
 	}
@@ -1678,7 +1688,15 @@ func autoConvert_v1beta1_LocalQueueStatus_To_v1beta2_LocalQueueStatus(in *LocalQ
 	out.FlavorsReservation = *(*[]v1beta2.LocalQueueFlavorUsage)(unsafe.Pointer(&in.FlavorsReservation))
 	// WARNING: in.FlavorUsage requires manual conversion: does not exist in peer-type
 	// WARNING: in.Flavors requires manual conversion: does not exist in peer-type
-	out.FairSharing = (*v1beta2.LocalQueueFairSharingStatus)(unsafe.Pointer(in.FairSharing))
+	if in.FairSharing != nil {
+		in, out := &in.FairSharing, &out.FairSharing
+		*out = new(v1beta2.LocalQueueFairSharingStatus)
+		if err := Convert_v1beta1_FairSharingStatus_To_v1beta2_LocalQueueFairSharingStatus(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.FairSharing = nil
+	}
 	return nil
 }
 
@@ -1689,7 +1707,15 @@ func autoConvert_v1beta2_LocalQueueStatus_To_v1beta1_LocalQueueStatus(in *v1beta
 	out.AdmittedWorkloads = in.AdmittedWorkloads
 	out.FlavorsReservation = *(*[]LocalQueueFlavorUsage)(unsafe.Pointer(&in.FlavorsReservation))
 	// WARNING: in.FlavorsUsage requires manual conversion: does not exist in peer-type
-	out.FairSharing = (*FairSharingStatus)(unsafe.Pointer(in.FairSharing))
+	if in.FairSharing != nil {
+		in, out := &in.FairSharing, &out.FairSharing
+		*out = new(FairSharingStatus)
+		if err := Convert_v1beta2_LocalQueueFairSharingStatus_To_v1beta1_FairSharingStatus(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.FairSharing = nil
+	}
 	return nil
 }
 

--- a/apis/kueue/v1beta2/localqueue_types.go
+++ b/apis/kueue/v1beta2/localqueue_types.go
@@ -123,16 +123,6 @@ type LocalQueueStatus struct {
 
 // LocalQueueFairSharingStatus contains the information about the current status of Fair Sharing.
 type LocalQueueFairSharingStatus struct {
-	// weightedShare represents the maximum of the ratios of usage
-	// above nominal quota to the lendable resources in the
-	// Cohort, among all the resources provided by the Node, and
-	// divided by the weight.  If zero, it means that the usage of
-	// the Node is below the nominal quota.  If the Node has a
-	// weight of zero and is borrowing, this will return
-	// 9223372036854775807, the maximum possible share value.
-	// +required
-	WeightedShare int64 `json:"weightedShare"`
-
 	// admissionFairSharingStatus represents information relevant to the Admission Fair Sharing
 	// +optional
 	AdmissionFairSharingStatus *LocalQueueAdmissionFairSharingStatus `json:"admissionFairSharingStatus,omitempty"`

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_localqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_localqueues.yaml
@@ -632,19 +632,6 @@ spec:
                         - consumedResources
                         - lastUpdate
                       type: object
-                    weightedShare:
-                      description: |-
-                        weightedShare represents the maximum of the ratios of usage
-                        above nominal quota to the lendable resources in the
-                        Cohort, among all the resources provided by the Node, and
-                        divided by the weight.  If zero, it means that the usage of
-                        the Node is below the nominal quota.  If the Node has a
-                        weight of zero and is borrowing, this will return
-                        9223372036854775807, the maximum possible share value.
-                      format: int64
-                      type: integer
-                  required:
-                    - weightedShare
                   type: object
                 flavorsReservation:
                   description: |-

--- a/client-go/applyconfiguration/kueue/v1beta2/localqueuefairsharingstatus.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/localqueuefairsharingstatus.go
@@ -23,14 +23,6 @@ package v1beta2
 //
 // LocalQueueFairSharingStatus contains the information about the current status of Fair Sharing.
 type LocalQueueFairSharingStatusApplyConfiguration struct {
-	// weightedShare represents the maximum of the ratios of usage
-	// above nominal quota to the lendable resources in the
-	// Cohort, among all the resources provided by the Node, and
-	// divided by the weight.  If zero, it means that the usage of
-	// the Node is below the nominal quota.  If the Node has a
-	// weight of zero and is borrowing, this will return
-	// 9223372036854775807, the maximum possible share value.
-	WeightedShare *int64 `json:"weightedShare,omitempty"`
 	// admissionFairSharingStatus represents information relevant to the Admission Fair Sharing
 	AdmissionFairSharingStatus *LocalQueueAdmissionFairSharingStatusApplyConfiguration `json:"admissionFairSharingStatus,omitempty"`
 }
@@ -39,14 +31,6 @@ type LocalQueueFairSharingStatusApplyConfiguration struct {
 // apply.
 func LocalQueueFairSharingStatus() *LocalQueueFairSharingStatusApplyConfiguration {
 	return &LocalQueueFairSharingStatusApplyConfiguration{}
-}
-
-// WithWeightedShare sets the WeightedShare field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the WeightedShare field is set to the value of the last call.
-func (b *LocalQueueFairSharingStatusApplyConfiguration) WithWeightedShare(value int64) *LocalQueueFairSharingStatusApplyConfiguration {
-	b.WeightedShare = &value
-	return b
 }
 
 // WithAdmissionFairSharingStatus sets the AdmissionFairSharingStatus field in the declarative configuration to the given value

--- a/config/components/crd/bases/kueue.x-k8s.io_localqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_localqueues.yaml
@@ -618,19 +618,6 @@ spec:
                     - consumedResources
                     - lastUpdate
                     type: object
-                  weightedShare:
-                    description: |-
-                      weightedShare represents the maximum of the ratios of usage
-                      above nominal quota to the lendable resources in the
-                      Cohort, among all the resources provided by the Node, and
-                      divided by the weight.  If zero, it means that the usage of
-                      the Node is below the nominal quota.  If the Node has a
-                      weight of zero and is borrowing, this will return
-                      9223372036854775807, the maximum possible share value.
-                    format: int64
-                    type: integer
-                required:
-                - weightedShare
                 type: object
               flavorsReservation:
                 description: |-

--- a/site/content/en/docs/concepts/admission_fair_sharing.md
+++ b/site/content/en/docs/concepts/admission_fair_sharing.md
@@ -100,5 +100,5 @@ kubectl get lq user-queue -o jsonpath={.status.fairSharing}
 Output should be similar to:
 
 ```
-{"admissionFairSharingStatus":{"consumedResources":{"cpu":"31999m"},"lastUpdate":"2025-06-03T14:25:15Z"},"weightedShare":0}
+{"admissionFairSharingStatus":{"consumedResources":{"cpu":"31999m"},"lastUpdate":"2025-06-03T14:25:15Z"}}
 ```

--- a/site/content/en/docs/reference/kueue.v1beta2.md
+++ b/site/content/en/docs/reference/kueue.v1beta2.md
@@ -1712,19 +1712,6 @@ The value is populated if usage consumption functionality is enabled in Kueue co
 <tbody>
     
   
-<tr><td><code>weightedShare</code> <B>[Required]</B><br/>
-<code>int64</code>
-</td>
-<td>
-   <p>weightedShare represents the maximum of the ratios of usage
-above nominal quota to the lendable resources in the
-Cohort, among all the resources provided by the Node, and
-divided by the weight.  If zero, it means that the usage of
-the Node is below the nominal quota.  If the Node has a
-weight of zero and is borrowing, this will return
-9223372036854775807, the maximum possible share value.</p>
-</td>
-</tr>
 <tr><td><code>admissionFairSharingStatus</code><br/>
 <a href="#kueue-x-k8s-io-v1beta2-LocalQueueAdmissionFairSharingStatus"><code>LocalQueueAdmissionFairSharingStatus</code></a>
 </td>

--- a/site/content/zh-CN/docs/concepts/admission_fair_sharing.md
+++ b/site/content/zh-CN/docs/concepts/admission_fair_sharing.md
@@ -93,5 +93,5 @@ kubectl get lq user-queue -o jsonpath={.status.fairSharing}
 输出类似于：
 
 ```
-{"admissionFairSharingStatus":{"consumedResources":{"cpu":"31999m"},"lastUpdate":"2025-06-03T14:25:15Z"},"weightedShare":0}
+{"admissionFairSharingStatus":{"consumedResources":{"cpu":"31999m"},"lastUpdate":"2025-06-03T14:25:15Z"}}
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

/kind api-change
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

v1beta2.LocalQueueFairSharingStatus has a weightedShare field that's never actually set for LocalQueues. It only makes sense for preemption-based Fair Sharing at the ClusterQueue/Cohort level. Since #7793 split LocalQueue's fair sharing status out from CQ/Cohort, this field just sits there returning zero. This PR drops it from the v1beta2 API, adds the manual conversion functions needed to bridge the layout difference with v1beta1, and regenerates the downstream artifacts (CRDs, client-go, API docs).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11279

#### Special notes for your reviewer:

This PR was prepared with AI assistance; all the changes made have been verified and reviewed.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Removed `weightedShare` field from LocalQueue v1beta2 `status.fairSharing` schema.
  * Added `admissionFairSharingStatus` field to LocalQueue v1beta2 `status.fairSharing` for admission-related observability.
  * Implemented lossy conversion between v1beta1 and v1beta2: `weightedShare` is dropped in v1beta2 and reset to 0 when converting to v1beta1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->