### PR TITLE
Improve stability of the spark tests

### DIFF
--- a/test/e2e/sequential/extended/sparkapplication_test.go
+++ b/test/e2e/sequential/extended/sparkapplication_test.go
@@ -115,7 +115,7 @@ var _ = ginkgo.Describe("SparkApplication integration", ginkgo.Label("feature:sp
 			cq = utiltestingapi.MakeClusterQueue(clusterQueueName).
 				ResourceGroup(
 					*utiltestingapi.MakeFlavorQuotas(resourceFlavorName).
-						Resource(corev1.ResourceCPU, "200m").
+						Resource(corev1.ResourceCPU, "1").
 						Resource(corev1.ResourceMemory, "1Gi").
 						Obj(),
 				).
@@ -142,10 +142,10 @@ var _ = ginkgo.Describe("SparkApplication integration", ginkgo.Label("feature:sp
 				Image(sparkImage).
 				SparkVersion(util.VersionFromImage(sparkImage)).
 				DriverServiceAccount(sa.Name).
-				DriverCoreRequest("0.1").
+				DriverCoreRequest("500m").
 				DriverMemoryRequest("512m"). // 512MB
 				ExecutorServiceAccount(sa.Name).
-				ExecutorCoreRequest("0.1").
+				ExecutorCoreRequest("500m").
 				ExecutorMemoryRequest("512m"). // 512MB
 				ExecutorInstances(1).
 				Queue(lq.Name).
@@ -245,13 +245,13 @@ var _ = ginkgo.Describe("SparkApplication integration", ginkgo.Label("feature:sp
 					kueue.PodSetRequiredTopologyAnnotation, corev1.LabelHostname,
 				).
 				DriverServiceAccount(sa.Name).
-				DriverCoreRequest("0.1").
+				DriverCoreRequest("500m").
 				DriverMemoryRequest("512m"). // 512MB
 				ExecutorAnnotation(
 					kueue.PodSetRequiredTopologyAnnotation, corev1.LabelHostname,
 				).
 				ExecutorServiceAccount(sa.Name).
-				ExecutorCoreRequest("0.1").
+				ExecutorCoreRequest("500m").
 				ExecutorMemoryRequest("512m"). // 512MB
 				ExecutorInstances(1).
 				Queue(lq.Name).
@@ -321,7 +321,7 @@ var _ = ginkgo.Describe("SparkApplication integration", ginkgo.Label("feature:sp
 					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 					g.Expect(workload.HasQuotaReservation(createdWorkload)).Should(gomega.BeTrue())
 					g.Expect(createdWorkload.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
-				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+				}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
 	})


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12593

#### Special notes for your reviewer:

increasing cput 100m -> 500m should improve the pod execution time probably 20s -> 10s or so. However, still risk exists, so I propose to use VeryLongTimeout. Alternevely maybe we could increse LongTimeout to 100s?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated SparkApplication end-to-end test scenarios to use higher CPU requests and quotas that better match current sizing.
  * Extended the wait time for a TAS workload completion check to reduce false test failures in slower environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->