### PR TITLE
Sanitize remote metadata for MultiKueue external-framework jobs

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter.go
+++ b/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter.go
@@ -86,9 +86,7 @@ func (a *Adapter) SyncJob(ctx context.Context, localClient client.Client, remote
 func (a *Adapter) createRemoteObject(ctx context.Context, remoteClient client.Client, localObj *unstructured.Unstructured, workloadName, origin string) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	// Create a copy of the local object for the remote cluster
-	remoteObj := localObj.DeepCopy()
-	remoteObj.SetResourceVersion("")
+	remoteObj := cloneUnstructuredForCreation(localObj)
 
 	// Apply default transformation: remove the managedBy field
 	a.removeManagedByField(remoteObj)
@@ -99,6 +97,24 @@ func (a *Adapter) createRemoteObject(ctx context.Context, remoteClient client.Cl
 	// Create the object in the remote cluster
 	log.V(2).Info("Creating remote object", "gvk", a.gvk, "name", remoteObj.GetName(), "namespace", remoteObj.GetNamespace())
 	return remoteClient.Create(ctx, remoteObj)
+}
+
+// cloneUnstructuredForCreation creates a copy of obj containing only the GVK, name,
+// namespace, labels, annotations and spec, the unstructured analogue of
+// api.CloneObjectMetaForCreation; keep the two in sync. Dropping the rest (notably
+// ownerReferences, whose UIDs don't exist remotely) avoids the remote GC deleting the
+// copy in a create-delete loop.
+func cloneUnstructuredForCreation(obj *unstructured.Unstructured) *unstructured.Unstructured {
+	remote := &unstructured.Unstructured{Object: map[string]any{}}
+	remote.SetGroupVersionKind(obj.GroupVersionKind())
+	remote.SetName(obj.GetName())
+	remote.SetNamespace(obj.GetNamespace())
+	remote.SetLabels(obj.GetLabels())
+	remote.SetAnnotations(obj.GetAnnotations())
+	if spec, found, _ := unstructured.NestedFieldCopy(obj.Object, "spec"); found {
+		remote.Object["spec"] = spec
+	}
+	return remote
 }
 
 func (a *Adapter) syncStatus(ctx context.Context, localClient client.Client, localObj, remoteObj *unstructured.Unstructured) error {

--- a/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter.go
+++ b/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter.go
@@ -34,6 +34,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/util/api"
 )
 
 // Adapter implements the MultiKueueAdapter interface for external frameworks
@@ -86,7 +87,10 @@ func (a *Adapter) SyncJob(ctx context.Context, localClient client.Client, remote
 func (a *Adapter) createRemoteObject(ctx context.Context, remoteClient client.Client, localObj *unstructured.Unstructured, workloadName, origin string) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	remoteObj := cloneUnstructuredForCreation(localObj)
+	remoteObj, err := cloneUnstructuredForCreation(localObj)
+	if err != nil {
+		return err
+	}
 
 	// Apply default transformation: remove the managedBy field
 	a.removeManagedByField(remoteObj)
@@ -101,20 +105,32 @@ func (a *Adapter) createRemoteObject(ctx context.Context, remoteClient client.Cl
 
 // cloneUnstructuredForCreation creates a copy of obj containing only the GVK, name,
 // namespace, labels, annotations and spec, the unstructured analogue of
-// api.CloneObjectMetaForCreation; keep the two in sync. Dropping the rest (notably
-// ownerReferences, whose UIDs don't exist remotely) avoids the remote GC deleting the
-// copy in a create-delete loop.
-func cloneUnstructuredForCreation(obj *unstructured.Unstructured) *unstructured.Unstructured {
+// api.CloneObjectMetaForCreation, which it reuses for the metadata. Dropping the rest
+// (notably ownerReferences, whose UIDs don't exist remotely) avoids the remote GC
+// deleting the copy in a create-delete loop.
+func cloneUnstructuredForCreation(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	var meta metav1.ObjectMeta
+	if metaMap, found, err := unstructured.NestedMap(obj.Object, "metadata"); err != nil {
+		return nil, fmt.Errorf("reading metadata: %w", err)
+	} else if found {
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(metaMap, &meta); err != nil {
+			return nil, fmt.Errorf("converting metadata to ObjectMeta: %w", err)
+		}
+	}
+
+	cleaned := api.CloneObjectMetaForCreation(&meta)
+	cleanedMeta, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&cleaned)
+	if err != nil {
+		return nil, fmt.Errorf("converting cleaned metadata to unstructured: %w", err)
+	}
+
 	remote := &unstructured.Unstructured{Object: map[string]any{}}
 	remote.SetGroupVersionKind(obj.GroupVersionKind())
-	remote.SetName(obj.GetName())
-	remote.SetNamespace(obj.GetNamespace())
-	remote.SetLabels(obj.GetLabels())
-	remote.SetAnnotations(obj.GetAnnotations())
+	remote.Object["metadata"] = cleanedMeta
 	if spec, found, _ := unstructured.NestedFieldCopy(obj.Object, "spec"); found {
 		remote.Object["spec"] = spec
 	}
-	return remote
+	return remote, nil
 }
 
 func (a *Adapter) syncStatus(ctx context.Context, localClient client.Client, localObj, remoteObj *unstructured.Unstructured) error {

--- a/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter_test.go
+++ b/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter_test.go
@@ -149,6 +149,169 @@ func TestAdapter_IsJobManagedByKueue(t *testing.T) {
 	}
 }
 
+func TestCloneUnstructuredForCreation(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "test.example.com", Version: "v1", Kind: "TestJob"}
+
+	cases := map[string]struct {
+		metadata map[string]any
+		spec     any
+		want     *unstructured.Unstructured
+	}{
+		"strips ownerReferences, uid, resourceVersion, finalizers and managedFields": {
+			metadata: map[string]any{
+				"name":            "job1",
+				"namespace":       "ns1",
+				"uid":             "local-uid",
+				"resourceVersion": "123",
+				"labels":          map[string]any{"app": "foo"},
+				"annotations":     map[string]any{"k": "v"},
+				"ownerReferences": []any{map[string]any{"name": "owner", "uid": "owner-uid"}},
+				"finalizers":      []any{"some/finalizer"},
+				"managedFields":   []any{map[string]any{"manager": "kueue"}},
+			},
+			spec: map[string]any{"replicas": int64(3)},
+			want: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "test.example.com/v1",
+				"kind":       "TestJob",
+				"metadata": map[string]any{
+					"name":        "job1",
+					"namespace":   "ns1",
+					"labels":      map[string]any{"app": "foo"},
+					"annotations": map[string]any{"k": "v"},
+				},
+				"spec": map[string]any{"replicas": int64(3)},
+			}},
+		},
+		"keeps only name, namespace and spec when no labels or annotations": {
+			metadata: map[string]any{
+				"name":            "job1",
+				"namespace":       "ns1",
+				"ownerReferences": []any{map[string]any{"name": "owner", "uid": "owner-uid"}},
+			},
+			spec: map[string]any{"replicas": int64(1)},
+			want: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "test.example.com/v1",
+				"kind":       "TestJob",
+				"metadata": map[string]any{
+					"name":      "job1",
+					"namespace": "ns1",
+				},
+				"spec": map[string]any{"replicas": int64(1)},
+			}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			obj := &unstructured.Unstructured{Object: map[string]any{
+				"metadata": tc.metadata,
+				"spec":     tc.spec,
+				"status":   map[string]any{"phase": "Running"},
+			}}
+			obj.SetGroupVersionKind(gvk)
+
+			got := cloneUnstructuredForCreation(obj)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("cloneUnstructuredForCreation() (-want,+got):\n%s", diff)
+			}
+
+			// The returned spec must be an independent copy of the source.
+			if err := unstructured.SetNestedField(got.Object, int64(99), "spec", "replicas"); err != nil {
+				t.Fatalf("SetNestedField: %v", err)
+			}
+			if replicas, _, _ := unstructured.NestedInt64(obj.Object, "spec", "replicas"); replicas == 99 {
+				t.Errorf("mutating the clone's spec must not affect the source object")
+			}
+		})
+	}
+}
+
+func TestAdapter_CreateRemoteObject(t *testing.T) {
+	gvk := schema.GroupVersionKind{
+		Group:   "test.example.com",
+		Version: "v1",
+		Kind:    "TestJob",
+	}
+	adapter := &Adapter{gvk: gvk}
+
+	localObj := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
+			"name":            "test-job",
+			"namespace":       "default",
+			"uid":             "local-uid",
+			"resourceVersion": "999",
+			"labels":          map[string]any{"app": "foo"},
+			"annotations":     map[string]any{"key": "value"},
+			"ownerReferences": []any{
+				map[string]any{
+					"apiVersion": "batch/v1",
+					"kind":       "Job",
+					"name":       "owner",
+					"uid":        "owner-uid",
+				},
+			},
+			"finalizers": []any{"some/finalizer"},
+		},
+		"spec": map[string]any{
+			"managedBy": kueue.MultiKueueControllerName,
+			"replicas":  int64(3),
+		},
+		"status": map[string]any{
+			"phase": "Running",
+		},
+	}}
+	localObj.SetGroupVersionKind(gvk)
+
+	remoteClient := fake.NewClientBuilder().Build()
+
+	if err := adapter.createRemoteObject(t.Context(), remoteClient, localObj, "test-workload", "origin1"); err != nil {
+		t.Fatalf("createRemoteObject() error = %v", err)
+	}
+
+	created := &unstructured.Unstructured{}
+	created.SetGroupVersionKind(gvk)
+	key := types.NamespacedName{Name: "test-job", Namespace: "default"}
+	if err := remoteClient.Get(t.Context(), key, created); err != nil {
+		t.Fatalf("Get created remote object error = %v", err)
+	}
+
+	// ownerReferences must be dropped, else the remote GC would delete the object.
+	if refs := created.GetOwnerReferences(); len(refs) != 0 {
+		t.Errorf("remote object should have no ownerReferences, got %v", refs)
+	}
+	if uid := created.GetUID(); uid != "" {
+		t.Errorf("remote object should have no uid carried over, got %q", uid)
+	}
+	if finalizers := created.GetFinalizers(); len(finalizers) != 0 {
+		t.Errorf("remote object should have no finalizers, got %v", finalizers)
+	}
+	if _, exists, _ := unstructured.NestedMap(created.Object, "status"); exists {
+		t.Errorf("remote object should not carry over local status")
+	}
+
+	if got := created.GetAnnotations(); got["key"] != "value" {
+		t.Errorf("annotations should be preserved, got %v", got)
+	}
+	labels := created.GetLabels()
+	if labels["app"] != "foo" {
+		t.Errorf("labels should be preserved, got %v", labels)
+	}
+	if labels[kueue.MultiKueueOriginLabel] != "origin1" {
+		t.Errorf("MultiKueue origin label should be set, got %v", labels)
+	}
+	// The prebuilt name lands in a label or annotation per WorkloadIdentifierAnnotations.
+	if labels[constants.PrebuiltWorkloadLabel] != "test-workload" &&
+		created.GetAnnotations()[constants.PrebuiltWorkloadAnnotation] != "test-workload" {
+		t.Errorf("prebuilt workload name should be set, labels=%v annotations=%v", labels, created.GetAnnotations())
+	}
+	if _, exists, _ := unstructured.NestedString(created.Object, "spec", "managedBy"); exists {
+		t.Errorf("spec.managedBy should be removed")
+	}
+	if replicas, _, _ := unstructured.NestedInt64(created.Object, "spec", "replicas"); replicas != 3 {
+		t.Errorf("spec.replicas should be preserved, got %d", replicas)
+	}
+}
+
 func TestAdapter_RemoveManagedByField(t *testing.T) {
 	adapter := &Adapter{
 		gvk: schema.GroupVersionKind{

--- a/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter_test.go
+++ b/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter_test.go
@@ -210,7 +210,10 @@ func TestCloneUnstructuredForCreation(t *testing.T) {
 			}}
 			obj.SetGroupVersionKind(gvk)
 
-			got := cloneUnstructuredForCreation(obj)
+			got, err := cloneUnstructuredForCreation(obj)
+			if err != nil {
+				t.Fatalf("cloneUnstructuredForCreation() error: %v", err)
+			}
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("cloneUnstructuredForCreation() (-want,+got):\n%s", diff)
 			}

--- a/test/integration/multikueue/external_job_test.go
+++ b/test/integration/multikueue/external_job_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/onsi/gomega"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -350,6 +351,44 @@ var _ = ginkgo.Describe(
 				//
 				//	waitForWorkloadToFinishAndRemoteWorkloadToBeDeleted(wlLookupKey, finishJobReason)
 				// })
+			})
+
+			ginkgo.It("Should create the remote RayCluster without the manager's ownerReferences", func() {
+				admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
+					utiltestingapi.MakePodSetAssignment("head").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
+					utiltestingapi.MakePodSetAssignment("workers-group-0").
+						Flavor(corev1.ResourceCPU, multikueueTestFlavor).
+						Obj(),
+				)
+				raycluster := testingraycluster.MakeCluster("raycluster1", managerNs.Name).
+					Queue(managerLq.Name).
+					Obj()
+				// The owner UID exists only on the manager, so a worker GC would delete a copy that kept it.
+				raycluster.OwnerReferences = []metav1.OwnerReference{{
+					APIVersion: "example.com/v1",
+					Kind:       "FakeOwner",
+					Name:       "fake-owner",
+					UID:        "11111111-1111-1111-1111-111111111111",
+				}}
+				util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, raycluster)
+				wlLookupKey := types.NamespacedName{
+					Name:      workloadraycluster.GetWorkloadNameForRayCluster(raycluster.Name, raycluster.UID),
+					Namespace: managerNs.Name,
+				}
+
+				admitWorkloadAndCheckWorkerCopies(multiKueueAC.Name, wlLookupKey, admission)
+
+				// uid/resourceVersion are server-assigned, so only owner-refs/finalizers/status are checked.
+				ginkgo.By("checking the remote RayCluster carries no source-cluster metadata", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						createdRayCluster := rayv1.RayCluster{}
+						g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, client.ObjectKeyFromObject(raycluster), &createdRayCluster)).
+							To(gomega.Succeed())
+						g.Expect(createdRayCluster.OwnerReferences).To(gomega.BeEmpty())
+						g.Expect(createdRayCluster.Finalizers).To(gomega.BeEmpty())
+						g.Expect(createdRayCluster.Status).To(gomega.BeZero())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
 			})
 
 			ginkgo.It("Should run a RayCluster on worker if admitted (ManagedBy)", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/area multikueue

#### What this PR does / why we need it:

The external-framework MultiKueue adapter created remote objects from `localObj.DeepCopy()` and only cleared `resourceVersion`. This could copy source-cluster metadata such as ownerReferences to the worker cluster.

Since those owner UIDs do not exist on the worker, the worker garbage collector can delete the remote object, causing the adapter to recreate it repeatedly.

This PR builds the remote unstructured object from scratch instead, keeping only GVK, name, namespace, labels, annotations, and spec. This mirrors the `api.CloneObjectMetaForCreation` whitelist used by the typed adapters.

The integration test asserts that the remote object is created without `ownerReferences`, `finalizers`, or `status`. It does not assert the full create-delete loop because envtest does not run a real garbage collector. AI assistance was used for parts of this change.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12540

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MultiKueue: Fixed custom jobs using external-framework adapters being repeatedly created and deleted on worker clusters when source-cluster metadata was copied to the remote object.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remote objects created for admitted workloads are now sanitized to include only the expected creation-safe metadata (and spec only when present), avoiding unintended carryover such as local ownership details and status.
  * Worker-created resources no longer inherit source-cluster ownership, finalizers, or status metadata.

* **Tests**
  * Added unit tests to verify creation-safe cloning and remote object metadata/spec handling (including replicas/spec behavior).
  * Added an integration scenario ensuring worker-created RayCluster resources start without inherited source metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->