### PR TITLE
Add cloudbuild-periodic.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,16 +247,16 @@ image-build:
 .PHONY: image-pushing
 image-pushing:
 ifeq ($(JOB_TYPE),periodic)
-	$(MAKE) -j3 image-pushing-helper-artifacts
+	$(MAKE) -j3 image-pushing-periodic
 else
-	$(MAKE) -j5 image-pushing-release-artifacts
+	$(MAKE) -j5 image-pushing-postsubmit
 endif
 
-.PHONY: image-pushing-helper-artifacts
-image-pushing-helper-artifacts: debug-image-push importer-image-push ray-project-mini-image-build-push
+.PHONY: image-pushing-periodic
+image-pushing-periodic: debug-image-push importer-image-push ray-project-mini-image-build-push
 
-.PHONY: image-pushing-release-artifacts
-image-pushing-release-artifacts: image-push helm-chart-push kueueviz-image-push kueue-populator-image-push kueue-priority-booster-image-push
+.PHONY: image-pushing-postsubmit
+image-pushing-postsubmit: image-push helm-chart-push kueueviz-image-push kueue-populator-image-push kueue-priority-booster-image-push
 
 .PHONY: image-push
 image-push: PUSH=--push

--- a/Makefile
+++ b/Makefile
@@ -244,14 +244,6 @@ image-build:
 		$(IMAGE_BUILD_EXTRA_OPTS) \
 		./
 
-.PHONY: image-pushing
-image-pushing:
-ifeq ($(JOB_TYPE),periodic)
-	$(MAKE) -j3 image-pushing-periodic
-else
-	$(MAKE) -j5 image-pushing-postsubmit
-endif
-
 .PHONY: image-pushing-periodic
 image-pushing-periodic: debug-image-push importer-image-push ray-project-mini-image-build-push
 

--- a/cloudbuild-periodic.yaml
+++ b/cloudbuild-periodic.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 3000s
+timeout: 3600s
 # A build step specifies an action that you want cloudbuild to perform.
 # For each build step, cloudbuild executes a docker container.
 steps:

--- a/cloudbuild-periodic.yaml
+++ b/cloudbuild-periodic.yaml
@@ -7,7 +7,7 @@ steps:
   - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260127-c1affcc8de'
     entrypoint: make
     args:
-      - image-pushing-postsubmit
+      - image-pushing-periodic
     env:
       - DOCKER_BUILDX_CMD=/buildx-entrypoint
       - GOTOOLCHAIN=auto


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Add cloudbuild-periodic.yaml

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #12303

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the image build-and-push orchestration to separate periodic and postsubmit workflows, with dedicated workflow-specific entry points and dependencies.
  * Adjusted Cloud Build configuration to invoke the new postsubmit workflow target.
  * Updated periodic Cloud Build settings, including the container image tag and build timeout, while keeping the periodic execution behavior aligned with the new orchestration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->