### PR TITLE
test: move kueuectl e2e tests to integration tests

### DIFF
--- a/test/e2e/singlecluster/baseline/kueuectl_test.go
+++ b/test/e2e/singlecluster/baseline/kueuectl_test.go
@@ -17,20 +17,21 @@ limitations under the License.
 package baseline
 
 import (
+	"bytes"
 	"encoding/json"
 	"os/exec"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/test/util"
 )
 
+// Sanity check that the compiled kueuectl binary works end-to-end.
+// The remaining 7 cases live in the integration suite.
 var _ = ginkgo.Describe("Kueuectl", ginkgo.Label("area:singlecluster", "feature:kueuectl"), func() {
 	var (
 		ns *corev1.Namespace
@@ -49,168 +50,31 @@ var _ = ginkgo.Describe("Kueuectl", ginkgo.Label("area:singlecluster", "feature:
 		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
 	})
 
-	ginkgo.When("Creating a LocalQueue", func() {
-		ginkgo.It("Should create local queue", func() {
-			lqName := "e2e-lq"
+	ginkgo.It("Should create a local queue and list it back", func() {
+		lqName := "e2e-lq-sanity"
 
-			ginkgo.By("Create local queue by kueuectl", func() {
-				cmd := exec.Command(kueuectlPath, "create", "localqueue", lqName, "--clusterqueue", cq.Name, "--namespace", ns.Name)
-				output, err := cmd.CombinedOutput()
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
-			})
-
-			ginkgo.By("Check that the local queue successfully created", func() {
-				var createdQueue kueue.LocalQueue
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lqName, Namespace: ns.Name}, &createdQueue)).To(gomega.Succeed())
-					g.Expect(createdQueue.Name).Should(gomega.Equal(lqName))
-					g.Expect(createdQueue.Spec.ClusterQueue).Should(gomega.Equal(kueue.ClusterQueueReference(cq.Name)))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
+		ginkgo.By("Create local queue via the kueuectl binary", func() {
+			cmd := exec.Command(kueuectlPath, "create", "localqueue", lqName,
+				"--clusterqueue", cq.Name, "--namespace", ns.Name)
+			output, err := cmd.CombinedOutput()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
 		})
 
-		ginkgo.It("Shouldn't create local queue with unknown cluster queue", func() {
-			lqName := "e2e-lq"
-			cqName := "e2e-cq-unknown"
+		ginkgo.By("List local queues via the kueuectl binary and verify the new one appears", func() {
+			var stdout, stderr bytes.Buffer
+			cmd := exec.Command(kueuectlPath, "list", "localqueue",
+				"--namespace", ns.Name, "-o", "json")
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+			err := cmd.Run()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "stderr: %s", stderr.String())
 
-			ginkgo.By("Create local queue by kueuectl", func() {
-				cmd := exec.Command(kueuectlPath, "create", "localqueue", lqName, "--clusterqueue", cqName, "--namespace", ns.Name)
-				_, err := cmd.CombinedOutput()
-				gomega.Expect(err).To(gomega.HaveOccurred())
-			})
-
-			ginkgo.By("Check that the local queue did not create", func() {
-				var createdQueue kueue.LocalQueue
-				gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lqName, Namespace: ns.Name}, &createdQueue)).ToNot(gomega.Succeed())
-			})
-		})
-
-		ginkgo.It("Should print the created local queue as YAML", func() {
-			lqName := "e2e-lq-yaml"
-
-			var output []byte
-			ginkgo.By("Create local queue and capture YAML output", func() {
-				cmd := exec.Command(kueuectlPath, "create", "localqueue", lqName,
-					"--clusterqueue", cq.Name, "--namespace", ns.Name, "-o", "yaml")
-				var err error
-				output, err = cmd.CombinedOutput()
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
-			})
-
-			ginkgo.By("Verify the YAML output contains the resource", func() {
-				gomega.Expect(string(output)).To(gomega.ContainSubstring("kind: LocalQueue"))
-				gomega.Expect(string(output)).To(gomega.ContainSubstring("name: " + lqName))
-				gomega.Expect(string(output)).To(gomega.ContainSubstring("clusterQueue: " + cq.Name))
-			})
-		})
-
-		ginkgo.It("Should print the created local queue as JSON", func() {
-			lqName := "e2e-lq-json"
-
-			var output []byte
-			ginkgo.By("Create local queue and capture JSON output", func() {
-				cmd := exec.Command(kueuectlPath, "create", "localqueue", lqName,
-					"--clusterqueue", cq.Name, "--namespace", ns.Name, "-o", "json")
-				var err error
-				output, err = cmd.CombinedOutput()
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
-			})
-
-			ginkgo.By("Verify the JSON output round-trips into the LocalQueue type", func() {
-				var created kueue.LocalQueue
-				gomega.Expect(json.Unmarshal(output, &created)).To(gomega.Succeed())
-				gomega.Expect(created.Name).To(gomega.Equal(lqName))
-				gomega.Expect(string(created.Spec.ClusterQueue)).To(gomega.Equal(cq.Name))
-			})
-		})
-
-		ginkgo.It("Should not create local queue with --dry-run=client", func() {
-			lqName := "e2e-lq-dryrun"
-
-			var output []byte
-			ginkgo.By("Create local queue with --dry-run=client and capture output", func() {
-				cmd := exec.Command(kueuectlPath, "create", "localqueue", lqName,
-					"--clusterqueue", cq.Name, "--namespace", ns.Name, "--dry-run=client")
-				var err error
-				output, err = cmd.CombinedOutput()
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
-			})
-
-			ginkgo.By("Verify the local queue was NOT created in the cluster", func() {
-				var createdQueue kueue.LocalQueue
-				gomega.Consistently(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lqName, Namespace: ns.Name}, &createdQueue)).To(utiltesting.BeNotFoundError())
-				}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("Verify the local queue object is still printed to stdout", func() {
-				gomega.Expect(string(output)).To(gomega.ContainSubstring(lqName))
-			})
-		})
-	})
-
-	ginkgo.When("Listing a LocalQueue", func() {
-		ginkgo.BeforeEach(func() {
-			lq := utiltestingapi.MakeLocalQueue("e2e-lq-list", ns.Name).ClusterQueue(cq.Name).Obj()
-			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
-		})
-
-		ginkgo.It("Should list local queues in the current namespace as JSON", func() {
-			var output []byte
-			ginkgo.By("List local queues in JSON", func() {
-				cmd := exec.Command(kueuectlPath, "list", "localqueue", "--namespace", ns.Name, "-o", "json")
-				var err error
-				output, err = cmd.CombinedOutput()
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
-			})
-
-			ginkgo.By("Verify the JSON output round-trips into the LocalQueueList type", func() {
-				var list kueue.LocalQueueList
-				gomega.Expect(json.Unmarshal(output, &list)).To(gomega.Succeed())
-				gomega.Expect(list.Items).To(gomega.HaveLen(1))
-				gomega.Expect(list.Items[0].Name).To(gomega.Equal("e2e-lq-list"))
-				gomega.Expect(string(list.Items[0].Spec.ClusterQueue)).To(gomega.Equal(cq.Name))
-			})
-		})
-
-		ginkgo.It("Should list local queues across all namespaces with -A", func() {
-			otherNs := util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-other-")
-			ginkgo.DeferCleanup(func() {
-				gomega.Expect(util.DeleteNamespace(ctx, k8sClient, otherNs)).To(gomega.Succeed())
-			})
-			otherLq := utiltestingapi.MakeLocalQueue("e2e-lq-other", otherNs.Name).ClusterQueue(cq.Name).Obj()
-			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, otherLq)
-
-			var output []byte
-			ginkgo.By("List local queues with -A", func() {
-				cmd := exec.Command(kueuectlPath, "list", "localqueue", "-A", "-o", "json")
-				var err error
-				output, err = cmd.CombinedOutput()
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
-			})
-
-			ginkgo.By("Verify the output contains LQs from both namespaces", func() {
-				gomega.Expect(string(output)).To(gomega.ContainSubstring(ns.Name))
-				gomega.Expect(string(output)).To(gomega.ContainSubstring(otherNs.Name))
-			})
-		})
-	})
-
-	ginkgo.When("Deleting a Workload", func() {
-		ginkgo.It("Should delete a standalone workload with --yes", func() {
-			wlName := "e2e-wl-delete"
-			wl := utiltestingapi.MakeWorkload(wlName, ns.Name).Obj()
-			util.MustCreate(ctx, k8sClient, wl)
-
-			ginkgo.By("Run kueuectl delete workload with --yes", func() {
-				cmd := exec.Command(kueuectlPath, "delete", "workload", wlName, "--namespace", ns.Name, "--yes")
-				output, err := cmd.CombinedOutput()
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
-			})
-
-			ginkgo.By("Verify the workload is removed from the cluster", func() {
-				util.ExpectObjectToBeDeleted(ctx, k8sClient, wl, true)
-			})
+			var list kueue.LocalQueueList
+			gomega.Expect(json.Unmarshal(stdout.Bytes(), &list)).To(gomega.Succeed())
+			gomega.Expect(list.Items).To(gomega.ContainElement(gomega.SatisfyAll(
+				gomega.HaveField("Name", lqName),
+				gomega.HaveField("Spec.ClusterQueue", kueue.ClusterQueueReference(cq.Name)),
+			)))
 		})
 	})
 })

--- a/test/integration/singlecluster/kueuectl/create_test.go
+++ b/test/integration/singlecluster/kueuectl/create_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kueuectl
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -131,6 +132,122 @@ var _ = ginkgo.Describe("Kueuectl Create", func() {
 					g.Expect(createdQueue.Name).Should(gomega.Equal(lqName))
 					g.Expect(createdQueue.Spec.ClusterQueue).Should(gomega.Equal(kueue.ClusterQueueReference(cq.Name)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("Should not create a local queue with unknown cluster queue", func() {
+			lqName := "lq"
+			cqName := "cq-unknown"
+
+			ginkgo.By("Create a local queue with unknown cluster queue (no bypass flag)", func() {
+				streams, _, output, _ := genericiooptions.NewTestIOStreams()
+				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
+				kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+				kueuectl.SetOut(output)
+				kueuectl.SetErr(output)
+
+				kueuectl.SetArgs([]string{"create", "localqueue", lqName, "--clusterqueue", cqName, "--namespace", ns.Name})
+				err := kueuectl.Execute()
+				gomega.Expect(err).To(gomega.HaveOccurred(), "%s: %s", err, output)
+			})
+
+			ginkgo.By("Check that the local queue was not created", func() {
+				var createdQueue kueue.LocalQueue
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lqName, Namespace: ns.Name}, &createdQueue)).To(utiltesting.BeNotFoundError())
+				}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("Should print the created local queue as YAML", func() {
+			lqName := "lq-yaml"
+
+			var output string
+			ginkgo.By("Create a local queue and capture YAML output", func() {
+				streams, _, out, _ := genericiooptions.NewTestIOStreams()
+				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
+				kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+				kueuectl.SetOut(out)
+				kueuectl.SetErr(out)
+
+				kueuectl.SetArgs([]string{"create", "localqueue", lqName, "--clusterqueue", cq.Name, "--namespace", ns.Name, "-o", "yaml"})
+				err := kueuectl.Execute()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, out)
+				output = out.String()
+			})
+
+			ginkgo.By("Verify the YAML output contains the resource", func() {
+				gomega.Expect(output).To(gomega.ContainSubstring("kind: LocalQueue"))
+				gomega.Expect(output).To(gomega.ContainSubstring("name: " + lqName))
+				gomega.Expect(output).To(gomega.ContainSubstring("clusterQueue: " + cq.Name))
+			})
+
+			ginkgo.By("Check that the local queue is persisted in the cluster", func() {
+				var createdQueue kueue.LocalQueue
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lqName, Namespace: ns.Name}, &createdQueue)).To(gomega.Succeed())
+					g.Expect(createdQueue.Name).Should(gomega.Equal(lqName))
+					g.Expect(createdQueue.Spec.ClusterQueue).Should(gomega.Equal(kueue.ClusterQueueReference(cq.Name)))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("Should print the created local queue as JSON", func() {
+			lqName := "lq-json"
+
+			ginkgo.By("Create a local queue and capture JSON output", func() {
+				streams, _, out, _ := genericiooptions.NewTestIOStreams()
+				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
+				kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+				kueuectl.SetOut(out)
+				kueuectl.SetErr(out)
+
+				kueuectl.SetArgs([]string{"create", "localqueue", lqName, "--clusterqueue", cq.Name, "--namespace", ns.Name, "-o", "json"})
+				err := kueuectl.Execute()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, out)
+
+				ginkgo.By("Verify the JSON output round-trips into the LocalQueue type", func() {
+					var created kueue.LocalQueue
+					gomega.Expect(json.Unmarshal(out.Bytes(), &created)).To(gomega.Succeed())
+					gomega.Expect(created.Name).To(gomega.Equal(lqName))
+					gomega.Expect(string(created.Spec.ClusterQueue)).To(gomega.Equal(cq.Name))
+				})
+			})
+
+			ginkgo.By("Check that the local queue is persisted in the cluster", func() {
+				var createdQueue kueue.LocalQueue
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lqName, Namespace: ns.Name}, &createdQueue)).To(gomega.Succeed())
+					g.Expect(createdQueue.Name).Should(gomega.Equal(lqName))
+					g.Expect(createdQueue.Spec.ClusterQueue).Should(gomega.Equal(kueue.ClusterQueueReference(cq.Name)))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("Should not create a local queue with --dry-run=client", func() {
+			lqName := "lq-dryrun"
+
+			ginkgo.By("Create a local queue with --dry-run=client", func() {
+				streams, _, out, _ := genericiooptions.NewTestIOStreams()
+				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
+				kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+				kueuectl.SetOut(out)
+				kueuectl.SetErr(out)
+
+				kueuectl.SetArgs([]string{"create", "localqueue", lqName, "--clusterqueue", cq.Name, "--namespace", ns.Name, "--dry-run=client"})
+				err := kueuectl.Execute()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, out)
+
+				ginkgo.By("Verify the local queue was NOT created in the cluster", func() {
+					var createdQueue kueue.LocalQueue
+					gomega.Consistently(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lqName, Namespace: ns.Name}, &createdQueue)).To(utiltesting.BeNotFoundError())
+					}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Verify the local queue object is still printed to stdout", func() {
+					gomega.Expect(out.String()).To(gomega.ContainSubstring(lqName))
+				})
 			})
 		})
 	})

--- a/test/integration/singlecluster/kueuectl/delete_test.go
+++ b/test/integration/singlecluster/kueuectl/delete_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kueuectl
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/cmd/kueuectl/app"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("Kueuectl Delete", func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "ns-")
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+	})
+
+	ginkgo.When("Deleting a Workload", func() {
+		ginkgo.It("Should delete a standalone workload with --yes", func() {
+			wlName := "wl-delete"
+			wl := utiltestingapi.MakeWorkload(wlName, ns.Name).Obj()
+
+			ginkgo.By("Create a standalone workload (no owner references)", func() {
+				util.MustCreate(ctx, k8sClient, wl)
+			})
+
+			ginkgo.By("Run kueuectl delete workload with --yes", func() {
+				streams, _, output, _ := genericiooptions.NewTestIOStreams()
+				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
+				kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+				kueuectl.SetOut(output)
+				kueuectl.SetErr(output)
+
+				kueuectl.SetArgs([]string{"delete", "workload", wlName, "--namespace", ns.Name, "--yes"})
+				err := kueuectl.Execute()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
+			})
+
+			ginkgo.By("Verify the workload is removed from the cluster", func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, wl, true)
+			})
+		})
+
+		ginkgo.It("Should not delete a workload with owner references when confirmation is declined", func() {
+			wlName := "wl-protected"
+			jobGVK := schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
+			// K8s API rejects an empty UID on owner references; the API server
+			// fills it in once the owner object is created. A non-empty value
+			// is enough to exercise the delete-without-confirmation path.
+			wl := utiltestingapi.MakeWorkload(wlName, ns.Name).OwnerReference(jobGVK, "j-protected", "j-protected-uid").Obj()
+
+			ginkgo.By("Create a workload with an owner reference to a Job", func() {
+				util.MustCreate(ctx, k8sClient, wl)
+			})
+
+			ginkgo.By("Run kueuectl delete workload without --yes (declined confirmation)", func() {
+				streams, _, output, _ := genericiooptions.NewTestIOStreams()
+				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
+				kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+				kueuectl.SetOut(output)
+				kueuectl.SetErr(output)
+
+				// Stdin is empty; confirmation prompt receives no input, which the
+				// command treats as decline and prints "Deletion is canceled".
+				kueuectl.SetArgs([]string{"delete", "workload", wlName, "--namespace", ns.Name})
+				err := kueuectl.Execute()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
+				gomega.Expect(output.String()).To(gomega.ContainSubstring("Deletion is canceled"))
+			})
+
+			ginkgo.By("Verify the workload still exists in the cluster", func() {
+				var fetched kueue.Workload
+				err := k8sClient.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: wlName}, &fetched)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})
+		})
+	})
+})

--- a/test/integration/singlecluster/kueuectl/list_test.go
+++ b/test/integration/singlecluster/kueuectl/list_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kueuectl
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -110,6 +111,65 @@ very-long-local-queue-name   cq1                            0                   
 				duration.HumanDuration(executeTime.Sub(lq2.CreationTimestamp.Time)),
 				duration.HumanDuration(executeTime.Sub(lq3.CreationTimestamp.Time)),
 			)))
+		})
+
+		ginkgo.It("Should list local queues in the current namespace as JSON", func() {
+			streams, _, output, errOutput := genericiooptions.NewTestIOStreams()
+			configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
+			kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+
+			kueuectl.SetArgs([]string{"list", "localqueue", "--namespace", ns.Name, "-o", "json"})
+
+			err := kueuectl.Execute()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
+			gomega.Expect(errOutput.String()).Should(gomega.BeEmpty())
+
+			ginkgo.By("Verify the JSON output round-trips into the LocalQueueList type", func() {
+				var listOut kueue.LocalQueueList
+				gomega.Expect(json.Unmarshal(output.Bytes(), &listOut)).To(gomega.Succeed())
+				gomega.Expect(listOut.Items).To(gomega.HaveLen(3))
+				gomega.Expect(listOut.Items).To(gomega.ContainElement(gomega.SatisfyAll(
+					gomega.HaveField("Name", "lq1"),
+					gomega.HaveField("Spec.ClusterQueue", kueue.ClusterQueueReference("cq1")),
+				)))
+			})
+		})
+
+		ginkgo.It("Should list local queues across all namespaces with -A", func() {
+			otherNs := util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "ns-other-")
+			ginkgo.DeferCleanup(func() {
+				gomega.Expect(util.DeleteNamespace(ctx, k8sClient, otherNs)).To(gomega.Succeed())
+			})
+			otherLq := utiltestingapi.MakeLocalQueue("lq-other", otherNs.Name).ClusterQueue("cq1").Obj()
+			util.MustCreate(ctx, k8sClient, otherLq)
+
+			// Create an LQ in the primary namespace so we can assert that both
+			// LQs (primary and other-ns) appear in the cross-namespace list.
+			primaryLq := utiltestingapi.MakeLocalQueue("lq-primary", ns.Name).ClusterQueue("cq1").Obj()
+			util.MustCreate(ctx, k8sClient, primaryLq)
+
+			streams, _, output, errOutput := genericiooptions.NewTestIOStreams()
+			configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
+			kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+
+			kueuectl.SetArgs([]string{"list", "localqueue", "-A", "-o", "json"})
+
+			err := kueuectl.Execute()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
+			gomega.Expect(errOutput.String()).Should(gomega.BeEmpty())
+
+			ginkgo.By("Verify the JSON output contains the LQs from both namespaces", func() {
+				var listOut kueue.LocalQueueList
+				gomega.Expect(json.Unmarshal(output.Bytes(), &listOut)).To(gomega.Succeed())
+				gomega.Expect(listOut.Items).To(gomega.ContainElement(gomega.SatisfyAll(
+					gomega.HaveField("Name", "lq-primary"),
+					gomega.HaveField("Namespace", ns.Name),
+				)))
+				gomega.Expect(listOut.Items).To(gomega.ContainElement(gomega.SatisfyAll(
+					gomega.HaveField("Name", "lq-other"),
+					gomega.HaveField("Namespace", otherNs.Name),
+				)))
+			})
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind cleanup
/area testing

#### What this PR does / why we need it:

Move 7 of 8 `kueuectl` e2e tests to the integration suite; keep 1 as a binary sanity check.

| e2e (removed) | integration (added) |
| --- | --- |
| `Shouldn't create local queue with unknown cluster queue` | `create_test.go: Should not create a local queue with unknown cluster queue` |
| `Should print the created local queue as YAML` | `create_test.go: Should print the created local queue as YAML` |
| `Should print the created local queue as JSON` | `create_test.go: Should print the created local queue as JSON` |
| `Should not create local queue with --dry-run=client` | `create_test.go: Should not create a local queue with --dry-run=client` |
| `Should list local queues in the current namespace as JSON` | `list_test.go: Should list local queues in the current namespace as JSON` |
| `Should list local queues across all namespaces with -A` | `list_test.go: Should list local queues across all namespaces with -A` |
| `Should delete a standalone workload with --yes` | `delete_test.go: Should delete a standalone workload with --yes` |

`Should create local queue` already exists in integration, so it is removed from e2e without a counterpart.

| e2e (kept) | reason |
| --- | --- |
| `Should create a local queue and list it back` | Sanity check for the compiled binary. |

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
