### PR TITLE
feat: add times for makefile steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,19 @@ YAML_PROCESSOR_LOG_LEVEL ?= info
 
 IMAGE_PUSH_RETRY = $(PROJECT_DIR)/hack/testing/retry.sh --attempts 7 --delay 2 --exponential --stream --continue-if "grep -qiE 'context deadline exceeded' {output}" -- env
 
+MAKE_TIMING ?= $(if $(filter 1 true TRUE yes YES on ON,$(CI)),1,0)
+MAKE_TIMING_MIN_SECONDS ?= 1
+export MAKE_TIMING
+export MAKE_TIMING_MIN_SECONDS
+
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
-SHELL = /usr/bin/env bash -o pipefail
+ifeq ($(filter 1 true TRUE yes YES on ON,$(MAKE_TIMING)),)
+    SHELL = /usr/bin/env bash -o pipefail
+else
+    SHELL = $(PROJECT_DIR)/hack/make-timed-shell.sh
+endif
 .SHELLFLAGS = -ec
 
 # Setting SED allows macos users to install GNU sed and use the latter

--- a/Makefile-verify.mk
+++ b/Makefile-verify.mk
@@ -96,7 +96,7 @@ verify-tree-prereqs: verify-go-prereqs verify-docs-prereqs verify-helm-prereqs
 ## Read-only verification targets that should not mutate the repo.
 ## Add new check-only targets here.
 verify-checks: ## Phase 2 (parallel): checks that should run after generation completes.
-verify-checks: verify-ci-lint verify-lint-api verify-fmt-verify verify-e2e-common-test verify-shell-lint verify-helm-verify verify-helm-unit-test verify-npm-depcheck verify-kustomize-build verify-skills-lint
+verify-checks: verify-ci-lint verify-lint-api verify-fmt-verify verify-e2e-common-test verify-make-timed-shell-test verify-shell-lint verify-helm-verify verify-helm-unit-test verify-npm-depcheck verify-kustomize-build verify-skills-lint
 
 # ---- Shared check recipes -------------------------------------------------
 # Each recipe is stored in a variable so that both the lightweight standalone
@@ -137,6 +137,10 @@ endef
 
 define _e2e_common_test_recipe
 bash $(PROJECT_DIR)/hack/testing/e2e-common_test.sh
+endef
+
+define _make_timed_shell_test_recipe
+bash $(PROJECT_DIR)/hack/make-timed-shell_test.sh
 endef
 
 define _helm_verify_recipe
@@ -194,6 +198,9 @@ verify-shell-lint: verify-tree-prereqs ## Shell lint after generation
 verify-e2e-common-test: verify-tree-prereqs ## e2e-common shell helper tests after generation
 	$(_e2e_common_test_recipe)
 
+.PHONY: verify-make-timed-shell-test
+verify-make-timed-shell-test: make-timed-shell-test ## Verify Makefile timing shell wrapper.
+
 .PHONY: verify-helm-verify
 verify-helm-verify: verify-tree-prereqs helm ## Helm verification after generation
 	$(_helm_verify_recipe)
@@ -247,6 +254,10 @@ fmt-verify: ## Verify Go code formatting (no changes allowed).
 .PHONY: shell-lint
 shell-lint: ## Run shell script linting (via shellcheck).
 	$(_shell_lint_recipe)
+
+.PHONY: make-timed-shell-test
+make-timed-shell-test: ## Run Makefile timing shell wrapper tests.
+	$(_make_timed_shell_test_recipe)
 
 .PHONY: e2e-common-test
 e2e-common-test: ## Run e2e-common shell helper tests.

--- a/Makefile-verify.mk
+++ b/Makefile-verify.mk
@@ -96,7 +96,7 @@ verify-tree-prereqs: verify-go-prereqs verify-docs-prereqs verify-helm-prereqs
 ## Read-only verification targets that should not mutate the repo.
 ## Add new check-only targets here.
 verify-checks: ## Phase 2 (parallel): checks that should run after generation completes.
-verify-checks: verify-ci-lint verify-lint-api verify-fmt-verify verify-e2e-common-test verify-make-timed-shell-test verify-shell-lint verify-helm-verify verify-helm-unit-test verify-npm-depcheck verify-kustomize-build verify-skills-lint
+verify-checks: verify-ci-lint verify-lint-api verify-fmt-verify verify-e2e-common-test verify-shell-lint verify-helm-verify verify-helm-unit-test verify-npm-depcheck verify-kustomize-build verify-skills-lint
 
 # ---- Shared check recipes -------------------------------------------------
 # Each recipe is stored in a variable so that both the lightweight standalone
@@ -137,10 +137,6 @@ endef
 
 define _e2e_common_test_recipe
 bash $(PROJECT_DIR)/hack/testing/e2e-common_test.sh
-endef
-
-define _make_timed_shell_test_recipe
-bash $(PROJECT_DIR)/hack/make-timed-shell_test.sh
 endef
 
 define _helm_verify_recipe
@@ -198,9 +194,6 @@ verify-shell-lint: verify-tree-prereqs ## Shell lint after generation
 verify-e2e-common-test: verify-tree-prereqs ## e2e-common shell helper tests after generation
 	$(_e2e_common_test_recipe)
 
-.PHONY: verify-make-timed-shell-test
-verify-make-timed-shell-test: make-timed-shell-test ## Verify Makefile timing shell wrapper.
-
 .PHONY: verify-helm-verify
 verify-helm-verify: verify-tree-prereqs helm ## Helm verification after generation
 	$(_helm_verify_recipe)
@@ -254,10 +247,6 @@ fmt-verify: ## Verify Go code formatting (no changes allowed).
 .PHONY: shell-lint
 shell-lint: ## Run shell script linting (via shellcheck).
 	$(_shell_lint_recipe)
-
-.PHONY: make-timed-shell-test
-make-timed-shell-test: ## Run Makefile timing shell wrapper tests.
-	$(_make_timed_shell_test_recipe)
 
 .PHONY: e2e-common-test
 e2e-common-test: ## Run e2e-common shell helper tests.

--- a/hack/make-timed-shell.sh
+++ b/hack/make-timed-shell.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o pipefail
+
+is_truthy() {
+  case "${1:-}" in
+    1 | true | TRUE | yes | YES | on | ON)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+command_preview() {
+  local command=$1
+
+  command=${command//$'\n'/; }
+  command=${command//$'\t'/ }
+  if [[ "${#command}" -gt 240 ]]; then
+    printf '%s...' "${command:0:237}"
+  else
+    printf '%s' "${command}"
+  fi
+}
+
+if ! is_truthy "${MAKE_TIMING:-}"; then
+  exec /usr/bin/env bash -o pipefail "$@"
+fi
+
+command=""
+if [[ "$#" -gt 0 ]]; then
+  command="${!#}"
+fi
+preview=$(command_preview "${command}")
+min_seconds="${MAKE_TIMING_MIN_SECONDS:-1}"
+if ! [[ "${min_seconds}" =~ ^[0-9]+$ ]]; then
+  min_seconds=1
+fi
+
+start_epoch=$(date +%s)
+start_time=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+/usr/bin/env bash -o pipefail "$@"
+status=$?
+
+end_epoch=$(date +%s)
+end_time=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+duration=$((end_epoch - start_epoch))
+if [[ "${status}" -ne 0 || "${duration}" -ge "${min_seconds}" ]]; then
+  printf 'make-timing: started=%s finished=%s status=%d duration=%ss command=%s\n' \
+    "${start_time}" "${end_time}" "${status}" "${duration}" "${preview}" >&2
+fi
+
+exit "${status}"


### PR DESCRIPTION
#### What type of PR is this?

/area testing

#### Which issue(s) this PR fixes:

Fixes #12660

#### Does this PR introduce a user-facing change?

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional timing output for `make` runs, automatically enabled in CI and configurable with environment variables.
  * Timing information is only shown for slower runs or failures, keeping normal output cleaner.

* **Tests**
  * Added a verification step to cover the new timed shell behavior and keep `make verify` aligned with the updated execution flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->