### PR TITLE
test: extend kueuectl e2e coverage

### DIFF
--- a/test/e2e/singlecluster/baseline/kueuectl_test.go
+++ b/test/e2e/singlecluster/baseline/kueuectl_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package baseline
 
 import (
+	"encoding/json"
 	"os/exec"
 
 	"github.com/onsi/ginkgo/v2"
@@ -25,11 +26,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Label("area:singlecluster", "feature:kueuectl"), func() {
+var _ = ginkgo.Describe("Kueuectl", ginkgo.Label("area:singlecluster", "feature:kueuectl"), func() {
 	var (
 		ns *corev1.Namespace
 		cq *kueue.ClusterQueue
@@ -41,7 +43,6 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Label("area:singlecluster", "f
 		cq = utiltestingapi.MakeClusterQueue("e2e-cq-" + ns.Name).Obj()
 		util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
 	})
-
 	ginkgo.AfterEach(func() {
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
@@ -81,6 +82,134 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Label("area:singlecluster", "f
 			ginkgo.By("Check that the local queue did not create", func() {
 				var createdQueue kueue.LocalQueue
 				gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lqName, Namespace: ns.Name}, &createdQueue)).ToNot(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("Should print the created local queue as YAML", func() {
+			lqName := "e2e-lq-yaml"
+
+			var output []byte
+			ginkgo.By("Create local queue and capture YAML output", func() {
+				cmd := exec.Command(kueuectlPath, "create", "localqueue", lqName,
+					"--clusterqueue", cq.Name, "--namespace", ns.Name, "-o", "yaml")
+				var err error
+				output, err = cmd.CombinedOutput()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
+			})
+
+			ginkgo.By("Verify the YAML output contains the resource", func() {
+				gomega.Expect(string(output)).To(gomega.ContainSubstring("kind: LocalQueue"))
+				gomega.Expect(string(output)).To(gomega.ContainSubstring("name: " + lqName))
+				gomega.Expect(string(output)).To(gomega.ContainSubstring("clusterQueue: " + cq.Name))
+			})
+		})
+
+		ginkgo.It("Should print the created local queue as JSON", func() {
+			lqName := "e2e-lq-json"
+
+			var output []byte
+			ginkgo.By("Create local queue and capture JSON output", func() {
+				cmd := exec.Command(kueuectlPath, "create", "localqueue", lqName,
+					"--clusterqueue", cq.Name, "--namespace", ns.Name, "-o", "json")
+				var err error
+				output, err = cmd.CombinedOutput()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
+			})
+
+			ginkgo.By("Verify the JSON output round-trips into the LocalQueue type", func() {
+				var created kueue.LocalQueue
+				gomega.Expect(json.Unmarshal(output, &created)).To(gomega.Succeed())
+				gomega.Expect(created.Name).To(gomega.Equal(lqName))
+				gomega.Expect(string(created.Spec.ClusterQueue)).To(gomega.Equal(cq.Name))
+			})
+		})
+
+		ginkgo.It("Should not create local queue with --dry-run=client", func() {
+			lqName := "e2e-lq-dryrun"
+
+			var output []byte
+			ginkgo.By("Create local queue with --dry-run=client and capture output", func() {
+				cmd := exec.Command(kueuectlPath, "create", "localqueue", lqName,
+					"--clusterqueue", cq.Name, "--namespace", ns.Name, "--dry-run=client")
+				var err error
+				output, err = cmd.CombinedOutput()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
+			})
+
+			ginkgo.By("Verify the local queue was NOT created in the cluster", func() {
+				var createdQueue kueue.LocalQueue
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lqName, Namespace: ns.Name}, &createdQueue)).To(utiltesting.BeNotFoundError())
+				}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Verify the local queue object is still printed to stdout", func() {
+				gomega.Expect(string(output)).To(gomega.ContainSubstring(lqName))
+			})
+		})
+	})
+
+	ginkgo.When("Listing a LocalQueue", func() {
+		ginkgo.BeforeEach(func() {
+			lq := utiltestingapi.MakeLocalQueue("e2e-lq-list", ns.Name).ClusterQueue(cq.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+		})
+
+		ginkgo.It("Should list local queues in the current namespace as JSON", func() {
+			var output []byte
+			ginkgo.By("List local queues in JSON", func() {
+				cmd := exec.Command(kueuectlPath, "list", "localqueue", "--namespace", ns.Name, "-o", "json")
+				var err error
+				output, err = cmd.CombinedOutput()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
+			})
+
+			ginkgo.By("Verify the JSON output round-trips into the LocalQueueList type", func() {
+				var list kueue.LocalQueueList
+				gomega.Expect(json.Unmarshal(output, &list)).To(gomega.Succeed())
+				gomega.Expect(list.Items).To(gomega.HaveLen(1))
+				gomega.Expect(list.Items[0].Name).To(gomega.Equal("e2e-lq-list"))
+				gomega.Expect(string(list.Items[0].Spec.ClusterQueue)).To(gomega.Equal(cq.Name))
+			})
+		})
+
+		ginkgo.It("Should list local queues across all namespaces with -A", func() {
+			otherNs := util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-other-")
+			ginkgo.DeferCleanup(func() {
+				gomega.Expect(util.DeleteNamespace(ctx, k8sClient, otherNs)).To(gomega.Succeed())
+			})
+			otherLq := utiltestingapi.MakeLocalQueue("e2e-lq-other", otherNs.Name).ClusterQueue(cq.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, otherLq)
+
+			var output []byte
+			ginkgo.By("List local queues with -A", func() {
+				cmd := exec.Command(kueuectlPath, "list", "localqueue", "-A", "-o", "json")
+				var err error
+				output, err = cmd.CombinedOutput()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
+			})
+
+			ginkgo.By("Verify the output contains LQs from both namespaces", func() {
+				gomega.Expect(string(output)).To(gomega.ContainSubstring(ns.Name))
+				gomega.Expect(string(output)).To(gomega.ContainSubstring(otherNs.Name))
+			})
+		})
+	})
+
+	ginkgo.When("Deleting a Workload", func() {
+		ginkgo.It("Should delete a standalone workload with --yes", func() {
+			wlName := "e2e-wl-delete"
+			wl := utiltestingapi.MakeWorkload(wlName, ns.Name).Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+
+			ginkgo.By("Run kueuectl delete workload with --yes", func() {
+				cmd := exec.Command(kueuectlPath, "delete", "workload", wlName, "--namespace", ns.Name, "--yes")
+				output, err := cmd.CombinedOutput()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
+			})
+
+			ginkgo.By("Verify the workload is removed from the cluster", func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, wl, true)
 			})
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind cleanup
/area testing

#### What this PR does / why we need it:

Adds 7 e2e tests to `kueuectl_test.go` for `--ignore-unknown-cq`, `-o yaml/json`, `--dry-run=client`, `list localqueue -o json`, `list -A`, and `delete workload --yes`. The outer `Describe` is renamed from "Kueuectl Create" to "Kueuectl".

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for `kueuectl` workflows.
  * Added `kueuectl create localqueue` assertions for both `-o yaml` and `-o json`, including correct `name` and `clusterQueue` values.
  * Added `--dry-run=client` checks to confirm the `LocalQueue` is not created in the cluster while stdout output remains correct.
  * Extended `kueuectl list localqueue` JSON validation for the current namespace and with `-A` across all namespaces.
  * Added end-to-end verification for deleting a standalone workload using `--yes`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->