### PR TITLE
test: fix provisioning request retention assertion on workload finish

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -541,7 +541,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		},
-		"request removed on workload finished": {
+		"request not removed on workload finished": {
 			workload: (&utiltestingapi.WorkloadWrapper{Workload: *baseWorkload.DeepCopy()}).
 				Condition(metav1.Condition{
 					Type:   kueue.WorkloadFinished,
@@ -549,12 +549,14 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 
-			checks:               []kueue.AdmissionCheck{*baseCheck.DeepCopy()},
-			flavors:              []kueue.ResourceFlavor{*baseFlavor1.DeepCopy(), *baseFlavor2.DeepCopy()},
-			configs:              []kueue.ProvisioningRequestConfig{*baseConfigWithRetryStrategy.DeepCopy()},
-			requests:             []autoscaling.ProvisioningRequest{*baseRequest.DeepCopy()},
-			templates:            []corev1.PodTemplate{*baseTemplate1.DeepCopy(), *baseTemplate2.DeepCopy()},
-			wantRequestsNotFound: []string{"wl-check1"},
+			checks:    []kueue.AdmissionCheck{*baseCheck.DeepCopy()},
+			flavors:   []kueue.ResourceFlavor{*baseFlavor1.DeepCopy(), *baseFlavor2.DeepCopy()},
+			configs:   []kueue.ProvisioningRequestConfig{*baseConfigWithRetryStrategy.DeepCopy()},
+			requests:  []autoscaling.ProvisioningRequest{*baseRequest.DeepCopy()},
+			templates: []corev1.PodTemplate{*baseTemplate1.DeepCopy(), *baseTemplate2.DeepCopy()},
+			wantRequests: map[string]*autoscaling.ProvisioningRequest{
+				baseRequest.Name: baseRequest.DeepCopy(),
+			},
 		},
 		"when request fails and is retried": {
 			workload: baseWorkload.DeepCopy(),


### PR DESCRIPTION
#### What this PR does / why we need it:

/kind failing-test
/area testing

#### Which issue(s) this PR fixes:

Corrects the test assertion for the case where a workload reaches the `Finished` state while a ProvisioningRequest is still present.

Due to a race condition (#2196) where a workload can complete due to MaxRunDuration timeout before ClusterAutoscaler sets `CapacityRevoked=true`, ProvisioningRequests are intentionally preserved after a workload finishes so that Kueue can still react to that condition.

The previous test checked for `"wl-check1"` instead of `"wl-check1-1"`, missing the attempt suffix, resulting in the  assertion passing trivially. The test is now updated to assert the correct behavior: the ProvisioningRequest `"wl-check1-1"` is preserved after reconciliation of a finished workload.


#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where `ProvisioningRequest` resources were being incorrectly removed when workloads completed. These resources now persist after workload completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->