### PR TITLE
Automated cherry pick of #12516: Remove mgr.GetEventRecorderFor is deprecated exclusion.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -92,9 +92,6 @@ linters:
         text: 'SA1019: features.* is deprecated: planned to be removed in .*'
       - linters:
           - staticcheck
-        text: 'SA1019: mgr.GetEventRecorderFor is deprecated: this uses the old events API and will be removed in a future release. Please use GetEventRecorder instead.'
-      - linters:
-          - staticcheck
         text: 'SA1019: scheme.Builder is deprecated: This helper is only useful in api packages'
       - linters:
           - fatcontext


### PR DESCRIPTION
Cherry pick of #12516 on release-0.18.

#12516: Remove mgr.GetEventRecorderFor is deprecated exclusion.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```