### PR TITLE
KueueViz: enforce websocket read limit to prevent OOM

### DIFF
--- a/cmd/kueueviz/backend/handlers/websocket_handler.go
+++ b/cmd/kueueviz/backend/handlers/websocket_handler.go
@@ -54,6 +54,7 @@ func (h *Handlers) GenericWebSocketHandler(dataFetcher func(ctx context.Context)
 			return
 		}
 		defer conn.Close()
+		conn.SetReadLimit(8192)
 		slog.Debug("WebSocket connection established", "duration", time.Since(connStart))
 
 		ctx, cancel := context.WithCancel(c.Request.Context())

--- a/cmd/kueueviz/backend/handlers/websocket_handler_test.go
+++ b/cmd/kueueviz/backend/handlers/websocket_handler_test.go
@@ -321,6 +321,45 @@ func TestWebSocketHandleInformerUpdates(t *testing.T) {
 				}
 			},
 		},
+		"enforces websocket read limit": {
+			run: func(t *testing.T) {
+				gvk := schema.GroupVersionKind{Group: "group", Version: "v1", Kind: "Kind"}
+
+				informer := newMockInformer()
+				client := newMockClient(map[schema.GroupVersionKind]*mockInformer{gvk: informer})
+
+				dataFetcher := func(_ context.Context) (any, error) {
+					return map[string]string{"status": "ok"}, nil
+				}
+
+				conn, closeServer := newTestWebSocketConnection(t, &Handlers{client: client}, dataFetcher, gvk)
+				defer closeServer()
+				defer conn.Close()
+
+				readMessage(t, conn)
+
+				payload := make([]byte, 9000)
+
+				err := conn.WriteMessage(websocket.BinaryMessage, payload)
+				if err != nil {
+					t.Fatalf("failed to write 9KB message to server: %v", err)
+				}
+
+				if err := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+					t.Fatalf("set read deadline: %v", err)
+				}
+
+				_, _, err = conn.ReadMessage()
+
+				if err == nil {
+					t.Fatalf("expected read error due to limit, but got nil")
+				}
+
+				if !websocket.IsCloseError(err, websocket.CloseMessageTooBig) && !strings.Contains(err.Error(), "close 1009") {
+					t.Fatalf("expected CloseMessageTooBig (1009), got: %v", err)
+				}
+			},
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/area dashboard

#### What this PR does / why we need it:

Enforces a maximum read limit on WebSocket connections in the KueueViz backend by calling `conn.SetReadLimit()` immediately after each connection is upgraded.

Previously, `gorilla/websocket` would allocate memory unboundedly to accommodate arbitrarily large frames sent by a client. A malicious (or buggy) client could exploit this by sending a single oversized WebSocket frame, causing the backend process to exhaust available memory and crash (OOM), taking down the entire KueueViz dashboard until the pod is restarted.

The fix adds `conn.SetReadLimit(8192)` (8 KiB) since the frontend client only receives data and does not send large payloads back up to the server.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12549

#### Special notes for your reviewer:

The original issue was generated by an automated scanner that flagged 5 files in its "Blast Radius" analysis. After manually auditing all 5, the other 4 turned out to be false positives. They use or connect to WebSocket, but none of them call `upgrader.Upgrade` to initialize the server-side connection. The vulnerability was fully contained to the single `upgrader.Upgrade` call in `websocket_handler.go`, which is the only place `SetReadLimit` needed to be added.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
KueueViz: Fixed a Denial of Service vulnerability where an oversized WebSocket frame could exhaust backend memory (OOM). Connections now enforce an 8 KiB read limit.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket connections now enforce a maximum incoming message size, helping prevent oversized frames from impacting stability.
  * Added coverage to verify the server correctly rejects messages that exceed the limit, returning the expected “message too big” behavior to the client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->