### PR TITLE
Fix ray-mini image by pinning Python 3.13 and re-enable for presubmits

### DIFF
--- a/hack/testing/ray-mini/Dockerfile
+++ b/hack/testing/ray-mini/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim@sha256:63a4c7f612a00f92042cbdcc7cdc6a306f38485af0a200b9c89de7d9b1607d15
+FROM python:3.13-slim@sha256:2b7445fb71ca9cb15e9aab053fe8cb3162796f8e1d92ada12a49c766a811bc1e
 
 # Set environment variable to avoid interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Python 3.14 ships with protobuf v34+ which removed `FieldDescriptor.label`. Ray 2.55.1 uses this API in `serve/_private/config.py`, causing RayService `DEPLOY_FAILED`. The fix exists on Ray main (ray-project/ray#64362) but is unreleased.

This PR pins the ray-mini image to Python 3.13 and reverts #12581 to re-enable raymini for presubmits.

#### Which issue(s) this PR fixes:
Fixes #12588

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the container base image to a newer, pinned Python runtime version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->