### PR TITLE
Fix: Clear Ungate Expectations on No-Op Elastic Pod Patch

### DIFF
--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -148,7 +148,9 @@ func (r *elasticJobUngater) Reconcile(ctx context.Context, req reconcile.Request
 			log.Error(e, "failed ungating elastic pod", "pod", klog.KObj(pod))
 			return e
 		}
-		if ungated {
+		if !ungated {
+			r.expectationsStore.ObservedUID(log, req.NamespacedName, pod.UID)
+		} else {
 			utilpod.RecordPodSchedulingGateRemovalSeconds(r.clock, kueue.ElasticJobSchedulingGate, wl, false)
 		}
 		return nil


### PR DESCRIPTION
 

#### What type of PR is this?
 
/kind bug
 

#### What this PR does / why we need it:

The scenario is a race around ElasticJob pod ungating. 

The controller records expected pod update events before patching the gated pods. If a pod has already had the ElasticJob scheduling gate removed by another reconcile or external/concurrent update before the patch runs, `utilpod.Ungate` returns `ungated=false`. 
In that path no API update is sent, so no pod update event will be observed later. Without explicitly marking the UID as observed, the expectation stays pending and the ElasticJob workload can remain blocked by pending ungate operations.

```
func (r *elasticJobUngater) Reconcile(..）{
    ...
    r.expectationsStore.ExpectUIDs(log, req.NamespacedName, uids)      <--------- register
    ...
    err = parallelize.Until(ctx, len(pods), func(i int) error {
       ...
        ungated = Patch(pod)
        if error  → ObservedUID(pod.UID)  // fail to patch, manually clear
        if ungated → OnPodUpdate          // patch succeeded, event handler clears
        if !ungated → ???                 // no-op, ObservedUID never called  ← BUG
    }
}
```

The consequence is that the workload may keep requeueing/backing off instead of completing the ungating flow, even though the pod no longer has the scheduling gate.

Expected behavior is to clear the expectation immediately when no patch/update event is expected. This matches the existing logic in  [pkg/controller/tas/topology_ungater.go](https://github.com/kubernetes-sigs/kueue/blob/main/pkg/controller/tas/topology_ungater.go#L303) .



 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
ElasticJob: Added a defensive safeguard to avoid stale pending expectations in no-op pod ungate paths, following 
the pattern from the TAS topology ungater.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pod scheduling gate handling so gates are removed and tracked more consistently during reconciliation.
  * Fixed the order of internal status updates to better reflect when pods have actually been ungated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->