### PR TITLE
KueueViz: Fix dashboard crash when flavor has empty resources array

### DIFF
--- a/cmd/kueueviz/frontend/src/ClusterQueueDetail.jsx
+++ b/cmd/kueueviz/frontend/src/ClusterQueueDetail.jsx
@@ -139,7 +139,7 @@ const ClusterQueueDetail = () => {
                   <React.Fragment key={`resourceGroup-${groupIndex}`}>
                     {group.flavors.map((flavor, flavorIndex) => (
                       <React.Fragment key={`${groupIndex}-${flavor.name}`}>
-                        {flavor.resources.map((resource, resourceIndex) => {
+                        {flavor.resources?.map((resource, resourceIndex) => {
                           const usageFlavor = clusterQueue.status?.flavorsUsage?.find(f => f.name === flavor.name);
                           const usageRes = usageFlavor?.resources?.find(r => r.name === resource.name);
                           const usageVal = toNumber(usageRes?.total);

--- a/cmd/kueueviz/frontend/src/FlavorTable.jsx
+++ b/cmd/kueueviz/frontend/src/FlavorTable.jsx
@@ -35,7 +35,7 @@ const FlavorTable = ({ title, flavorData, linkToFlavor, showBorrowingColumn }) =
         <TableBody>
           {flavorData?.map((flavor, index) => (
             <React.Fragment key={flavor.name}>
-              {flavor.resources.map((resource, resIndex) => (
+              {flavor.resources?.map((resource, resIndex) => (
                 <TableRow key={`${index}-${resIndex}`}>
                   {/* Display Flavor Name with rowSpan across all its resources */}
                   {resIndex === 0 && (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/area dashboard

#### What this PR does / why we need it:

When a flavor has no resources, the backend quietly drops the resources field from the JSON response because of the omitempty tag on the Go struct. On the frontend, that means `flavor.resources` comes in as `undefined`. It calls `.map()` on `undefined` and throws a TypeError that takes down the entire dashboard UI.

This fix adds optional chaining `(?.)` to `flavor.resources` in both `FlavorTable.jsx` and `ClusterQueueDetail.jsx`, so the map is simply skipped when the field isn't there, and the dashboard keeps running normally.

| Before | After |
|--------|-------|
| <img width="400" alt="Before" src="https://github.com/user-attachments/assets/676668de-af1b-4b33-9c60-d28c90853859" /> | <img width="400" alt="After" src="https://github.com/user-attachments/assets/b44512f3-8bad-4c4a-8d32-3b3cf45c525f" /> |


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  #12566

#### Special notes for your reviewer:
`cmd/kueueviz/frontend/src/ClusterQueueDetail.jsx` doesn't really need optional chaining, its already being validated for undefined. Added optional chaining here as well for consistency.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
KueueViz: Fixed dashboard crash caused by missing optional chaining on flavor.resources
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the cluster queue and flavor views to handle missing resource lists gracefully.
  * Prevented runtime errors when a flavor has no resources defined, so tables continue to render normally.
  * Preserved existing usage, quota, reservation, and row layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->