### PR TITLE
docs: fix shared-quota-sample-job example

### DIFF
--- a/site/static/examples/admin/shared-quota-sample-job.yaml
+++ b/site/static/examples/admin/shared-quota-sample-job.yaml
@@ -16,7 +16,8 @@ spec:
       containers:
       - name: worker
         image: registry.k8s.io/e2e-test-images/agnhost:2.53
-        args: ["sleep", "300"]
+        command: ["/bin/sh"]
+        args: ["-c", "sleep 300"]
         resources:
           requests:
             cpu: "3"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation
/area website

#### What this PR does / why we need it:

The example `shared-quota-sample-job.yaml` used `args: ["sleep", "300"]` without overriding the container entrypoint. Since agnhost does not have a `sleep` subcommand, Kubernetes attempted to run `/agnhost sleep 300`, immediately crashing the Pod with `Error: unknown command "sleep" for "app"`. This fix adds an explicit `command: ["/bin/sh"]` entrypoint so the shell's `sleep` is used correctly.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12610

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the sample job startup command so the container now launches through a shell before running `sleep 300`, improving compatibility for the example workload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->