### PR TITLE
Automated cherry pick of #12335: Fix image-pushing flake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,10 +237,12 @@ image-build:
 		./
 
 .PHONY: image-pushing-periodic
-image-pushing-periodic: debug-image-push importer-image-push ray-project-mini-image-build-push
+image-pushing-periodic:
+	$(MAKE) -j3 debug-image-push importer-image-push ray-project-mini-image-build-push
 
 .PHONY: image-pushing-postsubmit
-image-pushing-postsubmit: image-push helm-chart-push kueueviz-image-push kueue-populator-image-push kueue-priority-booster-image-push
+image-pushing-postsubmit:
+	$(MAKE) -j5 image-push helm-chart-push kueueviz-image-push kueue-populator-image-push kueue-priority-booster-image-push
 
 .PHONY: image-push
 image-push: PUSH=--push

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ image-pushing-periodic:
 
 .PHONY: image-pushing-postsubmit
 image-pushing-postsubmit:
-	$(MAKE) -j5 image-push helm-chart-push kueueviz-image-push kueue-populator-image-push kueue-priority-booster-image-push
+	$(MAKE) -j4 image-push helm-chart-push kueueviz-image-push kueue-populator-image-push
 
 .PHONY: image-push
 image-push: PUSH=--push

--- a/cloudbuild-periodic.yaml
+++ b/cloudbuild-periodic.yaml
@@ -7,7 +7,6 @@ steps:
   - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260127-c1affcc8de'
     entrypoint: make
     args:
-      - -j3
       - image-pushing-periodic
     env:
       - DOCKER_BUILDX_CMD=/buildx-entrypoint

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,6 @@ steps:
   - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260127-c1affcc8de'
     entrypoint: make
     args:
-      - -j5
       - image-pushing-postsubmit
     env:
       - DOCKER_BUILDX_CMD=/buildx-entrypoint


### PR DESCRIPTION
Cherry pick of #12335 on release-0.17.

#12335: Fix image-pushing flake

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug
/kind flake

Fixes #12345 


```release-note
NONE
```