### PR TITLE
Granular status reasons for unadmitted workloads in workload_controller

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -1838,7 +1838,7 @@ func (r *WorkloadReconciler) resolveGranularUnadmittedQuotaReservedCondition(
 		if err != nil {
 			log := ctrl.LoggerFrom(ctx)
 			log.Error(err, "Invalid ClusterQueue NamespaceSelector", "clusterQueue", cq.Name)
-			selector = labels.Nothing()
+			return r.newQuotaReservedCondition(wl, kueue.WorkloadQuotaReservedReasonMisconfigured, fmt.Sprintf("invalid namespace selector: %v", err)), nil
 		}
 		wlInfo := workload.NewInfo(wl)
 		admissibilityErr = workload.ValidateAdmissibility(ctx, r.client, wlInfo, selector)
@@ -1866,10 +1866,6 @@ func (r *WorkloadReconciler) resolveGranularUnadmittedQuotaReservedCondition(
 		return r.newQuotaReservedCondition(wl, kueue.WorkloadQuotaReservedReasonMisconfigured, admissibilityErr.Error()), nil
 	case workload.HasAdmissionGate(wl):
 		return r.newQuotaReservedCondition(wl, kueue.WorkloadAdmissionGated, fmt.Sprintf("Admission is gated by: %s", wl.Annotations[constants.AdmissionGatedByAnnotation])), nil
-	case cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == kueue.WorkloadQuotaReservedReasonNoMatchingFlavor:
-		return r.newQuotaReservedCondition(wl, cond.Reason, cond.Message), nil
-	case cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == kueue.WorkloadQuotaReservedReasonWaitingForPodsReady:
-		return r.newQuotaReservedCondition(wl, cond.Reason, cond.Message), nil
 	case cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason != "" &&
 		cond.Reason != kueue.WorkloadQuotaReservedReasonSuspended &&
 		cond.Reason != kueue.WorkloadQuotaReservedReasonMisconfigured:

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -1817,7 +1817,14 @@ func (r *WorkloadReconciler) resolveUnadmittedQuotaReservedCondition(
 	cq *kueue.ClusterQueue,
 ) (*metav1.Condition, error) {
 	if features.Enabled(features.UnadmittedWorkloadsObservability) {
-		return r.resolveGranularUnadmittedQuotaReservedCondition(ctx, wl, lqExists, lqActive, cqOk, cqActive, cq)
+		reason, message, err := r.resolveGranularUnadmittedQuotaReservedCondition(ctx, wl, lqExists, lqActive, cqOk, cqActive, cq)
+		if err != nil {
+			return nil, err
+		}
+		if reason == "" {
+			return nil, nil
+		}
+		return r.newQuotaReservedCondition(wl, reason, message), nil
 	}
 	return r.resolveLegacyUnadmittedQuotaReservedCondition(wl, lqExists, lqActive, cqOk, cqActive), nil
 }
@@ -1827,7 +1834,7 @@ func (r *WorkloadReconciler) resolveGranularUnadmittedQuotaReservedCondition(
 	wl *kueue.Workload,
 	lqExists, lqActive, cqOk, cqActive bool,
 	cq *kueue.ClusterQueue,
-) (*metav1.Condition, error) {
+) (string, string, error) {
 	cond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
 
 	var admissibilityErr error
@@ -1838,45 +1845,46 @@ func (r *WorkloadReconciler) resolveGranularUnadmittedQuotaReservedCondition(
 		if err != nil {
 			log := ctrl.LoggerFrom(ctx)
 			log.Error(err, "Invalid ClusterQueue NamespaceSelector", "clusterQueue", cq.Name)
-			return r.newQuotaReservedCondition(wl, kueue.WorkloadQuotaReservedReasonMisconfigured, fmt.Sprintf("invalid namespace selector: %v", err)), nil
+			return kueue.WorkloadQuotaReservedReasonMisconfigured, fmt.Sprintf("invalid namespace selector: %v", err), nil
 		}
 		wlInfo := workload.NewInfo(wl)
 		admissibilityErr = workload.ValidateAdmissibility(ctx, r.client, wlInfo, selector)
 		if admissibilityErr != nil && errors.Is(admissibilityErr, workload.ErrInternal) {
-			return nil, admissibilityErr
+			return "", "", admissibilityErr
 		}
 	}
 
 	switch {
 	case !workload.IsActive(wl):
-		return r.newQuotaReservedCondition(wl, kueue.WorkloadDeactivated, "The workload is deactivated"), nil
+		return kueue.WorkloadDeactivated, "The workload is deactivated", nil
 	case workload.IsOnHold(wl):
-		return r.newQuotaReservedCondition(wl, cond.Reason, cond.Message), nil
+		return cond.Reason, cond.Message, nil
 	case !lqExists:
-		return r.newQuotaReservedCondition(wl, kueue.WorkloadQuotaReservedReasonMisconfigured, fmt.Sprintf("LocalQueue %s doesn't exist", wl.Spec.QueueName)), nil
+		return kueue.WorkloadQuotaReservedReasonMisconfigured, fmt.Sprintf("LocalQueue %s doesn't exist", wl.Spec.QueueName), nil
 	case !lqActive:
-		return r.newQuotaReservedCondition(wl, kueue.WorkloadQuotaReservedReasonSuspended, fmt.Sprintf("LocalQueue %s is inactive", wl.Spec.QueueName)), nil
+		return kueue.WorkloadQuotaReservedReasonSuspended, fmt.Sprintf("LocalQueue %s is inactive", wl.Spec.QueueName), nil
 	case !cqOk:
 		cqName, _ := r.queues.ClusterQueueForWorkload(wl)
-		return r.newQuotaReservedCondition(wl, kueue.WorkloadQuotaReservedReasonMisconfigured, fmt.Sprintf("ClusterQueue %s doesn't exist", cqName)), nil
+		return kueue.WorkloadQuotaReservedReasonMisconfigured, fmt.Sprintf("ClusterQueue %s doesn't exist", cqName), nil
 	case !cqActive:
 		cqName, _ := r.queues.ClusterQueueForWorkload(wl)
-		return r.newQuotaReservedCondition(wl, kueue.WorkloadQuotaReservedReasonSuspended, fmt.Sprintf("ClusterQueue %s is inactive", cqName)), nil
+		return kueue.WorkloadQuotaReservedReasonSuspended, fmt.Sprintf("ClusterQueue %s is inactive", cqName), nil
 	case admissibilityErr != nil:
-		return r.newQuotaReservedCondition(wl, kueue.WorkloadQuotaReservedReasonMisconfigured, admissibilityErr.Error()), nil
+		return kueue.WorkloadQuotaReservedReasonMisconfigured, admissibilityErr.Error(), nil
 	case workload.HasAdmissionGate(wl):
-		return r.newQuotaReservedCondition(wl, kueue.WorkloadAdmissionGated, fmt.Sprintf("Admission is gated by: %s", wl.Annotations[constants.AdmissionGatedByAnnotation])), nil
+		return kueue.WorkloadAdmissionGated, fmt.Sprintf("Admission is gated by: %s", wl.Annotations[constants.AdmissionGatedByAnnotation]), nil
 	case cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason != "" &&
 		cond.Reason != kueue.WorkloadQuotaReservedReasonSuspended &&
-		cond.Reason != kueue.WorkloadQuotaReservedReasonMisconfigured:
-		return r.newQuotaReservedCondition(wl, cond.Reason, cond.Message), nil
+		cond.Reason != kueue.WorkloadQuotaReservedReasonMisconfigured &&
+		cond.Reason != kueue.WorkloadDeactivated:
+		return cond.Reason, cond.Message, nil
 	default:
 		// Stamping the condition on creation is deferred to the next feature gate:
 		// UnadmittedWorkloadsObservabilityExplicitStatus.
 		if cond == nil {
-			return nil, nil
+			return "", "", nil
 		}
-		return r.newQuotaReservedCondition(wl, kueue.WorkloadQuotaReservedReasonPendingEvaluation, "Workload is pending evaluation in the scheduling queue"), nil
+		return kueue.WorkloadQuotaReservedReasonPendingEvaluation, "Workload is pending evaluation in the scheduling queue", nil
 	}
 }
 

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -667,27 +667,20 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if !workload.IsAdmitted(&wl) {
 		var updated bool
 		err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-			if features.Enabled(features.UnadmittedWorkloadsObservability) {
-				if !workload.HasQuotaReservation(wl) {
-					cqActive := cqOk && r.cache.ClusterQueueActive(cqName)
-					cond, err := r.resolveUnadmittedQuotaReservedCondition(ctx, wl, lqExists, lqActive, cqOk, cqActive, cq)
-					if err != nil {
-						return false, err
-					}
-					if cond != nil {
-						if apimeta.SetStatusCondition(&wl.Status.Conditions, *cond) {
-							updated = true
-						}
-					}
-					if wl.Status.Admission != nil {
-						wl.Status.Admission = nil
-						updated = true
-					}
+			if !workload.HasQuotaReservation(wl) {
+				cqActive := cqOk && r.cache.ClusterQueueActive(cqName)
+				var cond *metav1.Condition
+				var err error
+				if features.Enabled(features.UnadmittedWorkloadsObservability) {
+					cond, err = r.resolveUnadmittedQuotaReservedCondition(ctx, wl, lqExists, lqActive, cqOk, cqActive, cq)
+				} else {
+					cond = r.resolveLegacyUnadmittedQuotaReservedCondition(wl, lqExists, lqActive, cqOk, cqActive)
 				}
-				if workload.HasRejectedChecks(wl) {
-					rejectedChecks := workload.RejectedChecks(wl)
-					message := buildAdmissionChecksMessage(rejectedChecks, kueue.CheckStateRejected)
-					if workload.SetDeactivationTarget(wl, kueue.WorkloadEvictedByAdmissionCheck, message) {
+				if err != nil {
+					return false, err
+				}
+				if cond != nil {
+					if apimeta.SetStatusCondition(&wl.Status.Conditions, *cond) {
 						updated = true
 					}
 				}
@@ -699,12 +692,6 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		})
 		if err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
-		}
-		// If the observability feature gate is enabled and the workload has no quota reservation,
-		// we have already resolved and patched the granular conditions (e.g., missing or inactive
-		// queue) in the block above.
-		if features.Enabled(features.UnadmittedWorkloadsObservability) && !workload.HasQuotaReservation(&wl) {
-			return ctrl.Result{}, nil
 		}
 		isAdmitted := workload.IsAdmitted(&wl)
 		if isAdmitted {
@@ -774,41 +761,6 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			recheckAfter = max(podsReadyRecheckAfter, maxExecRecheckAfter)
 		}
 		return ctrl.Result{RequeueAfter: recheckAfter}, nil
-	}
-
-	switch {
-	case !lqExists:
-		log.V(3).Info("Workload is inadmissible because of missing LocalQueue", "localQueue", klog.KRef(wl.Namespace, string(wl.Spec.QueueName)))
-		if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonMisconfigured, kueue.WorkloadInadmissible)
-			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf("LocalQueue %s doesn't exist", wl.Spec.QueueName), r.clock.Now()), nil
-		}); err != nil {
-			return ctrl.Result{}, client.IgnoreNotFound(err)
-		}
-	case !lqActive:
-		log.V(3).Info("Workload is inadmissible because of stopped LocalQueue", "localQueue", klog.KRef(wl.Namespace, string(wl.Spec.QueueName)))
-		if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonSuspended, kueue.WorkloadInadmissible)
-			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf("LocalQueue %s is inactive", wl.Spec.QueueName), r.clock.Now()), nil
-		}); err != nil {
-			return ctrl.Result{}, client.IgnoreNotFound(err)
-		}
-	case !cqOk:
-		log.V(3).Info("Workload is inadmissible because of missing ClusterQueue", "clusterQueue", klog.KRef("", string(cqName)))
-		if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonMisconfigured, kueue.WorkloadInadmissible)
-			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf("ClusterQueue %s doesn't exist", cqName), r.clock.Now()), nil
-		}); err != nil {
-			return ctrl.Result{}, client.IgnoreNotFound(err)
-		}
-	case !r.cache.ClusterQueueActive(cqName):
-		log.V(3).Info("Workload is inadmissible because ClusterQueue is inactive", "clusterQueue", klog.KRef("", string(cqName)))
-		if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonSuspended, kueue.WorkloadInadmissible)
-			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf("ClusterQueue %s is inactive", cqName), r.clock.Now()), nil
-		}); err != nil {
-			return ctrl.Result{}, client.IgnoreNotFound(err)
-		}
 	}
 
 	return ctrl.Result{}, nil
@@ -1872,7 +1824,7 @@ func (r *WorkloadReconciler) resolveUnadmittedQuotaReservedCondition(
 		}
 		wlInfo := workload.NewInfo(wl)
 		admissibilityErr = workload.ValidateAdmissibility(ctx, r.client, wlInfo, selector)
-		if admissibilityErr != nil && errors.Is(admissibilityErr, workload.ErrAPI) {
+		if admissibilityErr != nil && errors.Is(admissibilityErr, workload.ErrInternal) {
 			return nil, admissibilityErr
 		}
 	}
@@ -1911,6 +1863,23 @@ func (r *WorkloadReconciler) resolveUnadmittedQuotaReservedCondition(
 			return nil, nil
 		}
 		return r.newQuotaReservedCondition(wl, kueue.WorkloadQuotaReservedReasonPendingEvaluation, "Workload is pending evaluation in the scheduling queue"), nil
+	}
+}
+
+func (r *WorkloadReconciler) resolveLegacyUnadmittedQuotaReservedCondition(wl *kueue.Workload, lqExists, lqActive, cqOk, cqActive bool) *metav1.Condition {
+	switch {
+	case !lqExists:
+		return r.newQuotaReservedCondition(wl, kueue.WorkloadInadmissible, fmt.Sprintf("LocalQueue %s doesn't exist", wl.Spec.QueueName))
+	case !lqActive:
+		return r.newQuotaReservedCondition(wl, kueue.WorkloadInadmissible, fmt.Sprintf("LocalQueue %s is inactive", wl.Spec.QueueName))
+	case !cqOk:
+		cqName, _ := r.queues.ClusterQueueForWorkload(wl)
+		return r.newQuotaReservedCondition(wl, kueue.WorkloadInadmissible, fmt.Sprintf("ClusterQueue %s doesn't exist", cqName))
+	case !cqActive:
+		cqName, _ := r.queues.ClusterQueueForWorkload(wl)
+		return r.newQuotaReservedCondition(wl, kueue.WorkloadInadmissible, fmt.Sprintf("ClusterQueue %s is inactive", cqName))
+	default:
+		return nil
 	}
 }
 

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -668,8 +668,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		var updated bool
 		err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
 			if !workload.HasQuotaReservation(wl) {
-				cqActive := cqOk && r.cache.ClusterQueueActive(cqName)
-				if changed, err := r.syncQuotaReservedFalseCondition(ctx, wl, lqExists, lqActive, cqOk, cqActive, cq); err != nil {
+				if changed, err := r.syncQuotaReservedFalseCondition(ctx, wl, lqExists, lqActive, cq); err != nil {
 					return false, err
 				} else if changed {
 					updated = true
@@ -1797,10 +1796,10 @@ func (h *deviceClassHandler) reconcileWorkloads(ctx context.Context, q workqueue
 func (r *WorkloadReconciler) syncQuotaReservedFalseCondition(
 	ctx context.Context,
 	wl *kueue.Workload,
-	lqExists, lqActive, cqOk, cqActive bool,
+	lqExists, lqActive bool,
 	cq *kueue.ClusterQueue,
 ) (bool, error) {
-	cond, err := r.resolveUnadmittedQuotaReservedCondition(ctx, wl, lqExists, lqActive, cqOk, cqActive, cq)
+	cond, err := r.resolveUnadmittedQuotaReservedCondition(ctx, wl, lqExists, lqActive, cq)
 	if err != nil {
 		return false, err
 	}
@@ -1813,11 +1812,11 @@ func (r *WorkloadReconciler) syncQuotaReservedFalseCondition(
 func (r *WorkloadReconciler) resolveUnadmittedQuotaReservedCondition(
 	ctx context.Context,
 	wl *kueue.Workload,
-	lqExists, lqActive, cqOk, cqActive bool,
+	lqExists, lqActive bool,
 	cq *kueue.ClusterQueue,
 ) (*metav1.Condition, error) {
 	if features.Enabled(features.UnadmittedWorkloadsObservability) {
-		reason, message, err := r.resolveGranularUnadmittedQuotaReservedCondition(ctx, wl, lqExists, lqActive, cqOk, cqActive, cq)
+		reason, message, err := r.resolveGranularUnadmittedQuotaReservedCondition(ctx, wl, lqExists, lqActive, cq)
 		if err != nil {
 			return nil, err
 		}
@@ -1826,19 +1825,19 @@ func (r *WorkloadReconciler) resolveUnadmittedQuotaReservedCondition(
 		}
 		return r.newQuotaReservedCondition(wl, reason, message), nil
 	}
-	return r.resolveLegacyUnadmittedQuotaReservedCondition(wl, lqExists, lqActive, cqOk, cqActive), nil
+	return r.resolveLegacyUnadmittedQuotaReservedCondition(wl, lqExists, lqActive, cq), nil
 }
 
 func (r *WorkloadReconciler) resolveGranularUnadmittedQuotaReservedCondition(
 	ctx context.Context,
 	wl *kueue.Workload,
-	lqExists, lqActive, cqOk, cqActive bool,
+	lqExists, lqActive bool,
 	cq *kueue.ClusterQueue,
 ) (string, string, error) {
 	cond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
 
 	var admissibilityErr error
-	if cqOk && cq != nil {
+	if cq != nil {
 		var selector labels.Selector
 		var err error
 		selector, err = metav1.LabelSelectorAsSelector(cq.Spec.NamespaceSelector)
@@ -1859,16 +1858,13 @@ func (r *WorkloadReconciler) resolveGranularUnadmittedQuotaReservedCondition(
 		return kueue.WorkloadDeactivated, "The workload is deactivated", nil
 	case workload.IsOnHold(wl):
 		return cond.Reason, cond.Message, nil
-	case !lqExists:
-		return kueue.WorkloadQuotaReservedReasonMisconfigured, fmt.Sprintf("LocalQueue %s doesn't exist", wl.Spec.QueueName), nil
-	case !lqActive:
-		return kueue.WorkloadQuotaReservedReasonSuspended, fmt.Sprintf("LocalQueue %s is inactive", wl.Spec.QueueName), nil
-	case !cqOk:
-		cqName, _ := r.queues.ClusterQueueForWorkload(wl)
-		return kueue.WorkloadQuotaReservedReasonMisconfigured, fmt.Sprintf("ClusterQueue %s doesn't exist", cqName), nil
-	case !cqActive:
-		cqName, _ := r.queues.ClusterQueueForWorkload(wl)
-		return kueue.WorkloadQuotaReservedReasonSuspended, fmt.Sprintf("ClusterQueue %s is inactive", cqName), nil
+	}
+
+	if reason, message := r.getQueueBlocker(wl, lqExists, lqActive, cq); reason != "" {
+		return reason, message, nil
+	}
+
+	switch {
 	case admissibilityErr != nil:
 		return kueue.WorkloadQuotaReservedReasonMisconfigured, admissibilityErr.Error(), nil
 	case workload.HasAdmissionGate(wl):
@@ -1876,7 +1872,11 @@ func (r *WorkloadReconciler) resolveGranularUnadmittedQuotaReservedCondition(
 	case cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason != "" &&
 		cond.Reason != kueue.WorkloadQuotaReservedReasonSuspended &&
 		cond.Reason != kueue.WorkloadQuotaReservedReasonMisconfigured &&
-		cond.Reason != kueue.WorkloadDeactivated:
+		cond.Reason != kueue.WorkloadDeactivated &&
+		// Exclude legacy reasons so we can transition from them to more granular reasons
+		// when the UnadmittedWorkloadsObservability feature gate is enabled.
+		cond.Reason != kueue.WorkloadPending && //nolint:staticcheck // SA1019: legacy reason
+		cond.Reason != kueue.WorkloadWaiting: //nolint:staticcheck // SA1019: legacy reason
 		return cond.Reason, cond.Message, nil
 	default:
 		// Stamping the condition on creation is deferred to the next feature gate:
@@ -1888,21 +1888,11 @@ func (r *WorkloadReconciler) resolveGranularUnadmittedQuotaReservedCondition(
 	}
 }
 
-func (r *WorkloadReconciler) resolveLegacyUnadmittedQuotaReservedCondition(wl *kueue.Workload, lqExists, lqActive, cqOk, cqActive bool) *metav1.Condition {
-	switch {
-	case !lqExists:
-		return r.newQuotaReservedCondition(wl, kueue.WorkloadInadmissible, fmt.Sprintf("LocalQueue %s doesn't exist", wl.Spec.QueueName))
-	case !lqActive:
-		return r.newQuotaReservedCondition(wl, kueue.WorkloadInadmissible, fmt.Sprintf("LocalQueue %s is inactive", wl.Spec.QueueName))
-	case !cqOk:
-		cqName, _ := r.queues.ClusterQueueForWorkload(wl)
-		return r.newQuotaReservedCondition(wl, kueue.WorkloadInadmissible, fmt.Sprintf("ClusterQueue %s doesn't exist", cqName))
-	case !cqActive:
-		cqName, _ := r.queues.ClusterQueueForWorkload(wl)
-		return r.newQuotaReservedCondition(wl, kueue.WorkloadInadmissible, fmt.Sprintf("ClusterQueue %s is inactive", cqName))
-	default:
-		return nil
+func (r *WorkloadReconciler) resolveLegacyUnadmittedQuotaReservedCondition(wl *kueue.Workload, lqExists, lqActive bool, cq *kueue.ClusterQueue) *metav1.Condition {
+	if _, message := r.getQueueBlocker(wl, lqExists, lqActive, cq); message != "" {
+		return r.newQuotaReservedCondition(wl, kueue.WorkloadInadmissible, message)
 	}
+	return nil
 }
 
 func (r *WorkloadReconciler) newQuotaReservedCondition(wl *kueue.Workload, reason, message string) *metav1.Condition {
@@ -1913,5 +1903,21 @@ func (r *WorkloadReconciler) newQuotaReservedCondition(wl *kueue.Workload, reaso
 		Message:            api.TruncateConditionMessage(message),
 		LastTransitionTime: metav1.NewTime(r.clock.Now()),
 		ObservedGeneration: wl.Generation,
+	}
+}
+
+func (r *WorkloadReconciler) getQueueBlocker(wl *kueue.Workload, lqExists, lqActive bool, cq *kueue.ClusterQueue) (reason string, message string) {
+	switch {
+	case !lqExists:
+		return kueue.WorkloadQuotaReservedReasonMisconfigured, fmt.Sprintf("LocalQueue %s doesn't exist", wl.Spec.QueueName)
+	case !lqActive:
+		return kueue.WorkloadQuotaReservedReasonSuspended, fmt.Sprintf("LocalQueue %s is inactive", wl.Spec.QueueName)
+	case cq == nil:
+		cqName, _ := r.queues.ClusterQueueForWorkload(wl)
+		return kueue.WorkloadQuotaReservedReasonMisconfigured, fmt.Sprintf("ClusterQueue %s doesn't exist", cqName)
+	case !r.cache.ClusterQueueActive(kueue.ClusterQueueReference(cq.Name)):
+		return kueue.WorkloadQuotaReservedReasonSuspended, fmt.Sprintf("ClusterQueue %s is inactive", cq.Name)
+	default:
+		return "", ""
 	}
 }

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -669,20 +669,10 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
 			if !workload.HasQuotaReservation(wl) {
 				cqActive := cqOk && r.cache.ClusterQueueActive(cqName)
-				var cond *metav1.Condition
-				var err error
-				if features.Enabled(features.UnadmittedWorkloadsObservability) {
-					cond, err = r.resolveUnadmittedQuotaReservedCondition(ctx, wl, lqExists, lqActive, cqOk, cqActive, cq)
-				} else {
-					cond = r.resolveLegacyUnadmittedQuotaReservedCondition(wl, lqExists, lqActive, cqOk, cqActive)
-				}
-				if err != nil {
+				if changed, err := r.syncQuotaReservedFalseCondition(ctx, wl, lqExists, lqActive, cqOk, cqActive, cq); err != nil {
 					return false, err
-				}
-				if cond != nil {
-					if apimeta.SetStatusCondition(&wl.Status.Conditions, *cond) {
-						updated = true
-					}
+				} else if changed {
+					updated = true
 				}
 			}
 			if workload.SyncAdmittedCondition(wl, r.clock.Now()) {
@@ -1804,7 +1794,35 @@ func (h *deviceClassHandler) reconcileWorkloads(ctx context.Context, q workqueue
 	}
 }
 
+func (r *WorkloadReconciler) syncQuotaReservedFalseCondition(
+	ctx context.Context,
+	wl *kueue.Workload,
+	lqExists, lqActive, cqOk, cqActive bool,
+	cq *kueue.ClusterQueue,
+) (bool, error) {
+	cond, err := r.resolveUnadmittedQuotaReservedCondition(ctx, wl, lqExists, lqActive, cqOk, cqActive, cq)
+	if err != nil {
+		return false, err
+	}
+	if cond != nil {
+		return apimeta.SetStatusCondition(&wl.Status.Conditions, *cond), nil
+	}
+	return false, nil
+}
+
 func (r *WorkloadReconciler) resolveUnadmittedQuotaReservedCondition(
+	ctx context.Context,
+	wl *kueue.Workload,
+	lqExists, lqActive, cqOk, cqActive bool,
+	cq *kueue.ClusterQueue,
+) (*metav1.Condition, error) {
+	if features.Enabled(features.UnadmittedWorkloadsObservability) {
+		return r.resolveGranularUnadmittedQuotaReservedCondition(ctx, wl, lqExists, lqActive, cqOk, cqActive, cq)
+	}
+	return r.resolveLegacyUnadmittedQuotaReservedCondition(wl, lqExists, lqActive, cqOk, cqActive), nil
+}
+
+func (r *WorkloadReconciler) resolveGranularUnadmittedQuotaReservedCondition(
 	ctx context.Context,
 	wl *kueue.Workload,
 	lqExists, lqActive, cqOk, cqActive bool,

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -80,6 +80,13 @@ var (
 	realClock = clock.RealClock{}
 )
 
+const (
+	localQueueDoesNotExistMsgFormat   = "LocalQueue %s doesn't exist"
+	clusterQueueDoesNotExistMsgFormat = "ClusterQueue %s doesn't exist"
+	localQueueIsInactiveMsgFormat     = "LocalQueue %s is inactive"
+	clusterQueueIsInactiveMsgFormat   = "ClusterQueue %s is inactive"
+)
+
 // hasInternalError reports whether the field error list contains an internal
 // error. DRA resolution reports retryable failures — API errors and cluster-state
 // shortages that clear once ResourceSlices change — as internal errors, so the
@@ -776,7 +783,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		log.V(3).Info("Workload is inadmissible because of missing LocalQueue", "localQueue", klog.KRef(wl.Namespace, string(wl.Spec.QueueName)))
 		if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
 			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonMisconfigured, kueue.WorkloadInadmissible)
-			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf("LocalQueue %s doesn't exist", wl.Spec.QueueName), r.clock.Now()), nil
+			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf(localQueueDoesNotExistMsgFormat, wl.Spec.QueueName), r.clock.Now()), nil
 		}); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
@@ -784,7 +791,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		log.V(3).Info("Workload is inadmissible because of stopped LocalQueue", "localQueue", klog.KRef(wl.Namespace, string(wl.Spec.QueueName)))
 		if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
 			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonSuspended, kueue.WorkloadInadmissible)
-			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf("LocalQueue %s is inactive", wl.Spec.QueueName), r.clock.Now()), nil
+			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf(localQueueIsInactiveMsgFormat, wl.Spec.QueueName), r.clock.Now()), nil
 		}); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
@@ -792,7 +799,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		log.V(3).Info("Workload is inadmissible because of missing ClusterQueue", "clusterQueue", klog.KRef("", string(cqName)))
 		if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
 			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonMisconfigured, kueue.WorkloadInadmissible)
-			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf("ClusterQueue %s doesn't exist", cqName), r.clock.Now()), nil
+			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf(clusterQueueDoesNotExistMsgFormat, cqName), r.clock.Now()), nil
 		}); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
@@ -800,7 +807,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		log.V(3).Info("Workload is inadmissible because ClusterQueue is inactive", "clusterQueue", klog.KRef("", string(cqName)))
 		if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
 			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonSuspended, kueue.WorkloadInadmissible)
-			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf("ClusterQueue %s is inactive", cqName), r.clock.Now()), nil
+			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf(clusterQueueIsInactiveMsgFormat, cqName), r.clock.Now()), nil
 		}); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
@@ -1857,31 +1864,39 @@ func (r *WorkloadReconciler) resolveUnadmittedQuotaReservedCondition(wl *kueue.W
 		newMsg = "The workload is deactivated"
 	case !lqExists:
 		newReason = kueue.WorkloadQuotaReservedReasonMisconfigured
-		newMsg = fmt.Sprintf("LocalQueue %s doesn't exist", wl.Spec.QueueName)
+		newMsg = fmt.Sprintf(localQueueDoesNotExistMsgFormat, wl.Spec.QueueName)
 	case !lqActive:
 		newReason = kueue.WorkloadQuotaReservedReasonSuspended
-		newMsg = fmt.Sprintf("LocalQueue %s is inactive", wl.Spec.QueueName)
+		newMsg = fmt.Sprintf(localQueueIsInactiveMsgFormat, wl.Spec.QueueName)
 	case !cqOk:
 		cqName, _ := r.queues.ClusterQueueForWorkload(wl)
 		newReason = kueue.WorkloadQuotaReservedReasonMisconfigured
-		newMsg = fmt.Sprintf("ClusterQueue %s doesn't exist", cqName)
+		newMsg = fmt.Sprintf(clusterQueueDoesNotExistMsgFormat, cqName)
 	case cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == kueue.WorkloadQuotaReservedReasonNoMatchingFlavor:
 		newReason = cond.Reason
 		newMsg = cond.Message
 	case !cqActive:
 		cqName, _ := r.queues.ClusterQueueForWorkload(wl)
 		newReason = kueue.WorkloadQuotaReservedReasonSuspended
-		newMsg = fmt.Sprintf("ClusterQueue %s is inactive", cqName)
+		newMsg = fmt.Sprintf(clusterQueueIsInactiveMsgFormat, cqName)
 	case workload.HasAdmissionGate(wl):
 		newReason = kueue.WorkloadAdmissionGated
 		newMsg = fmt.Sprintf("Admission is gated by: %s", wl.Annotations[constants.AdmissionGatedByAnnotation])
 	case cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == kueue.WorkloadQuotaReservedReasonWaitingForPodsReady:
 		newReason = cond.Reason
 		newMsg = cond.Message
-	case cond != nil && cond.Status == metav1.ConditionFalse && (cond.Reason == kueue.WorkloadQuotaReservedReasonExceedsMaxQuota ||
-		cond.Reason == kueue.WorkloadQuotaReservedReasonWaitingForQuota ||
-		cond.Reason == kueue.WorkloadQuotaReservedReasonTopologyPlacementFailed ||
-		cond.Reason == kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads):
+	case cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == kueue.WorkloadQuotaReservedReasonMisconfigured:
+		cqName, _ := r.queues.ClusterQueueForWorkload(wl)
+		if cond.Message == fmt.Sprintf(localQueueDoesNotExistMsgFormat, wl.Spec.QueueName) ||
+			cond.Message == fmt.Sprintf(clusterQueueDoesNotExistMsgFormat, cqName) {
+			newReason = kueue.WorkloadQuotaReservedReasonPendingEvaluation
+			newMsg = "Workload is pending evaluation in the scheduling queue"
+		} else {
+			newReason = cond.Reason
+			newMsg = cond.Message
+		}
+	case cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason != "" &&
+		cond.Reason != kueue.WorkloadQuotaReservedReasonSuspended:
 		newReason = cond.Reason
 		newMsg = cond.Message
 	default:

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -1799,33 +1799,23 @@ func (r *WorkloadReconciler) syncQuotaReservedFalseCondition(
 	lqExists, lqActive bool,
 	cq *kueue.ClusterQueue,
 ) (bool, error) {
-	cond, err := r.resolveUnadmittedQuotaReservedCondition(ctx, wl, lqExists, lqActive, cq)
-	if err != nil {
-		return false, err
+	var cond *metav1.Condition
+	if features.Enabled(features.UnadmittedWorkloadsObservability) {
+		reason, message, err := r.resolveGranularUnadmittedQuotaReservedCondition(ctx, wl, lqExists, lqActive, cq)
+		if err != nil {
+			return false, err
+		}
+		if reason != "" {
+			cond = r.newQuotaReservedCondition(wl, reason, message)
+		}
+	} else {
+		cond = r.resolveLegacyUnadmittedQuotaReservedCondition(wl, lqExists, lqActive, cq)
 	}
+
 	if cond != nil {
 		return apimeta.SetStatusCondition(&wl.Status.Conditions, *cond), nil
 	}
 	return false, nil
-}
-
-func (r *WorkloadReconciler) resolveUnadmittedQuotaReservedCondition(
-	ctx context.Context,
-	wl *kueue.Workload,
-	lqExists, lqActive bool,
-	cq *kueue.ClusterQueue,
-) (*metav1.Condition, error) {
-	if features.Enabled(features.UnadmittedWorkloadsObservability) {
-		reason, message, err := r.resolveGranularUnadmittedQuotaReservedCondition(ctx, wl, lqExists, lqActive, cq)
-		if err != nil {
-			return nil, err
-		}
-		if reason == "" {
-			return nil, nil
-		}
-		return r.newQuotaReservedCondition(wl, reason, message), nil
-	}
-	return r.resolveLegacyUnadmittedQuotaReservedCondition(wl, lqExists, lqActive, cq), nil
 }
 
 func (r *WorkloadReconciler) resolveGranularUnadmittedQuotaReservedCondition(
@@ -1835,6 +1825,17 @@ func (r *WorkloadReconciler) resolveGranularUnadmittedQuotaReservedCondition(
 	cq *kueue.ClusterQueue,
 ) (string, string, error) {
 	cond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
+
+	switch {
+	case !workload.IsActive(wl):
+		return kueue.WorkloadDeactivated, "The workload is deactivated", nil
+	case workload.IsOnHold(wl):
+		return cond.Reason, cond.Message, nil
+	}
+
+	if reason, message := r.getQueueBlocker(wl, lqExists, lqActive, cq); reason != "" {
+		return reason, message, nil
+	}
 
 	var admissibilityErr error
 	if cq != nil {
@@ -1852,21 +1853,9 @@ func (r *WorkloadReconciler) resolveGranularUnadmittedQuotaReservedCondition(
 			return "", "", admissibilityErr
 		}
 	}
-
-	switch {
-	case !workload.IsActive(wl):
-		return kueue.WorkloadDeactivated, "The workload is deactivated", nil
-	case workload.IsOnHold(wl):
-		return cond.Reason, cond.Message, nil
-	}
-
-	if reason, message := r.getQueueBlocker(wl, lqExists, lqActive, cq); reason != "" {
-		return reason, message, nil
-	}
-
 	switch {
 	case admissibilityErr != nil:
-		return kueue.WorkloadQuotaReservedReasonMisconfigured, admissibilityErr.Error(), nil
+		return kueue.WorkloadQuotaReservedReasonMisconfigured, admissibilityErr.Error(), nil //nolint:nilerr // admissibility validation failure does not require retry
 	case workload.HasAdmissionGate(wl):
 		return kueue.WorkloadAdmissionGated, fmt.Sprintf("Admission is gated by: %s", wl.Annotations[constants.AdmissionGatedByAnnotation]), nil
 	case cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason != "" &&

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -19,6 +19,7 @@ package core
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"time"
@@ -32,6 +33,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -78,13 +80,6 @@ import (
 
 var (
 	realClock = clock.RealClock{}
-)
-
-const (
-	localQueueDoesNotExistMsgFormat   = "LocalQueue %s doesn't exist"
-	clusterQueueDoesNotExistMsgFormat = "ClusterQueue %s doesn't exist"
-	localQueueIsInactiveMsgFormat     = "LocalQueue %s is inactive"
-	clusterQueueIsInactiveMsgFormat   = "ClusterQueue %s is inactive"
 )
 
 // hasInternalError reports whether the field error list contains an internal
@@ -649,10 +644,11 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	cqName, cqOk := r.queues.ClusterQueueForWorkload(&wl)
+	var cq *kueue.ClusterQueue
 	if cqOk {
 		// because we need to react to API cluster cq events, the list of checks from a cache can lead to race conditions
-		cq := kueue.ClusterQueue{}
-		if err := r.client.Get(ctx, types.NamespacedName{Name: string(cqName)}, &cq); err != nil {
+		cq = &kueue.ClusterQueue{}
+		if err := r.client.Get(ctx, types.NamespacedName{Name: string(cqName)}, cq); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
 		// If stopped cluster queue is started we need to set the WorkloadRequeued condition to true.
@@ -661,7 +657,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				return workload.SetRequeuedCondition(wl, kueue.WorkloadClusterQueueRestarted, "The ClusterQueue was restarted after being stopped", true), nil
 			}))
 		}
-		if updated, err := r.reconcileSyncAdmissionChecks(ctx, &wl, &cq); updated || err != nil {
+		if updated, err := r.reconcileSyncAdmissionChecks(ctx, &wl, cq); updated || err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -674,7 +670,10 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			if features.Enabled(features.UnadmittedWorkloadsObservability) {
 				if !workload.HasQuotaReservation(wl) {
 					cqActive := cqOk && r.cache.ClusterQueueActive(cqName)
-					cond := r.resolveUnadmittedQuotaReservedCondition(wl, lqExists, lqActive, cqOk, cqActive)
+					cond, err := r.resolveUnadmittedQuotaReservedCondition(ctx, wl, lqExists, lqActive, cqOk, cqActive, cq)
+					if err != nil {
+						return false, err
+					}
 					if cond != nil {
 						if apimeta.SetStatusCondition(&wl.Status.Conditions, *cond) {
 							updated = true
@@ -745,7 +744,6 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				)
 			}
 		}
-
 	}
 
 	if workload.HasQuotaReservation(&wl) {
@@ -783,7 +781,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		log.V(3).Info("Workload is inadmissible because of missing LocalQueue", "localQueue", klog.KRef(wl.Namespace, string(wl.Spec.QueueName)))
 		if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
 			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonMisconfigured, kueue.WorkloadInadmissible)
-			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf(localQueueDoesNotExistMsgFormat, wl.Spec.QueueName), r.clock.Now()), nil
+			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf("LocalQueue %s doesn't exist", wl.Spec.QueueName), r.clock.Now()), nil
 		}); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
@@ -791,7 +789,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		log.V(3).Info("Workload is inadmissible because of stopped LocalQueue", "localQueue", klog.KRef(wl.Namespace, string(wl.Spec.QueueName)))
 		if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
 			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonSuspended, kueue.WorkloadInadmissible)
-			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf(localQueueIsInactiveMsgFormat, wl.Spec.QueueName), r.clock.Now()), nil
+			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf("LocalQueue %s is inactive", wl.Spec.QueueName), r.clock.Now()), nil
 		}); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
@@ -799,7 +797,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		log.V(3).Info("Workload is inadmissible because of missing ClusterQueue", "clusterQueue", klog.KRef("", string(cqName)))
 		if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
 			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonMisconfigured, kueue.WorkloadInadmissible)
-			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf(clusterQueueDoesNotExistMsgFormat, cqName), r.clock.Now()), nil
+			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf("ClusterQueue %s doesn't exist", cqName), r.clock.Now()), nil
 		}); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
@@ -807,7 +805,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		log.V(3).Info("Workload is inadmissible because ClusterQueue is inactive", "clusterQueue", klog.KRef("", string(cqName)))
 		if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
 			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonSuspended, kueue.WorkloadInadmissible)
-			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf(clusterQueueIsInactiveMsgFormat, cqName), r.clock.Now()), nil
+			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf("ClusterQueue %s is inactive", cqName), r.clock.Now()), nil
 		}); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
@@ -1854,67 +1852,74 @@ func (h *deviceClassHandler) reconcileWorkloads(ctx context.Context, q workqueue
 	}
 }
 
-func (r *WorkloadReconciler) resolveUnadmittedQuotaReservedCondition(wl *kueue.Workload, lqExists, lqActive, cqOk, cqActive bool) *metav1.Condition {
+func (r *WorkloadReconciler) resolveUnadmittedQuotaReservedCondition(
+	ctx context.Context,
+	wl *kueue.Workload,
+	lqExists, lqActive, cqOk, cqActive bool,
+	cq *kueue.ClusterQueue,
+) (*metav1.Condition, error) {
 	cond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
 
-	var newReason, newMsg string
+	var admissibilityErr error
+	if cqOk && cq != nil {
+		var selector labels.Selector
+		var err error
+		selector, err = metav1.LabelSelectorAsSelector(cq.Spec.NamespaceSelector)
+		if err != nil {
+			log := ctrl.LoggerFrom(ctx)
+			log.Error(err, "Invalid ClusterQueue NamespaceSelector", "clusterQueue", cq.Name)
+			selector = labels.Nothing()
+		}
+		wlInfo := workload.NewInfo(wl)
+		admissibilityErr = workload.ValidateAdmissibility(ctx, r.client, wlInfo, selector)
+		if admissibilityErr != nil && errors.Is(admissibilityErr, workload.ErrAPI) {
+			return nil, admissibilityErr
+		}
+	}
+
 	switch {
 	case !workload.IsActive(wl):
-		newReason = kueue.WorkloadDeactivated
-		newMsg = "The workload is deactivated"
+		return r.newQuotaReservedCondition(wl, kueue.WorkloadDeactivated, "The workload is deactivated"), nil
+	case workload.IsOnHold(wl):
+		return r.newQuotaReservedCondition(wl, cond.Reason, cond.Message), nil
 	case !lqExists:
-		newReason = kueue.WorkloadQuotaReservedReasonMisconfigured
-		newMsg = fmt.Sprintf(localQueueDoesNotExistMsgFormat, wl.Spec.QueueName)
+		return r.newQuotaReservedCondition(wl, kueue.WorkloadQuotaReservedReasonMisconfigured, fmt.Sprintf("LocalQueue %s doesn't exist", wl.Spec.QueueName)), nil
 	case !lqActive:
-		newReason = kueue.WorkloadQuotaReservedReasonSuspended
-		newMsg = fmt.Sprintf(localQueueIsInactiveMsgFormat, wl.Spec.QueueName)
+		return r.newQuotaReservedCondition(wl, kueue.WorkloadQuotaReservedReasonSuspended, fmt.Sprintf("LocalQueue %s is inactive", wl.Spec.QueueName)), nil
 	case !cqOk:
 		cqName, _ := r.queues.ClusterQueueForWorkload(wl)
-		newReason = kueue.WorkloadQuotaReservedReasonMisconfigured
-		newMsg = fmt.Sprintf(clusterQueueDoesNotExistMsgFormat, cqName)
-	case cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == kueue.WorkloadQuotaReservedReasonNoMatchingFlavor:
-		newReason = cond.Reason
-		newMsg = cond.Message
+		return r.newQuotaReservedCondition(wl, kueue.WorkloadQuotaReservedReasonMisconfigured, fmt.Sprintf("ClusterQueue %s doesn't exist", cqName)), nil
 	case !cqActive:
 		cqName, _ := r.queues.ClusterQueueForWorkload(wl)
-		newReason = kueue.WorkloadQuotaReservedReasonSuspended
-		newMsg = fmt.Sprintf(clusterQueueIsInactiveMsgFormat, cqName)
+		return r.newQuotaReservedCondition(wl, kueue.WorkloadQuotaReservedReasonSuspended, fmt.Sprintf("ClusterQueue %s is inactive", cqName)), nil
+	case admissibilityErr != nil:
+		return r.newQuotaReservedCondition(wl, kueue.WorkloadQuotaReservedReasonMisconfigured, admissibilityErr.Error()), nil
 	case workload.HasAdmissionGate(wl):
-		newReason = kueue.WorkloadAdmissionGated
-		newMsg = fmt.Sprintf("Admission is gated by: %s", wl.Annotations[constants.AdmissionGatedByAnnotation])
+		return r.newQuotaReservedCondition(wl, kueue.WorkloadAdmissionGated, fmt.Sprintf("Admission is gated by: %s", wl.Annotations[constants.AdmissionGatedByAnnotation])), nil
+	case cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == kueue.WorkloadQuotaReservedReasonNoMatchingFlavor:
+		return r.newQuotaReservedCondition(wl, cond.Reason, cond.Message), nil
 	case cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == kueue.WorkloadQuotaReservedReasonWaitingForPodsReady:
-		newReason = cond.Reason
-		newMsg = cond.Message
-	case cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == kueue.WorkloadQuotaReservedReasonMisconfigured:
-		cqName, _ := r.queues.ClusterQueueForWorkload(wl)
-		if cond.Message == fmt.Sprintf(localQueueDoesNotExistMsgFormat, wl.Spec.QueueName) ||
-			cond.Message == fmt.Sprintf(clusterQueueDoesNotExistMsgFormat, cqName) {
-			newReason = kueue.WorkloadQuotaReservedReasonPendingEvaluation
-			newMsg = "Workload is pending evaluation in the scheduling queue"
-		} else {
-			newReason = cond.Reason
-			newMsg = cond.Message
-		}
+		return r.newQuotaReservedCondition(wl, cond.Reason, cond.Message), nil
 	case cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason != "" &&
-		cond.Reason != kueue.WorkloadQuotaReservedReasonSuspended:
-		newReason = cond.Reason
-		newMsg = cond.Message
+		cond.Reason != kueue.WorkloadQuotaReservedReasonSuspended &&
+		cond.Reason != kueue.WorkloadQuotaReservedReasonMisconfigured:
+		return r.newQuotaReservedCondition(wl, cond.Reason, cond.Message), nil
 	default:
-		newReason = kueue.WorkloadQuotaReservedReasonPendingEvaluation
-		newMsg = "Workload is pending evaluation in the scheduling queue"
+		// Stamping the condition on creation is deferred to the next feature gate:
+		// UnadmittedWorkloadsObservabilityExplicitStatus.
+		if cond == nil {
+			return nil, nil
+		}
+		return r.newQuotaReservedCondition(wl, kueue.WorkloadQuotaReservedReasonPendingEvaluation, "Workload is pending evaluation in the scheduling queue"), nil
 	}
+}
 
-	// Stamping the condition on creation is deferred to the next feature gate:
-	// UnadmittedWorkloadsObservabilityExplicitStatus.
-	if newReason == kueue.WorkloadQuotaReservedReasonPendingEvaluation && cond == nil {
-		return nil
-	}
-
+func (r *WorkloadReconciler) newQuotaReservedCondition(wl *kueue.Workload, reason, message string) *metav1.Condition {
 	return &metav1.Condition{
 		Type:               kueue.WorkloadQuotaReserved,
 		Status:             metav1.ConditionFalse,
-		Reason:             newReason,
-		Message:            api.TruncateConditionMessage(newMsg),
+		Reason:             reason,
+		Message:            api.TruncateConditionMessage(message),
 		LastTransitionTime: metav1.NewTime(r.clock.Now()),
 		ObservedGeneration: wl.Generation,
 	}

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -663,11 +663,42 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// false before the workloads eviction.
 	if !workload.IsAdmitted(&wl) {
 		var updated bool
-		if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-			updated = workload.SyncAdmittedCondition(wl, r.clock.Now())
+		err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
+			if features.Enabled(features.UnadmittedWorkloadsObservability) {
+				if !workload.HasQuotaReservation(wl) {
+					cqActive := cqOk && r.cache.ClusterQueueActive(cqName)
+					cond := r.resolveUnadmittedQuotaReservedCondition(wl, lqExists, lqActive, cqOk, cqActive)
+					if cond != nil {
+						if apimeta.SetStatusCondition(&wl.Status.Conditions, *cond) {
+							updated = true
+						}
+					}
+					if wl.Status.Admission != nil {
+						wl.Status.Admission = nil
+						updated = true
+					}
+				}
+				if workload.HasRejectedChecks(wl) {
+					rejectedChecks := workload.RejectedChecks(wl)
+					message := buildAdmissionChecksMessage(rejectedChecks, kueue.CheckStateRejected)
+					if workload.SetDeactivationTarget(wl, kueue.WorkloadEvictedByAdmissionCheck, message) {
+						updated = true
+					}
+				}
+			}
+			if workload.SyncAdmittedCondition(wl, r.clock.Now()) {
+				updated = true
+			}
 			return updated, nil
-		}); err != nil {
+		})
+		if err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+		// If the observability feature gate is enabled and the workload has no quota reservation,
+		// we have already resolved and patched the granular conditions (e.g., missing or inactive
+		// queue) in the block above.
+		if features.Enabled(features.UnadmittedWorkloadsObservability) && !workload.HasQuotaReservation(&wl) {
+			return ctrl.Result{}, nil
 		}
 		isAdmitted := workload.IsAdmitted(&wl)
 		if isAdmitted {
@@ -707,6 +738,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				)
 			}
 		}
+
 	}
 
 	if workload.HasQuotaReservation(&wl) {
@@ -1812,5 +1844,63 @@ func (h *deviceClassHandler) reconcileWorkloads(ctx context.Context, q workqueue
 				},
 			}, time.Second)
 		}
+	}
+}
+
+func (r *WorkloadReconciler) resolveUnadmittedQuotaReservedCondition(wl *kueue.Workload, lqExists, lqActive, cqOk, cqActive bool) *metav1.Condition {
+	cond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
+
+	var newReason, newMsg string
+	switch {
+	case !workload.IsActive(wl):
+		newReason = kueue.WorkloadDeactivated
+		newMsg = "The workload is deactivated"
+	case !lqExists:
+		newReason = kueue.WorkloadQuotaReservedReasonMisconfigured
+		newMsg = fmt.Sprintf("LocalQueue %s doesn't exist", wl.Spec.QueueName)
+	case !lqActive:
+		newReason = kueue.WorkloadQuotaReservedReasonSuspended
+		newMsg = fmt.Sprintf("LocalQueue %s is inactive", wl.Spec.QueueName)
+	case !cqOk:
+		cqName, _ := r.queues.ClusterQueueForWorkload(wl)
+		newReason = kueue.WorkloadQuotaReservedReasonMisconfigured
+		newMsg = fmt.Sprintf("ClusterQueue %s doesn't exist", cqName)
+	case cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == kueue.WorkloadQuotaReservedReasonNoMatchingFlavor:
+		newReason = cond.Reason
+		newMsg = cond.Message
+	case !cqActive:
+		cqName, _ := r.queues.ClusterQueueForWorkload(wl)
+		newReason = kueue.WorkloadQuotaReservedReasonSuspended
+		newMsg = fmt.Sprintf("ClusterQueue %s is inactive", cqName)
+	case workload.HasAdmissionGate(wl):
+		newReason = kueue.WorkloadAdmissionGated
+		newMsg = fmt.Sprintf("Admission is gated by: %s", wl.Annotations[constants.AdmissionGatedByAnnotation])
+	case cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == kueue.WorkloadQuotaReservedReasonWaitingForPodsReady:
+		newReason = cond.Reason
+		newMsg = cond.Message
+	case cond != nil && cond.Status == metav1.ConditionFalse && (cond.Reason == kueue.WorkloadQuotaReservedReasonExceedsMaxQuota ||
+		cond.Reason == kueue.WorkloadQuotaReservedReasonWaitingForQuota ||
+		cond.Reason == kueue.WorkloadQuotaReservedReasonTopologyPlacementFailed ||
+		cond.Reason == kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads):
+		newReason = cond.Reason
+		newMsg = cond.Message
+	default:
+		newReason = kueue.WorkloadQuotaReservedReasonPendingEvaluation
+		newMsg = "Workload is pending evaluation in the scheduling queue"
+	}
+
+	// Stamping the condition on creation is deferred to the next feature gate:
+	// UnadmittedWorkloadsObservabilityExplicitStatus.
+	if newReason == kueue.WorkloadQuotaReservedReasonPendingEvaluation && cond == nil {
+		return nil
+	}
+
+	return &metav1.Condition{
+		Type:               kueue.WorkloadQuotaReserved,
+		Status:             metav1.ConditionFalse,
+		Reason:             newReason,
+		Message:            api.TruncateConditionMessage(newMsg),
+		LastTransitionTime: metav1.NewTime(r.clock.Now()),
+		ObservedGeneration: wl.Generation,
 	}
 }

--- a/pkg/controller/core/workload_controller_inadmissible_test.go
+++ b/pkg/controller/core/workload_controller_inadmissible_test.go
@@ -22,9 +22,11 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 )
 
@@ -439,6 +441,226 @@ func TestReconcileInadmissible(t *testing.T) {
 					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
 					Message: "The workload has no reservation",
 				}).
+				Obj(),
+		},
+		"should set status QuotaReserved conditions to False with reason Deactivated if workload is deactivated even if LocalQueue doesn't exist": {
+			featureGates: map[featuregate.Feature]bool{
+				features.UnadmittedWorkloadsObservability: true,
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(false).
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadEvicted,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueue.WorkloadDeactivated,
+					Message: "The workload is deactivated",
+				}).
+				Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(false).
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadEvicted,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueue.WorkloadDeactivated,
+					Message: "The workload is deactivated",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadDeactivated,
+					Message: "The workload is deactivated",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				}).
+				Obj(),
+		},
+		"should preserve NoMatchingFlavor reason": {
+			featureGates: map[featuregate.Feature]bool{
+				features.UnadmittedWorkloadsObservability: true,
+			},
+			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonNoMatchingFlavor,
+					Message: "No matching flavor",
+				}).
+				Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonNoMatchingFlavor,
+					Message: "No matching flavor",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				}).
+				Obj(),
+		},
+		"should preserve WaitingForPodsReady reason": {
+			featureGates: map[featuregate.Feature]bool{
+				features.UnadmittedWorkloadsObservability: true,
+			},
+			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonWaitingForPodsReady,
+					Message: "Waiting for pods ready",
+				}).
+				Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonWaitingForPodsReady,
+					Message: "Waiting for pods ready",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				}).
+				Obj(),
+		},
+		"should preserve ExceedsMaxQuota reason": {
+			featureGates: map[featuregate.Feature]bool{
+				features.UnadmittedWorkloadsObservability: true,
+			},
+			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonExceedsMaxQuota,
+					Message: "Exceeds max quota",
+				}).
+				Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonExceedsMaxQuota,
+					Message: "Exceeds max quota",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				}).
+				Obj(),
+		},
+		"should write AdmissionGated reason when admission gate is active": {
+			featureGates: map[featuregate.Feature]bool{
+				features.UnadmittedWorkloadsObservability: true,
+				features.AdmissionGatedBy:                 true,
+			},
+			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				Queue("lq").
+				Annotation("kueue.x-k8s.io/admission-gated-by", "foo-gate").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmissionGated,
+					Message: "Admission is gated by: foo-gate",
+				}).
+				Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				Queue("lq").
+				Annotation("kueue.x-k8s.io/admission-gated-by", "foo-gate").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmissionGated,
+					Message: "Admission is gated by: foo-gate",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				}).
+				Obj(),
+		},
+		"should transition to PendingEvaluation when all blockages are resolved": {
+			featureGates: map[featuregate.Feature]bool{
+				features.UnadmittedWorkloadsObservability: true,
+			},
+			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonSuspended,
+					Message: "LocalQueue lq is inactive",
+				}).
+				Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonPendingEvaluation,
+					Message: "Workload is pending evaluation in the scheduling queue",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				}).
+				Obj(),
+		},
+		"should not write QuotaReserved condition on newly created workload": {
+			featureGates: map[featuregate.Feature]bool{
+				features.UnadmittedWorkloadsObservability: true,
+			},
+			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				Queue("lq").
+				Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				Queue("lq").
 				Obj(),
 		},
 		"should set status QuotaReserved conditions to False with reason Suspended if quota not reserved LocalQueue StopPolicy=Hold": {

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -1113,7 +1113,7 @@ func TestReconcile(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadPending,
+					Reason:  kueue.WorkloadPending, //nolint:staticcheck // SA1019: legacy reason
 					Message: "Workload is pending",
 				}).
 				Obj(),

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -997,6 +997,80 @@ func TestReconcile(t *testing.T) {
 				Obj(),
 			wantResult: reconcile.Result{},
 		},
+		"workload that is deactivated should set QuotaReserved condition to Deactivated (observability enabled)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.UnadmittedWorkloadsObservability: true,
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Active(false).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadEvicted,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueue.WorkloadDeactivated,
+					Message: "The workload is deactivated",
+				}).
+				SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Deactivated", Count: 1}).
+				Obj(),
+			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Active(false).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadEvicted,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueue.WorkloadDeactivated,
+					Message: "The workload is deactivated",
+				}).
+				SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Deactivated", Count: 1}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadDeactivated,
+					Message: "The workload is deactivated",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				}).
+				Obj(),
+		},
+		"workload that is reactivated should clear Deactivated condition and transition to PendingEvaluation (observability enabled)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.UnadmittedWorkloadsObservability: true,
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Active(true).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadDeactivated,
+					Message: "The workload is deactivated",
+				}).
+				Obj(),
+			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Active(true).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonPendingEvaluation,
+					Message: "Workload is pending evaluation in the scheduling queue",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				}).
+				Obj(),
+		},
 		"workload with AdmissionGatedBy annotation should set QuotaReserved condition to AdmissionGated": {
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				Queue("lq").

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -1104,6 +1104,98 @@ func TestReconcile(t *testing.T) {
 			},
 			reconcilerOpts: []Option{},
 		},
+		"workload with legacy Pending reason should transition to PendingEvaluation (observability enabled)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.UnadmittedWorkloadsObservability: true,
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadPending,
+					Message: "Workload is pending",
+				}).
+				Obj(),
+			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonPendingEvaluation,
+					Message: "Workload is pending evaluation in the scheduling queue",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				}).
+				Obj(),
+		},
+		"workload with granular PendingEvaluation reason should preserve it when queue is active (observability enabled)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.UnadmittedWorkloadsObservability: true,
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonPendingEvaluation,
+					Message: "Workload is pending evaluation in the scheduling queue",
+				}).
+				Obj(),
+			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonPendingEvaluation,
+					Message: "Workload is pending evaluation in the scheduling queue",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				}).
+				Obj(),
+		},
+		"workload with granular PendingEvaluation reason should transition to Inadmissible when queue is missing (observability disabled)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.UnadmittedWorkloadsObservability: false,
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonPendingEvaluation,
+					Message: "Workload is pending evaluation in the scheduling queue",
+				}).
+				Obj(),
+			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadInadmissible,
+					Message: "LocalQueue lq doesn't exist",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				}).
+				Obj(),
+		},
 		"workload with AdmissionGatedBy annotation removed should clear the gate and emit event": {
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				Queue("lq").

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -431,6 +431,7 @@ type reconcileTestCase struct {
 	wantEvents                []utiltesting.EventRecord
 	wantResult                reconcile.Result
 	reconcilerOpts            []Option
+	beforeReconcile           func(context.Context, client.Client)
 }
 
 func TestUpdateSkipsRequeueForOnHoldWorkload(t *testing.T) {
@@ -1253,6 +1254,48 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 		},
+		"inadmissible workload due to broken ClusterQueue namespace selector (observability enabled)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.UnadmittedWorkloadsObservability: true,
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Obj(),
+			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			beforeReconcile: func(ctx context.Context, cl client.Client) {
+				cq := &kueue.ClusterQueue{}
+				if err := cl.Get(ctx, types.NamespacedName{Name: "cq"}, cq); err != nil {
+					panic(err)
+				}
+				cq.Spec.NamespaceSelector = &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "invalid-operator",
+							Operator: "InvalOp",
+						},
+					},
+				}
+				if err := cl.Update(ctx, cq); err != nil {
+					panic(err)
+				}
+			},
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
+					Message: "invalid namespace selector: \"InvalOp\" is not a valid label selector operator",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				}).
+				Obj(),
+		},
 	}
 	runReconcileTestCases(t, cases, fakeClock)
 }
@@ -1409,6 +1452,10 @@ func runReconcileTestCases(t *testing.T, cases map[string]reconcileTestCase, fak
 						t.Fatalf("Failed to initialize DRA mapper: %v", err)
 					}
 					reconciler.draMapper = draMapper
+				}
+
+				if tc.beforeReconcile != nil {
+					tc.beforeReconcile(ctx, cl)
 				}
 
 				gotResult, gotError := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(testWl)})

--- a/pkg/util/testing/observability.go
+++ b/pkg/util/testing/observability.go
@@ -44,7 +44,7 @@ func AdjustConditionsForDisabledObservabilityInWorkloadController(conditions []m
 		if cond.Type == kueue.WorkloadQuotaReserved && cond.Status == metav1.ConditionFalse {
 			switch cond.Reason {
 			case kueue.WorkloadQuotaReservedReasonWaitingForPodsReady:
-				cond.Reason = kueue.WorkloadWaiting
+				cond.Reason = kueue.WorkloadWaiting //nolint:staticcheck // SA1019: legacy reason
 			case kueue.WorkloadAdmissionGated:
 				// Keep as is
 			case kueue.WorkloadQuotaReservedReasonMisconfigured,
@@ -52,7 +52,7 @@ func AdjustConditionsForDisabledObservabilityInWorkloadController(conditions []m
 				kueue.WorkloadInadmissible:
 				cond.Reason = kueue.WorkloadInadmissible
 			default:
-				cond.Reason = kueue.WorkloadPending
+				cond.Reason = kueue.WorkloadPending //nolint:staticcheck // SA1019: legacy reason
 			}
 		}
 		filtered = append(filtered, cond)
@@ -96,9 +96,9 @@ func AdjustConditionsForDisabledObservabilityInScheduler(conditions []metav1.Con
 		if cond.Type == kueue.WorkloadQuotaReserved && cond.Status == metav1.ConditionFalse {
 			switch cond.Reason {
 			case kueue.WorkloadQuotaReservedReasonWaitingForPodsReady:
-				cond.Reason = kueue.WorkloadWaiting
+				cond.Reason = kueue.WorkloadWaiting //nolint:staticcheck // SA1019: legacy reason
 			default:
-				cond.Reason = kueue.WorkloadPending
+				cond.Reason = kueue.WorkloadPending //nolint:staticcheck // SA1019: legacy reason
 			}
 		}
 		filtered = append(filtered, cond)

--- a/pkg/util/testing/observability.go
+++ b/pkg/util/testing/observability.go
@@ -44,7 +44,7 @@ func AdjustConditionsForDisabledObservabilityInWorkloadController(conditions []m
 		if cond.Type == kueue.WorkloadQuotaReserved && cond.Status == metav1.ConditionFalse {
 			switch cond.Reason {
 			case kueue.WorkloadQuotaReservedReasonWaitingForPodsReady:
-				cond.Reason = "Waiting"
+				cond.Reason = kueue.WorkloadWaiting
 			case kueue.WorkloadAdmissionGated:
 				// Keep as is
 			case kueue.WorkloadQuotaReservedReasonMisconfigured,
@@ -52,7 +52,7 @@ func AdjustConditionsForDisabledObservabilityInWorkloadController(conditions []m
 				kueue.WorkloadInadmissible:
 				cond.Reason = kueue.WorkloadInadmissible
 			default:
-				cond.Reason = "Pending"
+				cond.Reason = kueue.WorkloadPending
 			}
 		}
 		filtered = append(filtered, cond)
@@ -96,9 +96,9 @@ func AdjustConditionsForDisabledObservabilityInScheduler(conditions []metav1.Con
 		if cond.Type == kueue.WorkloadQuotaReserved && cond.Status == metav1.ConditionFalse {
 			switch cond.Reason {
 			case kueue.WorkloadQuotaReservedReasonWaitingForPodsReady:
-				cond.Reason = "Waiting"
+				cond.Reason = kueue.WorkloadWaiting
 			default:
-				cond.Reason = "Pending"
+				cond.Reason = kueue.WorkloadPending
 			}
 		}
 		filtered = append(filtered, cond)

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -1231,6 +1231,86 @@ var _ = ginkgo.Describe("Workload controller interaction with scheduler", func()
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
+
+	ginkgo.When("the queue doesn't exist and is then created under the observability feature gate", func() {
+		var (
+			ns                   *corev1.Namespace
+			wl                   *kueue.Workload
+			localQueue           *kueue.LocalQueue
+			updatedQueueWorkload kueue.Workload
+			cq                   *kueue.ClusterQueue
+			rf                   *kueue.ResourceFlavor
+		)
+		ginkgo.BeforeEach(func() {
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.UnadmittedWorkloadsObservability, true)
+			startManager()
+			ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "core-workload-")
+
+			rf = utiltestingapi.MakeResourceFlavor("default-flavor").Obj()
+			util.MustCreate(ctx, k8sClient, rf)
+
+			cq = utiltestingapi.MakeClusterQueue("cluster-queue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("default-flavor").
+						Resource(corev1.ResourceCPU, "0").
+						Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, cq)
+		})
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+			if rf != nil {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, rf, true)
+			}
+			stopManager()
+		})
+		ginkgo.It("Should transition status from Misconfigured to ExceedsMaxQuota when the queue is created", func() {
+			wl = utiltestingapi.MakeWorkload("transition-test", ns.Name).
+				Queue("delayed-queue").
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+
+			ginkgo.By("Creating workload referencing non-existent queue")
+			util.MustCreate(ctx, k8sClient, wl)
+
+			ginkgo.By("Verifying workload is marked as misconfigured (missing queue)")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedQueueWorkload)).To(gomega.Succeed())
+
+				cond := apimeta.FindStatusCondition(updatedQueueWorkload.Status.Conditions, kueue.WorkloadQuotaReserved)
+				g.Expect(cond).NotTo(gomega.BeNil())
+				g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(gomega.Equal(kueue.WorkloadQuotaReservedReasonMisconfigured))
+				g.Expect(cond.Message).To(gomega.Equal(fmt.Sprintf("LocalQueue %s doesn't exist", "delayed-queue")))
+
+				admittedCond := apimeta.FindStatusCondition(updatedQueueWorkload.Status.Conditions, kueue.WorkloadAdmitted)
+				g.Expect(admittedCond).NotTo(gomega.BeNil())
+				g.Expect(admittedCond.Status).To(gomega.Equal(metav1.ConditionFalse))
+				g.Expect(admittedCond.Reason).To(gomega.Equal("NoReservation"))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Creating the LocalQueue")
+			localQueue = utiltestingapi.MakeLocalQueue("delayed-queue", ns.Name).ClusterQueue(cq.Name).Obj()
+			util.MustCreate(ctx, k8sClient, localQueue)
+
+			ginkgo.By("Verifying workload transitions to ExceedsMaxQuota")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedQueueWorkload)).To(gomega.Succeed())
+
+				cond := apimeta.FindStatusCondition(updatedQueueWorkload.Status.Conditions, kueue.WorkloadQuotaReserved)
+				g.Expect(cond).NotTo(gomega.BeNil())
+				g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(gomega.Equal(kueue.WorkloadQuotaReservedReasonExceedsMaxQuota))
+
+				admittedCond := apimeta.FindStatusCondition(updatedQueueWorkload.Status.Conditions, kueue.WorkloadAdmitted)
+				g.Expect(admittedCond).NotTo(gomega.BeNil())
+				g.Expect(admittedCond.Status).To(gomega.Equal(metav1.ConditionFalse))
+				g.Expect(admittedCond.Reason).To(gomega.Equal("NoReservation"))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
 })
 
 var _ = ginkgo.Describe("Workload controller with resource retention", func() {

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -646,6 +646,238 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Label("controller:workload
 			})
 		})
 	})
+
+	ginkgo.Context("with UnadmittedWorkloadsObservability feature gate enabled", func() {
+		var (
+			clusterQueue *kueue.ClusterQueue
+			localQueue   *kueue.LocalQueue
+			flavor       *kueue.ResourceFlavor
+			inactiveCq   *kueue.ClusterQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			inactiveCq = nil
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.UnadmittedWorkloadsObservability, true)
+			flavor = utiltestingapi.MakeResourceFlavor(flavorOnDemand).Obj()
+			gomega.Expect(k8sClient.Create(ctx, flavor)).Should(gomega.Succeed())
+			clusterQueue = utiltestingapi.MakeClusterQueue("cq").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas(flavorOnDemand).
+					Resource(corev1.ResourceCPU, "1").Obj()).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).To(gomega.Succeed())
+			localQueue = utiltestingapi.MakeLocalQueue("q", ns.Name).ClusterQueue("cq").Obj()
+			gomega.Expect(k8sClient.Create(ctx, localQueue)).To(gomega.Succeed())
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			if inactiveCq != nil {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, inactiveCq, true)
+			}
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, flavor, true)
+		})
+
+		ginkgo.It("should write granular conditions and reasons when queue is missing", func() {
+			wl := utiltestingapi.MakeWorkload("wl-missing-queue", ns.Name).Queue("non-existent-queue").Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+			var updatedWl kueue.Workload
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(updatedWl.Status.Conditions).Should(gomega.HaveLen(2))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			wantConditions := []metav1.Condition{
+				{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
+					Message: "LocalQueue non-existent-queue doesn't exist",
+				},
+				{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  "NoReservation",
+					Message: "The workload has no reservation",
+				},
+			}
+			for _, wantCond := range wantConditions {
+				cond := apimeta.FindStatusCondition(updatedWl.Status.Conditions, wantCond.Type)
+				gomega.Expect(cond).NotTo(gomega.BeNil())
+				gomega.Expect(*cond).To(gomega.BeComparableTo(wantCond, util.IgnoreConditionTimestampsAndObservedGeneration))
+			}
+		})
+
+		ginkgo.It("should write granular conditions and reasons when clusterQueue is missing", func() {
+			lq := utiltestingapi.MakeLocalQueue("missing-cq-q", ns.Name).ClusterQueue("non-existent-cq").Obj()
+			gomega.Expect(k8sClient.Create(ctx, lq)).To(gomega.Succeed())
+
+			// Wait for LocalQueue to be reconciled and registered in the Queue Manager
+			gomega.Eventually(func(g gomega.Gomega) {
+				var fetchedLq kueue.LocalQueue
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lq), &fetchedLq)).To(gomega.Succeed())
+				g.Expect(apimeta.FindStatusCondition(fetchedLq.Status.Conditions, kueue.LocalQueueActive)).NotTo(gomega.BeNil())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			wl := utiltestingapi.MakeWorkload("wl-missing-cq", ns.Name).Queue("missing-cq-q").Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+			var updatedWl kueue.Workload
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(updatedWl.Status.Conditions).Should(gomega.HaveLen(2))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			wantConditions := []metav1.Condition{
+				{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
+					Message: "ClusterQueue non-existent-cq doesn't exist",
+				},
+				{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  "NoReservation",
+					Message: "The workload has no reservation",
+				},
+			}
+			for _, wantCond := range wantConditions {
+				cond := apimeta.FindStatusCondition(updatedWl.Status.Conditions, wantCond.Type)
+				gomega.Expect(cond).NotTo(gomega.BeNil())
+				gomega.Expect(*cond).To(gomega.BeComparableTo(wantCond, util.IgnoreConditionTimestampsAndObservedGeneration))
+			}
+		})
+
+		ginkgo.It("should write granular conditions and reasons when localQueue is inactive", func() {
+			lq := utiltestingapi.MakeLocalQueue("inactive-q", ns.Name).ClusterQueue("cq").Obj()
+			lq.Spec.StopPolicy = ptr.To(kueue.Hold)
+			gomega.Expect(k8sClient.Create(ctx, lq)).To(gomega.Succeed())
+
+			// Wait for LocalQueue to be reconciled and registered in the Queue Manager
+			gomega.Eventually(func(g gomega.Gomega) {
+				var fetchedLq kueue.LocalQueue
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lq), &fetchedLq)).To(gomega.Succeed())
+				g.Expect(apimeta.FindStatusCondition(fetchedLq.Status.Conditions, kueue.LocalQueueActive)).NotTo(gomega.BeNil())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			wl := utiltestingapi.MakeWorkload("wl-inactive-q", ns.Name).Queue("inactive-q").Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+			var updatedWl kueue.Workload
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(updatedWl.Status.Conditions).Should(gomega.HaveLen(2))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			wantConditions := []metav1.Condition{
+				{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonSuspended,
+					Message: "LocalQueue inactive-q is inactive",
+				},
+				{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  "NoReservation",
+					Message: "The workload has no reservation",
+				},
+			}
+			for _, wantCond := range wantConditions {
+				cond := apimeta.FindStatusCondition(updatedWl.Status.Conditions, wantCond.Type)
+				gomega.Expect(cond).NotTo(gomega.BeNil())
+				gomega.Expect(*cond).To(gomega.BeComparableTo(wantCond, util.IgnoreConditionTimestampsAndObservedGeneration))
+			}
+		})
+
+		ginkgo.It("should write granular conditions and reasons when clusterQueue is inactive", func() {
+			inactiveCq = utiltestingapi.MakeClusterQueue("inactive-cq").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas(flavorOnDemand).
+					Resource(corev1.ResourceCPU, "1").Obj()).
+				Obj()
+			inactiveCq.Spec.StopPolicy = ptr.To(kueue.Hold)
+			gomega.Expect(k8sClient.Create(ctx, inactiveCq)).To(gomega.Succeed())
+
+			lq := utiltestingapi.MakeLocalQueue("inactive-cq-q", ns.Name).ClusterQueue("inactive-cq").Obj()
+			gomega.Expect(k8sClient.Create(ctx, lq)).To(gomega.Succeed())
+
+			// Wait for LocalQueue to be reconciled and registered in the Queue Manager
+			gomega.Eventually(func(g gomega.Gomega) {
+				var fetchedLq kueue.LocalQueue
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lq), &fetchedLq)).To(gomega.Succeed())
+				g.Expect(apimeta.FindStatusCondition(fetchedLq.Status.Conditions, kueue.LocalQueueActive)).NotTo(gomega.BeNil())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			wl := utiltestingapi.MakeWorkload("wl-inactive-cq", ns.Name).Queue("inactive-cq-q").Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+			var updatedWl kueue.Workload
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(updatedWl.Status.Conditions).Should(gomega.HaveLen(2))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			wantConditions := []metav1.Condition{
+				{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonSuspended,
+					Message: "ClusterQueue inactive-cq is inactive",
+				},
+				{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  "NoReservation",
+					Message: "The workload has no reservation",
+				},
+			}
+			for _, wantCond := range wantConditions {
+				cond := apimeta.FindStatusCondition(updatedWl.Status.Conditions, wantCond.Type)
+				gomega.Expect(cond).NotTo(gomega.BeNil())
+				gomega.Expect(*cond).To(gomega.BeComparableTo(wantCond, util.IgnoreConditionTimestampsAndObservedGeneration))
+			}
+		})
+
+		ginkgo.It("should write granular conditions and reasons when workload is deactivated", func() {
+			wl := utiltestingapi.MakeWorkload("wl-deactivated", ns.Name).Queue("q").Obj()
+			wl.Spec.Active = new(false)
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+			var updatedWl kueue.Workload
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(updatedWl.Status.Conditions).Should(gomega.HaveLen(3))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			wantConditions := []metav1.Condition{
+				{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadDeactivated,
+					Message: "The workload is deactivated",
+				},
+				{
+					Type:    kueue.WorkloadEvicted,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueue.WorkloadDeactivated,
+					Message: "The workload is deactivated",
+				},
+				{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  "NoReservation",
+					Message: "The workload has no reservation",
+				},
+			}
+			for _, wantCond := range wantConditions {
+				cond := apimeta.FindStatusCondition(updatedWl.Status.Conditions, wantCond.Type)
+				gomega.Expect(cond).NotTo(gomega.BeNil())
+				gomega.Expect(*cond).To(gomega.BeComparableTo(wantCond, util.IgnoreConditionTimestampsAndObservedGeneration))
+			}
+		})
+	})
 })
 
 var _ = ginkgo.Describe("Workload controller interaction with scheduler", func() {
@@ -834,7 +1066,6 @@ var _ = ginkgo.Describe("Workload controller interaction with scheduler", func()
 			ginkgo.By("restarting the manager", func() {
 				restartManager()
 			})
-
 			ginkgo.By("checking no 'quota reserved' event appearing for the workload", func() {
 				gomega.Consistently(func(g gomega.Gomega) {
 					count, err := utiltesting.HasMatchingEventAppearedTimes(ctx, k8sClient, func(e *eventsv1.Event) bool {
@@ -848,6 +1079,156 @@ var _ = ginkgo.Describe("Workload controller interaction with scheduler", func()
 					g.Expect(count).To(gomega.Equal(1))
 				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 			})
+		})
+	})
+
+	ginkgo.Context("with UnadmittedWorkloadsObservability feature gate enabled", func() {
+		var (
+			clusterQueue *kueue.ClusterQueue
+			localQueue   *kueue.LocalQueue
+			flavor       *kueue.ResourceFlavor
+		)
+
+		ginkgo.BeforeEach(func() {
+			startManager()
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.UnadmittedWorkloadsObservability, true)
+			ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "core-workload-")
+			flavor = utiltestingapi.MakeResourceFlavor(flavorOnDemand).Obj()
+			gomega.Expect(k8sClient.Create(ctx, flavor)).Should(gomega.Succeed())
+			clusterQueue = utiltestingapi.MakeClusterQueue("cq").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas(flavorOnDemand).
+					Resource(corev1.ResourceCPU, "1").Obj()).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).To(gomega.Succeed())
+			localQueue = utiltestingapi.MakeLocalQueue("q", ns.Name).ClusterQueue("cq").Obj()
+			gomega.Expect(k8sClient.Create(ctx, localQueue)).To(gomega.Succeed())
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, flavor, true)
+			stopManager()
+		})
+
+		ginkgo.It("should write granular reasons when waiting for quota", func() {
+			wl1 := utiltestingapi.MakeWorkload("wl-consuming-quota", ns.Name).Queue("q").Request(corev1.ResourceCPU, "1").Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl1)).To(gomega.Succeed())
+
+			wl1Key := client.ObjectKeyFromObject(wl1)
+			admission := utiltestingapi.MakeAdmission("cq").
+				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(flavor.Name), "1").
+					Obj()).
+				Obj()
+			util.SetQuotaReservation(ctx, k8sClient, wl1Key, admission)
+			util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, wl1)
+
+			wl2 := utiltestingapi.MakeWorkload("wl-waiting-for-quota", ns.Name).Queue("q").Request(corev1.ResourceCPU, "1").Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl2)).To(gomega.Succeed())
+
+			var updatedWl kueue.Workload
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), &updatedWl)).To(gomega.Succeed())
+				g.Expect(updatedWl.Status.Conditions).Should(gomega.HaveLen(2))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Expect(updatedWl.Status.Conditions).To(gomega.ContainElements(
+				gomega.BeComparableTo(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonWaitingForQuota,
+					Message: "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor on-demand, 1 more needed",
+				}, util.IgnoreConditionTimestampsAndObservedGeneration),
+				gomega.BeComparableTo(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  "NoReservation",
+					Message: "The workload has no reservation",
+				}, util.IgnoreConditionTimestampsAndObservedGeneration),
+			))
+		})
+
+		ginkgo.It("should dynamically transition between reasons based on precedence", func() {
+			ginkgo.By("creating a workload that waits for quota")
+			wl1 := utiltestingapi.MakeWorkload("wl-consuming-quota", ns.Name).Queue("q").Request(corev1.ResourceCPU, "1").Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl1)).To(gomega.Succeed())
+			wl1Key := client.ObjectKeyFromObject(wl1)
+			admission := utiltestingapi.MakeAdmission("cq").
+				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(flavor.Name), "1").
+					Obj()).
+				Obj()
+			util.SetQuotaReservation(ctx, k8sClient, wl1Key, admission)
+			util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, wl1)
+
+			wl2 := utiltestingapi.MakeWorkload("wl-transitioning", ns.Name).Queue("q").Request(corev1.ResourceCPU, "1").Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl2)).To(gomega.Succeed())
+			wl2Key := client.ObjectKeyFromObject(wl2)
+
+			var updatedWl kueue.Workload
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wl2Key, &updatedWl)).To(gomega.Succeed())
+				cond := apimeta.FindStatusCondition(updatedWl.Status.Conditions, kueue.WorkloadQuotaReserved)
+				g.Expect(cond).NotTo(gomega.BeNil())
+				g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(gomega.Equal(string(kueue.WorkloadQuotaReservedReasonWaitingForQuota)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("making the LocalQueue inactive (should transition to Suspended)")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var fetchedLq kueue.LocalQueue
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(localQueue), &fetchedLq)).To(gomega.Succeed())
+				fetchedLq.Spec.StopPolicy = ptr.To(kueue.Hold)
+				g.Expect(k8sClient.Update(ctx, &fetchedLq)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wl2Key, &updatedWl)).To(gomega.Succeed())
+				cond := apimeta.FindStatusCondition(updatedWl.Status.Conditions, kueue.WorkloadQuotaReserved)
+				g.Expect(cond).NotTo(gomega.BeNil())
+				g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(gomega.Equal(kueue.WorkloadQuotaReservedReasonSuspended))
+				g.Expect(cond.Message).To(gomega.Equal(fmt.Sprintf("LocalQueue %s is inactive", localQueue.Name)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("deactivating the workload (should transition to Deactivated)")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wl2Key, &updatedWl)).To(gomega.Succeed())
+				updatedWl.Spec.Active = new(false)
+				g.Expect(k8sClient.Update(ctx, &updatedWl)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wl2Key, &updatedWl)).To(gomega.Succeed())
+				cond := apimeta.FindStatusCondition(updatedWl.Status.Conditions, kueue.WorkloadQuotaReserved)
+				g.Expect(cond).NotTo(gomega.BeNil())
+				g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(gomega.Equal(kueue.WorkloadDeactivated))
+				g.Expect(cond.Message).To(gomega.Equal("The workload is deactivated"))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("reactivating the workload and making the LocalQueue active again (should transition back to WaitingForQuota)")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wl2Key, &updatedWl)).To(gomega.Succeed())
+				updatedWl.Spec.Active = new(true)
+				g.Expect(k8sClient.Update(ctx, &updatedWl)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				var fetchedLq kueue.LocalQueue
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(localQueue), &fetchedLq)).To(gomega.Succeed())
+				fetchedLq.Spec.StopPolicy = ptr.To(kueue.None)
+				g.Expect(k8sClient.Update(ctx, &fetchedLq)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wl2Key, &updatedWl)).To(gomega.Succeed())
+				cond := apimeta.FindStatusCondition(updatedWl.Status.Conditions, kueue.WorkloadQuotaReserved)
+				g.Expect(cond).NotTo(gomega.BeNil())
+				g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(gomega.Equal(string(kueue.WorkloadQuotaReservedReasonWaitingForQuota)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
 })

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -702,12 +702,13 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Label("controller:workload
 			lq := utiltestingapi.MakeLocalQueue("missing-cq-q", ns.Name).ClusterQueue("non-existent-cq").Obj()
 			gomega.Expect(k8sClient.Create(ctx, lq)).To(gomega.Succeed())
 
-			// Wait for LocalQueue to be reconciled and registered in the Queue Manager
-			gomega.Eventually(func(g gomega.Gomega) {
-				var fetchedLq kueue.LocalQueue
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lq), &fetchedLq)).To(gomega.Succeed())
-				g.Expect(apimeta.FindStatusCondition(fetchedLq.Status.Conditions, kueue.LocalQueueActive)).NotTo(gomega.BeNil())
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			ginkgo.By("Wait for LocalQueue to be reconciled and registered in the Queue Manager", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					var fetchedLq kueue.LocalQueue
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lq), &fetchedLq)).To(gomega.Succeed())
+					g.Expect(apimeta.FindStatusCondition(fetchedLq.Status.Conditions, kueue.LocalQueueActive)).NotTo(gomega.BeNil())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
 
 			wl := utiltestingapi.MakeWorkload("wl-missing-cq", ns.Name).Queue("missing-cq-q").Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -682,31 +682,20 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Label("controller:workload
 			wl := utiltestingapi.MakeWorkload("wl-missing-queue", ns.Name).Queue("non-existent-queue").Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 
-			var updatedWl kueue.Workload
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
-				g.Expect(updatedWl.Status.Conditions).Should(gomega.HaveLen(2))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			wantConditions := []metav1.Condition{
-				{
+			util.ExpectWorkloadToHaveConditions(ctx, k8sClient, client.ObjectKeyFromObject(wl),
+				metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
 					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
 					Message: "LocalQueue non-existent-queue doesn't exist",
 				},
-				{
+				metav1.Condition{
 					Type:    kueue.WorkloadAdmitted,
 					Status:  metav1.ConditionFalse,
-					Reason:  "NoReservation",
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
 					Message: "The workload has no reservation",
 				},
-			}
-			for _, wantCond := range wantConditions {
-				cond := apimeta.FindStatusCondition(updatedWl.Status.Conditions, wantCond.Type)
-				gomega.Expect(cond).NotTo(gomega.BeNil())
-				gomega.Expect(*cond).To(gomega.BeComparableTo(wantCond, util.IgnoreConditionTimestampsAndObservedGeneration))
-			}
+			)
 		})
 
 		ginkgo.It("should write granular conditions and reasons when clusterQueue is missing", func() {
@@ -723,31 +712,20 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Label("controller:workload
 			wl := utiltestingapi.MakeWorkload("wl-missing-cq", ns.Name).Queue("missing-cq-q").Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 
-			var updatedWl kueue.Workload
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
-				g.Expect(updatedWl.Status.Conditions).Should(gomega.HaveLen(2))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			wantConditions := []metav1.Condition{
-				{
+			util.ExpectWorkloadToHaveConditions(ctx, k8sClient, client.ObjectKeyFromObject(wl),
+				metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
 					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
 					Message: "ClusterQueue non-existent-cq doesn't exist",
 				},
-				{
+				metav1.Condition{
 					Type:    kueue.WorkloadAdmitted,
 					Status:  metav1.ConditionFalse,
-					Reason:  "NoReservation",
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
 					Message: "The workload has no reservation",
 				},
-			}
-			for _, wantCond := range wantConditions {
-				cond := apimeta.FindStatusCondition(updatedWl.Status.Conditions, wantCond.Type)
-				gomega.Expect(cond).NotTo(gomega.BeNil())
-				gomega.Expect(*cond).To(gomega.BeComparableTo(wantCond, util.IgnoreConditionTimestampsAndObservedGeneration))
-			}
+			)
 		})
 
 		ginkgo.It("should write granular conditions and reasons when localQueue is inactive", func() {
@@ -765,31 +743,20 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Label("controller:workload
 			wl := utiltestingapi.MakeWorkload("wl-inactive-q", ns.Name).Queue("inactive-q").Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 
-			var updatedWl kueue.Workload
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
-				g.Expect(updatedWl.Status.Conditions).Should(gomega.HaveLen(2))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			wantConditions := []metav1.Condition{
-				{
+			util.ExpectWorkloadToHaveConditions(ctx, k8sClient, client.ObjectKeyFromObject(wl),
+				metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
 					Reason:  kueue.WorkloadQuotaReservedReasonSuspended,
 					Message: "LocalQueue inactive-q is inactive",
 				},
-				{
+				metav1.Condition{
 					Type:    kueue.WorkloadAdmitted,
 					Status:  metav1.ConditionFalse,
-					Reason:  "NoReservation",
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
 					Message: "The workload has no reservation",
 				},
-			}
-			for _, wantCond := range wantConditions {
-				cond := apimeta.FindStatusCondition(updatedWl.Status.Conditions, wantCond.Type)
-				gomega.Expect(cond).NotTo(gomega.BeNil())
-				gomega.Expect(*cond).To(gomega.BeComparableTo(wantCond, util.IgnoreConditionTimestampsAndObservedGeneration))
-			}
+			)
 		})
 
 		ginkgo.It("should write granular conditions and reasons when clusterQueue is inactive", func() {
@@ -813,31 +780,20 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Label("controller:workload
 			wl := utiltestingapi.MakeWorkload("wl-inactive-cq", ns.Name).Queue("inactive-cq-q").Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 
-			var updatedWl kueue.Workload
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
-				g.Expect(updatedWl.Status.Conditions).Should(gomega.HaveLen(2))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			wantConditions := []metav1.Condition{
-				{
+			util.ExpectWorkloadToHaveConditions(ctx, k8sClient, client.ObjectKeyFromObject(wl),
+				metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
 					Reason:  kueue.WorkloadQuotaReservedReasonSuspended,
 					Message: "ClusterQueue inactive-cq is inactive",
 				},
-				{
+				metav1.Condition{
 					Type:    kueue.WorkloadAdmitted,
 					Status:  metav1.ConditionFalse,
-					Reason:  "NoReservation",
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
 					Message: "The workload has no reservation",
 				},
-			}
-			for _, wantCond := range wantConditions {
-				cond := apimeta.FindStatusCondition(updatedWl.Status.Conditions, wantCond.Type)
-				gomega.Expect(cond).NotTo(gomega.BeNil())
-				gomega.Expect(*cond).To(gomega.BeComparableTo(wantCond, util.IgnoreConditionTimestampsAndObservedGeneration))
-			}
+			)
 		})
 
 		ginkgo.It("should write granular conditions and reasons when workload is deactivated", func() {
@@ -845,37 +801,26 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Label("controller:workload
 			wl.Spec.Active = new(false)
 			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 
-			var updatedWl kueue.Workload
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
-				g.Expect(updatedWl.Status.Conditions).Should(gomega.HaveLen(3))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			wantConditions := []metav1.Condition{
-				{
+			util.ExpectWorkloadToHaveConditions(ctx, k8sClient, client.ObjectKeyFromObject(wl),
+				metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
 					Reason:  kueue.WorkloadDeactivated,
 					Message: "The workload is deactivated",
 				},
-				{
+				metav1.Condition{
 					Type:    kueue.WorkloadEvicted,
 					Status:  metav1.ConditionTrue,
 					Reason:  kueue.WorkloadDeactivated,
 					Message: "The workload is deactivated",
 				},
-				{
+				metav1.Condition{
 					Type:    kueue.WorkloadAdmitted,
 					Status:  metav1.ConditionFalse,
-					Reason:  "NoReservation",
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
 					Message: "The workload has no reservation",
 				},
-			}
-			for _, wantCond := range wantConditions {
-				cond := apimeta.FindStatusCondition(updatedWl.Status.Conditions, wantCond.Type)
-				gomega.Expect(cond).NotTo(gomega.BeNil())
-				gomega.Expect(*cond).To(gomega.BeComparableTo(wantCond, util.IgnoreConditionTimestampsAndObservedGeneration))
-			}
+			)
 		})
 	})
 })
@@ -1127,26 +1072,20 @@ var _ = ginkgo.Describe("Workload controller interaction with scheduler", func()
 			wl2 := utiltestingapi.MakeWorkload("wl-waiting-for-quota", ns.Name).Queue("q").Request(corev1.ResourceCPU, "1").Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl2)).To(gomega.Succeed())
 
-			var updatedWl kueue.Workload
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), &updatedWl)).To(gomega.Succeed())
-				g.Expect(updatedWl.Status.Conditions).Should(gomega.HaveLen(2))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			gomega.Expect(updatedWl.Status.Conditions).To(gomega.ContainElements(
-				gomega.BeComparableTo(metav1.Condition{
+			util.ExpectWorkloadToHaveConditions(ctx, k8sClient, client.ObjectKeyFromObject(wl2),
+				metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
 					Reason:  kueue.WorkloadQuotaReservedReasonWaitingForQuota,
 					Message: "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor on-demand, 1 more needed",
-				}, util.IgnoreConditionTimestampsAndObservedGeneration),
-				gomega.BeComparableTo(metav1.Condition{
+				},
+				metav1.Condition{
 					Type:    kueue.WorkloadAdmitted,
 					Status:  metav1.ConditionFalse,
-					Reason:  "NoReservation",
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
 					Message: "The workload has no reservation",
-				}, util.IgnoreConditionTimestampsAndObservedGeneration),
-			))
+				},
+			)
 		})
 
 		ginkgo.It("should dynamically transition between reasons based on precedence", func() {
@@ -1234,12 +1173,11 @@ var _ = ginkgo.Describe("Workload controller interaction with scheduler", func()
 
 	ginkgo.When("the queue doesn't exist and is then created under the observability feature gate", func() {
 		var (
-			ns                   *corev1.Namespace
-			wl                   *kueue.Workload
-			localQueue           *kueue.LocalQueue
-			updatedQueueWorkload kueue.Workload
-			cq                   *kueue.ClusterQueue
-			rf                   *kueue.ResourceFlavor
+			ns         *corev1.Namespace
+			wl         *kueue.Workload
+			localQueue *kueue.LocalQueue
+			cq         *kueue.ClusterQueue
+			rf         *kueue.ResourceFlavor
 		)
 		ginkgo.BeforeEach(func() {
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.UnadmittedWorkloadsObservability, true)
@@ -1276,39 +1214,39 @@ var _ = ginkgo.Describe("Workload controller interaction with scheduler", func()
 			util.MustCreate(ctx, k8sClient, wl)
 
 			ginkgo.By("Verifying workload is marked as misconfigured (missing queue)")
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedQueueWorkload)).To(gomega.Succeed())
-
-				cond := apimeta.FindStatusCondition(updatedQueueWorkload.Status.Conditions, kueue.WorkloadQuotaReserved)
-				g.Expect(cond).NotTo(gomega.BeNil())
-				g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
-				g.Expect(cond.Reason).To(gomega.Equal(kueue.WorkloadQuotaReservedReasonMisconfigured))
-				g.Expect(cond.Message).To(gomega.Equal(fmt.Sprintf("LocalQueue %s doesn't exist", "delayed-queue")))
-
-				admittedCond := apimeta.FindStatusCondition(updatedQueueWorkload.Status.Conditions, kueue.WorkloadAdmitted)
-				g.Expect(admittedCond).NotTo(gomega.BeNil())
-				g.Expect(admittedCond.Status).To(gomega.Equal(metav1.ConditionFalse))
-				g.Expect(admittedCond.Reason).To(gomega.Equal("NoReservation"))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.ExpectWorkloadToHaveConditions(ctx, k8sClient, client.ObjectKeyFromObject(wl),
+				metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
+					Message: "LocalQueue delayed-queue doesn't exist",
+				},
+				metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				},
+			)
 
 			ginkgo.By("Creating the LocalQueue")
 			localQueue = utiltestingapi.MakeLocalQueue("delayed-queue", ns.Name).ClusterQueue(cq.Name).Obj()
 			util.MustCreate(ctx, k8sClient, localQueue)
 
 			ginkgo.By("Verifying workload transitions to ExceedsMaxQuota")
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedQueueWorkload)).To(gomega.Succeed())
-
-				cond := apimeta.FindStatusCondition(updatedQueueWorkload.Status.Conditions, kueue.WorkloadQuotaReserved)
-				g.Expect(cond).NotTo(gomega.BeNil())
-				g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
-				g.Expect(cond.Reason).To(gomega.Equal(kueue.WorkloadQuotaReservedReasonExceedsMaxQuota))
-
-				admittedCond := apimeta.FindStatusCondition(updatedQueueWorkload.Status.Conditions, kueue.WorkloadAdmitted)
-				g.Expect(admittedCond).NotTo(gomega.BeNil())
-				g.Expect(admittedCond.Status).To(gomega.Equal(metav1.ConditionFalse))
-				g.Expect(admittedCond.Reason).To(gomega.Equal("NoReservation"))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.ExpectWorkloadToHaveConditions(ctx, k8sClient, client.ObjectKeyFromObject(wl),
+				metav1.Condition{
+					Type:   kueue.WorkloadQuotaReserved,
+					Status: metav1.ConditionFalse,
+					Reason: kueue.WorkloadQuotaReservedReasonExceedsMaxQuota,
+				},
+				metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				},
+			)
 		})
 	})
 })
@@ -1583,16 +1521,15 @@ var _ = ginkgo.Describe("Workload controller with resource retention", func() {
 			wlKey := client.ObjectKeyFromObject(wl)
 			var updatedWl kueue.Workload
 
-			ginkgo.By("verifying that QuotaReserved is False with Reason Misconfigured", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, wlKey, &updatedWl)).To(gomega.Succeed())
-					cond := apimeta.FindStatusCondition(updatedWl.Status.Conditions, kueue.WorkloadQuotaReserved)
-					g.Expect(cond).NotTo(gomega.BeNil())
-					g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
-					g.Expect(cond.Reason).To(gomega.Equal(string(kueue.WorkloadQuotaReservedReasonMisconfigured)))
-					g.Expect(cond.Message).To(gomega.Equal("workload namespace doesn't match ClusterQueue selector"))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
+			ginkgo.By("verifying that QuotaReserved is False with Reason Misconfigured")
+			util.ExpectWorkloadToHaveConditions(ctx, k8sClient, wlKey,
+				metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
+					Message: "workload namespace doesn't match ClusterQueue selector",
+				},
+			)
 
 			ginkgo.By("updating the Namespace to match ClusterQueue's selector", func() {
 				var fetchedNs corev1.Namespace
@@ -1613,16 +1550,15 @@ var _ = ginkgo.Describe("Workload controller with resource retention", func() {
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			ginkgo.By("verifying that QuotaReserved transitions to PendingEvaluation", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, wlKey, &updatedWl)).To(gomega.Succeed())
-					cond := apimeta.FindStatusCondition(updatedWl.Status.Conditions, kueue.WorkloadQuotaReserved)
-					g.Expect(cond).NotTo(gomega.BeNil())
-					g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
-					g.Expect(cond.Reason).To(gomega.Equal(string(kueue.WorkloadQuotaReservedReasonPendingEvaluation)))
-					g.Expect(cond.Message).To(gomega.Equal("Workload is pending evaluation in the scheduling queue"))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
+			ginkgo.By("verifying that QuotaReserved transitions to PendingEvaluation")
+			util.ExpectWorkloadToHaveConditions(ctx, k8sClient, wlKey,
+				metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonPendingEvaluation,
+					Message: "Workload is pending evaluation in the scheduling queue",
+				},
+			)
 		})
 	})
 })

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -1534,4 +1534,95 @@ var _ = ginkgo.Describe("Workload controller with resource retention", func() {
 			})
 		})
 	})
+
+	ginkgo.Context("with UnadmittedWorkloadsObservability feature gate enabled, namespace selector validation", func() {
+		var (
+			clusterQueue *kueue.ClusterQueue
+			localQueue   *kueue.LocalQueue
+			flavor       *kueue.ResourceFlavor
+			ns           *corev1.Namespace
+		)
+
+		startManager := func() {
+			fwk.StartManager(ctx, cfg, managerSetup)
+		}
+
+		stopManager := func() {
+			fwk.StopManager(ctx)
+		}
+
+		ginkgo.BeforeEach(func() {
+			startManager()
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.UnadmittedWorkloadsObservability, true)
+			ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "core-workload-ns-selector-")
+			flavor = utiltestingapi.MakeResourceFlavor(flavorOnDemand).Obj()
+			gomega.Expect(k8sClient.Create(ctx, flavor)).Should(gomega.Succeed())
+			clusterQueue = utiltestingapi.MakeClusterQueue("cq-ns-selector").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas(flavorOnDemand).
+					Resource(corev1.ResourceCPU, "1").Obj()).
+				NamespaceSelector(&metav1.LabelSelector{
+					MatchLabels: map[string]string{"foo": "bar"},
+				}).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).To(gomega.Succeed())
+			localQueue = utiltestingapi.MakeLocalQueue("q-ns-selector", ns.Name).ClusterQueue("cq-ns-selector").Obj()
+			gomega.Expect(k8sClient.Create(ctx, localQueue)).To(gomega.Succeed())
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, flavor, true)
+			stopManager()
+		})
+
+		ginkgo.It("should set Misconfigured on namespace mismatch and clear it when mismatch resolved", func() {
+			wl := utiltestingapi.MakeWorkload("wl-ns-mismatch", ns.Name).Queue("q-ns-selector").Request(corev1.ResourceCPU, "1").Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+			wlKey := client.ObjectKeyFromObject(wl)
+			var updatedWl kueue.Workload
+
+			ginkgo.By("verifying that QuotaReserved is False with Reason Misconfigured", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &updatedWl)).To(gomega.Succeed())
+					cond := apimeta.FindStatusCondition(updatedWl.Status.Conditions, kueue.WorkloadQuotaReserved)
+					g.Expect(cond).NotTo(gomega.BeNil())
+					g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+					g.Expect(cond.Reason).To(gomega.Equal(string(kueue.WorkloadQuotaReservedReasonMisconfigured)))
+					g.Expect(cond.Message).To(gomega.Equal("workload namespace doesn't match ClusterQueue selector"))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("updating the Namespace to match ClusterQueue's selector", func() {
+				var fetchedNs corev1.Namespace
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ns), &fetchedNs)).To(gomega.Succeed())
+				fetchedNs.Labels = map[string]string{"foo": "bar"}
+				gomega.Expect(k8sClient.Update(ctx, &fetchedNs)).To(gomega.Succeed())
+			})
+
+			ginkgo.By("triggering reconciliation of the workload", func() {
+				// We can update a dummy annotation on the workload to trigger reconcile
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &updatedWl)).To(gomega.Succeed())
+					if updatedWl.Annotations == nil {
+						updatedWl.Annotations = make(map[string]string)
+					}
+					updatedWl.Annotations["trigger-reconcile"] = "true"
+					g.Expect(k8sClient.Update(ctx, &updatedWl)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verifying that QuotaReserved transitions to PendingEvaluation", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &updatedWl)).To(gomega.Succeed())
+					cond := apimeta.FindStatusCondition(updatedWl.Status.Conditions, kueue.WorkloadQuotaReserved)
+					g.Expect(cond).NotTo(gomega.BeNil())
+					g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+					g.Expect(cond.Reason).To(gomega.Equal(string(kueue.WorkloadQuotaReservedReasonPendingEvaluation)))
+					g.Expect(cond.Message).To(gomega.Equal("Workload is pending evaluation in the scheduling queue"))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	})
 })

--- a/test/integration/singlecluster/controller/dra/dra_pd_test.go
+++ b/test/integration/singlecluster/controller/dra/dra_pd_test.go
@@ -584,5 +584,62 @@ var _ = ginkgo.Describe("DRA Partitionable Devices Integration", ginkgo.Ordered,
 				)))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
+
+		ginkgo.It("Should write granular conditions and reasons when DRA claim resolution fails under the observability feature gate", func() {
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.UnadmittedWorkloadsObservability, true)
+
+			ginkgo.By("Creating a ResourceSlice with MIG devices")
+			slice := utiltesting.MakeResourceSlice("pd-nomatch-observability-slice", "gpu.example.com").
+				Pool("node1-gpu0", 1, 1).
+				Device("gpu-0").Attribute("type", "gpu").
+				CounterConsumption("gpu-0-counter-set", "memory", "40320Mi").
+				Device("gpu-0-mig-1g5gb-0").Attribute("type", "mig").Attribute("profile", "1g.5gb").
+				CounterConsumption("gpu-0-counter-set", "memory", "4864Mi").
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, slice)).To(gomega.Succeed())
+			ginkgo.DeferCleanup(func() {
+				gomega.Expect(k8sClient.Delete(ctx, slice)).To(gomega.Succeed())
+			})
+
+			ginkgo.By("Creating RCT with non-matching CEL selectors")
+			rct := utiltesting.MakeResourceClaimTemplate("mig-nonexistent-obs", ns.Name).
+				DeviceRequest("gpu", "mig.example.com", 1).
+				WithCELSelectors("device.attributes['gpu.example.com'].profile == 'nonexistent'").
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, rct)).To(gomega.Succeed())
+
+			ginkgo.By("Creating workload")
+			wl := utiltestingapi.MakeWorkload("pd-nomatch-observability-wl", ns.Name).
+				Queue("pd-lq").
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					ResourceClaimTemplate("mig", "mig-nonexistent-obs").
+					Obj()).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+			ginkgo.By("Verifying workload is marked as inadmissible with granular reasons")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeFalse())
+				g.Expect(updatedWl.Status.Conditions).Should(gomega.HaveLen(3))
+
+				g.Expect(updatedWl.Status.Conditions).To(gomega.ContainElement(gomega.And(
+					gomega.HaveField("Type", kueue.WorkloadQuotaReserved),
+					gomega.HaveField("Status", metav1.ConditionFalse),
+					gomega.HaveField("Reason", kueue.WorkloadQuotaReservedReasonMisconfigured),
+				)))
+				g.Expect(updatedWl.Status.Conditions).To(gomega.ContainElement(gomega.And(
+					gomega.HaveField("Type", kueue.WorkloadAdmitted),
+					gomega.HaveField("Status", metav1.ConditionFalse),
+					gomega.HaveField("Reason", "NoReservation"),
+				)))
+				g.Expect(updatedWl.Status.Conditions).To(gomega.ContainElement(gomega.And(
+					gomega.HaveField("Type", kueue.WorkloadRequeued),
+					gomega.HaveField("Status", metav1.ConditionFalse),
+					gomega.HaveField("Reason", kueue.WorkloadInadmissible),
+				)))
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+		})
 	})
 })

--- a/test/integration/singlecluster/controller/dra/dra_pd_test.go
+++ b/test/integration/singlecluster/controller/dra/dra_pd_test.go
@@ -618,28 +618,26 @@ var _ = ginkgo.Describe("DRA Partitionable Devices Integration", ginkgo.Ordered,
 			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 
 			ginkgo.By("Verifying workload is marked as inadmissible with granular reasons")
-			gomega.Eventually(func(g gomega.Gomega) {
-				var updatedWl kueue.Workload
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
-				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeFalse())
-				g.Expect(updatedWl.Status.Conditions).Should(gomega.HaveLen(3))
-
-				g.Expect(updatedWl.Status.Conditions).To(gomega.ContainElement(gomega.And(
-					gomega.HaveField("Type", kueue.WorkloadQuotaReserved),
-					gomega.HaveField("Status", metav1.ConditionFalse),
-					gomega.HaveField("Reason", kueue.WorkloadQuotaReservedReasonMisconfigured),
-				)))
-				g.Expect(updatedWl.Status.Conditions).To(gomega.ContainElement(gomega.And(
-					gomega.HaveField("Type", kueue.WorkloadAdmitted),
-					gomega.HaveField("Status", metav1.ConditionFalse),
-					gomega.HaveField("Reason", "NoReservation"),
-				)))
-				g.Expect(updatedWl.Status.Conditions).To(gomega.ContainElement(gomega.And(
-					gomega.HaveField("Type", kueue.WorkloadRequeued),
-					gomega.HaveField("Status", metav1.ConditionFalse),
-					gomega.HaveField("Reason", kueue.WorkloadInadmissible),
-				)))
-			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			util.ExpectWorkloadToHaveConditions(ctx, k8sClient, client.ObjectKeyFromObject(wl),
+				metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
+					Message: "spec.podSets[0].template.spec.resourceClaims[0].devices.requests[0].exactly.selectors: Internal error: ResourceClaimTemplate mig-nonexistent-obs: insufficient matching devices for CEL selector in DeviceClass mig.example.com: 0 device(s) match in the cluster but 1 requested",
+				},
+				metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				},
+				metav1.Condition{
+					Type:    kueue.WorkloadRequeued,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadInadmissible,
+					Message: "spec.podSets[0].template.spec.resourceClaims[0].devices.requests[0].exactly.selectors: Internal error: ResourceClaimTemplate mig-nonexistent-obs: insufficient matching devices for CEL selector in DeviceClass mig.example.com: 0 device(s) match in the cluster but 1 requested",
+				},
+			)
 		})
 	})
 })

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -2378,7 +2378,7 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 				metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadPending,
+					Reason:  kueue.WorkloadPending, //nolint:staticcheck // SA1019: legacy reason
 					Message: fmt.Sprintf("Exceeded the PodsReady timeout %s", wlKey.String()),
 				},
 				metav1.Condition{
@@ -2429,7 +2429,7 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 				metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadPending,
+					Reason:  kueue.WorkloadPending, //nolint:staticcheck // SA1019: legacy reason
 					Message: "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
 				},
 				metav1.Condition{

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -2367,45 +2367,45 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 				g.Expect(wl.Status.RequeueState).ShouldNot(gomega.BeNil())
 				g.Expect(wl.Status.RequeueState.Count).Should(gomega.Equal(ptr.To[int32](1)))
 				g.Expect(wl.Status.RequeueState.RequeueAt).Should(gomega.BeNil())
-				g.Expect(wl.Status.Conditions).To(gomega.ContainElements(
-					gomega.BeComparableTo(metav1.Condition{
-						Type:    kueue.WorkloadPodsReady,
-						Status:  metav1.ConditionFalse,
-						Reason:  kueue.WorkloadWaitForStart,
-						Message: "Not all pods are ready or succeeded",
-					}, util.IgnoreConditionTimestampsAndObservedGeneration),
-					gomega.BeComparableTo(metav1.Condition{
-						Type:    kueue.WorkloadQuotaReserved,
-						Status:  metav1.ConditionFalse,
-						Reason:  "Pending",
-						Message: fmt.Sprintf("Exceeded the PodsReady timeout %s", wlKey.String()),
-					}, util.IgnoreConditionTimestampsAndObservedGeneration),
-					gomega.BeComparableTo(metav1.Condition{
-						Type:    kueue.WorkloadEvicted,
-						Status:  metav1.ConditionTrue,
-						Reason:  "PodsReadyTimeout",
-						Message: fmt.Sprintf("Exceeded the PodsReady timeout %s", wlKey.String()),
-					}, util.IgnoreConditionTimestampsAndObservedGeneration),
-					gomega.BeComparableTo(metav1.Condition{
-						Type:    kueue.WorkloadAdmitted,
-						Status:  metav1.ConditionFalse,
-						Reason:  "NoReservation",
-						Message: "The workload has no reservation",
-					}, util.IgnoreConditionTimestampsAndObservedGeneration),
-					gomega.BeComparableTo(metav1.Condition{
-						Type:    kueue.WorkloadRequeued,
-						Status:  metav1.ConditionTrue,
-						Reason:  kueue.WorkloadBackoffFinished,
-						Message: "The workload backoff was finished",
-					}, util.IgnoreConditionTimestampsAndObservedGeneration),
-					gomega.BeComparableTo(metav1.Condition{
-						Type:    podcontroller.WorkloadWaitingForReplacementPods,
-						Status:  metav1.ConditionTrue,
-						Reason:  "PodsReadyTimeout",
-						Message: fmt.Sprintf("Exceeded the PodsReady timeout %s", wlKey.String()),
-					}, util.IgnoreConditionTimestampsAndObservedGeneration),
-				))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.ExpectWorkloadToHaveConditions(ctx, k8sClient, wlKey,
+				metav1.Condition{
+					Type:    kueue.WorkloadPodsReady,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadWaitForStart,
+					Message: "Not all pods are ready or succeeded",
+				},
+				metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadPending,
+					Message: fmt.Sprintf("Exceeded the PodsReady timeout %s", wlKey.String()),
+				},
+				metav1.Condition{
+					Type:    kueue.WorkloadEvicted,
+					Status:  metav1.ConditionTrue,
+					Reason:  "PodsReadyTimeout",
+					Message: fmt.Sprintf("Exceeded the PodsReady timeout %s", wlKey.String()),
+				},
+				metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				},
+				metav1.Condition{
+					Type:    kueue.WorkloadRequeued,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueue.WorkloadBackoffFinished,
+					Message: "The workload backoff was finished",
+				},
+				metav1.Condition{
+					Type:    podcontroller.WorkloadWaitingForReplacementPods,
+					Status:  metav1.ConditionTrue,
+					Reason:  "PodsReadyTimeout",
+					Message: fmt.Sprintf("Exceeded the PodsReady timeout %s", wlKey.String()),
+				},
+			)
 
 			ginkgo.By("re-admit the workload to exceed the backoffLimitCount", func() {
 				util.SetQuotaReservation(ctx, k8sClient, wlKey, admission)
@@ -2417,40 +2417,40 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 				g.Expect(workload.IsActive(wl)).Should(gomega.BeFalse())
 				g.Expect(wl.Status.RequeueState).Should(gomega.BeNil())
-				g.Expect(wl.Status.Conditions).To(gomega.ContainElements(
-					gomega.BeComparableTo(metav1.Condition{
-						Type:    kueue.WorkloadPodsReady,
-						Status:  metav1.ConditionFalse,
-						Reason:  kueue.WorkloadWaitForStart,
-						Message: "Not all pods are ready or succeeded",
-					}, util.IgnoreConditionTimestampsAndObservedGeneration),
-					gomega.BeComparableTo(metav1.Condition{
-						Type:    kueue.WorkloadQuotaReserved,
-						Status:  metav1.ConditionFalse,
-						Reason:  "Pending",
-						Message: "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
-					}, util.IgnoreConditionTimestampsAndObservedGeneration),
-					gomega.BeComparableTo(metav1.Condition{
-						Type:    kueue.WorkloadEvicted,
-						Status:  metav1.ConditionTrue,
-						Reason:  "DeactivatedDueToRequeuingLimitExceeded",
-						Message: "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
-					}, util.IgnoreConditionTimestampsAndObservedGeneration),
-					gomega.BeComparableTo(metav1.Condition{
-						Type:    kueue.WorkloadAdmitted,
-						Status:  metav1.ConditionFalse,
-						Reason:  "NoReservation",
-						Message: "The workload has no reservation",
-					}, util.IgnoreConditionTimestampsAndObservedGeneration),
-					gomega.BeComparableTo(metav1.Condition{
-						Type:    podcontroller.WorkloadWaitingForReplacementPods,
-						Status:  metav1.ConditionTrue,
-						Reason:  "DeactivatedDueToRequeuingLimitExceeded",
-						Message: "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
-					}, util.IgnoreConditionTimestampsAndObservedGeneration),
-				))
 				g.Expect(wl.Status.Conditions).ShouldNot(utiltesting.HaveCondition(kueue.WorkloadDeactivationTarget))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.ExpectWorkloadToHaveConditions(ctx, k8sClient, wlKey,
+				metav1.Condition{
+					Type:    kueue.WorkloadPodsReady,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadWaitForStart,
+					Message: "Not all pods are ready or succeeded",
+				},
+				metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadPending,
+					Message: "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
+				},
+				metav1.Condition{
+					Type:    kueue.WorkloadEvicted,
+					Status:  metav1.ConditionTrue,
+					Reason:  "DeactivatedDueToRequeuingLimitExceeded",
+					Message: "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
+				},
+				metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				},
+				metav1.Condition{
+					Type:    podcontroller.WorkloadWaitingForReplacementPods,
+					Status:  metav1.ConditionTrue,
+					Reason:  "DeactivatedDueToRequeuingLimitExceeded",
+					Message: "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
+				},
+			)
 		})
 	})
 })

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -479,8 +479,8 @@ func ExpectWorkloadsToBePending(ctx context.Context, k8sClient client.Client, wl
 }
 
 var pendingQuotaReservedReasons = sets.New(
-	kueue.WorkloadPending,
-	kueue.WorkloadWaiting,
+	kueue.WorkloadPending, //nolint:staticcheck // SA1019: legacy reason
+	kueue.WorkloadWaiting, //nolint:staticcheck // SA1019: legacy reason
 	kueue.WorkloadQuotaReservedReasonPendingEvaluation,
 	kueue.WorkloadQuotaReservedReasonWaitingForQuota,
 	kueue.WorkloadQuotaReservedReasonExceedsMaxQuota,
@@ -721,7 +721,7 @@ func ExpectWorkloadsToBeWaiting(ctx context.Context, k8sClient client.Client, wl
 			wl := &kueue.Workload{}
 			g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
 			cond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
-			if cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == kueue.WorkloadWaiting {
+			if cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == kueue.WorkloadWaiting { //nolint:staticcheck // SA1019: legacy reason
 				waiting = append(waiting, wlKey)
 			}
 			wlObjects[i] = wl
@@ -876,7 +876,7 @@ func FinishEvictionForWorkloads(ctx context.Context, k8sClient client.Client, wl
 			if workload.HasQuotaReservation(wl) {
 				g.Expect(
 					workloadpatching.PatchAdmissionStatus(ctx, k8sClient, wl, RealClock, func(wl *kueue.Workload) (bool, error) {
-						return workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadPending, "By test", time.Now()), nil
+						return workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadPending, "By test", time.Now()), nil //nolint:staticcheck // SA1019: legacy reason
 					}),
 				).Should(gomega.Succeed(), fmt.Sprintf("Unable to unset quota reservation for %q", key))
 			}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -477,6 +477,18 @@ func ExpectWorkloadsToBePending(ctx context.Context, k8sClient client.Client, wl
 	ExpectWorkloadsToBePendingByKeys(ctx, k8sClient, wlKeys...)
 }
 
+var pendingQuotaReservedReasons = sets.New(
+	"Pending",
+	"Waiting",
+	kueue.WorkloadQuotaReservedReasonPendingEvaluation,
+	kueue.WorkloadQuotaReservedReasonWaitingForQuota,
+	kueue.WorkloadQuotaReservedReasonExceedsMaxQuota,
+	kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+	kueue.WorkloadQuotaReservedReasonTopologyPlacementFailed,
+	kueue.WorkloadQuotaReservedReasonWaitingForPodsReady,
+	kueue.WorkloadQuotaReservedReasonNoMatchingFlavor,
+)
+
 func ExpectWorkloadsToBePendingByKeys(ctx context.Context, k8sClient client.Client, wlKeys ...client.ObjectKey) {
 	ginkgo.GinkgoHelper()
 	wlKeys = uniqueKeys(wlKeys)
@@ -487,7 +499,7 @@ func ExpectWorkloadsToBePendingByKeys(ctx context.Context, k8sClient client.Clie
 			wl := &kueue.Workload{}
 			g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
 			cond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
-			if cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == "Pending" {
+			if cond != nil && cond.Status == metav1.ConditionFalse && pendingQuotaReservedReasons.Has(cond.Reason) {
 				pending = append(pending, wlKey)
 			}
 			wlObjects[i] = wl

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	gocmp "github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	kfmpi "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
 	sparkv1beta2 "github.com/kubeflow/spark-operator/v2/api/v1beta2"
@@ -478,8 +479,8 @@ func ExpectWorkloadsToBePending(ctx context.Context, k8sClient client.Client, wl
 }
 
 var pendingQuotaReservedReasons = sets.New(
-	"Pending",
-	"Waiting",
+	kueue.WorkloadPending,
+	kueue.WorkloadWaiting,
 	kueue.WorkloadQuotaReservedReasonPendingEvaluation,
 	kueue.WorkloadQuotaReservedReasonWaitingForQuota,
 	kueue.WorkloadQuotaReservedReasonExceedsMaxQuota,
@@ -720,7 +721,7 @@ func ExpectWorkloadsToBeWaiting(ctx context.Context, k8sClient client.Client, wl
 			wl := &kueue.Workload{}
 			g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
 			cond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
-			if cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == "Waiting" {
+			if cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == kueue.WorkloadWaiting {
 				waiting = append(waiting, wlKey)
 			}
 			wlObjects[i] = wl
@@ -875,7 +876,7 @@ func FinishEvictionForWorkloads(ctx context.Context, k8sClient client.Client, wl
 			if workload.HasQuotaReservation(wl) {
 				g.Expect(
 					workloadpatching.PatchAdmissionStatus(ctx, k8sClient, wl, RealClock, func(wl *kueue.Workload) (bool, error) {
-						return workload.UnsetQuotaReservationWithCondition(wl, "Pending", "By test", time.Now()), nil
+						return workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadPending, "By test", time.Now()), nil
 					}),
 				).Should(gomega.Succeed(), fmt.Sprintf("Unable to unset quota reservation for %q", key))
 			}
@@ -1684,4 +1685,26 @@ func WaitForDRAExampleDriverAvailability(ctx context.Context, k8sClient client.C
 		g.Expect(daemonset.Status.DesiredNumberScheduled).To(gomega.Equal(daemonset.Status.NumberAvailable))
 	}, VeryLongTimeout, Interval).Should(gomega.Succeed())
 	ginkgo.GinkgoLogr.Info("DaemonSet is available in the cluster", "daemonset", dsKey, "cluster", clusterName, "waitingTime", time.Since(waitForAvailableStart))
+}
+
+func ExpectWorkloadToHaveConditions(
+	ctx context.Context,
+	k8sClient client.Client,
+	wlKey client.ObjectKey,
+	wantConditions ...metav1.Condition,
+) {
+	ginkgo.GinkgoHelper()
+	wl := &kueue.Workload{}
+	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
+		g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
+		for _, wantCond := range wantConditions {
+			cond := apimeta.FindStatusCondition(wl.Status.Conditions, wantCond.Type)
+			g.Expect(cond).NotTo(gomega.BeNil())
+			opts := []gocmp.Option{IgnoreConditionTimestampsAndObservedGeneration}
+			if wantCond.Message == "" {
+				opts = append(opts, IgnoreConditionMessage)
+			}
+			g.Expect(*cond).To(gomega.BeComparableTo(wantCond, opts...))
+		}
+	}, Timeout, Interval).Should(gomega.Succeed(), AssertMsg("Workload conditions did not match expectations", wl))
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR implements the status condition and granular reason resolution for unadmitted workloads in the workload_controller, as part of the UnadmittedWorkloadsObservability feature gate.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #10852

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Observability: Added support for the UnadmittedWorkloadsObservability feature gate in the workload controller. When enabled, Kueue populates the QuotaReserved workload condition with granular reasons (such as Misconfigured, Suspended, or AdmissionGated) and detailed messages when a workload cannot be admitted, making it easier for operators to diagnose admission issues.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added more detailed workload status tracking so pending, blocked, and unadmitted states now surface clearer reasons and messages.
  * Expanded DRA and scheduler scenarios to show why a workload is not ready or cannot proceed.

* **Bug Fixes**
  * Improved how workload conditions are updated when queues are missing, inactive, on hold, or admission is gated.
  * Preserved more specific quota-related status reasons instead of replacing them with generic pending states.

* **Tests**
  * Added broader integration coverage for feature-gated workload behavior and condition transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->