### PR TITLE
Automated cherry pick of #12386: test: make AppWrapper test more robust by more resources and SuccessPolicy

### DIFF
--- a/pkg/util/testingjobs/jobset/wrappers.go
+++ b/pkg/util/testingjobs/jobset/wrappers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package jobset
 
 import (
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -56,6 +57,7 @@ type ReplicatedJobRequirements struct {
 	PodAnnotations map[string]string
 	Image          string
 	Args           []string
+	SuccessPolicy  *batchv1.SuccessPolicy
 }
 
 // MakeJobSet creates a wrapper for a suspended JobSet
@@ -84,6 +86,10 @@ func (j *JobSetWrapper) ReplicatedJobs(replicatedJobs ...ReplicatedJobRequiremen
 		jt.Spec.Parallelism = ptr.To(req.Parallelism)
 		jt.Spec.Completions = ptr.To(req.Completions)
 		jt.Spec.Template.Annotations = req.PodAnnotations
+		jt.Spec.SuccessPolicy = req.SuccessPolicy
+		if jt.Spec.SuccessPolicy != nil {
+			jt.Spec.CompletionMode = ptr.To(batchv1.IndexedCompletion)
+		}
 		if req.BackoffLimit != nil {
 			jt.Spec.BackoffLimit = req.BackoffLimit
 		} else if len(req.Image) > 0 {

--- a/test/e2e/sequential/extended/managejobswithoutqueuename_test.go
+++ b/test/e2e/sequential/extended/managejobswithoutqueuename_test.go
@@ -246,11 +246,17 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Label("feature:mana
 								Completions: 2,
 								Image:       util.GetAgnHostImage(),
 								Args:        util.BehaviorExitFast,
+								SuccessPolicy: &batchv1.SuccessPolicy{Rules: []batchv1.SuccessPolicyRule{
+									{
+										SucceededCount: ptr.To(int32(1)),
+									},
+								}},
 							},
 						).
 						SetTypeMeta().
 						Suspend(false).
-						RequestAndLimit("replicated-job-1", corev1.ResourceCPU, "200m").
+						RequestAndLimit("replicated-job-1", corev1.ResourceCPU, "300m").
+						RequestAndLimit("replicated-job-1", corev1.ResourceMemory, "300Mi").
 						Obj(),
 				}).
 				Suspend(false).
@@ -312,11 +318,17 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Label("feature:mana
 								Labels: map[string]string{
 									controllerconstants.QueueLabel: localQueue.Name,
 								},
+								SuccessPolicy: &batchv1.SuccessPolicy{Rules: []batchv1.SuccessPolicyRule{
+									{
+										SucceededCount: ptr.To(int32(1)),
+									},
+								}},
 							},
 						).
 						SetTypeMeta().
 						Suspend(false).
-						RequestAndLimit("replicated-job-1", corev1.ResourceCPU, "200m").
+						RequestAndLimit("replicated-job-1", corev1.ResourceCPU, "300m").
+						RequestAndLimit("replicated-job-1", corev1.ResourceMemory, "300Mi").
 						Queue(localQueue.Name).
 						Obj(),
 				}).
@@ -378,7 +390,8 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Label("feature:mana
 				).
 				SetTypeMeta().
 				Suspend(false).
-				RequestAndLimit("replicated-job-1", corev1.ResourceCPU, "200m").
+				RequestAndLimit("replicated-job-1", corev1.ResourceCPU, "300m").
+				RequestAndLimit("replicated-job-1", corev1.ResourceMemory, "300Mi").
 				Obj()
 
 			ginkgo.By("Creating an unsuspended JobSet without a queue-name", func() {
@@ -1008,11 +1021,17 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName without JobSet integration",
 								Completions: 2,
 								Image:       util.GetAgnHostImage(),
 								Args:        util.BehaviorExitFast,
+								SuccessPolicy: &batchv1.SuccessPolicy{Rules: []batchv1.SuccessPolicyRule{
+									{
+										SucceededCount: ptr.To(int32(1)),
+									},
+								}},
 							},
 						).
 						SetTypeMeta().
 						Suspend(false).
-						RequestAndLimit("replicated-job-1", corev1.ResourceCPU, "200m").
+						RequestAndLimit("replicated-job-1", corev1.ResourceCPU, "300m").
+						RequestAndLimit("replicated-job-1", corev1.ResourceMemory, "300Mi").
 						Obj(),
 				}).
 				Suspend(false).


### PR DESCRIPTION
Cherry pick of #12386 on release-0.17.

#12386: test: make AppWrapper test more robust by more resources and SuccessPolicy

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```