### PR TITLE
Commonize the scheduler test run procedure across core scheduling tests

### DIFF
--- a/pkg/scheduler/scheduler_concurrent_admission_test.go
+++ b/pkg/scheduler/scheduler_concurrent_admission_test.go
@@ -17,29 +17,17 @@ limitations under the License.
 package scheduler
 
 import (
-	"context"
-	"fmt"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
-	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
-	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/features"
-	"sigs.k8s.io/kueue/pkg/metrics"
-	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
-	"sigs.k8s.io/kueue/pkg/util/routine"
-	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -74,18 +62,7 @@ func TestScheduleConcurrentAdmission(t *testing.T) {
 		*utiltestingapi.MakeLocalQueue("concurrent-queue", "eng-alpha").ClusterQueue("concurrent-cq").Obj(),
 	}
 
-	cases := map[string]struct {
-		featureGates map[featuregate.Feature]bool
-
-		workloads []kueue.Workload
-
-		additionalClusterQueues []kueue.ClusterQueue
-		additionalLocalQueues   []kueue.LocalQueue
-
-		wantAssignments map[workload.Reference]kueue.Admission
-		wantWorkloads   []kueue.Workload
-		wantLeft        map[kueue.ClusterQueueReference][]workload.Reference
-	}{
+	cases := map[string]scheduleTestCase{
 		"concurrent admission: more favorable variant evicts less favorable sibling": {
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("sibling-less-favorable", "eng-alpha").
@@ -329,120 +306,12 @@ func TestScheduleConcurrentAdmission(t *testing.T) {
 		},
 	}
 
-	for name, tc := range cases {
-		for _, enabled := range []bool{false, true} {
-			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", name, enabled), func(t *testing.T) {
-				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, enabled)
-				metrics.AdmissionCyclePreemptionSkips.Reset()
-				features.SetFeatureGatesDuringTest(t, tc.featureGates)
-
-				ctx, log := utiltesting.ContextWithLog(t)
-
-				allQueues := append(queues, tc.additionalLocalQueues...)
-				allClusterQueues := append(clusterQueues, tc.additionalClusterQueues...)
-
-				clientBuilder := utiltesting.NewClientBuilder().
-					WithLists(&kueue.WorkloadList{Items: tc.workloads}, &kueue.LocalQueueList{Items: allQueues}).
-					WithObjects(
-						utiltesting.MakeNamespaceWrapper("default").Obj(),
-						utiltesting.MakeNamespaceWrapper("eng-alpha").Label("dep", "eng").Obj(),
-					).
-					WithStatusSubresource(&kueue.Workload{}).
-					WithInterceptorFuncs(interceptor.Funcs{
-						SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge,
-					})
-
-				cl := clientBuilder.Build()
-				recorder := &utiltesting.EventRecorder{}
-				cqCache := schdcache.New(cl)
-				qManager := qcache.NewManagerForUnitTests(cl, cqCache)
-
-				for _, q := range allQueues {
-					if err := qManager.AddLocalQueue(ctx, &q); err != nil {
-						t.Fatalf("Inserting queue %s/%s in manager: %v", q.Namespace, q.Name, err)
-					}
-				}
-				for i := range resourceFlavors {
-					cqCache.AddOrUpdateResourceFlavor(log, resourceFlavors[i])
-				}
-				for _, cq := range allClusterQueues {
-					if err := cqCache.AddClusterQueue(ctx, &cq); err != nil {
-						t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
-					}
-					if err := qManager.AddClusterQueue(ctx, &cq); err != nil {
-						t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
-					}
-					if err := cl.Create(ctx, &cq); err != nil {
-						t.Errorf("couldn't create the cluster queue: %v", err)
-					}
-				}
-
-				scheduler := New(qManager, cqCache, cl, recorder,
-					WithClock(t, fakeClock), WithPreemptionExpectations(preemptexpectations.New()))
-				wg := sync.WaitGroup{}
-				scheduler.setAdmissionRoutineWrapper(routine.NewWrapper(
-					func() { wg.Add(1) },
-					func() { wg.Done() },
-				))
-
-				ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-				go qManager.CleanUpOnContext(ctx)
-				defer cancel()
-
-				scheduler.schedule(ctx)
-				wg.Wait()
-
-				gotAssignments := make(map[workload.Reference]kueue.Admission)
-				snapshot, err := cqCache.Snapshot(ctx)
-				if err != nil {
-					t.Fatalf("unexpected error while building snapshot: %v", err)
-				}
-				for cqName, c := range snapshot.ClusterQueues() {
-					for name, w := range c.Workloads {
-						switch {
-						case !workload.HasQuotaReservation(w.Obj):
-							t.Errorf("Workload %s is not admitted by a clusterQueue, but it is found as member of clusterQueue %s in the cache", name, cqName)
-						case w.Obj.Status.Admission.ClusterQueue != cqName:
-							t.Errorf("Workload %s is admitted by clusterQueue %s, but it is found as member of clusterQueue %s in the cache", name, w.Obj.Status.Admission.ClusterQueue, cqName)
-						default:
-							gotAssignments[name] = *w.Obj.Status.Admission
-						}
-					}
-				}
-
-				gotWorkloads := &kueue.WorkloadList{}
-				err = cl.List(ctx, gotWorkloads)
-				if err != nil {
-					t.Fatalf("Unexpected list workloads error: %v", err)
-				}
-
-				defaultWorkloadCmpOpts := cmp.Options{
-					cmpopts.EquateEmpty(),
-					cmpopts.IgnoreFields(kueue.AdmissionCheckState{}, "LastTransitionTime"),
-					cmpopts.IgnoreFields(kueue.Workload{}, "ObjectMeta.ResourceVersion", "ObjectMeta.CreationTimestamp"),
-					cmpopts.SortSlices(func(a, b metav1.Condition) bool { return a.Type < b.Type }),
-					cmpopts.SortSlices(func(a, b kueue.Workload) bool { return a.Name < b.Name }),
-				}
-
-				if diff := cmp.Diff(tc.wantWorkloads, gotWorkloads.Items, defaultWorkloadCmpOpts); diff != "" {
-					t.Errorf("Unexpected workloads (-want,+got):\n%s", diff)
-				}
-
-				if len(gotAssignments) == 0 {
-					gotAssignments = nil
-				}
-				if diff := cmp.Diff(tc.wantAssignments, gotAssignments); diff != "" {
-					t.Errorf("Unexpected assigned clusterQueues in cache (-want,+got):\n%s", diff)
-				}
-
-				qDump := qManager.Dump()
-				cmpDump := cmp.Options{
-					cmpopts.SortSlices(func(a, b string) bool { return a < b }),
-				}
-				if diff := cmp.Diff(tc.wantLeft, qDump, cmpDump...); diff != "" {
-					t.Errorf("Unexpected elements left in the queue (-want,+got):\n%s", diff)
-				}
-			})
-		}
-	}
+	runScheduleTestCases(t, scheduleTestConfig{
+		queues:             queues,
+		clusterQueues:      clusterQueues,
+		resourceFlavors:    resourceFlavors,
+		fakeClock:          fakeClock,
+		schedulingTimeout:  10 * time.Second,
+		unorderedWorkloads: true,
+	}, cases)
 }

--- a/pkg/scheduler/scheduler_fs_test.go
+++ b/pkg/scheduler/scheduler_fs_test.go
@@ -17,9 +17,6 @@ limitations under the License.
 package scheduler
 
 import (
-	"context"
-	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -28,21 +25,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/component-base/metrics/testutil"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
-	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
-	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
-	"sigs.k8s.io/kueue/pkg/features"
-	"sigs.k8s.io/kueue/pkg/metrics"
-	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
-	"sigs.k8s.io/kueue/pkg/util/roletracker"
-	"sigs.k8s.io/kueue/pkg/util/routine"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -154,33 +140,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 		*utiltestingapi.MakeLocalQueue("lend-a-queue", "lend").ClusterQueue("lend-a").Obj(),
 		*utiltestingapi.MakeLocalQueue("lend-b-queue", "lend").ClusterQueue("lend-b").Obj(),
 	}
-	cases := map[string]struct {
-		enableFairSharing bool
-
-		workloads []kueue.Workload
-		objects   []client.Object
-
-		// additional*Queues can hold any extra queues needed by the tc
-		additionalClusterQueues []kueue.ClusterQueue
-		additionalLocalQueues   []kueue.LocalQueue
-
-		cohorts []kueue.Cohort
-
-		// wantAssignments is a summary of all the admissions in the cache after this cycle.
-		wantAssignments map[workload.Reference]kueue.Admission
-		// wantWorkloads is the subset of workloads that got admitted in this cycle.
-		wantWorkloads []kueue.Workload
-		// wantLeft is the workload keys that are left in the queues after this cycle.
-		wantLeft map[kueue.ClusterQueueReference][]workload.Reference
-		// wantInadmissibleLeft is the workload keys that are left in the inadmissible state after this cycle.
-		wantInadmissibleLeft map[kueue.ClusterQueueReference][]workload.Reference
-		// wantEvents ignored if empty, the Message is ignored (it contains the duration)
-		wantEvents []utiltesting.EventRecord
-		// eventCmpOpts are the cmp options to compare recorded events.
-		eventCmpOpts cmp.Options
-
-		wantSkippedPreemptions map[string]int
-	}{
+	cases := map[string]scheduleTestCase{
 		"with fair sharing: schedule workload with lowest share first": {
 			enableFairSharing: true,
 			additionalClusterQueues: []kueue.ClusterQueue{
@@ -3456,154 +3416,10 @@ func TestScheduleForFairSharing(t *testing.T) {
 			},
 		},
 	}
-	for name, tc := range cases {
-		for _, enabled := range []bool{false, true} {
-			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", name, enabled), func(t *testing.T) {
-				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, enabled)
-				metrics.AdmissionCyclePreemptionSkips.Reset()
-
-				ctx, log := utiltesting.ContextWithLog(t)
-
-				allQueues := append(queues, tc.additionalLocalQueues...)
-				allClusterQueues := append(clusterQueues, tc.additionalClusterQueues...)
-
-				clientBuilder := utiltesting.NewClientBuilder().
-					WithLists(&kueue.WorkloadList{Items: tc.workloads}, &kueue.LocalQueueList{Items: allQueues}).
-					WithObjects(append(
-						[]client.Object{
-							utiltesting.MakeNamespaceWrapper("default").Obj(),
-							utiltesting.MakeNamespaceWrapper("eng-alpha").Label("dep", "eng").Obj(),
-							utiltesting.MakeNamespaceWrapper("eng-beta").Label("dep", "eng").Obj(),
-							utiltesting.MakeNamespaceWrapper("eng-gamma").Label("dep", "eng").Obj(),
-							utiltesting.MakeNamespaceWrapper("sales").Label("dep", "sales").Obj(),
-							utiltesting.MakeNamespaceWrapper("lend").Label("dep", "lend").Obj(),
-						}, tc.objects...,
-					)...).
-					WithStatusSubresource(&kueue.Workload{}).
-					WithInterceptorFuncs(interceptor.Funcs{
-						SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge,
-					})
-
-				cl := clientBuilder.Build()
-				recorder := &utiltesting.EventRecorder{}
-				cqCache := schdcache.New(cl)
-				qManager := qcache.NewManagerForUnitTests(cl, cqCache)
-				// Workloads are loaded into queues or clusterQueues as we add them.
-				for _, q := range allQueues {
-					if err := qManager.AddLocalQueue(ctx, &q); err != nil {
-						t.Fatalf("Inserting queue %s/%s in manager: %v", q.Namespace, q.Name, err)
-					}
-				}
-				for i := range resourceFlavors {
-					cqCache.AddOrUpdateResourceFlavor(log, resourceFlavors[i])
-				}
-				for _, cq := range allClusterQueues {
-					if err := cqCache.AddClusterQueue(ctx, &cq); err != nil {
-						t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
-					}
-					if err := qManager.AddClusterQueue(ctx, &cq); err != nil {
-						t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
-					}
-					if err := cl.Create(ctx, &cq); err != nil {
-						t.Errorf("couldn't create the cluster queue: %v", err)
-					}
-				}
-
-				for _, cohort := range tc.cohorts {
-					if err := cqCache.AddOrUpdateCohort(&cohort); err != nil {
-						t.Fatalf("Inserting Cohort %s in cache: %v", cohort.Name, err)
-					}
-				}
-
-				var fairSharing *config.FairSharing
-				if tc.enableFairSharing {
-					fairSharing = &config.FairSharing{}
-				}
-				scheduler := New(qManager, cqCache, cl, recorder,
-					WithFairSharing(fairSharing), WithClock(t, fakeClock), WithPreemptionExpectations(preemptexpectations.New()))
-				wg := sync.WaitGroup{}
-				scheduler.setAdmissionRoutineWrapper(routine.NewWrapper(
-					func() { wg.Add(1) },
-					func() { wg.Done() },
-				))
-
-				ctx, cancel := context.WithTimeout(ctx, queueingTimeout)
-				go qManager.CleanUpOnContext(ctx)
-				defer cancel()
-
-				scheduler.schedule(ctx)
-				wg.Wait()
-
-				// Verify assignments in cache.
-				gotAssignments := make(map[workload.Reference]kueue.Admission)
-				snapshot, err := cqCache.Snapshot(ctx)
-				if err != nil {
-					t.Fatalf("unexpected error while building snapshot: %v", err)
-				}
-				for cqName, c := range snapshot.ClusterQueues() {
-					for name, w := range c.Workloads {
-						switch {
-						case !workload.HasQuotaReservation(w.Obj):
-							t.Errorf("Workload %s is not admitted by a clusterQueue, but it is found as member of clusterQueue %s in the cache", name, cqName)
-						case w.Obj.Status.Admission.ClusterQueue != cqName:
-							t.Errorf("Workload %s is admitted by clusterQueue %s, but it is found as member of clusterQueue %s in the cache", name, w.Obj.Status.Admission.ClusterQueue, cqName)
-						default:
-							gotAssignments[name] = *w.Obj.Status.Admission
-						}
-					}
-				}
-
-				gotWorkloads := &kueue.WorkloadList{}
-				err = cl.List(ctx, gotWorkloads)
-				if err != nil {
-					t.Fatalf("Unexpected list workloads error: %v", err)
-				}
-
-				defaultWorkloadCmpOpts := cmp.Options{
-					cmpopts.EquateEmpty(),
-					cmpopts.IgnoreFields(kueue.AdmissionCheckState{}, "LastTransitionTime"),
-					cmpopts.IgnoreFields(kueue.Workload{}, "ObjectMeta.ResourceVersion", "ObjectMeta.CreationTimestamp"),
-					cmpopts.SortSlices(func(a, b metav1.Condition) bool { return a.Type < b.Type }),
-				}
-
-				if diff := cmp.Diff(tc.wantWorkloads, gotWorkloads.Items, defaultWorkloadCmpOpts); diff != "" {
-					t.Errorf("Unexpected workloads (-want,+got):\n%s", diff)
-				}
-
-				if len(gotAssignments) == 0 {
-					gotAssignments = nil
-				}
-				if diff := cmp.Diff(tc.wantAssignments, gotAssignments); diff != "" {
-					t.Errorf("Unexpected assigned clusterQueues in cache (-want,+got):\n%s", diff)
-				}
-
-				qDump := qManager.Dump()
-				if diff := cmp.Diff(tc.wantLeft, qDump, cmpDump...); diff != "" {
-					t.Errorf("Unexpected elements left in the queue (-want,+got):\n%s", diff)
-				}
-				qDumpInadmissible := qManager.DumpInadmissible()
-				if diff := cmp.Diff(tc.wantInadmissibleLeft, qDumpInadmissible, cmpDump...); diff != "" {
-					t.Errorf("Unexpected elements left in inadmissible workloads (-want,+got):\n%s", diff)
-				}
-
-				if len(tc.wantEvents) > 0 {
-					if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents, tc.eventCmpOpts...); diff != "" {
-						t.Errorf("unexpected events (-want/+got):\n%s", diff)
-					}
-				}
-
-				for cqName, want := range tc.wantSkippedPreemptions {
-					lvs := []string{cqName, roletracker.RoleStandalone}
-					val, err := testutil.GetGaugeMetricValue(metrics.AdmissionCyclePreemptionSkips.WithLabelValues(lvs...))
-					if err != nil {
-						t.Fatalf("Couldn't get value for metric admission_cycle_preemption_skips for %q: %v", cqName, err)
-					}
-					got := int(val)
-					if want != got {
-						t.Errorf("Counted %d skips for %q, want %d", got, cqName, want)
-					}
-				}
-			})
-		}
-	}
+	runScheduleTestCases(t, scheduleTestConfig{
+		queues:          queues,
+		clusterQueues:   clusterQueues,
+		resourceFlavors: resourceFlavors,
+		fakeClock:       fakeClock,
+	}, cases)
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -66,6 +66,233 @@ var cmpDump = cmp.Options{
 	cmpopts.SortSlices(func(a, b string) bool { return a < b }),
 }
 
+// scheduleTestCase is the shared case definition for the core scheduling tests
+// (TestSchedule, TestScheduleForFairSharing, TestScheduleConcurrentAdmission). Each
+// test sets only the fields it needs; unused fields keep their zero value.
+type scheduleTestCase struct {
+	// Features
+	featureGates map[featuregate.Feature]bool
+
+	enableFairSharing bool
+
+	workloads      []kueue.Workload
+	objects        []client.Object
+	admissionError error
+
+	// additional*Queues can hold any extra queues needed by the tc
+	additionalClusterQueues []kueue.ClusterQueue
+	additionalLocalQueues   []kueue.LocalQueue
+
+	cohorts []kueue.Cohort
+
+	// wantAssignments is a summary of all the admissions in the cache after this cycle.
+	wantAssignments map[workload.Reference]kueue.Admission
+	// wantWorkloads is the subset of workloads that got admitted in this cycle.
+	wantWorkloads []kueue.Workload
+	// workload version to compensate for the difference between use of Apply and Merge patch in FakeClient
+	wantWorkloadUseMergePatch []kueue.Workload
+	// wantLeft is the workload keys that are left in the queues after this cycle.
+	wantLeft map[kueue.ClusterQueueReference][]workload.Reference
+	// wantInadmissibleLeft is the workload keys that are left in the inadmissible state after this cycle.
+	wantInadmissibleLeft map[kueue.ClusterQueueReference][]workload.Reference
+	// wantEvents ignored if empty, the Message is ignored (it contains the duration)
+	wantEvents []utiltesting.EventRecord
+	// eventCmpOpts are the cmp options to compare recorded events.
+	eventCmpOpts cmp.Options
+
+	wantSkippedPreemptions map[string]int
+}
+
+// scheduleTestConfig carries the per-suite fixtures and knobs shared by the core
+// scheduling run procedure.
+type scheduleTestConfig struct {
+	queues          []kueue.LocalQueue
+	clusterQueues   []kueue.ClusterQueue
+	resourceFlavors []*kueue.ResourceFlavor
+	fakeClock       *testingclock.FakeClock
+
+	// schedulingTimeout overrides the scheduling context timeout. Defaults to queueingTimeout.
+	schedulingTimeout time.Duration
+	// unorderedWorkloads tolerates non-deterministic ordering of the resulting workload
+	// list, as needed by concurrent admission where sibling order is not deterministic.
+	unorderedWorkloads bool
+}
+
+// runScheduleTestCases runs the shared "build client → schedule → assert" procedure for
+// the core scheduling tests, including the WorkloadRequestUseMergePatch on/off double run.
+func runScheduleTestCases(t *testing.T, cfg scheduleTestConfig, cases map[string]scheduleTestCase) {
+	t.Helper()
+	for name, tc := range cases {
+		for _, enabled := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", name, enabled), func(t *testing.T) {
+				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, enabled)
+				metrics.AdmissionCyclePreemptionSkips.Reset()
+				features.SetFeatureGatesDuringTest(t, tc.featureGates)
+
+				ctx, log := utiltesting.ContextWithLog(t)
+
+				allQueues := append(cfg.queues, tc.additionalLocalQueues...)
+				allClusterQueues := append(cfg.clusterQueues, tc.additionalClusterQueues...)
+
+				clientBuilder := utiltesting.NewClientBuilder().
+					WithLists(&kueue.WorkloadList{Items: tc.workloads}, &kueue.LocalQueueList{Items: allQueues}).
+					WithObjects(append(
+						[]client.Object{
+							utiltesting.MakeNamespaceWrapper("default").Obj(),
+							utiltesting.MakeNamespaceWrapper("eng-alpha").Label("dep", "eng").Obj(),
+							utiltesting.MakeNamespaceWrapper("eng-beta").Label("dep", "eng").Obj(),
+							utiltesting.MakeNamespaceWrapper("eng-gamma").Label("dep", "eng").Obj(),
+							utiltesting.MakeNamespaceWrapper("sales").Label("dep", "sales").Obj(),
+							utiltesting.MakeNamespaceWrapper("lend").Label("dep", "lend").Obj(),
+						}, tc.objects...,
+					)...).
+					WithStatusSubresource(&kueue.Workload{}).
+					WithInterceptorFuncs(interceptor.Funcs{
+						SubResourcePatch: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+							if _, ok := obj.(*kueue.Workload); ok && subResourceName == "status" && tc.admissionError != nil {
+								return tc.admissionError
+							}
+							return utiltesting.TreatSSAAsStrategicMerge(ctx, client, subResourceName, obj, patch, opts...)
+						},
+					})
+
+				cl := clientBuilder.Build()
+				recorder := &utiltesting.EventRecorder{}
+				cqCache := schdcache.New(cl)
+				qManager := qcache.NewManagerForUnitTests(cl, cqCache)
+				// Workloads are loaded into queues or clusterQueues as we add them.
+				for _, q := range allQueues {
+					if err := qManager.AddLocalQueue(ctx, &q); err != nil {
+						t.Fatalf("Inserting queue %s/%s in manager: %v", q.Namespace, q.Name, err)
+					}
+				}
+				for i := range cfg.resourceFlavors {
+					cqCache.AddOrUpdateResourceFlavor(log, cfg.resourceFlavors[i])
+				}
+				for _, cq := range allClusterQueues {
+					if err := cqCache.AddClusterQueue(ctx, &cq); err != nil {
+						t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
+					}
+					if err := qManager.AddClusterQueue(ctx, &cq); err != nil {
+						t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
+					}
+					if err := cl.Create(ctx, &cq); err != nil {
+						t.Errorf("couldn't create the cluster queue: %v", err)
+					}
+				}
+
+				for _, cohort := range tc.cohorts {
+					if err := cqCache.AddOrUpdateCohort(&cohort); err != nil {
+						t.Fatalf("Inserting Cohort %s in cache: %v", cohort.Name, err)
+					}
+				}
+
+				var fairSharing *config.FairSharing
+				if tc.enableFairSharing {
+					fairSharing = &config.FairSharing{}
+				}
+				scheduler := New(qManager, cqCache, cl, recorder,
+					WithFairSharing(fairSharing), WithClock(t, cfg.fakeClock), WithPreemptionExpectations(preemptexpectations.New()))
+				wg := sync.WaitGroup{}
+				scheduler.setAdmissionRoutineWrapper(routine.NewWrapper(
+					func() { wg.Add(1) },
+					func() { wg.Done() },
+				))
+
+				schedulingTimeout := cfg.schedulingTimeout
+				if schedulingTimeout == 0 {
+					schedulingTimeout = queueingTimeout
+				}
+				ctx, cancel := context.WithTimeout(ctx, schedulingTimeout)
+				go qManager.CleanUpOnContext(ctx)
+				defer cancel()
+
+				scheduler.schedule(ctx)
+				wg.Wait()
+
+				// Verify assignments in cache.
+				gotAssignments := make(map[workload.Reference]kueue.Admission)
+				snapshot, err := cqCache.Snapshot(ctx)
+				if err != nil {
+					t.Fatalf("unexpected error while building snapshot: %v", err)
+				}
+				for cqName, c := range snapshot.ClusterQueues() {
+					for name, w := range c.Workloads {
+						switch {
+						case !workload.HasQuotaReservation(w.Obj):
+							t.Errorf("Workload %s is not admitted by a clusterQueue, but it is found as member of clusterQueue %s in the cache", name, cqName)
+						case w.Obj.Status.Admission.ClusterQueue != cqName:
+							t.Errorf("Workload %s is admitted by clusterQueue %s, but it is found as member of clusterQueue %s in the cache", name, w.Obj.Status.Admission.ClusterQueue, cqName)
+						default:
+							gotAssignments[name] = *w.Obj.Status.Admission
+						}
+					}
+				}
+
+				gotWorkloads := &kueue.WorkloadList{}
+				err = cl.List(ctx, gotWorkloads)
+				if err != nil {
+					t.Fatalf("Unexpected list workloads error: %v", err)
+				}
+
+				workloadCmpOpts := cmp.Options{
+					cmpopts.EquateEmpty(),
+					cmpopts.IgnoreFields(kueue.AdmissionCheckState{}, "LastTransitionTime"),
+					cmpopts.IgnoreFields(kueue.Workload{}, "ObjectMeta.ResourceVersion", "ObjectMeta.CreationTimestamp"),
+					cmpopts.SortSlices(func(a, b metav1.Condition) bool { return a.Type < b.Type }),
+				}
+				if cfg.unorderedWorkloads {
+					workloadCmpOpts = append(workloadCmpOpts, cmpopts.SortSlices(func(a, b kueue.Workload) bool { return a.Name < b.Name }))
+				}
+
+				if features.Enabled(features.WorkloadRequestUseMergePatch) && tc.wantWorkloadUseMergePatch != nil {
+					if diff := cmp.Diff(tc.wantWorkloadUseMergePatch, gotWorkloads.Items, workloadCmpOpts); diff != "" {
+						t.Errorf("Unexpected workloads (-want,+got):\n%s", diff)
+					}
+				} else {
+					if diff := cmp.Diff(tc.wantWorkloads, gotWorkloads.Items, workloadCmpOpts); diff != "" {
+						t.Errorf("Unexpected workloads (-want,+got):\n%s", diff)
+					}
+				}
+
+				if len(gotAssignments) == 0 {
+					gotAssignments = nil
+				}
+				if diff := cmp.Diff(tc.wantAssignments, gotAssignments); diff != "" {
+					t.Errorf("Unexpected assigned clusterQueues in cache (-want,+got):\n%s", diff)
+				}
+
+				qDump := qManager.Dump()
+				if diff := cmp.Diff(tc.wantLeft, qDump, cmpDump...); diff != "" {
+					t.Errorf("Unexpected elements left in the queue (-want,+got):\n%s", diff)
+				}
+				qDumpInadmissible := qManager.DumpInadmissible()
+				if diff := cmp.Diff(tc.wantInadmissibleLeft, qDumpInadmissible, cmpDump...); diff != "" {
+					t.Errorf("Unexpected elements left in inadmissible workloads (-want,+got):\n%s", diff)
+				}
+
+				if len(tc.wantEvents) > 0 {
+					if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents, tc.eventCmpOpts...); diff != "" {
+						t.Errorf("unexpected events (-want/+got):\n%s", diff)
+					}
+				}
+
+				for cqName, want := range tc.wantSkippedPreemptions {
+					lvs := []string{cqName, roletracker.RoleStandalone}
+					val, err := testutil.GetGaugeMetricValue(metrics.AdmissionCyclePreemptionSkips.WithLabelValues(lvs...))
+					if err != nil {
+						t.Fatalf("Couldn't get value for metric admission_cycle_preemption_skips for %q: %v", cqName, err)
+					}
+					got := int(val)
+					if want != got {
+						t.Errorf("Counted %d skips for %q, want %d", got, cqName, want)
+					}
+				}
+			})
+		}
+	}
+}
+
 func TestSchedule(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	fakeClock := testingclock.NewFakeClock(now)
@@ -172,37 +399,7 @@ func TestSchedule(t *testing.T) {
 		*utiltestingapi.MakeLocalQueue("lend-a-queue", "lend").ClusterQueue("lend-a").Obj(),
 		*utiltestingapi.MakeLocalQueue("lend-b-queue", "lend").ClusterQueue("lend-b").Obj(),
 	}
-	cases := map[string]struct {
-		// Features
-		featureGates map[featuregate.Feature]bool
-
-		workloads      []kueue.Workload
-		objects        []client.Object
-		admissionError error
-
-		// additional*Queues can hold any extra queues needed by the tc
-		additionalClusterQueues []kueue.ClusterQueue
-		additionalLocalQueues   []kueue.LocalQueue
-
-		cohorts []kueue.Cohort
-
-		// wantAssignments is a summary of all the admissions in the cache after this cycle.
-		wantAssignments map[workload.Reference]kueue.Admission
-		// wantWorkloads is the subset of workloads that got admitted in this cycle.
-		wantWorkloads []kueue.Workload
-		// workload version to compensate for the difference between use of Apply and Merge patch in FakeClient
-		wantWorkloadUseMergePatch []kueue.Workload
-		// wantLeft is the workload keys that are left in the queues after this cycle.
-		wantLeft map[kueue.ClusterQueueReference][]workload.Reference
-		// wantInadmissibleLeft is the workload keys that are left in the inadmissible state after this cycle.
-		wantInadmissibleLeft map[kueue.ClusterQueueReference][]workload.Reference
-		// wantEvents ignored if empty, the Message is ignored (it contains the duration)
-		wantEvents []utiltesting.EventRecord
-		// eventCmpOpts are the cmp options to compare recorded events.
-		eventCmpOpts cmp.Options
-
-		wantSkippedPreemptions map[string]int
-	}{
+	cases := map[string]scheduleTestCase{
 		"use second flavor when the first has no preemption candidates; WhenCanPreempt: MayStopSearch": {
 			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
 			additionalClusterQueues: []kueue.ClusterQueue{
@@ -5884,164 +6081,12 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 	}
-	for name, tc := range cases {
-		for _, enabled := range []bool{false, true} {
-			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", name, enabled), func(t *testing.T) {
-				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, enabled)
-				metrics.AdmissionCyclePreemptionSkips.Reset()
-				features.SetFeatureGatesDuringTest(t, tc.featureGates)
-
-				ctx, log := utiltesting.ContextWithLog(t)
-
-				allQueues := append(queues, tc.additionalLocalQueues...)
-				allClusterQueues := append(clusterQueues, tc.additionalClusterQueues...)
-
-				clientBuilder := utiltesting.NewClientBuilder().
-					WithLists(&kueue.WorkloadList{Items: tc.workloads}, &kueue.LocalQueueList{Items: allQueues}).
-					WithObjects(append(
-						[]client.Object{
-							utiltesting.MakeNamespaceWrapper("default").Obj(),
-							utiltesting.MakeNamespaceWrapper("eng-alpha").Label("dep", "eng").Obj(),
-							utiltesting.MakeNamespaceWrapper("eng-beta").Label("dep", "eng").Obj(),
-							utiltesting.MakeNamespaceWrapper("eng-gamma").Label("dep", "eng").Obj(),
-							utiltesting.MakeNamespaceWrapper("sales").Label("dep", "sales").Obj(),
-							utiltesting.MakeNamespaceWrapper("lend").Label("dep", "lend").Obj(),
-						}, tc.objects...,
-					)...).
-					WithStatusSubresource(&kueue.Workload{}).
-					WithInterceptorFuncs(interceptor.Funcs{
-						SubResourcePatch: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
-							if _, ok := obj.(*kueue.Workload); ok && subResourceName == "status" && tc.admissionError != nil {
-								return tc.admissionError
-							}
-							return utiltesting.TreatSSAAsStrategicMerge(ctx, client, subResourceName, obj, patch, opts...)
-						},
-					})
-
-				cl := clientBuilder.Build()
-				recorder := &utiltesting.EventRecorder{}
-				cqCache := schdcache.New(cl)
-				qManager := qcache.NewManagerForUnitTests(cl, cqCache)
-				// Workloads are loaded into queues or clusterQueues as we add them.
-				for _, q := range allQueues {
-					if err := qManager.AddLocalQueue(ctx, &q); err != nil {
-						t.Fatalf("Inserting queue %s/%s in manager: %v", q.Namespace, q.Name, err)
-					}
-				}
-				for i := range resourceFlavors {
-					cqCache.AddOrUpdateResourceFlavor(log, resourceFlavors[i])
-				}
-				for _, cq := range allClusterQueues {
-					if err := cqCache.AddClusterQueue(ctx, &cq); err != nil {
-						t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
-					}
-					if err := qManager.AddClusterQueue(ctx, &cq); err != nil {
-						t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
-					}
-					if err := cl.Create(ctx, &cq); err != nil {
-						t.Errorf("couldn't create the cluster queue: %v", err)
-					}
-				}
-
-				for _, cohort := range tc.cohorts {
-					if err := cqCache.AddOrUpdateCohort(&cohort); err != nil {
-						t.Fatalf("Inserting Cohort %s in cache: %v", cohort.Name, err)
-					}
-				}
-
-				scheduler := New(qManager, cqCache, cl, recorder,
-					WithClock(t, fakeClock), WithPreemptionExpectations(preemptexpectations.New()))
-				wg := sync.WaitGroup{}
-				scheduler.setAdmissionRoutineWrapper(routine.NewWrapper(
-					func() { wg.Add(1) },
-					func() { wg.Done() },
-				))
-
-				ctx, cancel := context.WithTimeout(ctx, queueingTimeout)
-				go qManager.CleanUpOnContext(ctx)
-				defer cancel()
-
-				scheduler.schedule(ctx)
-				wg.Wait()
-
-				// Verify assignments in cache.
-				gotAssignments := make(map[workload.Reference]kueue.Admission)
-				snapshot, err := cqCache.Snapshot(ctx)
-				if err != nil {
-					t.Fatalf("unexpected error while building snapshot: %v", err)
-				}
-				for cqName, c := range snapshot.ClusterQueues() {
-					for name, w := range c.Workloads {
-						switch {
-						case !workload.HasQuotaReservation(w.Obj):
-							t.Errorf("Workload %s is not admitted by a clusterQueue, but it is found as member of clusterQueue %s in the cache", name, cqName)
-						case w.Obj.Status.Admission.ClusterQueue != cqName:
-							t.Errorf("Workload %s is admitted by clusterQueue %s, but it is found as member of clusterQueue %s in the cache", name, w.Obj.Status.Admission.ClusterQueue, cqName)
-						default:
-							gotAssignments[name] = *w.Obj.Status.Admission
-						}
-					}
-				}
-
-				gotWorkloads := &kueue.WorkloadList{}
-				err = cl.List(ctx, gotWorkloads)
-				if err != nil {
-					t.Fatalf("Unexpected list workloads error: %v", err)
-				}
-
-				defaultWorkloadCmpOpts := cmp.Options{
-					cmpopts.EquateEmpty(),
-					cmpopts.IgnoreFields(kueue.AdmissionCheckState{}, "LastTransitionTime"),
-					cmpopts.IgnoreFields(kueue.Workload{}, "ObjectMeta.ResourceVersion", "ObjectMeta.CreationTimestamp"),
-					cmpopts.SortSlices(func(a, b metav1.Condition) bool { return a.Type < b.Type }),
-				}
-
-				if features.Enabled(features.WorkloadRequestUseMergePatch) && tc.wantWorkloadUseMergePatch != nil {
-					if diff := cmp.Diff(tc.wantWorkloadUseMergePatch, gotWorkloads.Items, defaultWorkloadCmpOpts); diff != "" {
-						t.Errorf("Unexpected workloads (-want,+got):\n%s", diff)
-					}
-				} else {
-					if diff := cmp.Diff(tc.wantWorkloads, gotWorkloads.Items, defaultWorkloadCmpOpts); diff != "" {
-						t.Errorf("Unexpected workloads (-want,+got):\n%s", diff)
-					}
-				}
-
-				if len(gotAssignments) == 0 {
-					gotAssignments = nil
-				}
-				if diff := cmp.Diff(tc.wantAssignments, gotAssignments); diff != "" {
-					t.Errorf("Unexpected assigned clusterQueues in cache (-want,+got):\n%s", diff)
-				}
-
-				qDump := qManager.Dump()
-				if diff := cmp.Diff(tc.wantLeft, qDump, cmpDump...); diff != "" {
-					t.Errorf("Unexpected elements left in the queue (-want,+got):\n%s", diff)
-				}
-				qDumpInadmissible := qManager.DumpInadmissible()
-				if diff := cmp.Diff(tc.wantInadmissibleLeft, qDumpInadmissible, cmpDump...); diff != "" {
-					t.Errorf("Unexpected elements left in inadmissible workloads (-want,+got):\n%s", diff)
-				}
-
-				if len(tc.wantEvents) > 0 {
-					if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents, tc.eventCmpOpts...); diff != "" {
-						t.Errorf("unexpected events (-want/+got):\n%s", diff)
-					}
-				}
-
-				for cqName, want := range tc.wantSkippedPreemptions {
-					lvs := []string{cqName, roletracker.RoleStandalone}
-					val, err := testutil.GetGaugeMetricValue(metrics.AdmissionCyclePreemptionSkips.WithLabelValues(lvs...))
-					if err != nil {
-						t.Fatalf("Couldn't get value for metric admission_cycle_preemption_skips for %q: %v", cqName, err)
-					}
-					got := int(val)
-					if want != got {
-						t.Errorf("Counted %d skips for %q, want %d", got, cqName, want)
-					}
-				}
-			})
-		}
-	}
+	runScheduleTestCases(t, scheduleTestConfig{
+		queues:          queues,
+		clusterQueues:   clusterQueues,
+		resourceFlavors: resourceFlavors,
+		fakeClock:       fakeClock,
+	}, cases)
 }
 
 func TestEntryOrdering(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/area testing

#### What this PR does / why we need it:

The core scheduling tests duplicated the same Schedule run/assert procedure.

This extracts a shared `scheduleTestCase` and `runScheduleTestCases` helper, then converts: 

- `TestSchedule`
- `TestScheduleForFairSharing`
- `TestScheduleConcurrentAdmission`

TAS and AFS scheduling tests are left for follow-up PRs since their structures diverge more.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #12442

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized scheduler test suite with consolidated test execution infrastructure. The refactoring improves code organization and maintainability across concurrent admission, fair-sharing, and general scheduling test cases, with no impact on test coverage or validation thoroughness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->