### PR TITLE
Refactor cloudbuild and introduce parallelism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,6 +244,20 @@ image-build:
 		$(IMAGE_BUILD_EXTRA_OPTS) \
 		./
 
+.PHONY: image-pushing-presubmit
+image-pushing-presubmit:
+	$(MAKE) -j5 run-image-pushing-presubmit
+
+.PHONY: run-image-pushing-presubmit
+run-image-pushing-presubmit: image-push helm-chart-push kueueviz-image-push kueue-populator-image-push kueue-priority-booster-image-push
+
+.PHONY: image-pushing-periodic
+image-pushing-periodic:
+	$(MAKE) -j3 run-image-pushing-periodic
+
+.PHONY: run-image-pushing-periodic
+run-image-pushing-periodic: debug-image-push importer-image-push ray-project-mini-image-build-push
+
 .PHONY: image-push
 image-push: PUSH=--push
 image-push: image-build

--- a/Makefile
+++ b/Makefile
@@ -244,19 +244,19 @@ image-build:
 		$(IMAGE_BUILD_EXTRA_OPTS) \
 		./
 
-.PHONY: image-pushing-presubmit
-image-pushing-presubmit:
-	$(MAKE) -j5 run-image-pushing-presubmit
+.PHONY: image-pushing
+image-pushing:
+ifeq ($(JOB_TYPE),periodic)
+	$(MAKE) -j3 image-pushing-helper-artifacts
+else
+	$(MAKE) -j5 image-pushing-release-artifacts
+endif
 
-.PHONY: run-image-pushing-presubmit
-run-image-pushing-presubmit: image-push helm-chart-push kueueviz-image-push kueue-populator-image-push kueue-priority-booster-image-push
+.PHONY: image-pushing-helper-artifacts
+image-pushing-helper-artifacts: debug-image-push importer-image-push ray-project-mini-image-build-push
 
-.PHONY: image-pushing-periodic
-image-pushing-periodic:
-	$(MAKE) -j3 run-image-pushing-periodic
-
-.PHONY: run-image-pushing-periodic
-run-image-pushing-periodic: debug-image-push importer-image-push ray-project-mini-image-build-push
+.PHONY: image-pushing-release-artifacts
+image-pushing-release-artifacts: image-push helm-chart-push kueueviz-image-push kueue-populator-image-push kueue-priority-booster-image-push
 
 .PHONY: image-push
 image-push: PUSH=--push

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,8 +7,7 @@ steps:
   - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260127-c1affcc8de'
     entrypoint: make
     args:
-      - image-pushing-presubmit
-      - image-pushing-periodic
+      - image-pushing
     env:
       - DOCKER_BUILDX_CMD=/buildx-entrypoint
       - GOTOOLCHAIN=auto

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,14 +7,8 @@ steps:
   - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260127-c1affcc8de'
     entrypoint: make
     args:
-      - image-push
-      - debug-image-push
-      - importer-image-push
-      - helm-chart-push
-      - kueueviz-image-push
-      - kueue-populator-image-push
-      - kueue-priority-booster-image-push
-      - ray-project-mini-image-build-push
+      - image-pushing-presubmit
+      - image-pushing-periodic
     env:
       - DOCKER_BUILDX_CMD=/buildx-entrypoint
       - GOTOOLCHAIN=auto


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Split cloudbuild for presubmit and periodic.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #12303

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build orchestration for publishing container image and chart artifacts, adding dedicated release-artifacts and helper aggregation workflows.
  * Improved build performance by adjusting parallelism based on run type (periodic vs non-periodic).
  * Streamlined the CI image-push stage by invoking a single consolidated `make` target instead of multiple individual image-push targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->