### PR TITLE
Inject ResourceFlavor nodeLabels and tolerations in ElasticJobUngater

### DIFF
--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -169,7 +169,7 @@ func (r *elasticJobUngater) Reconcile(ctx context.Context, req reconcile.Request
 			}
 			if info, ok := infoFor(pod); ok {
 				if mergeErr := podset.Merge(&pod.ObjectMeta, &pod.Spec, info); mergeErr != nil {
-					log.Error(mergeErr, "failed merging PodSet info before ungating; ungating without flavor injection",
+					log.Error(mergeErr, "failed merging PodSet info after ungating; pod released without flavor injection",
 						"pod", klog.KObj(pod))
 				} else {
 					log.V(3).Info("ungating elastic pod with assigned flavor info",

--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -132,8 +132,10 @@ func (r *elasticJobUngater) Reconcile(ctx context.Context, req reconcile.Request
 		return reconcile.Result{}, fmt.Errorf("building PodSet info for elastic ungater: %w", err)
 	}
 	infoByPodSet := make(map[kueue.PodSetReference]podset.PodSetInfo, len(infos))
+	flavorsByPodSet := make(map[kueue.PodSetReference]map[corev1.ResourceName]kueue.ResourceFlavorReference, len(infos))
 	for i := range infos {
 		infoByPodSet[infos[i].Name] = infos[i]
+		flavorsByPodSet[infos[i].Name] = wl.Status.Admission.PodSetAssignments[i].Flavors
 	}
 	var singleInfo *podset.PodSetInfo
 	if len(infos) == 1 {
@@ -167,13 +169,14 @@ func (r *elasticJobUngater) Reconcile(ctx context.Context, req reconcile.Request
 			}
 			if info, ok := infoFor(pod); ok {
 				if mergeErr := podset.Merge(&pod.ObjectMeta, &pod.Spec, info); mergeErr != nil {
-					log.V(2).Info("failed merging PodSet info before ungating; ungating without flavor injection",
-						"pod", klog.KObj(pod), "error", mergeErr)
+					log.Error(mergeErr, "failed merging PodSet info before ungating; ungating without flavor injection",
+						"pod", klog.KObj(pod))
 				} else {
-					log.V(3).Info("ungating elastic pod with assigned flavor info", "pod", klog.KObj(pod))
+					log.V(3).Info("ungating elastic pod with assigned flavor info",
+						"pod", klog.KObj(pod), "flavors", flavorsByPodSet[info.Name])
 				}
 			} else {
-				log.V(2).Info("ungating elastic pod without flavor info; no matching PodSet",
+				log.V(0).Info("ungating elastic pod without flavor info; no matching PodSet",
 					"pod", klog.KObj(pod))
 			}
 			return true, nil

--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -40,6 +40,8 @@ import (
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/podset"
 	utilclient "sigs.k8s.io/kueue/pkg/util/client"
 	"sigs.k8s.io/kueue/pkg/util/expectations"
 	"sigs.k8s.io/kueue/pkg/util/parallelize"
@@ -123,6 +125,31 @@ func (r *elasticJobUngater) Reconcile(ctx context.Context, req reconcile.Request
 		return reconcile.Result{}, nil
 	}
 
+	// Elastic jobs bypass startJob, so inject the same PodSetInfo here before
+	// ungating.
+	infos, err := jobframework.GetPodSetsInfoFromStatus(ctx, r.client, wl)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("building PodSet info for elastic ungater: %w", err)
+	}
+	infoByPodSet := make(map[kueue.PodSetReference]podset.PodSetInfo, len(infos))
+	for i := range infos {
+		infoByPodSet[infos[i].Name] = infos[i]
+	}
+	var singleInfo *podset.PodSetInfo
+	if len(infos) == 1 {
+		singleInfo = &infos[0]
+	}
+	infoFor := func(pod *corev1.Pod) (podset.PodSetInfo, bool) {
+		if name, found := pod.Labels[constants.PodSetLabel]; found {
+			info, ok := infoByPodSet[kueue.PodSetReference(name)]
+			return info, ok
+		}
+		if singleInfo != nil {
+			return *singleInfo, true
+		}
+		return podset.PodSetInfo{}, false
+	}
+
 	log.V(2).Info("identified elastic pods to ungate", "count", len(pods))
 	uids := make([]types.UID, len(pods))
 	for i := range pods {
@@ -135,10 +162,21 @@ func (r *elasticJobUngater) Reconcile(ctx context.Context, req reconcile.Request
 		var ungated bool
 		e := utilclient.Patch(ctx, r.client, pod, func() (bool, error) {
 			ungated = utilpod.Ungate(pod, kueue.ElasticJobSchedulingGate)
-			if ungated {
-				log.V(3).Info("ungating elastic pod", "pod", klog.KObj(pod))
+			if !ungated {
+				return false, nil
 			}
-			return ungated, nil
+			if info, ok := infoFor(pod); ok {
+				if mergeErr := podset.Merge(&pod.ObjectMeta, &pod.Spec, info); mergeErr != nil {
+					log.V(2).Info("failed merging PodSet info before ungating; ungating without flavor injection",
+						"pod", klog.KObj(pod), "error", mergeErr)
+				} else {
+					log.V(3).Info("ungating elastic pod with assigned flavor info", "pod", klog.KObj(pod))
+				}
+			} else {
+				log.V(2).Info("ungating elastic pod without flavor info; no matching PodSet",
+					"pod", klog.KObj(pod))
+			}
+			return true, nil
 		})
 		if e != nil {
 			r.expectationsStore.ObservedUID(log, req.NamespacedName, pod.UID)

--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/constants"
 	coreindexer "sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/expectations"
@@ -48,14 +49,19 @@ var podCmpOpts = []gocmp.Option{
 
 func TestReconcile(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
+	// Queue-label assignment is exercised in jobframework tests; disable it
+	// here so the expected pods only reflect behavior under test
+	// (PodSetLabel, nodeSelectors, tolerations).
+	features.SetFeatureGateDuringTest(t, features.AssignQueueLabelsForPods, false)
 	now := time.Now().Truncate(time.Second)
 
 	testCases := map[string]struct {
-		expectUIDs []types.UID
-		workloads  []kueue.Workload
-		pods       []corev1.Pod
-		wantPods   []corev1.Pod
-		wantErr    error
+		expectUIDs      []types.UID
+		workloads       []kueue.Workload
+		pods            []corev1.Pod
+		resourceFlavors []kueue.ResourceFlavor
+		wantPods        []corev1.Pod
+		wantErr         error
 	}{
 		"ungate single pod": {
 			workloads: []kueue.Workload{
@@ -73,6 +79,9 @@ func TestReconcile(t *testing.T) {
 					AdmittedAt(true, now).
 					Obj(),
 			},
+			resourceFlavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("flavor").Obj(),
+			},
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl").
@@ -84,6 +93,7 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("pod", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl").
 					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 			},
 		},
@@ -103,6 +113,9 @@ func TestReconcile(t *testing.T) {
 					AdmittedAt(true, now).
 					Obj(),
 			},
+			resourceFlavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("flavor").Obj(),
+			},
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod-0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl").
@@ -124,14 +137,17 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("pod-0", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl").
 					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 				*testingpod.MakePod("pod-1", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl").
 					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 				*testingpod.MakePod("pod-2", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl").
 					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 			},
 		},
@@ -151,6 +167,9 @@ func TestReconcile(t *testing.T) {
 					AdmittedAt(true, now).
 					Obj(),
 			},
+			resourceFlavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("flavor").Obj(),
+			},
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod-gated", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl").
@@ -166,6 +185,7 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("pod-gated", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl").
 					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 				*testingpod.MakePod("pod-ungated", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl").
@@ -278,6 +298,9 @@ func TestReconcile(t *testing.T) {
 					AdmittedAt(true, now).
 					Obj(),
 			},
+			resourceFlavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("flavor").Obj(),
+			},
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod-from-parent", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl").
@@ -299,6 +322,7 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("pod-from-scale-up", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl-slice-1").
 					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 			},
 		},
@@ -324,6 +348,9 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
 					Obj(),
 			},
+			resourceFlavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("flavor").Obj(),
+			},
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod-from-admitted-slice", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl").
@@ -340,6 +367,7 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("pod-from-admitted-slice", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl").
 					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 				*testingpod.MakePod("pod-from-pending-slice", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl-slice-1").
@@ -364,6 +392,9 @@ func TestReconcile(t *testing.T) {
 					AdmittedAt(true, now).
 					Obj(),
 			},
+			resourceFlavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("flavor").Obj(),
+			},
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl").
@@ -376,9 +407,192 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("pod", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl").
 					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
+		},
+		"inject nodeLabels and tolerations from assigned flavor (single PodSet)": {
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "flv", "1").
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			resourceFlavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("flv").
+					NodeLabel("cloud.google.com/gke-nodepool", "reserved-pool").
+					Toleration(corev1.Toleration{
+						Key:      "reserved-pool",
+						Operator: corev1.TolerationOpEqual,
+						Value:    "true",
+						Effect:   corev1.TaintEffectNoSchedule,
+					}).
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("pod", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("pod", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
+					NodeSelector("cloud.google.com/gke-nodepool", "reserved-pool").
+					Toleration(corev1.Toleration{
+						Key:      "reserved-pool",
+						Operator: corev1.TolerationOpEqual,
+						Value:    "true",
+						Effect:   corev1.TaintEffectNoSchedule,
+					}).
+					Obj(),
+			},
+		},
+		"inject flavor per PodSet using PodSetLabel (multi PodSet)": {
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					PodSets(
+						*utiltestingapi.MakePodSet("head", 1).Request(corev1.ResourceCPU, "1").Obj(),
+						*utiltestingapi.MakePodSet("workers", 2).Request(corev1.ResourceCPU, "1").Obj(),
+					).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(
+								utiltestingapi.MakePodSetAssignment("head").
+									Assignment(corev1.ResourceCPU, "head-flv", "1").Obj(),
+								utiltestingapi.MakePodSetAssignment("workers").
+									Assignment(corev1.ResourceCPU, "worker-flv", "2").Obj(),
+							).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			resourceFlavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("head-flv").
+					NodeLabel("role", "head").Obj(),
+				*utiltestingapi.MakeResourceFlavor("worker-flv").
+					NodeLabel("role", "worker").Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("head-pod", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Label(constants.PodSetLabel, "head").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+				*testingpod.MakePod("worker-pod", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Label(constants.PodSetLabel, "workers").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("head-pod", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Label(constants.PodSetLabel, "head").
+					NodeSelector("role", "head").
+					Obj(),
+				*testingpod.MakePod("worker-pod", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Label(constants.PodSetLabel, "workers").
+					NodeSelector("role", "worker").
+					Obj(),
+			},
+		},
+		"multi-PodSet pod without PodSetLabel is ungated without flavor injection": {
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					PodSets(
+						*utiltestingapi.MakePodSet("head", 1).Request(corev1.ResourceCPU, "1").Obj(),
+						*utiltestingapi.MakePodSet("workers", 1).Request(corev1.ResourceCPU, "1").Obj(),
+					).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(
+								utiltestingapi.MakePodSetAssignment("head").
+									Assignment(corev1.ResourceCPU, "head-flv", "1").Obj(),
+								utiltestingapi.MakePodSetAssignment("workers").
+									Assignment(corev1.ResourceCPU, "worker-flv", "1").Obj(),
+							).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			resourceFlavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("head-flv").
+					NodeLabel("role", "head").Obj(),
+				*utiltestingapi.MakeResourceFlavor("worker-flv").
+					NodeLabel("role", "worker").Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("pod", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("pod", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Obj(),
+			},
+		},
+		"missing ResourceFlavor blocks ungating so reconcile retries": {
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "missing-flv", "1").
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("pod", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("pod", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+			// Any non-nil error from the wrapped NotFound is acceptable; the
+			// pod-still-gated check below is the real assertion.
+			wantErr: cmpopts.AnyError,
 		},
 	}
 
@@ -400,6 +614,9 @@ func TestReconcile(t *testing.T) {
 			}
 			for i := range tc.workloads {
 				clientBuilder = clientBuilder.WithStatusSubresource(&tc.workloads[i])
+			}
+			for i := range tc.resourceFlavors {
+				clientBuilder = clientBuilder.WithObjects(&tc.resourceFlavors[i])
 			}
 
 			kClient := clientBuilder.Build()

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1212,7 +1212,7 @@ func expectedRunningPodSets(ctx context.Context, c client.Client, wl *kueue.Work
 	if !workload.HasQuotaReservation(wl) {
 		return nil
 	}
-	info, err := getPodSetsInfoFromStatus(ctx, c, wl)
+	info, err := GetPodSetsInfoFromStatus(ctx, c, wl)
 	if err != nil {
 		return nil
 	}
@@ -1299,7 +1299,7 @@ func (r *JobReconciler) updateWorkloadToMatchJob(ctx context.Context, job Generi
 
 // startJob will unsuspend the job, and also inject the node affinity.
 func (r *JobReconciler) startJob(ctx context.Context, job GenericJob, object client.Object, wl *kueue.Workload) error {
-	info, err := getPodSetsInfoFromStatus(ctx, r.client, wl)
+	info, err := GetPodSetsInfoFromStatus(ctx, r.client, wl)
 	if err != nil {
 		return err
 	}
@@ -1553,9 +1553,11 @@ func extractPriorityFromPodSets(podSets []kueue.PodSet) string {
 	return ""
 }
 
-// getPodSetsInfoFromStatus extracts podSetsInfo from workload status, based on
-// admission, and admission checks.
-func getPodSetsInfoFromStatus(ctx context.Context, c client.Client, w *kueue.Workload) ([]podset.PodSetInfo, error) {
+// GetPodSetsInfoFromStatus extracts podSetsInfo from workload status, based on
+// admission, and admission checks. The returned slice parallels
+// w.Status.Admission.PodSetAssignments: infos[i] corresponds to
+// PodSetAssignments[i] and w.Spec.PodSets[i].
+func GetPodSetsInfoFromStatus(ctx context.Context, c client.Client, w *kueue.Workload) ([]podset.PodSetInfo, error) {
 	if len(w.Status.Admission.PodSetAssignments) == 0 {
 		return nil, nil
 	}

--- a/pkg/util/testingjobs/pod/wrappers.go
+++ b/pkg/util/testingjobs/pod/wrappers.go
@@ -257,6 +257,12 @@ func (p *PodWrapper) NodeSelector(k, v string) *PodWrapper {
 	return p
 }
 
+// Toleration appends a Toleration to the PodSpec.
+func (p *PodWrapper) Toleration(t corev1.Toleration) *PodWrapper {
+	p.Spec.Tolerations = append(p.Spec.Tolerations, t)
+	return p
+}
+
 func (p *PodWrapper) RequiredDuringSchedulingIgnoredDuringExecution(nodeSelectorTerms []corev1.NodeSelectorTerm) *PodWrapper {
 	if p.Spec.Affinity == nil {
 		p.Spec.Affinity = &corev1.Affinity{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind bug
/area integrations

#### What this PR does / why we need it:

Elastic jobs that bypass `startJob` (RayCluster with autoscaling, batch/v1
Job with the elastic annotation) relied on the `ElasticJobUngater` only to
remove the `ElasticJobSchedulingGate`. The ungater never applied the
`PodSetInfo` that `startJob` injects via `RunWithPodSetsInfo` and
`podset.Merge`. So pods admitted to a ResourceFlavor with `nodeLabels`
never got those labels, and could land outside the target node pool.

The ungater now calls `jobframework.GetPodSetsInfoFromStatus` (exported
for this purpose) and merges the result into each pod before removing the
gate. Reusing the standard path also picks up admission-check
`PodSetUpdates`, the `PodSetLabel`, and slice/queue labels.

A missing ResourceFlavor now makes the reconcile retry, rather than
ungating pods without injection.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12350

#### Special notes for your reviewer:

Pod-to-PodSet mapping: by `kueue.x-k8s.io/podset` label first; falls back
to the single PodSet when the workload has one PodSet and the label is
absent (the issue's RayCluster-worker scenario); otherwise logs and
ungates without injection.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
`ElasticJobsViaWorkloadSlices`: fixed pods of elastic jobs not receiving
the assigned ResourceFlavor's nodeLabels and tolerations, which could
land them outside the target node pool. A missing ResourceFlavor now
makes the ungater retry rather than silently ungating pods.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Elastic jobs now inject PodSet “flavor” information during pod ungating, applying the correct node labels and tolerations from assigned resource flavors to improve scheduling reliability.

* **Tests**
  * Updated and expanded elastic job ungating coverage for single and multi–PodSet scenarios, including cases without PodSet labeling and situations where required resource flavors are missing (now validated to fail safely).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->