### PR TITLE
Extract preemption gate helpers into pkg/workload and reuse them in t…

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -558,7 +558,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		if remWlName != nil {
 			remWl := group.remotes[*remWlName]
 			remClient := group.remoteClients[*remWlName]
-			workload.SetPreemptionGatePosition(remWl, constants.MultiKueuePreemptionGate, kueue.PreemptionGatePositionOpen, metav1.NewTime(w.clock.Now()))
+			workload.OpenPreemptionGate(remWl, constants.MultiKueuePreemptionGate, metav1.NewTime(w.clock.Now()))
 			if err := remClient.client.Status().Update(ctx, remWl); err != nil {
 				return reconcile.Result{}, fmt.Errorf("failed to update remote workload: %w", err)
 			}
@@ -1104,14 +1104,11 @@ func (w *wlReconciler) workloadToOpenPreemptionGate(ctx context.Context, group *
 		if wl == nil {
 			continue
 		}
-		openMkGateStateIdx := slices.IndexFunc(wl.Status.PreemptionGates, func(gate kueue.PreemptionGateState) bool {
-			return gate.Name == constants.MultiKueuePreemptionGate && gate.Position == kueue.PreemptionGatePositionOpen
-		})
-		if openMkGateStateIdx == -1 {
+		mkGate := workload.FindPreemptionGate(wl, constants.MultiKueuePreemptionGate)
+		if mkGate == nil || mkGate.Position != kueue.PreemptionGatePositionOpen {
 			remoteWlLog.V(4).Info("Remote workload does not have an open preemption gate")
-			preemptionSignalCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadBlockedOnPreemptionGates)
-			wlRequiresPreemption := preemptionSignalCond != nil && preemptionSignalCond.Status == metav1.ConditionTrue
-			if !wlRequiresPreemption {
+			preemptionSignalCond := workload.BlockedOnPreemptionGatesCondition(wl)
+			if preemptionSignalCond == nil {
 				remoteWlLog.V(4).Info("Remote workload does not require preemption")
 				continue
 			}
@@ -1126,8 +1123,7 @@ func (w *wlReconciler) workloadToOpenPreemptionGate(ctx context.Context, group *
 			oldestPreemptionSignalTime = &preemptionSignalCond.LastTransitionTime
 		} else {
 			remoteWlLog.V(4).Info("Remote workload has an open preemption gate")
-			openMkGateState := wl.Status.PreemptionGates[openMkGateStateIdx]
-			gateOpenedTime := openMkGateState.LastTransitionTime
+			gateOpenedTime := mkGate.LastTransitionTime
 			if previousUngateTime == nil || gateOpenedTime.After(previousUngateTime.Time) {
 				remoteWlLog.V(4).Info("Remote workload has the new latest preemption ungating time")
 				previousUngateTime = &gateOpenedTime
@@ -1166,8 +1162,7 @@ func cloneForCreate(orig *kueue.Workload, origin string, preemptionGated bool) *
 	orig.Spec.DeepCopyInto(&remoteWl.Spec)
 
 	if features.Enabled(features.MultiKueueOrchestratedPreemption) && preemptionGated {
-		mkPreemptionGate := kueue.PreemptionGate{Name: constants.MultiKueuePreemptionGate}
-		remoteWl.Spec.PreemptionGates = append(remoteWl.Spec.PreemptionGates, mkPreemptionGate)
+		workload.EnsurePreemptionGateOnSpec(remoteWl, constants.MultiKueuePreemptionGate)
 	}
 
 	return remoteWl

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -1086,6 +1086,51 @@ func SetPreemptionGatePosition(w *kueue.Workload, gateName string, gatePosition 
 	return true
 }
 
+// Finds preemption gate with gateName, and returns pointer to that preemption gate state object
+func FindPreemptionGate(w *kueue.Workload, gateName string) *kueue.PreemptionGateState {
+	idx := slices.IndexFunc(w.Status.PreemptionGates, func(gate kueue.PreemptionGateState) bool {
+		return gate.Name == gateName
+	})
+	if idx == -1 {
+		return nil
+	}
+	return &w.Status.PreemptionGates[idx]
+}
+
+// HasOpenPreemptionGate reports whether the named preemption gate is open.
+func HasOpenPreemptionGate(w *kueue.Workload, gateName string) bool {
+	gate := FindPreemptionGate(w, gateName)
+	return gate != nil && gate.Position == kueue.PreemptionGatePositionOpen
+}
+
+// OpenPreemptionGate opens the named preemption gate, recording transitionTime
+// as the moment it opened. Returns true if opened gate and false if no change
+func OpenPreemptionGate(w *kueue.Workload, gateName string, transitionTime metav1.Time) bool {
+	return SetPreemptionGatePosition(w, gateName, kueue.PreemptionGatePositionOpen, transitionTime)
+}
+
+// EnsurePreemptionGateOnSpec appends the named preemption gate to the workload's
+// spec if it is not already present, and returns whether it was added.
+func EnsurePreemptionGateOnSpec(w *kueue.Workload, gateName string) bool {
+	if slices.ContainsFunc(w.Spec.PreemptionGates, func(g kueue.PreemptionGate) bool {
+		return g.Name == gateName
+	}) {
+		return false
+	}
+	w.Spec.PreemptionGates = append(w.Spec.PreemptionGates, kueue.PreemptionGate{Name: gateName})
+	return true
+}
+
+// BlockedOnPreemptionGatesCondition returns kueue.WorkloadBlockedOnPreemptionGates condition type
+// if condition status equals metav1.ConditionTrue returns condition otherwise returns nil
+func BlockedOnPreemptionGatesCondition(w *kueue.Workload) *metav1.Condition {
+	cond := apimeta.FindStatusCondition(w.Status.Conditions, kueue.WorkloadBlockedOnPreemptionGates)
+	if cond != nil && cond.Status == metav1.ConditionTrue {
+		return cond
+	}
+	return nil
+}
+
 // PropagateResourceRequests synchronizes w.Status.ResourceRequests to
 // with info.TotalRequests if the feature gate is enabled and returns true if w was updated
 func PropagateResourceRequests(w *kueue.Workload, info *Info) bool {


### PR DESCRIPTION
…he MultiKueue controller

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Extract preemption gate helpers into pkg/workload and reuse them in the MultiKueue controller
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #11872 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved preemption gate handling in MultiKueue with enhanced reliability and fairness in determining which workloads require preemption. System now uses more robust detection mechanisms and selects candidates based on the oldest preemption signals for fairer scheduling decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->