### PR TITLE
test: retry kind cluster creation on transient failures

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -550,7 +550,9 @@ function cluster_create {
 
     local log_file="$ARTIFACTS/$cluster-create.log"
     local create_cmd="$KIND create cluster --name \"$cluster\" --image \"$E2E_KIND_VERSION\" --config \"$kind_config\" --kubeconfig=\"$kubeconfig\" --wait 5m -v 5 > \"$log_file\" 2>&1"
-    local continue_if="grep -q 'port is already allocated' \"$log_file\""
+    # Retry only known-transient failures so real bugs still fail fast (#11586, #12307).
+    local retriable_errors="port is already allocated|error execution phase wait-control-plane"
+    local continue_if="grep -qE '${retriable_errors}' \"$log_file\""
     local cleanup_cmd="if [ -f \"$log_file\" ]; then mv \"$log_file\" \"${log_file}.failed-\$(date +%s)\"; fi; $KIND delete cluster --name \"$cluster\" 2>/dev/null || true"
 
     echo "Creating kind cluster '$cluster'..."


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake
/kind bug
/area testing

#### What this PR does / why we need it:

`cluster_create` already retries `kind create cluster`, but only for the `port is already allocated` case added in #11586.

In #12307, kind failed during kubeadm's `wait-control-plane` phase, so the existing allowlist did not match and `retry.sh` aborted after attempt 1/3.

This keeps the allowlist narrow and adds one known transient cluster start-up signature:

`error execution phase wait-control-plane`

The existing cleanup deletes the partial kind cluster before retrying.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Addresses the observed failure mode in #12307.

#### Special notes for your reviewer:
An alternative approach (flip to retry-by-default + a `non_retriable_errors` list, mirroring `e2e_docker_pull_if_needed`) is being discussed in #12307. Happy to switch this PR to that shape if reviewer prefers it.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test infrastructure to handle a broader range of transient errors during cluster setup, improving overall test reliability and reducing false failures in the CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->