### PR TITLE
fix(tas): account for elastic workload leaders

### DIFF
--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -5884,6 +5884,155 @@ func TestFindTopologyAssignments(t *testing.T) {
 				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
 			},
 		},
+		"elastic workload scale down with leader: truncates workers, reuses leader": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("4"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x2").
+					Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			levels: defaultOneLevel,
+			podSets: []PodSetTestCase{
+				{
+					podSetName: "leader",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Unconstrained: new(true),
+					},
+					requests: resources.Requests{
+						corev1.ResourceCPU: 1000,
+					},
+					count:           1,
+					podSetGroupName: new("elastic-group"),
+					previousAssignment: tas.V1Beta2From(&tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"x2"}},
+						},
+					}),
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"x2"}},
+						},
+					},
+				},
+				{
+					podSetName: "workers",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Unconstrained: new(true),
+					},
+					requests: resources.Requests{
+						corev1.ResourceCPU: 1000,
+					},
+					count:           3,
+					podSetGroupName: new("elastic-group"),
+					previousAssignment: tas.V1Beta2From(&tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 3, Values: []string{"x1"}},
+							{Count: 2, Values: []string{"x2"}},
+						},
+					}),
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 3, Values: []string{"x1"}},
+						},
+					},
+				},
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:        true,
+				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
+			},
+		},
+		"elastic workload same count with leader: reuses both assignments exactly": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("4"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x2").
+					Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("4"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			levels: defaultOneLevel,
+			podSets: []PodSetTestCase{
+				{
+					podSetName: "leader",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Unconstrained: new(true),
+					},
+					requests: resources.Requests{
+						corev1.ResourceCPU: 1000,
+					},
+					count:           1,
+					podSetGroupName: new("elastic-group"),
+					previousAssignment: tas.V1Beta2From(&tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"x2"}},
+						},
+					}),
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"x2"}},
+						},
+					},
+				},
+				{
+					podSetName: "workers",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Unconstrained: new(true),
+					},
+					requests: resources.Requests{
+						corev1.ResourceCPU: 1000,
+					},
+					count:           3,
+					podSetGroupName: new("elastic-group"),
+					previousAssignment: tas.V1Beta2From(&tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 2, Values: []string{"x1"}},
+							{Count: 1, Values: []string{"x2"}},
+						},
+					}),
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 2, Values: []string{"x1"}},
+							{Count: 1, Values: []string{"x2"}},
+						},
+					},
+				},
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:        true,
+				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
+			},
+		},
 		"multi-layer topology: block required; rack slices of 4; host slices of 2; TASMultiLayerTopology": {
 			// 4-level topology: block → rack → hostname
 			//              b1

--- a/pkg/cache/scheduler/tas_elastic_workloads.go
+++ b/pkg/cache/scheduler/tas_elastic_workloads.go
@@ -51,18 +51,15 @@ func (s *TASFlavorSnapshot) handleElasticWorkload(
 	}
 
 	previousCount := utiltas.CountPodsInAssignment(prevAssignment)
-	result := make(map[kueue.PodSetReference]tasPodSetAssignmentResult)
 
 	switch {
 	case workers.Count > previousCount:
 		return s.handleScaleUp(workers, leader, prevAssignment, previousCount, assumedUsage, opts)
 	case workers.Count < previousCount:
-		return s.handleScaleDown(workers, prevAssignment, assumedUsage)
+		return s.handleScaleDown(workers, leader, prevAssignment, assumedUsage)
 	default:
 		// Same count: reuse previous assignment
-		result[workers.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: prevAssignment}
-		addAssumedUsage(assumedUsage, prevAssignment, &workers)
-		return elasticPlacementResult{applied: true, assignments: result}
+		return s.finalizeElasticAssignment(workers, prevAssignment, leader, assumedUsage)
 	}
 }
 
@@ -108,13 +105,32 @@ func (s *TASFlavorSnapshot) handleScaleUp(
 // handleScaleDown truncates the previous assignment to fit fewer pods.
 func (s *TASFlavorSnapshot) handleScaleDown(
 	workers TASPodSetRequests,
+	leader *TASPodSetRequests,
 	prevAssignment *utiltas.TopologyAssignment,
 	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
 ) elasticPlacementResult {
-	result := make(map[kueue.PodSetReference]tasPodSetAssignmentResult)
-
 	truncatedAssignment := utiltas.TruncateAssignment(prevAssignment, workers.Count)
-	result[workers.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: truncatedAssignment}
-	addAssumedUsage(assumedUsage, truncatedAssignment, &workers)
+	return s.finalizeElasticAssignment(workers, truncatedAssignment, leader, assumedUsage)
+}
+
+// finalizeElasticAssignment builds a result with the workers' assignment and, when
+// present, the leader's previous assignment. It also accounts for the resource usage
+// of both.
+func (s *TASFlavorSnapshot) finalizeElasticAssignment(
+	workers TASPodSetRequests,
+	workersAssignment *utiltas.TopologyAssignment,
+	leader *TASPodSetRequests,
+	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
+) elasticPlacementResult {
+	result := make(map[kueue.PodSetReference]tasPodSetAssignmentResult)
+	result[workers.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: workersAssignment}
+	addAssumedUsage(assumedUsage, workersAssignment, &workers)
+
+	if leader != nil {
+		leaderPrevAssignment := utiltas.InternalFrom(leader.PreviousAssignment)
+		result[leader.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: leaderPrevAssignment}
+		addAssumedUsage(assumedUsage, leaderPrevAssignment, leader)
+	}
+
 	return elasticPlacementResult{applied: true, assignments: result}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/area tas

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

This PR fixes TAS placement for elastic workloads with leader/worker pod sets.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12409

#### Special notes for your reviewer:

Validation:
- `go test ./pkg/cache/scheduler -count=1`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Fixed elastic workload placement to preserve leader pod set assignments and capacity accounting when worker counts stay the same or scale down.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for elastic workload pod set recomputation across scale-down and same-count scenarios, verifying correct preservation/reuse of leader and worker pod assignments.

* **Bug Fixes**
  * Fixed elastic workload scheduling to correctly handle leader assignment preservation during worker truncation on scale-down, and to reuse prior topology assignments appropriately when pod counts remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->