### PR TITLE
TAS: Strip test finalizer to prevent cross-suite capacity leakage

### DIFF
--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -517,9 +517,14 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					g.Expect(workload.IsAdmitted(wl)).To(gomega.BeFalse())
 				}, util.ShortConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 			})
-			// note to future developer: this non-TAS pod doesn't delete properly after ns clean-up,
-			// so it will keep taking node1's capacity.
-			// need to debug this before writing future tests.
+
+			ginkgo.By("cleanup: remove finalizer to let the pod delete", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(nonTasPod), nonTasPod))).Should(gomega.Succeed())
+					nonTasPod.Finalizers = nil
+					g.Expect(client.IgnoreNotFound(k8sClient.Update(ctx, nonTasPod))).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
 		})
 	})
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area tas
/area testing

#### What this PR does / why we need it:
For #12256, we might want to run the TAS tests twice (with and without WAS integration) and to avoid code duplication, we would re-use the suite.

The suite heavily relies on `ginkgo.Ordered` and it has some rough edges which materialize when you run it the second time. This is one of them - the non TAS pod leaks into the other suite run.

We have other places in this suite where we add finalizers, but then we explicitly remove them:
https://github.com/kshalot/kueue/blob/e03d45371ab2cc55be9596086772e036c0f74375/test/integration/singlecluster/tas/tas_test.go#L1632-L1641
https://github.com/kshalot/kueue/blob/e03d45371ab2cc55be9596086772e036c0f74375/test/integration/singlecluster/tas/tas_test.go#L2457-L2461

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure to ensure proper cleanup and resource management in integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->