### PR TITLE
docs: activate version dropdown on release-0.16

### DIFF
--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -110,17 +110,32 @@ ignoreFiles = []
 
   # A link to latest version of the docs. Used in the "version-banner" partial to
   # point people to the main doc site.
-  url_latest_version = "https://sigs.k8s.io/kueue/docs"
+  url_latest_version = "https://kueue.sigs.k8s.io"
 
   # A variable used in various docs to determine URLs for config files etc.
   # To find occurrences, search the repo for 'params "githubbranch"'.
-  githubbranch = "main"
+  githubbranch = "release-0.16"
 
   # These entries appear in the drop-down menu at the top of the website.
-  # [[params.versions]]
-  #   version = "main"
-  #   githubbranch = "main"
-  #   url = "https://kueue.sigs.k8s.io"
+  [[params.versions]]
+    version = "main"
+    githubbranch = "main"
+    url = "https://kueue.sigs.k8s.io"
+
+  [[params.versions]]
+    version = "v0.18"
+    githubbranch = "release-0.18"
+    url = "https://v0-18.kueue.sigs.k8s.io"
+
+  [[params.versions]]
+    version = "v0.17"
+    githubbranch = "release-0.17"
+    url = "https://v0-17.kueue.sigs.k8s.io"
+
+  [[params.versions]]
+    version = "v0.16"
+    githubbranch = "release-0.16"
+    url = "https://v0-16.kueue.sigs.k8s.io"
 
   # User interface configuration
   [params.ui]


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/area website

#### What this PR does / why we need it:

Part of the versioned-docs set (see #12396). Activates the version-switcher dropdown on the `release-0.16` docs build, which Netlify branch-deploys to `v0-16.kueue.sigs.k8s.io`.

**`site/hugo.toml`:**
- Adds `[[params.versions]]` for `main` + v0.18/v0.17/v0.16
- Points top-level `githubbranch` at `release-0.16` (so "edit this page" links resolve to this branch)
- Fixes `url_latest_version` (stale `sigs.k8s.io/kueue/docs` redirect -> `https://kueue.sigs.k8s.io`)

**Does not set `archived_version`.** v0.16 is within the N-2 support window, and Docsy's archived banner reads *"no longer actively maintained… an archived snapshot"* — inaccurate for a supported release. The flag is reserved for versions that age out of support (documented in #12396's `RELEASE.md`).

> Note: This PR was developed with AI assistance (Claude Code).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
