### PR TITLE
[release-0.17] Fix flavor selector using per-flavor label keys

### DIFF
--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -347,25 +347,17 @@ func (c *clusterQueue) isTASViolated() bool {
 // UpdateWithFlavors updates a ClusterQueue based on the passed ResourceFlavors set.
 // Exported only for testing.
 func (c *clusterQueue) UpdateWithFlavors(log logr.Logger, flavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) {
-	c.updateLabelKeys(flavors)
+	c.updateFlavorMetadata(flavors)
 	c.updateQueueStatus(log)
 }
 
-func (c *clusterQueue) updateLabelKeys(flavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) {
+func (c *clusterQueue) updateFlavorMetadata(flavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) {
 	c.missingFlavors = nil
 	c.tasFlavors = nil
 	for i := range c.ResourceGroups {
 		rg := &c.ResourceGroups[i]
-		if len(rg.Flavors) == 0 {
-			rg.LabelKeys = nil
-			continue
-		}
-		keys := sets.New[string]()
 		for _, fName := range rg.Flavors {
 			if flv, exist := flavors[fName]; exist {
-				for k := range flv.Spec.NodeLabels {
-					keys.Insert(k)
-				}
 				if flv.Spec.TopologyName != nil {
 					if c.tasFlavors == nil {
 						c.tasFlavors = make(map[kueue.ResourceFlavorReference]kueue.TopologyReference, 1)
@@ -375,10 +367,6 @@ func (c *clusterQueue) updateLabelKeys(flavors map[kueue.ResourceFlavorReference
 			} else {
 				c.missingFlavors = append(c.missingFlavors, fName)
 			}
-		}
-
-		if keys.Len() > 0 {
-			rg.LabelKeys = keys
 		}
 	}
 }

--- a/pkg/cache/scheduler/resource.go
+++ b/pkg/cache/scheduler/resource.go
@@ -29,17 +29,12 @@ import (
 type ResourceGroup struct {
 	CoveredResources sets.Set[corev1.ResourceName]
 	Flavors          []kueue.ResourceFlavorReference
-	// The set of key labels from all flavors.
-	// Those keys define the affinity terms of a workload
-	// that can be matched against the flavors.
-	LabelKeys sets.Set[string]
 }
 
 func (rg *ResourceGroup) Clone() ResourceGroup {
 	return ResourceGroup{
 		CoveredResources: rg.CoveredResources.Clone(),
 		Flavors:          rg.Flavors,
-		LabelKeys:        rg.LabelKeys.Clone(),
 	}
 }
 

--- a/pkg/cache/scheduler/snapshot_test.go
+++ b/pkg/cache/scheduler/snapshot_test.go
@@ -243,7 +243,6 @@ func TestSnapshot(t *testing.T) {
 									{
 										CoveredResources: sets.New(corev1.ResourceCPU),
 										Flavors:          []kueue.ResourceFlavorReference{"demand", "spot"},
-										LabelKeys:        sets.New("instance"),
 									},
 								},
 								ResourceNode: resourceNode{
@@ -284,7 +283,6 @@ func TestSnapshot(t *testing.T) {
 									{
 										CoveredResources: sets.New(corev1.ResourceCPU),
 										Flavors:          []kueue.ResourceFlavorReference{"spot"},
-										LabelKeys:        sets.New("instance"),
 									},
 									{
 										CoveredResources: sets.New[corev1.ResourceName]("example.com/gpu"),
@@ -505,7 +503,6 @@ func TestSnapshot(t *testing.T) {
 									{
 										CoveredResources: sets.New(corev1.ResourceCPU),
 										Flavors:          []kueue.ResourceFlavorReference{"arm", "x86"},
-										LabelKeys:        sets.New("arch"),
 									},
 								},
 								ResourceNode: resourceNode{
@@ -567,7 +564,6 @@ func TestSnapshot(t *testing.T) {
 									{
 										CoveredResources: sets.New(corev1.ResourceCPU),
 										Flavors:          []kueue.ResourceFlavorReference{"arm", "x86"},
-										LabelKeys:        sets.New("arch"),
 									},
 								},
 								ResourceNode: resourceNode{

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -794,13 +794,8 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 	requests = filterRequestedResources(requests, resourceGroup.CoveredResources)
 
 	podSets := make([]*kueue.PodSet, len(psIDs))
-	selectors := make([]nodeaffinity.RequiredNodeAffinity, len(psIDs))
-
 	for idx, psID := range psIDs {
-		ps := &a.wl.Obj.Spec.PodSets[psID]
-		podSets[idx] = ps
-
-		selectors[idx] = flavorSelector(&ps.Template.Spec, resourceGroup.LabelKeys)
+		podSets[idx] = &a.wl.Obj.Spec.PodSets[psID]
 	}
 
 	var bestAssignment ResourceAssignment
@@ -814,7 +809,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 		attemptedFlavorIdx = idx
 		fName := resourceGroup.Flavors[idx]
 
-		if flavorStatus := a.checkFlavorForPodSets(log, fName, psIDs, podSets, selectors, resourceGroup); !flavorStatus.IsFit() {
+		if flavorStatus := a.checkFlavorForPodSets(log, fName, psIDs, podSets, resourceGroup); !flavorStatus.IsFit() {
 			status.reasons = append(status.reasons, flavorStatus.reasons...)
 			consideredFlavors.AddNoFitFlavorAttempt(fName, flavorStatus)
 			if flavorStatus.err != nil {
@@ -920,7 +915,6 @@ func (a *FlavorAssigner) checkFlavorForPodSets(
 	flavorName kueue.ResourceFlavorReference,
 	psIDs []int,
 	podSets []*kueue.PodSet,
-	selectors []nodeaffinity.RequiredNodeAffinity,
 	rg *schdcache.ResourceGroup,
 ) *Status {
 	status := NewStatus()
@@ -931,6 +925,11 @@ func (a *FlavorAssigner) checkFlavorForPodSets(
 		status.appendf("flavor %s not found", flavorName)
 		return status
 	}
+
+	// Use only this flavor's own label keys (not the union across all flavors in
+	// the resource group) so that affinity terms referencing keys from other
+	// flavors are correctly ignored when evaluating this flavor.
+	flavorLabelKeys := sets.KeySet(flavor.Spec.NodeLabels)
 
 	for psIdx, psID := range psIDs {
 		if features.Enabled(features.TopologyAwareScheduling) {
@@ -949,7 +948,7 @@ func (a *FlavorAssigner) checkFlavorForPodSets(
 			status.appendf("untolerated taint %s in flavor %s", taint, flavorName)
 			return status
 		}
-		selector := selectors[psIdx]
+		selector := flavorSelector(&podSpec, flavorLabelKeys)
 		if match, err := selector.Match(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Labels: flavor.Spec.NodeLabels}}); !match || err != nil {
 			if err != nil {
 				status.err = err

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -199,8 +199,10 @@ func TestAssignFlavors(t *testing.T) {
 				Effect:   corev1.TaintEffectNoSchedule,
 			}).
 			Obj(),
-		"tas-a": utiltestingapi.MakeResourceFlavor("tas-a").TopologyName("tas-topo-a").Obj(),
-		"tas-b": utiltestingapi.MakeResourceFlavor("tas-b").TopologyName("tas-topo-b").Obj(),
+		"label-x-a":  utiltestingapi.MakeResourceFlavor("label-x-a").NodeLabel("x", "a").Obj(),
+		"label-xy-b": utiltestingapi.MakeResourceFlavor("label-xy-b").NodeLabel("x", "b").NodeLabel("y", "k").Obj(),
+		"tas-a":      utiltestingapi.MakeResourceFlavor("tas-a").TopologyName("tas-topo-a").Obj(),
+		"tas-b":      utiltestingapi.MakeResourceFlavor("tas-b").TopologyName("tas-topo-b").Obj(),
 	}
 
 	cases := map[string]struct {
@@ -1111,6 +1113,80 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: 1_000,
+				}},
+			},
+		},
+		"multiple flavors with different label keys, selector only uses flavor's own keys": {
+			wlPods: []kueue.PodSet{
+				*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					NodeSelector(map[string]string{"x": "a", "y": "g"}).
+					Containers(
+						utiltesting.SingleContainerForRequest(map[corev1.ResourceName]string{
+							corev1.ResourceCPU: "1",
+						})...,
+					).
+					Obj(),
+			},
+			clusterQueue: *utiltestingapi.MakeClusterQueue("test-clusterqueue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("label-x-a").
+						Resource(corev1.ResourceCPU, "4").
+						Obj(),
+					*utiltestingapi.MakeFlavorQuotas("label-xy-b").
+						Resource(corev1.ResourceCPU, "4").
+						Obj(),
+				).Obj(),
+			wantRepMode: Fit,
+			wantAssignment: Assignment{
+				PodSets: []PodSetAssignment{{
+					Name: kueue.DefaultPodSetName,
+					Flavors: ResourceAssignment{
+						corev1.ResourceCPU: {Name: "label-x-a", Mode: Fit, TriedFlavorIdx: 0},
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("1"),
+					},
+					Count: 1,
+				}},
+				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+					{Flavor: "label-x-a", Resource: corev1.ResourceCPU}: 1_000,
+				}},
+			},
+		},
+		"labelless flavor in group with labeled flavor, workload uses labeled selector": {
+			wlPods: []kueue.PodSet{
+				*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					NodeSelector(map[string]string{"type": "two"}).
+					Containers(
+						utiltesting.SingleContainerForRequest(map[corev1.ResourceName]string{
+							corev1.ResourceCPU: "1",
+						})...,
+					).
+					Obj(),
+			},
+			clusterQueue: *utiltestingapi.MakeClusterQueue("test-clusterqueue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "4").
+						Obj(),
+					*utiltestingapi.MakeFlavorQuotas("two").
+						Resource(corev1.ResourceCPU, "4").
+						Obj(),
+				).Obj(),
+			wantRepMode: Fit,
+			wantAssignment: Assignment{
+				PodSets: []PodSetAssignment{{
+					Name: kueue.DefaultPodSetName,
+					Flavors: ResourceAssignment{
+						corev1.ResourceCPU: {Name: "default", Mode: Fit, TriedFlavorIdx: 0},
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("1"),
+					},
+					Count: 1,
+				}},
+				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+					{Flavor: "default", Resource: corev1.ResourceCPU}: 1_000,
 				}},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

Cherry-pick of #12449 to release-0.17.

`flavorSelector` was built once per resource group using the union of all flavors' label keys. This caused a flavor to be rejected when the workload referenced a label key declared by a different flavor in the same group, leaving workloads stuck pending forever. This PR computes the selector per-flavor using only that flavor's own keys.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12446

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Scheduling: Fixed a bug where a workload could be stuck pending when its node selector referenced a label key declared by a different flavor in the same resource group.
```
