### PR TITLE
Fix image-pushing flake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,10 +245,12 @@ image-build:
 		./
 
 .PHONY: image-pushing-periodic
-image-pushing-periodic: debug-image-push importer-image-push ray-project-mini-image-build-push
+image-pushing-periodic:
+	$(MAKE) -j3 debug-image-push importer-image-push ray-project-mini-image-build-push
 
 .PHONY: image-pushing-postsubmit
-image-pushing-postsubmit: image-push helm-chart-push kueueviz-image-push kueue-populator-image-push kueue-priority-booster-image-push
+image-pushing-postsubmit:
+	$(MAKE) -j5 image-push helm-chart-push kueueviz-image-push kueue-populator-image-push kueue-priority-booster-image-push
 
 .PHONY: image-push
 image-push: PUSH=--push

--- a/cloudbuild-periodic.yaml
+++ b/cloudbuild-periodic.yaml
@@ -7,7 +7,6 @@ steps:
   - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260127-c1affcc8de'
     entrypoint: make
     args:
-      - -j3
       - image-pushing-periodic
     env:
       - DOCKER_BUILDX_CMD=/buildx-entrypoint

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,6 @@ steps:
   - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260127-c1affcc8de'
     entrypoint: make
     args:
-      - -j5
       - image-pushing-postsubmit
     env:
       - DOCKER_BUILDX_CMD=/buildx-entrypoint


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Fix image-pushing flake

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build system image-pushing targets to manage parallelism more efficiently via explicit Make recipes rather than prerequisite lists.
  * Removed redundant parallelism flags from Cloud Build configurations as parallelism control is now centralized in the build targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->