### PR TITLE
Stabilize  Appwrapper tests from JobSet -> Job (Don't use SuccessPolicy)

### DIFF
--- a/test/e2e/sequential/extended/managejobswithoutqueuename_test.go
+++ b/test/e2e/sequential/extended/managejobswithoutqueuename_test.go
@@ -147,15 +147,10 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Label("feature:mana
 							testingjobset.ReplicatedJobRequirements{
 								Name:        "replicated-job-1",
 								Replicas:    2,
-								Parallelism: 2,
-								Completions: 2,
+								Parallelism: 1,
+								Completions: 1,
 								Image:       util.GetAgnHostImage(),
 								Args:        util.BehaviorExitFast,
-								SuccessPolicy: &batchv1.SuccessPolicy{Rules: []batchv1.SuccessPolicyRule{
-									{
-										SucceededCount: new(int32(1)),
-									},
-								}},
 							},
 						).
 						SetTypeMeta().
@@ -216,18 +211,13 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Label("feature:mana
 							testingjobset.ReplicatedJobRequirements{
 								Name:        "replicated-job-1",
 								Replicas:    2,
-								Parallelism: 2,
-								Completions: 2,
+								Parallelism: 1,
+								Completions: 1,
 								Image:       util.GetAgnHostImage(),
 								Args:        util.BehaviorExitFast,
 								Labels: map[string]string{
 									controllerconstants.QueueLabel: localQueue.Name,
 								},
-								SuccessPolicy: &batchv1.SuccessPolicy{Rules: []batchv1.SuccessPolicyRule{
-									{
-										SucceededCount: new(int32(1)),
-									},
-								}},
 							},
 						).
 						SetTypeMeta().
@@ -781,15 +771,10 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName without JobSet integration",
 							testingjobset.ReplicatedJobRequirements{
 								Name:        "replicated-job-1",
 								Replicas:    2,
-								Parallelism: 2,
-								Completions: 2,
+								Parallelism: 1,
+								Completions: 1,
 								Image:       util.GetAgnHostImage(),
 								Args:        util.BehaviorExitFast,
-								SuccessPolicy: &batchv1.SuccessPolicy{Rules: []batchv1.SuccessPolicyRule{
-									{
-										SucceededCount: new(int32(1)),
-									},
-								}},
 							},
 						).
 						SetTypeMeta().


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12389

#### Special notes for your reviewer:

Seems like SuccessPolicy is not too well supported by AppWrapper, because it still counts pods by numbers.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test cases for job management scenarios to use single-execution parameters instead of parallel execution, and adjusted success policy configurations accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->