### PR TITLE
Automated cherry pick of #12304: Refactor cloudbuild and introduce parallelism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,20 @@ image-build:
 		$(IMAGE_BUILD_EXTRA_OPTS) \
 		./
 
+.PHONY: image-pushing-presubmit
+image-pushing-presubmit:
+	$(MAKE) -j5 run-image-pushing-presubmit
+
+.PHONY: run-image-pushing-presubmit
+run-image-pushing-presubmit: image-push helm-chart-push kueueviz-image-push kueue-populator-image-push
+
+.PHONY: image-pushing-periodic
+image-pushing-periodic:
+	$(MAKE) -j3 run-image-pushing-periodic
+
+.PHONY: run-image-pushing-periodic
+run-image-pushing-periodic: debug-image-push importer-image-push ray-project-mini-image-build-push
+
 .PHONY: image-push
 image-push: PUSH=--push
 image-push: image-build

--- a/Makefile
+++ b/Makefile
@@ -236,19 +236,19 @@ image-build:
 		$(IMAGE_BUILD_EXTRA_OPTS) \
 		./
 
-.PHONY: image-pushing-presubmit
-image-pushing-presubmit:
-	$(MAKE) -j5 run-image-pushing-presubmit
+.PHONY: image-pushing
+image-pushing:
+ifeq ($(JOB_TYPE),periodic)
+	$(MAKE) -j3 image-pushing-helper-artifacts
+else
+	$(MAKE) -j5 image-pushing-release-artifacts
+endif
 
-.PHONY: run-image-pushing-presubmit
-run-image-pushing-presubmit: image-push helm-chart-push kueueviz-image-push kueue-populator-image-push
+.PHONY: image-pushing-helper-artifacts
+image-pushing-helper-artifacts: debug-image-push importer-image-push ray-project-mini-image-build-push
 
-.PHONY: image-pushing-periodic
-image-pushing-periodic:
-	$(MAKE) -j3 run-image-pushing-periodic
-
-.PHONY: run-image-pushing-periodic
-run-image-pushing-periodic: debug-image-push importer-image-push ray-project-mini-image-build-push
+.PHONY: image-pushing-release-artifacts
+image-pushing-release-artifacts: image-push helm-chart-push kueueviz-image-push kueue-populator-image-push
 
 .PHONY: image-push
 image-push: PUSH=--push

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,8 +7,7 @@ steps:
   - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260127-c1affcc8de'
     entrypoint: make
     args:
-      - image-pushing-presubmit
-      - image-pushing-periodic
+      - image-pushing
     env:
       - DOCKER_BUILDX_CMD=/buildx-entrypoint
       - GOTOOLCHAIN=auto

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,13 +7,8 @@ steps:
   - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260127-c1affcc8de'
     entrypoint: make
     args:
-      - image-push
-      - debug-image-push
-      - importer-image-push
-      - helm-chart-push
-      - kueueviz-image-push
-      - kueue-populator-image-push
-      - ray-project-mini-image-build-push
+      - image-pushing-presubmit
+      - image-pushing-periodic
     env:
       - DOCKER_BUILDX_CMD=/buildx-entrypoint
       - GOTOOLCHAIN=auto


### PR DESCRIPTION
Cherry pick of #12304 on release-0.17.

#12304: Refactor cloudbuild and introduce parallelism

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```