### PR TITLE
TAS: Skip flavors with no schedulable topology domains during flavor assignment

### DIFF
--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1140,6 +1140,11 @@ func (s *TASFlavorSnapshot) HasLevel(r *kueue.PodSetTopologyRequest) bool {
 	return true
 }
 
+// HasAnyDomain returns true if the flavor currently has at least one topology domain available for scheduling.
+func (s *TASFlavorSnapshot) HasAnyDomain() bool {
+	return len(s.domains) > 0
+}
+
 func (s *TASFlavorSnapshot) sliceLevelKeyWithDefault(topologyRequest *kueue.PodSetTopologyRequest, defaultSliceLevelKey string) string {
 	if topologyRequest != nil {
 		if topologyRequest.PodSetSliceRequiredTopology != nil {

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scheduler
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -425,6 +426,46 @@ func TestHasLevel(t *testing.T) {
 			got := s.HasLevel(tc.podSetTopologyRequest)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected HasLevel result (-want,+got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestHasAnyDomain(t *testing.T) {
+	levels := []string{"level-1"}
+
+	testCases := map[string]struct {
+		nodeLabels []map[string]string
+		want       bool
+	}{
+		"no nodes - empty flavor (cordoned/NotReady/absent)": {
+			nodeLabels: nil,
+			want:       false,
+		},
+		"one node": {
+			nodeLabels: []map[string]string{{"level-1": "a"}},
+			want:       true,
+		},
+		"multiple nodes": {
+			nodeLabels: []map[string]string{{"level-1": "a"}, {"level-1": "b"}},
+			want:       true,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
+			s := newTASFlavorSnapshot(log, "dummy", levels)
+			for i, labels := range tc.nodeLabels {
+				n := node.MakeNode(fmt.Sprintf("node-%d", i))
+				for k, v := range labels {
+					n = n.Label(k, v)
+				}
+				s.addNode(newNodeInfo(n.Obj()))
+			}
+			s.initialize()
+			got := s.HasAnyDomain()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("unexpected HasAnyDomain result (-want,+got): %s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/tas"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
@@ -218,6 +219,7 @@ func TestAssignFlavors(t *testing.T) {
 		preemptWorkloadSlice       *workload.Info
 		featureGates               map[featuregate.Feature]bool
 		topologies                 []*kueue.Topology
+		nodes                      []corev1.Node
 	}{
 		"single flavor, fits": {
 			wlPods: []kueue.PodSet{
@@ -3325,6 +3327,10 @@ func TestAssignFlavors(t *testing.T) {
 				utiltestingapi.MakeTopology("tas-topo-a").Levels(corev1.LabelHostname).Obj(),
 				utiltestingapi.MakeTopology("tas-topo-b").Levels(corev1.LabelHostname).Obj(),
 			},
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("node-a").Label(corev1.LabelHostname, "node-a").Ready().Obj(),
+				*testingnode.MakeNode("node-b").Label(corev1.LabelHostname, "node-b").Ready().Obj(),
+			},
 			wlPods: []kueue.PodSet{
 				*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 					Request(corev1.ResourceCPU, "1").
@@ -3369,6 +3375,78 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 			},
 		},
+		"explicit TAS skips flavor with no schedulable topology domains": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling: true,
+			},
+			topologies: []*kueue.Topology{
+				utiltestingapi.MakeTopology("tas-topo-a").Levels(corev1.LabelHostname).Obj(),
+			},
+			// No nodes are synced, so the TAS flavor has no schedulable topology domains.
+			wlPods: []kueue.PodSet{
+				*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					Request(corev1.ResourceCPU, "1").
+					RequiredTopologyRequest(corev1.LabelHostname).
+					Obj(),
+			},
+			clusterQueue: *utiltestingapi.MakeClusterQueue("test-clusterqueue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("tas-a").
+						Resource(corev1.ResourceCPU, "10").
+						Obj(),
+				).
+				Obj(),
+			wantRepMode: NoFit,
+			wantAssignment: Assignment{
+				PodSets: []PodSetAssignment{
+					{
+						Name: kueue.DefaultPodSetName,
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+						Count:  1,
+						Status: *NewStatus(`Flavor "tas-a" has no schedulable topology domains`),
+					},
+				},
+				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+			},
+		},
+		"implied TAS on TAS-only ClusterQueue skips flavor with no schedulable topology domains": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling: true,
+			},
+			topologies: []*kueue.Topology{
+				utiltestingapi.MakeTopology("tas-topo-a").Levels(corev1.LabelHostname).Obj(),
+			},
+			// No nodes are synced, so the TAS flavor has no schedulable topology domains.
+			// The PodSet does not explicitly request TAS, so TAS is implied by the TAS-only CQ.
+			wlPods: []kueue.PodSet{
+				*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					Request(corev1.ResourceCPU, "1").
+					Obj(),
+			},
+			clusterQueue: *utiltestingapi.MakeClusterQueue("test-clusterqueue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("tas-a").
+						Resource(corev1.ResourceCPU, "10").
+						Obj(),
+				).
+				Obj(),
+			wantRepMode: NoFit,
+			wantAssignment: Assignment{
+				PodSets: []PodSetAssignment{
+					{
+						Name: kueue.DefaultPodSetName,
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+						Count:  1,
+						Status: *NewStatus(`Flavor "tas-a" has no schedulable topology domains`),
+					},
+				},
+				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -3401,6 +3479,9 @@ func TestAssignFlavors(t *testing.T) {
 				for _, topology := range tc.topologies {
 					cache.AddOrUpdateTopology(log, topology)
 				}
+			}
+			for i := range tc.nodes {
+				cache.TASCache().SyncNode(&tc.nodes[i])
 			}
 
 			if err := cache.AddOrUpdateCohort(utiltestingapi.MakeCohort(tc.clusterQueue.Spec.CohortName).Obj()); err != nil {

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -5238,6 +5238,7 @@ func TestIsNoFitDueToCapacityAndLimits(t *testing.T) {
 		siblingCQUsage     map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities
 		replaceWl          *workload.Info
 		topologies         []*kueue.Topology
+		nodes              []corev1.Node
 		allowedFlavors     []kueue.ResourceFlavorReference
 		featureGates       map[featuregate.Feature]bool
 		simulationResult   map[resources.FlavorResource]simulationResultForFlavor
@@ -5390,6 +5391,13 @@ func TestIsNoFitDueToCapacityAndLimits(t *testing.T) {
 			topologies: []*kueue.Topology{
 				utiltestingapi.MakeTopology("topology-tas").Levels("rack").Obj(),
 			},
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("node-tas").
+					Label("rack", "rack-1").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")}).
+					Ready().
+					Obj(),
+			},
 			podSet: *utiltestingapi.MakePodSet("main", 1).
 				Request(corev1.ResourceCPU, "1").
 				RequiredTopologyRequest("rack").
@@ -5409,6 +5417,13 @@ func TestIsNoFitDueToCapacityAndLimits(t *testing.T) {
 			cq:              tasCQ,
 			topologies: []*kueue.Topology{
 				utiltestingapi.MakeTopology("topology-tas").Levels("rack").Obj(),
+			},
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("node-tas").
+					Label("rack", "rack-1").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")}).
+					Ready().
+					Obj(),
 			},
 			podSet: *utiltestingapi.MakePodSet("main", 1).
 				Request(corev1.ResourceCPU, "3").
@@ -5430,6 +5445,13 @@ func TestIsNoFitDueToCapacityAndLimits(t *testing.T) {
 			cq:              tasCQ,
 			topologies: []*kueue.Topology{
 				utiltestingapi.MakeTopology("topology-tas").Levels("rack").Obj(),
+			},
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("node-tas").
+					Label("rack", "rack-1").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")}).
+					Ready().
+					Obj(),
 			},
 			podSet: *utiltestingapi.MakePodSet("main", 1).
 				Request(corev1.ResourceCPU, "1").
@@ -5605,6 +5627,9 @@ func TestIsNoFitDueToCapacityAndLimits(t *testing.T) {
 			}
 			for _, topology := range tc.topologies {
 				cache.AddOrUpdateTopology(log, topology)
+			}
+			for i := range tc.nodes {
+				cache.TASCache().SyncNode(&tc.nodes[i])
 			}
 			snapshot, err := cache.Snapshot(ctx)
 			if err != nil {

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -171,10 +171,16 @@ func onlyTASFlavor(
 
 func checkPodSetAndFlavorMatchForTAS(cq *schdcache.ClusterQueueSnapshot, ps *kueue.PodSet, flavor *kueue.ResourceFlavor, rg *schdcache.ResourceGroup) *string {
 	if isTASRequested(ps, cq) {
+		flavorRef := kueue.ResourceFlavorReference(flavor.Name)
 		if isTASImplied(ps, cq) {
 			// If this is a TAS-only CQ, then we don't need to check the flavor because
 			// all flavors in the ClusterQueue are TAS flavors, and all Workloads submitted
 			// to this ClusterQueue are expected to use TAS, and it's a match.
+			// We still reject flavors with no schedulable domains to avoid selecting them on
+			// quota and then failing topology assignment, which would force a requeue.
+			if s := cq.TASFlavors[flavorRef]; s != nil {
+				return emptyTASFlavorMessage(cq, s, flavorRef)
+			}
 			return nil
 		}
 		// PodSet explicitly requires TAS, so we need to check if the flavor supports it.
@@ -187,7 +193,7 @@ func checkPodSetAndFlavorMatchForTAS(cq *schdcache.ClusterQueueSnapshot, ps *kue
 			}
 			return new(fmt.Sprintf("Flavor %q does not support TopologyAwareScheduling", flavor.Name))
 		}
-		s := cq.TASFlavors[kueue.ResourceFlavorReference(flavor.Name)]
+		s := cq.TASFlavors[flavorRef]
 		if s == nil {
 			// Skip Flavors if they don't have TAS information. This should generally
 			// not happen, but possible in race-situation when the ResourceFlavor
@@ -198,6 +204,9 @@ func checkPodSetAndFlavorMatchForTAS(cq *schdcache.ClusterQueueSnapshot, ps *kue
 			// Skip flavors which don't have the requested level
 			return new(fmt.Sprintf("Flavor %q does not contain the requested level", flavor.Name))
 		}
+		if msg := emptyTASFlavorMessage(cq, s, flavorRef); msg != nil {
+			return msg
+		}
 		// PodSet requires TAS and the flavor supports it, so it's a match.
 		return nil
 	}
@@ -206,6 +215,19 @@ func checkPodSetAndFlavorMatchForTAS(cq *schdcache.ClusterQueueSnapshot, ps *kue
 		return new(fmt.Sprintf("Flavor %q supports only TopologyAwareScheduling", flavor.Name))
 	}
 	// PodSet doesn't require TAS and the flavor doesn't support it, so it's a match.
+	return nil
+}
+
+// emptyTASFlavorMessage returns a rejection message when the TAS flavor currently has no
+// schedulable topology domains and TAS placement is not deferred to ProvisioningRequest or
+// MultiKueue. Such a flavor would be selected on quota and then fail topology assignment,
+// forcing a requeue.
+func emptyTASFlavorMessage(cq *schdcache.ClusterQueueSnapshot, s *schdcache.TASFlavorSnapshot, flavorRef kueue.ResourceFlavorReference) *string {
+	if !s.HasAnyDomain() &&
+		!cq.HasProvRequestAdmissionCheck(flavorRef) &&
+		!cq.HasMultiKueueAdmissionCheck() {
+		return new(fmt.Sprintf("Flavor %q has no schedulable topology domains", flavorRef))
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature 
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

We have a CQ with a lot of TAS RFs linked to nodes that that may be in unschedulable state. Depending on the RF order in the CQ and the nodes unschedulable state we see significant requeues and scheduling latency since the scheduler tries every flavor in order. The scheduler should not try to use flavors that do not have domains. The check is cheap so I don't think these changes will add performance regressions

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

```
TAS: the flavor assigner now skips TAS flavors without domains to improve scheduling performance.
```

* **Bug Fixes**
  * Improved Topology-Aware Scheduling flavor validation: the scheduler now more reliably rejects TAS flavors that have no schedulable topology domains, including cases where a TAS flavor is implied but placement cannot proceed.
* **Tests**
  * Added unit coverage for detecting when TAS flavor snapshots contain available topology domains.
  * Expanded flavor assignment tests to simulate node availability affecting schedulable TAS placement outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->