### PR TITLE
bug: support for pod level resources

### DIFF
--- a/pkg/controller/core/indexer/indexer.go
+++ b/pkg/controller/core/indexer/indexer.go
@@ -38,7 +38,7 @@ const (
 	WorkloadQueueKey                     = "spec.queueName"
 	WorkloadClusterQueueKey              = "status.admission.clusterQueue"
 	QueueClusterQueueKey                 = "spec.clusterQueue"
-	LimitRangeHasContainerType           = "spec.hasContainerType"
+	LimitRangeHasContainerOrPodType      = "spec.hasContainerOrPodType"
 	WorkloadQuotaReservedKey             = "status.quotaReserved"
 	WorkloadRuntimeClassKey              = "spec.runtimeClass"
 	OwnerReferenceUID                    = "metadata.ownerReferences.uid"
@@ -126,14 +126,14 @@ func IndexWorkloadClusterQueue(obj client.Object) []string {
 	return []string{string(wl.Status.Admission.ClusterQueue)}
 }
 
-func IndexLimitRangeHasContainerType(obj client.Object) []string {
+func IndexLimitRangeHasContainerOrPodType(obj client.Object) []string {
 	lr, ok := obj.(*corev1.LimitRange)
 	if !ok {
 		return nil
 	}
-
 	for i := range lr.Spec.Limits {
-		if lr.Spec.Limits[i].Type == corev1.LimitTypeContainer {
+		t := lr.Spec.Limits[i].Type
+		if t == corev1.LimitTypeContainer || t == corev1.LimitTypePod {
 			return []string{"true"}
 		}
 	}
@@ -277,8 +277,8 @@ func Setup(ctx context.Context, indexer client.FieldIndexer) error {
 	if err := indexer.IndexField(ctx, &kueue.LocalQueue{}, QueueClusterQueueKey, IndexQueueClusterQueue); err != nil {
 		return fmt.Errorf("setting index on clusterQueue for localQueue: %w", err)
 	}
-	if err := indexer.IndexField(ctx, &corev1.LimitRange{}, LimitRangeHasContainerType, IndexLimitRangeHasContainerType); err != nil {
-		return fmt.Errorf("setting index on hasContainerType for limitRange: %w", err)
+	if err := indexer.IndexField(ctx, &corev1.LimitRange{}, LimitRangeHasContainerOrPodType, IndexLimitRangeHasContainerOrPodType); err != nil {
+		return fmt.Errorf("setting index on hasContainerOrPodType for limitRange: %w", err)
 	}
 	if err := indexer.IndexField(ctx, &kueue.Workload{}, OwnerReferenceUID, IndexOwnerUID); err != nil {
 		return fmt.Errorf("setting index on ownerReferences.uid for Workload: %w", err)

--- a/pkg/controller/core/indexer/indexer_test.go
+++ b/pkg/controller/core/indexer/indexer_test.go
@@ -271,7 +271,7 @@ func TestIndexWorkloadClusterQueue(t *testing.T) {
 	}
 }
 
-func TestIndexLimitRangeHasContainerType(t *testing.T) {
+func TestIndexLimitRangeHasContainerOrPodType(t *testing.T) {
 	cases := map[string]struct {
 		obj  client.Object
 		want []string
@@ -286,7 +286,7 @@ func TestIndexLimitRangeHasContainerType(t *testing.T) {
 		},
 		"LimitRange with only Pod type returns nil": {
 			obj:  makeLimitRange("lr", "ns", corev1.LimitTypePod),
-			want: nil,
+			want: []string{"true"},
 		},
 		"LimitRange with Container type returns true": {
 			obj:  makeLimitRange("lr", "ns", corev1.LimitTypeContainer),
@@ -300,7 +300,7 @@ func TestIndexLimitRangeHasContainerType(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := IndexLimitRangeHasContainerType(tc.obj)
+			got := IndexLimitRangeHasContainerOrPodType(tc.obj)
 			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/util/pod/pod.go
+++ b/pkg/util/pod/pod.go
@@ -136,7 +136,7 @@ func GenerateRoleHash(podSpec *corev1.PodSpec) (string, error) {
 }
 
 func SpecShape(podSpec *corev1.PodSpec) (result map[string]any) {
-	return map[string]any{
+	shape := map[string]any{
 		"initContainers":            ContainersShape(podSpec.InitContainers),
 		"containers":                ContainersShape(podSpec.Containers),
 		"nodeSelector":              podSpec.NodeSelector,
@@ -148,6 +148,12 @@ func SpecShape(podSpec *corev1.PodSpec) (result map[string]any) {
 		"overhead":                  podSpec.Overhead,
 		"resourceClaims":            podSpec.ResourceClaims,
 	}
+	// Pod-level resources (KEP-2837) only contribute to the shape when set, so that
+	// role hashes computed for pods without them stay stable across upgrades.
+	if podSpec.Resources != nil {
+		shape["resources"] = podSpec.Resources.Requests
+	}
+	return shape
 }
 
 func ContainersShape(containers []corev1.Container) (result []map[string]any) {

--- a/pkg/util/pod/pod_test.go
+++ b/pkg/util/pod/pod_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
@@ -247,6 +248,79 @@ func TestIsTerminated(t *testing.T) {
 			got := IsTerminated(tc.pod)
 			if tc.wantTerminated != got {
 				t.Errorf("Unexpected Pod terminal\nwant: %v\ngot: %v\n", tc.wantTerminated, got)
+			}
+		})
+	}
+}
+
+func TestSpecShape(t *testing.T) {
+	podResources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+		Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+	}
+	cases := map[string]struct {
+		podSpec       *corev1.PodSpec
+		wantResources any
+		wantPresent   bool
+	}{
+		"pod-level resources omitted when unset": {
+			podSpec:     &corev1.PodSpec{Containers: []corev1.Container{{Name: "c"}}},
+			wantPresent: false,
+		},
+		"pod-level resources included when set": {
+			podSpec:       &corev1.PodSpec{Containers: []corev1.Container{{Name: "c"}}, Resources: podResources},
+			wantResources: podResources.Requests,
+			wantPresent:   true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, present := SpecShape(tc.podSpec)["resources"]
+			if present != tc.wantPresent {
+				t.Fatalf("Unexpected presence of \"resources\" key: want %v, got %v", tc.wantPresent, present)
+			}
+			if diff := cmp.Diff(tc.wantResources, got); diff != "" {
+				t.Errorf("Unexpected resources shape (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGenerateRoleHash(t *testing.T) {
+	withoutPodResources := &corev1.PodSpec{Containers: []corev1.Container{{Name: "c"}}}
+	withPodResources := &corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "c"}},
+		Resources: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+		},
+	}
+
+	baseHash, err := GenerateRoleHash(withoutPodResources)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	cases := map[string]struct {
+		podSpec      *corev1.PodSpec
+		wantBaseHash bool
+	}{
+		"pod-level resources change the role hash": {
+			podSpec: withPodResources,
+		},
+		"spec without pod-level resources has a stable role hash": {
+			podSpec:      withoutPodResources.DeepCopy(),
+			wantBaseHash: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			gotHash, err := GenerateRoleHash(tc.podSpec)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if gotBaseHash := gotHash == baseHash; gotBaseHash != tc.wantBaseHash {
+				t.Errorf("Unexpected role hash comparison with base hash: want equality %t, base hash %q, got hash %q", tc.wantBaseHash, baseHash, gotHash)
 			}
 		})
 	}

--- a/pkg/util/testing/v1beta2/wrappers.go
+++ b/pkg/util/testing/v1beta2/wrappers.go
@@ -587,6 +587,28 @@ func (p *PodSetWrapper) Limit(r corev1.ResourceName, q string) *PodSetWrapper {
 	return p
 }
 
+func (p *PodSetWrapper) PodLevelRequest(r corev1.ResourceName, q string) *PodSetWrapper {
+	if p.Template.Spec.Resources == nil {
+		p.Template.Spec.Resources = &corev1.ResourceRequirements{}
+	}
+	if p.Template.Spec.Resources.Requests == nil {
+		p.Template.Spec.Resources.Requests = corev1.ResourceList{}
+	}
+	p.Template.Spec.Resources.Requests[r] = resource.MustParse(q)
+	return p
+}
+
+func (p *PodSetWrapper) PodLevelLimit(r corev1.ResourceName, q string) *PodSetWrapper {
+	if p.Template.Spec.Resources == nil {
+		p.Template.Spec.Resources = &corev1.ResourceRequirements{}
+	}
+	if p.Template.Spec.Resources.Limits == nil {
+		p.Template.Spec.Resources.Limits = corev1.ResourceList{}
+	}
+	p.Template.Spec.Resources.Limits[r] = resource.MustParse(q)
+	return p
+}
+
 func (p *PodSetWrapper) Image(image string) *PodSetWrapper {
 	p.Template.Spec.Containers[0].Image = image
 	return p

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -67,7 +67,7 @@ func handlePodOverhead(ctx context.Context, cl client.Client, wl *kueue.Workload
 func handlePodLimitRange(ctx context.Context, cl client.Client, wl *kueue.Workload) error {
 	// get the list of limit ranges
 	var limitRanges corev1.LimitRangeList
-	if err := cl.List(ctx, &limitRanges, &client.ListOptions{Namespace: wl.Namespace}, client.MatchingFields{indexer.LimitRangeHasContainerType: "true"}); err != nil {
+	if err := cl.List(ctx, &limitRanges, &client.ListOptions{Namespace: wl.Namespace}, client.MatchingFields{indexer.LimitRangeHasContainerOrPodType: "true"}); err != nil {
 		return err
 	}
 
@@ -75,22 +75,31 @@ func handlePodLimitRange(ctx context.Context, cl client.Client, wl *kueue.Worklo
 		return nil
 	}
 	summary := limitrange.Summarize(limitRanges.Items...)
-	containerLimits, found := summary[corev1.LimitTypeContainer]
-	if !found {
+	podLimits, foundPodLimits := summary[corev1.LimitTypePod]
+	containerLimits, foundContainerLimits := summary[corev1.LimitTypeContainer]
+	if !foundPodLimits && !foundContainerLimits {
 		return nil
 	}
 
 	for pi := range wl.Spec.PodSets {
 		pod := &wl.Spec.PodSets[pi].Template.Spec
-		for ci := range pod.InitContainers {
-			res := &pod.InitContainers[ci].Resources
-			res.Limits = resource.MergeResourceListKeepFirst(res.Limits, containerLimits.Default)
-			res.Requests = resource.MergeResourceListKeepFirst(res.Requests, containerLimits.DefaultRequest)
+		if foundContainerLimits {
+			for ci := range pod.InitContainers {
+				res := &pod.InitContainers[ci].Resources
+				res.Limits = resource.MergeResourceListKeepFirst(res.Limits, containerLimits.Default)
+				res.Requests = resource.MergeResourceListKeepFirst(res.Requests, containerLimits.DefaultRequest)
+			}
+			for ci := range pod.Containers {
+				res := &pod.Containers[ci].Resources
+				res.Limits = resource.MergeResourceListKeepFirst(res.Limits, containerLimits.Default)
+				res.Requests = resource.MergeResourceListKeepFirst(res.Requests, containerLimits.DefaultRequest)
+			}
 		}
-		for ci := range pod.Containers {
-			res := &pod.Containers[ci].Resources
-			res.Limits = resource.MergeResourceListKeepFirst(res.Limits, containerLimits.Default)
-			res.Requests = resource.MergeResourceListKeepFirst(res.Requests, containerLimits.DefaultRequest)
+		// Pod-level resources (KEP-2837) are an optional pointer, only set when the
+		// PodLevelResources feature is enabled and used.
+		if pod.Resources != nil && foundPodLimits {
+			pod.Resources.Limits = resource.MergeResourceListKeepFirst(pod.Resources.Limits, podLimits.Default)
+			pod.Resources.Requests = resource.MergeResourceListKeepFirst(pod.Resources.Requests, podLimits.DefaultRequest)
 		}
 	}
 	return nil
@@ -112,6 +121,11 @@ func UseLimitsAsMissingRequestsInPod(pod *corev1.PodSpec) {
 	for ci := range pod.Containers {
 		res := &pod.Containers[ci].Resources
 		res.Requests = resource.MergeResourceListKeepFirst(res.Requests, res.Limits)
+	}
+	// Pod-level resources (KEP-2837) are an optional pointer, only set when the
+	// PodLevelResources feature is enabled and used.
+	if pod.Resources != nil {
+		pod.Resources.Requests = resource.MergeResourceListKeepFirst(pod.Resources.Requests, pod.Resources.Limits)
 	}
 }
 
@@ -154,6 +168,17 @@ func ValidateResources(wi *Info) field.ErrorList {
 				allErrors = append(
 					allErrors,
 					field.Invalid(podSpecPath.Child("containers").Index(i), resNames, RequestsMustNotExceedLimitMessage),
+				)
+			}
+		}
+
+		// Pod-level resources (KEP-2837) are an optional pointer, only set when the
+		// PodLevelResources feature is enabled and used.
+		if podResources := ps.Template.Spec.Resources; podResources != nil {
+			if resNames := resources.NewRequests(podResources.Requests).GreaterKeys(resources.NewRequests(podResources.Limits)); len(resNames) > 0 {
+				allErrors = append(
+					allErrors,
+					field.Invalid(podSpecPath.Child("resources"), resNames, RequestsMustNotExceedLimitMessage),
 				)
 			}
 		}

--- a/pkg/workload/resources_test.go
+++ b/pkg/workload/resources_test.go
@@ -293,6 +293,52 @@ func TestAdjustResources(t *testing.T) {
 				).
 				Obj(),
 		},
+		"Handle pod-level resources with pod limit range": {
+			limitranges: []corev1.LimitRange{
+				utiltesting.MakeLimitRange("foo", "").
+					WithType(corev1.LimitTypePod).
+					WithValue(
+						"Default", corev1.ResourceCPU, "4",
+					).
+					WithValue(
+						"Default", corev1.ResourceMemory, "1Gi",
+					).
+					WithValue(
+						"DefaultRequest", corev1.ResourceCPU, "3",
+					).
+					WithValue(
+						"DefaultRequest", corev1.ResourceMemory, "512Mi",
+					).
+					LimitRange,
+			},
+			wl: utiltestingapi.MakeWorkload("foo", "").
+				PodSets(
+					*utiltestingapi.MakePodSet("a", 1).
+						PodLevelLimit(corev1.ResourceMemory, "2Gi").
+						Obj(),
+					*utiltestingapi.MakePodSet("b", 1).
+						PodLevelLimit(corev1.ResourceCPU, "6").
+						PodLevelRequest(corev1.ResourceCPU, "1").
+						Obj(),
+				).
+				Obj(),
+			wantWl: utiltestingapi.MakeWorkload("foo", "").
+				PodSets(
+					*utiltestingapi.MakePodSet("a", 1).
+						PodLevelLimit(corev1.ResourceCPU, "4").
+						PodLevelLimit(corev1.ResourceMemory, "2Gi").
+						PodLevelRequest(corev1.ResourceCPU, "3").
+						PodLevelRequest(corev1.ResourceMemory, "512Mi").
+						Obj(),
+					*utiltestingapi.MakePodSet("b", 1).
+						PodLevelLimit(corev1.ResourceCPU, "6").
+						PodLevelLimit(corev1.ResourceMemory, "1Gi").
+						PodLevelRequest(corev1.ResourceCPU, "1").
+						PodLevelRequest(corev1.ResourceMemory, "512Mi").
+						Obj(),
+				).
+				Obj(),
+		},
 		"Handle empty container limit range": {
 			limitranges: []corev1.LimitRange{
 				utiltesting.MakeLimitRange("foo", "").
@@ -316,6 +362,37 @@ func TestAdjustResources(t *testing.T) {
 					*utiltestingapi.MakePodSet("b", 1).
 						Limit(corev1.ResourceCPU, "6").
 						Request(corev1.ResourceCPU, "1").
+						Obj(),
+				).
+				Obj(),
+		},
+		"Apply pod-level limits to requests": {
+			wl: utiltestingapi.MakeWorkload("foo", "").
+				PodSets(
+					*utiltestingapi.MakePodSet("a", 1).
+						PodLevelLimit(corev1.ResourceCPU, "1").
+						PodLevelLimit(corev1.ResourceMemory, "1Gi").
+						Obj(),
+					*utiltestingapi.MakePodSet("b", 1).
+						PodLevelRequest(corev1.ResourceCPU, "2").
+						PodLevelLimit(corev1.ResourceCPU, "3").
+						PodLevelLimit(corev1.ResourceMemory, "1Gi").
+						Obj(),
+				).
+				Obj(),
+			wantWl: utiltestingapi.MakeWorkload("foo", "").
+				PodSets(
+					*utiltestingapi.MakePodSet("a", 1).
+						PodLevelLimit(corev1.ResourceCPU, "1").
+						PodLevelLimit(corev1.ResourceMemory, "1Gi").
+						PodLevelRequest(corev1.ResourceCPU, "1").
+						PodLevelRequest(corev1.ResourceMemory, "1Gi").
+						Obj(),
+					*utiltestingapi.MakePodSet("b", 1).
+						PodLevelRequest(corev1.ResourceCPU, "2").
+						PodLevelLimit(corev1.ResourceCPU, "3").
+						PodLevelLimit(corev1.ResourceMemory, "1Gi").
+						PodLevelRequest(corev1.ResourceMemory, "1Gi").
 						Obj(),
 				).
 				Obj(),
@@ -478,7 +555,7 @@ func TestAdjustResources(t *testing.T) {
 			cl := utiltesting.NewClientBuilder().WithLists(
 				&nodev1.RuntimeClassList{Items: tc.runtimeClasses},
 				&corev1.LimitRangeList{Items: tc.limitranges},
-			).WithIndex(&corev1.LimitRange{}, indexer.LimitRangeHasContainerType, indexer.IndexLimitRangeHasContainerType).
+			).WithIndex(&corev1.LimitRange{}, indexer.LimitRangeHasContainerOrPodType, indexer.IndexLimitRangeHasContainerOrPodType).
 				Build()
 			ctx, _ := utiltesting.ContextWithLog(t)
 			AdjustResources(ctx, cl, tc.wl)
@@ -515,6 +592,32 @@ func TestValidateResources(t *testing.T) {
 									Obj()).
 							Obj(),
 					).Obj(),
+			},
+		},
+		"valid workload with pod-level resources": {
+			workloadInfo: &Info{
+				Obj: utiltestingapi.MakeWorkload("alpha", metav1.NamespaceDefault).
+					PodSets(
+						*utiltestingapi.MakePodSet("a", 1).
+							PodLevelRequest(corev1.ResourceCPU, "100m").
+							PodLevelLimit(corev1.ResourceCPU, "200m").
+							Obj(),
+					).Obj(),
+			},
+		},
+		"invalid workload; pod-level requests exceed limits": {
+			workloadInfo: &Info{
+				Obj: utiltestingapi.MakeWorkload("alpha", metav1.NamespaceDefault).
+					PodSets(
+						*utiltestingapi.MakePodSet("a", 1).
+							PodLevelRequest(corev1.ResourceCPU, "300m").
+							PodLevelLimit(corev1.ResourceCPU, "200m").
+							Obj(),
+					).Obj(),
+			},
+			wantError: field.ErrorList{
+				field.Invalid(PodSetsPath.Index(0).Child("template").Child("spec").Child("resources"),
+					[]corev1.ResourceName{corev1.ResourceCPU}, RequestsMustNotExceedLimitMessage),
 			},
 		},
 		"invalid workload; multiple PodSet has invalid initContainers and containers": {

--- a/site/content/en/docs/concepts/workload.md
+++ b/site/content/en/docs/concepts/workload.md
@@ -81,13 +81,17 @@ Kueue uses the `podSets` resources requests to calculate the quota used by a Wor
 
 Kueue calculates the total resources usage for a Workload as the sum of the resource requests for each `podSet`. The resource usage of a `podSet` is equal to the resource requests of the pod spec multiplied by the `count`.
 
+#### Pod-level resources
+
+When the [`PodLevelResources`](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pod-level-resources/) feature is enabled in the cluster (Kubernetes 1.32+), a pod may declare CPU and memory requests and limits at the pod level via `pod.spec.resources` instead of, or in addition to, the per-container requests. Kueue accounts for these pod-level requests when computing a Workload's quota usage, and the requests-value adjustment and validation described below apply to `pod.spec.resources` as well as to container resources.
+
 #### Requests values adjustment
 
 Depending on the cluster setup, Kueue will adjust the resource usage of a Workload based on:
 
 - The cluster defines default values in [Limit Ranges](https://kubernetes.io/docs/concepts/policy/limit-range/), the default values will be used if not provided in the `spec`.
 - The created pods are subject of a [Runtime Class Overhead](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-overhead/).
-- The spec defines only resource limits, case in which the limit values will be treated as requests.
+- The spec defines only resource limits, case in which the limit values will be treated as requests. This also applies to limits set at the pod level via `pod.spec.resources`.
 
 #### Requests values validation
 
@@ -160,7 +164,7 @@ the requeueState (`.status.requeueState`) will be reset to null.
 
 ## Replicate labels from Jobs into Workloads
 You can configure Kueue to copy labels, at Workload creation, into the new Workload from the underlying Job or Pod objects. This can be useful for Workload identification and debugging.
-You can specify which labels should be copied by setting the `labelKeysToCopy` field in the configuration API (under `integrations`). By default, Kueue does not copy any Job or Pod label into the Workload. 
+You can specify which labels should be copied by setting the `labelKeysToCopy` field in the configuration API (under `integrations`). By default, Kueue does not copy any Job or Pod label into the Workload.
 
 ## Maximum execution time
 
@@ -176,7 +180,7 @@ Once deactivated, the accumulated time spent as active in previous "Admit/Evict"
 
 If `maximumExecutionTimeSeconds` is not specified, the workload has no execution time limit.
 
-You can configure the `maximumExecutionTimeSeconds` of the Workload associated with any supported Kueue Job by specifying the desired value as `kueue.x-k8s.io/max-exec-time-seconds` label of the job. 
+You can configure the `maximumExecutionTimeSeconds` of the Workload associated with any supported Kueue Job by specifying the desired value as `kueue.x-k8s.io/max-exec-time-seconds` label of the job.
 
 ## Workload updates by Kueue
 
@@ -191,13 +195,13 @@ for instructions on configuring feature gates.
 {{% /alert %}}
 
 
-By default Workload status updates are performed by Kueue using the [Server-Side Apply (SSA)](https://kubernetes.io/docs/reference/using-api/server-side-apply/). 
+By default Workload status updates are performed by Kueue using the [Server-Side Apply (SSA)](https://kubernetes.io/docs/reference/using-api/server-side-apply/).
 
 However due to the limitations of SSA ([missing support for duplicated key/value pairs](https://github.com/kubernetes/kubernetes/issues/113482)) we also offer to enable updating the Workload status
-with Merge Patches, by enabling the `WorkloadRequestUseMergePatch` feature gate. 
+with Merge Patches, by enabling the `WorkloadRequestUseMergePatch` feature gate.
 
 In particular, this allows users of Kueue to handle the following two issues:
-- [Add option to disable strict pod spec validation](https://github.com/kubernetes-sigs/kueue/issues/3540) 
+- [Add option to disable strict pod spec validation](https://github.com/kubernetes-sigs/kueue/issues/3540)
 Switching from ServerSideApply to Merge Patch allows partial updates without requiring the entire resource specification.
 This can bypass the strict validation rules causing issues with duplicated environment variables, aligning Kueue's behavior more closely with plain Kubernetes
 - [MultiKueue: remove the limitation that the external dispatches need to use kueue-admission field manager ](https://github.com/kubernetes-sigs/kueue/issues/6185)

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -2258,6 +2258,185 @@ var _ = ginkgo.Describe("Scheduler", func() {
 		)
 	})
 
+	ginkgo.When("The workload's podSet pod-level resource requests are not valid", func() {
+		var (
+			cq    *kueue.ClusterQueue
+			queue *kueue.LocalQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			cq = utiltestingapi.MakeClusterQueue("cluster-queue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, cq)
+			queue = utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue(cq.Name).Obj()
+			util.MustCreate(ctx, k8sClient, queue)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		})
+
+		expectQuotaReservedConditionMessage := func(wl *kueue.Workload, wantedStatus string) {
+			ginkgo.GinkgoHelper()
+			gomega.Eventually(func(g gomega.Gomega) {
+				rwl := kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &rwl)).Should(gomega.Succeed())
+				cond := meta.FindStatusCondition(rwl.Status.Conditions, kueue.WorkloadQuotaReserved)
+				g.Expect(cond).ShouldNot(gomega.BeNil())
+				g.Expect(cond.Message).Should(gomega.ContainSubstring(wantedStatus))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		}
+
+		ginkgo.It("blocks workloads when pod-level requests exceed pod-level limits", func() {
+			wl := utiltestingapi.MakeWorkload("pod-request-over-limit", ns.Name).
+				Queue(kueue.LocalQueueName(queue.Name)).
+				PodSets(
+					*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+						Request(corev1.ResourceCPU, "1").
+						Limit(corev1.ResourceCPU, "2").
+						PodLevelRequest(corev1.ResourceCPU, "3").
+						PodLevelLimit(corev1.ResourceCPU, "2").
+						Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+			expectQuotaReservedConditionMessage(wl, "resources validation failed:")
+		})
+
+		ginkgo.It("blocks workloads when pod-level requests exceed the pod LimitRange max", func() {
+			lr := utiltesting.MakeLimitRange("pod-max-limit", ns.Name).
+				WithType(corev1.LimitTypePod).
+				WithValue("Max", corev1.ResourceCPU, "1").
+				Obj()
+			util.MustCreate(ctx, k8sClient, lr)
+
+			wl := utiltestingapi.MakeWorkload("pod-request-over-max", ns.Name).
+				Queue(kueue.LocalQueueName(queue.Name)).
+				PodSets(
+					*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+						Request(corev1.ResourceCPU, "500m").
+						Limit(corev1.ResourceCPU, "500m").
+						PodLevelRequest(corev1.ResourceCPU, "2").
+						PodLevelLimit(corev1.ResourceCPU, "3").
+						Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+			expectQuotaReservedConditionMessage(wl, "resources didn't satisfy LimitRange constraints:")
+		})
+
+		ginkgo.It("blocks workloads when pod-level requests are below the pod LimitRange min", func() {
+			lr := utiltesting.MakeLimitRange("pod-min-limit", ns.Name).
+				WithType(corev1.LimitTypePod).
+				WithValue("Min", corev1.ResourceCPU, "3").
+				Obj()
+			util.MustCreate(ctx, k8sClient, lr)
+
+			wl := utiltestingapi.MakeWorkload("pod-request-under-min", ns.Name).
+				Queue(kueue.LocalQueueName(queue.Name)).
+				PodSets(
+					*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+						Request(corev1.ResourceCPU, "500m").
+						Limit(corev1.ResourceCPU, "500m").
+						PodLevelRequest(corev1.ResourceCPU, "2").
+						PodLevelLimit(corev1.ResourceCPU, "3").
+						Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+			expectQuotaReservedConditionMessage(wl, "resources didn't satisfy LimitRange constraints:")
+		})
+
+		ginkgo.It("admits workloads when pod-level resources satisfy the pod LimitRange", func() {
+			lr := utiltesting.MakeLimitRange("pod-resource-range", ns.Name).
+				WithType(corev1.LimitTypePod).
+				WithValue("Min", corev1.ResourceCPU, "1").
+				WithValue("Max", corev1.ResourceCPU, "4").
+				Obj()
+			util.MustCreate(ctx, k8sClient, lr)
+			wl := utiltestingapi.MakeWorkload("valid-pod-resources", ns.Name).
+				Queue(kueue.LocalQueueName(queue.Name)).
+				PodSets(
+					*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+						Request(corev1.ResourceCPU, "500m").
+						Limit(corev1.ResourceCPU, "500m").
+						PodLevelRequest(corev1.ResourceCPU, "2").
+						PodLevelLimit(corev1.ResourceCPU, "3").
+						Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, wl)
+		})
+	})
+
+	ginkgo.When("Pod-level resources are counted against ClusterQueue quota", func() {
+		var (
+			cq    *kueue.ClusterQueue
+			queue *kueue.LocalQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			cq = utiltestingapi.MakeClusterQueue("cluster-queue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "3").Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, cq)
+			queue = utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue(cq.Name).Obj()
+			util.MustCreate(ctx, k8sClient, queue)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		})
+		// Each workload has container-level req=500m (both would fit in 3 CPU if the
+		// scheduler used container values) and pod-level req=2 CPU (only one fits in 3
+		// CPU). The test verifies the scheduler accounts for the pod-level value.
+		ginkgo.It("Should block a second workload when pod-level requests exhaust quota", func() {
+			ginkgo.By("creating the first workload with pod-level CPU request of 2")
+			wl1 := utiltestingapi.MakeWorkload("wl1", ns.Name).
+				Queue(kueue.LocalQueueName(queue.Name)).
+				PodSets(
+					*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+						Request(corev1.ResourceCPU, "500m").
+						Limit(corev1.ResourceCPU, "500m").
+						PodLevelRequest(corev1.ResourceCPU, "2").
+						PodLevelLimit(corev1.ResourceCPU, "2").
+						Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl1)
+
+			ginkgo.By("verifying the first workload is admitted")
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, wl1)
+
+			ginkgo.By("creating the second workload with the same pod-level CPU request")
+			wl2 := utiltestingapi.MakeWorkload("wl2", ns.Name).
+				Queue(kueue.LocalQueueName(queue.Name)).
+				PodSets(
+					*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+						Request(corev1.ResourceCPU, "500m").
+						Limit(corev1.ResourceCPU, "500m").
+						PodLevelRequest(corev1.ResourceCPU, "2").
+						PodLevelLimit(corev1.ResourceCPU, "2").
+						Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl2)
+
+			ginkgo.By("verifying the second workload is pending due to insufficient quota")
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
+			util.ExpectPendingWorkloadsMetric(cq, 0, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq, "", 1)
+		})
+	})
+
 	ginkgo.When("Using clusterQueue stop policy", func() {
 		var (
 			cq    *kueue.ClusterQueue

--- a/test/integration/singlecluster/scheduler/workload_controller_test.go
+++ b/test/integration/singlecluster/scheduler/workload_controller_test.go
@@ -453,6 +453,50 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 				gomega.Expect(wl.Spec.PodSets).Should(gomega.BeComparableTo(wlRead.Spec.PodSets))
 			})
 		})
+
+		ginkgo.It("The pod-level limits should be used as pod-level request values", func() {
+			ginkgo.By("Create workload with only a pod-level limit (no pod-level request) and then create the LocalQueue", func() {
+				wl = utiltestingapi.MakeWorkload("pod-level-limit", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							PodLevelLimit(corev1.ResourceCPU, "2").
+							Obj(),
+					).
+					Obj()
+				util.MustCreate(ctx, k8sClient, wl)
+				util.MustCreate(ctx, k8sClient, localQueue)
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					read := kueue.Workload{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).Should(gomega.Succeed())
+					g.Expect(workload.HasQuotaReservation(&read)).Should(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Check queue resource consumption reflects the pod-level limit used as request", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
+					g.Expect(updatedCQ.Status).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
+						PendingWorkloads:   0,
+						ReservingWorkloads: 1,
+						FlavorsReservation: []kueue.FlavorUsage{{
+							Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+							Resources: []kueue.ResourceUsage{{
+								Name:  corev1.ResourceCPU,
+								Total: resource.MustParse("2"),
+							}},
+						}},
+					}, ignoreCqCondition, ignoreInClusterQueueStatus))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Check podSets spec is not mutated by synthesized pod-level requests", func() {
+				wlRead := kueue.Workload{}
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &wlRead)).To(gomega.Succeed())
+				gomega.Expect(wlRead.Spec.PodSets).Should(gomega.BeComparableTo(wl.Spec.PodSets))
+			})
+		})
 	})
 
 	ginkgo.When("Resource transformations are applied", func() {
@@ -740,6 +784,64 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 							Resources: []kueue.ResourceUsage{{
 								Name:  corev1.ResourceCPU,
 								Total: resource.MustParse("5"),
+							}},
+						}},
+					}, ignoreCqCondition, ignoreInClusterQueueStatus))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("Should sync the pod-level resource requests with the pod-level limit", framework.SlowSpec, func() {
+			// Workloads carry only a pod-level limit (no explicit pod-level request).
+			// The pod-level limit differs from the container LimitRange default request,
+			// so the ClusterQueue reservation verifies which value was used.
+			ginkgo.By("Create and wait for the first workload admission", func() {
+				wl = utiltestingapi.MakeWorkload("pod-level-one", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							PodLevelLimit(corev1.ResourceCPU, "4").
+							Obj(),
+					).
+					Obj()
+				util.MustCreate(ctx, k8sClient, wl)
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					read := kueue.Workload{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).Should(gomega.Succeed())
+					g.Expect(workload.HasQuotaReservation(&read)).Should(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			var wl2 *kueue.Workload
+			ginkgo.By("Create a second workload with the same pod-level limit; it should stay pending", func() {
+				wl2 = utiltestingapi.MakeWorkload("pod-level-two", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							PodLevelLimit(corev1.ResourceCPU, "4").
+							Obj(),
+					).
+					Obj()
+				util.MustCreate(ctx, k8sClient, wl2)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
+				util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
+				util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
+			})
+
+			ginkgo.By("Check queue resource consumption reflects the pod-level limit used as request", func() {
+				// 4 CPU from the first workload's pod-level limit (synced to request);
+				// 1 CPU remaining, not enough for the second workload.
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
+					g.Expect(updatedCQ.Status).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
+						PendingWorkloads:   1,
+						ReservingWorkloads: 1,
+						FlavorsReservation: []kueue.FlavorUsage{{
+							Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+							Resources: []kueue.ResourceUsage{{
+								Name:  corev1.ResourceCPU,
+								Total: resource.MustParse("4"),
 							}},
 						}},
 					}, ignoreCqCondition, ignoreInClusterQueueStatus))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

/area website

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
This PR adds support for pod-level resources ([KEP-2837](https://kubernetes.io/docs/concepts/workloads/pods/#pod-level-resources), GA-track on Kubernetes 1.32+), where a pod declares CPU/memory requests and limits at the pod level via pod.spec.resources instead of, or in addition to, per-container requests. Previously Kueue only looked at container-level resources, so pod-level declarations were ignored in role hashing, request adjustment, and validation. This PR makes Kueue's workload resource handling pod-level-aware across all four of those paths:

Role hashing `pod.SpecShape` : pod-level requests now contribute to the pod-spec shape used to compute role hashes. They are only added to the shape when podSpec.Resources is non-nil, so role hashes for pods without pod-level resources stay stable across upgrades.
LimitRange defaulting `handlePodLimitRange` : LimitRange Default/DefaultRequest values are now also merged into pod.spec.resources, mirroring the existing container behavior.
Limits-as-missing-requests `UseLimitsAsMissingRequestsInPod`: when only pod-level limits are set, they are treated as the pod-level requests, consistent with how container limits are handled.
Validation `ValidateResources` : pod-level requests are validated not to exceed pod-level limits, producing the same requests must not exceed its limits error (scoped to spec.podSets[*].template.spec.resources) already emitted for containers.
All pod-level handling is guarded by an if pod.Resources != nil check, since the field is an optional pointer only populated when the cluster's PodLevelResources feature gate is enabled and used — so behavior is unchanged for clusters not using the feature.

Also adds PodLevelRequest/PodLevelLimit test wrappers, unit tests for the new paths, and documents pod-level resource accounting in the Workload concepts page.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#4233](https://github.com/kubernetes-sigs/kueue/issues/4233)

#### Special notes for your reviewer:
- Not sure if adding limits to `SpecShape()` or `ContainersShape` function would result in fragmentation of multiple PodSets, so did not add it in this PR. 
- Will add Integration tests in a follow up PR. 
- AI tools were used to assist in preparing this change.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Scheduling: Fixed resource accounting and validation for Pods using Kubernetes pod-level
resources (`pod.spec.resources`), including LimitRange defaulting and request/limit
validation.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes 1.32+ pod-level resources (`pod.spec.resources`) support for request/limit adjustment, validation, and quota accounting.
* **Bug Fixes**
  * Ensure stable role hashing when pod-level resources are omitted.
  * Apply LimitRange defaults for pod-type limits, adjust pod requests from pod limits, and validate pod-level requests vs pod-level limits.
* **Tests**
  * Expanded unit, integration, and end-to-end coverage for pod-level quota and gating behavior.
* **Documentation**
  * Updated workload docs with “Pod-level resources” guidance and validation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->