### PR TITLE
Always sort events in the TAS scheduling test assertions for determinism

### DIFF
--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -3519,14 +3519,11 @@ type tasScheduleTestCase struct {
 	featureGates map[featuregate.Feature]bool
 }
 
-// tasScheduleTestConfig carries the per-suite fixtures and knobs shared by the TAS
-// preemption and cohort scheduling run procedure.
+// tasScheduleTestConfig carries the per-suite fixtures shared by the TAS preemption
+// and cohort scheduling run procedure.
 type tasScheduleTestConfig struct {
 	queues []kueue.LocalQueue
 	now    time.Time
-	// sortEvents compares recorded events order-insensitively, matching the cohort
-	// scheduling test's assertion.
-	sortEvents bool
 }
 
 // runTASScheduleTestCases runs the shared "build client → schedule → assert" procedure for
@@ -3698,10 +3695,9 @@ func runTASScheduleTestCases(t *testing.T, cfg tasScheduleTestConfig, cases map[
 					if diff := cmp.Diff(tc.wantInadmissibleLeft, qDumpInadmissible, cmpDump...); diff != "" {
 						t.Errorf("Unexpected elements left in inadmissible workloads (-want,+got):\n%s", diff)
 					}
-					eventCmpOpts := tc.eventCmpOpts
-					if cfg.sortEvents {
-						eventCmpOpts = append(eventCmpOpts, cmpopts.SortSlices(utiltesting.SortEvents))
-					}
+					// Recorded event order is not guaranteed, so sort both sides to keep the
+					// assertion deterministic.
+					eventCmpOpts := append(tc.eventCmpOpts, cmpopts.SortSlices(utiltesting.SortEvents))
 					if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents, eventCmpOpts...); diff != "" {
 						t.Errorf("unexpected events (-want/+got):\n%s", diff)
 					}
@@ -5052,7 +5048,6 @@ func TestScheduleForTASPreemption(t *testing.T) {
 			},
 			eventCmpOpts: cmp.Options{
 				eventIgnoreMessage,
-				cmpopts.SortSlices(utiltesting.SortEvents),
 			},
 		},
 		// Same-flavor preemption correctly accounts for sibling-flavor usage on the
@@ -5259,7 +5254,6 @@ func TestScheduleForTASPreemption(t *testing.T) {
 			},
 			eventCmpOpts: cmp.Options{
 				eventIgnoreMessage,
-				cmpopts.SortSlices(utiltesting.SortEvents),
 			},
 			wantEvents: []utiltesting.EventRecord{
 				utiltesting.MakeEventRecord("default", "w1-low-prio-a", "EvictedDueToPreempted", corev1.EventTypeNormal).Obj(),
@@ -7497,9 +7491,8 @@ func TestScheduleForTASCohorts(t *testing.T) {
 		},
 	}
 	runTASScheduleTestCases(t, tasScheduleTestConfig{
-		queues:     queues,
-		now:        now,
-		sortEvents: true,
+		queues: queues,
+		now:    now,
 	}, cases)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/area testing

#### What this PR does / why we need it:

Follow-up to #12445, addressing this review comment (https://github.com/kubernetes-sigs/kueue/pull/12445#discussion_r3465190055).

Scheduler event order is not guaranteed, so fixed-order event comparisons can flake. This makes `runTASScheduleTestCases` always sort expected and actual events with `cmpopts.SortSlices(utiltesting.SortEvents)`.

As a result, both TAS preemption and cohort scheduling tests compare events deterministically, and the now-unneeded `sortEvents` knob / inline sort options are removed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved determinism in scheduling test assertions by standardizing event ordering in the shared test harness.
  * Simplified several test cases by removing repeated event-sorting setup, making the tests easier to maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->