### PR TITLE
Fix RayJob dropping admission constraints for default submitter pod template

### DIFF
--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -174,6 +174,9 @@ func (j *RayJob) RunWithPodSetsInfo(ctx context.Context, _ client.Client, podSet
 		if err := podset.Merge(&submitterPod.ObjectMeta, &submitterPod.Spec, info); err != nil {
 			return err
 		}
+		if j.Spec.SubmitterPodTemplate == nil {
+			j.Spec.SubmitterPodTemplate = submitterPod
+		}
 	}
 
 	return nil

--- a/pkg/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_test.go
@@ -685,6 +685,140 @@ func TestNodeSelectors(t *testing.T) {
 
 			wantFinal: baseJob.DeepCopy(),
 		},
+		"K8sJobMode with nil SubmitterPodTemplate persists admission constraints": {
+			job: func() *rayv1.RayJob {
+				j := testingrayutil.MakeJob("job", "ns").
+					WithSubmissionMode(rayv1.K8sJobMode).
+					Obj()
+				j.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector = map[string]string{}
+				j.Spec.RayClusterSpec.WorkerGroupSpecs = baseJob.Spec.RayClusterSpec.WorkerGroupSpecs
+				return j
+			}(),
+			runInfo: []podset.PodSetInfo{
+				{
+					NodeSelector: map[string]string{
+						"newKey": "newValue",
+					},
+				},
+				{
+					NodeSelector: map[string]string{
+						"key-wg1": "value-wg1",
+					},
+				},
+				{
+					NodeSelector: map[string]string{},
+				},
+				{
+					NodeSelector: map[string]string{
+						"submitter-key": "submitter-value",
+					},
+				},
+			},
+			restoreInfo: []podset.PodSetInfo{
+				{
+					NodeSelector: map[string]string{},
+				},
+				{
+					NodeSelector: map[string]string{
+						"key-wg1": "value-wg1",
+					},
+				},
+				{
+					NodeSelector: map[string]string{
+						"key-wg2": "value-wg2",
+					},
+				},
+				{
+					NodeSelector: map[string]string{},
+				},
+			},
+			wantAfterRun: func() *rayv1.RayJob {
+				j := testingrayutil.MakeJob("job", "ns").
+					Suspend(false).
+					WithSubmissionMode(rayv1.K8sJobMode).
+					Obj()
+				headImage := j.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Image
+				j.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector = map[string]string{
+					"newKey": "newValue",
+				}
+				j.Spec.RayClusterSpec.WorkerGroupSpecs = []rayv1.WorkerGroupSpec{
+					{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								NodeSelector: map[string]string{
+									"key-wg1": "value-wg1",
+								},
+							},
+						},
+					},
+					{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								NodeSelector: map[string]string{
+									"key-wg2": "value-wg2",
+								},
+							},
+						},
+					},
+				}
+				j.Spec.SubmitterPodTemplate = &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "ray-job-submitter",
+								Image: headImage,
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("1"),
+										corev1.ResourceMemory: resource.MustParse("1Gi"),
+									},
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("500m"),
+										corev1.ResourceMemory: resource.MustParse("200Mi"),
+									},
+								},
+							},
+						},
+						RestartPolicy: corev1.RestartPolicyNever,
+						NodeSelector: map[string]string{
+							"submitter-key": "submitter-value",
+						},
+					},
+				}
+				return j
+			}(),
+			wantFinal: func() *rayv1.RayJob {
+				j := testingrayutil.MakeJob("job", "ns").
+					WithSubmissionMode(rayv1.K8sJobMode).
+					Obj()
+				headImage := j.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Image
+				j.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector = map[string]string{}
+				j.Spec.RayClusterSpec.WorkerGroupSpecs = baseJob.Spec.RayClusterSpec.WorkerGroupSpecs
+				j.Spec.SubmitterPodTemplate = &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "ray-job-submitter",
+								Image: headImage,
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("1"),
+										corev1.ResourceMemory: resource.MustParse("1Gi"),
+									},
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("500m"),
+										corev1.ResourceMemory: resource.MustParse("200Mi"),
+									},
+								},
+							},
+						},
+						RestartPolicy: corev1.RestartPolicyNever,
+						NodeSelector:  map[string]string{},
+					},
+				}
+				return j
+			}(),
+		},
 		"invalid runInfo": {
 			job: baseJob.DeepCopy(),
 			runInfo: []podset.PodSetInfo{

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -566,6 +566,35 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
 		util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 	})
+
+	ginkgo.It("Should persist admission constraints on default submitter pod template", framework.SlowSpec, func() {
+		ginkgo.By("creating localQueue")
+		localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+		util.MustCreate(ctx, k8sClient, localQueue)
+
+		ginkgo.By("creating a K8sJobMode RayJob with nil SubmitterPodTemplate")
+		job := testingrayjob.MakeJob("submitter-job", ns.Name).Queue(localQueue.Name).
+			WithSubmissionMode(rayv1.K8sJobMode).
+			RequestHead(corev1.ResourceCPU, "3").
+			RequestWorkerGroup(corev1.ResourceCPU, "4").
+			Obj()
+		gomega.Expect(job.Spec.SubmitterPodTemplate).Should(gomega.BeNil(), "precondition: SubmitterPodTemplate must be nil to exercise the default-template path")
+		util.MustCreate(ctx, k8sClient, job)
+		setInitStatus(job.Name, job.Namespace)
+
+		ginkgo.By("awaiting for the job to be admitted and unsuspended")
+		createdJob := &rayv1.RayJob{}
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, createdJob)).
+				Should(gomega.Succeed())
+			g.Expect(createdJob.Spec.Suspend).Should(gomega.BeFalse())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("checking the submitter pod template is populated with node selectors")
+		gomega.Expect(createdJob.Spec.SubmitterPodTemplate).ShouldNot(gomega.BeNil(),
+			"SubmitterPodTemplate must be non-nil after admission; without the fix it remains nil and placement constraints are lost")
+		gomega.Expect(createdJob.Spec.SubmitterPodTemplate.Spec.NodeSelector).Should(gomega.HaveKey(instanceKey))
+	})
 })
 
 var _ = ginkgo.Describe("Job controller with preemption enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/area integrations
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

When a RayJob uses `submissionMode: K8sJobMode` with no explicit `submitterPodTemplate`, `getSubmitterTemplate()` returns a new, disconnected `PodTemplateSpec`. `podset.Merge` applies Kueue's admission constraints (nodeSelector, tolerations, nodeAffinity) to this local struct, but it is never assigned back to `j.Spec.SubmitterPodTemplate`. The patch callback then serializes a nil `SubmitterPodTemplate`, and the constraints are silently dropped. KubeRay creates the submitter Job with its own unconstrained default template. This PR assigns the merged template back to `j.Spec.SubmitterPodTemplate` when it was originally nil, in both `RunWithPodSetsInfo` and `RestorePodSetsInfo`. This follows the same pattern used by the SparkApplication controller for nil `Driver.Template` / `Executor.Template`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12567

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
RayJob: Fix the integration controller dropping Kueue admission placement constraints (nodeSelector, tolerations, nodeAffinity) for the submitter pod when submitterPodTemplate is not explicitly set and submissionMode is K8sJobMode.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job handling so submitter pod settings are preserved when running in Kubernetes Job mode.
  * Fixed an issue where admission-related placement constraints could be lost for jobs that start without a submitter pod template.
  * Ensured node selector settings are restored correctly after job suspension and reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->