### PR TITLE
Remove mgr.GetEventRecorderFor is deprecated exclusion.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -92,9 +92,6 @@ linters:
         text: 'SA1019: features.* is deprecated: planned to be removed in .*'
       - linters:
           - staticcheck
-        text: 'SA1019: mgr.GetEventRecorderFor is deprecated: this uses the old events API and will be removed in a future release. Please use GetEventRecorder instead.'
-      - linters:
-          - staticcheck
         text: 'SA1019: scheme.Builder is deprecated: This helper is only useful in api packages'
       - linters:
           - fatcontext

--- a/pkg/controller/admissionchecks/multikueue/clusterqueue_test.go
+++ b/pkg/controller/admissionchecks/multikueue/clusterqueue_test.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -455,7 +454,8 @@ func TestCQReconcile(t *testing.T) {
 				Build()
 
 			adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
-			cRec := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, record.NewFakeRecorder(10))
+			recorder := &utiltesting.EventRecorder{}
+			cRec := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, recorder)
 			cRec.rootContext = ctx
 			for worker, wState := range tc.workers {
 				workerClient := NewNeverCachingClient(utiltesting.NewClientBuilder().

--- a/pkg/controller/admissionchecks/multikueue/controllers.go
+++ b/pkg/controller/admissionchecks/multikueue/controllers.go
@@ -155,7 +155,7 @@ func SetupControllers(mgr ctrl.Manager, namespace string, opts ...SetupOption) e
 	cRec := newClustersReconciler(
 		mgr.GetClient(), namespace, options.gcInterval, options.origin, fsWatcher,
 		options.adapters, cpAccessProvider, options.roleTracker,
-		mgr.GetEventRecorderFor("multikueue-cluster"),
+		mgr.GetEventRecorder("multikueue-cluster"),
 	)
 	err = cRec.setupWithManager(mgr)
 	if err != nil {

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -46,7 +46,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
@@ -585,7 +585,7 @@ type clustersReconciler struct {
 	localClient          client.Client
 	configNamespace      string
 	kubeConfigPathPrefix string
-	recorder             record.EventRecorder
+	recorder             events.EventRecorder
 
 	lock sync.RWMutex
 	// The list of remote remoteClients, indexed by the cluster name.
@@ -724,7 +724,7 @@ func (c *clustersReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 	if cluster.Spec.ClusterSource.KubeConfig != nil &&
 		cluster.Spec.ClusterSource.KubeConfig.LocationType == kueue.PathLocationType &&
 		!features.Enabled(features.MultiKueueKubeConfigPathValidation) {
-		c.recorder.Event(cluster, corev1.EventTypeWarning, "DeprecatedPathUsage",
+		c.recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "DeprecatedPathUsage", "DeprecatedPathUsage",
 			"Using locationType=Path without MultiKueueKubeConfigPathValidation feature gate is deprecated and will be removed in a future release. "+
 				"Enable the MultiKueueKubeConfigPathValidation feature gate and place kubeconfig files under /etc/multikueue/kubeconfigs/.")
 	}
@@ -1047,7 +1047,7 @@ func newClustersReconciler(
 	adapters map[string]jobframework.MultiKueueAdapter,
 	cpAccessProvider clusterProfileAccessProvider,
 	roleTracker *roletracker.RoleTracker,
-	recorder record.EventRecorder,
+	recorder events.EventRecorder,
 ) *clustersReconciler {
 	return &clustersReconciler{
 		localClient:                  c,

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
 	inventoryv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
@@ -197,7 +196,7 @@ func TestUpdateConfig(t *testing.T) {
 		wantRequeueAfter              time.Duration
 		wantCancelCalled              int
 		wantErr                       error
-		wantEvent                     string
+		wantEvents                    []utiltesting.EventRecord
 		overrideKubeConfigPrefix      bool
 		multiKueueSafePathFeatureGate bool
 	}{
@@ -634,7 +633,14 @@ func TestUpdateConfig(t *testing.T) {
 				"worker1": newTestClient(ctx, []byte(testKubeconfig("worker1")), nil, nil),
 			},
 			multiKueueSafePathFeatureGate: false,
-			wantEvent:                     "Warning DeprecatedPathUsage Using locationType=Path without MultiKueueKubeConfigPathValidation feature gate is deprecated and will be removed in a future release. Enable the MultiKueueKubeConfigPathValidation feature gate and place kubeconfig files under /etc/multikueue/kubeconfigs/.",
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "worker1"},
+					EventType: "Warning",
+					Reason:    "DeprecatedPathUsage",
+					Message:   "Using locationType=Path without MultiKueueKubeConfigPathValidation feature gate is deprecated and will be removed in a future release. Enable the MultiKueueKubeConfigPathValidation feature gate and place kubeconfig files under /etc/multikueue/kubeconfigs/.",
+				},
+			},
 		},
 		"invalid rest config from cluster profile": {
 			reconcileFor: "invalid",
@@ -675,8 +681,8 @@ func TestUpdateConfig(t *testing.T) {
 			c := builder.Build()
 
 			adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
-			fakeRecorder := record.NewFakeRecorder(10)
-			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, tc.cpAccessProvider, nil, fakeRecorder)
+			recorder := &utiltesting.EventRecorder{}
+			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, tc.cpAccessProvider, nil, recorder)
 
 			reconciler.rootContext = ctx
 
@@ -755,23 +761,8 @@ func TestUpdateConfig(t *testing.T) {
 				t.Errorf("unexpected controllers (-want/+got):\n%s", diff)
 			}
 
-			// Check for expected events.
-			if tc.wantEvent != "" {
-				select {
-				case gotEvent := <-fakeRecorder.Events:
-					if diff := cmp.Diff(tc.wantEvent, gotEvent); diff != "" {
-						t.Errorf("unexpected event (-want/+got):\n%s", diff)
-					}
-				default:
-					t.Error("expected a warning event but none was recorded")
-				}
-			} else {
-				select {
-				case gotEvent := <-fakeRecorder.Events:
-					t.Errorf("unexpected event recorded: %s", gotEvent)
-				default:
-					// No event expected, none received. Good.
-				}
+			if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents); diff != "" {
+				t.Errorf("unexpected events (-want/+got):\n%s", diff)
 			}
 		})
 	}
@@ -849,7 +840,8 @@ func TestReconnectBackoff(t *testing.T) {
 			c := builder.Build()
 
 			adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
-			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileAccessProvider{}, nil, record.NewFakeRecorder(10))
+			recorder := &utiltesting.EventRecorder{}
+			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileAccessProvider{}, nil, recorder)
 			reconciler.rootContext = ctx
 
 			var buildCalls int
@@ -904,7 +896,8 @@ func TestDisconnectedClientReconnectsWithSameConfig(t *testing.T) {
 	c := builder.Build()
 
 	adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
-	reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileAccessProvider{}, nil, record.NewFakeRecorder(10))
+	recorder := &utiltesting.EventRecorder{}
+	reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileAccessProvider{}, nil, recorder)
 	reconciler.rootContext = ctx
 
 	var buildCalls int
@@ -1232,7 +1225,8 @@ func TestClustersReconcilerEventFilters(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
 			c := getClientBuilder(ctx).Build()
-			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, newKubeConfigFSWatcher(), nil, &NoOpClusterProfileAccessProvider{}, nil, record.NewFakeRecorder(10))
+			recorder := &utiltesting.EventRecorder{}
+			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, newKubeConfigFSWatcher(), nil, &NoOpClusterProfileAccessProvider{}, nil, recorder)
 			reconciler.rootContext = ctx
 
 			if got := tc.invoke(reconciler); got != tc.wantReconcile {
@@ -1398,7 +1392,8 @@ func TestSetRemoteClientConfigDoesNotBlockOtherClusters(t *testing.T) {
 		WithStatusSubresource(slowCluster, fastCluster).
 		Build()
 
-	reconciler := newClustersReconciler(localClient, TestNamespace, 0, defaultOrigin, nil, nil, &NoOpClusterProfileAccessProvider{}, nil, record.NewFakeRecorder(10))
+	recorder := &utiltesting.EventRecorder{}
+	reconciler := newClustersReconciler(localClient, TestNamespace, 0, defaultOrigin, nil, nil, &NoOpClusterProfileAccessProvider{}, nil, recorder)
 	reconciler.rootContext = ctx
 	reconciler.builderOverride = gatedBuilder
 

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/tools/record"
 	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
@@ -1630,7 +1629,8 @@ func TestWlReconcile(t *testing.T) {
 
 				managerClient := managerBuilder.Build()
 				adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
-				cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, record.NewFakeRecorder(10))
+				recorder := &utiltesting.EventRecorder{}
+				cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, recorder)
 
 				worker1Client := NewNeverCachingClient(getClientBuilder(ctx).
 					WithLists(&kueue.WorkloadList{Items: tc.worker1Workloads}, &batchv1.JobList{Items: tc.worker1Jobs}).
@@ -1678,7 +1678,6 @@ func TestWlReconcile(t *testing.T) {
 				}
 
 				helper, _ := admissioncheck.NewMultiKueueStoreHelper(managerClient)
-				recorder := &utiltesting.EventRecorder{}
 				mkDispatcherName := ptr.Deref(tc.dispatcherName, config.MultiKueueDispatcherModeAllAtOnce)
 				reconciler := newWlReconciler(managerClient, helper, cRec, defaultOrigin, recorder, defaultWorkerLostTimeout, time.Second, adapters, mkDispatcherName, nil, WithClock(t, fakeClock))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area testing

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Remove mgr.GetEventRecorderFor is deprecated exclusion.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated linting exclusion rules to align with current standards, reducing deprecated API warning noise.
  * Refined static analysis suppressions for additional deprecations and narrowed a fatcontext rule for test paths.
* **Tests**
  * Updated multikueue controller tests to use a shared custom event recorder and structured event assertions instead of client-go fake recorders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->