### PR TITLE
Add on-demand link check for Netlify deploy previews

### DIFF
--- a/Makefile-verify.mk
+++ b/Makefile-verify.mk
@@ -271,6 +271,10 @@ skills-lint: ## Lint agent skills with skillsaw.
 verify-website-links: ## Check for broken internal links on the public website.
 	$(PROJECT_DIR)/hack/testing/linkchecker/verify.sh
 
+.PHONY: verify-website-links-preview
+verify-website-links-preview: ## Check links on a PR Netlify deploy preview; skips if no fresh same-commit preview exists.
+	$(PROJECT_DIR)/hack/testing/linkchecker/verify-preview.sh
+
 .PHONY: i18n-verify
 i18n-verify: ## Verify localized docs are in sync with English. Usage: make i18n-verify [TARGET_LANG=zh-CN]
 	@if [ -n "$(TARGET_LANG)" ]; then \

--- a/hack/testing/linkchecker/verify-preview.sh
+++ b/hack/testing/linkchecker/verify-preview.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs the website link checker against a PR's Netlify deploy preview.
+#
+# The deploy/netlify commit status on the PR head SHA gates freshness; once it
+# succeeds, links are checked against the PR's deploy-preview alias. If no fresh
+# same-commit preview can be resolved, this script skips successfully; otherwise
+# the link checker runs and its result is preserved.
+#
+# The resolved Netlify URL is a mutable per-PR preview alias, not an immutable
+# per-deploy URL, but the status itself is attached to the exact SHA under test.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SOURCE_DIR="$(cd "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+ROOT_DIR="${SOURCE_DIR}/../../.."
+
+# Prow injects these on presubmits; default the repo coordinates for safety.
+PULL_NUMBER="${PULL_NUMBER:-}"
+PULL_PULL_SHA="${PULL_PULL_SHA:-}"
+PULL_BASE_SHA="${PULL_BASE_SHA:-}"
+REPO_OWNER="${REPO_OWNER:-kubernetes-sigs}"
+REPO_NAME="${REPO_NAME:-kueue}"
+
+GH_API="${GH_API:-https://api.github.com}"
+STATUS_CONTEXT="deploy/netlify"
+# Netlify site slug for the PR's deploy-preview URL (built below).
+NETLIFY_SITE="${NETLIFY_SITE:-kubernetes-sigs-kueue}"
+# Bounded wait for the preview build: 20 checks × 30s (~9.5 min), then skip.
+PREVIEW_WAIT_ATTEMPTS="${PREVIEW_WAIT_ATTEMPTS:-20}"
+PREVIEW_WAIT_DELAY="${PREVIEW_WAIT_DELAY:-30}"
+
+log()  { echo "[verify-website-links-preview] $*"; }
+skip() { log "SKIP: $*"; log "Treating as success (non-blocking link check)."; exit 0; }
+
+# Outside a Prow presubmit (e.g. a local run) there is no PR preview to resolve.
+if [[ -z "${PULL_NUMBER}" || -z "${PULL_PULL_SHA}" ]]; then
+  skip "not running in a Prow presubmit (PULL_NUMBER/PULL_PULL_SHA unset)."
+fi
+
+# If the PR does not touch site/, Netlify builds no preview (the netlify.toml
+# ignore rule), so skip instead of waiting out the timeout. If the diff can't be
+# computed, fall through and let the resolution step decide.
+if [[ -n "${PULL_BASE_SHA}" ]] && \
+   git -C "${ROOT_DIR}" diff --quiet "${PULL_BASE_SHA}" "${PULL_PULL_SHA}" -- site/ 2>/dev/null; then
+  skip "PR #${PULL_NUMBER} does not modify site/; no preview expected."
+fi
+
+# A missing binary won't appear mid-loop, so short-circuit before polling.
+# Still skip (not exit 1) to keep the job non-blocking.
+for bin in curl jq; do
+  command -v "${bin}" >/dev/null 2>&1 || skip "${bin} is unavailable; cannot resolve deploy preview."
+done
+
+# Unauthenticated GitHub API calls are rate-limited (60/h per IP); set GH_TOKEN to
+# raise the limit. API failures are treated as skip, so rate limits never fail a PR.
+auth=()
+if [[ -n "${GH_TOKEN:-}" ]]; then
+  auth=(-H "Authorization: Bearer ${GH_TOKEN}")
+fi
+
+preview_url=""
+for (( attempt=1; attempt<=PREVIEW_WAIT_ATTEMPTS; attempt++ )); do
+  body=""
+  if ! body="$(curl --connect-timeout 10 --max-time 20 -fsSL "${auth[@]+"${auth[@]}"}" \
+      "${GH_API}/repos/${REPO_OWNER}/${REPO_NAME}/commits/${PULL_PULL_SHA}/status" 2>/dev/null)"; then
+    log "GitHub API call failed (attempt ${attempt}/${PREVIEW_WAIT_ATTEMPTS})."
+    body=""
+  fi
+
+  # Guard jq parsing: a non-JSON 200 body (curl -f does not reject it) must not
+  # fail the job. Any jq error yields "", routing to the skip path below.
+  state=""
+  if [[ -n "${body}" ]]; then
+    state="$(jq -r --arg c "${STATUS_CONTEXT}" \
+      'first(.statuses[]? | select(.context==$c)) | .state // empty' <<<"${body}" 2>/dev/null || true)"
+  fi
+
+  case "${state}" in
+    success)
+      # target_url here is Netlify's admin deploy page, not the rendered preview,
+      # so build the PR's deploy-preview alias instead.
+      preview_url="https://deploy-preview-${PULL_NUMBER}--${NETLIFY_SITE}.netlify.app/"
+      break
+      ;;
+    failure|error)
+      skip "Netlify deploy preview '${state}' for commit ${PULL_PULL_SHA}; nothing fresh to check."
+      ;;
+    *)
+      log "preview not ready (state='${state:-none}'), attempt ${attempt}/${PREVIEW_WAIT_ATTEMPTS}."
+      ;;
+  esac
+
+  if (( attempt < PREVIEW_WAIT_ATTEMPTS )); then
+    sleep "${PREVIEW_WAIT_DELAY}"
+  fi
+done
+
+if [[ -z "${preview_url}" ]]; then
+  skip "no ready same-commit deploy preview for ${PULL_PULL_SHA} after bounded wait."
+fi
+
+log "checking fresh preview for commit ${PULL_PULL_SHA}: ${preview_url}"
+
+# Run the link checker against the resolved preview and preserve its result.
+LINK_CHECK_URL="${preview_url}" exec "${SOURCE_DIR}/verify.sh"

--- a/hack/testing/linkchecker/verify.sh
+++ b/hack/testing/linkchecker/verify.sh
@@ -22,11 +22,15 @@ DOCKER="${DOCKER:-docker}"
 SOURCE_DIR="$(cd "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 ROOT_DIR="${SOURCE_DIR}/../../.."
 
+# Site to check. Defaults to the live site so the periodic job is unchanged;
+# verify-preview.sh overrides this to point at a PR's Netlify deploy preview.
+LINK_CHECK_URL="${LINK_CHECK_URL:-https://kueue.sigs.k8s.io/}"
+
 echo "Building linkchecker Docker image..."
 "${DOCKER}" build --load -f "${SOURCE_DIR}/Dockerfile" -t linkchecker "${SOURCE_DIR}"
 
-echo "Running linkchecker..."
+echo "Running linkchecker against ${LINK_CHECK_URL} ..."
 "${ROOT_DIR}/hack/testing/retry.sh" --attempts 5 --delay 5 --stream -- \
-    "${DOCKER}" run --rm linkchecker --no-warnings --ignore-url='^mailto:' --ignore-url='^tel:' https://kueue.sigs.k8s.io/
+    "${DOCKER}" run --rm linkchecker --no-warnings --ignore-url='^mailto:' --ignore-url='^tel:' "${LINK_CHECK_URL}"
 
 echo "Link check completed successfully"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/area testing
/area website

#### What this PR does / why we need it:

This PR adds the Kueue-side `target/script` for checking website links against a PR's Netlify deploy preview. A follow-up in `kubernetes/test-infra` will wire it as an on-demand, optional/non-blocking presubmit.

This adds make `verify-website-links-preview`, which runs the existing website link checker against the PR preview site instead of the live site.

The new target resolves the preview URL from the `deploy/netlify `commit status on the PR head SHA, instead of parsing PR comments. This follows the direction discussed in #12472: the commit status is attached to the exact commit being tested, which gives us a stronger same-commit signal while avoiding comment parsing.

If no fresh same-commit preview is available, including non-site PRs or previews that are not built yet, the target exits successfully. Only actual broken links fail the check.

The existing `verify-website-links` target and the 24h periodic job are unchanged.

Per the issue discussion, this starts with on-demand/non-blocking coverage, then consider broader or blocking coverage once proven reliable.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Part of #12472

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PR Netlify deploy-preview website link verification (via a dedicated verification command).
  * Link checks can now run against a configurable target URL using `LINK_CHECK_URL` (with a default).
* **Bug Fixes**
  * Preview-based verification is non-blocking: it skips cleanly when required context, tools, or a ready preview URL aren’t available.
  * Verification avoids unnecessary runs when changes don’t affect `site/`, and tolerates API/parse issues without failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->