### PR TITLE
Preparatory - workload observability flow for UnadmittedWorkloadObservability feature gate

### DIFF
--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -1055,6 +1055,16 @@ const (
 	// integrations may reuse the same reason in the future.
 	WorkloadOnHold = "OnHold"
 
+	// WorkloadPending indicates that the workload is pending evaluation or scheduling.
+	// Also used as the legacy fallback reason for WorkloadQuotaReservedReasonPendingEvaluation
+	// when the UnadmittedWorkloadsObservability feature gate is disabled.
+	WorkloadPending = "Pending"
+
+	// WorkloadWaiting indicates that the workload is waiting for pods to be ready.
+	// Deprecated: Use WorkloadQuotaReservedReasonWaitingForPodsReady instead when the
+	// UnadmittedWorkloadsObservability feature gate is enabled.
+	WorkloadWaiting = "Waiting"
+
 	// WorkloadAdmissionGated indicates that the workload is inadmissible
 	// due to an AdmissionGatedBy annotation.
 	WorkloadAdmissionGated = "AdmissionGated"

--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -1056,11 +1056,15 @@ const (
 	WorkloadOnHold = "OnHold"
 
 	// WorkloadPending indicates that the workload is pending evaluation or scheduling.
-	// Also used as the legacy fallback reason for WorkloadQuotaReservedReasonPendingEvaluation
-	// when the UnadmittedWorkloadsObservability feature gate is disabled.
+	//
+	// Deprecated: Use the more granular WorkloadQuotaReservedReason* reasons (e.g.,
+	// WorkloadQuotaReservedReasonWaitingForQuota, WorkloadQuotaReservedReasonPendingEvaluation)
+	// instead when the UnadmittedWorkloadsObservability feature gate is enabled.
+	// See KEP-10852 for details.
 	WorkloadPending = "Pending"
 
 	// WorkloadWaiting indicates that the workload is waiting for pods to be ready.
+	//
 	// Deprecated: Use WorkloadQuotaReservedReasonWaitingForPodsReady instead when the
 	// UnadmittedWorkloadsObservability feature gate is enabled.
 	WorkloadWaiting = "Waiting"

--- a/pkg/controller/concurrentadmission/controller.go
+++ b/pkg/controller/concurrentadmission/controller.go
@@ -345,7 +345,7 @@ func (r *variantReconciler) clearWorkloadAdmission(ctx context.Context, wl *kueu
 		setRequeued := (evCond.Reason == kueue.WorkloadEvictedByPreemption) ||
 			(evCond.Reason == kueue.WorkloadEvictedDueToNodeFailures)
 		updated := workload.SetRequeuedCondition(w, evCond.Reason, evCond.Message, setRequeued)
-		if workload.UnsetQuotaReservationWithCondition(w, "Pending", evCond.Message, r.clock.Now()) {
+		if workload.UnsetQuotaReservationWithCondition(w, kueue.WorkloadPending, evCond.Message, r.clock.Now()) {
 			updated = true
 		}
 		return updated, nil

--- a/pkg/controller/concurrentadmission/controller.go
+++ b/pkg/controller/concurrentadmission/controller.go
@@ -345,7 +345,12 @@ func (r *variantReconciler) clearWorkloadAdmission(ctx context.Context, wl *kueu
 		setRequeued := (evCond.Reason == kueue.WorkloadEvictedByPreemption) ||
 			(evCond.Reason == kueue.WorkloadEvictedDueToNodeFailures)
 		updated := workload.SetRequeuedCondition(w, evCond.Reason, evCond.Message, setRequeued)
-		if workload.UnsetQuotaReservationWithCondition(w, kueue.WorkloadPending, evCond.Message, r.clock.Now()) {
+		if workload.UnsetQuotaReservationWithCondition(
+			w,
+			kueue.WorkloadPending, //nolint:staticcheck // SA1019: fallback
+			evCond.Message,
+			r.clock.Now(),
+		) {
 			updated = true
 		}
 		return updated, nil

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -1069,7 +1069,10 @@ func (r *WorkloadReconciler) mayUpdateConditionForAdmissionGatedBy(ctx context.C
 	if !hasGatedAnnotation && hasGatedCondition {
 		// This previously gated workload is becoming admissible because its AdmissionGatedBy annotation is cleared
 		err := workloadpatching.PatchAdmissionStatus(ctx, r.client, wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonPendingEvaluation, kueue.WorkloadPending)
+			reason := workload.UnadmittedWorkloadReasonWithFallback(
+				kueue.WorkloadQuotaReservedReasonPendingEvaluation,
+				kueue.WorkloadPending, //nolint:staticcheck // SA1019: fallback
+			)
 			// Update the condition to indicate the gate is cleared, rather than removing it
 			return workload.UnsetQuotaReservationWithCondition(wl, reason, "AdmissionGatedBy cleared, waiting for quota reservation", r.clock.Now()), nil
 		})

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -1069,7 +1069,7 @@ func (r *WorkloadReconciler) mayUpdateConditionForAdmissionGatedBy(ctx context.C
 	if !hasGatedAnnotation && hasGatedCondition {
 		// This previously gated workload is becoming admissible because its AdmissionGatedBy annotation is cleared
 		err := workloadpatching.PatchAdmissionStatus(ctx, r.client, wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonPendingEvaluation, "Pending")
+			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonPendingEvaluation, kueue.WorkloadPending)
 			// Update the condition to indicate the gate is cleared, rather than removing it
 			return workload.UnsetQuotaReservationWithCondition(wl, reason, "AdmissionGatedBy cleared, waiting for quota reservation", r.clock.Now()), nil
 		})

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -707,12 +707,6 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				)
 			}
 		}
-		// Return early if the status was updated and either:
-		// 1. The observability feature gate is disabled (legacy behavior).
-		// 2. The workload actually transitioned to Admitted.
-		if updated && (!features.Enabled(features.UnadmittedWorkloadsObservability) || isAdmitted) {
-			return ctrl.Result{}, nil
-		}
 	}
 
 	if workload.HasQuotaReservation(&wl) {

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -321,7 +321,8 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		workload.HasDRA(&wl) {
 		log.V(3).Info("Rejecting workload that uses DRA resources because KueueDRAIntegration feature gate is disabled")
 		err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-			updated := workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadInadmissible,
+			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonMisconfigured, kueue.WorkloadInadmissible)
+			updated := workload.UnsetQuotaReservationWithCondition(wl, reason,
 				"Workload uses DRA resources but the KueueDRAIntegration feature gate is not enabled",
 				r.clock.Now())
 			if workload.SetRequeuedCondition(wl, kueue.WorkloadInadmissible,
@@ -340,7 +341,8 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		if workload.HasResourceClaim(&wl) {
 			log.V(3).Info("Workload is inadmissible because it uses resource claims which is not supported")
 			err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-				updated := workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadInadmissible, "KueueDRAIntegration feature does not support use of resource claims", r.clock.Now())
+				reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonMisconfigured, kueue.WorkloadInadmissible)
+				updated := workload.UnsetQuotaReservationWithCondition(wl, reason, "KueueDRAIntegration feature does not support use of resource claims", r.clock.Now())
 				if updated && workload.SetRequeuedCondition(wl, kueue.WorkloadInadmissible, "DRA resource claims not supported", false) {
 					updated = true
 				}
@@ -360,7 +362,8 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			err := fieldErrs.ToAggregate()
 			log.Error(err, "Failed to process DRA resources for workload")
 			updateErr := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-				updated := workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadInadmissible, err.Error(), r.clock.Now())
+				reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonMisconfigured, kueue.WorkloadInadmissible)
+				updated := workload.UnsetQuotaReservationWithCondition(wl, reason, err.Error(), r.clock.Now())
 				if updated && workload.SetRequeuedCondition(wl, kueue.WorkloadInadmissible, err.Error(), false) {
 					updated = true
 				}
@@ -385,7 +388,8 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				err := extFieldErrs.ToAggregate()
 				log.Error(err, "Failed to process DRA extended resources for workload")
 				updateErr := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-					updated := workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadInadmissible, err.Error(), r.clock.Now())
+					reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonMisconfigured, kueue.WorkloadInadmissible)
+					updated := workload.UnsetQuotaReservationWithCondition(wl, reason, err.Error(), r.clock.Now())
 					if updated && workload.SetRequeuedCondition(wl, kueue.WorkloadInadmissible, err.Error(), false) {
 						updated = true
 					}
@@ -423,7 +427,8 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				err := counterFieldErrs.ToAggregate()
 				log.Error(err, "Failed to process DRA counter resources for workload")
 				updateErr := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-					updated := workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadInadmissible, err.Error(), r.clock.Now())
+					reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonMisconfigured, kueue.WorkloadInadmissible)
+					updated := workload.UnsetQuotaReservationWithCondition(wl, reason, err.Error(), r.clock.Now())
 					if updated && workload.SetRequeuedCondition(wl, kueue.WorkloadInadmissible, err.Error(), false) {
 						updated = true
 					}
@@ -740,28 +745,32 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	case !lqExists:
 		log.V(3).Info("Workload is inadmissible because of missing LocalQueue", "localQueue", klog.KRef(wl.Namespace, string(wl.Spec.QueueName)))
 		if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-			return workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadInadmissible, fmt.Sprintf("LocalQueue %s doesn't exist", wl.Spec.QueueName), r.clock.Now()), nil
+			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonMisconfigured, kueue.WorkloadInadmissible)
+			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf("LocalQueue %s doesn't exist", wl.Spec.QueueName), r.clock.Now()), nil
 		}); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
 	case !lqActive:
 		log.V(3).Info("Workload is inadmissible because of stopped LocalQueue", "localQueue", klog.KRef(wl.Namespace, string(wl.Spec.QueueName)))
 		if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-			return workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadInadmissible, fmt.Sprintf("LocalQueue %s is inactive", wl.Spec.QueueName), r.clock.Now()), nil
+			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonSuspended, kueue.WorkloadInadmissible)
+			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf("LocalQueue %s is inactive", wl.Spec.QueueName), r.clock.Now()), nil
 		}); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
 	case !cqOk:
 		log.V(3).Info("Workload is inadmissible because of missing ClusterQueue", "clusterQueue", klog.KRef("", string(cqName)))
 		if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-			return workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadInadmissible, fmt.Sprintf("ClusterQueue %s doesn't exist", cqName), r.clock.Now()), nil
+			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonMisconfigured, kueue.WorkloadInadmissible)
+			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf("ClusterQueue %s doesn't exist", cqName), r.clock.Now()), nil
 		}); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
 	case !r.cache.ClusterQueueActive(cqName):
 		log.V(3).Info("Workload is inadmissible because ClusterQueue is inactive", "clusterQueue", klog.KRef("", string(cqName)))
 		if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-			return workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadInadmissible, fmt.Sprintf("ClusterQueue %s is inactive", cqName), r.clock.Now()), nil
+			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonSuspended, kueue.WorkloadInadmissible)
+			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf("ClusterQueue %s is inactive", cqName), r.clock.Now()), nil
 		}); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
@@ -979,14 +988,16 @@ func (r *WorkloadReconciler) reconcileOnLocalQueueActiveState(ctx context.Contex
 	if !lqExists || !lq.DeletionTimestamp.IsZero() {
 		log.V(3).Info("Workload is inadmissible because the LocalQueue is terminating or missing", "localQueue", klog.KRef("", string(wl.Spec.QueueName)))
 		return true, workloadpatching.PatchAdmissionStatus(ctx, r.client, wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-			return workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadInadmissible, fmt.Sprintf("LocalQueue %s is terminating or missing", wl.Spec.QueueName), r.clock.Now()), nil
+			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonMisconfigured, kueue.WorkloadInadmissible)
+			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf("LocalQueue %s is terminating or missing", wl.Spec.QueueName), r.clock.Now()), nil
 		})
 	}
 
 	if queueStopPolicy != kueue.None {
 		log.V(3).Info("Workload is inadmissible because the LocalQueue is stopped", "localQueue", klog.KRef("", string(wl.Spec.QueueName)))
 		return true, workloadpatching.PatchAdmissionStatus(ctx, r.client, wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-			return workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadInadmissible, fmt.Sprintf("LocalQueue %s is stopped", wl.Spec.QueueName), r.clock.Now()), nil
+			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonSuspended, kueue.WorkloadInadmissible)
+			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf("LocalQueue %s is stopped", wl.Spec.QueueName), r.clock.Now()), nil
 		})
 	}
 
@@ -1022,14 +1033,16 @@ func (r *WorkloadReconciler) reconcileOnClusterQueueActiveState(ctx context.Cont
 	if !cqExists || !cq.DeletionTimestamp.IsZero() {
 		log.V(3).Info("Workload is inadmissible because the ClusterQueue is terminating or missing", "clusterQueue", klog.KRef("", string(cqName)))
 		return true, workloadpatching.PatchAdmissionStatus(ctx, r.client, wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-			return workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadInadmissible, fmt.Sprintf("ClusterQueue %s is terminating or missing", cqName), r.clock.Now()), nil
+			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonMisconfigured, kueue.WorkloadInadmissible)
+			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf("ClusterQueue %s is terminating or missing", cqName), r.clock.Now()), nil
 		})
 	}
 
 	if queueStopPolicy != kueue.None {
 		log.V(3).Info("Workload is inadmissible because the ClusterQueue is stopped", "clusterQueue", klog.KRef("", string(cqName)))
 		return true, workloadpatching.PatchAdmissionStatus(ctx, r.client, wl, r.clock, func(wl *kueue.Workload) (bool, error) {
-			return workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadInadmissible, fmt.Sprintf("ClusterQueue %s is stopped", cqName), r.clock.Now()), nil
+			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonSuspended, kueue.WorkloadInadmissible)
+			return workload.UnsetQuotaReservationWithCondition(wl, reason, fmt.Sprintf("ClusterQueue %s is stopped", cqName), r.clock.Now()), nil
 		})
 	}
 
@@ -1052,8 +1065,9 @@ func (r *WorkloadReconciler) mayUpdateConditionForAdmissionGatedBy(ctx context.C
 	if !hasGatedAnnotation && hasGatedCondition {
 		// This previously gated workload is becoming admissible because its AdmissionGatedBy annotation is cleared
 		err := workloadpatching.PatchAdmissionStatus(ctx, r.client, wl, r.clock, func(wl *kueue.Workload) (bool, error) {
+			reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonPendingEvaluation, "Pending")
 			// Update the condition to indicate the gate is cleared, rather than removing it
-			return workload.UnsetQuotaReservationWithCondition(wl, "Pending", "AdmissionGatedBy cleared, waiting for quota reservation", r.clock.Now()), nil
+			return workload.UnsetQuotaReservationWithCondition(wl, reason, "AdmissionGatedBy cleared, waiting for quota reservation", r.clock.Now()), nil
 		})
 		if err != nil {
 			return false, err

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -669,7 +669,8 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
-		if workload.IsAdmitted(&wl) {
+		isAdmitted := workload.IsAdmitted(&wl)
+		if isAdmitted {
 			queuedWaitTime := workload.QueuedWaitTime(&wl, r.clock)
 			quotaReservedCondition := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
 			quotaReservedWaitTime := r.clock.Since(quotaReservedCondition.LastTransitionTime.Time)
@@ -706,7 +707,10 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				)
 			}
 		}
-		if updated {
+		// Return early if the status was updated and either:
+		// 1. The observability feature gate is disabled (legacy behavior).
+		// 2. The workload actually transitioned to Admitted.
+		if updated && (!features.Enabled(features.UnadmittedWorkloadsObservability) || isAdmitted) {
 			return ctrl.Result{}, nil
 		}
 	}

--- a/pkg/controller/core/workload_controller_dra_test.go
+++ b/pkg/controller/core/workload_controller_dra_test.go
@@ -66,8 +66,14 @@ func TestReconcileDRA(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
 					Message: "KueueDRAIntegration feature does not support use of resource claims",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadRequeued,
@@ -104,8 +110,14 @@ func TestReconcileDRA(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
 					Message: "Workload uses DRA resources but the KueueDRAIntegration feature gate is not enabled",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadRequeued,
@@ -142,8 +154,14 @@ func TestReconcileDRA(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
 					Message: "Workload uses DRA resources but the KueueDRAIntegration feature gate is not enabled",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadRequeued,
@@ -186,8 +204,14 @@ func TestReconcileDRA(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonSuspended,
 					Message: "ClusterQueue cq is inactive",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 			wantEvents: nil,
@@ -224,8 +248,14 @@ func TestReconcileDRA(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonSuspended,
 					Message: "ClusterQueue cq is inactive",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 			wantEvents: nil,
@@ -261,8 +291,14 @@ func TestReconcileDRA(t *testing.T) {
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadQuotaReserved,
 						Status:  metav1.ConditionFalse,
-						Reason:  kueue.WorkloadInadmissible,
+						Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
 						Message: "spec.podSets[0].template.spec.resourceClaims[0].resourceClaimTemplateName: Not found: \"DeviceClass unmapped.example.com is not mapped in DRA configuration for podset main\"",
+					}).
+					Condition(metav1.Condition{
+						Type:    kueue.WorkloadAdmitted,
+						Status:  metav1.ConditionFalse,
+						Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+						Message: "The workload has no reservation",
 					}).
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadRequeued,
@@ -307,8 +343,14 @@ func TestReconcileDRA(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
 					Message: "spec.podSets[0].template.spec.containers[0].resources.requests.example.com/gpu: Invalid value: \"1500m\": extended resource quantity must be an integer",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadRequeued,
@@ -343,8 +385,14 @@ func TestReconcileDRA(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
 					Message: `spec.podSets[0].template.spec.resourceClaims[0]: Internal error: failed to get claim spec for ResourceClaimTemplate missing-template in podset main: resourceclaimtemplates.resource.k8s.io "missing-template" not found`,
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadRequeued,

--- a/pkg/controller/core/workload_controller_eviction_test.go
+++ b/pkg/controller/core/workload_controller_eviction_test.go
@@ -68,6 +68,12 @@ func TestReconcileEviction(t *testing.T) {
 						Reason:  "AdmissionCheck",
 						Message: `AdmissionCheck in Rejected state: "check"`,
 					},
+					metav1.Condition{
+						Type:    kueue.WorkloadAdmitted,
+						Status:  metav1.ConditionFalse,
+						Reason:  kueue.WorkloadAdmittedReasonUnsatisfiedAdmissionChecks,
+						Message: "The workload has not all checks ready",
+					},
 				).
 				Obj(),
 			wantEvents: []utiltesting.EventRecord{
@@ -315,6 +321,12 @@ func TestReconcileEviction(t *testing.T) {
 					Reason:  "AdmissionCheck",
 					Message: `Evicted due to AdmissionCheck in Retry state: "check-1"`,
 				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonUnsatisfiedAdmissionChecks,
+					Message: "The workload has not all checks ready",
+				}).
 				SchedulingStatsEviction(
 					kueue.WorkloadSchedulingStatsEviction{
 						Reason: kueue.WorkloadEvictedByAdmissionCheck,
@@ -470,6 +482,12 @@ func TestReconcileEviction(t *testing.T) {
 					Status:  "True",
 					Reason:  "AdmissionCheck",
 					Message: `Evicted due to AdmissionChecks in Retry state: "check-1" (infrastructure not prepared); "check-3" (budget exhausted)`,
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonUnsatisfiedAdmissionChecks,
+					Message: "The workload has not all checks ready",
 				}).
 				SchedulingStatsEviction(
 					kueue.WorkloadSchedulingStatsEviction{

--- a/pkg/controller/core/workload_controller_inadmissible_test.go
+++ b/pkg/controller/core/workload_controller_inadmissible_test.go
@@ -35,7 +35,7 @@ func TestReconcileInadmissible(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(now)
 
 	cases := map[string]reconcileTestCase{
-		"should set the Inadmissible reason on QuotaReservation condition when the LocalQueue was deleted": {
+		"should set the Misconfigured reason on QuotaReservation condition when the LocalQueue was deleted": {
 			cq: utiltestingapi.MakeClusterQueue("cq").
 				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("flavor1").Obj()).
 				AdmissionChecks("check").Obj(),
@@ -67,8 +67,14 @@ func TestReconcileInadmissible(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
 					Message: "LocalQueue lq is terminating or missing",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 			wantWorkloadUseMergePatch: utiltestingapi.MakeWorkload("wl", "ns").
@@ -81,12 +87,18 @@ func TestReconcileInadmissible(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
 					Message: "LocalQueue lq is terminating or missing",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 		},
-		"should set the Inadmissible reason on QuotaReservation condition when the LocalQueue is terminating": {
+		"should set the Misconfigured reason on QuotaReservation condition when the LocalQueue is terminating": {
 			cq: utiltestingapi.MakeClusterQueue("cq").
 				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("flavor1").Obj()).
 				AdmissionChecks("check").Obj(),
@@ -120,8 +132,14 @@ func TestReconcileInadmissible(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
 					Message: "LocalQueue lq is terminating or missing",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 			wantWorkloadUseMergePatch: utiltestingapi.MakeWorkload("wl", "ns").
@@ -134,12 +152,18 @@ func TestReconcileInadmissible(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
 					Message: "LocalQueue lq is terminating or missing",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 		},
-		"should set the Inadmissible reason on QuotaReservation condition when the LocalQueue was Hold": {
+		"should set the Suspended reason on QuotaReservation condition when the LocalQueue was Hold": {
 			cq: utiltestingapi.MakeClusterQueue("cq").
 				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("flavor1").Obj()).
 				AdmissionChecks("check").Obj(),
@@ -172,8 +196,14 @@ func TestReconcileInadmissible(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonSuspended,
 					Message: "LocalQueue lq is stopped",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 			wantWorkloadUseMergePatch: utiltestingapi.MakeWorkload("wl", "ns").
@@ -186,12 +216,18 @@ func TestReconcileInadmissible(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonSuspended,
 					Message: "LocalQueue lq is stopped",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 		},
-		"should set the Inadmissible reason on QuotaReservation condition when the ClusterQueue was deleted": {
+		"should set the Misconfigured reason on QuotaReservation condition when the ClusterQueue was deleted": {
 			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				Active(true).
@@ -221,8 +257,14 @@ func TestReconcileInadmissible(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
 					Message: "ClusterQueue cq is terminating or missing",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 			wantWorkloadUseMergePatch: utiltestingapi.MakeWorkload("wl", "ns").
@@ -235,12 +277,18 @@ func TestReconcileInadmissible(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
 					Message: "ClusterQueue cq is terminating or missing",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 		},
-		"should set the Inadmissible reason on QuotaReservation condition when the ClusterQueue is terminating": {
+		"should set the Misconfigured reason on QuotaReservation condition when the ClusterQueue is terminating": {
 			cq: utiltestingapi.MakeClusterQueue("cq").
 				Cohort("cohort").
 				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("flavor1").Obj()).
@@ -276,8 +324,14 @@ func TestReconcileInadmissible(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
 					Message: "ClusterQueue cq is terminating or missing",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 			wantWorkloadUseMergePatch: utiltestingapi.MakeWorkload("wl", "ns").
@@ -290,12 +344,18 @@ func TestReconcileInadmissible(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
 					Message: "ClusterQueue cq is terminating or missing",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 		},
-		"should set the Inadmissible reason on QuotaReservation condition when the ClusterQueue was Hold": {
+		"should set the Suspended reason on QuotaReservation condition when the ClusterQueue was Hold": {
 			cq: utiltestingapi.MakeClusterQueue("cq").
 				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("flavor1").Obj()).
 				AdmissionChecks("check").StopPolicy(kueue.Hold).Obj(),
@@ -328,8 +388,14 @@ func TestReconcileInadmissible(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonSuspended,
 					Message: "ClusterQueue cq is stopped",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 			wantWorkloadUseMergePatch: utiltestingapi.MakeWorkload("wl", "ns").
@@ -342,12 +408,18 @@ func TestReconcileInadmissible(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonSuspended,
 					Message: "ClusterQueue cq is stopped",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 		},
-		"should set status QuotaReserved conditions to False with reason Inadmissible if quota not reserved LocalQueue is not created": {
+		"should set status QuotaReserved conditions to False with reason Misconfigured if quota not reserved LocalQueue is not created": {
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				Active(true).
 				Queue("lq").
@@ -358,12 +430,18 @@ func TestReconcileInadmissible(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
 					Message: "LocalQueue lq doesn't exist",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 		},
-		"should set status QuotaReserved conditions to False with reason Inadmissible if quota not reserved LocalQueue StopPolicy=Hold": {
+		"should set status QuotaReserved conditions to False with reason Suspended if quota not reserved LocalQueue StopPolicy=Hold": {
 			lq: utiltestingapi.MakeLocalQueue("lq", "ns").StopPolicy(kueue.Hold).Obj(),
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				Active(true).
@@ -375,12 +453,18 @@ func TestReconcileInadmissible(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonSuspended,
 					Message: "LocalQueue lq is inactive",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 		},
-		"should set status QuotaReserved conditions to False with reason Inadmissible if quota not reserved LocalQueue StopPolicy=HoldAndDrain": {
+		"should set status QuotaReserved conditions to False with reason Suspended if quota not reserved LocalQueue StopPolicy=HoldAndDrain": {
 			lq: utiltestingapi.MakeLocalQueue("lq", "ns").StopPolicy(kueue.HoldAndDrain).Obj(),
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				Active(true).
@@ -392,12 +476,18 @@ func TestReconcileInadmissible(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonSuspended,
 					Message: "LocalQueue lq is inactive",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 		},
-		"should set status QuotaReserved conditions to False with reason Inadmissible if quota not reserved ClusterQueue is not created": {
+		"should set status QuotaReserved conditions to False with reason Misconfigured if quota not reserved ClusterQueue is not created": {
 			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").StopPolicy(kueue.None).Obj(),
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				Active(true).
@@ -409,12 +499,18 @@ func TestReconcileInadmissible(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
 					Message: "ClusterQueue cq doesn't exist",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 		},
-		"should set status QuotaReserved conditions to False with reason Inadmissible if quota not reserved ClusterQueue StopPolicy=Hold": {
+		"should set status QuotaReserved conditions to False with reason Suspended if quota not reserved ClusterQueue StopPolicy=Hold": {
 			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").StopPolicy(kueue.None).Obj(),
 			cq: utiltestingapi.MakeClusterQueue("cq").StopPolicy(kueue.Hold).Obj(),
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
@@ -427,8 +523,14 @@ func TestReconcileInadmissible(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonSuspended,
 					Message: "ClusterQueue cq is inactive",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 		},

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"maps"
 	"strings"
 	"testing"
 	"time"
@@ -949,8 +950,14 @@ func TestReconcile(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonSuspended,
 					Message: "ClusterQueue cq is inactive",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 			wantWorkloadUseMergePatch: utiltestingapi.MakeWorkload("wl", "ns").
@@ -977,8 +984,14 @@ func TestReconcile(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonSuspended,
 					Message: "ClusterQueue cq is inactive",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 			wantResult: reconcile.Result{},
@@ -998,6 +1011,12 @@ func TestReconcile(t *testing.T) {
 					Status:  metav1.ConditionFalse,
 					Reason:  kueue.WorkloadAdmissionGated,
 					Message: "Admission is gated by: example.com/controller1",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 			wantEvents: []utiltesting.EventRecord{
@@ -1027,8 +1046,14 @@ func TestReconcile(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  "Pending",
+					Reason:  kueue.WorkloadQuotaReservedReasonPendingEvaluation,
 					Message: "AdmissionGatedBy cleared, waiting for quota reservation",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 			wantEvents: []utiltesting.EventRecord{
@@ -1056,6 +1081,12 @@ func TestReconcile(t *testing.T) {
 					Status:  metav1.ConditionFalse,
 					Reason:  kueue.WorkloadAdmissionGated,
 					Message: "Admission is gated by: example.com/controller1,example.com/controller2",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 			wantEvents: []utiltesting.EventRecord{
@@ -1086,6 +1117,12 @@ func TestReconcile(t *testing.T) {
 					Reason:  kueue.WorkloadAdmissionGated,
 					Message: "Admission is gated by: example.com/controller1",
 				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				}).
 				Obj(),
 			wantWorkloadUseMergePatch: utiltestingapi.MakeWorkload("wl", "ns").
 				Queue("lq").
@@ -1095,6 +1132,12 @@ func TestReconcile(t *testing.T) {
 					Status:  metav1.ConditionFalse,
 					Reason:  kueue.WorkloadAdmissionGated,
 					Message: "Admission is gated by: example.com/controller1",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 			wantEvents: []utiltesting.EventRecord{
@@ -1118,13 +1161,18 @@ func TestReconcile(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonSuspended,
 					Message: "ClusterQueue cq is inactive",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 			reconcilerOpts: []Option{},
 		},
-
 		"workload with existing controller owner should not be finished": {
 			featureGates: map[featuregate.Feature]bool{
 				features.FinishOrphanedWorkloads: true,
@@ -1146,8 +1194,62 @@ func TestReconcile(t *testing.T) {
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
 					Status:  metav1.ConditionFalse,
-					Reason:  kueue.WorkloadInadmissible,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
 					Message: "LocalQueue  doesn't exist",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				}).
+				Obj(),
+		},
+		"inadmissible workload due to missing LocalQueue (observability enabled)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.UnadmittedWorkloadsObservability: true,
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("non-existent-lq").
+				Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("non-existent-lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
+					Message: "LocalQueue non-existent-lq doesn't exist",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				}).
+				Obj(),
+		},
+		"inadmissible workload due to stopped ClusterQueue (observability enabled)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.UnadmittedWorkloadsObservability: true,
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Obj(),
+			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).StopPolicy(kueue.HoldAndDrain).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonSuspended,
+					Message: "ClusterQueue cq is inactive",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
 				}).
 				Obj(),
 		},
@@ -1156,15 +1258,57 @@ func TestReconcile(t *testing.T) {
 }
 
 func runReconcileTestCases(t *testing.T, cases map[string]reconcileTestCase, fakeClock *testingclock.FakeClock) {
+	scenarios := []map[featuregate.Feature]bool{
+		{
+			features.WorkloadRequestUseMergePatch:     false,
+			features.UnadmittedWorkloadsObservability: false,
+		},
+		{
+			features.WorkloadRequestUseMergePatch:     false,
+			features.UnadmittedWorkloadsObservability: true,
+		},
+		{
+			features.WorkloadRequestUseMergePatch:     true,
+			features.UnadmittedWorkloadsObservability: false,
+		},
+		{
+			features.WorkloadRequestUseMergePatch:     true,
+			features.UnadmittedWorkloadsObservability: true,
+		},
+	}
+
 	for name, tc := range cases {
-		for _, enabled := range []bool{false, true} {
-			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t", name, enabled), func(t *testing.T) {
-				features.SetFeatureGatesDuringTest(t, tc.featureGates)
-				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, enabled)
+		for _, scenario := range scenarios {
+			// Skip scenarios where the test case overrides the scenario's feature gate value
+			// to avoid running duplicate tests and misreporting the gate values in the subtest name.
+			skip := false
+			for fg, val := range tc.featureGates {
+				if scenarioVal, exists := scenario[fg]; exists && scenarioVal != val {
+					skip = true
+					break
+				}
+			}
+			if skip {
+				continue
+			}
+
+			t.Run(fmt.Sprintf("%s WorkloadRequestUseMergePatch enabled: %t, UnadmittedWorkloadsObservability enabled: %t",
+				name, scenario[features.WorkloadRequestUseMergePatch], scenario[features.UnadmittedWorkloadsObservability]), func(t *testing.T) {
+				fgMap := make(map[featuregate.Feature]bool)
+				maps.Copy(fgMap, scenario)
+				maps.Copy(fgMap, tc.featureGates)
+				features.SetFeatureGatesDuringTest(t, fgMap)
 				features.SetFeatureGateDuringTest(t, features.AdmissionGatedBy, true)
 
 				testWl := tc.workload.DeepCopy()
 				objs := []client.Object{testWl}
+				if testWl.Namespace != "" {
+					objs = append(objs, &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: testWl.Namespace,
+						},
+					})
+				}
 				objs = append(objs, tc.additionalObjects...)
 				for _, rc := range tc.resourceClaims {
 					objs = append(objs, rc)
@@ -1298,14 +1442,23 @@ func runReconcileTestCases(t *testing.T, cases map[string]reconcileTestCase, fak
 						}
 						t.Fatalf("expected workload to persist")
 					}
+
+					var wantWl *kueue.Workload
 					if features.Enabled(features.WorkloadRequestUseMergePatch) && tc.wantWorkloadUseMergePatch != nil {
-						if diff := cmp.Diff(tc.wantWorkloadUseMergePatch, gotWorkload, workloadCmpOpts...); diff != "" {
-							t.Errorf("Workloads after reconcile (-want,+got):\n%s", diff)
-						}
+						wantWl = tc.wantWorkloadUseMergePatch.DeepCopy()
 					} else {
-						if diff := cmp.Diff(tc.wantWorkload, gotWorkload, workloadCmpOpts...); diff != "" {
-							t.Errorf("Workloads after reconcile (-want,+got):\n%s", diff)
-						}
+						wantWl = tc.wantWorkload.DeepCopy()
+					}
+
+					if !features.Enabled(features.UnadmittedWorkloadsObservability) {
+						wantWl.Status.Conditions = utiltesting.AdjustConditionsForDisabledObservabilityInWorkloadController(
+							wantWl.Status.Conditions,
+							apimeta.IsStatusConditionTrue(tc.workload.Status.Conditions, kueue.WorkloadAdmitted),
+						)
+					}
+
+					if diff := cmp.Diff(wantWl, gotWorkload, workloadCmpOpts...); diff != "" {
+						t.Errorf("Workloads after reconcile (-want,+got):\n%s", diff)
 					}
 				}
 				if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents); diff != "" {

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -559,7 +559,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 					// The requeued condition status set to true only on EvictedByPreemption
 					setRequeued := (evCond.Reason == kueue.WorkloadEvictedByPreemption) || (evCond.Reason == kueue.WorkloadEvictedDueToNodeFailures)
 					updated := workload.SetRequeuedCondition(wl, evCond.Reason, evCond.Message, setRequeued)
-					if workload.UnsetQuotaReservationWithCondition(wl, "Pending", evCond.Message, r.clock.Now()) {
+					if workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadPending, evCond.Message, r.clock.Now()) {
 						updated = true
 					}
 					return updated, nil

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -559,7 +559,12 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 					// The requeued condition status set to true only on EvictedByPreemption
 					setRequeued := (evCond.Reason == kueue.WorkloadEvictedByPreemption) || (evCond.Reason == kueue.WorkloadEvictedDueToNodeFailures)
 					updated := workload.SetRequeuedCondition(wl, evCond.Reason, evCond.Message, setRequeued)
-					if workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadPending, evCond.Message, r.clock.Now()) {
+					if workload.UnsetQuotaReservationWithCondition(
+						wl,
+						kueue.WorkloadPending, //nolint:staticcheck // SA1019: fallback
+						evCond.Message,
+						r.clock.Now(),
+					) {
 						updated = true
 					}
 					return updated, nil

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -632,7 +632,8 @@ func (s *Scheduler) nominate(ctx context.Context, workloads []workload.Info, sna
 			e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonMisconfigured
 		} else if err := workload.ValidateAdmissibility(ctx, s.client, &w, e.clusterQueueSnapshot.NamespaceSelector); err != nil {
 			e.inadmissibleMsg = err.Error()
-			if errors.Is(err, workload.ErrAPI) {
+			if errors.Is(err, workload.ErrInternal) {
+				log.Error(err, "Failed to validate workload admissibility")
 				e.skipStatusUpdate = true
 			} else {
 				e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonMisconfigured

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -538,7 +538,7 @@ func (s *Scheduler) waitForPodsReadyIfBlocked(ctx context.Context, log logr.Logg
 	log.V(5).Info("Waiting for all admitted workloads to be in the PodsReady condition")
 	wl := e.Obj.DeepCopy()
 	if err := workloadpatching.PatchAdmissionStatus(ctx, s.client, wl, s.clock, func(wl *kueue.Workload) (bool, error) {
-		reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonWaitingForPodsReady, "Waiting")
+		reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonWaitingForPodsReady, kueue.WorkloadWaiting)
 		return workload.UnsetQuotaReservationWithCondition(wl, reason, "waiting for all admitted workloads to be in PodsReady condition", s.clock.Now()), nil
 	}, workloadpatching.WithLooseOnApply(), workloadpatching.WithRetryOnConflict()); err != nil {
 		log.Error(err, "Could not update Workload status")
@@ -626,10 +626,10 @@ func (s *Scheduler) nominate(ctx context.Context, workloads []workload.Info, sna
 		} else if e.clusterQueueSnapshot == nil {
 			e.inadmissibleMsg = fmt.Sprintf("ClusterQueue %s not found", w.ClusterQueue)
 			e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonMisconfigured
-		} else if msg, isNamespaceMismatch := workload.ValidateAdmissibility(ctx, s.client, &w, e.clusterQueueSnapshot.NamespaceSelector); msg != "" {
-			e.inadmissibleMsg = msg
+		} else if err := workload.ValidateAdmissibility(ctx, s.client, &w, e.clusterQueueSnapshot.NamespaceSelector); err != nil {
+			e.inadmissibleMsg = err.Error()
 			e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonMisconfigured
-			if isNamespaceMismatch {
+			if errors.Is(err, workload.ErrNamespaceMismatch) {
 				e.requeueReason = qcache.RequeueReasonNamespaceMismatch
 			}
 		} else {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -538,7 +538,10 @@ func (s *Scheduler) waitForPodsReadyIfBlocked(ctx context.Context, log logr.Logg
 	log.V(5).Info("Waiting for all admitted workloads to be in the PodsReady condition")
 	wl := e.Obj.DeepCopy()
 	if err := workloadpatching.PatchAdmissionStatus(ctx, s.client, wl, s.clock, func(wl *kueue.Workload) (bool, error) {
-		reason := workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonWaitingForPodsReady, kueue.WorkloadWaiting)
+		reason := workload.UnadmittedWorkloadReasonWithFallback(
+			kueue.WorkloadQuotaReservedReasonWaitingForPodsReady,
+			kueue.WorkloadWaiting, //nolint:staticcheck // SA1019: fallback
+		)
 		return workload.UnsetQuotaReservationWithCondition(wl, reason, "waiting for all admitted workloads to be in PodsReady condition", s.clock.Now()), nil
 	}, workloadpatching.WithLooseOnApply(), workloadpatching.WithRetryOnConflict()); err != nil {
 		log.Error(err, "Could not update Workload status")

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -30,7 +30,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/events"
@@ -66,9 +65,7 @@ import (
 )
 
 const (
-	errCouldNotAdmitWL                           = "Could not admit Workload and assign flavors in apiserver"
-	errInvalidWLResources                        = "resources validation failed"
-	errLimitRangeConstraintsUnsatisfiedResources = "resources didn't satisfy LimitRange constraints"
+	errCouldNotAdmitWL = "Could not admit Workload and assign flavors in apiserver"
 )
 
 var (
@@ -615,7 +612,6 @@ func (s *Scheduler) nominate(ctx context.Context, workloads []workload.Info, sna
 	var inadmissibleEntries []entry
 	for _, w := range workloads {
 		log := log.WithValues("workload", klog.KObj(w.Obj), "clusterQueue", klog.KRef("", string(w.ClusterQueue)))
-		ns := corev1.Namespace{}
 		e := entry{Info: w}
 		e.clusterQueueSnapshot = snap.ClusterQueue(w.ClusterQueue)
 		if !workload.NeedsSecondPass(w.Obj) && s.cache.IsAdded(w) {
@@ -630,19 +626,12 @@ func (s *Scheduler) nominate(ctx context.Context, workloads []workload.Info, sna
 		} else if e.clusterQueueSnapshot == nil {
 			e.inadmissibleMsg = fmt.Sprintf("ClusterQueue %s not found", w.ClusterQueue)
 			e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonMisconfigured
-		} else if err := s.client.Get(ctx, types.NamespacedName{Name: w.Obj.Namespace}, &ns); err != nil {
-			e.inadmissibleMsg = fmt.Sprintf("Could not obtain workload namespace: %v", err)
+		} else if msg, isNamespaceMismatch := workload.ValidateAdmissibility(ctx, s.client, &w, e.clusterQueueSnapshot.NamespaceSelector); msg != "" {
+			e.inadmissibleMsg = msg
 			e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonMisconfigured
-		} else if !e.clusterQueueSnapshot.NamespaceSelector.Matches(labels.Set(ns.Labels)) {
-			e.inadmissibleMsg = "Workload namespace doesn't match ClusterQueue selector"
-			e.requeueReason = qcache.RequeueReasonNamespaceMismatch
-			e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonMisconfigured
-		} else if err := workload.ValidateResources(&w); err != nil {
-			e.inadmissibleMsg = fmt.Sprintf("%s: %v", errInvalidWLResources, err.ToAggregate())
-			e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonMisconfigured
-		} else if err := workload.ValidateLimitRange(ctx, s.client, &w); err != nil {
-			e.inadmissibleMsg = fmt.Sprintf("%s: %v", errLimitRangeConstraintsUnsatisfiedResources, err.ToAggregate())
-			e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonMisconfigured
+			if isNamespaceMismatch {
+				e.requeueReason = qcache.RequeueReasonNamespaceMismatch
+			}
 		} else {
 			assignment, targets := s.getAssignments(log, &e.Info, snap)
 			e.recordAssignment(assignment, targets)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -589,6 +589,7 @@ type entry struct {
 	preemptionTargets    []*preemption.Target
 	clusterQueueSnapshot *schdcache.ClusterQueueSnapshot
 	quotaReservedReason  string
+	skipStatusUpdate     bool
 }
 
 func (e *entry) assignmentUsage(log logr.Logger) workload.Usage {
@@ -631,9 +632,13 @@ func (s *Scheduler) nominate(ctx context.Context, workloads []workload.Info, sna
 			e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonMisconfigured
 		} else if err := workload.ValidateAdmissibility(ctx, s.client, &w, e.clusterQueueSnapshot.NamespaceSelector); err != nil {
 			e.inadmissibleMsg = err.Error()
-			e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonMisconfigured
-			if errors.Is(err, workload.ErrNamespaceMismatch) {
-				e.requeueReason = qcache.RequeueReasonNamespaceMismatch
+			if errors.Is(err, workload.ErrAPI) {
+				e.skipStatusUpdate = true
+			} else {
+				e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonMisconfigured
+				if errors.Is(err, workload.ErrNamespaceMismatch) {
+					e.requeueReason = qcache.RequeueReasonNamespaceMismatch
+				}
 			}
 		} else {
 			assignment, targets := s.getAssignments(log, &e.Info, snap)
@@ -1017,6 +1022,10 @@ func (s *Scheduler) requeueAndUpdate(ctx context.Context, e entry) {
 	log.V(2).
 		Info("Workload re-queued", "workload", klog.KObj(e.Obj), "clusterQueue", klog.KRef("", string(e.ClusterQueue)), "queue", klog.KRef(e.Obj.Namespace, string(e.Obj.Spec.QueueName)), "requeueReason", e.requeueReason, "added", added, "status", e.status)
 	if e.status == notNominated || e.status == skipped || e.status == preemptionGated {
+		if e.skipStatusUpdate {
+			log.V(3).Info("Skipping Workload status update", "workload", klog.KObj(e.Obj), "reason", e.inadmissibleMsg)
+			return
+		}
 		wl := e.Obj.DeepCopy()
 		condReason := workload.UnadmittedWorkloadReasonWithFallback(e.quotaReservedReason, "Pending")
 		if err := workloadpatching.PatchAdmissionStatus(ctx, s.client, wl, s.clock, func(wl *kueue.Workload) (bool, error) {

--- a/pkg/scheduler/scheduler_afs_test.go
+++ b/pkg/scheduler/scheduler_afs_test.go
@@ -622,7 +622,7 @@ func TestScheduleForAFS(t *testing.T) {
 						wantWorkloads[i] = *tc.wantWorkloads[i].DeepCopy()
 					}
 					if !scenario[features.UnadmittedWorkloadsObservability] {
-						utiltesting.AdjustWorkloadsForDisabledObservability(wantWorkloads)
+						utiltesting.AdjustWorkloadsForDisabledObservabilityInScheduler(wantWorkloads)
 					}
 
 					clientBuilder := utiltesting.NewClientBuilder().

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -3566,7 +3566,7 @@ func runTASScheduleTestCases(t *testing.T, cfg tasScheduleTestConfig, cases map[
 							wantWorkloads[i] = *tc.wantWorkloads[i].DeepCopy()
 						}
 						if !scenario[features.UnadmittedWorkloadsObservability] {
-							utiltesting.AdjustWorkloadsForDisabledObservability(wantWorkloads)
+							utiltesting.AdjustWorkloadsForDisabledObservabilityInScheduler(wantWorkloads)
 						}
 					}
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -163,7 +163,7 @@ func runScheduleTestCases(t *testing.T, cfg scheduleTestConfig, cases map[string
 							wantWorkloads[i] = *tc.wantWorkloads[i].DeepCopy()
 						}
 						if !scenario[features.UnadmittedWorkloadsObservability] {
-							utiltesting.AdjustWorkloadsForDisabledObservability(wantWorkloads)
+							utiltesting.AdjustWorkloadsForDisabledObservabilityInScheduler(wantWorkloads)
 						}
 					}
 
@@ -174,7 +174,7 @@ func runScheduleTestCases(t *testing.T, cfg scheduleTestConfig, cases map[string
 							wantWorkloadUseMergePatch[i] = *tc.wantWorkloadUseMergePatch[i].DeepCopy()
 						}
 						if !scenario[features.UnadmittedWorkloadsObservability] {
-							utiltesting.AdjustWorkloadsForDisabledObservability(wantWorkloadUseMergePatch)
+							utiltesting.AdjustWorkloadsForDisabledObservabilityInScheduler(wantWorkloadUseMergePatch)
 						}
 					}
 
@@ -4401,7 +4401,7 @@ func TestSchedule(t *testing.T) {
 			wantEvents: []utiltesting.EventRecord{
 				utiltesting.MakeEventRecord("sales", "new", "Pending", corev1.EventTypeWarning).
 					Message(fmt.Sprintf("%s: %s",
-						errLimitRangeConstraintsUnsatisfiedResources,
+						workload.ErrLimitRangeConstraintsUnsatisfiedResources,
 						field.Invalid(
 							workload.PodSetsPath.Index(0).Child("template").Child("spec").Child("containers").Index(0),
 							[]corev1.ResourceName{corev1.ResourceCPU},
@@ -4456,7 +4456,7 @@ func TestSchedule(t *testing.T) {
 			wantEvents: []utiltesting.EventRecord{
 				utiltesting.MakeEventRecord("sales", "new", "Pending", corev1.EventTypeWarning).
 					Message(fmt.Sprintf("%s: %s",
-						errInvalidWLResources,
+						workload.ErrInvalidWLResources,
 						field.Invalid(
 							workload.PodSetsPath.Index(0).Child("template").Child("spec").Child("containers").Index(0),
 							[]corev1.ResourceName{corev1.ResourceCPU}, workload.RequestsMustNotExceedLimitMessage,
@@ -7711,7 +7711,7 @@ func TestLastSchedulingContext(t *testing.T) {
 						wantWorkloads[i] = *tc.wantWorkloads[i].DeepCopy()
 					}
 					if !scenario[features.UnadmittedWorkloadsObservability] {
-						utiltesting.AdjustWorkloadsForDisabledObservability(wantWorkloads)
+						utiltesting.AdjustWorkloadsForDisabledObservabilityInScheduler(wantWorkloads)
 					}
 					clientBuilder := utiltesting.NewClientBuilder().
 						WithLists(
@@ -8013,7 +8013,7 @@ func TestRequeueAndUpdate(t *testing.T) {
 
 				wantStatus := *tc.wantStatus.DeepCopy()
 				if !unadmittedWorkloadsObservabilityEnabled {
-					wantStatus.Conditions = utiltesting.AdjustConditionsForDisabledObservability(wantStatus.Conditions)
+					wantStatus.Conditions = utiltesting.AdjustConditionsForDisabledObservabilityInScheduler(wantStatus.Conditions)
 				}
 
 				if diff := cmp.Diff(wantStatus, updatedWl.Status,
@@ -8632,7 +8632,7 @@ func TestSchedulerWhenWorkloadModifiedConcurrently(t *testing.T) {
 						wantWorkloads[i] = *tc.wantWorkloads[i].DeepCopy()
 					}
 					if !scenario[features.UnadmittedWorkloadsObservability] {
-						utiltesting.AdjustWorkloadsForDisabledObservability(wantWorkloads)
+						utiltesting.AdjustWorkloadsForDisabledObservabilityInScheduler(wantWorkloads)
 					}
 
 					opts := cmp.Options{

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1009,7 +1009,7 @@ func TestSchedule(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonMisconfigured,
-						Message:            "Workload namespace doesn't match ClusterQueue selector",
+						Message:            "workload namespace doesn't match ClusterQueue selector",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{

--- a/pkg/util/testing/observability.go
+++ b/pkg/util/testing/observability.go
@@ -17,37 +17,24 @@ limitations under the License.
 package testing
 
 import (
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 )
 
-// AdjustConditionsForDisabledObservability adjusts a slice of workload status conditions
-// to match the scenario when the UnadmittedWorkloadsObservability feature gate is disabled.
-// Specifically, it performs the following modifications:
-//  1. For queueing workloads (not evicted/preempted), it removes the false 'Admitted' condition
-//     entirely, as legacy Kueue left it absent during initial queueing.
-//  2. For evicted/preempted workloads, it keeps the false 'Admitted' condition but rolls back
-//     its reason from 'UnsatisfiedAdmissionChecks' to the legacy 'UnsatisfiedChecks'.
-//  3. Removes the false 'Admitted' condition if its reason is 'NoReservation'.
-//  4. Rolls back the reason of the 'QuotaReserved: False' condition to the generic "Pending".
-func AdjustConditionsForDisabledObservability(conditions []metav1.Condition) []metav1.Condition {
-	isEvicted := false
-	for _, cond := range conditions {
-		if (cond.Type == kueue.WorkloadEvicted || cond.Type == kueue.WorkloadPreempted) && cond.Status == metav1.ConditionTrue {
-			isEvicted = true
-			break
-		}
-	}
-
+// AdjustConditionsForDisabledObservabilityInWorkloadController adjusts a slice of workload status conditions
+// to match the scenario when the UnadmittedWorkloadsObservability feature gate is disabled,
+// specifically from the perspective of the workload controller.
+func AdjustConditionsForDisabledObservabilityInWorkloadController(conditions []metav1.Condition, wasAdmitted bool) []metav1.Condition {
 	var filtered []metav1.Condition
 	for _, cond := range conditions {
 		if cond.Type == kueue.WorkloadAdmitted && cond.Status == metav1.ConditionFalse {
-			if !isEvicted {
-				// In the queueing case, legacy Kueue never sets Admitted: False.
+			if !wasAdmitted {
+				// In legacy Kueue, if the workload was never admitted, we never write Admitted: False.
 				continue
 			}
-			if cond.Reason == kueue.WorkloadAdmittedReasonNoReservation {
+			if cond.Reason == kueue.WorkloadAdmittedReasonNoReservation || cond.Reason == "NoReservationUnsatisfiedChecks" {
 				continue
 			}
 			if cond.Reason == kueue.WorkloadAdmittedReasonUnsatisfiedAdmissionChecks {
@@ -55,19 +42,76 @@ func AdjustConditionsForDisabledObservability(conditions []metav1.Condition) []m
 			}
 		}
 		if cond.Type == kueue.WorkloadQuotaReserved && cond.Status == metav1.ConditionFalse {
-			cond.Reason = "Pending"
+			switch cond.Reason {
+			case kueue.WorkloadQuotaReservedReasonWaitingForPodsReady:
+				cond.Reason = "Waiting"
+			case kueue.WorkloadAdmissionGated:
+				// Keep as is
+			case kueue.WorkloadQuotaReservedReasonMisconfigured,
+				kueue.WorkloadQuotaReservedReasonSuspended,
+				kueue.WorkloadInadmissible:
+				cond.Reason = kueue.WorkloadInadmissible
+			default:
+				cond.Reason = "Pending"
+			}
 		}
 		filtered = append(filtered, cond)
 	}
 	return filtered
 }
 
-// AdjustWorkloadsForDisabledObservability adjusts the workload status conditions in-place for
+// AdjustWorkloadsForDisabledObservabilityInWorkloadController adjusts the workload status conditions in-place for
 // a slice of workloads, matching the scenario when the UnadmittedWorkloadsObservability
-// feature gate is disabled. It delegates the condition adjustments to AdjustConditionsForDisabledObservability.
-func AdjustWorkloadsForDisabledObservability(workloads []kueue.Workload) {
+// feature gate is disabled. It delegates the condition adjustments to AdjustConditionsForDisabledObservabilityInWorkloadController.
+func AdjustWorkloadsForDisabledObservabilityInWorkloadController(workloads []kueue.Workload) {
 	for i := range workloads {
 		wl := &workloads[i]
-		wl.Status.Conditions = AdjustConditionsForDisabledObservability(wl.Status.Conditions)
+		wasAdmitted := false
+		if cond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadAdmitted); cond != nil {
+			if cond.Status == metav1.ConditionTrue {
+				wasAdmitted = true
+			} else if cond.Reason != kueue.WorkloadAdmittedReasonNoReservation &&
+				cond.Reason != "NoReservationUnsatisfiedChecks" {
+				wasAdmitted = true
+			}
+		}
+		if !wasAdmitted && (apimeta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadEvicted) ||
+			apimeta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadFinished)) {
+			wasAdmitted = true
+		}
+		wl.Status.Conditions = AdjustConditionsForDisabledObservabilityInWorkloadController(wl.Status.Conditions, wasAdmitted)
+	}
+}
+
+// AdjustConditionsForDisabledObservabilityInScheduler adjusts a slice of workload status conditions
+// to match the scenario when the UnadmittedWorkloadsObservability feature gate is disabled,
+// specifically from the perspective of the scheduler.
+func AdjustConditionsForDisabledObservabilityInScheduler(conditions []metav1.Condition) []metav1.Condition {
+	var filtered []metav1.Condition
+	for _, cond := range conditions {
+		if cond.Type == kueue.WorkloadAdmitted && cond.Status == metav1.ConditionFalse {
+			// The scheduler never writes or manages Admitted: False.
+			continue
+		}
+		if cond.Type == kueue.WorkloadQuotaReserved && cond.Status == metav1.ConditionFalse {
+			switch cond.Reason {
+			case kueue.WorkloadQuotaReservedReasonWaitingForPodsReady:
+				cond.Reason = "Waiting"
+			default:
+				cond.Reason = "Pending"
+			}
+		}
+		filtered = append(filtered, cond)
+	}
+	return filtered
+}
+
+// AdjustWorkloadsForDisabledObservabilityInScheduler adjusts the workload status conditions in-place for
+// a slice of workloads, matching the scenario when the UnadmittedWorkloadsObservability
+// feature gate is disabled. It delegates the condition adjustments to AdjustConditionsForDisabledObservabilityInScheduler.
+func AdjustWorkloadsForDisabledObservabilityInScheduler(workloads []kueue.Workload) {
+	for i := range workloads {
+		wl := &workloads[i]
+		wl.Status.Conditions = AdjustConditionsForDisabledObservabilityInScheduler(wl.Status.Conditions)
 	}
 }

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -39,6 +40,7 @@ import (
 var (
 	PodSetsPath          = field.NewPath("spec").Child("podSets")
 	ErrNamespaceMismatch = errors.New("workload namespace doesn't match ClusterQueue selector")
+	ErrAPI               = errors.New("api lookup failure")
 )
 
 const (
@@ -189,6 +191,15 @@ func ValidateLimitRange(ctx context.Context, c client.Client, wi *Info) field.Er
 	return allErrs
 }
 
+func hasInternalError(errs field.ErrorList) bool {
+	for _, e := range errs {
+		if e.Type == field.ErrorTypeInternal {
+			return true
+		}
+	}
+	return false
+}
+
 // ValidateAdmissibility checks if the workload's namespace matches the ClusterQueue's
 // namespace selector, and if its resource requests are valid and satisfy LimitRanges.
 // Returns the admissibility error if any.
@@ -200,7 +211,10 @@ func ValidateAdmissibility(
 ) error {
 	var ns corev1.Namespace
 	if err := c.Get(ctx, types.NamespacedName{Name: wi.Obj.Namespace}, &ns); err != nil {
-		return fmt.Errorf("could not obtain workload namespace: %w", err)
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("workload namespace %q does not exist: %w", wi.Obj.Namespace, err)
+		}
+		return fmt.Errorf("%w: %w", ErrAPI, err)
 	}
 	if cqNamespaceSelector != nil && !cqNamespaceSelector.Matches(labels.Set(ns.Labels)) {
 		return ErrNamespaceMismatch
@@ -211,6 +225,9 @@ func ValidateAdmissibility(
 	}
 
 	if errs := ValidateLimitRange(ctx, c, wi); len(errs) > 0 {
+		if hasInternalError(errs) {
+			return fmt.Errorf("%w: %w", ErrAPI, errs.ToAggregate())
+		}
 		return fmt.Errorf("%s: %w", ErrLimitRangeConstraintsUnsatisfiedResources, errs.ToAggregate())
 	}
 

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -40,7 +40,7 @@ import (
 var (
 	PodSetsPath          = field.NewPath("spec").Child("podSets")
 	ErrNamespaceMismatch = errors.New("workload namespace doesn't match ClusterQueue selector")
-	ErrAPI               = errors.New("api lookup failure")
+	ErrInternal          = errors.New("internal lookup failure")
 )
 
 const (
@@ -214,7 +214,7 @@ func ValidateAdmissibility(
 		if apierrors.IsNotFound(err) {
 			return fmt.Errorf("workload namespace %q does not exist: %w", wi.Obj.Namespace, err)
 		}
-		return fmt.Errorf("%w: %w", ErrAPI, err)
+		return fmt.Errorf("%w: %w", ErrInternal, err)
 	}
 	if cqNamespaceSelector != nil && !cqNamespaceSelector.Matches(labels.Set(ns.Labels)) {
 		return ErrNamespaceMismatch
@@ -226,7 +226,7 @@ func ValidateAdmissibility(
 
 	if errs := ValidateLimitRange(ctx, c, wi); len(errs) > 0 {
 		if hasInternalError(errs) {
-			return fmt.Errorf("%w: %w", ErrAPI, errs.ToAggregate())
+			return fmt.Errorf("%w: %w", ErrInternal, errs.ToAggregate())
 		}
 		return fmt.Errorf("%s: %w", ErrLimitRangeConstraintsUnsatisfiedResources, errs.ToAggregate())
 	}

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -40,6 +41,9 @@ var (
 
 const (
 	RequestsMustNotExceedLimitMessage = "requests must not exceed its limits"
+
+	ErrInvalidWLResources                        = "resources validation failed"
+	ErrLimitRangeConstraintsUnsatisfiedResources = "resources didn't satisfy LimitRange constraints"
 )
 
 // We do not verify Pod's RuntimeClass legality here as this will be performed in admission controller.
@@ -181,4 +185,32 @@ func ValidateLimitRange(ctx context.Context, c client.Client, wi *Info) field.Er
 		allErrs = append(allErrs, summary.ValidatePodSpec(&ps.Template.Spec, PodSetsPath.Index(i).Child("template").Child("spec"))...)
 	}
 	return allErrs
+}
+
+// ValidateAdmissibility checks if the workload's namespace matches the ClusterQueue's
+// namespace selector, and if its resource requests are valid and satisfy LimitRanges.
+// Returns the admissibility error message and a boolean indicating if it was a namespace mismatch.
+func ValidateAdmissibility(
+	ctx context.Context,
+	c client.Client,
+	wi *Info,
+	cqNamespaceSelector labels.Selector,
+) (string, bool) {
+	var ns corev1.Namespace
+	if err := c.Get(ctx, types.NamespacedName{Name: wi.Obj.Namespace}, &ns); err != nil {
+		return fmt.Sprintf("Could not obtain workload namespace: %v", err), false
+	}
+	if cqNamespaceSelector != nil && !cqNamespaceSelector.Matches(labels.Set(ns.Labels)) {
+		return "Workload namespace doesn't match ClusterQueue selector", true
+	}
+
+	if errs := ValidateResources(wi); len(errs) > 0 {
+		return fmt.Sprintf("%s: %v", ErrInvalidWLResources, errs.ToAggregate()), false
+	}
+
+	if errs := ValidateLimitRange(ctx, c, wi); len(errs) > 0 {
+		return fmt.Sprintf("%s: %v", ErrLimitRangeConstraintsUnsatisfiedResources, errs.ToAggregate()), false
+	}
+
+	return "", false
 }

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -18,6 +18,7 @@ package workload
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -36,7 +37,8 @@ import (
 )
 
 var (
-	PodSetsPath = field.NewPath("spec").Child("podSets")
+	PodSetsPath          = field.NewPath("spec").Child("podSets")
+	ErrNamespaceMismatch = errors.New("Workload namespace doesn't match ClusterQueue selector")
 )
 
 const (
@@ -189,28 +191,28 @@ func ValidateLimitRange(ctx context.Context, c client.Client, wi *Info) field.Er
 
 // ValidateAdmissibility checks if the workload's namespace matches the ClusterQueue's
 // namespace selector, and if its resource requests are valid and satisfy LimitRanges.
-// Returns the admissibility error message and a boolean indicating if it was a namespace mismatch.
+// Returns the admissibility error if any.
 func ValidateAdmissibility(
 	ctx context.Context,
 	c client.Client,
 	wi *Info,
 	cqNamespaceSelector labels.Selector,
-) (string, bool) {
+) error {
 	var ns corev1.Namespace
 	if err := c.Get(ctx, types.NamespacedName{Name: wi.Obj.Namespace}, &ns); err != nil {
-		return fmt.Sprintf("Could not obtain workload namespace: %v", err), false
+		return fmt.Errorf("could not obtain workload namespace: %w", err)
 	}
 	if cqNamespaceSelector != nil && !cqNamespaceSelector.Matches(labels.Set(ns.Labels)) {
-		return "Workload namespace doesn't match ClusterQueue selector", true
+		return ErrNamespaceMismatch
 	}
 
 	if errs := ValidateResources(wi); len(errs) > 0 {
-		return fmt.Sprintf("%s: %v", ErrInvalidWLResources, errs.ToAggregate()), false
+		return fmt.Errorf("%s: %w", ErrInvalidWLResources, errs.ToAggregate())
 	}
 
 	if errs := ValidateLimitRange(ctx, c, wi); len(errs) > 0 {
-		return fmt.Sprintf("%s: %v", ErrLimitRangeConstraintsUnsatisfiedResources, errs.ToAggregate()), false
+		return fmt.Errorf("%s: %w", ErrLimitRangeConstraintsUnsatisfiedResources, errs.ToAggregate())
 	}
 
-	return "", false
+	return nil
 }

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -38,7 +38,7 @@ import (
 
 var (
 	PodSetsPath          = field.NewPath("spec").Child("podSets")
-	ErrNamespaceMismatch = errors.New("Workload namespace doesn't match ClusterQueue selector")
+	ErrNamespaceMismatch = errors.New("workload namespace doesn't match ClusterQueue selector")
 )
 
 const (


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This is a preparatory PR based on https://github.com/kubernetes-sigs/kueue/pull/12510.

This PR introduces dynamic resolution of reasons for QuotaReserved condition based on UnadmittedWorkloadsObservability feature gate and adds some preparatory functions for the following PRs

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #https://github.com/kubernetes-sigs/kueue/issues/10852

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admission checks now validate workloads against the ClusterQueue namespace selector, improving outcomes when namespaces don’t match.

* **Bug Fixes**
  * Unadmitted and requeued workloads now show more precise quota-reservation and admitted-condition reasons (e.g., misconfigured vs suspended; pending vs waiting), including DRA-related and queue-state transitions.
  * “Pending/Waiting” messaging is normalized for quota-reservation unset and admission-gated scenarios, with improved behavior when unadmitted-workloads observability is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->