### PR TITLE
Fix KueueViz secure deployments

### DIFF
--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -166,7 +166,7 @@ The following table lists the configurable parameters of the kueue chart and the
 | kueueViz.backend.priorityClassName | string | `nil` | Enable PriorityClass for KueueViz dashboard backend deployments |
 | kueueViz.backend.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"500m","memory":"512Mi"}}` | KueueViz backend pod resources |
 | kueueViz.backend.tolerations | list | `[]` | KueueViz backend tolerations |
-| kueueViz.frontend.containerSecurityContext | object | `{}` | KueueViz frontend container securityContext |
+| kueueViz.frontend.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | KueueViz frontend container securityContext |
 | kueueViz.frontend.env | list | `[]` | Environment variables for KueueViz frontend deployment |
 | kueueViz.frontend.image.pullPolicy | string | `"Always"` | KueueViz dashboard frontend image pullPolicy. This should be set to 'IfNotPresent' for released version |
 | kueueViz.frontend.image.repository | string | `"us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-frontend"` | KueueViz dashboard frontend image repository |
@@ -178,7 +178,7 @@ The following table lists the configurable parameters of the kueue chart and the
 | kueueViz.frontend.ingress.ingressClassName | string | `nil` | KueueViz dashboard frontend ingress class name |
 | kueueViz.frontend.ingress.tlsSecretName | string | `"kueueviz-frontend-tls"` | KueueViz dashboard frontend ingress tls secret name |
 | kueueViz.frontend.nodeSelector | object | `{}` | KueueViz frontend nodeSelector |
-| kueueViz.frontend.podSecurityContext | object | `{}` | KueueViz frontend pod securityContext |
+| kueueViz.frontend.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}}` | KueueViz frontend pod securityContext |
 | kueueViz.frontend.priorityClassName | string | `nil` | Enable PriorityClass for KueueViz dashboard frontend deployments |
 | kueueViz.frontend.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"500m","memory":"512Mi"}}` | KueueViz frontend pod resources |
 | kueueViz.frontend.tolerations | list | `[]` | KueueViz frontend tolerations |

--- a/charts/kueue/templates/kueueviz/backend-deployment.yaml
+++ b/charts/kueue/templates/kueueviz/backend-deployment.yaml
@@ -77,4 +77,16 @@ spec:
           {{- end }}
           ports:
             - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
 {{- end }}

--- a/charts/kueue/templates/kueueviz/frontend-deployment.yaml
+++ b/charts/kueue/templates/kueueviz/frontend-deployment.yaml
@@ -78,4 +78,16 @@ spec:
               mountPath: /app/build/env.js
               subPath: env.js
               readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
 {{- end }}

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -312,6 +312,7 @@ kueueViz:
     # -- KueueViz frontend pod securityContext
     podSecurityContext:
       runAsNonRoot: true
+      runAsUser: 1000
       seccompProfile:
         type: RuntimeDefault
     # -- KueueViz frontend container securityContext

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -310,9 +310,17 @@ kueueViz:
         cpu: 500m
         memory: 512Mi
     # -- KueueViz frontend pod securityContext
-    podSecurityContext: {}
+    podSecurityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
     # -- KueueViz frontend container securityContext
-    containerSecurityContext: {}
+    containerSecurityContext:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
     # -- Environment variables for KueueViz frontend deployment
     env: []
     ingress:

--- a/config/components/kueueviz/backend-deployment.yaml
+++ b/config/components/kueueviz/backend-deployment.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         app: kueueviz-backend
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: backend
           image: backend:lastest
@@ -27,3 +31,21 @@ spec:
             requests:
               cpu: 500m
               memory: 512Mi
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10

--- a/config/components/kueueviz/frontend-deployment.yaml
+++ b/config/components/kueueviz/frontend-deployment.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         app: kueueviz-frontend
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
         - name: env-config
           configMap:
@@ -36,3 +40,21 @@ spec:
               mountPath: /app/build/env.js
               subPath: env.js
               readOnly: true
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10

--- a/config/components/kueueviz/frontend-deployment.yaml
+++ b/config/components/kueueviz/frontend-deployment.yaml
@@ -16,6 +16,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
       volumes:

--- a/hack/processing-plan.yaml
+++ b/hack/processing-plan.yaml
@@ -419,6 +419,18 @@ files:
       - type: DELETE
         key: .spec.template.spec.containers.[].resources
         onFileCondition: '.kind == "Deployment" and .metadata.name | contains("kueueviz-frontend")'
+      - type: DELETE
+        key: .spec.template.spec.securityContext
+        onFileCondition: '.kind == "Deployment" and .metadata.name | contains("kueueviz-backend")'
+      - type: DELETE
+        key: .spec.template.spec.containers.[].securityContext
+        onFileCondition: '.kind == "Deployment" and .metadata.name | contains("kueueviz-backend")'
+      - type: DELETE
+        key: .spec.template.spec.securityContext
+        onFileCondition: '.kind == "Deployment" and .metadata.name | contains("kueueviz-frontend")'
+      - type: DELETE
+        key: .spec.template.spec.containers.[].securityContext
+        onFileCondition: '.kind == "Deployment" and .metadata.name | contains("kueueviz-frontend")'
     postOperations:
       - type: INSERT_TEXT
         key: .spec


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/area dashboard

#### What this PR does / why we need it:

Populates the frontend Helm defaults to match the backend (runAsNonRoot: true, seccompProfile RuntimeDefault, readOnlyRootFilesystem: true, allowPrivilegeEscalation: false, drop ALL) and mirrors into config/components/kueueviz/*-deployment.yaml. Adds httpGet liveness/readiness probes on the serving port for both workloads.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12481

#### Special notes for your reviewer:

The server only exposes `/healthz` (no `/readyz`), so I have used it for both liveness and readiness probes for the backend. Frontend is serving static files, there is no health endpoint, so I have used `/` for both httpGet liveness/readiness probes.

The `runAsUser: 1000` is set in the frontend deployment because `runAsNonRoot: true` rejects the default root user in `node:26-slim`.

Note: AI tools were used to assist with code review and guidance during this change.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
KueueViz: frontend and backend deployments include securityContext defaults (runAsNonRoot, readOnlyRootFilesystem, drop ALL capabilities) and httpGet liveness/readiness probes.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added Kubernetes liveness and readiness probes for both the KueueViz frontend and backend to improve reliability during startup and runtime.
* **Bug Fixes**
  * Improved availability detection so services are only marked ready when they’re actually responding.
* **Security**
  * Hardened KueueViz frontend and backend deployments with non-root execution, read-only root filesystems, and reduced Linux privileges.  
* **Documentation**
  * Updated the chart’s default security settings documentation to reflect the hardened defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->