### PR TITLE
Fix verify-skills-lint on macOS arm64 by skipping Linux-only SELinux

### DIFF
--- a/Makefile-verify.mk
+++ b/Makefile-verify.mk
@@ -22,8 +22,13 @@ VERIFY_NPROCS ?= 8
 # Requires GNU Make 4.0+. Values: target, line, recurse, or empty.
 ifeq ($(shell uname),Darwin)
     VERIFY_OUTPUT_SYNC ?=
+    # SELinux :Z relabeling and label confinement are Linux-only.
+    VOLUME_FLAGS ?=
+    CONTAINER_SECURITY_OPTS ?= --security-opt label=disable
 else
     VERIFY_OUTPUT_SYNC ?= target
+    VOLUME_FLAGS ?= :Z
+    CONTAINER_SECURITY_OPTS ?=
 endif
 # Paths whose content is expected to be fully reproducible from sources.
 # The final step of `make verify` enforces that these paths have:
@@ -163,7 +168,7 @@ endef
 # Validates skills against https://agentskills.io/specification
 define _skills_lint_recipe
 mkdir -p $(ARTIFACTS)
-$(CONTAINER_ENGINE) run --rm -v $(PROJECT_DIR):/workspace:Z -v $(ARTIFACTS):/out:Z $(SKILLSAW_IMAGE) --output /out/skillsaw-summary.html
+$(CONTAINER_ENGINE) run --rm $(CONTAINER_SECURITY_OPTS) -v $(PROJECT_DIR):/workspace$(VOLUME_FLAGS) -v $(ARTIFACTS):/out$(VOLUME_FLAGS) $(SKILLSAW_IMAGE) --output /out/skillsaw-summary.html
 endef
 
 


### PR DESCRIPTION
  #### What type of PR is this?

  /kind bug

  #### What this PR does / why we need it:

  `make verify` fails on macOS arm64 at the `verify-skills-lint` target because the container run command uses Linux only SELinux flags, ie: `:Z` volume suffix and label confinement.

This simple change extends the detection block in `Makefile-verify.mk` with two variables:
  - `VOLUME_FLAGS`: empty on macOS, `:Z` on Linux
  - `CONTAINER_SECURITY_OPTS`: `--security-opt label=disable` on macOS, empty on Linux

On Linux the container command expands to exactly what it was before.

  #### Which issue(s) this PR fixes:

See #12469.

  #### Special notes for your reviewer:

  Tested on macOS Darwin arm64 with podman 5.x. 

`make skills-lint` passes with 24 skills scanned, 34 rules run, all checks passed.

  #### Does this PR introduce a user-facing change?

  ```release-note
  NONE
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container-based verification to work more reliably across different platforms, including macOS.
  * Updated mount and security handling so verification runs use the right settings automatically without manual tweaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->