### PR TITLE
Add flavor assigner diagnostic reasons for NoFit results

### DIFF
--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -957,6 +957,34 @@ const (
 	// requirements that cannot be satisfied with the current cluster topology usage.
 	WorkloadQuotaReservedReasonTopologyPlacementFailed = "TopologyPlacementFailed"
 
+	// WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads indicates that the workload is waiting
+	// for preempted workloads to release their quota.
+	WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads = "WaitingForPreemptedWorkloads"
+
+	// WorkloadQuotaReservedReasonMisconfigured indicates that the workload is inadmissible due to
+	// misconfiguration, such as missing LocalQueue or ClusterQueue.
+	WorkloadQuotaReservedReasonMisconfigured = "Misconfigured"
+
+	// WorkloadQuotaReservedReasonSuspended indicates that the workload is inadmissible because
+	// the LocalQueue or ClusterQueue StopPolicy is active.
+	WorkloadQuotaReservedReasonSuspended = "Suspended"
+
+	// WorkloadQuotaReservedReasonPendingEvaluation indicates that the workload is pending evaluation in the scheduling queue.
+	WorkloadQuotaReservedReasonPendingEvaluation = "PendingEvaluation"
+
+	// WorkloadQuotaReservedReasonWaitingForPodsReady indicates that the workload is waiting
+	// for previously admitted workloads to reach PodsReady condition under waitForPodsReady configuration.
+	WorkloadQuotaReservedReasonWaitingForPodsReady = "WaitingForPodsReady"
+
+	// WorkloadAdmittedReasonNoReservation indicates that the workload has no reservation.
+	WorkloadAdmittedReasonNoReservation = "NoReservation"
+
+	// WorkloadAdmittedReasonUnsatisfiedAdmissionChecks indicates that the workload has not all checks ready.
+	WorkloadAdmittedReasonUnsatisfiedAdmissionChecks = "UnsatisfiedAdmissionChecks"
+
+	// WorkloadAdmittedReasonPendingDelayedTopologyRequests indicates that there are pending delayed topology requests.
+	WorkloadAdmittedReasonPendingDelayedTopologyRequests = "PendingDelayedTopologyRequests"
+
 	// WorkloadFinished means that the workload associated to the
 	// ResourceClaim finished running (failed or succeeded).
 	WorkloadFinished = "Finished"

--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -938,6 +938,25 @@ const (
 	// WorkloadQuotaReserved means that the Workload has reserved quota a ClusterQueue.
 	WorkloadQuotaReserved = "QuotaReserved"
 
+	// Reasons for the WorkloadQuotaReserved condition.
+
+	// WorkloadQuotaReservedReasonNoMatchingFlavor indicates that the workload cannot be scheduled
+	// because no resource flavor matches its nodeSelector or taints.
+	WorkloadQuotaReservedReasonNoMatchingFlavor = "NoMatchingFlavor"
+
+	// WorkloadQuotaReservedReasonWaitingForQuota indicates that the workload is waiting for
+	// sufficient unused quota to become available in the ClusterQueue/Cohort.
+	WorkloadQuotaReservedReasonWaitingForQuota = "WaitingForQuota"
+
+	// WorkloadQuotaReservedReasonExceedsMaxQuota indicates that the workload requests resources
+	// exceeding the maximum capacity limits of the ClusterQueue or Cohort.
+	// This also includes exceeding ClusterQueue nominal + borrowingLimit constraints.
+	WorkloadQuotaReservedReasonExceedsMaxQuota = "ExceedsMaxQuota"
+
+	// WorkloadQuotaReservedReasonTopologyPlacementFailed indicates that the workload has topology
+	// requirements that cannot be satisfied with the current cluster topology usage.
+	WorkloadQuotaReservedReasonTopologyPlacementFailed = "TopologyPlacementFailed"
+
 	// WorkloadFinished means that the workload associated to the
 	// ResourceClaim finished running (failed or succeeded).
 	WorkloadFinished = "Finished"

--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -957,34 +957,6 @@ const (
 	// requirements that cannot be satisfied with the current cluster topology usage.
 	WorkloadQuotaReservedReasonTopologyPlacementFailed = "TopologyPlacementFailed"
 
-	// WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads indicates that the workload is waiting
-	// for preempted workloads to release their quota.
-	WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads = "WaitingForPreemptedWorkloads"
-
-	// WorkloadQuotaReservedReasonMisconfigured indicates that the workload is inadmissible due to
-	// misconfiguration, such as missing LocalQueue or ClusterQueue.
-	WorkloadQuotaReservedReasonMisconfigured = "Misconfigured"
-
-	// WorkloadQuotaReservedReasonSuspended indicates that the workload is inadmissible because
-	// the LocalQueue or ClusterQueue StopPolicy is active.
-	WorkloadQuotaReservedReasonSuspended = "Suspended"
-
-	// WorkloadQuotaReservedReasonPendingEvaluation indicates that the workload is pending evaluation in the scheduling queue.
-	WorkloadQuotaReservedReasonPendingEvaluation = "PendingEvaluation"
-
-	// WorkloadQuotaReservedReasonWaitingForPodsReady indicates that the workload is waiting
-	// for previously admitted workloads to reach PodsReady condition under waitForPodsReady configuration.
-	WorkloadQuotaReservedReasonWaitingForPodsReady = "WaitingForPodsReady"
-
-	// WorkloadAdmittedReasonNoReservation indicates that the workload has no reservation.
-	WorkloadAdmittedReasonNoReservation = "NoReservation"
-
-	// WorkloadAdmittedReasonUnsatisfiedAdmissionChecks indicates that the workload has not all checks ready.
-	WorkloadAdmittedReasonUnsatisfiedAdmissionChecks = "UnsatisfiedAdmissionChecks"
-
-	// WorkloadAdmittedReasonPendingDelayedTopologyRequests indicates that there are pending delayed topology requests.
-	WorkloadAdmittedReasonPendingDelayedTopologyRequests = "PendingDelayedTopologyRequests"
-
 	// WorkloadFinished means that the workload associated to the
 	// ResourceClaim finished running (failed or succeeded).
 	WorkloadFinished = "Finished"

--- a/pkg/cache/scheduler/clusterqueue_snapshot.go
+++ b/pkg/cache/scheduler/clusterqueue_snapshot.go
@@ -216,7 +216,10 @@ func (c *ClusterQueueSnapshot) FindTopologyAssignmentsForWorkload(
 			flvOpts = append(slices.Clone(options), WithAggregatedDomainUsages(aggregatedDomainUsages))
 		}
 		flvResult := tasFlavorCache.FindTopologyAssignmentsForFlavor(flavorTASRequests, flvOpts...)
-		maps.Copy(result, flvResult)
+		for psName, res := range flvResult {
+			res.Flavor = tasFlavor
+			result[psName] = res
+		}
 	}
 	return result
 }

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -400,6 +400,9 @@ type FailureInfo struct {
 
 	// Reason indicates the reason why computing the TAS assignment failed.
 	Reason string
+
+	// Flavor indicates the resource flavor associated with the failure.
+	Flavor kueue.ResourceFlavorReference
 }
 
 type TASAssignmentsResult map[kueue.PodSetReference]tasPodSetAssignmentResult
@@ -407,7 +410,11 @@ type TASAssignmentsResult map[kueue.PodSetReference]tasPodSetAssignmentResult
 func (r TASAssignmentsResult) Failure() *FailureInfo {
 	for psName, psAssignment := range r {
 		if psAssignment.FailureReason != "" {
-			return &FailureInfo{PodSetName: psName, Reason: psAssignment.FailureReason}
+			return &FailureInfo{
+				PodSetName: psName,
+				Reason:     psAssignment.FailureReason,
+				Flavor:     psAssignment.Flavor,
+			}
 		}
 	}
 	return nil
@@ -416,6 +423,7 @@ func (r TASAssignmentsResult) Failure() *FailureInfo {
 type tasPodSetAssignmentResult struct {
 	TopologyAssignment *utiltas.TopologyAssignment
 	FailureReason      string
+	Flavor             kueue.ResourceFlavorReference
 }
 
 type FlavorTASRequests []TASPodSetRequests

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -445,13 +445,6 @@ const (
 	// UnadmittedWorkloadsObservability enables granular Prometheus metrics and
 	// updates status reasons for QuotaReserved/Admitted conditions to use tiered reasons.
 	UnadmittedWorkloadsObservability featuregate.Feature = "UnadmittedWorkloadsObservability"
-
-	// owner: @j-skiba
-	// kep: https://github.com/kubernetes-sigs/kueue/issues/10852
-	//
-	// UnadmittedWorkloadsExplicitStatus gates the immediate, proactive initialization of
-	// QuotaReserved and Admitted status conditions to False on a workload's first reconcile.
-	UnadmittedWorkloadsExplicitStatus featuregate.Feature = "UnadmittedWorkloadsExplicitStatus"
 )
 
 func init() {
@@ -696,9 +689,6 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
 	},
 	UnadmittedWorkloadsObservability: {
-		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Beta},
-	},
-	UnadmittedWorkloadsExplicitStatus: {
 		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Beta},
 	},
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -432,11 +432,26 @@ const (
 	// issue: https://github.com/kubernetes-sigs/kueue/issues/7539
 	// Enable reporting of Cohort related metrics (also including ClusterQueueInfo metric).
 	MetricsForCohorts featuregate.Feature = "MetricsForCohorts"
+
 	// owner: @tenzen-y
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-scheduling
 	// issue: https://github.com/kubernetes-sigs/kueue/issues/10659
 	// Enable accurately topology aware scheduling when multiple flavors cover the same Node.
 	TASHandleOverlappingFlavors featuregate.Feature = "TASHandleOverlappingFlavors"
+
+	// owner: @j-skiba
+	// kep: https://github.com/kubernetes-sigs/kueue/issues/10852
+	//
+	// UnadmittedWorkloadsObservability enables granular Prometheus metrics and
+	// updates status reasons for QuotaReserved/Admitted conditions to use tiered reasons.
+	UnadmittedWorkloadsObservability featuregate.Feature = "UnadmittedWorkloadsObservability"
+
+	// owner: @j-skiba
+	// kep: https://github.com/kubernetes-sigs/kueue/issues/10852
+	//
+	// UnadmittedWorkloadsExplicitStatus gates the immediate, proactive initialization of
+	// QuotaReserved and Admitted status conditions to False on a workload's first reconcile.
+	UnadmittedWorkloadsExplicitStatus featuregate.Feature = "UnadmittedWorkloadsExplicitStatus"
 )
 
 func init() {
@@ -679,6 +694,12 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	TASHandleOverlappingFlavors: {
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
+	},
+	UnadmittedWorkloadsObservability: {
+		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Beta},
+	},
+	UnadmittedWorkloadsExplicitStatus: {
+		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Beta},
 	},
 }
 

--- a/pkg/scheduler/flavorassigner/flavor_assigner_attempts.go
+++ b/pkg/scheduler/flavorassigner/flavor_assigner_attempts.go
@@ -26,6 +26,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/features"
 	preemptioncommon "sigs.k8s.io/kueue/pkg/scheduler/preemption/common"
 )
 
@@ -54,7 +55,9 @@ func (fa *FlavorAssignmentAttempts) AddNoFitFlavorAttempt(flavor kueue.ResourceF
 	}
 	if status != nil {
 		flavorAttempt.Reasons = append(flavorAttempt.Reasons, status.reasons...)
-		flavorAttempt.NoFitReason = status.NoFitReason
+		if features.Enabled(features.UnadmittedWorkloadsObservability) {
+			flavorAttempt.NoFitReason = status.NoFitReason
+		}
 	}
 	*fa = append(*fa, flavorAttempt)
 }
@@ -71,7 +74,9 @@ func (fa *FlavorAssignmentAttempts) AddRepresentativeModeFlavorAttempt(
 		Mode:                  flavorAssignmentMode,
 		PreemptionPossibility: preemptionMode.preemptionPossibility(),
 		Borrow:                maxBorrow,
-		NoFitReason:           noFitReason,
+	}
+	if features.Enabled(features.UnadmittedWorkloadsObservability) {
+		flavorAttempt.NoFitReason = noFitReason
 	}
 	if len(reasons) > 0 {
 		slices.Sort(reasons)
@@ -108,7 +113,9 @@ func mergeFlavorAttemptsForResource(
 				}
 				at.Reasons = mergeUnique(at.Reasons, []string{msg})
 				slices.Sort(at.Reasons)
-				at.NoFitReason = kueue.WorkloadQuotaReservedReasonNoMatchingFlavor
+				if features.Enabled(features.UnadmittedWorkloadsObservability) {
+					at.NoFitReason = kueue.WorkloadQuotaReservedReasonNoMatchingFlavor
+				}
 				dst[flv] = at
 			}
 		}
@@ -131,13 +138,17 @@ func mergeFlavorAttempts(dst map[kueue.ResourceFlavorReference]FlavorAssignmentA
 
 			reasons := mergeUnique(existing.Reasons, at.Reasons)
 			slices.Sort(reasons)
+			var noFitReason string
+			if features.Enabled(features.UnadmittedWorkloadsObservability) {
+				noFitReason = mostSevereReason(existing.NoFitReason, at.NoFitReason)
+			}
 			dst[at.Flavor] = FlavorAssignmentAttempt{
 				Flavor:                at.Flavor,
 				Mode:                  worst,
 				Borrow:                maxBorrow,
 				PreemptionPossibility: existingPreemption,
 				Reasons:               reasons,
-				NoFitReason:           worstReason(existing.NoFitReason, at.NoFitReason),
+				NoFitReason:           noFitReason,
 			}
 			continue
 		}

--- a/pkg/scheduler/flavorassigner/flavor_assigner_attempts.go
+++ b/pkg/scheduler/flavorassigner/flavor_assigner_attempts.go
@@ -37,6 +37,7 @@ type FlavorAssignmentAttempt struct {
 	Borrow                int
 	PreemptionPossibility *preemptioncommon.PreemptionPossibility
 	Reasons               []string
+	NoFitReason           string
 }
 
 type FlavorAssignmentAttempts []FlavorAssignmentAttempt
@@ -53,6 +54,7 @@ func (fa *FlavorAssignmentAttempts) AddNoFitFlavorAttempt(flavor kueue.ResourceF
 	}
 	if status != nil {
 		flavorAttempt.Reasons = append(flavorAttempt.Reasons, status.reasons...)
+		flavorAttempt.NoFitReason = status.NoFitReason
 	}
 	*fa = append(*fa, flavorAttempt)
 }
@@ -61,6 +63,7 @@ func (fa *FlavorAssignmentAttempts) AddRepresentativeModeFlavorAttempt(
 	flavor kueue.ResourceFlavorReference,
 	preemptionMode preemptionMode,
 	maxBorrow int, reasons []string,
+	noFitReason string,
 ) {
 	flavorAssignmentMode := preemptionMode.flavorAssignmentMode()
 	flavorAttempt := FlavorAssignmentAttempt{
@@ -68,6 +71,7 @@ func (fa *FlavorAssignmentAttempts) AddRepresentativeModeFlavorAttempt(
 		Mode:                  flavorAssignmentMode,
 		PreemptionPossibility: preemptionMode.preemptionPossibility(),
 		Borrow:                maxBorrow,
+		NoFitReason:           noFitReason,
 	}
 	if len(reasons) > 0 {
 		slices.Sort(reasons)
@@ -104,6 +108,7 @@ func mergeFlavorAttemptsForResource(
 				}
 				at.Reasons = mergeUnique(at.Reasons, []string{msg})
 				slices.Sort(at.Reasons)
+				at.NoFitReason = kueue.WorkloadQuotaReservedReasonNoMatchingFlavor
 				dst[flv] = at
 			}
 		}
@@ -132,6 +137,7 @@ func mergeFlavorAttempts(dst map[kueue.ResourceFlavorReference]FlavorAssignmentA
 				Borrow:                maxBorrow,
 				PreemptionPossibility: existingPreemption,
 				Reasons:               reasons,
+				NoFitReason:           worstReason(existing.NoFitReason, at.NoFitReason),
 			}
 			continue
 		}
@@ -142,6 +148,7 @@ func mergeFlavorAttempts(dst map[kueue.ResourceFlavorReference]FlavorAssignmentA
 			Borrow:                at.Borrow,
 			PreemptionPossibility: at.PreemptionPossibility,
 			Reasons:               mergeUnique(nil, at.Reasons),
+			NoFitReason:           at.NoFitReason,
 		}
 		slices.Sort(cp.Reasons)
 		dst[at.Flavor] = cp

--- a/pkg/scheduler/flavorassigner/flavor_assigner_attempts.go
+++ b/pkg/scheduler/flavorassigner/flavor_assigner_attempts.go
@@ -56,7 +56,7 @@ func (fa *FlavorAssignmentAttempts) AddNoFitFlavorAttempt(flavor kueue.ResourceF
 	if status != nil {
 		flavorAttempt.Reasons = append(flavorAttempt.Reasons, status.reasons...)
 		if features.Enabled(features.UnadmittedWorkloadsObservability) {
-			flavorAttempt.NoFitReason = status.NoFitReason
+			flavorAttempt.NoFitReason = status.noFitReason
 		}
 	}
 	*fa = append(*fa, flavorAttempt)

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -274,7 +274,7 @@ func reasonSeverity(reason string) int {
 type Status struct {
 	reasons     []string
 	err         error
-	NoFitReason string
+	noFitReason string
 }
 
 func NewStatus(reasons ...string) *Status {
@@ -958,7 +958,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 		}
 
 		if flavorStatus := a.checkFlavorForPodSets(log, fName, psIDs, podSets, selectors, resourceGroup); !flavorStatus.IsFit() {
-			flavorStatus.NoFitReason = kueue.WorkloadQuotaReservedReasonNoMatchingFlavor
+			flavorStatus.noFitReason = kueue.WorkloadQuotaReservedReasonNoMatchingFlavor
 			status.reasons = append(status.reasons, flavorStatus.reasons...)
 			consideredFlavors.AddNoFitFlavorAttempt(fName, flavorStatus)
 			if flavorStatus.err != nil {
@@ -1005,7 +1005,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 			if s != nil {
 				flavorQuotaReasons = append(flavorQuotaReasons, s.reasons...)
 				status.reasons = append(status.reasons, s.reasons...)
-				flavorNoFitReason = mostSevereReason(flavorNoFitReason, s.NoFitReason)
+				flavorNoFitReason = mostSevereReason(flavorNoFitReason, s.noFitReason)
 			}
 			maxBorrow = max(maxBorrow, borrow)
 			mode := granularMode{preemptionMode, borrowingLevel(borrow)}
@@ -1188,7 +1188,7 @@ func (a *FlavorAssigner) fitsResourceQuota(
 	rQuota schdcache.ResourceQuota,
 ) (preemptionMode, int, *Status) {
 	status := Status{
-		NoFitReason: kueue.WorkloadQuotaReservedReasonWaitingForQuota,
+		noFitReason: kueue.WorkloadQuotaReservedReasonWaitingForQuota,
 	}
 
 	available := a.cq.Available(fr)
@@ -1206,7 +1206,7 @@ func (a *FlavorAssigner) fitsResourceQuota(
 			resources.ResourceQuantityString(fr.Resource, requestUsage),
 			resources.AmountQuantityString(fr.Resource, maxCapacity),
 		)
-		status.NoFitReason = kueue.WorkloadQuotaReservedReasonExceedsMaxQuota
+		status.noFitReason = kueue.WorkloadQuotaReservedReasonExceedsMaxQuota
 		return noFit, 0, &status
 	}
 
@@ -1224,7 +1224,7 @@ func (a *FlavorAssigner) fitsResourceQuota(
 		preemptionPossiblity, borrowAfterPreemptions := a.oracle.SimulatePreemption(log, a.cq, *a.wl, fr, val)
 		mode := fromPreemptionPossibility(preemptionPossiblity)
 		if mode != noFit {
-			status.NoFitReason = ""
+			status.noFitReason = ""
 		}
 		return mode, borrowAfterPreemptions, &status
 	}

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -359,9 +359,10 @@ func (psa *PodSetAssignment) reason(reason string) {
 	psa.Status.reasons = append(psa.Status.reasons, reason)
 }
 
-func (psa *PodSetAssignment) markFlavorAttemptReason(flavor kueue.ResourceFlavorReference, reason string) {
+func (psa *PodSetAssignment) markFlavorAttempt(flavor kueue.ResourceFlavorReference, mode FlavorAssignmentMode, reason string) {
 	for i := range psa.FlavorAssignmentAttempts {
 		if psa.FlavorAssignmentAttempts[i].Flavor == flavor {
+			psa.FlavorAssignmentAttempts[i].Mode = mode
 			psa.FlavorAssignmentAttempts[i].NoFitReason = reason
 			break
 		}
@@ -794,7 +795,7 @@ func (a *FlavorAssigner) assignFlavors(log logr.Logger, counts []int32) Assignme
 				// all workloads are preempted.
 				psAssignment := assignment.podSetAssignmentByName(failure.PodSetName)
 				if features.Enabled(features.UnadmittedWorkloadsObservability) {
-					psAssignment.markFlavorAttemptReason(failure.Flavor, kueue.WorkloadQuotaReservedReasonTopologyPlacementFailed)
+					psAssignment.markFlavorAttempt(failure.Flavor, NoFit, kueue.WorkloadQuotaReservedReasonTopologyPlacementFailed)
 				}
 				// update the mode for all flavors and the representative mode
 				assignment.updateMode(failure.PodSetName, NoFit)
@@ -820,6 +821,9 @@ func (a *Assignment) resolveNoFitReason(cq *schdcache.ClusterQueueSnapshot) {
 	var overallReason string
 
 	for _, ps := range a.PodSets {
+		if ps.RepresentativeMode() != NoFit {
+			continue
+		}
 		if len(ps.FlavorAssignmentAttempts) == 0 {
 			overallReason = mostSevereReason(overallReason, kueue.WorkloadQuotaReservedReasonNoMatchingFlavor)
 			continue
@@ -829,6 +833,9 @@ func (a *Assignment) resolveNoFitReason(cq *schdcache.ClusterQueueSnapshot) {
 		rgMinReason := make(map[int]string)
 
 		for i, att := range ps.FlavorAssignmentAttempts {
+			if att.Mode != NoFit {
+				continue
+			}
 			r := att.NoFitReason
 			rgIndices := findRGIndicesByFlavor(cq, att.Flavor)
 			if len(rgIndices) == 0 {
@@ -1216,6 +1223,9 @@ func (a *FlavorAssigner) fitsResourceQuota(
 	if rQuota.Nominal.Cmp(val) >= 0 || mayReclaimInHierarchy || a.canPreemptWhileBorrowing() {
 		preemptionPossiblity, borrowAfterPreemptions := a.oracle.SimulatePreemption(log, a.cq, *a.wl, fr, val)
 		mode := fromPreemptionPossibility(preemptionPossiblity)
+		if mode != noFit {
+			status.NoFitReason = ""
+		}
 		return mode, borrowAfterPreemptions, &status
 	}
 	return noFit, borrow, &status

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -249,7 +249,7 @@ func IgnoreUndeclaredResources(quotaCheckStrategy configapi.QuotaCheckStrategy) 
 	return features.Enabled(features.QuotaCheckStrategy) && quotaCheckStrategy == configapi.QuotaCheckIgnoreUndeclared
 }
 
-func worstReason(a, b string) string {
+func mostSevereReason(a, b string) string {
 	if reasonSeverity(a) >= reasonSeverity(b) {
 		return a
 	}
@@ -275,20 +275,6 @@ type Status struct {
 	reasons     []string
 	err         error
 	NoFitReason string
-}
-
-func (s *Status) MarkNoMatchingFlavor() *Status {
-	if s != nil {
-		s.NoFitReason = kueue.WorkloadQuotaReservedReasonNoMatchingFlavor
-	}
-	return s
-}
-
-func (s *Status) MarkExceedsMaxQuota() *Status {
-	if s != nil {
-		s.NoFitReason = kueue.WorkloadQuotaReservedReasonExceedsMaxQuota
-	}
-	return s
 }
 
 func NewStatus(reasons ...string) *Status {
@@ -772,12 +758,16 @@ func (a *FlavorAssigner) assignFlavors(log logr.Logger, counts []int32) Assignme
 			}
 		}
 		if atLeastOnePodsAssignmentFailed {
-			assignment.resolveNoFitReason(a.cq)
+			if features.Enabled(features.UnadmittedWorkloadsObservability) {
+				assignment.resolveNoFitReason(a.cq)
+			}
 			return assignment
 		}
 	}
 	if assignment.RepresentativeMode() == NoFit {
-		assignment.resolveNoFitReason(a.cq)
+		if features.Enabled(features.UnadmittedWorkloadsObservability) {
+			assignment.resolveNoFitReason(a.cq)
+		}
 		return assignment
 	}
 
@@ -803,7 +793,9 @@ func (a *FlavorAssigner) assignFlavors(log logr.Logger, counts []int32) Assignme
 				// There is at least one PodSet which does not fit even if
 				// all workloads are preempted.
 				psAssignment := assignment.podSetAssignmentByName(failure.PodSetName)
-				psAssignment.markFlavorAttemptReason(failure.Flavor, kueue.WorkloadQuotaReservedReasonTopologyPlacementFailed)
+				if features.Enabled(features.UnadmittedWorkloadsObservability) {
+					psAssignment.markFlavorAttemptReason(failure.Flavor, kueue.WorkloadQuotaReservedReasonTopologyPlacementFailed)
+				}
 				// update the mode for all flavors and the representative mode
 				assignment.updateMode(failure.PodSetName, NoFit)
 			} else {
@@ -814,7 +806,9 @@ func (a *FlavorAssigner) assignFlavors(log logr.Logger, counts []int32) Assignme
 			}
 		}
 	}
-	assignment.resolveNoFitReason(a.cq)
+	if features.Enabled(features.UnadmittedWorkloadsObservability) {
+		assignment.resolveNoFitReason(a.cq)
+	}
 	return assignment
 }
 
@@ -827,7 +821,7 @@ func (a *Assignment) resolveNoFitReason(cq *schdcache.ClusterQueueSnapshot) {
 
 	for _, ps := range a.PodSets {
 		if len(ps.FlavorAssignmentAttempts) == 0 {
-			overallReason = worstReason(overallReason, kueue.WorkloadQuotaReservedReasonNoMatchingFlavor)
+			overallReason = mostSevereReason(overallReason, kueue.WorkloadQuotaReservedReasonNoMatchingFlavor)
 			continue
 		}
 
@@ -836,33 +830,39 @@ func (a *Assignment) resolveNoFitReason(cq *schdcache.ClusterQueueSnapshot) {
 
 		for i, att := range ps.FlavorAssignmentAttempts {
 			r := att.NoFitReason
-			rgIdx := findRGIndexByFlavor(cq, att.Flavor)
-			if rgIdx == -1 {
+			rgIndices := findRGIndicesByFlavor(cq, att.Flavor)
+			if len(rgIndices) == 0 {
 				// Special case: flavor not found in any group (e.g. deleted).
 				// Treat it as a unique independent group using a negative index.
-				rgIdx = -1 - i
+				rgIndices = []int{-1 - i}
 			}
 
-			if existing, ok := rgMinReason[rgIdx]; !ok || reasonSeverity(r) < reasonSeverity(existing) {
-				rgMinReason[rgIdx] = r
+			for _, rgIdx := range rgIndices {
+				if existing, ok := rgMinReason[rgIdx]; !ok || reasonSeverity(r) < reasonSeverity(existing) {
+					rgMinReason[rgIdx] = r
+				}
 			}
 		}
 
 		// Across groups, we take the maximum severity (co-requisites).
 		var podSetReason string
 		for _, reason := range rgMinReason {
-			podSetReason = worstReason(podSetReason, reason)
+			podSetReason = mostSevereReason(podSetReason, reason)
 		}
 
-		overallReason = worstReason(overallReason, podSetReason)
+		overallReason = mostSevereReason(overallReason, podSetReason)
 	}
 	a.NoFitReason = overallReason
 }
 
-func findRGIndexByFlavor(cq *schdcache.ClusterQueueSnapshot, flavor kueue.ResourceFlavorReference) int {
-	return slices.IndexFunc(cq.ResourceGroups, func(rg schdcache.ResourceGroup) bool {
-		return slices.Contains(rg.Flavors, flavor)
-	})
+func findRGIndicesByFlavor(cq *schdcache.ClusterQueueSnapshot, flavor kueue.ResourceFlavorReference) []int {
+	var indices []int
+	for i, rg := range cq.ResourceGroups {
+		if slices.Contains(rg.Flavors, flavor) {
+			indices = append(indices, i)
+		}
+	}
+	return indices
 }
 
 func (a *Assignment) append(requests resources.Requests, psAssignment *PodSetAssignment) {
@@ -951,7 +951,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 		}
 
 		if flavorStatus := a.checkFlavorForPodSets(log, fName, psIDs, podSets, selectors, resourceGroup); !flavorStatus.IsFit() {
-			flavorStatus.MarkNoMatchingFlavor()
+			flavorStatus.NoFitReason = kueue.WorkloadQuotaReservedReasonNoMatchingFlavor
 			status.reasons = append(status.reasons, flavorStatus.reasons...)
 			consideredFlavors.AddNoFitFlavorAttempt(fName, flavorStatus)
 			if flavorStatus.err != nil {
@@ -981,7 +981,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 						msg := fmt.Sprintf("could not assign %s flavor since the original workload is assigned: %s", fName, originalFlavor)
 						status.reasons = append(status.reasons, msg)
 						flavorQuotaReasons = append(flavorQuotaReasons, msg)
-						flavorNoFitReason = worstReason(flavorNoFitReason, kueue.WorkloadQuotaReservedReasonNoMatchingFlavor)
+						flavorNoFitReason = mostSevereReason(flavorNoFitReason, kueue.WorkloadQuotaReservedReasonNoMatchingFlavor)
 						break
 					}
 
@@ -998,7 +998,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 			if s != nil {
 				flavorQuotaReasons = append(flavorQuotaReasons, s.reasons...)
 				status.reasons = append(status.reasons, s.reasons...)
-				flavorNoFitReason = worstReason(flavorNoFitReason, s.NoFitReason)
+				flavorNoFitReason = mostSevereReason(flavorNoFitReason, s.NoFitReason)
 			}
 			maxBorrow = max(maxBorrow, borrow)
 			mode := granularMode{preemptionMode, borrowingLevel(borrow)}
@@ -1199,7 +1199,7 @@ func (a *FlavorAssigner) fitsResourceQuota(
 			resources.ResourceQuantityString(fr.Resource, requestUsage),
 			resources.AmountQuantityString(fr.Resource, maxCapacity),
 		)
-		status.MarkExceedsMaxQuota()
+		status.NoFitReason = kueue.WorkloadQuotaReservedReasonExceedsMaxQuota
 		return noFit, 0, &status
 	}
 

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -76,6 +76,9 @@ type Assignment struct {
 
 	// quotaCheckStrategy is the strategy to use for quota check.
 	quotaCheckStrategy configapi.QuotaCheckStrategy
+
+	// NoFitReason contains the reason why the overall assignment failed with NoFit.
+	NoFitReason string
 }
 
 // UpdateForTASResult updates the Assignment with the TAS result
@@ -246,9 +249,46 @@ func IgnoreUndeclaredResources(quotaCheckStrategy configapi.QuotaCheckStrategy) 
 	return features.Enabled(features.QuotaCheckStrategy) && quotaCheckStrategy == configapi.QuotaCheckIgnoreUndeclared
 }
 
+func worstReason(a, b string) string {
+	if reasonSeverity(a) >= reasonSeverity(b) {
+		return a
+	}
+	return b
+}
+
+func reasonSeverity(reason string) int {
+	switch reason {
+	case kueue.WorkloadQuotaReservedReasonNoMatchingFlavor:
+		return 4
+	case kueue.WorkloadQuotaReservedReasonExceedsMaxQuota:
+		return 3
+	case kueue.WorkloadQuotaReservedReasonWaitingForQuota:
+		return 2
+	case kueue.WorkloadQuotaReservedReasonTopologyPlacementFailed:
+		return 1
+	default:
+		return 0
+	}
+}
+
 type Status struct {
-	reasons []string
-	err     error
+	reasons     []string
+	err         error
+	NoFitReason string
+}
+
+func (s *Status) MarkNoMatchingFlavor() *Status {
+	if s != nil {
+		s.NoFitReason = kueue.WorkloadQuotaReservedReasonNoMatchingFlavor
+	}
+	return s
+}
+
+func (s *Status) MarkExceedsMaxQuota() *Status {
+	if s != nil {
+		s.NoFitReason = kueue.WorkloadQuotaReservedReasonExceedsMaxQuota
+	}
+	return s
 }
 
 func NewStatus(reasons ...string) *Status {
@@ -331,6 +371,15 @@ func (psa *PodSetAssignment) updateMode(newMode FlavorAssignmentMode) {
 
 func (psa *PodSetAssignment) reason(reason string) {
 	psa.Status.reasons = append(psa.Status.reasons, reason)
+}
+
+func (psa *PodSetAssignment) markFlavorAttemptReason(flavor kueue.ResourceFlavorReference, reason string) {
+	for i := range psa.FlavorAssignmentAttempts {
+		if psa.FlavorAssignmentAttempts[i].Flavor == flavor {
+			psa.FlavorAssignmentAttempts[i].NoFitReason = reason
+			break
+		}
+	}
 }
 
 func (psa *PodSetAssignment) error(err error) {
@@ -723,10 +772,12 @@ func (a *FlavorAssigner) assignFlavors(log logr.Logger, counts []int32) Assignme
 			}
 		}
 		if atLeastOnePodsAssignmentFailed {
+			assignment.resolveNoFitReason(a.cq)
 			return assignment
 		}
 	}
 	if assignment.RepresentativeMode() == NoFit {
+		assignment.resolveNoFitReason(a.cq)
 		return assignment
 	}
 
@@ -751,6 +802,8 @@ func (a *FlavorAssigner) assignFlavors(log logr.Logger, counts []int32) Assignme
 			if failure := result.Failure(); failure != nil {
 				// There is at least one PodSet which does not fit even if
 				// all workloads are preempted.
+				psAssignment := assignment.podSetAssignmentByName(failure.PodSetName)
+				psAssignment.markFlavorAttemptReason(failure.Flavor, kueue.WorkloadQuotaReservedReasonTopologyPlacementFailed)
 				// update the mode for all flavors and the representative mode
 				assignment.updateMode(failure.PodSetName, NoFit)
 			} else {
@@ -761,7 +814,55 @@ func (a *FlavorAssigner) assignFlavors(log logr.Logger, counts []int32) Assignme
 			}
 		}
 	}
+	assignment.resolveNoFitReason(a.cq)
 	return assignment
+}
+
+func (a *Assignment) resolveNoFitReason(cq *schdcache.ClusterQueueSnapshot) {
+	if a.RepresentativeMode() != NoFit {
+		return
+	}
+
+	var overallReason string
+
+	for _, ps := range a.PodSets {
+		if len(ps.FlavorAssignmentAttempts) == 0 {
+			overallReason = worstReason(overallReason, kueue.WorkloadQuotaReservedReasonNoMatchingFlavor)
+			continue
+		}
+
+		// Map from resource group index to the minimum severity blocker (alternative flavors) for that group.
+		rgMinReason := make(map[int]string)
+
+		for i, att := range ps.FlavorAssignmentAttempts {
+			r := att.NoFitReason
+			rgIdx := findRGIndexByFlavor(cq, att.Flavor)
+			if rgIdx == -1 {
+				// Special case: flavor not found in any group (e.g. deleted).
+				// Treat it as a unique independent group using a negative index.
+				rgIdx = -1 - i
+			}
+
+			if existing, ok := rgMinReason[rgIdx]; !ok || reasonSeverity(r) < reasonSeverity(existing) {
+				rgMinReason[rgIdx] = r
+			}
+		}
+
+		// Across groups, we take the maximum severity (co-requisites).
+		var podSetReason string
+		for _, reason := range rgMinReason {
+			podSetReason = worstReason(podSetReason, reason)
+		}
+
+		overallReason = worstReason(overallReason, podSetReason)
+	}
+	a.NoFitReason = overallReason
+}
+
+func findRGIndexByFlavor(cq *schdcache.ClusterQueueSnapshot, flavor kueue.ResourceFlavorReference) int {
+	return slices.IndexFunc(cq.ResourceGroups, func(rg schdcache.ResourceGroup) bool {
+		return slices.Contains(rg.Flavors, flavor)
+	})
 }
 
 func (a *Assignment) append(requests resources.Requests, psAssignment *PodSetAssignment) {
@@ -850,6 +951,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 		}
 
 		if flavorStatus := a.checkFlavorForPodSets(log, fName, psIDs, podSets, selectors, resourceGroup); !flavorStatus.IsFit() {
+			flavorStatus.MarkNoMatchingFlavor()
 			status.reasons = append(status.reasons, flavorStatus.reasons...)
 			consideredFlavors.AddNoFitFlavorAttempt(fName, flavorStatus)
 			if flavorStatus.err != nil {
@@ -864,6 +966,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 		representativeMode := bestGranularMode()
 		maxBorrow := 0
 		var flavorQuotaReasons []string
+		var flavorNoFitReason string
 
 		for rName, val := range requests {
 			// Ensure the same resource flavor is used for the workload slice as in the original admitted slice.
@@ -878,6 +981,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 						msg := fmt.Sprintf("could not assign %s flavor since the original workload is assigned: %s", fName, originalFlavor)
 						status.reasons = append(status.reasons, msg)
 						flavorQuotaReasons = append(flavorQuotaReasons, msg)
+						flavorNoFitReason = worstReason(flavorNoFitReason, kueue.WorkloadQuotaReservedReasonNoMatchingFlavor)
 						break
 					}
 
@@ -894,6 +998,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 			if s != nil {
 				flavorQuotaReasons = append(flavorQuotaReasons, s.reasons...)
 				status.reasons = append(status.reasons, s.reasons...)
+				flavorNoFitReason = worstReason(flavorNoFitReason, s.NoFitReason)
 			}
 			maxBorrow = max(maxBorrow, borrow)
 			mode := granularMode{preemptionMode, borrowingLevel(borrow)}
@@ -912,7 +1017,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 			}
 		}
 
-		consideredFlavors.AddRepresentativeModeFlavorAttempt(fName, representativeMode.preemptionMode, maxBorrow, flavorQuotaReasons)
+		consideredFlavors.AddRepresentativeModeFlavorAttempt(fName, representativeMode.preemptionMode, maxBorrow, flavorQuotaReasons, flavorNoFitReason)
 
 		if features.Enabled(features.FlavorFungibility) {
 			if !shouldTryNextFlavor(representativeMode, a.cq.FlavorFungibility) {
@@ -1075,7 +1180,9 @@ func (a *FlavorAssigner) fitsResourceQuota(
 	requestUsage int64,
 	rQuota schdcache.ResourceQuota,
 ) (preemptionMode, int, *Status) {
-	var status Status
+	status := Status{
+		NoFitReason: kueue.WorkloadQuotaReservedReasonWaitingForQuota,
+	}
 
 	available := a.cq.Available(fr)
 	maxCapacity := a.cq.PotentialAvailable(fr)
@@ -1092,6 +1199,7 @@ func (a *FlavorAssigner) fitsResourceQuota(
 			resources.ResourceQuantityString(fr.Resource, requestUsage),
 			resources.AmountQuantityString(fr.Resource, maxCapacity),
 		)
+		status.MarkExceedsMaxQuota()
 		return noFit, 0, &status
 	}
 

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -256,18 +256,26 @@ func mostSevereReason(a, b string) string {
 	return b
 }
 
+const (
+	reasonSeverityNone int = iota
+	reasonSeverityTopologyPlacementFailed
+	reasonSeverityWaitingForQuota
+	reasonSeverityExceedsMaxQuota
+	reasonSeverityNoMatchingFlavor
+)
+
 func reasonSeverity(reason string) int {
 	switch reason {
 	case kueue.WorkloadQuotaReservedReasonNoMatchingFlavor:
-		return 4
+		return reasonSeverityNoMatchingFlavor
 	case kueue.WorkloadQuotaReservedReasonExceedsMaxQuota:
-		return 3
+		return reasonSeverityExceedsMaxQuota
 	case kueue.WorkloadQuotaReservedReasonWaitingForQuota:
-		return 2
+		return reasonSeverityWaitingForQuota
 	case kueue.WorkloadQuotaReservedReasonTopologyPlacementFailed:
-		return 1
+		return reasonSeverityTopologyPlacementFailed
 	default:
-		return 0
+		return reasonSeverityNone
 	}
 }
 

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -3502,9 +3502,9 @@ func TestAssignFlavors(t *testing.T) {
 		},
 	}
 	for name, tc := range cases {
-		for _, enabled := range []bool{false, true} {
-			t.Run(fmt.Sprintf("%s/gate_%t", name, enabled), func(t *testing.T) {
-				features.SetFeatureGateDuringTest(t, features.UnadmittedWorkloadsObservability, enabled)
+		for _, unadmittedWorkloadsObservabilityEnabled := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/gate_%t", name, unadmittedWorkloadsObservabilityEnabled), func(t *testing.T) {
+				features.SetFeatureGateDuringTest(t, features.UnadmittedWorkloadsObservability, unadmittedWorkloadsObservabilityEnabled)
 				ctx, log := utiltesting.ContextWithLog(t)
 				for fg, val := range tc.featureGates {
 					features.SetFeatureGateDuringTest(t, fg, val)
@@ -3576,7 +3576,7 @@ func TestAssignFlavors(t *testing.T) {
 				}
 
 				var cmpOpts []cmp.Option
-				if !enabled {
+				if !unadmittedWorkloadsObservabilityEnabled {
 					cmpOpts = append(cmpOpts, cmpopts.IgnoreFields(Assignment{}, "NoFitReason"))
 					cmpOpts = append(cmpOpts, cmpopts.IgnoreFields(FlavorAssignmentAttempt{}, "NoFitReason"))
 				}

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -358,6 +358,7 @@ func TestAssignFlavors(t *testing.T) {
 							Mode:                  Preempt,
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor default, 1 more needed"},
+							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -406,16 +407,18 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    NoFit,
-							Reasons: []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (3) > maximum capacity (2)"},
+							Flavor:      "one",
+							Mode:        NoFit,
+							Reasons:     []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (3) > maximum capacity (2)"},
+							NoFitReason: "ExceedsMaxQuota",
 						},
 						{Flavor: "two", Mode: Fit},
 						{Flavor: "b_one", Mode: Fit},
 						{
-							Flavor:  "b_two",
-							Mode:    NoFit,
-							Reasons: []string{"flavor b_two does not provide resource memory"},
+							Flavor:      "b_two",
+							Mode:        NoFit,
+							Reasons:     []string{"flavor b_two does not provide resource memory"},
+							NoFitReason: "NoMatchingFlavor",
 						},
 					},
 					Count: 1,
@@ -460,9 +463,10 @@ func TestAssignFlavors(t *testing.T) {
 						},
 						FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 							{
-								Flavor:  "one",
-								Mode:    NoFit,
-								Reasons: []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (9) > maximum capacity (4)"},
+								Flavor:      "one",
+								Mode:        NoFit,
+								Reasons:     []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (9) > maximum capacity (4)"},
+								NoFitReason: "ExceedsMaxQuota",
 							},
 							{Flavor: "two", Mode: Fit},
 						},
@@ -478,9 +482,10 @@ func TestAssignFlavors(t *testing.T) {
 						},
 						FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 							{
-								Flavor:  "one",
-								Mode:    NoFit,
-								Reasons: []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (9) > maximum capacity (4)"},
+								Flavor:      "one",
+								Mode:        NoFit,
+								Reasons:     []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (9) > maximum capacity (4)"},
+								NoFitReason: "ExceedsMaxQuota",
 							},
 							{Flavor: "two", Mode: Fit},
 						},
@@ -611,9 +616,10 @@ func TestAssignFlavors(t *testing.T) {
 						),
 						FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 							{
-								Flavor:  "one",
-								Mode:    NoFit,
-								Reasons: []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (5) > maximum capacity (4)"},
+								Flavor:      "one",
+								Mode:        NoFit,
+								Reasons:     []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (5) > maximum capacity (4)"},
+								NoFitReason: "ExceedsMaxQuota",
 							},
 							{
 								Flavor: "two",
@@ -621,6 +627,7 @@ func TestAssignFlavors(t *testing.T) {
 								Reasons: []string{
 									"insufficient quota for example.com/gpu in flavor two, previously considered podsets requests (0) + current podset request (4) > maximum capacity (0)",
 								},
+								NoFitReason: "ExceedsMaxQuota",
 							},
 						},
 						Count: 4,
@@ -636,9 +643,10 @@ func TestAssignFlavors(t *testing.T) {
 						),
 						FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 							{
-								Flavor:  "one",
-								Mode:    NoFit,
-								Reasons: []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (5) > maximum capacity (4)"},
+								Flavor:      "one",
+								Mode:        NoFit,
+								Reasons:     []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (5) > maximum capacity (4)"},
+								NoFitReason: "ExceedsMaxQuota",
 							},
 							{
 								Flavor: "two",
@@ -646,11 +654,13 @@ func TestAssignFlavors(t *testing.T) {
 								Reasons: []string{
 									"insufficient quota for example.com/gpu in flavor two, previously considered podsets requests (0) + current podset request (4) > maximum capacity (0)",
 								},
+								NoFitReason: "ExceedsMaxQuota",
 							},
 						},
 						Count: 1,
 					}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				Usage:       workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				NoFitReason: "ExceedsMaxQuota",
 			},
 		},
 		"multiple resource groups, one could fit with preemption, other doesn't fit": {
@@ -687,14 +697,16 @@ func TestAssignFlavors(t *testing.T) {
 					),
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "b_one",
-							Mode:    NoFit,
-							Reasons: []string{"insufficient quota for memory in flavor b_one, previously considered podsets requests (0) + current podset request (10Mi) > maximum capacity (1Mi)"},
+							Flavor:      "b_one",
+							Mode:        NoFit,
+							Reasons:     []string{"insufficient quota for memory in flavor b_one, previously considered podsets requests (0) + current podset request (10Mi) > maximum capacity (1Mi)"},
+							NoFitReason: "ExceedsMaxQuota",
 						},
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				Usage:       workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				NoFitReason: "ExceedsMaxQuota",
 			},
 		},
 		"multiple resource groups with multiple resources, fits": {
@@ -741,9 +753,10 @@ func TestAssignFlavors(t *testing.T) {
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{Flavor: "b_one", Mode: Fit},
 						{
-							Flavor:  "one",
-							Mode:    NoFit,
-							Reasons: []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (3) > maximum capacity (2)"},
+							Flavor:      "one",
+							Mode:        NoFit,
+							Reasons:     []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (3) > maximum capacity (2)"},
+							NoFitReason: "ExceedsMaxQuota",
 						},
 						{Flavor: "two", Mode: Fit},
 					},
@@ -822,17 +835,21 @@ func TestAssignFlavors(t *testing.T) {
 							Mode:                  Preempt,
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for example.com/gpu in flavor b_one, 1 more needed"},
+							NoFitReason:           "WaitingForQuota",
 						},
 						{
-							Flavor:  "one",
-							Mode:    NoFit,
-							Reasons: []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (3) > maximum capacity (2)"}},
+							Flavor:      "one",
+							Mode:        NoFit,
+							Reasons:     []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (3) > maximum capacity (2)"},
+							NoFitReason: "ExceedsMaxQuota",
+						},
 						{
 							Flavor:                "two",
 							Mode:                  Preempt,
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for memory in flavor two, 5Mi more needed"},
+							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -876,19 +893,22 @@ func TestAssignFlavors(t *testing.T) {
 					),
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    NoFit,
-							Reasons: []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (3) > maximum capacity (2)"},
+							Flavor:      "one",
+							Mode:        NoFit,
+							Reasons:     []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (3) > maximum capacity (2)"},
+							NoFitReason: "ExceedsMaxQuota",
 						},
 						{
-							Flavor:  "two",
-							Mode:    NoFit,
-							Reasons: []string{"insufficient quota for memory in flavor two, previously considered podsets requests (0) + current podset request (10Mi) > maximum capacity (5Mi)"},
+							Flavor:      "two",
+							Mode:        NoFit,
+							Reasons:     []string{"insufficient quota for memory in flavor two, previously considered podsets requests (0) + current podset request (10Mi) > maximum capacity (5Mi)"},
+							NoFitReason: "ExceedsMaxQuota",
 						},
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				Usage:       workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				NoFitReason: "ExceedsMaxQuota",
 			},
 		},
 		"multiple flavors, fits while skipping tainted flavor": {
@@ -918,9 +938,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "tainted",
-							Mode:    NoFit,
-							Reasons: []string{"untolerated taint {instance spot NoSchedule <nil>} in flavor tainted"},
+							Flavor:      "tainted",
+							Mode:        NoFit,
+							Reasons:     []string{"untolerated taint {instance spot NoSchedule <nil>} in flavor tainted"},
+							NoFitReason: "NoMatchingFlavor",
 						},
 						{Flavor: "two", Mode: Fit},
 					},
@@ -976,8 +997,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor: "one", Mode: NoFit,
-							Reasons: []string{"flavor one doesn't match node affinity"},
+							Flavor:      "one",
+							Mode:        NoFit,
+							Reasons:     []string{"flavor one doesn't match node affinity"},
+							NoFitReason: "NoMatchingFlavor",
 						},
 						{Flavor: "two", Mode: Fit},
 					},
@@ -1037,9 +1060,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    NoFit,
-							Reasons: []string{"flavor one doesn't match node affinity"},
+							Flavor:      "one",
+							Mode:        NoFit,
+							Reasons:     []string{"flavor one doesn't match node affinity"},
+							NoFitReason: "NoMatchingFlavor",
 						},
 						{Flavor: "two", Mode: Fit},
 					},
@@ -1157,19 +1181,23 @@ func TestAssignFlavors(t *testing.T) {
 						"flavor two doesn't match node affinity",
 					),
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
-						{Flavor: "one",
-							Mode:    NoFit,
-							Reasons: []string{"flavor one doesn't match node affinity"},
+						{
+							Flavor:      "one",
+							Mode:        NoFit,
+							Reasons:     []string{"flavor one doesn't match node affinity"},
+							NoFitReason: "NoMatchingFlavor",
 						},
 						{
-							Flavor:  "two",
-							Mode:    NoFit,
-							Reasons: []string{"flavor two doesn't match node affinity"},
+							Flavor:      "two",
+							Mode:        NoFit,
+							Reasons:     []string{"flavor two doesn't match node affinity"},
+							NoFitReason: "NoMatchingFlavor",
 						},
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				Usage:       workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				NoFitReason: "NoMatchingFlavor",
 			},
 		},
 		"multiple specs, fit different flavors": {
@@ -1204,9 +1232,10 @@ func TestAssignFlavors(t *testing.T) {
 						},
 						FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 							{
-								Flavor:  "one",
-								Mode:    NoFit,
-								Reasons: []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (5) > maximum capacity (4)"},
+								Flavor:      "one",
+								Mode:        NoFit,
+								Reasons:     []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (5) > maximum capacity (4)"},
+								NoFitReason: "ExceedsMaxQuota",
 							},
 							{Flavor: "two", Mode: Fit},
 						},
@@ -1333,14 +1362,16 @@ func TestAssignFlavors(t *testing.T) {
 					Status: *NewStatus("insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (2) > maximum capacity (1)"),
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    NoFit,
-							Reasons: []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (2) > maximum capacity (1)"},
+							Flavor:      "one",
+							Mode:        NoFit,
+							Reasons:     []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (2) > maximum capacity (1)"},
+							NoFitReason: "ExceedsMaxQuota",
 						},
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				Usage:       workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				NoFitReason: "ExceedsMaxQuota",
 			},
 		},
 		"past max, but can preempt in ClusterQueue": {
@@ -1391,6 +1422,7 @@ func TestAssignFlavors(t *testing.T) {
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
+							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -1433,6 +1465,7 @@ func TestAssignFlavors(t *testing.T) {
 							Mode:                  Preempt,
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
+							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -1489,6 +1522,7 @@ func TestAssignFlavors(t *testing.T) {
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 2 more needed"},
+							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -1536,15 +1570,17 @@ func TestAssignFlavors(t *testing.T) {
 					),
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    NoFit,
-							Reasons: []string{"flavor one doesn't match node affinity"},
+							Flavor:      "one",
+							Mode:        NoFit,
+							Reasons:     []string{"flavor one doesn't match node affinity"},
+							NoFitReason: "NoMatchingFlavor",
 						},
 						{
 							Flavor:                "two",
 							Mode:                  Preempt,
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor two, 1 more needed"},
+							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -1603,11 +1639,13 @@ func TestAssignFlavors(t *testing.T) {
 								Mode:                  Preempt,
 								PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 								Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
+								NoFitReason:           "WaitingForQuota",
 							},
 							{
-								Flavor:  "tainted",
-								Mode:    NoFit,
-								Reasons: []string{"untolerated taint {instance spot NoSchedule <nil>} in flavor tainted"},
+								Flavor:      "tainted",
+								Mode:        NoFit,
+								Reasons:     []string{"untolerated taint {instance spot NoSchedule <nil>} in flavor tainted"},
+								NoFitReason: "NoMatchingFlavor",
 							},
 						},
 						Count: 1,
@@ -1626,15 +1664,17 @@ func TestAssignFlavors(t *testing.T) {
 						),
 						FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 							{
-								Flavor:  "one",
-								Mode:    NoFit,
-								Reasons: []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (2) + current podset request (10) > maximum capacity (4)"},
+								Flavor:      "one",
+								Mode:        NoFit,
+								Reasons:     []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (2) + current podset request (10) > maximum capacity (4)"},
+								NoFitReason: "ExceedsMaxQuota",
 							},
 							{
 								Flavor:                "tainted",
 								Mode:                  Preempt,
 								PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 								Reasons:               []string{"insufficient unused quota for cpu in flavor tainted, 3 more needed"},
+								NoFitReason:           "WaitingForQuota",
 							},
 						},
 						Count: 10,
@@ -1667,7 +1707,8 @@ func TestAssignFlavors(t *testing.T) {
 					Status: *NewStatus("resource example.com/gpu unavailable in ClusterQueue"),
 					Count:  1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				Usage:       workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				NoFitReason: "NoMatchingFlavor",
 			},
 		},
 		"zero resource request not in clusterQueue should succeed": {
@@ -1803,14 +1844,16 @@ func TestAssignFlavors(t *testing.T) {
 					Status: *NewStatus("insufficient quota for pods in flavor default, previously considered podsets requests (0) + current podset request (3) > maximum capacity (2)"),
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "default",
-							Mode:    NoFit,
-							Reasons: []string{"insufficient quota for pods in flavor default, previously considered podsets requests (0) + current podset request (3) > maximum capacity (2)"},
+							Flavor:      "default",
+							Mode:        NoFit,
+							Reasons:     []string{"insufficient quota for pods in flavor default, previously considered podsets requests (0) + current podset request (3) > maximum capacity (2)"},
+							NoFitReason: "ExceedsMaxQuota",
 						},
 					},
 					Count: 3,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				Usage:       workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				NoFitReason: "ExceedsMaxQuota",
 			},
 		},
 		"with reclaimable pods; reclaimablePods on": {
@@ -1938,6 +1981,7 @@ func TestAssignFlavors(t *testing.T) {
 							Mode:                  Preempt,
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
+							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -1988,6 +2032,7 @@ func TestAssignFlavors(t *testing.T) {
 							Mode:                  Preempt,
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
+							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -2036,6 +2081,7 @@ func TestAssignFlavors(t *testing.T) {
 							Mode:                  Preempt,
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
+							NoFitReason:           "WaitingForQuota",
 						},
 						{Flavor: "two", Mode: Fit},
 					},
@@ -2093,8 +2139,10 @@ func TestAssignFlavors(t *testing.T) {
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{Flavor: "one", Mode: Fit, Borrow: 1},
 						{
-							Flavor:  "two",
-							Reasons: []string{"insufficient quota for cpu in flavor two, previously considered podsets requests (0) + current podset request (9) > maximum capacity (1)"},
+							Flavor:      "two",
+							Mode:        NoFit,
+							Reasons:     []string{"insufficient quota for cpu in flavor two, previously considered podsets requests (0) + current podset request (9) > maximum capacity (1)"},
+							NoFitReason: "ExceedsMaxQuota",
 						},
 					},
 					Count: 1,
@@ -2271,6 +2319,7 @@ func TestAssignFlavors(t *testing.T) {
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
+							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -2338,6 +2387,7 @@ func TestAssignFlavors(t *testing.T) {
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
+							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -2405,6 +2455,7 @@ func TestAssignFlavors(t *testing.T) {
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
+							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -2472,6 +2523,7 @@ func TestAssignFlavors(t *testing.T) {
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
+							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -2632,14 +2684,16 @@ func TestAssignFlavors(t *testing.T) {
 						},
 						FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 							{
-								Flavor:  "one",
-								Mode:    NoFit,
-								Reasons: []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (12) > maximum capacity (11)"},
+								Flavor:      "one",
+								Mode:        NoFit,
+								Reasons:     []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (12) > maximum capacity (11)"},
+								NoFitReason: "ExceedsMaxQuota",
 							},
 						},
 						Count: 1,
 					},
 				},
+				NoFitReason: "ExceedsMaxQuota",
 			},
 		},
 		"lend try next flavor, found the second flavor": {
@@ -2745,9 +2799,10 @@ func TestAssignFlavors(t *testing.T) {
 						{Flavor: "one", Mode: Fit, Borrow: 1},
 
 						{
-							Flavor:  "two",
-							Mode:    NoFit,
-							Reasons: []string{"insufficient quota for cpu in flavor two, previously considered podsets requests (0) + current podset request (9) > maximum capacity (1)"},
+							Flavor:      "two",
+							Mode:        NoFit,
+							Reasons:     []string{"insufficient quota for cpu in flavor two, previously considered podsets requests (0) + current podset request (9) > maximum capacity (1)"},
+							NoFitReason: "ExceedsMaxQuota",
 						},
 					},
 					Count: 1,
@@ -2815,6 +2870,7 @@ func TestAssignFlavors(t *testing.T) {
 							Mode:                  Preempt,
 							PreemptionPossibility: ptr.To(preemptioncommon.NoCandidates),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 2 more needed"},
+							NoFitReason:           "WaitingForQuota",
 						},
 						{Flavor: "two", Mode: Fit, Borrow: 1},
 					},
@@ -2882,6 +2938,7 @@ func TestAssignFlavors(t *testing.T) {
 							Mode:                  Preempt,
 							PreemptionPossibility: ptr.To(preemptioncommon.NoCandidates),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 2 more needed"},
+							NoFitReason:           "WaitingForQuota",
 						},
 						{Flavor: "two", Mode: Fit, Borrow: 1},
 					},
@@ -2941,6 +2998,7 @@ func TestAssignFlavors(t *testing.T) {
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
+							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -3003,6 +3061,7 @@ func TestAssignFlavors(t *testing.T) {
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
+							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -3063,6 +3122,7 @@ func TestAssignFlavors(t *testing.T) {
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
+							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -3116,10 +3176,11 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    NoFit,
-							Borrow:  1,
-							Reasons: []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
+							Flavor:      "one",
+							Mode:        NoFit,
+							Borrow:      1,
+							Reasons:     []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
+							NoFitReason: "WaitingForQuota",
 						},
 						{Flavor: "two", Mode: Fit},
 					},
@@ -3174,10 +3235,11 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    NoFit,
-							Borrow:  1,
-							Reasons: []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
+							Flavor:      "one",
+							Mode:        NoFit,
+							Borrow:      1,
+							Reasons:     []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
+							NoFitReason: "WaitingForQuota",
 						},
 						{Flavor: "two", Mode: Fit},
 					},
@@ -3242,6 +3304,7 @@ func TestAssignFlavors(t *testing.T) {
 							Reasons: []string{
 								"could not assign one flavor since the original workload is assigned: two",
 							},
+							NoFitReason: "NoMatchingFlavor",
 						},
 						{Flavor: "two", Mode: Fit},
 					},
@@ -3303,18 +3366,21 @@ func TestAssignFlavors(t *testing.T) {
 					),
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "one",
-							Mode:    NoFit,
-							Reasons: []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (1) > maximum capacity (500m)"},
+							Flavor:      "one",
+							Mode:        NoFit,
+							Reasons:     []string{"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (1) > maximum capacity (500m)"},
+							NoFitReason: "ExceedsMaxQuota",
 						},
 						{
-							Flavor:  "two",
-							Mode:    NoFit,
-							Reasons: []string{"could not assign two flavor since the original workload is assigned: one"},
+							Flavor:      "two",
+							Mode:        NoFit,
+							Reasons:     []string{"could not assign two flavor since the original workload is assigned: one"},
+							NoFitReason: "NoMatchingFlavor",
 						},
 					},
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				Usage:       workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				NoFitReason: "ExceedsMaxQuota",
 			},
 		},
 		"multiple TAS flavors assigned to different resources in the same PodSet leads to NoFit": {
@@ -3675,9 +3741,10 @@ func TestDeletedFlavors(t *testing.T) {
 					},
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "deleted-flavor",
-							Mode:    NoFit,
-							Reasons: []string{"flavor deleted-flavor not found"},
+							Flavor:      "deleted-flavor",
+							Mode:        NoFit,
+							Reasons:     []string{"flavor deleted-flavor not found"},
+							NoFitReason: "NoMatchingFlavor",
 						},
 						{Flavor: "flavor", Mode: Fit},
 					},
@@ -3710,13 +3777,15 @@ func TestDeletedFlavors(t *testing.T) {
 					Count:  1,
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
 						{
-							Flavor:  "deleted-flavor",
-							Mode:    NoFit,
-							Reasons: []string{"flavor deleted-flavor not found"},
+							Flavor:      "deleted-flavor",
+							Mode:        NoFit,
+							Reasons:     []string{"flavor deleted-flavor not found"},
+							NoFitReason: "NoMatchingFlavor",
 						},
 					},
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				Usage:       workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				NoFitReason: "NoMatchingFlavor",
 			},
 		},
 	}
@@ -4929,6 +4998,417 @@ func TestAssignFlavorsWithAllowedFlavors(t *testing.T) {
 				gotFlavor := psAssignment.Flavors[corev1.ResourceCPU].Name
 				if gotFlavor != tc.wantFlavor {
 					t.Errorf("Assigned flavor = %v, want %v", gotFlavor, tc.wantFlavor)
+				}
+			}
+		})
+	}
+}
+
+func TestIsNoFitDueToCapacityAndLimits(t *testing.T) {
+	resourceFlavors := map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
+		"flavor-a": utiltestingapi.MakeResourceFlavor("flavor-a").NodeLabel("type", "a").Obj(),
+		"flavor-b": utiltestingapi.MakeResourceFlavor("flavor-b").
+			Taint(corev1.Taint{
+				Key:    "key",
+				Value:  "val",
+				Effect: corev1.TaintEffectNoSchedule,
+			}).Obj(),
+		"flavor-tas": utiltestingapi.MakeResourceFlavor("flavor-tas").TopologyName("topology-tas").Obj(),
+	}
+
+	cq := *utiltestingapi.MakeClusterQueue("cq").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("flavor-a").Resource(corev1.ResourceCPU, "2", "4").Obj(),
+			*utiltestingapi.MakeFlavorQuotas("flavor-b").Resource(corev1.ResourceCPU, "2", "4").Obj(),
+		).Obj()
+
+	tasCQ := utiltestingapi.MakeClusterQueue("cq-tas").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("flavor-a").Resource(corev1.ResourceCPU, "2", "2").Obj(),
+			*utiltestingapi.MakeFlavorQuotas("flavor-b").Resource(corev1.ResourceCPU, "2", "2").Obj(),
+			*utiltestingapi.MakeFlavorQuotas("flavor-tas").Resource(corev1.ResourceCPU, "2", "2").Obj(),
+		).Obj()
+	tasFlavors := map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
+		"flavor-a":   resourceFlavors["flavor-a"],
+		"flavor-b":   resourceFlavors["flavor-b"],
+		"flavor-tas": resourceFlavors["flavor-tas"],
+	}
+
+	tests := map[string]struct {
+		podSet             kueue.PodSet
+		cq                 *kueue.ClusterQueue
+		siblingCQs         []*kueue.ClusterQueue
+		resourceFlavors    map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor
+		cqUsage            resources.FlavorResourceQuantities
+		siblingCQUsage     map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities
+		replaceWl          *workload.Info
+		topologies         []*kueue.Topology
+		allowedFlavors     []kueue.ResourceFlavorReference
+		featureGates       map[featuregate.Feature]bool
+		simulationResult   map[resources.FlavorResource]simulationResultForFlavor
+		wantNoFitReason    string
+		wantFlavorAttempts map[kueue.ResourceFlavorReference]string
+	}{
+		"succeeds to schedule on flavor-a": {
+			podSet:          *utiltestingapi.MakePodSet("main", 1).Request(corev1.ResourceCPU, "1").Obj(),
+			wantNoFitReason: "",
+			wantFlavorAttempts: map[kueue.ResourceFlavorReference]string{
+				"flavor-a": "",
+				"flavor-b": "NoMatchingFlavor",
+			},
+		},
+		"insufficient quota": {
+			podSet:          *utiltestingapi.MakePodSet("main", 1).Request(corev1.ResourceCPU, "3").Obj(),
+			wantNoFitReason: "ExceedsMaxQuota",
+			wantFlavorAttempts: map[kueue.ResourceFlavorReference]string{
+				"flavor-a": "ExceedsMaxQuota",
+				"flavor-b": "NoMatchingFlavor",
+			},
+		},
+		"exceeds max capacity limits": {
+			podSet:          *utiltestingapi.MakePodSet("main", 1).Request(corev1.ResourceCPU, "5").Obj(),
+			wantNoFitReason: "ExceedsMaxQuota",
+			wantFlavorAttempts: map[kueue.ResourceFlavorReference]string{
+				"flavor-a": "ExceedsMaxQuota",
+				"flavor-b": "NoMatchingFlavor",
+			},
+		},
+		"taints mismatch": {
+			podSet: *utiltestingapi.MakePodSet("main", 1).
+				Request(corev1.ResourceCPU, "1").
+				NodeSelector(map[string]string{"type": "wrong"}).
+				Obj(),
+			wantNoFitReason: "NoMatchingFlavor",
+			wantFlavorAttempts: map[kueue.ResourceFlavorReference]string{
+				"flavor-a": "NoMatchingFlavor",
+				"flavor-b": "NoMatchingFlavor",
+			},
+		},
+		"node affinity mismatch": {
+			podSet: *utiltestingapi.MakePodSet("main", 1).
+				Request(corev1.ResourceCPU, "1").
+				NodeSelector(map[string]string{"type": "non-existent"}).
+				Toleration(corev1.Toleration{Key: "key", Operator: corev1.TolerationOpEqual, Value: "val", Effect: corev1.TaintEffectNoSchedule}).
+				Obj(),
+			wantNoFitReason: "NoMatchingFlavor",
+			wantFlavorAttempts: map[kueue.ResourceFlavorReference]string{
+				"flavor-a": "NoMatchingFlavor",
+				"flavor-b": "NoMatchingFlavor",
+			},
+		},
+		"flavor mismatch for workload slices": {
+			podSet: *utiltestingapi.MakePodSet("main", 1).
+				Request(corev1.ResourceCPU, "2").
+				NodeSelector(map[string]string{"type": "a"}).
+				Obj(),
+			replaceWl: workload.NewInfo(
+				utiltestingapi.MakeWorkload("wl-old", "ns").
+					PodSets(*utiltestingapi.MakePodSet("main", 1).Request(corev1.ResourceCPU, "1").Obj()).
+					Admission(utiltestingapi.MakeAdmission("cq", "main").
+						PodSets(kueue.PodSetAssignment{
+							Name: "main",
+							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+								corev1.ResourceCPU: "flavor-b",
+							},
+						}).Obj()).
+					Obj(),
+			),
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices: true,
+			},
+			wantNoFitReason: "NoMatchingFlavor",
+			wantFlavorAttempts: map[kueue.ResourceFlavorReference]string{
+				"flavor-a": "NoMatchingFlavor",
+			},
+		},
+		"prioritization of structural mismatch over capacity mismatch": {
+			podSet: *utiltestingapi.MakePodSet("main", 1).
+				Request(corev1.ResourceCPU, "3").
+				Request(corev1.ResourceMemory, "20Gi").
+				NodeSelector(map[string]string{"type": "wrong"}).
+				Obj(),
+			wantNoFitReason: "NoMatchingFlavor",
+			wantFlavorAttempts: map[kueue.ResourceFlavorReference]string{
+				"flavor-a": "NoMatchingFlavor",
+				"flavor-b": "NoMatchingFlavor",
+			},
+		},
+		"TAS not supported": {
+			podSet: *utiltestingapi.MakePodSet("main", 1).
+				Request(corev1.ResourceCPU, "1").
+				RequiredTopologyRequest("rack").
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling: true,
+			},
+			wantNoFitReason: "NoMatchingFlavor",
+			wantFlavorAttempts: map[kueue.ResourceFlavorReference]string{
+				"flavor-a": "NoMatchingFlavor",
+			},
+		},
+		"TAS level not supported": {
+			podSet: *utiltestingapi.MakePodSet("main", 1).
+				Request(corev1.ResourceCPU, "1").
+				RequiredTopologyRequest("block").
+				Obj(),
+			cq:              tasCQ,
+			resourceFlavors: tasFlavors,
+			topologies: []*kueue.Topology{
+				utiltestingapi.MakeTopology("topology-tas").Levels("rack").Obj(),
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling: true,
+			},
+			wantNoFitReason: "NoMatchingFlavor",
+			wantFlavorAttempts: map[kueue.ResourceFlavorReference]string{
+				"flavor-a":   "NoMatchingFlavor",
+				"flavor-b":   "NoMatchingFlavor",
+				"flavor-tas": "NoMatchingFlavor",
+			},
+		},
+		"TAS only flavor mismatch": {
+			podSet: *utiltestingapi.MakePodSet("main", 1).
+				Request(corev1.ResourceCPU, "1").
+				NodeSelector(map[string]string{"type": "wrong"}).
+				Obj(),
+			cq:              tasCQ,
+			resourceFlavors: tasFlavors,
+			topologies: []*kueue.Topology{
+				utiltestingapi.MakeTopology("topology-tas").Levels("rack").Obj(),
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling: true,
+			},
+			wantNoFitReason: "NoMatchingFlavor",
+			wantFlavorAttempts: map[kueue.ResourceFlavorReference]string{
+				"flavor-a":   "NoMatchingFlavor",
+				"flavor-b":   "NoMatchingFlavor",
+				"flavor-tas": "NoMatchingFlavor",
+			},
+		},
+		"tas placement fails": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling: true,
+			},
+			resourceFlavors: tasFlavors,
+			cq:              tasCQ,
+			topologies: []*kueue.Topology{
+				utiltestingapi.MakeTopology("topology-tas").Levels("rack").Obj(),
+			},
+			podSet: *utiltestingapi.MakePodSet("main", 1).
+				Request(corev1.ResourceCPU, "1").
+				RequiredTopologyRequest("rack").
+				Obj(),
+			wantNoFitReason: "TopologyPlacementFailed",
+			wantFlavorAttempts: map[kueue.ResourceFlavorReference]string{
+				"flavor-a":   "NoMatchingFlavor",
+				"flavor-b":   "NoMatchingFlavor",
+				"flavor-tas": "TopologyPlacementFailed",
+			},
+		},
+		"tas placement fails, cohort has no capacity": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling: true,
+			},
+			resourceFlavors: tasFlavors,
+			cq:              tasCQ,
+			topologies: []*kueue.Topology{
+				utiltestingapi.MakeTopology("topology-tas").Levels("rack").Obj(),
+			},
+			podSet: *utiltestingapi.MakePodSet("main", 1).
+				Request(corev1.ResourceCPU, "3").
+				RequiredTopologyRequest("rack").
+				Obj(),
+			wantNoFitReason: "ExceedsMaxQuota",
+			wantFlavorAttempts: map[kueue.ResourceFlavorReference]string{
+				"flavor-a":   "NoMatchingFlavor",
+				"flavor-b":   "NoMatchingFlavor",
+				"flavor-tas": "ExceedsMaxQuota",
+			},
+		},
+		"tas placement fails, but queue has available capacity (waiting for preemption)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling: true,
+				features.ConcurrentAdmission:     true,
+			},
+			resourceFlavors: tasFlavors,
+			cq:              tasCQ,
+			topologies: []*kueue.Topology{
+				utiltestingapi.MakeTopology("topology-tas").Levels("rack").Obj(),
+			},
+			podSet: *utiltestingapi.MakePodSet("main", 1).
+				Request(corev1.ResourceCPU, "1").
+				RequiredTopologyRequest("rack").
+				Obj(),
+			cqUsage: resources.FlavorResourceQuantities{
+				{Flavor: "flavor-tas", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
+			},
+			wantNoFitReason: "TopologyPlacementFailed",
+			wantFlavorAttempts: map[kueue.ResourceFlavorReference]string{
+				"flavor-a":   "NoMatchingFlavor",
+				"flavor-b":   "NoMatchingFlavor",
+				"flavor-tas": "TopologyPlacementFailed",
+			},
+		},
+		"flavor not allowed by annotations": {
+			podSet: *utiltestingapi.MakePodSet("main", 1).Request(corev1.ResourceCPU, "1").Obj(),
+			cqUsage: resources.FlavorResourceQuantities{
+				{Flavor: "flavor-a", Resource: corev1.ResourceCPU}: resources.NewAmount(4_000),
+			},
+			allowedFlavors: []kueue.ResourceFlavorReference{"flavor-a"},
+			featureGates: map[featuregate.Feature]bool{
+				features.ConcurrentAdmission: true,
+			},
+			wantNoFitReason: "",
+			wantFlavorAttempts: map[kueue.ResourceFlavorReference]string{
+				"flavor-b": "NoMatchingFlavor",
+			},
+		},
+		"insufficient capacity, cohort has available capacity (waiting for quota)": {
+			podSet: *utiltestingapi.MakePodSet("main", 1).Request(corev1.ResourceCPU, "3").Obj(),
+			cq: utiltestingapi.MakeClusterQueue("cq").
+				Cohort("cohort").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("flavor-a").Resource(corev1.ResourceCPU, "2", "2").Obj(),
+					*utiltestingapi.MakeFlavorQuotas("flavor-b").Resource(corev1.ResourceCPU, "2", "2").Obj(),
+				).Obj(),
+			siblingCQs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("sibling").
+					Cohort("cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("flavor-a").Resource(corev1.ResourceCPU, "2", "2").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("flavor-b").Resource(corev1.ResourceCPU, "2", "2").Obj(),
+					).Obj(),
+			},
+			siblingCQUsage: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
+				"sibling": {
+					{Flavor: "flavor-a", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
+					{Flavor: "flavor-b", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
+				},
+			},
+			wantNoFitReason: "WaitingForQuota",
+			wantFlavorAttempts: map[kueue.ResourceFlavorReference]string{
+				"flavor-a": "WaitingForQuota",
+				"flavor-b": "NoMatchingFlavor",
+			},
+		},
+		"exceeds cohort max capacity limits": {
+			podSet: *utiltestingapi.MakePodSet("main", 1).Request(corev1.ResourceCPU, "5").Obj(),
+			cq: utiltestingapi.MakeClusterQueue("cq").
+				Cohort("cohort").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("flavor-a").Resource(corev1.ResourceCPU, "2", "2").Obj(),
+					*utiltestingapi.MakeFlavorQuotas("flavor-b").Resource(corev1.ResourceCPU, "2", "2").Obj(),
+				).Obj(),
+			siblingCQs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("sibling").
+					Cohort("cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("flavor-a").Resource(corev1.ResourceCPU, "2", "2").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("flavor-b").Resource(corev1.ResourceCPU, "2", "2").Obj(),
+					).Obj(),
+			},
+			wantNoFitReason: "ExceedsMaxQuota",
+			wantFlavorAttempts: map[kueue.ResourceFlavorReference]string{
+				"flavor-a": "ExceedsMaxQuota",
+				"flavor-b": "NoMatchingFlavor",
+			},
+		},
+		"exceeds borrowing limit but cohort has capacity": {
+			podSet: *utiltestingapi.MakePodSet("main", 1).Request(corev1.ResourceCPU, "4").Obj(),
+			cq: utiltestingapi.MakeClusterQueue("cq").
+				Cohort("cohort").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("flavor-a").Resource(corev1.ResourceCPU, "2", "1").Obj(),
+					*utiltestingapi.MakeFlavorQuotas("flavor-b").Resource(corev1.ResourceCPU, "2", "1").Obj(),
+				).Obj(),
+			siblingCQs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("sibling").
+					Cohort("cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("flavor-a").Resource(corev1.ResourceCPU, "5", "5").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("flavor-b").Resource(corev1.ResourceCPU, "5", "5").Obj(),
+					).Obj(),
+			},
+			wantNoFitReason: "ExceedsMaxQuota",
+			wantFlavorAttempts: map[kueue.ResourceFlavorReference]string{
+				"flavor-a": "ExceedsMaxQuota",
+				"flavor-b": "NoMatchingFlavor",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			for fg, val := range tc.featureGates {
+				features.SetFeatureGateDuringTest(t, fg, val)
+			}
+
+			testCQ := cq
+			if tc.cq != nil {
+				testCQ = *tc.cq
+			}
+			testFlavors := resourceFlavors
+			if tc.resourceFlavors != nil {
+				testFlavors = tc.resourceFlavors
+			}
+
+			wlBuilder := utiltestingapi.MakeWorkload("wl", "ns").
+				PodSets(tc.podSet)
+			if len(tc.allowedFlavors) > 0 {
+				wlBuilder = wlBuilder.AllowedFlavors(tc.allowedFlavors...)
+			}
+			wl := wlBuilder.Obj()
+			wlInfo := workload.NewInfo(wl)
+
+			ctx, log := utiltesting.ContextWithLog(t)
+			cache := schdcache.New(utiltesting.NewFakeClient())
+			if err := cache.AddClusterQueue(ctx, &testCQ); err != nil {
+				t.Fatalf("Failed to add CQ to cache: %v", err)
+			}
+			for _, sibling := range tc.siblingCQs {
+				if err := cache.AddClusterQueue(ctx, sibling); err != nil {
+					t.Fatalf("Failed to add sibling CQ to cache: %v", err)
+				}
+			}
+			for _, rf := range testFlavors {
+				cache.AddOrUpdateResourceFlavor(log, rf)
+			}
+			for _, topology := range tc.topologies {
+				cache.AddOrUpdateTopology(log, topology)
+			}
+			snapshot, err := cache.Snapshot(ctx)
+			if err != nil {
+				t.Fatalf("unexpected error while building snapshot: %v", err)
+			}
+			cqSnapshot := snapshot.ClusterQueue(kueue.ClusterQueueReference(testCQ.Name))
+			if len(tc.cqUsage) > 0 {
+				cqSnapshot.AddUsage(workload.Usage{Quota: tc.cqUsage})
+			}
+			for siblingName, usage := range tc.siblingCQUsage {
+				siblingSnapshot := snapshot.ClusterQueue(siblingName)
+				if siblingSnapshot == nil {
+					t.Fatalf("Sibling ClusterQueue %s not found in snapshot", siblingName)
+				}
+				siblingSnapshot.AddUsage(workload.Usage{Quota: usage})
+			}
+
+			assigner := New(wlInfo, cqSnapshot, testFlavors, false, &testOracle{simulationResult: tc.simulationResult}, tc.replaceWl, configapi.QuotaCheckBlockUndeclared)
+			gotAssignment := assigner.Assign(log, nil)
+
+			if gotAssignment.NoFitReason != tc.wantNoFitReason {
+				t.Errorf("gotAssignment.NoFitReason = %q, want %q", gotAssignment.NoFitReason, tc.wantNoFitReason)
+			}
+
+			if len(tc.wantFlavorAttempts) > 0 {
+				for _, ps := range gotAssignment.PodSets {
+					for _, att := range ps.FlavorAssignmentAttempts {
+						if wantReason, ok := tc.wantFlavorAttempts[att.Flavor]; ok {
+							if att.NoFitReason != wantReason {
+								t.Errorf("attempt for flavor %q got reason %q, want %q", att.Flavor, att.NoFitReason, wantReason)
+							}
+						}
+					}
 				}
 			}
 		})

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -359,7 +359,6 @@ func TestAssignFlavors(t *testing.T) {
 							Mode:                  Preempt,
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor default, 1 more needed"},
-							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -836,7 +835,6 @@ func TestAssignFlavors(t *testing.T) {
 							Mode:                  Preempt,
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for example.com/gpu in flavor b_one, 1 more needed"},
-							NoFitReason:           "WaitingForQuota",
 						},
 						{
 							Flavor:      "one",
@@ -850,7 +848,6 @@ func TestAssignFlavors(t *testing.T) {
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for memory in flavor two, 5Mi more needed"},
-							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -1423,7 +1420,6 @@ func TestAssignFlavors(t *testing.T) {
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
-							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -1466,7 +1462,6 @@ func TestAssignFlavors(t *testing.T) {
 							Mode:                  Preempt,
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
-							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -1523,7 +1518,6 @@ func TestAssignFlavors(t *testing.T) {
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 2 more needed"},
-							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -1581,7 +1575,6 @@ func TestAssignFlavors(t *testing.T) {
 							Mode:                  Preempt,
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor two, 1 more needed"},
-							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -1640,7 +1633,6 @@ func TestAssignFlavors(t *testing.T) {
 								Mode:                  Preempt,
 								PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 								Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
-								NoFitReason:           "WaitingForQuota",
 							},
 							{
 								Flavor:      "tainted",
@@ -1675,7 +1667,6 @@ func TestAssignFlavors(t *testing.T) {
 								Mode:                  Preempt,
 								PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 								Reasons:               []string{"insufficient unused quota for cpu in flavor tainted, 3 more needed"},
-								NoFitReason:           "WaitingForQuota",
 							},
 						},
 						Count: 10,
@@ -1982,7 +1973,6 @@ func TestAssignFlavors(t *testing.T) {
 							Mode:                  Preempt,
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
-							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -2033,7 +2023,6 @@ func TestAssignFlavors(t *testing.T) {
 							Mode:                  Preempt,
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
-							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -2082,7 +2071,6 @@ func TestAssignFlavors(t *testing.T) {
 							Mode:                  Preempt,
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
-							NoFitReason:           "WaitingForQuota",
 						},
 						{Flavor: "two", Mode: Fit},
 					},
@@ -2320,7 +2308,6 @@ func TestAssignFlavors(t *testing.T) {
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
-							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -2388,7 +2375,6 @@ func TestAssignFlavors(t *testing.T) {
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
-							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -2456,7 +2442,6 @@ func TestAssignFlavors(t *testing.T) {
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
-							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -2524,7 +2509,6 @@ func TestAssignFlavors(t *testing.T) {
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
-							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -2871,7 +2855,6 @@ func TestAssignFlavors(t *testing.T) {
 							Mode:                  Preempt,
 							PreemptionPossibility: ptr.To(preemptioncommon.NoCandidates),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 2 more needed"},
-							NoFitReason:           "WaitingForQuota",
 						},
 						{Flavor: "two", Mode: Fit, Borrow: 1},
 					},
@@ -2939,7 +2922,6 @@ func TestAssignFlavors(t *testing.T) {
 							Mode:                  Preempt,
 							PreemptionPossibility: ptr.To(preemptioncommon.NoCandidates),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 2 more needed"},
-							NoFitReason:           "WaitingForQuota",
 						},
 						{Flavor: "two", Mode: Fit, Borrow: 1},
 					},
@@ -2999,7 +2981,6 @@ func TestAssignFlavors(t *testing.T) {
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
-							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -3062,7 +3043,6 @@ func TestAssignFlavors(t *testing.T) {
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
-							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -3123,7 +3103,6 @@ func TestAssignFlavors(t *testing.T) {
 							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
-							NoFitReason:           "WaitingForQuota",
 						},
 					},
 					Count: 1,
@@ -3434,6 +3413,91 @@ func TestAssignFlavors(t *testing.T) {
 					{Flavor: "tas-a", Resource: corev1.ResourceCPU}:    resources.NewAmount(1_000),
 					{Flavor: "tas-b", Resource: corev1.ResourceMemory}: resources.NewAmount(utiltesting.Mi),
 				}},
+			},
+		},
+		"multi-podset, one fits and another fails, fitting podset attempts skipped in resolveNoFitReason": {
+			wlPods: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("fitting-podset", 1).
+					Request(corev1.ResourceCPU, "1").
+					NodeSelector(map[string]string{"type": "one"}).
+					Obj(),
+				*utiltestingapi.MakePodSet("blocking-podset", 1).
+					Request(corev1.ResourceCPU, "5").
+					Obj(),
+			},
+			clusterQueue: *utiltestingapi.MakeClusterQueue("test-clusterqueue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("one").
+						Resource(corev1.ResourceCPU, "2").
+						Obj(),
+					*utiltestingapi.MakeFlavorQuotas("two").
+						Resource(corev1.ResourceCPU, "2").
+						Obj(),
+				).Obj(),
+			wantRepMode: NoFit,
+			wantAssignment: Assignment{
+				NoFitReason: "ExceedsMaxQuota",
+				PodSets: []PodSetAssignment{
+					{
+						Name: "fitting-podset",
+						Flavors: ResourceAssignment{
+							corev1.ResourceCPU: {Name: "one", Mode: Fit, TriedFlavorIdx: 0},
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+						Count: 1,
+						FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
+							{
+								Flavor: "one",
+								Mode:   Fit,
+							},
+							{
+								Flavor:      "two",
+								Mode:        NoFit,
+								NoFitReason: "NoMatchingFlavor",
+							},
+						},
+					},
+					{
+						Name: "blocking-podset",
+						Status: Status{
+							reasons: []string{
+								"insufficient quota for cpu in flavor one, previously considered podsets requests (1) + current podset request (5) > maximum capacity (2)",
+								"insufficient quota for cpu in flavor two, previously considered podsets requests (0) + current podset request (5) > maximum capacity (2)",
+							},
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("5"),
+						},
+						Count: 1,
+						FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
+							{
+								Flavor:      "one",
+								Mode:        NoFit,
+								Borrow:      0,
+								NoFitReason: "ExceedsMaxQuota",
+								Reasons: []string{
+									"insufficient quota for cpu in flavor one, previously considered podsets requests (1) + current podset request (5) > maximum capacity (2)",
+								},
+							},
+							{
+								Flavor:      "two",
+								Mode:        NoFit,
+								Borrow:      0,
+								NoFitReason: "ExceedsMaxQuota",
+								Reasons: []string{
+									"insufficient quota for cpu in flavor two, previously considered podsets requests (0) + current podset request (5) > maximum capacity (2)",
+								},
+							},
+						},
+					},
+				},
+				Usage: workload.Usage{
+					Quota: resources.FlavorResourceQuantities{
+						{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(1000),
+					},
+				},
 			},
 		},
 	}

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -18,6 +18,7 @@ package flavorassigner
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -63,7 +64,7 @@ var (
 //   - if actual has ANY Fit for that podset -> we don't require that all wanted
 //     flavors appear; it's OK if actual only returned the "winning" flavor;
 //   - if actual has NO Fit -> we require that all wanted flavors appear.
-func flexAssertConsidered(t *testing.T, want, got Assignment) {
+func flexAssertConsidered(t *testing.T, want, got Assignment, opts ...cmp.Option) {
 	wantByName := make(map[string]PodSetAssignment, len(want.PodSets))
 	for _, ps := range want.PodSets {
 		wantByName[string(ps.Name)] = ps
@@ -84,11 +85,11 @@ func flexAssertConsidered(t *testing.T, want, got Assignment) {
 			continue
 		}
 
-		assertPodSetConsideredFlexible(t, name, wantPS.FlavorAssignmentAttempts, gotPS.FlavorAssignmentAttempts)
+		assertPodSetConsideredFlexible(t, name, wantPS.FlavorAssignmentAttempts, gotPS.FlavorAssignmentAttempts, opts...)
 	}
 }
 
-func assertPodSetConsideredFlexible(t *testing.T, podSetName string, want, got []FlavorAssignmentAttempt) {
+func assertPodSetConsideredFlexible(t *testing.T, podSetName string, want, got []FlavorAssignmentAttempt, opts ...cmp.Option) {
 	wantByFlavor := make(map[kueue.ResourceFlavorReference]FlavorAssignmentAttempt, len(want))
 	for _, wa := range want {
 		wantByFlavor[wa.Flavor] = wa
@@ -115,7 +116,7 @@ func assertPodSetConsideredFlexible(t *testing.T, podSetName string, want, got [
 				continue
 			}
 
-			if diff := cmp.Diff(wa, ga); diff != "" {
+			if diff := cmp.Diff(wa, ga, opts...); diff != "" {
 				t.Errorf("podset %q: flavor %q mismatch (fit case) (-want +got):\n%s", podSetName, flavor, diff)
 			}
 		}
@@ -129,7 +130,7 @@ func assertPodSetConsideredFlexible(t *testing.T, podSetName string, want, got [
 			t.Errorf("podset %q: expected flavor %q in FlavorAssignmentAttempts (no-fit case)", podSetName, flavor)
 			continue
 		}
-		if diff := cmp.Diff(wa, ga); diff != "" {
+		if diff := cmp.Diff(wa, ga, opts...); diff != "" {
 			t.Errorf("podset %q: flavor %q mismatch (no-fit case) (-want +got):\n%s", podSetName, flavor, diff)
 		}
 	}
@@ -3437,88 +3438,99 @@ func TestAssignFlavors(t *testing.T) {
 		},
 	}
 	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			ctx, log := utiltesting.ContextWithLog(t)
-			for fg, enabled := range tc.featureGates {
-				features.SetFeatureGateDuringTest(t, fg, enabled)
-			}
-			wlInfo := workload.NewInfo(&kueue.Workload{
-				Spec: kueue.WorkloadSpec{
-					PodSets: tc.wlPods,
-				},
-				Status: kueue.WorkloadStatus{
-					ReclaimablePods: tc.wlReclaimablePods,
-				},
+		for _, enabled := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/gate_%t", name, enabled), func(t *testing.T) {
+				features.SetFeatureGateDuringTest(t, features.UnadmittedWorkloadsObservability, enabled)
+				ctx, log := utiltesting.ContextWithLog(t)
+				for fg, val := range tc.featureGates {
+					features.SetFeatureGateDuringTest(t, fg, val)
+				}
+				wlInfo := workload.NewInfo(&kueue.Workload{
+					Spec: kueue.WorkloadSpec{
+						PodSets: tc.wlPods,
+					},
+					Status: kueue.WorkloadStatus{
+						ReclaimablePods: tc.wlReclaimablePods,
+					},
+				})
+
+				cache := schdcache.New(utiltesting.NewFakeClient())
+				if err := cache.AddClusterQueue(ctx, &tc.clusterQueue); err != nil {
+					t.Fatalf("Failed to add CQ to cache")
+				}
+				if tc.secondaryClusterQueue != nil {
+					if err := cache.AddClusterQueue(ctx, tc.secondaryClusterQueue); err != nil {
+						t.Fatalf("Failed to add secondary CQ to cache")
+					}
+				}
+				for _, rf := range resourceFlavors {
+					cache.AddOrUpdateResourceFlavor(log, rf)
+				}
+				if tc.topologies != nil {
+					for _, topology := range tc.topologies {
+						cache.AddOrUpdateTopology(log, topology)
+					}
+				}
+
+				if err := cache.AddOrUpdateCohort(utiltestingapi.MakeCohort(tc.clusterQueue.Spec.CohortName).Obj()); err != nil {
+					t.Fatalf("Failed to create a cohort")
+				}
+
+				snapshot, err := cache.Snapshot(ctx)
+				if err != nil {
+					t.Fatalf("unexpected error while building snapshot: %v", err)
+				}
+				clusterQueue := snapshot.ClusterQueue(kueue.ClusterQueueReference(tc.clusterQueue.Name))
+
+				if clusterQueue == nil {
+					t.Fatalf("Failed to create CQ snapshot")
+				}
+				if tc.clusterQueueUsage != nil {
+					clusterQueue.AddUsage(workload.Usage{Quota: tc.clusterQueueUsage})
+				}
+
+				if tc.secondaryClusterQueue != nil {
+					secondaryClusterQueue := snapshot.ClusterQueue(kueue.ClusterQueueReference(tc.secondaryClusterQueue.Name))
+					if secondaryClusterQueue == nil {
+						t.Fatalf("Failed to create secondary CQ snapshot")
+					}
+					secondaryClusterQueue.AddUsage(workload.Usage{Quota: tc.secondaryClusterQueueUsage})
+				}
+
+				flvAssigner := New(
+					wlInfo,
+					clusterQueue,
+					resourceFlavors,
+					tc.enableFairSharing,
+					&testOracle{simulationResult: tc.simulationResult},
+					tc.preemptWorkloadSlice,
+					configapi.QuotaCheckBlockUndeclared,
+				)
+				assignment := flvAssigner.Assign(log, nil)
+				if repMode := assignment.RepresentativeMode(); repMode != tc.wantRepMode {
+					t.Errorf("e.assignFlavors(_).RepresentativeMode()=%s, want %s", repMode, tc.wantRepMode)
+				}
+
+				var cmpOpts []cmp.Option
+				if !enabled {
+					cmpOpts = append(cmpOpts, cmpopts.IgnoreFields(Assignment{}, "NoFitReason"))
+					cmpOpts = append(cmpOpts, cmpopts.IgnoreFields(FlavorAssignmentAttempt{}, "NoFitReason"))
+				}
+
+				if diff := cmp.Diff(tc.wantAssignment, assignment,
+					append(cmpOpts,
+						cmpopts.EquateEmpty(),
+						cmpopts.IgnoreUnexported(Assignment{}, FlavorAssignment{}),
+						statusComparer, cmpopts.IgnoreFields(Assignment{}, "LastState"),
+						cmpopts.IgnoreFields(PodSetAssignment{}, "FlavorAssignmentAttempts"),
+					)...,
+				); diff != "" {
+					t.Errorf("Unexpected assignment (-want,+got):\n%s", diff)
+				}
+
+				flexAssertConsidered(t, tc.wantAssignment, assignment, cmpOpts...)
 			})
-
-			cache := schdcache.New(utiltesting.NewFakeClient())
-			if err := cache.AddClusterQueue(ctx, &tc.clusterQueue); err != nil {
-				t.Fatalf("Failed to add CQ to cache")
-			}
-			if tc.secondaryClusterQueue != nil {
-				if err := cache.AddClusterQueue(ctx, tc.secondaryClusterQueue); err != nil {
-					t.Fatalf("Failed to add secondary CQ to cache")
-				}
-			}
-			for _, rf := range resourceFlavors {
-				cache.AddOrUpdateResourceFlavor(log, rf)
-			}
-			if tc.topologies != nil {
-				for _, topology := range tc.topologies {
-					cache.AddOrUpdateTopology(log, topology)
-				}
-			}
-
-			if err := cache.AddOrUpdateCohort(utiltestingapi.MakeCohort(tc.clusterQueue.Spec.CohortName).Obj()); err != nil {
-				t.Fatalf("Failed to create a cohort")
-			}
-
-			snapshot, err := cache.Snapshot(ctx)
-			if err != nil {
-				t.Fatalf("unexpected error while building snapshot: %v", err)
-			}
-			clusterQueue := snapshot.ClusterQueue(kueue.ClusterQueueReference(tc.clusterQueue.Name))
-
-			if clusterQueue == nil {
-				t.Fatalf("Failed to create CQ snapshot")
-			}
-			if tc.clusterQueueUsage != nil {
-				clusterQueue.AddUsage(workload.Usage{Quota: tc.clusterQueueUsage})
-			}
-
-			if tc.secondaryClusterQueue != nil {
-				secondaryClusterQueue := snapshot.ClusterQueue(kueue.ClusterQueueReference(tc.secondaryClusterQueue.Name))
-				if secondaryClusterQueue == nil {
-					t.Fatalf("Failed to create secondary CQ snapshot")
-				}
-				secondaryClusterQueue.AddUsage(workload.Usage{Quota: tc.secondaryClusterQueueUsage})
-			}
-
-			flvAssigner := New(
-				wlInfo,
-				clusterQueue,
-				resourceFlavors,
-				tc.enableFairSharing,
-				&testOracle{simulationResult: tc.simulationResult},
-				tc.preemptWorkloadSlice,
-				configapi.QuotaCheckBlockUndeclared,
-			)
-			assignment := flvAssigner.Assign(log, nil)
-			if repMode := assignment.RepresentativeMode(); repMode != tc.wantRepMode {
-				t.Errorf("e.assignFlavors(_).RepresentativeMode()=%s, want %s", repMode, tc.wantRepMode)
-			}
-
-			if diff := cmp.Diff(tc.wantAssignment, assignment,
-				cmpopts.EquateEmpty(),
-				cmpopts.IgnoreUnexported(Assignment{}, FlavorAssignment{}),
-				statusComparer, cmpopts.IgnoreFields(Assignment{}, "LastState"),
-				cmpopts.IgnoreFields(PodSetAssignment{}, "FlavorAssignmentAttempts"),
-			); diff != "" {
-				t.Errorf("Unexpected assignment (-want,+got):\n%s", diff)
-			}
-
-			flexAssertConsidered(t, tc.wantAssignment, assignment)
-		})
+		}
 	}
 }
 
@@ -3791,62 +3803,73 @@ func TestDeletedFlavors(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			ctx, _ := utiltesting.ContextWithLog(t)
-			log := testr.NewWithOptions(t, testr.Options{
-				Verbosity: 2,
+		for _, enabled := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/gate_%t", name, enabled), func(t *testing.T) {
+				features.SetFeatureGateDuringTest(t, features.UnadmittedWorkloadsObservability, enabled)
+				ctx, _ := utiltesting.ContextWithLog(t)
+				log := testr.NewWithOptions(t, testr.Options{
+					Verbosity: 2,
+				})
+				wlInfo := workload.NewInfo(&kueue.Workload{
+					Spec: kueue.WorkloadSpec{
+						PodSets: tc.wlPods,
+					},
+					Status: kueue.WorkloadStatus{
+						ReclaimablePods: tc.wlReclaimablePods,
+					},
+				})
+
+				cache := schdcache.New(utiltesting.NewFakeClient())
+				if err := cache.AddClusterQueue(ctx, &tc.clusterQueue); err != nil {
+					t.Fatalf("Failed to add CQ to cache")
+				}
+
+				flavorMap := map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
+					"flavor":         utiltestingapi.MakeResourceFlavor("flavor").Obj(),
+					"deleted-flavor": utiltestingapi.MakeResourceFlavor("deleted-flavor").Obj(),
+				}
+
+				// we have to add the deleted flavor to the cache before snapshot,
+				// or else snapshot will fail
+				for _, flavor := range flavorMap {
+					cache.AddOrUpdateResourceFlavor(log, flavor)
+				}
+				snapshot, err := cache.Snapshot(ctx)
+				if err != nil {
+					t.Fatalf("unexpected error while building snapshot: %v", err)
+				}
+				clusterQueue := snapshot.ClusterQueue(kueue.ClusterQueueReference(tc.clusterQueue.Name))
+				if clusterQueue == nil {
+					t.Fatalf("Failed to create CQ snapshot")
+				}
+
+				// and we delete it
+				cache.DeleteResourceFlavor(log, flavorMap["deleted-flavor"])
+				delete(flavorMap, "deleted-flavor")
+
+				flvAssigner := New(wlInfo, clusterQueue, flavorMap, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared)
+
+				assignment := flvAssigner.Assign(log, nil)
+				if repMode := assignment.RepresentativeMode(); repMode != tc.wantRepMode {
+					t.Errorf("e.assignFlavors(_).RepresentativeMode()=%s, want %s", repMode, tc.wantRepMode)
+				}
+
+				var cmpOpts []cmp.Option
+				if !enabled {
+					cmpOpts = append(cmpOpts, cmpopts.IgnoreFields(Assignment{}, "NoFitReason"))
+					cmpOpts = append(cmpOpts, cmpopts.IgnoreFields(FlavorAssignmentAttempt{}, "NoFitReason"))
+				}
+
+				if diff := cmp.Diff(tc.wantAssignment, assignment,
+					append(cmpOpts,
+						cmpopts.EquateEmpty(),
+						cmpopts.IgnoreUnexported(Assignment{}, FlavorAssignment{}), statusComparer, cmpopts.IgnoreFields(Assignment{}, "LastState"),
+					)...,
+				); diff != "" {
+					t.Errorf("Unexpected assignment (-want,+got):\n%s", diff)
+				}
 			})
-			wlInfo := workload.NewInfo(&kueue.Workload{
-				Spec: kueue.WorkloadSpec{
-					PodSets: tc.wlPods,
-				},
-				Status: kueue.WorkloadStatus{
-					ReclaimablePods: tc.wlReclaimablePods,
-				},
-			})
-
-			cache := schdcache.New(utiltesting.NewFakeClient())
-			if err := cache.AddClusterQueue(ctx, &tc.clusterQueue); err != nil {
-				t.Fatalf("Failed to add CQ to cache")
-			}
-
-			flavorMap := map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
-				"flavor":         utiltestingapi.MakeResourceFlavor("flavor").Obj(),
-				"deleted-flavor": utiltestingapi.MakeResourceFlavor("deleted-flavor").Obj(),
-			}
-
-			// we have to add the deleted flavor to the cache before snapshot,
-			// or else snapshot will fail
-			for _, flavor := range flavorMap {
-				cache.AddOrUpdateResourceFlavor(log, flavor)
-			}
-			snapshot, err := cache.Snapshot(ctx)
-			if err != nil {
-				t.Fatalf("unexpected error while building snapshot: %v", err)
-			}
-			clusterQueue := snapshot.ClusterQueue(kueue.ClusterQueueReference(tc.clusterQueue.Name))
-			if clusterQueue == nil {
-				t.Fatalf("Failed to create CQ snapshot")
-			}
-
-			// and we delete it
-			cache.DeleteResourceFlavor(log, flavorMap["deleted-flavor"])
-			delete(flavorMap, "deleted-flavor")
-
-			flvAssigner := New(wlInfo, clusterQueue, flavorMap, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared)
-
-			assignment := flvAssigner.Assign(log, nil)
-			if repMode := assignment.RepresentativeMode(); repMode != tc.wantRepMode {
-				t.Errorf("e.assignFlavors(_).RepresentativeMode()=%s, want %s", repMode, tc.wantRepMode)
-			}
-
-			if diff := cmp.Diff(tc.wantAssignment, assignment,
-				cmpopts.EquateEmpty(),
-				cmpopts.IgnoreUnexported(Assignment{}, FlavorAssignment{}), statusComparer, cmpopts.IgnoreFields(Assignment{}, "LastState"),
-			); diff != "" {
-				t.Errorf("Unexpected assignment (-want,+got):\n%s", diff)
-			}
-		})
+		}
 	}
 }
 
@@ -5034,6 +5057,31 @@ func TestIsNoFitDueToCapacityAndLimits(t *testing.T) {
 		"flavor-tas": resourceFlavors["flavor-tas"],
 	}
 
+	sharedCQ := *utiltestingapi.MakeClusterQueue("shared-cq").
+		Cohort("cohort").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("flavor-shared").Resource(corev1.ResourceCPU, "2", "4").Obj(),
+			*utiltestingapi.MakeFlavorQuotas("flavor-a").Resource(corev1.ResourceCPU, "2", "4").Obj(),
+		).
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("flavor-shared").Resource(corev1.ResourceMemory, "2Gi", "4Gi").Obj(),
+		).Obj()
+
+	siblingCQ := utiltestingapi.MakeClusterQueue("sibling").
+		Cohort("cohort").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("flavor-shared").Resource(corev1.ResourceCPU, "2", "2").Obj(),
+			*utiltestingapi.MakeFlavorQuotas("flavor-a").Resource(corev1.ResourceCPU, "2", "2").Obj(),
+		).
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("flavor-shared").Resource(corev1.ResourceMemory, "2Gi", "2Gi").Obj(),
+		).Obj()
+
+	sharedFlavors := map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
+		"flavor-shared": utiltestingapi.MakeResourceFlavor("flavor-shared").NodeLabel("type", "shared").Obj(),
+		"flavor-a":      utiltestingapi.MakeResourceFlavor("flavor-a").NodeLabel("type", "a").Obj(),
+	}
+
 	tests := map[string]struct {
 		podSet             kueue.PodSet
 		cq                 *kueue.ClusterQueue
@@ -5336,10 +5384,44 @@ func TestIsNoFitDueToCapacityAndLimits(t *testing.T) {
 				"flavor-b": "NoMatchingFlavor",
 			},
 		},
+		"flavor spanning multiple resource groups": {
+			podSet: *utiltestingapi.MakePodSet("main", 1).
+				Request(corev1.ResourceCPU, "3").
+				Request(corev1.ResourceMemory, "3Gi").
+				NodeSelector(map[string]string{"type": "a"}).
+				Obj(),
+			cq:         &sharedCQ,
+			siblingCQs: []*kueue.ClusterQueue{siblingCQ},
+			siblingCQUsage: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
+				"sibling": {
+					{Flavor: "flavor-shared", Resource: corev1.ResourceCPU}:    resources.NewAmount(2_000),
+					{Flavor: "flavor-shared", Resource: corev1.ResourceMemory}: resources.NewAmount(2 * utiltesting.Gi),
+					{Flavor: "flavor-a", Resource: corev1.ResourceCPU}:         resources.NewAmount(2_000),
+				},
+			},
+			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
+				{Flavor: "flavor-shared", Resource: corev1.ResourceCPU}: {
+					preemptionPossiblity: preemptioncommon.NoCandidates,
+				},
+				{Flavor: "flavor-shared", Resource: corev1.ResourceMemory}: {
+					preemptionPossiblity: preemptioncommon.NoCandidates,
+				},
+				{Flavor: "flavor-a", Resource: corev1.ResourceCPU}: {
+					preemptionPossiblity: preemptioncommon.NoCandidates,
+				},
+			},
+			resourceFlavors: sharedFlavors,
+			wantNoFitReason: "NoMatchingFlavor",
+			wantFlavorAttempts: map[kueue.ResourceFlavorReference]string{
+				"flavor-shared": "NoMatchingFlavor",
+				"flavor-a":      "WaitingForQuota",
+			},
+		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.UnadmittedWorkloadsObservability, true)
 			for fg, val := range tc.featureGates {
 				features.SetFeatureGateDuringTest(t, fg, val)
 			}

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -487,12 +487,6 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.14"
-- name: UnadmittedWorkloadsExplicitStatus
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Beta
-    version: "0.19"
 - name: UnadmittedWorkloadsObservability
   versionedSpecs:
   - default: false

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -487,6 +487,18 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.14"
+- name: UnadmittedWorkloadsExplicitStatus
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
+- name: UnadmittedWorkloadsObservability
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
 - name: VisibilityOnDemand
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -487,12 +487,6 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.14"
-- name: UnadmittedWorkloadsExplicitStatus
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Beta
-    version: "0.19"
 - name: UnadmittedWorkloadsObservability
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -487,6 +487,18 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.14"
+- name: UnadmittedWorkloadsExplicitStatus
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
+- name: UnadmittedWorkloadsObservability
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
 - name: VisibilityOnDemand
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR implements the scheduler-side logic specified in [KEP-10852](https://github.com/kubernetes-sigs/kueue/blob/main/keps/10852-inadmissible-workloads-observability) to track why a workload cannot fit within any resource flavors. It satisfies the following points from the KEP:

- Distinguish configuration faults vs. normal capacity wait
     - Adds `NoFitReason` tracking to the individual flavor assignment attempts.
     - Classifies attempts as:
          - `NoMatchingFlavor` for structural mismatches (node selectors, taints, or topology constraints).
          - `ExceedsMaxQuota` when exceeding absolute limits (cohort max capacity, or `ClusterQueue` nominal + borrowingLimit).
          - `WaitingForQuota` when waiting for preemption or cohort quota availability.
          - `TopologyPlacementFailed` when TAS placement requirements cannot be satisfied.
- Tiered Reason Precedence & Multi-PodSet Resolution
   - Implements the precedence tiers outlined in [Nominated Flavor Reasons](https://github.com/kubernetes-sigs/kueue/tree/main/keps/10852-inadmissible-workloads-observability#2-nominated-flavor-reasons) using a `reasonSeverity` ranking.
   - Provides `Assignment.resolveNoFitReason()` to calculate the final `NoFitReason` for the workload:
        - Alternatives (within a Resource Group): Resolves to the minimum severity blocker (best chance of success).
        - Co-requisites (across Resource Groups): Resolves to the maximum severity blocker (worst-case blocker).

#### Which issue(s) this PR fixes:
Part of #10852

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

> AI assistance disclosure: this change was developed with the assistance of an AI coding tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the `UnadmittedWorkloadsObservability` feature gate to enable more detailed scheduling “no-fit” diagnostics.

* **Bug Fixes**
  * Expanded “no-fit” reason reporting for quota/resource flavor matching and topology placement failures.
  * Improved flavor attribution in topology assignment failure details so returned diagnostics are labeled with the correct flavor.

* **Tests**
  * Updated scheduling diagnostics tests to validate top-level and per-flavor reason fields, including feature-gate on/off behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->