### PR TITLE
Increase code coverage for DRA errors and terminating queues in workload controller

### DIFF
--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -415,6 +415,8 @@ func TestReconcile(t *testing.T) {
 		additionalObjects         []client.Object
 		cq                        *kueue.ClusterQueue
 		lq                        *kueue.LocalQueue
+		shouldDeleteCQ            bool
+		shouldDeleteLQ            bool
 		resourceClaims            []*resourcev1.ResourceClaim
 		resourceClaimTemplates    []*resourcev1.ResourceClaimTemplate
 		patchErr                  error
@@ -2589,7 +2591,8 @@ func TestReconcile(t *testing.T) {
 			cq: utiltestingapi.MakeClusterQueue("cq").
 				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("flavor1").Obj()).
 				AdmissionChecks("check").Obj(),
-			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").DeletionTimestamp(now).Obj(),
+			lq:             utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			shouldDeleteLQ: true,
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				Active(true).
 				ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").
@@ -2743,9 +2746,9 @@ func TestReconcile(t *testing.T) {
 				Cohort("cohort").
 				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("flavor1").Obj()).
 				AdmissionChecks("check").
-				DeletionTimestamp(now).
 				Obj(),
-			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			lq:             utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			shouldDeleteCQ: true,
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				Active(true).
 				ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").
@@ -3645,11 +3648,11 @@ func TestReconcile(t *testing.T) {
 				defer ctxCancel()
 
 				if tc.cq != nil {
-					setupClusterQueue(ctx, t, cl, qManager, cqCache, tc.cq)
+					setupClusterQueue(ctx, t, cl, qManager, cqCache, tc.cq, tc.shouldDeleteCQ)
 				}
 
 				if tc.lq != nil {
-					setupLocalQueue(ctx, t, cl, qManager, tc.lq)
+					setupLocalQueue(ctx, t, cl, qManager, tc.lq, tc.shouldDeleteLQ)
 				}
 
 				if testWl != nil && testWl.Namespace == "ns" &&
@@ -3912,12 +3915,10 @@ func TestReconcileSyncAdmissionChecks(t *testing.T) {
 	}
 }
 
-func setupClusterQueue(ctx context.Context, t *testing.T, cl client.Client, qManager *qcache.Manager, cqCache *schdcache.Cache, cq *kueue.ClusterQueue) {
+func setupClusterQueue(ctx context.Context, t *testing.T, cl client.Client, qManager *qcache.Manager, cqCache *schdcache.Cache, cq *kueue.ClusterQueue, shouldDelete bool) {
 	t.Helper()
 	testCq := cq.DeepCopy()
 	// DeletionTimestamp cannot be directly set during creation. We simulate it by deleting the object with a finalizer.
-	shouldDelete := testCq.DeletionTimestamp != nil
-	testCq.DeletionTimestamp = nil
 	if shouldDelete && len(testCq.Finalizers) == 0 {
 		testCq.Finalizers = []string{"testing-finalizer"}
 	}
@@ -3940,12 +3941,10 @@ func setupClusterQueue(ctx context.Context, t *testing.T, cl client.Client, qMan
 	}
 }
 
-func setupLocalQueue(ctx context.Context, t *testing.T, cl client.Client, qManager *qcache.Manager, lq *kueue.LocalQueue) {
+func setupLocalQueue(ctx context.Context, t *testing.T, cl client.Client, qManager *qcache.Manager, lq *kueue.LocalQueue, shouldDelete bool) {
 	t.Helper()
 	testLq := lq.DeepCopy()
 	// DeletionTimestamp cannot be directly set during creation. We simulate it by deleting the object with a finalizer.
-	shouldDelete := testLq.DeletionTimestamp != nil
-	testLq.DeletionTimestamp = nil
 	if shouldDelete && len(testLq.Finalizers) == 0 {
 		testLq.Finalizers = []string{"testing-finalizer"}
 	}

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -410,7 +410,14 @@ func TestReconcile(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(now)
 
 	cases := map[string]struct {
-		featureGates              map[featuregate.Feature]bool
+		featureGates map[featuregate.Feature]bool
+
+		// Set to true to simulate a terminating ClusterQueue or LocalQueue.
+		// The setup helper will attach a finalizer and delete the object,
+		// which automatically populates its DeletionTimestamp in the fake client.
+		shouldDeleteCQ bool
+		shouldDeleteLQ bool
+
 		workload                  *kueue.Workload
 		additionalObjects         []client.Object
 		cq                        *kueue.ClusterQueue
@@ -428,12 +435,6 @@ func TestReconcile(t *testing.T) {
 		wantEvents                []utiltesting.EventRecord
 		wantResult                reconcile.Result
 		reconcilerOpts            []Option
-
-		// Set to true to simulate a terminating ClusterQueue or LocalQueue.
-		// The setup helper will attach a finalizer and delete the object,
-		// which automatically populates its DeletionTimestamp in the fake client.
-		shouldDeleteCQ bool
-		shouldDeleteLQ bool
 	}{
 		"reconcile DRA ResourceClaim should be rejected as inadmissible": {
 			featureGates: map[featuregate.Feature]bool{

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -3916,9 +3916,9 @@ func setupClusterQueue(ctx context.Context, t *testing.T, cl client.Client, qMan
 	t.Helper()
 	testCq := cq.DeepCopy()
 	// DeletionTimestamp cannot be directly set during creation. We simulate it by deleting the object with a finalizer.
-	wantDeleted := testCq.DeletionTimestamp != nil
+	shouldDelete := testCq.DeletionTimestamp != nil
 	testCq.DeletionTimestamp = nil
-	if wantDeleted && len(testCq.Finalizers) == 0 {
+	if shouldDelete && len(testCq.Finalizers) == 0 {
 		testCq.Finalizers = []string{"testing-finalizer"}
 	}
 	if err := cl.Create(ctx, testCq); err != nil {
@@ -3928,12 +3928,12 @@ func setupClusterQueue(ctx context.Context, t *testing.T, cl client.Client, qMan
 		t.Fatalf("couldn't add the cluster queue to the cache: %v", err)
 	}
 	isActive := apimeta.IsStatusConditionTrue(testCq.Status.Conditions, kueue.ClusterQueueActive)
-	if isActive || wantDeleted {
+	if isActive || shouldDelete {
 		if err := cqCache.AddClusterQueue(ctx, testCq); err != nil {
 			t.Fatalf("couldn't add the cluster queue to the scheduler cache: %v", err)
 		}
 	}
-	if wantDeleted {
+	if shouldDelete {
 		if err := cl.Delete(ctx, testCq); err != nil {
 			t.Fatalf("couldn't delete the cluster queue: %v", err)
 		}
@@ -3944,9 +3944,9 @@ func setupLocalQueue(ctx context.Context, t *testing.T, cl client.Client, qManag
 	t.Helper()
 	testLq := lq.DeepCopy()
 	// DeletionTimestamp cannot be directly set during creation. We simulate it by deleting the object with a finalizer.
-	wantDeleted := testLq.DeletionTimestamp != nil
+	shouldDelete := testLq.DeletionTimestamp != nil
 	testLq.DeletionTimestamp = nil
-	if wantDeleted && len(testLq.Finalizers) == 0 {
+	if shouldDelete && len(testLq.Finalizers) == 0 {
 		testLq.Finalizers = []string{"testing-finalizer"}
 	}
 	if err := cl.Create(ctx, testLq); err != nil {
@@ -3955,7 +3955,7 @@ func setupLocalQueue(ctx context.Context, t *testing.T, cl client.Client, qManag
 	if err := qManager.AddLocalQueue(ctx, testLq); err != nil {
 		t.Fatalf("couldn't add the local queue to the cache: %v", err)
 	}
-	if wantDeleted {
+	if shouldDelete {
 		if err := cl.Delete(ctx, testLq); err != nil {
 			t.Fatalf("couldn't delete the local queue: %v", err)
 		}

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -3922,20 +3922,20 @@ func setupClusterQueue(ctx context.Context, t *testing.T, cl client.Client, qMan
 		testCq.Finalizers = []string{"testing-finalizer"}
 	}
 	if err := cl.Create(ctx, testCq); err != nil {
-		t.Errorf("couldn't create the cluster queue: %v", err)
+		t.Fatalf("couldn't create the cluster queue: %v", err)
 	}
 	if err := qManager.AddClusterQueue(ctx, testCq); err != nil {
-		t.Errorf("couldn't add the cluster queue to the cache: %v", err)
+		t.Fatalf("couldn't add the cluster queue to the cache: %v", err)
 	}
 	isActive := apimeta.IsStatusConditionTrue(testCq.Status.Conditions, kueue.ClusterQueueActive)
 	if isActive || wantDeleted {
 		if err := cqCache.AddClusterQueue(ctx, testCq); err != nil {
-			t.Errorf("couldn't add the cluster queue to the scheduler cache: %v", err)
+			t.Fatalf("couldn't add the cluster queue to the scheduler cache: %v", err)
 		}
 	}
 	if wantDeleted {
 		if err := cl.Delete(ctx, testCq); err != nil {
-			t.Errorf("couldn't delete the cluster queue: %v", err)
+			t.Fatalf("couldn't delete the cluster queue: %v", err)
 		}
 	}
 }
@@ -3950,14 +3950,14 @@ func setupLocalQueue(ctx context.Context, t *testing.T, cl client.Client, qManag
 		testLq.Finalizers = []string{"testing-finalizer"}
 	}
 	if err := cl.Create(ctx, testLq); err != nil {
-		t.Errorf("couldn't create the local queue: %v", err)
+		t.Fatalf("couldn't create the local queue: %v", err)
 	}
 	if err := qManager.AddLocalQueue(ctx, testLq); err != nil {
-		t.Errorf("couldn't add the local queue to the cache: %v", err)
+		t.Fatalf("couldn't add the local queue to the cache: %v", err)
 	}
 	if wantDeleted {
 		if err := cl.Delete(ctx, testLq); err != nil {
-			t.Errorf("couldn't delete the local queue: %v", err)
+			t.Fatalf("couldn't delete the local queue: %v", err)
 		}
 	}
 }

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -30,6 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -45,6 +46,7 @@ import (
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/constants"
+	utilindexer "sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/dra"
 	"sigs.k8s.io/kueue/pkg/features"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
@@ -671,6 +673,43 @@ func TestReconcile(t *testing.T) {
 				return wl
 			}(),
 			wantEvents: nil,
+		},
+		"reconcile DRA validation fails with KueueDRAIntegrationExtendedResource enabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.KueueDRAIntegration:                 true,
+				features.KueueDRAIntegrationExtendedResource: true,
+			},
+			workload: utiltestingapi.MakeWorkload("wl-invalid-extended-resource", "ns").
+				Queue("lq").
+				Request("example.com/gpu", "1500m"). // 1.5 GPUs is invalid because extended resources must be integer quantities
+				Obj(),
+			additionalObjects: []client.Object{
+				utiltesting.MakeDeviceClass("gpu-class").
+					ExtendedResourceName("example.com/gpu").
+					Obj(),
+			},
+			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("flavor1").
+						Resource("example.com/gpu", "2").Obj(),
+				).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl-invalid-extended-resource", "ns").
+				Queue("lq").
+				Request("example.com/gpu", "1500m").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadInadmissible,
+					Message: "spec.podSets[0].template.spec.containers[0].resources.requests.example.com/gpu: Invalid value: \"1500m\": extended resource quantity must be an integer",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadRequeued,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadInadmissible,
+					Message: "spec.podSets[0].template.spec.containers[0].resources.requests.example.com/gpu: Invalid value: \"1500m\": extended resource quantity must be an integer",
+				}).
+				Obj(),
 		},
 		"reconcile DRA ResourceClaimTemplate not found should return error": {
 			featureGates: map[featuregate.Feature]bool{
@@ -2546,6 +2585,58 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 		},
+		"should set the Inadmissible reason on QuotaReservation condition when the LocalQueue is terminating": {
+			cq: utiltestingapi.MakeClusterQueue("cq").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("flavor1").Obj()).
+				AdmissionChecks("check").Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").DeletionTimestamp(now).Obj(),
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "flavor1", "1").
+						Obj()).
+					Obj(), now).
+				AdmissionCheck(kueue.AdmissionCheckState{
+					Name:  "check",
+					State: kueue.CheckStatePending,
+				}).
+				Queue("lq").
+				Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				Admission(utiltestingapi.MakeAdmission("cq").
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "flavor1", "1").
+						Obj()).
+					Obj()).
+				AdmissionCheck(kueue.AdmissionCheckState{
+					Name:  "check",
+					State: kueue.CheckStatePending,
+				}).
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadInadmissible,
+					Message: "LocalQueue lq is terminating or missing",
+				}).
+				Obj(),
+			wantWorkloadUseMergePatch: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				AdmissionCheck(kueue.AdmissionCheckState{
+					Name:  "check",
+					State: kueue.CheckStatePending,
+				}).
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadInadmissible,
+					Message: "LocalQueue lq is terminating or missing",
+				}).
+				Obj(),
+		},
 		"should set the Inadmissible reason on QuotaReservation condition when the LocalQueue was Hold": {
 			cq: utiltestingapi.MakeClusterQueue("cq").
 				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("flavor1").Obj()).
@@ -2599,6 +2690,61 @@ func TestReconcile(t *testing.T) {
 				Obj(),
 		},
 		"should set the Inadmissible reason on QuotaReservation condition when the ClusterQueue was deleted": {
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "flavor1", "1").
+						Obj()).
+					Obj(), now).
+				AdmissionCheck(kueue.AdmissionCheckState{
+					Name:  "check",
+					State: kueue.CheckStatePending,
+				}).
+				Queue("lq").
+				Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				Admission(utiltestingapi.MakeAdmission("cq").
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "flavor1", "1").
+						Obj()).
+					Obj()).
+				AdmissionCheck(kueue.AdmissionCheckState{
+					Name:  "check",
+					State: kueue.CheckStatePending,
+				}).
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadInadmissible,
+					Message: "ClusterQueue cq is terminating or missing",
+				}).
+				Obj(),
+			wantWorkloadUseMergePatch: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				AdmissionCheck(kueue.AdmissionCheckState{
+					Name:  "check",
+					State: kueue.CheckStatePending,
+				}).
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadInadmissible,
+					Message: "ClusterQueue cq is terminating or missing",
+				}).
+				Obj(),
+		},
+		"should set the Inadmissible reason on QuotaReservation condition when the ClusterQueue is terminating": {
+			cq: utiltestingapi.MakeClusterQueue("cq").
+				Cohort("cohort").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("flavor1").Obj()).
+				AdmissionChecks("check").
+				DeletionTimestamp(now).
+				Obj(),
 			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				Active(true).
@@ -3467,13 +3613,27 @@ func TestReconcile(t *testing.T) {
 							return c.List(ctx, list, opts...)
 						},
 					})
+				if features.Enabled(features.KueueDRAIntegrationExtendedResource) {
+					clientBuilder = clientBuilder.WithIndex(&resourcev1.DeviceClass{}, utilindexer.DeviceClassExtendedResourceNameIndex, utilindexer.IndexDeviceClassExtendedResourceName)
+				}
 				cl := clientBuilder.Build()
 				recorder := &utiltesting.EventRecorder{}
 
 				cqCache := schdcache.New(cl)
+				var draCache *dra.ExtendedResourceCache
+				if features.Enabled(features.KueueDRAIntegration) {
+					draCache = setupDRACache(objs)
+				}
 				queueOptions := []qcache.Option{qcache.WithPreemptionExpectations(preemptexpectations.New())}
+				if draCache != nil {
+					queueOptions = append(queueOptions, qcache.WithDRABackedResources(draCache))
+				}
 				qManager := qcache.NewManagerForUnitTests(cl, cqCache, queueOptions...)
-				reconciler := NewWorkloadReconciler(cl, qManager, cqCache, recorder, tc.reconcilerOpts...)
+				reconcilerOpts := tc.reconcilerOpts
+				if draCache != nil {
+					reconcilerOpts = append(reconcilerOpts, WithDRABackedResources(draCache))
+				}
+				reconciler := NewWorkloadReconciler(cl, qManager, cqCache, recorder, reconcilerOpts...)
 				if features.Enabled(features.KueueDRAIntegration) {
 					qManager.SetDRAReconcileChannel(reconciler.GetDRAReconcileChannel())
 				}
@@ -3485,23 +3645,11 @@ func TestReconcile(t *testing.T) {
 				defer ctxCancel()
 
 				if tc.cq != nil {
-					testCq := tc.cq.DeepCopy()
-					if err := cl.Create(ctx, testCq); err != nil {
-						t.Errorf("couldn't create the cluster queue: %v", err)
-					}
-					if err := qManager.AddClusterQueue(ctx, testCq); err != nil {
-						t.Errorf("couldn't add the cluster queue to the cache: %v", err)
-					}
+					setupClusterQueue(ctx, t, cl, qManager, cqCache, tc.cq)
 				}
 
 				if tc.lq != nil {
-					testLq := tc.lq.DeepCopy()
-					if err := cl.Create(ctx, testLq); err != nil {
-						t.Errorf("couldn't create the local queue: %v", err)
-					}
-					if err := qManager.AddLocalQueue(ctx, testLq); err != nil {
-						t.Errorf("couldn't add the local queue to the cache: %v", err)
-					}
+					setupLocalQueue(ctx, t, cl, qManager, tc.lq)
 				}
 
 				if testWl != nil && testWl.Namespace == "ns" &&
@@ -3762,4 +3910,66 @@ func TestReconcileSyncAdmissionChecks(t *testing.T) {
 			}
 		})
 	}
+}
+
+func setupClusterQueue(ctx context.Context, t *testing.T, cl client.Client, qManager *qcache.Manager, cqCache *schdcache.Cache, cq *kueue.ClusterQueue) {
+	t.Helper()
+	testCq := cq.DeepCopy()
+	// DeletionTimestamp cannot be directly set during creation. We simulate it by deleting the object with a finalizer.
+	wantDeleted := testCq.DeletionTimestamp != nil
+	testCq.DeletionTimestamp = nil
+	if wantDeleted && len(testCq.Finalizers) == 0 {
+		testCq.Finalizers = []string{"testing-finalizer"}
+	}
+	if err := cl.Create(ctx, testCq); err != nil {
+		t.Errorf("couldn't create the cluster queue: %v", err)
+	}
+	if err := qManager.AddClusterQueue(ctx, testCq); err != nil {
+		t.Errorf("couldn't add the cluster queue to the cache: %v", err)
+	}
+	isActive := apimeta.IsStatusConditionTrue(testCq.Status.Conditions, kueue.ClusterQueueActive)
+	if isActive || wantDeleted {
+		if err := cqCache.AddClusterQueue(ctx, testCq); err != nil {
+			t.Errorf("couldn't add the cluster queue to the scheduler cache: %v", err)
+		}
+	}
+	if wantDeleted {
+		if err := cl.Delete(ctx, testCq); err != nil {
+			t.Errorf("couldn't delete the cluster queue: %v", err)
+		}
+	}
+}
+
+func setupLocalQueue(ctx context.Context, t *testing.T, cl client.Client, qManager *qcache.Manager, lq *kueue.LocalQueue) {
+	t.Helper()
+	testLq := lq.DeepCopy()
+	// DeletionTimestamp cannot be directly set during creation. We simulate it by deleting the object with a finalizer.
+	wantDeleted := testLq.DeletionTimestamp != nil
+	testLq.DeletionTimestamp = nil
+	if wantDeleted && len(testLq.Finalizers) == 0 {
+		testLq.Finalizers = []string{"testing-finalizer"}
+	}
+	if err := cl.Create(ctx, testLq); err != nil {
+		t.Errorf("couldn't create the local queue: %v", err)
+	}
+	if err := qManager.AddLocalQueue(ctx, testLq); err != nil {
+		t.Errorf("couldn't add the local queue to the cache: %v", err)
+	}
+	if wantDeleted {
+		if err := cl.Delete(ctx, testLq); err != nil {
+			t.Errorf("couldn't delete the local queue: %v", err)
+		}
+	}
+}
+
+func setupDRACache(objs []client.Object) *dra.ExtendedResourceCache {
+	draCache := dra.NewExtendedResourceCache()
+	for _, obj := range objs {
+		if dc, ok := obj.(*resourcev1.DeviceClass); ok {
+			if dc.Spec.ExtendedResourceName != nil {
+				draCache.Add(corev1.ResourceName(*dc.Spec.ExtendedResourceName), dc.Name)
+			}
+		}
+	}
+	return draCache
 }

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -415,8 +415,6 @@ func TestReconcile(t *testing.T) {
 		additionalObjects         []client.Object
 		cq                        *kueue.ClusterQueue
 		lq                        *kueue.LocalQueue
-		shouldDeleteCQ            bool
-		shouldDeleteLQ            bool
 		resourceClaims            []*resourcev1.ResourceClaim
 		resourceClaimTemplates    []*resourcev1.ResourceClaimTemplate
 		patchErr                  error
@@ -430,6 +428,12 @@ func TestReconcile(t *testing.T) {
 		wantEvents                []utiltesting.EventRecord
 		wantResult                reconcile.Result
 		reconcilerOpts            []Option
+
+		// Set to true to simulate a terminating ClusterQueue or LocalQueue.
+		// The setup helper will attach a finalizer and delete the object,
+		// which automatically populates its DeletionTimestamp in the fake client.
+		shouldDeleteCQ bool
+		shouldDeleteLQ bool
 	}{
 		"reconcile DRA ResourceClaim should be rejected as inadmissible": {
 			featureGates: map[featuregate.Feature]bool{
@@ -2592,7 +2596,7 @@ func TestReconcile(t *testing.T) {
 				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("flavor1").Obj()).
 				AdmissionChecks("check").Obj(),
 			lq:             utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
-			shouldDeleteLQ: true,
+			shouldDeleteLQ: true, // The setup helper will attach a finalizer and delete the object, which automatically populates its DeletionTimestamp in the fake client.
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				Active(true).
 				ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").
@@ -2748,7 +2752,7 @@ func TestReconcile(t *testing.T) {
 				AdmissionChecks("check").
 				Obj(),
 			lq:             utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
-			shouldDeleteCQ: true,
+			shouldDeleteCQ: true, // The setup helper will attach a finalizer and delete the object, which automatically populates its DeletionTimestamp in the fake client.
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				Active(true).
 				ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").

--- a/pkg/util/testing/v1beta2/wrappers.go
+++ b/pkg/util/testing/v1beta2/wrappers.go
@@ -783,6 +783,12 @@ func (q *LocalQueueWrapper) Creation(t time.Time) *LocalQueueWrapper {
 	return q
 }
 
+// DeletionTimestamp sets the deletion timestamp of the LocalQueue.
+func (q *LocalQueueWrapper) DeletionTimestamp(t time.Time) *LocalQueueWrapper {
+	q.LocalQueue.DeletionTimestamp = new(metav1.NewTime(t).Rfc3339Copy())
+	return q
+}
+
 // Label sets the label on the LocalQueue.
 func (q *LocalQueueWrapper) Label(k, v string) *LocalQueueWrapper {
 	if q.Labels == nil {

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -891,3 +891,30 @@ func (w *ResourceSliceWrapper) CounterConsumption(counterSet, counterName, value
 func (w *ResourceSliceWrapper) Obj() *resourcev1.ResourceSlice {
 	return &w.ResourceSlice
 }
+
+// DeviceClassWrapper wraps a resourcev1.DeviceClass.
+type DeviceClassWrapper struct {
+	resourcev1.DeviceClass
+}
+
+// MakeDeviceClass creates a DeviceClassWrapper with basic metadata.
+func MakeDeviceClass(name string) *DeviceClassWrapper {
+	return &DeviceClassWrapper{
+		resourcev1.DeviceClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		},
+	}
+}
+
+// ExtendedResourceName sets the extended resource name on the DeviceClass.
+func (d *DeviceClassWrapper) ExtendedResourceName(name string) *DeviceClassWrapper {
+	d.Spec.ExtendedResourceName = new(name)
+	return d
+}
+
+// Obj returns the inner DeviceClass.
+func (d *DeviceClassWrapper) Obj() *resourcev1.DeviceClass {
+	return &d.DeviceClass
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR improves code coverage of two things in workload controller:
- DRA validation issues
- handling of workloads where local/cluster queues are terminating

This is also a preparatory PR before the one that will implement https://github.com/kubernetes-sigs/kueue/tree/main/keps/10852-inadmissible-workloads-observability KEP. I would like to keep the code coverage as high as possible for the new feature and that would require implementing these tests anyway so I think it's better to keep it separate to offload the incoming PR.

#### Which issue(s) this PR fixes:
Part of #10852

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded DRA extended-resource validation to mark workloads inadmissible when the requested quantity is not an integer, including the expected “extended resource quantity must be an integer” message.
  * Improved ClusterQueue and LocalQueue terminating/deletion scenarios to better cover “terminating or missing” inadmissibility outcomes.
  * Refactored reconciliation test setup to more realistically exercise DRA integration paths and queue lifecycle behavior.
* **Chores**
  * Enhanced testing wrappers with a DeviceClass builder and added LocalQueue deletion-timestamp support to simulate object termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->