### PR TITLE
Automated cherry pick of #12311: Add cloudbuild-periodic.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,14 +236,6 @@ image-build:
 		$(IMAGE_BUILD_EXTRA_OPTS) \
 		./
 
-.PHONY: image-pushing
-image-pushing:
-ifeq ($(JOB_TYPE),periodic)
-	$(MAKE) -j3 image-pushing-periodic
-else
-	$(MAKE) -j5 image-pushing-postsubmit
-endif
-
 .PHONY: image-pushing-periodic
 image-pushing-periodic: debug-image-push importer-image-push ray-project-mini-image-build-push
 

--- a/Makefile
+++ b/Makefile
@@ -239,16 +239,16 @@ image-build:
 .PHONY: image-pushing
 image-pushing:
 ifeq ($(JOB_TYPE),periodic)
-	$(MAKE) -j3 image-pushing-helper-artifacts
+	$(MAKE) -j3 image-pushing-periodic
 else
-	$(MAKE) -j5 image-pushing-release-artifacts
+	$(MAKE) -j5 image-pushing-postsubmit
 endif
 
-.PHONY: image-pushing-helper-artifacts
-image-pushing-helper-artifacts: debug-image-push importer-image-push ray-project-mini-image-build-push
+.PHONY: image-pushing-periodic
+image-pushing-periodic: debug-image-push importer-image-push ray-project-mini-image-build-push
 
-.PHONY: image-pushing-release-artifacts
-image-pushing-release-artifacts: image-push helm-chart-push kueueviz-image-push kueue-populator-image-push
+.PHONY: image-pushing-postsubmit
+image-pushing-postsubmit: image-push helm-chart-push kueueviz-image-push kueue-populator-image-push kueue-priority-booster-image-push
 
 .PHONY: image-push
 image-push: PUSH=--push

--- a/cloudbuild-periodic.yaml
+++ b/cloudbuild-periodic.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 3000s
+timeout: 3600s
 # A build step specifies an action that you want cloudbuild to perform.
 # For each build step, cloudbuild executes a docker container.
 steps:

--- a/cloudbuild-periodic.yaml
+++ b/cloudbuild-periodic.yaml
@@ -7,7 +7,7 @@ steps:
   - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260127-c1affcc8de'
     entrypoint: make
     args:
-      - image-pushing-postsubmit
+      - image-pushing-periodic
     env:
       - DOCKER_BUILDX_CMD=/buildx-entrypoint
       - GOTOOLCHAIN=auto


### PR DESCRIPTION
Cherry pick of #12311 on release-0.17.

#12311: Add cloudbuild-periodic.yaml

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note
NONE
```