### PR TITLE
self-nominate amy for kueue reviewer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -12,6 +12,7 @@ aliases:
     - olekzabl
     - kshalot
     - sohankunkerkar
+    - amy
   dependency-approvers:
     - mbobrovskyi
     - pbundyra


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup 

#### What this PR does / why we need it:
I believe I've met the [requirements](https://github.com/kubernetes/community/blob/main/community-membership.md#requirements-1) and would like to self-nominate as a Kueue Reviewer.
  - [x] _Member for at least 3 months:_ kubernetes/org#5727
  - [x] _Primary reviewer for at least 5 PRs to the codebase:_ [27 merged 
  PRs](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+is%3Amerged+assignee%3Aamy) where I was "assignee". A representative set across the areas I review in:
    - _Fair sharing / scheduling correctness:_
      - #6617 — Fix fairsharing reclamation bug
      - #6925 — [Fair Sharing] Fix Rounding Bug
    - _Topology-Aware Scheduling:_
      - #6872 — Refine IsActive logic to ignore Pods stuck terminating in pod-integration pod-groups
    - _Agent skills / tooling:_
      - #11088 — AgentSkills: Add code-eval skill
  - [x] _Reviewed or merged at least 20 substantial PRs to the codebase:_
    - [Reviewed and commented on 39 
  PRs](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+reviewed-by%3Aamy+commenter%3Aamy+-author%3Aamy) total:
      - [34 of which were >=`size/M`](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+reviewed-by%3Aamy+commenter%3Aamy+-author%3Aamy+-label%3Asize%2FXS+-label%3Asize%2FS)
      - [32 of which were >=`size/L`](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+reviewed-by%3Aamy+commenter%3Aamy+-author%3Aamy+-label%3Asize%2FXS+-label%3Asize%2FS+-label%3Asize%2FM)
      - Including design-level reviews on several KEPs: #10745 (13 review comments), #10145, and #11720.
    - [Merged 20 PRs](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+author%3Aamy+is%3Amerged) total:
      - [11 of which were >=`size/M`](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+author%3Aamy+is%3Amerged+-label%3Asize%2FXS+-label%3Asize%2FS)
  My contributions cluster around four areas of Kueue:
  - **Scheduling correctness — preemption & fair sharing.** I've filed and fixed bugs here and review regularly — e.g.
  fixing incorrect admission on cluster-queue deletion (#5985) and preemption/eviction condition messaging (#6819), and
  reviewing the fair-sharing work (#6617, #6925, #6986, #6888).
  - **Observability & metrics.** I've added scheduler metrics and the logging behind them — pending-workload resource
  metrics (#10485), podsReady→preemption duration (#5923), and fair-sharing target-selection logging (#6656).
  - **Topology-Aware Scheduling.** TAS reconciliation fixes (#11033) and review (#6872).
  - **Agent tooling.** Agent skills and tooling, where I'm already in `agent-reviewers` and `agent-approvers` —
  including authoring the reviewer skill (#10819) and reviewing the code-eval skill (#11088).
  
Overall, I think my contributions are valuable due to both my previous experience as an end-user and now advocate for end users.
  
#### Which issue(s) this PR fixes:
  N/A
#### Special notes for your reviewer:
#### Does this PR introduce a user-facing change?
```release-note
  NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership and review assignment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->