### PR TITLE
MultiKueue: gate JobSuspended workaround behind Alpha feature gate

### DIFF
--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -144,47 +143,7 @@ func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remot
 	//    which could block further spec updates; see: https://github.com/kubernetes-sigs/kueue/pull/3685).
 	// 2. We rely on the MultiKueue admission lifecycle to eventually bring localJob to unsuspended state
 	//    (remote admitted -> MultiKueue AdmissionCheck ready -> local admitted -> local unsuspended).
-	// 3. However, to avoid clashing with K8s 1.36 validation rules
-	//    (since https://github.com/kubernetes/kubernetes/pull/135104 until https://github.com/kubernetes/kubernetes/pull/139287)
-	//    we manually patch a "JobSuspended=True" condition to unblock further spec updates.
-	// Once we're on a K8s version unaffected by #3, the "if" block below can be removed.
-
-	if !isJobStatusConditionTrue(localJob.Status.Conditions, batchv1.JobSuspended) {
-		newLocalStatus := localJob.Status.DeepCopy()
-		newLocalStatus.Conditions = setJobStatusCondition(newLocalStatus.Conditions,
-			batchv1.JobCondition{
-				Type:               batchv1.JobSuspended,
-				Status:             corev1.ConditionTrue,
-				Reason:             "MultiKueueAdapter",
-				Message:            "Set by MultiKueue adapter",
-				LastTransitionTime: metav1.Now(),
-				LastProbeTime:      metav1.Now(),
-			})
-		log.V(2).Info("Updating the suspended local Job to comply with Kubernetes validation rules", "oldStatus", localJob.Status, "newStatus", newLocalStatus)
-		return newLocalStatus, true
-	}
-
 	return &localJob.Status, true
-}
-
-func setJobStatusCondition(list []batchv1.JobCondition, condition batchv1.JobCondition) []batchv1.JobCondition {
-	for i := range list {
-		if list[i].Type == condition.Type {
-			list[i] = condition
-			return list
-		}
-	}
-	list = append(list, condition)
-	return list
-}
-
-func isJobStatusConditionTrue(conditions []batchv1.JobCondition, condType batchv1.JobConditionType) bool {
-	for _, c := range conditions {
-		if c.Type == condType {
-			return c.Status == corev1.ConditionTrue
-		}
-	}
-	return false
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -143,7 +144,49 @@ func determineStatusUpdate(ctx context.Context, log logr.Logger, localJob, remot
 	//    which could block further spec updates; see: https://github.com/kubernetes-sigs/kueue/pull/3685).
 	// 2. We rely on the MultiKueue admission lifecycle to eventually bring localJob to unsuspended state
 	//    (remote admitted -> MultiKueue AdmissionCheck ready -> local admitted -> local unsuspended).
+	// 3. However, to avoid clashing with K8s 1.36 validation rules
+	//    (since https://github.com/kubernetes/kubernetes/pull/135104 until https://github.com/kubernetes/kubernetes/pull/139287)
+	//    we manually patch a "JobSuspended=True" condition to unblock further spec updates.
+	// Once we're on a K8s version unaffected by #3, the "if" block below can be removed.
+
+	if !features.Enabled(features.MultiKueueJobSuspendedWorkaroundDisabled) {
+		if !isJobStatusConditionTrue(localJob.Status.Conditions, batchv1.JobSuspended) {
+			newLocalStatus := localJob.Status.DeepCopy()
+			newLocalStatus.Conditions = setJobStatusCondition(newLocalStatus.Conditions,
+				batchv1.JobCondition{
+					Type:               batchv1.JobSuspended,
+					Status:             corev1.ConditionTrue,
+					Reason:             "MultiKueueAdapter",
+					Message:            "Set by MultiKueue adapter",
+					LastTransitionTime: metav1.Now(),
+					LastProbeTime:      metav1.Now(),
+				})
+			log.V(2).Info("Updating the suspended local Job to comply with Kubernetes validation rules", "oldStatus", localJob.Status, "newStatus", newLocalStatus)
+			return newLocalStatus, true
+		}
+	}
+
 	return &localJob.Status, true
+}
+
+func setJobStatusCondition(list []batchv1.JobCondition, condition batchv1.JobCondition) []batchv1.JobCondition {
+	for i := range list {
+		if list[i].Type == condition.Type {
+			list[i] = condition
+			return list
+		}
+	}
+	list = append(list, condition)
+	return list
+}
+
+func isJobStatusConditionTrue(conditions []batchv1.JobCondition, condType batchv1.JobConditionType) bool {
+	for _, c := range conditions {
+		if c.Type == condType {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/job/job_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter_test.go
@@ -613,6 +613,76 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 					Obj(),
 			},
 		},
+		// Workaround for Kubernetes 1.36.0/1.36.1 (kubernetes/kubernetes#139281):
+		// when local is suspended and remote is unsuspended+not-finished,
+		// the adapter must patch JobSuspended=True on the local Job so that
+		// further spec updates (e.g. nodeSelector injection) are not blocked.
+		"WorkaroundEnabled_PatchesJobSuspendedCondition": {
+			fields: fields{
+				featureGates: map[featuregate.Feature]bool{features.MultiKueueJobSuspendedWorkaroundDisabled: false},
+			},
+			args: args{
+				// local: suspended (default), no JobSuspended condition yet.
+				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().Obj()).Build(),
+				// remote: unsuspended and not finished.
+				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().Suspend(false).Active(1).Obj()).Build(),
+				key:          client.ObjectKeyFromObject(newJob().Obj()),
+			},
+			want: want{
+				deferred: true,
+				localJob: newJob().
+					ResourceVersion("2").
+					Condition(batchv1.JobCondition{
+						Type:    batchv1.JobSuspended,
+						Status:  corev1.ConditionTrue,
+						Reason:  "MultiKueueAdapter",
+						Message: "Set by MultiKueue adapter",
+					}).
+					Obj(),
+			},
+		},
+		// When JobSuspended=True is already set, no additional patch should occur.
+		"WorkaroundEnabled_AlreadyHasJobSuspendedCondition": {
+			fields: fields{
+				featureGates: map[featuregate.Feature]bool{features.MultiKueueJobSuspendedWorkaroundDisabled: false},
+			},
+			args: args{
+				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					Condition(batchv1.JobCondition{
+						Type:   batchv1.JobSuspended,
+						Status: corev1.ConditionTrue,
+					}).
+					Obj()).Build(),
+				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().Suspend(false).Active(1).Obj()).Build(),
+				key:          client.ObjectKeyFromObject(newJob().Obj()),
+			},
+			want: want{
+				deferred: true,
+				localJob: newJob().
+					Condition(batchv1.JobCondition{
+						Type:   batchv1.JobSuspended,
+						Status: corev1.ConditionTrue,
+					}).
+					Obj(),
+			},
+		},
+		// When MultiKueueJobSuspendedWorkaroundDisabled is enabled (Kubernetes 1.36.2+),
+		// the adapter must NOT patch JobSuspended=True.
+		"WorkaroundDisabled_SkipsJobSuspendedPatch": {
+			fields: fields{
+				featureGates: map[featuregate.Feature]bool{features.MultiKueueJobSuspendedWorkaroundDisabled: true},
+			},
+			args: args{
+				localClient:  fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().Obj()).Build(),
+				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().Suspend(false).Active(1).Obj()).Build(),
+				key:          client.ObjectKeyFromObject(newJob().Obj()),
+			},
+			want: want{
+				deferred: true,
+				localJob: newJob().Obj(), // no conditions patched
+			},
+		},
+
 		// Regression test for #11115: when an elastic sync is needed AND the local
 		// Job is still suspended (remote unsuspended and not finished), SyncJob must
 		// still report deferred=true — the deferred flag must not be dropped on the
@@ -700,7 +770,10 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 				if err := tt.args.localClient.Get(ctx, client.ObjectKeyFromObject(tt.want.localJob), got); err != nil {
 					t.Errorf("SyncJob() unexpected assertion error retrieving local job: %v", err)
 				}
-				if diff := cmp.Diff(tt.want.localJob, got, cmpopts.EquateEmpty(), cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")); diff != "" {
+				if diff := cmp.Diff(tt.want.localJob, got,
+					cmpopts.EquateEmpty(),
+					cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
+					cmpopts.IgnoreFields(batchv1.JobCondition{}, "LastTransitionTime", "LastProbeTime")); diff != "" {
 					t.Errorf("SyncJob() localJob (-want,+got):\n%s", diff)
 				}
 			}

--- a/pkg/controller/jobs/job/job_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter_test.go
@@ -639,9 +639,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 				key:          client.ObjectKeyFromObject(newJob().Obj()),
 				workloadName: jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration("test", "", gvk, 0),
 			},
-			// localJob/remoteJob left nil: the deferred path patches the local
-			// JobSuspended condition with a wall-clock timestamp not worth asserting
-			// here. This case guards the deferred flag, not the patched objects.
+			// localJob/remoteJob left nil: only the deferred flag is asserted here.
 			want: want{
 				deferred: true,
 			},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -519,6 +519,15 @@ const (
 	//
 	// Rejects Workloads with non-positive TAS slice sizes in PodSet topology requests.
 	TASValidateWorkloadSliceSize featuregate.Feature = "TASValidateWorkloadSliceSize"
+
+	// owner: @k-ngs
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/11863
+	//
+	// MultiKueueJobSuspendedWorkaroundDisabled disables the workaround that patches
+	// JobSuspended=True on the local Job for compatibility with Kubernetes 1.36.0 and 1.36.1.
+	// Enable this gate when running on Kubernetes 1.36.2+ where the underlying issue
+	// (kubernetes/kubernetes#139281) is fixed.
+	MultiKueueJobSuspendedWorkaroundDisabled featuregate.Feature = "MultiKueueJobSuspendedWorkaroundDisabled"
 )
 
 func init() {
@@ -798,6 +807,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 
 	TASValidateWorkloadSliceSize: {
 		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta}, // GA in 0.21
+	},
+
+	MultiKueueJobSuspendedWorkaroundDisabled: {
+		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }
 

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -221,6 +221,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: MultiKueueJobSuspendedWorkaroundDisabled
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.18"
 - name: MultiKueueKubeConfigPathValidation
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -221,6 +221,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: MultiKueueJobSuspendedWorkaroundDisabled
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.18"
 - name: MultiKueueKubeConfigPathValidation
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area multikueue

#### What this PR does / why we need it:

Introduces the `MultiKueueJobSuspendedWorkaroundDisabled` Alpha feature gate to control the workaround that manually patches a `JobSuspended=True` condition on the local Job in the MultiKueue adapter (#11649).

The workaround avoids a K8s 1.36 validation regression (kubernetes/kubernetes#139281), where modifications to scheduling directives on a suspended Job were rejected if the `JobSuspended` condition had not yet been set by the job controller. 
The regression was fixed in kubernetes/kubernetes#139287 and cherry-picked to 1.36.2.

Rather than removing the workaround outright, this PR gates it so that:
- Gate disabled (default): the workaround is applied, keeping users on
  Kubernetes 1.36.0/1.36.1 protected.
- Gate enabled: the workaround is skipped, which is safe on Kubernetes 1.36.2+
  where the underlying issue is fixed.

Changes:
- Add the `MultiKueueJobSuspendedWorkaroundDisabled` Alpha feature gate
- Guard the `JobSuspended=True` patching in `determineStatusUpdate` behind the gate
- Add tests covering both gate states and the already-patched case

#### Which issue(s) this PR fixes:

Fixes #11863

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
```release-note
MultiKueue: Added the `MultiKueueJobSuspendedWorkaroundDisabled` Alpha feature gate (disabled by default). 
When disabled, Kueue keeps patching `JobSuspended=True` on the local Job to remain compatible with Kubernetes 1.36.0/1.36.1 (kubernetes/kubernetes#139281).
Enable it on Kubernetes 1.36.2+, where the underlying issue is fixed, to skip the workaround.
```

Note: I investigated and implemented this change with the assistance of an AI tool.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job synchronization when a locally suspended job becomes unsuspended remotely but remains unfinished.
  * Applied the `JobSuspended=True` compatibility behavior only when needed for Kubernetes 1.36.0 and 1.36.1.

* **New Features**
  * Added the `MultiKueueJobSuspendedWorkaroundDisabled` feature gate to control this compatibility behavior.

* **Tests**
  * Expanded coverage for enabled, disabled, and already-applied workaround scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->