### PR TITLE
Fix MultiKueue remote client data race during reconnect

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/clusterqueue.go
+++ b/pkg/controller/admissionchecks/multikueue/clusterqueue.go
@@ -195,7 +195,7 @@ func (r *cqReconciler) aggregateWorkerQuotas(ctx context.Context, cq *kueue.Clus
 		}
 		remoteLQList := &kueue.LocalQueueList{}
 		// This List is cached (by the selectivelyCachingClient).
-		if err := rc.client.List(ctx, remoteLQList); err != nil {
+		if err := rc.getClient().List(ctx, remoteLQList); err != nil {
 			return nil, err
 		}
 		remoteCQKeys := sets.New[types.NamespacedName]()
@@ -207,7 +207,7 @@ func (r *cqReconciler) aggregateWorkerQuotas(ctx context.Context, cq *kueue.Clus
 
 		remoteCQList := &kueue.ClusterQueueList{}
 		// This List is cached (by the selectivelyCachingClient).
-		if err := rc.client.List(ctx, remoteCQList); err != nil {
+		if err := rc.getClient().List(ctx, remoteCQList); err != nil {
 			return nil, err
 		}
 

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -267,7 +267,10 @@ func (rc *remoteClient) setConfig(watchCtx context.Context, config *clientConfig
 		return rc.increaseFailedConnAttempt(), err
 	}
 
+	// Lock the swap so a concurrent getClient() never reads a torn rc.client. See #12557.
+	rc.mu.Lock()
 	rc.client = remoteClient
+	rc.mu.Unlock()
 
 	err = rc.startWatcher(watchCtx, kueue.GroupVersion.WithKind("Workload").GroupKind().String(), &workloadKueueWatcher{})
 	if err != nil {
@@ -444,8 +447,12 @@ func (rc *remoteClient) startQueueWatchers(ctx context.Context) error {
 func (rc *remoteClient) queueEventsForCQ(ctx context.Context, remoteCQ *kueue.ClusterQueue) {
 	log := ctrl.LoggerFrom(ctx).WithValues("remoteCQ", remoteCQ.Name)
 
+	remoteCl := rc.getClient()
+	if remoteCl == nil {
+		return
+	}
 	lqList := kueue.LocalQueueList{}
-	err := rc.client.List(ctx, &lqList, client.MatchingFields{indexer.QueueClusterQueueKey: remoteCQ.Name})
+	err := remoteCl.List(ctx, &lqList, client.MatchingFields{indexer.QueueClusterQueueKey: remoteCQ.Name})
 	if err != nil {
 		log.Error(err, "Failed to list remote LocalQueues from cache")
 		return
@@ -481,6 +488,14 @@ func (rc *remoteClient) getRetryConnNextAttempt() metav1.Time {
 	rc.mu.RLock()
 	defer rc.mu.RUnlock()
 	return rc.retryConnNextAttempt
+}
+
+// getClient reads rc.client under the read lock so callers never observe a torn
+// value while setConfig swaps it on a reconnect. See #12557.
+func (rc *remoteClient) getClient() SelectivelyCachingClient {
+	rc.mu.RLock()
+	defer rc.mu.RUnlock()
+	return rc.client
 }
 
 func (rc *remoteClient) StopWatchers() {
@@ -531,8 +546,13 @@ func (rc *remoteClient) runGC(ctx context.Context) {
 		return
 	}
 
+	remoteCl := rc.getClient()
+	if remoteCl == nil {
+		return
+	}
+
 	wls := &kueue.WorkloadList{}
-	err := rc.client.List(ctx, wls, client.MatchingLabels{kueue.MultiKueueOriginLabel: rc.origin})
+	err := remoteCl.List(ctx, wls, client.MatchingLabels{kueue.MultiKueueOriginLabel: rc.origin})
 	if err != nil {
 		log.Error(err, "Listing remote workloads")
 		return
@@ -561,14 +581,14 @@ func (rc *remoteClient) runGC(ctx context.Context) {
 			} else {
 				wlLog.V(5).Info("MultiKueueGC deleting workload owner", "ownerKey", ownerKey, "ownerKind", controller)
 				wlKey := types.NamespacedName{Name: controller.Name, Namespace: remoteWl.Namespace}
-				err := jobframework.DeleteRemoteObjectIfOwned(ctx, rc.localClient, rc.client, adapter, wlKey, rc.origin)
+				err := jobframework.DeleteRemoteObjectIfOwned(ctx, rc.localClient, remoteCl, adapter, wlKey, rc.origin)
 				if client.IgnoreNotFound(err) != nil {
 					wlLog.Error(err, "Deleting remote workload's owner", "ownerKey", ownerKey)
 				}
 			}
 		}
 		wlLog.V(5).Info("MultiKueueGC deleting remote workload")
-		if err := rc.client.Delete(ctx, &remoteWl); client.IgnoreNotFound(err) != nil {
+		if err := remoteCl.Delete(ctx, &remoteWl); client.IgnoreNotFound(err) != nil {
 			wlLog.Error(err, "Deleting remote workload")
 		}
 	}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -134,9 +134,10 @@ type remoteClient struct {
 	failedConnAttempts   uint
 	retryConnNextAttempt metav1.Time
 
-	// Held during setConfig. Without it, one stuck remote would stall every
-	// other cluster's reconcile via clustersReconciler.lock. See #11297.
-	setConfigLock sync.Mutex
+	// Held during updateConfigAndRefreshWatchers. Without it, one stuck remote
+	// would stall every other cluster's reconcile via clustersReconciler.lock.
+	// See #11297.
+	updateConfigLock sync.Mutex
 
 	clock clock.Clock
 
@@ -232,10 +233,10 @@ func (rc *remoteClient) increaseFailedConnAttempt() *time.Duration {
 	return &d
 }
 
-// setConfig - will try to recreate the k8s client and restart watching if the new config is different than
+// updateConfigAndRefreshWatchers - will try to recreate the k8s client and restart watching if the new config is different than
 // the one currently used, a reconnect was requested, or the client was marked as disconnected.
 // If the encountered error is not permanent the duration after which a retry should be done is returned.
-func (rc *remoteClient) setConfig(watchCtx context.Context, config *clientConfig) (*time.Duration, error) {
+func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context, config *clientConfig) (*time.Duration, error) {
 	configChanged := !equality.Semantic.DeepEqual(config, rc.config)
 	connecting := rc.connecting.Load()
 	disconnected := rc.disconnected.Load()
@@ -267,10 +268,7 @@ func (rc *remoteClient) setConfig(watchCtx context.Context, config *clientConfig
 		return rc.increaseFailedConnAttempt(), err
 	}
 
-	// Lock the swap so a concurrent getClient() never reads a torn rc.client. See #12557.
-	rc.mu.Lock()
-	rc.client = remoteClient
-	rc.mu.Unlock()
+	rc.setClient(remoteClient)
 
 	err = rc.startWatcher(watchCtx, kueue.GroupVersion.WithKind("Workload").GroupKind().String(), &workloadKueueWatcher{})
 	if err != nil {
@@ -320,7 +318,7 @@ func (cw *cancelOnStopWatcher) Stop() {
 // establishWatch opens a MultiKueue remote watch, bounded by the given
 // timeout. On timeout the in-flight Watch is canceled and
 // errWatchEstablishTimeout is returned so the caller falls back to the
-// standard failedConnAttempts / retryAfter backoff in setConfig.
+// standard failedConnAttempts / retryAfter backoff in updateConfigAndRefreshWatchers.
 func establishWatch(ctx context.Context, c client.WithWatch, obj client.ObjectList, origin string, timeout time.Duration) (watch.Interface, error) {
 	type result struct {
 		w   watch.Interface
@@ -449,6 +447,7 @@ func (rc *remoteClient) queueEventsForCQ(ctx context.Context, remoteCQ *kueue.Cl
 
 	remoteCl := rc.getClient()
 	if remoteCl == nil {
+		log.V(2).Info("Skipping queueing events for ClusterQueue; remote client is nil (cluster reconnecting or disconnected)")
 		return
 	}
 	lqList := kueue.LocalQueueList{}
@@ -491,11 +490,19 @@ func (rc *remoteClient) getRetryConnNextAttempt() metav1.Time {
 }
 
 // getClient reads rc.client under the read lock so callers never observe a torn
-// value while setConfig swaps it on a reconnect. See #12557.
+// value while setClient swaps it on a reconnect. See #12557.
 func (rc *remoteClient) getClient() SelectivelyCachingClient {
 	rc.mu.RLock()
 	defer rc.mu.RUnlock()
 	return rc.client
+}
+
+// setClient swaps rc.client under the write lock so a concurrent getClient()
+// never observes a torn value during a reconnect. See #12557.
+func (rc *remoteClient) setClient(c SelectivelyCachingClient) {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	rc.client = c
 }
 
 func (rc *remoteClient) StopWatchers() {
@@ -548,6 +555,7 @@ func (rc *remoteClient) runGC(ctx context.Context) {
 
 	remoteCl := rc.getClient()
 	if remoteCl == nil {
+		log.V(2).Info("Skipping garbage collection; remote client is nil (cluster reconnecting or disconnected)")
 		return
 	}
 
@@ -705,13 +713,13 @@ func (c *clustersReconciler) findOrCreateRemoteClient(clusterName, origin string
 func (c *clustersReconciler) setRemoteClientConfig(ctx context.Context, clusterName string, config *clientConfig, origin string) (*time.Duration, error) {
 	client := c.findOrCreateRemoteClient(clusterName, origin)
 
-	client.setConfigLock.Lock()
-	defer client.setConfigLock.Unlock()
+	client.updateConfigLock.Lock()
+	defer client.updateConfigLock.Unlock()
 
 	clientLog := ctrl.LoggerFrom(c.rootContext).WithValues("clusterName", clusterName)
 	clientCtx := ctrl.LoggerInto(c.rootContext, clientLog)
 
-	if retryAfter, err := client.setConfig(clientCtx, config); err != nil {
+	if retryAfter, err := client.updateConfigAndRefreshWatchers(clientCtx, config); err != nil {
 		ctrl.LoggerFrom(ctx).Error(err, "failed to set kubeConfig in the remote client")
 		return retryAfter, err
 	} else if retryAfter != nil {

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -1538,8 +1538,9 @@ func TestValidateKubeConfigPath(t *testing.T) {
 	}
 }
 
-// hammerSetConfigWithReader runs reader concurrently with setConfig swapping rc.client,
-// as a regression harness for the #12557 data race. Only meaningful under `go test -race`.
+// hammerSetConfigWithReader runs reader concurrently with updateConfigAndRefreshWatchers
+// swapping rc.client, as a regression harness for the #12557 data race. Only meaningful
+// under `go test -race`.
 func hammerSetConfigWithReader(t *testing.T, reader func(ctx context.Context, rc *remoteClient)) {
 	t.Helper()
 	ctx, cancel := context.WithCancel(t.Context())
@@ -1551,7 +1552,7 @@ func hammerSetConfigWithReader(t *testing.T, reader func(ctx context.Context, rc
 
 	// Seed an initial client so the first read has a client to observe.
 	rc.connecting.Store(true)
-	if _, err := rc.setConfig(ctx, rc.config); err != nil {
+	if _, err := rc.updateConfigAndRefreshWatchers(ctx, rc.config); err != nil {
 		t.Fatalf("seeding initial client: %v", err)
 	}
 
@@ -1559,13 +1560,13 @@ func hammerSetConfigWithReader(t *testing.T, reader func(ctx context.Context, rc
 	var writerDone atomic.Bool
 	var wg sync.WaitGroup
 
-	// Writer: swap rc.client each iteration; fail if setConfig errors (swaps would stop).
+	// Writer: swap rc.client each iteration; fail if the update errors (swaps would stop).
 	var writerErr error
 	wg.Go(func() {
 		defer writerDone.Store(true)
 		for i := range iterations {
 			cfg := &clientConfig{Kubeconfig: []byte(testKubeconfig(fmt.Sprintf("worker-%d", i)))}
-			if _, err := rc.setConfig(ctx, cfg); err != nil {
+			if _, err := rc.updateConfigAndRefreshWatchers(ctx, cfg); err != nil {
 				writerErr = err
 				return
 			}
@@ -1580,7 +1581,7 @@ func hammerSetConfigWithReader(t *testing.T, reader func(ctx context.Context, rc
 
 	wg.Wait()
 	if writerErr != nil {
-		t.Fatalf("writer setConfig: %v", writerErr)
+		t.Fatalf("writer updateConfigAndRefreshWatchers: %v", writerErr)
 	}
 }
 

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1535,4 +1536,68 @@ func TestValidateKubeConfigPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+// hammerSetConfigWithReader runs reader concurrently with setConfig swapping rc.client,
+// as a regression harness for the #12557 data race. Only meaningful under `go test -race`.
+func hammerSetConfigWithReader(t *testing.T, reader func(ctx context.Context, rc *remoteClient)) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	rc := newTestClient(ctx, []byte(testKubeconfig("worker1")), nil, nil)
+	rc.origin = defaultOrigin
+	rc.adapters = map[string]jobframework.MultiKueueAdapter{}
+
+	// Seed an initial client so the first read has a client to observe.
+	rc.connecting.Store(true)
+	if _, err := rc.setConfig(ctx, rc.config); err != nil {
+		t.Fatalf("seeding initial client: %v", err)
+	}
+
+	const iterations = 200
+	var writerDone atomic.Bool
+	var wg sync.WaitGroup
+
+	// Writer: swap rc.client each iteration; fail if setConfig errors (swaps would stop).
+	var writerErr error
+	wg.Go(func() {
+		defer writerDone.Store(true)
+		for i := range iterations {
+			cfg := &clientConfig{Kubeconfig: []byte(testKubeconfig(fmt.Sprintf("worker-%d", i)))}
+			if _, err := rc.setConfig(ctx, cfg); err != nil {
+				writerErr = err
+				return
+			}
+		}
+	})
+
+	wg.Go(func() {
+		for !writerDone.Load() {
+			reader(ctx, rc)
+		}
+	})
+
+	wg.Wait()
+	if writerErr != nil {
+		t.Fatalf("writer setConfig: %v", writerErr)
+	}
+}
+
+func TestRemoteClientConcurrentSetConfigAndGC(t *testing.T) {
+	hammerSetConfigWithReader(t, func(ctx context.Context, rc *remoteClient) {
+		rc.runGC(ctx)
+	})
+}
+
+func TestRemoteClientConcurrentSetConfigAndReaders(t *testing.T) {
+	wlKey := client.ObjectKey{Namespace: metav1.NamespaceDefault, Name: "wl"}
+	hammerSetConfigWithReader(t, func(ctx context.Context, rc *remoteClient) {
+		remoteCl := rc.getClient()
+		if remoteCl == nil {
+			return
+		}
+		_ = remoteCl.Get(ctx, wlKey, &kueue.Workload{}) // workload.go-style read
+		_ = remoteCl.List(ctx, &kueue.LocalQueueList{}) // clusterqueue.go-style read
+	})
 }

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -153,7 +153,7 @@ func (g *wlGroup) bestMatchByCondition(conditionType string) (*metav1.Condition,
 // The controller object is deleted first to handle cases where GC has already removed
 // the remote workload.
 func (g *wlGroup) RemoveRemoteObjects(ctx context.Context, cluster string) error {
-	remoteClient := g.remoteClients[cluster].client
+	remoteClient := g.remoteClients[cluster].getClient()
 	origin := g.remoteClients[cluster].origin
 	if err := jobframework.DeleteRemoteObjectIfOwned(ctx, g.localClient, remoteClient, g.jobAdapter, g.controllerKey, origin); err != nil {
 		return fmt.Errorf("deleting remote controller object: %w", err)
@@ -337,7 +337,7 @@ func (w *wlReconciler) readGroup(ctx context.Context, local *kueue.Workload, acN
 
 	for remote, rClient := range rClients {
 		wl := &kueue.Workload{}
-		err := rClient.client.Get(ctx, client.ObjectKeyFromObject(local), wl)
+		err := rClient.getClient().Get(ctx, client.ObjectKeyFromObject(local), wl)
 		if client.IgnoreNotFound(err) != nil {
 			return nil, err
 		}
@@ -382,14 +382,15 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		// it should not be problematic, but the "From remote xxxx:" could be lost ....
 
 		if group.jobAdapter != nil {
-			if _, err := jobframework.ValidateRemoteObjectOwnership(ctx, group.remoteClients[remote].client, group.controllerKey, group.jobAdapter.GVK(), w.origin); err != nil {
+			remoteCl := group.remoteClients[remote].getClient()
+			if _, err := jobframework.ValidateRemoteObjectOwnership(ctx, remoteCl, group.controllerKey, group.jobAdapter.GVK(), w.origin); err != nil {
 				log.Error(err, "validating remote controller object", "workerCluster", remote)
 				return reconcile.Result{}, err
 			}
 
 			// The deferred flag is irrelevant here: the remote workload is
 			// Finished, so determineStatusUpdate always syncs (never defers).
-			if _, err := group.jobAdapter.SyncJob(ctx, w.client, group.remoteClients[remote].client, group.controllerKey, group.local.Name, w.origin); err != nil {
+			if _, err := group.jobAdapter.SyncJob(ctx, w.client, remoteCl, group.controllerKey, group.local.Name, w.origin); err != nil {
 				log.V(2).Error(err, "copying remote controller status", "workerCluster", remote)
 				// we should retry this
 				return reconcile.Result{}, err
@@ -405,7 +406,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 	// 4. Handle workload eviction
 	remoteEvictCond, evictedRemote := group.bestMatchByCondition(kueue.WorkloadEvicted)
 	if remoteEvictCond != nil {
-		remoteCl := group.remoteClients[evictedRemote].client
+		remoteCl := group.remoteClients[evictedRemote].getClient()
 		remoteWl := group.remotes[evictedRemote]
 
 		log = log.WithValues("remote", evictedRemote, "remoteWorkload", klog.KObj(remoteWl))
@@ -485,7 +486,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 					remWl.Spec.PreemptionGates = remotePreemptionGates
 				}
 
-				if err := remClient.client.Update(ctx, remWl); err != nil {
+				if err := remClient.getClient().Update(ctx, remWl); err != nil {
 					return reconcile.Result{}, fmt.Errorf("failed to update remote workload: %w", err)
 				}
 				continue
@@ -513,7 +514,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 			}
 		}
 
-		remoteCl := group.remoteClients[reservingRemote].client
+		remoteCl := group.remoteClients[reservingRemote].getClient()
 		remoteWl := group.remotes[reservingRemote]
 
 		log = log.WithValues("remote", reservingRemote, "remoteWorkload", klog.KObj(remoteWl))
@@ -577,7 +578,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 			remWl := group.remotes[*remWlName]
 			remClient := group.remoteClients[*remWlName]
 			workload.OpenPreemptionGate(remWl, constants.MultiKueuePreemptionGate, metav1.NewTime(w.clock.Now()))
-			if err := remClient.client.Status().Update(ctx, remWl); err != nil {
+			if err := remClient.getClient().Status().Update(ctx, remWl); err != nil {
 				return reconcile.Result{}, fmt.Errorf("failed to update remote workload: %w", err)
 			}
 		}
@@ -739,7 +740,7 @@ func (w *wlReconciler) syncToSingleCluster(ctx context.Context, log klog.Logger,
 		if clusterName == targetCluster {
 			if remoteWl == nil {
 				clone := cloneForCreate(group.local, group.remoteClients[clusterName].origin, false)
-				if err := group.remoteClients[clusterName].client.Create(ctx, clone); err != nil {
+				if err := group.remoteClients[clusterName].getClient().Create(ctx, clone); err != nil {
 					log.V(2).Error(err, "creating remote workload", "cluster", clusterName)
 					errs = append(errs, err)
 				}
@@ -863,7 +864,7 @@ func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group 
 		if slices.Contains(nominatedWorkers, rem) {
 			if remoteWl == nil {
 				clone := cloneForCreate(group.local, group.remoteClients[rem].origin, true)
-				if err := group.remoteClients[rem].client.Create(ctx, clone); err != nil {
+				if err := group.remoteClients[rem].getClient().Create(ctx, clone); err != nil {
 					log.V(2).Error(err, "creating remote object", "remote", rem)
 					errs = append(errs, err)
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/area multikueue

#### What this PR does / why we need it:

`remoteClient.client` can be replaced by `setConfig` during reconnects or kubeconfig updates while other goroutines read it from the GC loop and the workload/clusterqueue paths. Since this is an unsynchronized read/write of an interface value, a reader may observe an inconsistent client and crash the controller manager.

This PR guards the client swap with the existing `remoteClient.mu` and routes concurrent readers through `getClient()`, which snapshots the client under `RLock`. Reads that happen synchronously inside `setConfig` remain direct.

Also add race-detector coverage for the remote client readers. AI assistance was used for parts of this change.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12557

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MultiKueue: Fixed a data race where reconnecting a remote cluster could swap the remote client while other goroutines were reading it, which could crash-loop the controller manager.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of remote reconciliation during configuration refreshes by synchronizing access to the remote Kubernetes client.
  * Remote queue and workload operations now consistently use the most up-to-date available connection, with safe handling when it’s not yet available.

* **Tests**
  * Added race-focused concurrency regression coverage that exercises concurrent configuration refresh with remote garbage collection and remote read/list operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->