### PR TITLE
Fix --dry-run flag ignored in kueuectl resume/stop localqueue and clusterqueue

### DIFF
--- a/cmd/kueuectl/app/resume/resume_clusterqueue.go
+++ b/cmd/kueuectl/app/resume/resume_clusterqueue.go
@@ -34,6 +34,7 @@ import (
 	kueuev1beta2 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/kueue/v1beta2"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/clientgetter"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/completion"
+	"sigs.k8s.io/kueue/cmd/kueuectl/app/dryrun"
 )
 
 var (
@@ -46,6 +47,7 @@ var (
 
 type ClusterQueueOptions struct {
 	ClusterQueueName string
+	DryRunStrategy   dryrun.Strategy
 	Client           kueuev1beta2.KueueV1beta2Interface
 	PrintFlags       *genericclioptions.PrintFlags
 	PrintObj         printers.ResourcePrinterFunc
@@ -73,7 +75,7 @@ func NewClusterQueueCmd(clientGetter clientgetter.ClientGetter, streams generici
 		ValidArgsFunction:     completion.ClusterQueueNameFunc(clientGetter, new(false)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			err := o.Complete(clientGetter, args)
+			err := o.Complete(clientGetter, cmd, args)
 			if err != nil {
 				return err
 			}
@@ -87,8 +89,19 @@ func NewClusterQueueCmd(clientGetter clientgetter.ClientGetter, streams generici
 }
 
 // Complete completes all the required options
-func (o *ClusterQueueOptions) Complete(clientGetter clientgetter.ClientGetter, args []string) error {
+func (o *ClusterQueueOptions) Complete(clientGetter clientgetter.ClientGetter, cmd *cobra.Command, args []string) error {
 	o.ClusterQueueName = args[0]
+
+	var err error
+	o.DryRunStrategy, err = dryrun.GetStrategy(cmd)
+	if err != nil {
+		return err
+	}
+
+	err = dryrun.PrintFlagsWithStrategy(o.PrintFlags, o.DryRunStrategy)
+	if err != nil {
+		return err
+	}
 
 	clientset, err := clientGetter.KueueClientSet()
 	if err != nil {
@@ -117,16 +130,21 @@ func (o *ClusterQueueOptions) Run(ctx context.Context) error {
 	cqOriginal := cq.DeepCopy()
 	cq.Spec.StopPolicy = ptr.To(kueue.None)
 
-	opts := metav1.PatchOptions{}
-	patch := client.MergeFrom(cqOriginal)
-	data, err := patch.Data(cq)
-	if err != nil {
-		return err
-	}
-	cq, err = o.Client.ClusterQueues().
-		Patch(ctx, o.ClusterQueueName, types.MergePatchType, data, opts)
-	if err != nil {
-		return err
+	if o.DryRunStrategy != dryrun.Client {
+		opts := metav1.PatchOptions{}
+		if o.DryRunStrategy == dryrun.Server {
+			opts.DryRun = []string{metav1.DryRunAll}
+		}
+		patch := client.MergeFrom(cqOriginal)
+		data, err := patch.Data(cq)
+		if err != nil {
+			return err
+		}
+		cq, err = o.Client.ClusterQueues().
+			Patch(ctx, o.ClusterQueueName, types.MergePatchType, data, opts)
+		if err != nil {
+			return err
+		}
 	}
 
 	return o.PrintObj(cq, o.Out)

--- a/cmd/kueuectl/app/resume/resume_localqueue.go
+++ b/cmd/kueuectl/app/resume/resume_localqueue.go
@@ -34,6 +34,7 @@ import (
 	kueuev1beta2 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/kueue/v1beta2"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/clientgetter"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/completion"
+	"sigs.k8s.io/kueue/cmd/kueuectl/app/dryrun"
 )
 
 var (
@@ -50,6 +51,7 @@ type LocalQueueOptions struct {
 
 	LocalQueueName string
 	Namespace      string
+	DryRunStrategy dryrun.Strategy
 
 	Client kueuev1beta2.KueueV1beta2Interface
 
@@ -77,7 +79,7 @@ func NewLocalQueueCmd(clientGetter clientgetter.ClientGetter, streams genericioo
 		ValidArgsFunction:     completion.LocalQueueNameFunc(clientGetter, new(false)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			err := o.Complete(clientGetter, args)
+			err := o.Complete(clientGetter, cmd, args)
 			if err != nil {
 				return err
 			}
@@ -91,7 +93,7 @@ func NewLocalQueueCmd(clientGetter clientgetter.ClientGetter, streams genericioo
 }
 
 // Complete completes all the required options
-func (o *LocalQueueOptions) Complete(clientGetter clientgetter.ClientGetter, args []string) error {
+func (o *LocalQueueOptions) Complete(clientGetter clientgetter.ClientGetter, cmd *cobra.Command, args []string) error {
 	o.LocalQueueName = args[0]
 
 	namespace, _, err := clientGetter.ToRawKubeConfigLoader().Namespace()
@@ -100,6 +102,16 @@ func (o *LocalQueueOptions) Complete(clientGetter clientgetter.ClientGetter, arg
 	}
 
 	o.Namespace = namespace
+
+	o.DryRunStrategy, err = dryrun.GetStrategy(cmd)
+	if err != nil {
+		return err
+	}
+
+	err = dryrun.PrintFlagsWithStrategy(o.PrintFlags, o.DryRunStrategy)
+	if err != nil {
+		return err
+	}
 
 	clientset, err := clientGetter.KueueClientSet()
 	if err != nil {
@@ -128,16 +140,21 @@ func (o *LocalQueueOptions) Run(ctx context.Context) error {
 	lqOriginal := lq.DeepCopy()
 	lq.Spec.StopPolicy = ptr.To(kueue.None)
 
-	opts := metav1.PatchOptions{}
-	patch := client.MergeFrom(lqOriginal)
-	data, err := patch.Data(lq)
-	if err != nil {
-		return err
-	}
-	lq, err = o.Client.LocalQueues(o.Namespace).
-		Patch(ctx, o.LocalQueueName, types.MergePatchType, data, opts)
-	if err != nil {
-		return err
+	if o.DryRunStrategy != dryrun.Client {
+		opts := metav1.PatchOptions{}
+		if o.DryRunStrategy == dryrun.Server {
+			opts.DryRun = []string{metav1.DryRunAll}
+		}
+		patch := client.MergeFrom(lqOriginal)
+		data, err := patch.Data(lq)
+		if err != nil {
+			return err
+		}
+		lq, err = o.Client.LocalQueues(o.Namespace).
+			Patch(ctx, o.LocalQueueName, types.MergePatchType, data, opts)
+		if err != nil {
+			return err
+		}
 	}
 
 	return o.PrintObj(lq, o.Out)

--- a/cmd/kueuectl/app/stop/stop_clusterqueue.go
+++ b/cmd/kueuectl/app/stop/stop_clusterqueue.go
@@ -34,6 +34,7 @@ import (
 	kueuev1beta2 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/kueue/v1beta2"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/clientgetter"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/completion"
+	"sigs.k8s.io/kueue/cmd/kueuectl/app/dryrun"
 )
 
 var (
@@ -47,6 +48,7 @@ var (
 type ClusterQueueOptions struct {
 	ClusterQueueName   string
 	KeepAlreadyRunning bool
+	DryRunStrategy     dryrun.Strategy
 	Client             kueuev1beta2.KueueV1beta2Interface
 	PrintFlags         *genericclioptions.PrintFlags
 	PrintObj           printers.ResourcePrinterFunc
@@ -74,7 +76,7 @@ func NewClusterQueueCmd(clientGetter clientgetter.ClientGetter, streams generici
 		ValidArgsFunction:     completion.ClusterQueueNameFunc(clientGetter, new(true)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			err := o.Complete(clientGetter, args)
+			err := o.Complete(clientGetter, cmd, args)
 			if err != nil {
 				return err
 			}
@@ -90,8 +92,19 @@ func NewClusterQueueCmd(clientGetter clientgetter.ClientGetter, streams generici
 }
 
 // Complete completes all the required options
-func (o *ClusterQueueOptions) Complete(clientGetter clientgetter.ClientGetter, args []string) error {
+func (o *ClusterQueueOptions) Complete(clientGetter clientgetter.ClientGetter, cmd *cobra.Command, args []string) error {
 	o.ClusterQueueName = args[0]
+
+	var err error
+	o.DryRunStrategy, err = dryrun.GetStrategy(cmd)
+	if err != nil {
+		return err
+	}
+
+	err = dryrun.PrintFlagsWithStrategy(o.PrintFlags, o.DryRunStrategy)
+	if err != nil {
+		return err
+	}
 
 	clientset, err := clientGetter.KueueClientSet()
 	if err != nil {
@@ -124,16 +137,21 @@ func (o *ClusterQueueOptions) Run(ctx context.Context) error {
 	cqOriginal := cq.DeepCopy()
 	o.stopClusterQueue(cq)
 
-	opts := metav1.PatchOptions{}
-	patch := client.MergeFrom(cqOriginal)
-	data, err := patch.Data(cq)
-	if err != nil {
-		return err
-	}
-	cq, err = o.Client.ClusterQueues().
-		Patch(ctx, o.ClusterQueueName, types.MergePatchType, data, opts)
-	if err != nil {
-		return err
+	if o.DryRunStrategy != dryrun.Client {
+		opts := metav1.PatchOptions{}
+		if o.DryRunStrategy == dryrun.Server {
+			opts.DryRun = []string{metav1.DryRunAll}
+		}
+		patch := client.MergeFrom(cqOriginal)
+		data, err := patch.Data(cq)
+		if err != nil {
+			return err
+		}
+		cq, err = o.Client.ClusterQueues().
+			Patch(ctx, o.ClusterQueueName, types.MergePatchType, data, opts)
+		if err != nil {
+			return err
+		}
 	}
 
 	return o.PrintObj(cq, o.Out)

--- a/cmd/kueuectl/app/stop/stop_localqueue.go
+++ b/cmd/kueuectl/app/stop/stop_localqueue.go
@@ -34,6 +34,7 @@ import (
 	kueuev1beta2 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/kueue/v1beta2"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/clientgetter"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/completion"
+	"sigs.k8s.io/kueue/cmd/kueuectl/app/dryrun"
 )
 
 var (
@@ -51,6 +52,7 @@ type LocalQueueOptions struct {
 	LocalQueueName     string
 	Namespace          string
 	KeepAlreadyRunning bool
+	DryRunStrategy     dryrun.Strategy
 
 	Client kueuev1beta2.KueueV1beta2Interface
 
@@ -78,7 +80,7 @@ func NewLocalQueueCmd(clientGetter clientgetter.ClientGetter, streams genericioo
 		ValidArgsFunction:     completion.LocalQueueNameFunc(clientGetter, new(true)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			err := o.Complete(clientGetter, args)
+			err := o.Complete(clientGetter, cmd, args)
 			if err != nil {
 				return err
 			}
@@ -94,7 +96,7 @@ func NewLocalQueueCmd(clientGetter clientgetter.ClientGetter, streams genericioo
 }
 
 // Complete completes all the required options
-func (o *LocalQueueOptions) Complete(clientGetter clientgetter.ClientGetter, args []string) error {
+func (o *LocalQueueOptions) Complete(clientGetter clientgetter.ClientGetter, cmd *cobra.Command, args []string) error {
 	o.LocalQueueName = args[0]
 
 	namespace, _, err := clientGetter.ToRawKubeConfigLoader().Namespace()
@@ -103,6 +105,16 @@ func (o *LocalQueueOptions) Complete(clientGetter clientgetter.ClientGetter, arg
 	}
 
 	o.Namespace = namespace
+
+	o.DryRunStrategy, err = dryrun.GetStrategy(cmd)
+	if err != nil {
+		return err
+	}
+
+	err = dryrun.PrintFlagsWithStrategy(o.PrintFlags, o.DryRunStrategy)
+	if err != nil {
+		return err
+	}
 
 	clientset, err := clientGetter.KueueClientSet()
 	if err != nil {
@@ -135,16 +147,21 @@ func (o *LocalQueueOptions) Run(ctx context.Context) error {
 	lqOriginal := lq.DeepCopy()
 	o.stopLocalQueue(lq)
 
-	opts := metav1.PatchOptions{}
-	patch := client.MergeFrom(lqOriginal)
-	data, err := patch.Data(lq)
-	if err != nil {
-		return err
-	}
-	lq, err = o.Client.LocalQueues(o.Namespace).
-		Patch(ctx, o.LocalQueueName, types.MergePatchType, data, opts)
-	if err != nil {
-		return err
+	if o.DryRunStrategy != dryrun.Client {
+		opts := metav1.PatchOptions{}
+		if o.DryRunStrategy == dryrun.Server {
+			opts.DryRun = []string{metav1.DryRunAll}
+		}
+		patch := client.MergeFrom(lqOriginal)
+		data, err := patch.Data(lq)
+		if err != nil {
+			return err
+		}
+		lq, err = o.Client.LocalQueues(o.Namespace).
+			Patch(ctx, o.LocalQueueName, types.MergePatchType, data, opts)
+		if err != nil {
+			return err
+		}
 	}
 
 	return o.PrintObj(lq, o.Out)

--- a/test/integration/singlecluster/kueuectl/resume_test.go
+++ b/test/integration/singlecluster/kueuectl/resume_test.go
@@ -125,6 +125,43 @@ var _ = ginkgo.Describe("Kueuectl Resume", func() {
 				kueue.Hold,
 			),
 		)
+
+		ginkgo.DescribeTable("Should not resume a LocalQueue with --dry-run",
+			func(name, dryRunStrategy string) {
+				lq := utiltestingapi.MakeLocalQueue(name, ns.Name).StopPolicy(kueue.HoldAndDrain).Obj()
+
+				ginkgo.By("Create a LocalQueue", func() {
+					util.MustCreate(ctx, k8sClient, lq)
+				})
+
+				createdLocalQueue := &kueue.LocalQueue{}
+				ginkgo.By("Get created LocalQueue", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lq), createdLocalQueue)).To(gomega.Succeed())
+						g.Expect(ptr.Deref(createdLocalQueue.Spec.StopPolicy, kueue.None)).Should(gomega.Equal(kueue.HoldAndDrain))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Resume with --dry-run="+dryRunStrategy, func() {
+					streams, _, output, _ := genericiooptions.NewTestIOStreams()
+					configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
+					kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+
+					kueuectl.SetArgs([]string{"resume", "localqueue", createdLocalQueue.Name, "--namespace", ns.Name, "--dry-run", dryRunStrategy})
+					err := kueuectl.Execute()
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
+				})
+
+				ginkgo.By("Check that the LocalQueue is still stopped", func() {
+					gomega.Consistently(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(createdLocalQueue), createdLocalQueue)).To(gomega.Succeed())
+						g.Expect(ptr.Deref(createdLocalQueue.Spec.StopPolicy, kueue.None)).Should(gomega.Equal(kueue.HoldAndDrain))
+					}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+				})
+			},
+			ginkgo.Entry("client", "lq-dry-run-client", "client"),
+			ginkgo.Entry("server", "lq-dry-run-server", "server"),
+		)
 	})
 
 	ginkgo.When("Resuming a ClusterQueue", func() {
@@ -170,6 +207,51 @@ var _ = ginkgo.Describe("Kueuectl Resume", func() {
 			ginkgo.Entry("Hold",
 				utiltestingapi.MakeClusterQueue("cq-2").StopPolicy(kueue.Hold).Obj(),
 				kueue.Hold,
+			),
+		)
+
+		ginkgo.DescribeTable("Should not resume a ClusterQueue with --dry-run",
+			func(cq *kueue.ClusterQueue, dryRunStrategy string) {
+				ginkgo.By("Create a ClusterQueue", func() {
+					util.MustCreate(ctx, k8sClient, cq)
+				})
+
+				ginkgo.DeferCleanup(func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+				})
+
+				createdClusterQueue := &kueue.ClusterQueue{}
+				ginkgo.By("Get created ClusterQueue", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), createdClusterQueue)).To(gomega.Succeed())
+						g.Expect(ptr.Deref(createdClusterQueue.Spec.StopPolicy, kueue.None)).Should(gomega.Equal(kueue.HoldAndDrain))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Resume with --dry-run="+dryRunStrategy, func() {
+					streams, _, output, _ := genericiooptions.NewTestIOStreams()
+					configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
+					kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+
+					kueuectl.SetArgs([]string{"resume", "clusterqueue", createdClusterQueue.Name, "--dry-run", dryRunStrategy})
+					err := kueuectl.Execute()
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
+				})
+
+				ginkgo.By("Check that the ClusterQueue is still stopped", func() {
+					gomega.Consistently(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(createdClusterQueue), createdClusterQueue)).To(gomega.Succeed())
+						g.Expect(ptr.Deref(createdClusterQueue.Spec.StopPolicy, kueue.None)).Should(gomega.Equal(kueue.HoldAndDrain))
+					}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+				})
+			},
+			ginkgo.Entry("client",
+				utiltestingapi.MakeClusterQueue("cq-dry-run-client").StopPolicy(kueue.HoldAndDrain).Obj(),
+				"client",
+			),
+			ginkgo.Entry("server",
+				utiltestingapi.MakeClusterQueue("cq-dry-run-server").StopPolicy(kueue.HoldAndDrain).Obj(),
+				"server",
 			),
 		)
 	})

--- a/test/integration/singlecluster/kueuectl/stop_test.go
+++ b/test/integration/singlecluster/kueuectl/stop_test.go
@@ -127,6 +127,43 @@ var _ = ginkgo.Describe("Kueuectl Stop", func() {
 				kueue.Hold,
 			),
 		)
+
+		ginkgo.DescribeTable("Should not stop a LocalQueue with --dry-run",
+			func(name, dryRunStrategy string) {
+				lq := utiltestingapi.MakeLocalQueue(name, ns.Name).Obj()
+
+				ginkgo.By("Create a LocalQueue", func() {
+					util.MustCreate(ctx, k8sClient, lq)
+				})
+
+				createdLocalQueue := &kueue.LocalQueue{}
+				ginkgo.By("Get created LocalQueue", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lq), createdLocalQueue)).To(gomega.Succeed())
+						g.Expect(ptr.Deref(createdLocalQueue.Spec.StopPolicy, kueue.None)).Should(gomega.Equal(kueue.None))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Stop with --dry-run="+dryRunStrategy, func() {
+					streams, _, output, _ := genericiooptions.NewTestIOStreams()
+					configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
+					kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+
+					kueuectl.SetArgs([]string{"stop", "localqueue", createdLocalQueue.Name, "--namespace", ns.Name, "--dry-run", dryRunStrategy})
+					err := kueuectl.Execute()
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
+				})
+
+				ginkgo.By("Check that the LocalQueue is still active", func() {
+					gomega.Consistently(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(createdLocalQueue), createdLocalQueue)).To(gomega.Succeed())
+						g.Expect(ptr.Deref(createdLocalQueue.Spec.StopPolicy, kueue.None)).Should(gomega.Equal(kueue.None))
+					}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+				})
+			},
+			ginkgo.Entry("client", "lq-dry-run-client", "client"),
+			ginkgo.Entry("server", "lq-dry-run-server", "server"),
+		)
 	})
 
 	ginkgo.When("Stopping a ClusterQueue", func() {
@@ -174,6 +211,51 @@ var _ = ginkgo.Describe("Kueuectl Stop", func() {
 				utiltestingapi.MakeClusterQueue("cq-2").Obj(),
 				[]string{"--keep-already-running"},
 				kueue.Hold,
+			),
+		)
+
+		ginkgo.DescribeTable("Should not stop a ClusterQueue with --dry-run",
+			func(cq *kueue.ClusterQueue, dryRunStrategy string) {
+				ginkgo.By("Create a ClusterQueue", func() {
+					util.MustCreate(ctx, k8sClient, cq)
+				})
+
+				ginkgo.DeferCleanup(func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+				})
+
+				createdClusterQueue := &kueue.ClusterQueue{}
+				ginkgo.By("Get created ClusterQueue", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), createdClusterQueue)).To(gomega.Succeed())
+						g.Expect(ptr.Deref(createdClusterQueue.Spec.StopPolicy, kueue.None)).Should(gomega.Equal(kueue.None))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Stop with --dry-run="+dryRunStrategy, func() {
+					streams, _, output, _ := genericiooptions.NewTestIOStreams()
+					configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
+					kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+
+					kueuectl.SetArgs([]string{"stop", "clusterqueue", createdClusterQueue.Name, "--dry-run", dryRunStrategy})
+					err := kueuectl.Execute()
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
+				})
+
+				ginkgo.By("Check that the ClusterQueue is still active", func() {
+					gomega.Consistently(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(createdClusterQueue), createdClusterQueue)).To(gomega.Succeed())
+						g.Expect(ptr.Deref(createdClusterQueue.Spec.StopPolicy, kueue.None)).Should(gomega.Equal(kueue.None))
+					}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+				})
+			},
+			ginkgo.Entry("client",
+				utiltestingapi.MakeClusterQueue("cq-dry-run-client").Obj(),
+				"client",
+			),
+			ginkgo.Entry("server",
+				utiltestingapi.MakeClusterQueue("cq-dry-run-server").Obj(),
+				"server",
 			),
 		)
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

The `--dry-run` flag is registered as a `PersistentFlag` on the parent `resume` and `stop` commands, making it available to all subcommands including `localqueue` and `clusterqueue`. However, these subcommands ignored the flag entirely, always performing the server-side Patch regardless of `--dry-run=client` or `--dry-run=server`.

This PR brings LocalQueue and ClusterQueue handling in line with the existing Workload implementation in `UpdateWorkloadActivationOptions`, which correctly gates the Patch call on `DryRunStrategy`:
- `--dry-run=client`: skip the Patch call entirely, print the locally-modified object.
- `--dry-run=server`: pass `DryRun: []string{metav1.DryRunAll}` to `PatchOptions`.
- `--dry-run=none` (default): behavior is unchanged.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12565

#### Special notes for your reviewer:

The fix applies the identical pattern across 4 files (`resume_localqueue.go`, `resume_clusterqueue.go`, `stop_localqueue.go`, `stop_clusterqueue.go`). Each change is structurally the same:
1. Add `DryRunStrategy dryrun.Strategy` field to the options struct.
2. Resolve the strategy in `Complete()` via `dryrun.GetStrategy(cmd)` and `dryrun.PrintFlagsWithStrategy()`.
3. Gate the `Patch()` call in `Run()` behind `o.DryRunStrategy != dryrun.Client`, and set `opts.DryRun` for server-side dry-run.
4. The `Complete()` parameter order follows the existing codebase convention (`clientGetter, cmd, args`).
Integration tests cover both `--dry-run=client` and `--dry-run=server` for all four affected subcommands.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
CLI: Fix --dry-run flag being silently ignored in kueuectl resume/stop localqueue and clusterqueue subcommands.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--dry-run` support to `kueuectl resume` and `kueuectl stop` for both LocalQueue and ClusterQueue commands.
  * Dry-run behavior now respects client-side and server-side modes while keeping command output consistent.

* **Tests**
  * Added integration coverage to verify queues remain unchanged when stop/resume is run with dry-run enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->