### PR TITLE
[ElasticWorkloadSlicing] Account for the autoscaler sidecar in RayCluster head PodSet quota

### DIFF
--- a/pkg/controller/jobs/raycluster/common.go
+++ b/pkg/controller/jobs/raycluster/common.go
@@ -79,6 +79,15 @@ func BuildPodSets(rayClusterSpec *rayv1.RayClusterSpec, annotations map[string]s
 			return nil, err
 		}
 	}
+	// When in-tree autoscaling is enabled, KubeRay injects an autoscaler sidecar
+	// container into the head Pod. It is added at Pod-build time and is not part
+	// of HeadGroupSpec.Template, so account for it here to keep quota accurate.
+	if ptr.Deref(rayClusterSpec.EnableInTreeAutoscaling, false) {
+		headPodSet.Template.Spec.Containers = append(
+			headPodSet.Template.Spec.Containers,
+			autoscalerContainer(rayClusterSpec.AutoscalerOptions),
+		)
+	}
 	podSets = append(podSets, headPodSet)
 
 	// workers
@@ -130,6 +139,40 @@ func redisCleanupResourceRequests() corev1.ResourceList {
 
 func shouldAccountForRedisCleanup(rayClusterSpec *rayv1.RayClusterSpec, annotations map[string]string) bool {
 	return rayutils.IsGCSFaultToleranceEnabled(rayClusterSpec, annotations)
+}
+
+// autoscalerContainerName is the name KubeRay gives the autoscaler sidecar.
+const autoscalerContainerName = "autoscaler"
+
+// defaultAutoscalerResources mirrors the resources KubeRay assigns to the Ray
+// autoscaler sidecar container when AutoscalerOptions.Resources is not set
+// (ray-operator/controllers/ray/common/pod.go: BuildAutoscalerContainer).
+func defaultAutoscalerResources() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+}
+
+// autoscalerContainer returns a container mirroring the Ray autoscaler sidecar
+// that KubeRay injects into the head Pod when in-tree autoscaling is enabled.
+// It uses AutoscalerOptions.Resources when provided, otherwise KubeRay's
+// defaults, matching how KubeRay builds the actual container.
+func autoscalerContainer(opts *rayv1.AutoscalerOptions) corev1.Container {
+	resources := defaultAutoscalerResources()
+	if opts != nil && opts.Resources != nil {
+		resources = *opts.Resources.DeepCopy()
+	}
+	return corev1.Container{
+		Name:      autoscalerContainerName,
+		Resources: resources,
+	}
 }
 
 func ExpectedPodSetsCount(rayClusterSpec *rayv1.RayClusterSpec) int {

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -307,6 +307,94 @@ func TestBuildPodSets(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		"autoscaler sidecar added to head podSet with default resources when in-tree autoscaling is enabled": {
+			rayClusterSpec: &rayv1.RayClusterSpec{
+				EnableInTreeAutoscaling: new(true),
+				HeadGroupSpec: rayv1.HeadGroupSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "head"}},
+						},
+					},
+				},
+				WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
+					{
+						GroupName: "workers",
+						Replicas:  ptr.To[int32](1),
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "worker"}},
+							},
+						},
+					},
+				},
+			},
+			wantPodSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
+					PodSpec(corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "head"},
+							{
+								Name: "autoscaler",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("500m"),
+										corev1.ResourceMemory: resource.MustParse("512Mi"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("500m"),
+										corev1.ResourceMemory: resource.MustParse("512Mi"),
+									},
+								},
+							},
+						},
+					}).
+					Obj(),
+				*utiltestingapi.MakePodSet("workers", 1).
+					PodSpec(corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "worker"}},
+					}).
+					Obj(),
+			},
+		},
+		"autoscaler sidecar uses AutoscalerOptions.Resources override when set": {
+			rayClusterSpec: &rayv1.RayClusterSpec{
+				EnableInTreeAutoscaling: new(true),
+				AutoscalerOptions: &rayv1.AutoscalerOptions{
+					Resources: &corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("250m"),
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+				HeadGroupSpec: rayv1.HeadGroupSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "head"}},
+						},
+					},
+				},
+			},
+			wantPodSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
+					PodSpec(corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "head"},
+							{
+								Name: "autoscaler",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("250m"),
+										corev1.ResourceMemory: resource.MustParse("256Mi"),
+									},
+								},
+							},
+						},
+					}).
+					Obj(),
+			},
+		},
 	}
 
 	for name, tc := range testCases {

--- a/pkg/controller/jobs/rayservice/rayservice_controller_test.go
+++ b/pkg/controller/jobs/rayservice/rayservice_controller_test.go
@@ -36,6 +36,27 @@ import (
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
+// headSpecWithAutoscaler returns the head PodSpec with the autoscaler sidecar
+// container appended, matching what BuildPodSets adds when in-tree autoscaling
+// is enabled (KubeRay's default 500m CPU / 512Mi memory).
+func headSpecWithAutoscaler(rayService *RayService) corev1.PodSpec {
+	spec := rayService.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.DeepCopy()
+	spec.Containers = append(spec.Containers, corev1.Container{
+		Name: "autoscaler",
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+		},
+	})
+	return *spec
+}
+
 func TestPodSets(t *testing.T) {
 	testCases := map[string]struct {
 		rayService   *RayService
@@ -294,7 +315,7 @@ func TestPodSets(t *testing.T) {
 			wantPodSets: func(rayService *RayService) []kueue.PodSet {
 				return []kueue.PodSet{
 					*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
-						PodSpec(*rayService.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.DeepCopy()).
+						PodSpec(headSpecWithAutoscaler(rayService)).
 						Obj(),
 					*utiltestingapi.MakePodSet("group1", 5). // Updated from RayCluster
 											PodSpec(*rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.DeepCopy()).
@@ -407,7 +428,7 @@ func TestPodSets(t *testing.T) {
 			wantPodSets: func(rayService *RayService) []kueue.PodSet {
 				return []kueue.PodSet{
 					*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
-						PodSpec(*rayService.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.DeepCopy()).
+						PodSpec(headSpecWithAutoscaler(rayService)).
 						Obj(),
 					*utiltestingapi.MakePodSet("group1", 3). // Fallback to spec count
 											PodSpec(*rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.DeepCopy()).
@@ -457,7 +478,7 @@ func TestPodSets(t *testing.T) {
 			wantPodSets: func(rayService *RayService) []kueue.PodSet {
 				return []kueue.PodSet{
 					*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
-						PodSpec(*rayService.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.DeepCopy()).
+						PodSpec(headSpecWithAutoscaler(rayService)).
 						Obj(),
 					*utiltestingapi.MakePodSet("group1", 2). // Uses spec count
 											PodSpec(*rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.DeepCopy()).

--- a/test/e2e/singlecluster/extended/kuberay_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_test.go
@@ -126,7 +126,11 @@ var _ = ginkgo.Describe("Kuberay", ginkgo.Label("area:singlecluster", "feature:k
 		cq = utiltestingapi.MakeClusterQueue(clusterQueueName).
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas(rf.Name).
-					Resource(corev1.ResourceCPU, "3").Obj()).
+					// 3 cores for the head + workers, plus 500m headroom for the
+					// autoscaler sidecar that BuildPodSets accounts for on
+					// in-tree-autoscaling clusters.
+					Resource(corev1.ResourceCPU, "3500m").
+					Resource(corev1.ResourceMemory, "2Gi").Obj()).
 			Obj()
 		util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
 
@@ -661,6 +665,86 @@ print([ray.get(my_task.remote(i, 1)) for i in range(20)])`,
 				g.Expect(createdRayCluster.Status.ReadyWorkerReplicas).To(gomega.Equal(int32(1)))
 				g.Expect(createdRayCluster.Status.AvailableWorkerReplicas).To(gomega.Equal(int32(1)))
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("RayCluster did not become ready", createdRayCluster))
+		})
+	})
+
+	ginkgo.It("Should account for the autoscaler sidecar in the head PodSet quota when in-tree autoscaling is enabled", ginkgo.Label("shard:kuberay-b"), func() {
+		kuberayTestImage := util.GetKuberayTestImage()
+
+		raycluster := testingraycluster.MakeCluster("raycluster-autoscaling", ns.Name).
+			Suspend(true).
+			Queue(localQueueName).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			WithEnableAutoscaling(new(true)).
+			RequestAndLimit(rayv1.HeadNode, corev1.ResourceCPU, "1").
+			RayStartParam(rayv1.HeadNode, "object-store-memory", objectStoreMemory).
+			RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "400m").
+			RayStartParam(rayv1.WorkerNode, "object-store-memory", objectStoreMemory).
+			Image(rayv1.HeadNode, kuberayTestImage, []string{}).
+			Image(rayv1.WorkerNode, kuberayTestImage, []string{}).
+			Obj()
+
+		ginkgo.By("Creating the RayCluster", func() {
+			gomega.Expect(k8sClient.Create(ctx, raycluster)).Should(gomega.Succeed())
+		})
+
+		// Elastic (workload-slice) jobs name their Workload with a generation
+		// suffix, so look it up by listing the namespace rather than computing
+		// the name.
+		createdWorkload := &kueue.Workload{}
+		ginkgo.By("Checking the workload is created and admitted", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				workloadList := &kueue.WorkloadList{}
+				g.Expect(k8sClient.List(ctx, workloadList, client.InNamespace(ns.Name))).To(gomega.Succeed())
+				active := util.FindNonFinishedWorkloads(workloadList.Items)
+				g.Expect(active).To(gomega.HaveLen(1), "expected exactly one non-finished workload")
+				g.Expect(workload.IsAdmitted(&active[0])).To(gomega.BeTrue(), "workload should be admitted")
+				*createdWorkload = active[0]
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		// Kueue's view: the head PodSet must include the autoscaler sidecar that
+		// KubeRay injects, otherwise its resources are not counted against quota.
+		var kueueAutoscalerRequests corev1.ResourceList
+		ginkgo.By("Checking the head PodSet includes the autoscaler sidecar container", func() {
+			var headPodSet *kueue.PodSet
+			for i := range createdWorkload.Spec.PodSets {
+				if createdWorkload.Spec.PodSets[i].Name == "head" {
+					headPodSet = &createdWorkload.Spec.PodSets[i]
+					break
+				}
+			}
+			gomega.Expect(headPodSet).NotTo(gomega.BeNil(), "workload should have a head PodSet")
+
+			var autoscaler *corev1.Container
+			for i := range headPodSet.Template.Spec.Containers {
+				if headPodSet.Template.Spec.Containers[i].Name == "autoscaler" {
+					autoscaler = &headPodSet.Template.Spec.Containers[i]
+					break
+				}
+			}
+			gomega.Expect(autoscaler).NotTo(gomega.BeNil(), "head PodSet should include the autoscaler sidecar container")
+			kueueAutoscalerRequests = autoscaler.Resources.Requests
+		})
+
+		// Drift check: the resources Kueue accounted for must match the autoscaler
+		// container that KubeRay actually injects into the head Pod.
+		ginkgo.By("Checking the accounted autoscaler resources match the real head Pod", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				headPod := getRayHeadPod(g)
+				var autoscaler *corev1.Container
+				for i := range headPod.Spec.Containers {
+					if headPod.Spec.Containers[i].Name == "autoscaler" {
+						autoscaler = &headPod.Spec.Containers[i]
+						break
+					}
+				}
+				g.Expect(autoscaler).NotTo(gomega.BeNil(), "KubeRay should inject an autoscaler container into the head Pod")
+				g.Expect(kueueAutoscalerRequests.Cpu().Cmp(*autoscaler.Resources.Requests.Cpu())).To(gomega.Equal(0),
+					"Kueue's accounted autoscaler CPU should match the head Pod's")
+				g.Expect(kueueAutoscalerRequests.Memory().Cmp(*autoscaler.Resources.Requests.Memory())).To(gomega.Equal(0),
+					"Kueue's accounted autoscaler memory should match the head Pod's")
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
 

--- a/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go
@@ -702,7 +702,7 @@ var _ = ginkgo.Describe("RayCluster with elastic jobs via workload-slices suppor
 		clusterQueue   *kueue.ClusterQueue
 		localQueue     *kueue.LocalQueue
 	)
-	cpuNominalQuota := 5
+	cpuNominalQuota := 6
 
 	ginkgo.BeforeAll(func() {
 		gomega.Expect(utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{string(features.ElasticJobsViaWorkloadSlices): true})).Should(gomega.Succeed())
@@ -719,7 +719,7 @@ var _ = ginkgo.Describe("RayCluster with elastic jobs via workload-slices suppor
 		util.MustCreate(ctx, k8sClient, resourceFlavor)
 
 		clusterQueue = utiltestingapi.MakeClusterQueue("default").
-			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).Resource(corev1.ResourceCPU, strconv.Itoa(cpuNominalQuota)).Obj()).
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).Resource(corev1.ResourceCPU, strconv.Itoa(cpuNominalQuota)).Resource(corev1.ResourceMemory, "5Gi").Obj()).
 			Preemption(kueue.ClusterQueuePreemption{
 				WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
 			}).
@@ -776,8 +776,8 @@ var _ = ginkgo.Describe("RayCluster with elastic jobs via workload-slices suppor
 			cq := &kueue.ClusterQueue{}
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), cq)).Should(gomega.Succeed())
 			g.Expect(len(cq.Status.FlavorsUsage)).Should(gomega.BeEquivalentTo(1))
-			g.Expect(len(cq.Status.FlavorsUsage[0].Resources)).Should(gomega.BeEquivalentTo(1))
-			g.Expect(cq.Status.FlavorsUsage[0].Resources[0].Total).Should(gomega.BeEquivalentTo(resource.MustParse("3")))
+			g.Expect(len(cq.Status.FlavorsUsage[0].Resources)).Should(gomega.BeEquivalentTo(2))
+			g.Expect(cq.Status.FlavorsUsage[0].Resources[0].Total).Should(gomega.BeEquivalentTo(resource.MustParse("3500m")))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		ginkgo.By("reducing the worker replicas to 1 to emulate scale-down operation")
@@ -792,8 +792,8 @@ var _ = ginkgo.Describe("RayCluster with elastic jobs via workload-slices suppor
 			cq := &kueue.ClusterQueue{}
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), cq)).Should(gomega.Succeed())
 			g.Expect(len(cq.Status.FlavorsUsage)).Should(gomega.BeEquivalentTo(1))
-			g.Expect(len(cq.Status.FlavorsUsage[0].Resources)).Should(gomega.BeEquivalentTo(1))
-			g.Expect(cq.Status.FlavorsUsage[0].Resources[0].Total).Should(gomega.BeEquivalentTo(resource.MustParse("2")))
+			g.Expect(len(cq.Status.FlavorsUsage[0].Resources)).Should(gomega.BeEquivalentTo(2))
+			g.Expect(cq.Status.FlavorsUsage[0].Resources[0].Total).Should(gomega.BeEquivalentTo(resource.MustParse("2500m")))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		ginkgo.By("assert the raycluster's workload is updated and still admitted")
@@ -824,9 +824,9 @@ var _ = ginkgo.Describe("RayCluster with elastic jobs via workload-slices suppor
 			cq := &kueue.ClusterQueue{}
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), cq)).Should(gomega.Succeed())
 			g.Expect(len(cq.Status.FlavorsUsage)).Should(gomega.BeEquivalentTo(1))
-			g.Expect(len(cq.Status.FlavorsUsage[0].Resources)).Should(gomega.BeEquivalentTo(1))
-			// 1 core for the head node, and 1 for each of the 2 workers
-			g.Expect(cq.Status.FlavorsUsage[0].Resources[0].Total).Should(gomega.BeEquivalentTo(resource.MustParse("3")))
+			g.Expect(len(cq.Status.FlavorsUsage[0].Resources)).Should(gomega.BeEquivalentTo(2))
+			// 1 core for the head node, 500m for the autoscaler sidecar, and 1 for each of the 2 workers
+			g.Expect(cq.Status.FlavorsUsage[0].Resources[0].Total).Should(gomega.BeEquivalentTo(resource.MustParse("3500m")))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		ginkgo.By("old workload is finished and new workload is admitted")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area integrations

#### What this PR does / why we need it:

When a Kueue-managed `RayCluster` enables in-tree autoscaling (`enableInTreeAutoscaling: true`, only allowed for elastic jobs via the `ElasticJobsViaWorkloadSlices` feature gate), KubeRay injects an **[autoscaler sidecar container](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/configuring-autoscaling.html#autoscaler-sidecar-container)** into the head Pod. This container is added at Pod-build time and is **not** part of `HeadGroupSpec.Template`, so Kueue never saw it when building the head `PodSet`.

As a result the head `PodSet` was under-counted against quota by the autoscaler's resources — KubeRay's [default `500m` CPU / `512Mi` memory (request and limit)](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/configuring-autoscaling.html#autoscaler-sidecar-container), or `spec.autoscalerOptions.resources` when set. A head Pod that actually needs `head + autoscaler` could be admitted against quota sized only for `head`, letting a ClusterQueue overcommit.

This PR mirrors KubeRay's behavior in `BuildPodSets`: when in-tree autoscaling is enabled, an `autoscaler` container is appended to the head `PodSet` using `AutoscalerOptions.Resources` when provided, otherwise KubeRay's documented defaults (matching `ray-operator/controllers/ray/common/pod.go: BuildAutoscalerContainer`). The change lives in the shared `BuildPodSets`, so both the `RayCluster` and `RayJob` integrations (both call `BuildPodSets`) get the fix from one place.

#### Manual test

* Gist: [autoscaling-raycluster.yaml](https://gist.github.com/kevin85421/5ba40fc3adbf25e9fbb3ddb6f96b668e#file-autoscaling-raycluster-yaml)

* Step 1: Create the RayCluster CR:
  * 1 head Pod (ray container: 1 CPU, autoscaler container: 500m CPU + 512 MB memory) + 1 worker Pod (400m CPU) = 1900m CPU + 512 MB memory
    ```sh
    kubectl apply -f autoscaling-raycluster.yaml
    ```
* Step 2: Check the Workload CR
  <img width="354" height="371" alt="image" src="https://github.com/user-attachments/assets/f8f727ff-9a5c-40ba-8e0a-e2d82a1d682a" />



#### Which issue(s) this PR fixes:

There is no existing tracked issue for this specific gap.

#### Special notes for your reviewer:

AI usage disclosure: This change was developed with the assistance of an AI coding tool (Claude Code). All code and tests were reviewed by the author before submission.

#### Does this PR introduce a user-facing change?

```release-note
RayCluster: Fixed a bug where the Ray autoscaler sidecar container's resources were not counted against quota when in-tree autoscaling was enabled, causing the head PodSet to be under-counted. The head PodSet now includes the autoscaler sidecar (KubeRay's default `500m` CPU / `512Mi` memory, or `spec.autoscalerOptions.resources` when set).

ACTION REQUIRED: users with autoscaling-enabled RayClusters may need to increase their ClusterQueue CPU quota by 500m and memory quota by 512Mi per head pod to avoid admission failures after upgrading.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated in-tree autoscaling quota calculations for RayCluster head pods to include the injected autoscaler sidecar’s CPU and memory (using default values or configured overrides).

* **Tests**
  * Expanded unit tests to verify autoscaler sidecar injection and resource override behavior in head PodSets.
  * Updated end-to-end and integration tests to include memory in quota/ClusterQueue setup and to confirm autoscaler CPU/memory consistency via drift checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->