### PR TITLE
Pin Dockerfile base images to sha256 digests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,7 +45,13 @@ updates:
   # Maintain Dockerfiles
   - package-ecosystem: "docker"
     directories:
+      - "/"
+      - "/cmd/importer"
+      - "/cmd/experimental/kueue-populator"
+      - "/cmd/experimental/kueue-priority-booster"
+      - "/cmd/kueueviz/backend"
       - "/cmd/kueueviz/frontend"
+      - "/hack/debugpod"
       - "/hack/releasing/krew-release-bot"
       - "/hack/testing/agnhost"
       - "/hack/testing/cypress"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # defaulted ARGs need to be declared first
-ARG BUILDER_IMAGE=golang:1.26
-ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
+ARG BUILDER_IMAGE=golang:1.26@sha256:32c0e6e5c4f6707717051091b4d0b077464a679eaab563e11474efc5328e2aa5
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 # compilation stage for the manager binary
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder
 WORKDIR /workspace

--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,9 @@ RAYMINI_VERSION ?= 0.0.3
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-BASE_IMAGE ?= gcr.io/distroless/static:nonroot
+BASE_IMAGE ?= gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 BASE_BUILDER_IMAGE ?= golang
-BUILDER_IMAGE ?= $(BASE_BUILDER_IMAGE):$(GO_VERSION)
+BUILDER_IMAGE ?= $(BASE_BUILDER_IMAGE):$(GO_VERSION)@sha256:32c0e6e5c4f6707717051091b4d0b077464a679eaab563e11474efc5328e2aa5
 CGO_ENABLED ?= 0
 
 YAML_PROCESSOR_LOG_LEVEL ?= info

--- a/cmd/experimental/kueue-populator/Dockerfile
+++ b/cmd/experimental/kueue-populator/Dockerfile
@@ -1,5 +1,5 @@
-ARG BUILDER_IMAGE=golang:1.26
-ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
+ARG BUILDER_IMAGE=golang:1.26@sha256:32c0e6e5c4f6707717051091b4d0b077464a679eaab563e11474efc5328e2aa5
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder
 

--- a/cmd/experimental/kueue-priority-booster/Dockerfile
+++ b/cmd/experimental/kueue-priority-booster/Dockerfile
@@ -1,5 +1,5 @@
-ARG BUILDER_IMAGE=golang:1.26
-ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
+ARG BUILDER_IMAGE=golang:1.26@sha256:32c0e6e5c4f6707717051091b4d0b077464a679eaab563e11474efc5328e2aa5
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder
 

--- a/cmd/kueueviz/backend/Dockerfile
+++ b/cmd/kueueviz/backend/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
-ARG BUILDER_IMAGE=golang:1.26
-ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
+ARG BUILDER_IMAGE=golang:1.26@sha256:32c0e6e5c4f6707717051091b4d0b077464a679eaab563e11474efc5328e2aa5
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder
 
 COPY cmd/kueueviz/backend/go.mod cmd/kueueviz/backend/go.sum ./

--- a/cmd/kueueviz/frontend/Dockerfile
+++ b/cmd/kueueviz/frontend/Dockerfile
@@ -3,7 +3,7 @@
 # linux/ppc64le or linux/s390x; running the build on BUILDPLATFORM keeps the
 # bundler off those archs entirely. The build output is static JS/CSS, so it
 # is architecture-agnostic.
-FROM --platform=${BUILDPLATFORM} node:26-slim AS builder
+FROM --platform=${BUILDPLATFORM} node:26-slim@sha256:f9b8bd6c62fcd007c08ce2bb2907485b624b968fd76094445822e0ec14002cf0 AS builder
 
 WORKDIR /app
 
@@ -24,7 +24,7 @@ RUN npm install --prefix /opt/serve serve
 # arch metadata for the multi-arch manifest. It contains no RUN steps, so
 # building it for ppc64le/s390x does not require QEMU binfmt_misc on the
 # build host — only file copies happen.
-FROM --platform=${TARGETPLATFORM} node:26-slim AS runtime
+FROM --platform=${TARGETPLATFORM} node:26-slim@sha256:f9b8bd6c62fcd007c08ce2bb2907485b624b968fd76094445822e0ec14002cf0 AS runtime
 
 WORKDIR /app
 

--- a/hack/debugpod/Dockerfile
+++ b/hack/debugpod/Dockerfile
@@ -1,2 +1,2 @@
-FROM debian:stable
+FROM debian:stable@sha256:9631e4628fccfb6f1ff9e27de2af0e82f61591c78d1584c778f92db9a541a3cc
 USER 65532:65532

--- a/hack/releasing/krew-release-bot/Dockerfile
+++ b/hack/releasing/krew-release-bot/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/rajatjindal/krew-release-bot:v0.0.51
+FROM ghcr.io/rajatjindal/krew-release-bot:v0.0.51@sha256:a1990089fb0184801af0b0a24931e1537580e97fe9ab79e840582f6c0d37c00c

--- a/hack/testing/cypress/Dockerfile
+++ b/hack/testing/cypress/Dockerfile
@@ -1,1 +1,1 @@
-FROM cypress/base:24.17.0
+FROM cypress/base:24.17.0@sha256:19d964a2633ab6c6b1e7bed240f6a7e07cd6ef3abb905a7cca14f614a8993eb4

--- a/hack/testing/depcheck/Dockerfile
+++ b/hack/testing/depcheck/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:26-alpine
+FROM node:26-alpine@sha256:a2dc166a387cc6ca1e62d0c8e265e49ca985d6e60abc9fe6e6c3d6ce8e63f606
 
 # Set working directory
 WORKDIR /app

--- a/hack/testing/linkchecker/Dockerfile
+++ b/hack/testing/linkchecker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.15.0b2-alpine
+FROM python:3.15.0b2-alpine@sha256:05458e2cf3a3b7a158d3c2e11940de557c626c064f41311f874a2c08ede01074
 
 RUN pip install --no-cache-dir linkchecker
 

--- a/hack/testing/ray-mini/Dockerfile
+++ b/hack/testing/ray-mini/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim
+FROM python:3.14-slim@sha256:63a4c7f612a00f92042cbdcc7cdc6a306f38485af0a200b9c89de7d9b1607d15
 
 # Set environment variable to avoid interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive

--- a/hack/testing/ray/Dockerfile
+++ b/hack/testing/ray/Dockerfile
@@ -1,1 +1,1 @@
-FROM rayproject/ray:2.55.1
+FROM rayproject/ray:2.55.1@sha256:830824adfdac9a8ec241f19a4ebab4db92092301781c21b1b720c2d08b8264eb

--- a/hack/testing/secretreader/Dockerfile
+++ b/hack/testing/secretreader/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
 ARG PLUGIN_VERSION
 RUN go install sigs.k8s.io/cluster-inventory-api/plugins/secretreader/cmd/plugin@${PLUGIN_VERSION}
 
 # Final image
-FROM alpine:3.24.1
+FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 USER 65534:65534
 # Place the binary at /bin to mirror the official secretreader image layout, so the
 # init-container fallback and the image-volume mount expose it at the same path.

--- a/hack/testing/shellcheck/Dockerfile
+++ b/hack/testing/shellcheck/Dockerfile
@@ -1,1 +1,1 @@
-FROM docker.io/koalaman/shellcheck-alpine:v0.11.0
+FROM docker.io/koalaman/shellcheck-alpine:v0.11.0@sha256:9955be09ea7f0dbf7ae942ac1f2094355bb30d96fffba0ec09f5432207544002

--- a/hack/testing/spark/Dockerfile
+++ b/hack/testing/spark/Dockerfile
@@ -1,1 +1,1 @@
-FROM apache/spark:4.1.2
+FROM apache/spark:4.1.2@sha256:e334db9626cb9c5a3e72928c2c2f0efc668769a0b605f116afe6ea7adb38f546


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Pins all Dockerfile `FROM` lines and `ARG *_IMAGE` defaults to `tag@sha256:digest` format.
This prevents silent changes from tag reassignment or registry compromise. OpenSSF Scorecard
currently reports Pinned-Dependencies: 1/10 for kubernetes-sigs/kueue; this change addresses that.

Also adds 6 missing Dockerfile directories to the Dependabot docker ecosystem config so digests
are kept up to date automatically:
- `/` (root Dockerfile)
- `/cmd/importer`
- `/cmd/experimental/kueue-populator`
- `/cmd/experimental/kueue-priority-booster`
- `/cmd/kueueviz/backend`
- `/hack/debugpod`

**AI disclosure:** This PR was developed with AI assistance.

#### Which issue(s) this PR fixes:

Fixes #12479

#### Special notes for your reviewer:

All version tags are preserved alongside the digest (e.g., `golang:1.26@sha256:...`) so
the golang version remains human-readable and Dependabot can track updates.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded Docker dependency scanning to cover more repository subdirectories.
  * Pinned several container base images to exact digests for more consistent builds and runtime behavior across tools, test images, and sample containers.
* **Bug Fixes**
  * Updated one debug container to run as a non-root user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->