### PR TITLE
[release-0.17] KueuePopulator: clean up created resources on helm uninstall

### DIFF
--- a/cmd/experimental/kueue-populator/Makefile
+++ b/cmd/experimental/kueue-populator/Makefile
@@ -119,7 +119,7 @@ test-integration: compile-crd-manifests $(ENVTEST) $(GINKGO)
 	GOWORK=off $(GINKGO) -procs=$(INTEGRATION_NPROCS) -v ./test/integration/...
 
 .PHONY: test-e2e
-test-e2e: helm-verify-install
+test-e2e: helm-verify-lifecycle
 	./run-e2e.sh
 
 .PHONY: test
@@ -168,6 +168,6 @@ helm-chart-package: $(HELM) $(YQ) ## Package a chart into a versioned chart arch
 helm-chart-push: HELM_CHART_PUSH=true
 helm-chart-push: helm-chart-package
 
-.PHONY: helm-verify-install
-helm-verify-install: ## Run Helm install verification script.
-	./test/verify-helm-install.sh
+.PHONY: helm-verify-lifecycle
+helm-verify-lifecycle: ## Run Helm install/uninstall lifecycle verification script.
+	./test/verify-helm-lifecycle.sh

--- a/cmd/experimental/kueue-populator/charts/kueue-populator/templates/_helpers.tpl
+++ b/cmd/experimental/kueue-populator/charts/kueue-populator/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{/*
+Kubectl image used by Helm hooks and tests.
+*/}}
+{{- define "kueue-populator.kubectlImage" -}}
+registry.k8s.io/kubectl:v1.33.6
+{{- end -}}

--- a/cmd/experimental/kueue-populator/charts/kueue-populator/templates/setup-hook.yaml
+++ b/cmd/experimental/kueue-populator/charts/kueue-populator/templates/setup-hook.yaml
@@ -127,7 +127,7 @@ spec:
       serviceAccountName: {{ .Release.Name }}-kueue-hook-sa
       containers:
       - name: kubectl-apply
-        image: registry.k8s.io/kubectl:v1.33.6
+        image: {{ include "kueue-populator.kubectlImage" . }}
         command:
         - kubectl
         - apply

--- a/cmd/experimental/kueue-populator/charts/kueue-populator/templates/setup-hook.yaml
+++ b/cmd/experimental/kueue-populator/charts/kueue-populator/templates/setup-hook.yaml
@@ -1,13 +1,9 @@
-# 1. ConfigMap containing Kueue resource definitions
+# 1. ConfigMap containing Kueue resource definitions.
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-kueue-resources
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation
 data:
   resources.yaml: |-
 {{- if .Values.kueuePopulator.config.topology }}
@@ -66,42 +62,32 @@ data:
 {{- end }}
 {{- end }}
 ---
-# 2. Service Account for the Job
+# 2. Service Account shared by the create (post-install) and delete (pre-delete) Jobs.
+# Regular release resource: present for both hooks and removed by Helm on uninstall.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}-kueue-hook-sa
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation
-
 ---
-# 3. ClusterRole with required permissions
+# 3. ClusterRole with permissions to create AND delete the Kueue resources.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Release.Name }}-kueue-hook-clusterrole
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation
 rules:
 - apiGroups: ["kueue.x-k8s.io"]
   resources: ["topologies", "resourceflavors", "clusterqueues", "localqueues"]
-  verbs: ["create", "get", "list", "patch", "update"]
+  verbs: ["create", "get", "list", "patch", "update", "delete"]
 - apiGroups: [""] # Core API group
   resources: ["configmaps", "endpoints"]
   verbs: ["get"]
-
 ---
-# 4. A ClusterRoleBinding to grant the permissions cluster-wide
+# 4. A ClusterRoleBinding to grant the permissions cluster-wide.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Release.Name }}-kueue-hook-crb
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -111,7 +97,7 @@ subjects:
   name: {{ .Release.Name }}-kueue-hook-sa
   namespace: {{ .Release.Namespace }}
 ---
-# 5. The Job that waits and applies the resources
+# 5. The Job that applies the resources after install/upgrade.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -119,7 +105,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "5"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   template:
@@ -133,6 +118,41 @@ spec:
         - apply
         - -f
         - /etc/config/resources.yaml
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config
+      restartPolicy: Never
+      volumes:
+      - name: config-volume
+        configMap:
+          name: {{ .Release.Name }}-kueue-resources
+  backoffLimit: 5
+---
+# 6. The Job that deletes the resources before the release is removed, so the
+# cluster-scoped Kueue objects created by the create Job above do not leak on
+# `helm uninstall`. It reuses the ConfigMap and ServiceAccount, which are still
+# present at pre-delete time.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-delete-kueue-resources-job"
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ .Release.Name }}-kueue-hook-sa
+      containers:
+      - name: kubectl-delete
+        image: {{ include "kueue-populator.kubectlImage" . }}
+        command:
+        - kubectl
+        - delete
+        - -f
+        - /etc/config/resources.yaml
+        - --ignore-not-found=true
         volumeMounts:
         - name: config-volume
           mountPath: /etc/config

--- a/cmd/experimental/kueue-populator/charts/kueue-populator/templates/tests/test-kueue-status.yaml
+++ b/cmd/experimental/kueue-populator/charts/kueue-populator/templates/tests/test-kueue-status.yaml
@@ -10,7 +10,7 @@ spec:
   serviceAccountName: "{{ .Release.Name }}-test-sa"
   containers:
     - name: check-kueue-controller-manager
-      image: registry.k8s.io/kubectl:v1.33.6
+      image: {{ include "kueue-populator.kubectlImage" . }}
       command: ["kubectl"]
       args: [
         "wait",

--- a/cmd/experimental/kueue-populator/charts/kueue-populator/templates/tests/test-populator-resources.yaml
+++ b/cmd/experimental/kueue-populator/charts/kueue-populator/templates/tests/test-populator-resources.yaml
@@ -10,7 +10,7 @@ spec:
   serviceAccountName: "{{ .Release.Name }}-test-sa"
   containers:
     - name: check-clusterqueue
-      image: registry.k8s.io/kubectl:v1.33.6
+      image: {{ include "kueue-populator.kubectlImage" . }}
       command: ["kubectl"]
       args: ["get", "clusterqueues.kueue.x-k8s.io", "{{ .Values.kueuePopulator.config.clusterQueue.name }}"]
 {{- if .Values.kueuePopulator.config.resourceFlavor }}

--- a/cmd/experimental/kueue-populator/test/verify-helm-lifecycle.sh
+++ b/cmd/experimental/kueue-populator/test/verify-helm-lifecycle.sh
@@ -53,7 +53,7 @@ IMAGE_TAG="us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue-populator:$
 echo "Building Helm dependencies..."
 "$HELM" dependency build charts/kueue-populator
 
-echo "Installing kueue-populator with Topology and ResourceFlavor..."
+echo "Installing kueue-populator with Topology, ResourceFlavor and ClusterQueue..."
 "$HELM" upgrade --install kueue-populator charts/kueue-populator \
   --namespace kueue-system \
   --create-namespace \
@@ -62,9 +62,39 @@ echo "Installing kueue-populator with Topology and ResourceFlavor..."
   --set image.pullPolicy=IfNotPresent \
   --set kueuePopulator.config.topology.levels[0].nodeLabel="cloud.google.com/gke-nodepool" \
   --set kueuePopulator.config.resourceFlavor.nodeLabels."cloud\.google\.com/gke-nodepool"="default-pool" \
+  --set kueuePopulator.config.clusterQueue.name="cluster-queue" \
+  --set kueuePopulator.config.clusterQueue.resources[0].name="cpu" \
+  --set kueuePopulator.config.clusterQueue.resources[0].nominalQuota=10 \
   --wait
 
 echo "Running Helm tests..."
 "$HELM" test kueue-populator --namespace kueue-system
+
+# The post-install Job creates the cluster-scoped Kueue resources from the chart's
+# ConfigMap (see charts/kueue-populator/templates/setup-hook.yaml).
+echo "Verifying the Kueue resources were created..."
+kubectl get topology default
+kubectl get resourceflavor tas-gpu-default
+kubectl get clusterqueue cluster-queue
+
+echo "Uninstalling kueue-populator (triggers the pre-delete cleanup hook)..."
+"$HELM" uninstall kueue-populator --namespace kueue-system
+
+# The pre-delete Job must delete the resources created above so they do not leak
+# on `helm uninstall`. helm waits for the hook Job to complete, so the objects
+# should already be gone once uninstall returns.
+echo "Verifying the Kueue resources were cleaned up by the pre-delete hook..."
+if kubectl get topology default >/dev/null 2>&1; then
+  echo "ERROR: Topology \"default\" still exists after helm uninstall" >&2
+  exit 1
+fi
+if kubectl get resourceflavor tas-gpu-default >/dev/null 2>&1; then
+  echo "ERROR: ResourceFlavor \"tas-gpu-default\" still exists after helm uninstall" >&2
+  exit 1
+fi
+if kubectl get clusterqueue cluster-queue >/dev/null 2>&1; then
+  echo "ERROR: ClusterQueue \"cluster-queue\" still exists after helm uninstall" >&2
+  exit 1
+fi
 
 echo "Verification passed!"


### PR DESCRIPTION
This is a manual cherry-pick of #12402 to `release-0.17`, replacing the automated #12433 which failed CI.

#12402's Helm hook references the `kueue-populator.kubectlImage` template helper introduced in #10925, which is not present on `release-0.17`. The automated cherry-pick of #12402 alone therefore failed to render. This PR cherry-picks both as separate commits, with the helper dependency first:

- Deduplicate kubectl image (#10925)
- KueuePopulator: clean up created resources on helm uninstall (#12402)

The only manual resolution was in the two Helm test templates, where `release-0.17` uses different container names than `main`; the `kueue-populator.kubectlImage` helper was applied while keeping the existing container names.

```release-note
KueuePopulator Helm: `helm uninstall` removes the ClusterQueue, ResourceFlavor, Topology, ConfigMap, and RBAC created by the chart, which previously leaked after uninstall.

ACTION REQUIRED: If you installed a previous version of the kueue-populator chart, its ConfigMap and RBAC (`*-kueue-hook-*` ServiceAccount/ClusterRole/ClusterRoleBinding and the `*-kueue-resources` ConfigMap) were created as Helm hooks and are not adopted by the new release. Delete them manually before upgrading to avoid `helm upgrade`/`install` ownership conflicts.
```

_Disclosure: used an AI coding tool to prepare this cherry-pick; reviewed by me._
