### PR TITLE
fix: sync ConcurrentAdmission variants on ClusterQueue flavor changes

### DIFF
--- a/pkg/controller/concurrentadmission/controller.go
+++ b/pkg/controller/concurrentadmission/controller.go
@@ -28,6 +28,7 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -43,7 +44,8 @@ import (
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/constants"
+	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
@@ -56,6 +58,7 @@ import (
 const (
 	ConcurrentAdmissionController  = "concurrent-admission-controller"
 	ReasonCreatedVariant           = "CreatedVariant"
+	ReasonDeletedVariant           = "DeletedVariant"
 	ReasonActivatedVariant         = "ActivatedVariant"
 	ReasonDeactivatedVariant       = "DeactivatedVariant"
 	ReasonPreemptionUngatedVariant = "PreemptionUngatedVariant"
@@ -112,6 +115,18 @@ func (r *variantReconciler) setupWithManager(mgr ctrl.Manager, cfg *configapi.Co
 			}),
 			r,
 		)).
+		WatchesRawSource(source.TypedKind(
+			mgr.GetCache(),
+			&kueue.ClusterQueue{},
+			handler.TypedFuncs[*kueue.ClusterQueue, reconcile.Request]{
+				UpdateFunc: func(ctx context.Context, e event.TypedUpdateEvent[*kueue.ClusterQueue], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+					for _, req := range r.parentsForClusterQueue(ctx, e.ObjectNew) {
+						q.AddAfter(req, constants.UpdatesBatchPeriod)
+					}
+				},
+			},
+			clusterQueueFlavorsChanged(),
+		)).
 		WithOptions(controller.Options{
 			NeedLeaderElection:      new(false),
 			MaxConcurrentReconciles: mgr.GetControllerOptions().GroupKindConcurrency[kueue.GroupVersion.WithKind("Workload").GroupKind().String()],
@@ -120,9 +135,54 @@ func (r *variantReconciler) setupWithManager(mgr ctrl.Manager, cfg *configapi.Co
 		Complete(r)
 }
 
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads,verbs=get;list;watch;create;update;patch
+func clusterQueueFlavorsChanged() predicate.TypedPredicate[*kueue.ClusterQueue] {
+	return predicate.TypedFuncs[*kueue.ClusterQueue]{
+		CreateFunc:  func(event.TypedCreateEvent[*kueue.ClusterQueue]) bool { return false },
+		DeleteFunc:  func(event.TypedDeleteEvent[*kueue.ClusterQueue]) bool { return false },
+		GenericFunc: func(event.TypedGenericEvent[*kueue.ClusterQueue]) bool { return false },
+		UpdateFunc: func(e event.TypedUpdateEvent[*kueue.ClusterQueue]) bool {
+			return !slices.EqualFunc(e.ObjectOld.Spec.ResourceGroups, e.ObjectNew.Spec.ResourceGroups,
+				func(a, b kueue.ResourceGroup) bool {
+					return slices.EqualFunc(a.Flavors, b.Flavors,
+						func(x, y kueue.FlavorQuotas) bool {
+							return x.Name == y.Name
+						})
+				})
+		},
+	}
+}
+
+func (r *variantReconciler) parentsForClusterQueue(ctx context.Context, cq *kueue.ClusterQueue) []reconcile.Request {
+	log := ctrl.LoggerFrom(ctx).WithValues("clusterQueue", klog.KObj(cq))
+	lqList := &kueue.LocalQueueList{}
+	if err := r.client.List(ctx, lqList, client.MatchingFields{indexer.QueueClusterQueueKey: cq.Name}); err != nil {
+		log.Error(err, "Failed to list LocalQueues for ClusterQueue")
+		return nil
+	}
+	var requests []reconcile.Request
+	for i := range lqList.Items {
+		lq := &lqList.Items[i]
+		wlList := &kueue.WorkloadList{}
+		if err := r.client.List(ctx, wlList,
+			client.InNamespace(lq.Namespace),
+			client.MatchingFields{indexer.WorkloadQueueKey: lq.Name},
+			client.MatchingLabels{controllerconsts.ConcurrentAdmissionParentLabelKey: "true"},
+		); err != nil {
+			log.Error(err, "Failed to list parent Workloads for LocalQueue", "localQueue", klog.KObj(lq))
+			continue
+		}
+		for j := range wlList.Items {
+			requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&wlList.Items[j])})
+		}
+	}
+	return requests
+}
+
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads/finalizers,verbs=update
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=clusterqueues,verbs=get;list;watch
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=localqueues,verbs=get;list;watch
 
 func (r *variantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
@@ -147,14 +207,14 @@ func (r *variantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// TODO: If ConcurrentAdmission is no longer enabled for this CQ, delete parent and variants.
 
-	if len(variants) < len(flavorOrder) {
-		log.V(3).Info("Too few variants, creating new ones", "desired", len(flavorOrder), "actual", len(variants))
-		if err := r.createVariants(ctx, parent, variants, cq.Spec.ResourceGroups[0].Flavors); err != nil {
-			return ctrl.Result{}, err
-		}
+	log.V(3).Info("Reconciling variants against ClusterQueue flavors", "desired", len(flavorOrder), "actual", len(variants))
+	if err := r.createVariants(ctx, parent, variants, cq.Spec.ResourceGroups[0].Flavors); err != nil {
+		return ctrl.Result{}, err
 	}
-	if len(variants) == len(flavorOrder) {
-		log.V(3).Info("Desired number of variants, no action needed", "desired", len(flavorOrder), "actual", len(variants))
+	variants, err = r.deleteStaleVariants(ctx, parent, variants, flavorOrder)
+	if err != nil {
+		log.Error(err, "Failed to delete stale variants")
+		return ctrl.Result{}, err
 	}
 
 	log.V(3).Info("Syncing variants if needed")
@@ -259,6 +319,10 @@ func (r *variantReconciler) createVariants(ctx context.Context, parent *kueue.Wo
 			return err
 		}
 		if err := r.client.Create(ctx, variant); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				log.V(3).Info("Variant already exists", "variant", klog.KObj(variant))
+				continue
+			}
 			log.V(3).Info("Failed to create variant", "variant", klog.KObj(variant), "error", err)
 			return err
 		}
@@ -266,6 +330,26 @@ func (r *variantReconciler) createVariants(ctx context.Context, parent *kueue.Wo
 		r.recorder.Eventf(parent, nil, corev1.EventTypeNormal, ReasonCreatedVariant, ReasonCreatedVariant, "Variant Workload %q created", klog.KObj(variant))
 	}
 	return nil
+}
+
+func (r *variantReconciler) deleteStaleVariants(ctx context.Context, parent *kueue.Workload, variants []kueue.Workload, flavorOrder map[kueue.ResourceFlavorReference]int) ([]kueue.Workload, error) {
+	log := ctrl.LoggerFrom(ctx)
+	freshVariants := make([]kueue.Workload, 0, len(variants))
+	for i := range variants {
+		v := &variants[i]
+		flavor := concurrentadmission.GetVariantFlavor(v)
+		if _, ok := flavorOrder[flavor]; ok {
+			freshVariants = append(freshVariants, *v)
+			continue
+		}
+		log.V(2).Info("Deleting variant whose flavor is no longer in the ClusterQueue", "variant", klog.KObj(v), "flavor", flavor)
+		if _, err := workload.Delete(ctx, r.client, v); err != nil && !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("deleting stale variant %s: %w", klog.KObj(v), err)
+		}
+		r.recorder.Eventf(parent, nil, corev1.EventTypeNormal, ReasonDeletedVariant, ReasonDeletedVariant,
+			"Variant Workload %q deleted; flavor %q no longer in ClusterQueue", klog.KObj(v), flavor)
+	}
+	return freshVariants, nil
 }
 
 func generateVariant(parent *kueue.Workload, flavor kueue.ResourceFlavorReference) *kueue.Workload {
@@ -281,9 +365,9 @@ func generateVariant(parent *kueue.Workload, flavor kueue.ResourceFlavorReferenc
 		Status: parent.Status,
 	}
 	variant.Spec.PreemptionGates = slices.Clone(variant.Spec.PreemptionGates)
-	workload.EnsurePreemptionGateOnSpec(variant, constants.ConcurrentAdmissionPreemptionGate)
-	delete(variant.Labels, constants.ConcurrentAdmissionParentLabelKey)
-	metav1.SetMetaDataAnnotation(&variant.ObjectMeta, constants.WorkloadAllowedResourceFlavorAnnotation, string(flavor))
+	workload.EnsurePreemptionGateOnSpec(variant, controllerconsts.ConcurrentAdmissionPreemptionGate)
+	delete(variant.Labels, controllerconsts.ConcurrentAdmissionParentLabelKey)
+	metav1.SetMetaDataAnnotation(&variant.ObjectMeta, controllerconsts.WorkloadAllowedResourceFlavorAnnotation, string(flavor))
 	return variant
 }
 
@@ -677,7 +761,7 @@ func (r *variantReconciler) selectVariantToOpenPreemptionGate(ctx context.Contex
 
 func firstCandidateVariant(log logr.Logger, admissibleVariants []*kueue.Workload) *kueue.Workload {
 	for _, wl := range admissibleVariants {
-		if workload.HasOpenPreemptionGate(wl, constants.ConcurrentAdmissionPreemptionGate) {
+		if workload.HasOpenPreemptionGate(wl, controllerconsts.ConcurrentAdmissionPreemptionGate) {
 			continue
 		}
 		wlLog := log.WithValues("candidateVariant", klog.KObj(wl), "flavor", concurrentadmission.GetVariantFlavor(wl))
@@ -694,7 +778,7 @@ func firstCandidateVariant(log logr.Logger, admissibleVariants []*kueue.Workload
 func latestOpenGateTime(log logr.Logger, admissibleVariants []*kueue.Workload) *metav1.Time {
 	var lastUngateTime *metav1.Time
 	for _, wl := range admissibleVariants {
-		openGate := workload.FindPreemptionGate(wl, constants.ConcurrentAdmissionPreemptionGate)
+		openGate := workload.FindPreemptionGate(wl, controllerconsts.ConcurrentAdmissionPreemptionGate)
 		if openGate == nil || openGate.Position != kueue.PreemptionGatePositionOpen {
 			continue
 		}
@@ -721,7 +805,7 @@ func (r *variantReconciler) openPreemptionGate(ctx context.Context, variant *kue
 	log.V(2).Info("Opening preemption gate for variant", "variant", klog.KObj(variant), "flavor", concurrentadmission.GetVariantFlavor(variant))
 	var opened bool
 	if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, variant, r.clock, func(wl *kueue.Workload) (bool, error) {
-		opened = workload.OpenPreemptionGate(wl, constants.ConcurrentAdmissionPreemptionGate, metav1.NewTime(r.clock.Now()))
+		opened = workload.OpenPreemptionGate(wl, controllerconsts.ConcurrentAdmissionPreemptionGate, metav1.NewTime(r.clock.Now()))
 		return opened, nil
 	}, workloadpatching.WithRetryOnConflict()); err != nil {
 		return fmt.Errorf("opening preemption gate on variant %s: %w", klog.KObj(variant), err)

--- a/pkg/controller/concurrentadmission/controller_test.go
+++ b/pkg/controller/concurrentadmission/controller_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -134,6 +135,14 @@ func TestReconcile(t *testing.T) {
 		Obj()
 	retainFirstAdmissionLQ := utiltestingapi.MakeLocalQueue("lq-hold", "default").ClusterQueue("cq-hold").Obj()
 
+	spotOnlyCQ := utiltestingapi.MakeClusterQueue("cq-spot-only").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("spot").Obj(),
+		).
+		ConcurrentAdmissionPolicy(kueue.ConcurrentAdmissionTryPreferredFlavors).
+		Obj()
+	spotOnlyLQ := utiltestingapi.MakeLocalQueue("lq-spot-only", "default").ClusterQueue("cq-spot-only").Obj()
+
 	testCases := map[string]struct {
 		parentWorkload       *kueue.Workload
 		variantWorkloads     []kueue.Workload
@@ -232,6 +241,177 @@ func TestReconcile(t *testing.T) {
 					Message:   "Variant Workload \"default/wl-variant-on-demand-480a3\" created",
 				},
 			},
+		},
+		"flavor removed from ClusterQueue; variant is deleted": {
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
+				Queue("lq").
+				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+				Obj(),
+			variantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
+					Queue("lq").
+					AllowedFlavors("on-demand").
+					PreemptionGates(caGate()).
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq").
+					AllowedFlavors("spot").
+					PreemptionGates(caGate()).
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Obj(),
+				// "stale" is not part of the "cq" ClusterQueue's resource group anymore.
+				*utiltestingapi.MakeWorkload("wl-variant-stale", "default").
+					Queue("lq").
+					AllowedFlavors("stale").
+					PreemptionGates(caGate()).
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Obj(),
+			},
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
+				Queue("lq").
+				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+				Obj(),
+			wantVariantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
+					Queue("lq").
+					AllowedFlavors("on-demand").
+					PreemptionGates(caGate()).
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq").
+					AllowedFlavors("spot").
+					PreemptionGates(caGate()).
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Namespace: "default", Name: "wl-12345"},
+					EventType: corev1.EventTypeNormal,
+					Reason:    ReasonDeletedVariant,
+					Message:   "Variant Workload \"default/wl-variant-stale\" deleted; flavor \"stale\" no longer in ClusterQueue",
+				},
+			},
+		},
+		"admitted variant's flavor removed; variant deleted and parent evicted": {
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
+				Queue("lq-spot-only").
+				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+				Request(corev1.ResourceCPU, "1").
+				SimpleReserveQuota("cq-spot-only", "on-demand", metav1.Now().Time).
+				AdmittedAt(true, metav1.Now().Time).
+				Obj(),
+			variantWorkloads: []kueue.Workload{
+				// The admitted variant runs on "on-demand", which cq-spot-only no longer offers.
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
+					Queue("lq-spot-only").
+					AllowedFlavors("on-demand").
+					Request(corev1.ResourceCPU, "1").
+					PreemptionGates(caGate()).
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					SimpleReserveQuota("cq-spot-only", "on-demand", metav1.Now().Time).
+					AdmittedAt(true, metav1.Now().Time).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq-spot-only").
+					AllowedFlavors("spot").
+					Request(corev1.ResourceCPU, "1").
+					PreemptionGates(caGate()).
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Obj(),
+			},
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
+				Queue("lq-spot-only").
+				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+				Request(corev1.ResourceCPU, "1").
+				SimpleReserveQuota("cq-spot-only", "on-demand", metav1.Now().Time).
+				AdmittedAt(true, metav1.Now().Time).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadEvicted,
+					Status:  metav1.ConditionTrue,
+					Reason:  "ConcurrentAdmission",
+					Message: "No variant is running",
+				}).
+				Obj(),
+			wantVariantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq-spot-only").
+					AllowedFlavors("spot").
+					Request(corev1.ResourceCPU, "1").
+					PreemptionGates(caGate()).
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Namespace: "default", Name: "wl-12345"},
+					EventType: corev1.EventTypeNormal,
+					Reason:    ReasonDeletedVariant,
+					Message:   "Variant Workload \"default/wl-variant-on-demand\" deleted; flavor \"on-demand\" no longer in ClusterQueue",
+				},
+			},
+		},
+		"deleting the variant holding the open preemption gate opens the next one's gate": {
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
+				Queue("lq-spot-only").
+				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+				Obj(),
+			variantWorkloads: []kueue.Workload{
+				// on-demand holds an open gate whose preemption timeout has NOT elapsed
+				// (opened at fakeNow), so the spot gate would normally stay closed.
+				// cq-spot-only no longer offers on-demand, so this variant is deleted.
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
+					Queue("lq-spot-only").
+					AllowedFlavors("on-demand").
+					Request(corev1.ResourceCPU, "1").
+					PreemptionGates(caGate()).
+					PreemptionGateStates(caGateState(kueue.PreemptionGatePositionOpen, fakeNow)).
+					Condition(blockedOnPreemptionCondition(fakeNow)).
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq-spot-only").
+					AllowedFlavors("spot").
+					Request(corev1.ResourceCPU, "1").
+					PreemptionGates(caGate()).
+					Condition(blockedOnPreemptionCondition(fakeNow)).
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Obj(),
+			},
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
+				Queue("lq-spot-only").
+				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+				Obj(),
+			wantVariantWorkloads: []kueue.Workload{
+				// on-demand deleted; spot's gate is opened even though on-demand's gate
+				// had not yet timed out, because the gate holder is gone.
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq-spot-only").
+					AllowedFlavors("spot").
+					Request(corev1.ResourceCPU, "1").
+					PreemptionGates(caGate()).
+					PreemptionGateStates(caGateState(kueue.PreemptionGatePositionOpen, fakeNow)).
+					Condition(blockedOnPreemptionCondition(fakeNow)).
+					ControllerReference(kueue.GroupVersion.WithKind("Workload"), "wl-12345", "").
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Namespace: "default", Name: "wl-12345"},
+					EventType: corev1.EventTypeNormal,
+					Reason:    ReasonDeletedVariant,
+					Message:   "Variant Workload \"default/wl-variant-on-demand\" deleted; flavor \"on-demand\" no longer in ClusterQueue",
+				},
+				{
+					Key:       types.NamespacedName{Namespace: "default", Name: "wl-variant-spot"},
+					EventType: corev1.EventTypeNormal,
+					Reason:    ReasonPreemptionUngatedVariant,
+					Message:   "Opened preemption gate for variant workload \"default/wl-variant-spot\"",
+				},
+			},
+			wantResult: reconcile.Result{RequeueAfter: preemptionTimeout},
 		},
 		"ungates the next-preferred variant once the open gate's preemption timeout elapses": {
 			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
@@ -1935,8 +2115,8 @@ func TestReconcile(t *testing.T) {
 			qManager := qcache.NewManagerForUnitTests(cl, nil, qcache.WithPreemptionExpectations(preemptionExpectations))
 			roleTracker := roletracker.NewFakeRoleTracker(roletracker.RoleLeader)
 
-			cqs := []*kueue.ClusterQueue{defaultCQ.DeepCopy(), migrationCQ.DeepCopy(), migrationCQNoConstraint.DeepCopy(), retainFirstAdmissionCQ.DeepCopy()}
-			lqs := []*kueue.LocalQueue{defaultLQ.DeepCopy(), migrationLQ.DeepCopy(), migrationLQNoConstraint.DeepCopy(), retainFirstAdmissionLQ.DeepCopy()}
+			cqs := []*kueue.ClusterQueue{defaultCQ.DeepCopy(), migrationCQ.DeepCopy(), migrationCQNoConstraint.DeepCopy(), retainFirstAdmissionCQ.DeepCopy(), spotOnlyCQ.DeepCopy()}
+			lqs := []*kueue.LocalQueue{defaultLQ.DeepCopy(), migrationLQ.DeepCopy(), migrationLQNoConstraint.DeepCopy(), retainFirstAdmissionLQ.DeepCopy(), spotOnlyLQ.DeepCopy()}
 
 			for _, cq := range cqs {
 				if err := cl.Create(t.Context(), cq); err != nil {
@@ -2023,5 +2203,186 @@ func TestReconcile(t *testing.T) {
 				t.Errorf("Unexpected events (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestClusterQueueFlavorsChanged(t *testing.T) {
+	base := utiltestingapi.MakeClusterQueue("cq").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj(),
+			*utiltestingapi.MakeFlavorQuotas("spot").Resource(corev1.ResourceCPU, "5").Obj(),
+		).Obj()
+
+	flavorAdded := base.DeepCopy()
+	flavorAdded.Spec.ResourceGroups[0].Flavors = append(flavorAdded.Spec.ResourceGroups[0].Flavors,
+		*utiltestingapi.MakeFlavorQuotas("reservation").Obj())
+
+	flavorRemoved := base.DeepCopy()
+	flavorRemoved.Spec.ResourceGroups[0].Flavors = flavorRemoved.Spec.ResourceGroups[0].Flavors[:1]
+
+	flavorsReordered := base.DeepCopy()
+	rg := &flavorsReordered.Spec.ResourceGroups[0]
+	rg.Flavors[0], rg.Flavors[1] = rg.Flavors[1], rg.Flavors[0]
+
+	quotaOnly := base.DeepCopy()
+	quotaOnly.Spec.ResourceGroups[0].Flavors[0].Resources[0].NominalQuota = resource.MustParse("99")
+
+	statusOnly := base.DeepCopy()
+	statusOnly.Status.PendingWorkloads = 5
+
+	pred := clusterQueueFlavorsChanged()
+
+	updateCases := map[string]struct {
+		old  *kueue.ClusterQueue
+		new  *kueue.ClusterQueue
+		want bool
+	}{
+		"flavor added":        {old: base, new: flavorAdded, want: true},
+		"flavor removed":      {old: base, new: flavorRemoved, want: true},
+		"flavors reordered":   {old: base, new: flavorsReordered, want: true},
+		"flavors unchanged":   {old: base, new: base.DeepCopy(), want: false},
+		"only quota changed":  {old: base, new: quotaOnly, want: false},
+		"only status changed": {old: base, new: statusOnly, want: false},
+	}
+	for name, tc := range updateCases {
+		t.Run(name, func(t *testing.T) {
+			got := pred.Update(event.TypedUpdateEvent[*kueue.ClusterQueue]{ObjectOld: tc.old, ObjectNew: tc.new})
+			if got != tc.want {
+				t.Errorf("Update() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	ignoredEventCases := map[string]bool{
+		"Create":  pred.Create(event.TypedCreateEvent[*kueue.ClusterQueue]{Object: base}),
+		"Delete":  pred.Delete(event.TypedDeleteEvent[*kueue.ClusterQueue]{Object: base}),
+		"Generic": pred.Generic(event.TypedGenericEvent[*kueue.ClusterQueue]{Object: base}),
+	}
+	for name, got := range ignoredEventCases {
+		t.Run(name, func(t *testing.T) {
+			if got {
+				t.Errorf("%s() = true, want false", name)
+			}
+		})
+	}
+}
+
+func TestParentsForClusterQueue(t *testing.T) {
+	parentWl := func(name, ns, lq string) *kueue.Workload {
+		return utiltestingapi.MakeWorkload(name, ns).
+			Queue(kueue.LocalQueueName(lq)).
+			Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+			Obj()
+	}
+	variantWl := func(name, ns, lq, flavor string) *kueue.Workload {
+		return utiltestingapi.MakeWorkload(name, ns).
+			Queue(kueue.LocalQueueName(lq)).
+			AllowedFlavors(kueue.ResourceFlavorReference(flavor)).
+			ControllerReference(kueue.GroupVersion.WithKind("Workload"), "parent", "").
+			Obj()
+	}
+	req := func(name, ns string) reconcile.Request {
+		return reconcile.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: name}}
+	}
+
+	testCases := map[string]struct {
+		clusterQueue string
+		localQueues  []*kueue.LocalQueue
+		workloads    []*kueue.Workload
+		want         []reconcile.Request
+	}{
+		"multiple parents under one ClusterQueue": {
+			clusterQueue: "cq",
+			localQueues:  []*kueue.LocalQueue{utiltestingapi.MakeLocalQueue("lq", "default").ClusterQueue("cq").Obj()},
+			workloads: []*kueue.Workload{
+				parentWl("parent-a", "default", "lq"),
+				parentWl("parent-b", "default", "lq"),
+			},
+			want: []reconcile.Request{req("parent-a", "default"), req("parent-b", "default")},
+		},
+		"parents across namespaces feeding the same ClusterQueue": {
+			clusterQueue: "cq",
+			localQueues: []*kueue.LocalQueue{
+				utiltestingapi.MakeLocalQueue("lq", "ns-a").ClusterQueue("cq").Obj(),
+				utiltestingapi.MakeLocalQueue("lq", "ns-b").ClusterQueue("cq").Obj(),
+			},
+			workloads: []*kueue.Workload{
+				parentWl("parent-a", "ns-a", "lq"),
+				parentWl("parent-b", "ns-b", "lq"),
+			},
+			want: []reconcile.Request{req("parent-a", "ns-a"), req("parent-b", "ns-b")},
+		},
+		"non-parent workloads are excluded": {
+			clusterQueue: "cq",
+			localQueues:  []*kueue.LocalQueue{utiltestingapi.MakeLocalQueue("lq", "default").ClusterQueue("cq").Obj()},
+			workloads: []*kueue.Workload{
+				parentWl("parent", "default", "lq"),
+				variantWl("variant", "default", "lq", "spot"),
+				utiltestingapi.MakeWorkload("plain", "default").Queue("lq").Obj(),
+			},
+			want: []reconcile.Request{req("parent", "default")},
+		},
+		"workloads of other ClusterQueues are excluded": {
+			clusterQueue: "cq",
+			localQueues: []*kueue.LocalQueue{
+				utiltestingapi.MakeLocalQueue("lq", "default").ClusterQueue("cq").Obj(),
+				utiltestingapi.MakeLocalQueue("lq-other", "default").ClusterQueue("cq-other").Obj(),
+			},
+			workloads: []*kueue.Workload{
+				parentWl("parent", "default", "lq"),
+				parentWl("parent-other", "default", "lq-other"),
+			},
+			want: []reconcile.Request{req("parent", "default")},
+		},
+		"no parents returns nothing": {
+			clusterQueue: "cq",
+			localQueues:  []*kueue.LocalQueue{utiltestingapi.MakeLocalQueue("lq", "default").ClusterQueue("cq").Obj()},
+			workloads:    []*kueue.Workload{utiltestingapi.MakeWorkload("plain", "default").Queue("lq").Obj()},
+			want:         nil,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var objects []client.Object
+			for _, lq := range tc.localQueues {
+				objects = append(objects, lq)
+			}
+			for _, wl := range tc.workloads {
+				objects = append(objects, wl)
+			}
+			cl := utiltesting.NewClientBuilder().WithObjects(objects...).Build()
+			r := &variantReconciler{client: cl}
+
+			got := r.parentsForClusterQueue(t.Context(), utiltestingapi.MakeClusterQueue(tc.clusterQueue).Obj())
+			if diff := cmp.Diff(tc.want, got, cmpopts.SortSlices(func(a, b reconcile.Request) bool {
+				return a.String() < b.String()
+			})); diff != "" {
+				t.Errorf("parentsForClusterQueue() unexpected requests (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestCreateVariantsAlreadyExists checks that createVariants treats an
+// already-existing Variant as a no-op instead of a reconcile error.
+func TestCreateVariantsAlreadyExists(t *testing.T) {
+	parent := utiltestingapi.MakeWorkload("parent-wl", "default").
+		Queue("lq").
+		Request(corev1.ResourceCPU, "1").
+		Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+		Obj()
+	existing := generateVariant(parent, "spot")
+	cl := utiltesting.NewClientBuilder().WithObjects(parent, existing).Build()
+	r := &variantReconciler{client: cl, recorder: &utiltesting.EventRecorder{}}
+
+	// Empty variants slice so hasVariantWithFlavor is false and Create is attempted.
+	err := r.createVariants(t.Context(), parent, nil, []kueue.FlavorQuotas{*utiltestingapi.MakeFlavorQuotas("spot").Obj()})
+	if err != nil {
+		t.Fatalf("createVariants() with a pre-existing variant should be a no-op, got error: %v", err)
+	}
+
+	if err := cl.Get(t.Context(), client.ObjectKeyFromObject(existing), &kueue.Workload{}); err != nil {
+		t.Fatalf("pre-existing variant should still exist: %v", err)
 	}
 }

--- a/test/integration/singlecluster/controller/concurrentadmission/concurrent_admission_test.go
+++ b/test/integration/singlecluster/controller/concurrentadmission/concurrent_admission_test.go
@@ -597,6 +597,180 @@ var _ = ginkgo.Describe("Concurrent Admission", func() {
 			})
 		})
 	})
+
+	ginkgo.When("Should react to changes in the ClusterQueue's resource flavors", func() {
+		var cq *kueue.ClusterQueue
+		var lq *kueue.LocalQueue
+		var flavorReservation *kueue.ResourceFlavor
+		var flavorSpot *kueue.ResourceFlavor
+		var flavorOnDemand *kueue.ResourceFlavor
+
+		ginkgo.BeforeEach(func() {
+			flavorReservation = utiltestingapi.MakeResourceFlavor("reservation").Obj()
+			util.MustCreate(ctx, k8sClient, flavorReservation)
+
+			flavorSpot = utiltestingapi.MakeResourceFlavor("spot").Obj()
+			util.MustCreate(ctx, k8sClient, flavorSpot)
+
+			flavorOnDemand = utiltestingapi.MakeResourceFlavor("on-demand").Obj()
+			util.MustCreate(ctx, k8sClient, flavorOnDemand)
+
+			// Zero quota keeps the parent pending so its variants stay in a stable state,
+			// isolating the variant-creation reaction to a flavor change from scheduling.
+			cq = utiltestingapi.MakeClusterQueue("cq-resourceflavors").
+				ConcurrentAdmissionPolicy(kueue.ConcurrentAdmissionTryPreferredFlavors).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(flavorReservation.Name).Resource(corev1.ResourceCPU, "0").Obj(),
+					*utiltestingapi.MakeFlavorQuotas(flavorSpot.Name).Resource(corev1.ResourceCPU, "0").Obj(),
+				).Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+			lq = utiltestingapi.MakeLocalQueue("lq", ns.Name).ClusterQueue(cq.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, lq, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, flavorOnDemand, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, flavorSpot, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, flavorReservation, true)
+		})
+
+		ginkgo.It("creates a variant for a flavor added to the ClusterQueue", func() {
+			parentWl := utiltestingapi.MakeWorkload("parent-wl-add", ns.Name).
+				Request(corev1.ResourceCPU, "1").
+				Queue(kueue.LocalQueueName(lq.Name)).
+				ParentVariant().
+				Obj()
+
+			ginkgo.By("Creating the parent workload", func() {
+				util.MustCreate(ctx, k8sClient, parentWl)
+			})
+
+			ginkgo.By("Verifying the initial variants exist", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					list := &kueue.WorkloadList{}
+					g.Expect(k8sClient.List(ctx, list, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					g.Expect(getVariantByFlavor(list, parentWl.Name, flavorReservation.Name)).ToNot(gomega.BeNil())
+					g.Expect(getVariantByFlavor(list, parentWl.Name, flavorSpot.Name)).ToNot(gomega.BeNil())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Adding the on-demand flavor to the ClusterQueue", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					var updatedCq kueue.ClusterQueue
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: cq.Name}, &updatedCq)).To(gomega.Succeed())
+					updatedCq.Spec.ResourceGroups[0].Flavors = append(updatedCq.Spec.ResourceGroups[0].Flavors,
+						*utiltestingapi.MakeFlavorQuotas(flavorOnDemand.Name).Resource(corev1.ResourceCPU, "0").Obj())
+					g.Expect(k8sClient.Update(ctx, &updatedCq)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Verifying a variant is created for the added flavor", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					list := &kueue.WorkloadList{}
+					g.Expect(k8sClient.List(ctx, list, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					g.Expect(getVariantByFlavor(list, parentWl.Name, flavorOnDemand.Name)).ToNot(gomega.BeNil(), "Variant for on-demand not found")
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	})
+
+	ginkgo.When("Should evict the parent when the admitted variant's flavor is removed", func() {
+		var cq *kueue.ClusterQueue
+		var lq *kueue.LocalQueue
+		var flavorReservation *kueue.ResourceFlavor
+		var flavorSpot *kueue.ResourceFlavor
+
+		ginkgo.BeforeEach(func() {
+			flavorReservation = utiltestingapi.MakeResourceFlavor("reservation").Obj()
+			util.MustCreate(ctx, k8sClient, flavorReservation)
+
+			flavorSpot = utiltestingapi.MakeResourceFlavor("spot").Obj()
+			util.MustCreate(ctx, k8sClient, flavorSpot)
+
+			// Both flavors have real quota so the parent admits on the preferred
+			// (first) flavor, reservation.
+			cq = utiltestingapi.MakeClusterQueue("cq-evict").
+				ConcurrentAdmissionPolicy(kueue.ConcurrentAdmissionTryPreferredFlavors).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(flavorReservation.Name).Resource(corev1.ResourceCPU, "5").Obj(),
+					*utiltestingapi.MakeFlavorQuotas(flavorSpot.Name).Resource(corev1.ResourceCPU, "5").Obj(),
+				).Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+			lq = utiltestingapi.MakeLocalQueue("lq", ns.Name).ClusterQueue(cq.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, lq, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, flavorSpot, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, flavorReservation, true)
+		})
+
+		ginkgo.It("re-admits the parent on a remaining flavor", func() {
+			parentWl := utiltestingapi.MakeWorkload("parent-wl-evict", ns.Name).
+				Request(corev1.ResourceCPU, "1").
+				Queue(kueue.LocalQueueName(lq.Name)).
+				ParentVariant().
+				Obj()
+
+			ginkgo.By("Creating the parent workload", func() {
+				util.MustCreate(ctx, k8sClient, parentWl)
+			})
+
+			ginkgo.By("Verifying the parent is admitted on the reservation flavor", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(parentWl), parentWl)).To(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(parentWl)).To(gomega.BeTrue())
+					g.Expect(parentWl.Status.Admission.PodSetAssignments[0].Flavors[corev1.ResourceCPU]).To(gomega.Equal(kueue.ResourceFlavorReference(flavorReservation.Name)))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Removing the reservation flavor (the one the parent is admitted on)", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					var updatedCq kueue.ClusterQueue
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: cq.Name}, &updatedCq)).To(gomega.Succeed())
+					flavors := updatedCq.Spec.ResourceGroups[0].Flavors
+					kept := flavors[:0]
+					for _, f := range flavors {
+						if f.Name != kueue.ResourceFlavorReference(flavorReservation.Name) {
+							kept = append(kept, f)
+						}
+					}
+					updatedCq.Spec.ResourceGroups[0].Flavors = kept
+					g.Expect(k8sClient.Update(ctx, &updatedCq)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Verifying the admitted reservation variant is deleted", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					list := &kueue.WorkloadList{}
+					g.Expect(k8sClient.List(ctx, list, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					g.Expect(getVariantByFlavor(list, parentWl.Name, flavorReservation.Name)).To(gomega.BeNil(), "Variant for reservation should be deleted")
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Finishing eviction of the parent workload", func() {
+				util.FinishEvictionForWorkloads(ctx, k8sClient, parentWl)
+			})
+
+			ginkgo.By("Verifying the parent re-admits on the surviving spot flavor", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(parentWl), parentWl)).To(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(parentWl)).To(gomega.BeTrue())
+					g.Expect(parentWl.Status.Admission).ToNot(gomega.BeNil())
+					g.Expect(parentWl.Status.Admission.PodSetAssignments).ToNot(gomega.BeEmpty())
+					g.Expect(parentWl.Status.Admission.PodSetAssignments[0].Flavors[corev1.ResourceCPU]).To(gomega.Equal(kueue.ResourceFlavorReference(flavorSpot.Name)))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	})
 })
 
 func getVariantByFlavor(list *kueue.WorkloadList, parentName string, flavor string) *kueue.Workload {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

The ConcurrentAdmission controller only created Variants when the parent Workload was reconciled and never deleted them, so it ignored ClusterQueue flavor-list changes at runtime. This PR makes it watch ClusterQueues and reconcile affected parents on flavor add/remove/reorder, keeping exactly one Variant per flavor; removing the admitted Variant's flavor evicts the parent so it re-admits on a remaining one.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10918

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
ConcurrentAdmission: Fixed Variants not being created or deleted when a ClusterQueue's resource flavors change.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workload variants now automatically track the latest `ClusterQueue` flavor configuration: variants are created when flavors are added and when the desired flavor order changes.
* **Bug Fixes**
  * Stale variant workloads are deleted when their flavors are removed or no longer match the `ClusterQueue` flavor order, with improved “variant deleted” event details.
  * If the currently admitted variant flavor is removed, the parent workload is evicted and then re-admitted using an available flavor.
* **Tests**
  * Added unit and integration coverage for flavor-change detection and add/remove scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->