### PR TITLE
Refactor `newTASFlavorSnapshot` to use the variadic options pattern

### DIFF
--- a/pkg/cache/scheduler/tas_balanced_placement_test.go
+++ b/pkg/cache/scheduler/tas_balanced_placement_test.go
@@ -73,7 +73,7 @@ func TestSelectOptimalDomainSetToFit(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "dummy", []string{}, nil)
+			s := newTASFlavorSnapshot(log, "dummy", []string{})
 			got := selectOptimalDomainSetToFit(s, tc.domains, tc.workerCount, tc.leaderCount, 1, true)
 			gotIDs := make([]string, len(got))
 			for i, d := range got {
@@ -151,7 +151,7 @@ func TestPlaceSlicesOnDomainsBalanced(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			domains := make([]*domain, len(tc.domains))
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "dummy", []string{}, nil)
+			s := newTASFlavorSnapshot(log, "dummy", []string{})
 			for i, d := range tc.domains {
 				clone := *d
 				domains[i] = &clone
@@ -222,7 +222,7 @@ func TestPruneDomainsBelowThreshold(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			domains, domainsByName := tc.domains()
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "dummy", []string{}, nil)
+			s := newTASFlavorSnapshot(log, "dummy", []string{})
 
 			s.pruneDomainsBelowThreshold(domains, tc.threshold, tc.sliceSize, tc.sliceLevelIdx, tc.level, tc.leaderRequired)
 
@@ -298,7 +298,7 @@ func TestFindBestDomainsForBalancedPlacement(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "dummy", []string{"block", "rack"}, nil)
+			s := newTASFlavorSnapshot(log, "dummy", []string{"block", "rack"})
 			domainsByID := make(map[string]*domain, len(tc.domains))
 			for _, spec := range tc.domains {
 				d := &domain{

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -132,7 +132,7 @@ func (c *TASFlavorCache) snapshot(
 	}
 	log.V(3).Info("Constructing TAS snapshot", infoKV...)
 
-	snapshot := newTASFlavorSnapshot(log, c.flavor.TopologyName, c.topology.Levels, c.flavor.Tolerations)
+	snapshot := newTASFlavorSnapshot(log, c.flavor.TopologyName, c.topology.Levels, withTolerations(c.flavor.Tolerations))
 	nodeToDomain := make(map[string]utiltas.TopologyDomainID)
 	for _, node := range nodes {
 		nodeToDomain[node.Name] = snapshot.addNode(node)

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -140,8 +140,27 @@ type TASFlavorSnapshot struct {
 	isLowestLevelNode bool
 }
 
+type tasFlavorSnapshotOptions struct {
+	tolerations []corev1.Toleration
+}
+
+type tasFlavorSnapshotOption func(*tasFlavorSnapshotOptions)
+
+func withTolerations(tolerations []corev1.Toleration) tasFlavorSnapshotOption {
+	return func(o *tasFlavorSnapshotOptions) {
+		o.tolerations = tolerations
+	}
+}
+
 func newTASFlavorSnapshot(log logr.Logger, topologyName kueue.TopologyReference,
-	levels []string, tolerations []corev1.Toleration) *TASFlavorSnapshot {
+	levels []string, opts ...tasFlavorSnapshotOption) *TASFlavorSnapshot {
+	options := &tasFlavorSnapshotOptions{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(options)
+		}
+	}
+
 	domainsPerLevel := make([]domainByID, len(levels))
 	for level := range levels {
 		domainsPerLevel[level] = make(domainByID)
@@ -152,7 +171,7 @@ func newTASFlavorSnapshot(log logr.Logger, topologyName kueue.TopologyReference,
 		topologyName:      topologyName,
 		levelKeys:         slices.Clone(levels),
 		leaves:            make(leafDomainByID),
-		tolerations:       slices.Clone(tolerations),
+		tolerations:       slices.Clone(options.tolerations),
 		domains:           make(domainByID),
 		roots:             make(domainByID),
 		domainsPerLevel:   domainsPerLevel,

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -346,7 +346,7 @@ func TestMergeTopologyAssignments(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "dummy", levels, nil)
+			s := newTASFlavorSnapshot(log, "dummy", levels)
 			for i := range nodes {
 				s.addNode(newNodeInfo(&nodes[i]))
 			}
@@ -421,7 +421,7 @@ func TestHasLevel(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "dummy", levels, nil)
+			s := newTASFlavorSnapshot(log, "dummy", levels)
 			got := s.HasLevel(tc.podSetTopologyRequest)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected HasLevel result (-want,+got): %s", diff)
@@ -530,7 +530,7 @@ func TestSortedDomainsWithLeader(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.TASRespectNodeAffinityPreferred, tc.enableTASPreferredSchedulingAffinity)
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "test", levels, nil)
+			s := newTASFlavorSnapshot(log, "test", levels)
 
 			sorted := s.sortedDomainsWithLeader(tc.domains, tc.unconstrained)
 
@@ -629,7 +629,7 @@ func TestSortedDomains(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.TASRespectNodeAffinityPreferred, tc.enableTASPreferredSchedulingAffinity)
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "test", levels, nil)
+			s := newTASFlavorSnapshot(log, "test", levels)
 
 			sorted := s.sortedDomains(tc.domains, tc.unconstrained)
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
`newTASFlavorSnapshot` will most likely require a new optional parameter to be passed to it (`schedulingSnapshot`, https://github.com/kubernetes-sigs/kueue/pull/12256).

To not pollute the call with multiple `nil` values, we can introduce the variadic options pattern to the constructor: https://github.com/kubernetes-sigs/kueue/pull/12256#discussion_r3413774663

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
The code and test changes were generated with Gemini.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal snapshot initialization to use a functional-options pattern for improved extensibility and maintainability.
  * Updated related test cases to align with the refactored initialization approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->