### PR TITLE
Fix SparkApplication node selector clobbering across driver and executor

### DIFF
--- a/pkg/controller/jobs/sparkapplication/sparkapplication_controller.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_controller.go
@@ -157,6 +157,8 @@ func (j *SparkApplication) RunWithPodSetsInfo(ctx context.Context, _ client.Clie
 
 	j.Spec.Suspend = new(false)
 
+	origGlobalNodeSelector := maps.Clone(j.Spec.NodeSelector)
+
 	mutatePodSetInfoFor := func(role string) error {
 		var podSetInfo podset.PodSetInfo
 		var nodeSelector map[string]string
@@ -170,8 +172,8 @@ func (j *SparkApplication) RunWithPodSetsInfo(ctx context.Context, _ client.Clie
 			}
 			// spec.NodeSelector and spec.driver.nodeSelector is mutually exclusive
 			nodeSelector = j.Spec.Driver.NodeSelector
-			if j.Spec.NodeSelector != nil {
-				nodeSelector = j.Spec.NodeSelector
+			if origGlobalNodeSelector != nil {
+				nodeSelector = maps.Clone(origGlobalNodeSelector)
 			}
 			sparkPodSpec = &j.Spec.Driver.SparkPodSpec
 		case sparkcommon.SparkRoleExecutor:
@@ -182,8 +184,8 @@ func (j *SparkApplication) RunWithPodSetsInfo(ctx context.Context, _ client.Clie
 			}
 			// spec.NodeSelector and spec.executor.nodeSelector is mutually exclusive
 			nodeSelector = j.Spec.Executor.NodeSelector
-			if j.Spec.NodeSelector != nil {
-				nodeSelector = j.Spec.NodeSelector
+			if origGlobalNodeSelector != nil {
+				nodeSelector = maps.Clone(origGlobalNodeSelector)
 			}
 		default:
 			return fmt.Errorf("unknown Spark role: %s", role)
@@ -201,11 +203,7 @@ func (j *SparkApplication) RunWithPodSetsInfo(ctx context.Context, _ client.Clie
 		}
 		sparkPodSpec.Annotations = sparkPodSetInfo.Annotations
 		sparkPodSpec.Labels = sparkPodSetInfo.Labels
-		if j.Spec.NodeSelector != nil {
-			j.Spec.NodeSelector = sparkPodSetInfo.NodeSelector
-		} else {
-			sparkPodSpec.NodeSelector = sparkPodSetInfo.NodeSelector
-		}
+		sparkPodSpec.NodeSelector = sparkPodSetInfo.NodeSelector
 		sparkPodSpec.Tolerations = sparkPodSetInfo.Tolerations
 		sparkPodSpec.Template.Spec.SchedulingGates = sparkPodSetInfo.SchedulingGates
 		return nil
@@ -218,6 +216,10 @@ func (j *SparkApplication) RunWithPodSetsInfo(ctx context.Context, _ client.Clie
 		return err
 	}
 
+	if origGlobalNodeSelector != nil {
+		j.Spec.NodeSelector = nil
+	}
+
 	return nil
 }
 
@@ -226,6 +228,8 @@ func (j *SparkApplication) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) b
 	if len(podSetsInfo) != expectedLength {
 		return false
 	}
+
+	hadGlobalNodeSelector := j.Spec.NodeSelector != nil
 
 	restorePodSetsInfoFrom := func(role string) bool {
 		var podSetInfo podset.PodSetInfo
@@ -254,16 +258,9 @@ func (j *SparkApplication) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) b
 			sparkPodSpec.Labels = maps.Clone(podSetInfo.Labels)
 			changed = true
 		}
-		if j.Spec.NodeSelector != nil {
-			if !maps.Equal(j.Spec.NodeSelector, podSetInfo.NodeSelector) {
-				j.Spec.NodeSelector = maps.Clone(podSetInfo.NodeSelector)
-				changed = true
-			}
-		} else {
-			if !maps.Equal(sparkPodSpec.NodeSelector, podSetInfo.NodeSelector) {
-				sparkPodSpec.NodeSelector = maps.Clone(podSetInfo.NodeSelector)
-				changed = true
-			}
+		if !maps.Equal(sparkPodSpec.NodeSelector, podSetInfo.NodeSelector) {
+			sparkPodSpec.NodeSelector = maps.Clone(podSetInfo.NodeSelector)
+			changed = true
 		}
 		if !slices.Equal(sparkPodSpec.Tolerations, podSetInfo.Tolerations) {
 			sparkPodSpec.Tolerations = slices.Clone(podSetInfo.Tolerations)
@@ -286,6 +283,13 @@ func (j *SparkApplication) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) b
 
 	driverChanged := restorePodSetsInfoFrom(sparkcommon.SparkRoleDriver)
 	executorChanged := restorePodSetsInfoFrom(sparkcommon.SparkRoleExecutor)
+
+	// Defensive: RunWithPodSetsInfo clears spec.nodeSelector, so this only
+	// fires if the object was never admitted or was re-populated externally.
+	if hadGlobalNodeSelector && j.Spec.NodeSelector != nil {
+		j.Spec.NodeSelector = nil
+		driverChanged = true
+	}
 
 	return driverChanged || executorChanged
 }

--- a/pkg/controller/jobs/sparkapplication/sparkapplication_controller_test.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_controller_test.go
@@ -356,6 +356,41 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		"should apply different node selectors per role when global nodeSelector is set": {
+			sparkApp: testSparkApp.Clone().
+				NodeSelector(map[string]string{"zone": "us-east"}).
+				Obj(),
+			podsetsInfo: []podset.PodSetInfo{
+				{
+					Name:         "driver",
+					NodeSelector: map[string]string{"zone": "us-east", "node-type": "cpu"},
+				},
+				{
+					Name:         "executor",
+					NodeSelector: map[string]string{"zone": "us-east", "node-type": "gpu"},
+				},
+			},
+			wantSparkApp: testSparkApp.Clone().
+				Suspend(false).
+				DriverNodeSelector(map[string]string{"zone": "us-east", "node-type": "cpu"}).
+				DriverTemplate(&corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: sparkcommon.SparkDriverContainerName},
+						},
+					},
+				}).
+				ExecutorNodeSelector(map[string]string{"zone": "us-east", "node-type": "gpu"}).
+				ExecutorTemplate(&corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: sparkcommon.Spark3DefaultExecutorContainerName},
+						},
+					},
+				}).
+				Obj(),
+			wantErr: false,
+		},
 		"should raise error if the wrong number of PodSet infos is provided": {
 			sparkApp: testSparkApp.DeepCopy(),
 			podsetsInfo: []podset.PodSetInfo{
@@ -518,6 +553,42 @@ func TestRestorePodSetsInfo(t *testing.T) {
 				ExecutorInstances(3).
 				Obj(),
 			wantChanged: false,
+		},
+		"should restore per-role node selectors when global nodeSelector is set": {
+			sparkApp: testSparkApp.Clone().
+				NodeSelector(map[string]string{"zone": "us-east"}).
+				Obj(),
+			podsetsInfo: []podset.PodSetInfo{
+				{
+					Name:         "driver",
+					NodeSelector: map[string]string{"zone": "us-east", "node-type": "cpu"},
+				},
+				{
+					Name:         "executor",
+					NodeSelector: map[string]string{"zone": "us-east", "node-type": "gpu"},
+					Count:        3,
+				},
+			},
+			wantSparkApp: testSparkApp.Clone().
+				DriverNodeSelector(map[string]string{"zone": "us-east", "node-type": "cpu"}).
+				DriverTemplate(&corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: sparkcommon.SparkDriverContainerName},
+						},
+					},
+				}).
+				ExecutorNodeSelector(map[string]string{"zone": "us-east", "node-type": "gpu"}).
+				ExecutorTemplate(&corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: sparkcommon.Spark3DefaultExecutorContainerName},
+						},
+					},
+				}).
+				ExecutorInstances(3).
+				Obj(),
+			wantChanged: true,
 		},
 		"should not modify the SparkApplication  if the wrong number of PodSet infos is provided": {
 			sparkApp: testSparkApp.DeepCopy(),

--- a/pkg/util/testingjobs/sparkapplication/wrappers_sparkapplication.go
+++ b/pkg/util/testingjobs/sparkapplication/wrappers_sparkapplication.go
@@ -103,6 +103,12 @@ func (w *SparkApplicationWrapper) Annotation(key, value string) *SparkApplicatio
 	return w
 }
 
+// NodeSelector sets the global nodeSelector on the SparkApplication.
+func (w *SparkApplicationWrapper) NodeSelector(s map[string]string) *SparkApplicationWrapper {
+	w.Spec.NodeSelector = s
+	return w
+}
+
 // DriverCoreRequest sets the driver core request.
 func (w *SparkApplicationWrapper) DriverCoreRequest(q string) *SparkApplicationWrapper {
 	w.Spec.Driver.CoreRequest = new(q)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/area integrations
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

When a SparkApplication uses `spec.nodeSelector` (global), `RunWithPodSetsInfo` overwrites `j.Spec.NodeSelector` on each role iteration inside the `mutatePodSetInfoFor` closure. The driver's merged NodeSelector is written to the global field, then the executor reads it as its merge base. This causes a merge conflict error (`conflict for key=..., value1=..., value2=...`) when flavors inject the same key with different values Silent clobbering when flavors inject non-overlapping keys, causing the Spark Operator to schedule both pods to the wrong node pool. The fix snapshots the original global nodeSelector before the loop, gives each role its own clone as the merge base, always writes the result to per-role `sparkPodSpec.NodeSelector`, and clears `spec.nodeSelector` afterward. Symmetric changes are applied to `RestorePodSetsInfo`.

AI-assisted: This change was developed with AI assistance, but was manually verified and tested.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes: #12547

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
SparkApplication: Fixed a bug where the global spec.nodeSelector could overwrite driver or executor node selectors when they were admitted to different ResourceFlavors.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Spark application `nodeSelector` settings so global and per-role (`driver`/`executor`) values are merged and applied consistently during updates and restores.
  * Fixed cases where a leftover global `nodeSelector` could persist after processing, potentially affecting scheduling.

* **New Features**
  * Enhanced Spark application test builder utilities with a `NodeSelector(...)` helper for easier setup of global `nodeSelector` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->