### PR TITLE
[release 0.17] Always sort events in the TAS scheduling test assertions for determinism

### DIFF
--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -3503,14 +3503,11 @@ type tasScheduleTestCase struct {
 	featureGates map[featuregate.Feature]bool
 }
 
-// tasScheduleTestConfig carries the per-suite fixtures and knobs shared by the TAS
-// preemption and cohort scheduling run procedure.
+// tasScheduleTestConfig carries the per-suite fixtures shared by the TAS preemption
+// and cohort scheduling run procedure.
 type tasScheduleTestConfig struct {
 	queues []kueue.LocalQueue
 	now    time.Time
-	// sortEvents compares recorded events order-insensitively, matching the cohort
-	// scheduling test's assertion.
-	sortEvents bool
 }
 
 // runTASScheduleTestCases runs the shared "build client → schedule → assert" procedure for
@@ -3649,10 +3646,9 @@ func runTASScheduleTestCases(t *testing.T, cfg tasScheduleTestConfig, cases map[
 				if diff := cmp.Diff(tc.wantInadmissibleLeft, qDumpInadmissible, cmpDump...); diff != "" {
 					t.Errorf("Unexpected elements left in inadmissible workloads (-want,+got):\n%s", diff)
 				}
-				eventCmpOpts := tc.eventCmpOpts
-				if cfg.sortEvents {
-					eventCmpOpts = append(eventCmpOpts, cmpopts.SortSlices(utiltesting.SortEvents))
-				}
+				// Recorded event order is not guaranteed, so sort both sides to keep the
+				// assertion deterministic.
+				eventCmpOpts := append(tc.eventCmpOpts, cmpopts.SortSlices(utiltesting.SortEvents))
 				if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents, eventCmpOpts...); diff != "" {
 					t.Errorf("unexpected events (-want/+got):\n%s", diff)
 				}
@@ -4939,7 +4935,6 @@ func TestScheduleForTASPreemption(t *testing.T) {
 			},
 			eventCmpOpts: cmp.Options{
 				eventIgnoreMessage,
-				cmpopts.SortSlices(utiltesting.SortEvents),
 			},
 		},
 		// Same-flavor preemption correctly accounts for sibling-flavor usage on the
@@ -5142,7 +5137,6 @@ func TestScheduleForTASPreemption(t *testing.T) {
 			},
 			eventCmpOpts: cmp.Options{
 				eventIgnoreMessage,
-				cmpopts.SortSlices(utiltesting.SortEvents),
 			},
 			wantEvents: []utiltesting.EventRecord{
 				utiltesting.MakeEventRecord("default", "w1-low-prio-a", "EvictedDueToPreempted", corev1.EventTypeNormal).Obj(),
@@ -7275,9 +7269,8 @@ func TestScheduleForTASCohorts(t *testing.T) {
 		},
 	}
 	runTASScheduleTestCases(t, tasScheduleTestConfig{
-		queues:     queues,
-		now:        now,
-		sortEvents: true,
+		queues: queues,
+		now:    now,
 	}, cases)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/area testing

#### What this PR does / why we need it:

Manual cherry-pick of https://github.com/kubernetes-sigs/kueue/pull/12468

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
