### PR TITLE
Add in-scope/out-of-scope to SECURITY-INSIGHTS.yaml

### DIFF
--- a/SECURITY-INSIGHTS.yaml
+++ b/SECURITY-INSIGHTS.yaml
@@ -1,6 +1,6 @@
 header:
   schema-version: 1.0.0
-  expiration-date: '2024-09-28T01:00:00.000Z'
+  expiration-date: '2027-06-26T01:00:00.000Z'
   last-updated: '2026-06-26'
   last-reviewed: '2026-06-26'
   commit-hash: "444058af81a08235306ef2a43581692289cd4822"
@@ -57,6 +57,25 @@ vulnerability-reporting:
   Security-policy: 'https://kubernetes.io/security/'
   bug-bounty-available: true
   bug-bounty-url: 'https://hackerone.com/kubernetes'
+  in-scope:
+    - Privilege escalation or workload admission bypass in the Kueue
+      controller-manager and its admission/validating webhooks
+    - Tenant isolation breakout across ClusterQueues, LocalQueues, and Cohorts
+      (e.g. quota borrowing or preemption affecting workloads of another tenant)
+    - Improper RBAC defaults in the shipped manifests and Helm chart that grant
+      excessive permissions to Kueue components
+    - Vulnerabilities in the optional KueueViz dashboard backend and frontend
+      (authentication, access control, or injection)
+  out-of-scope:
+    - Vulnerabilities in Kubernetes core, the kube-apiserver, or other core
+      Kubernetes components, which are handled by the Kubernetes security
+      process at https://kubernetes.io/security/
+    - Issues that only affect unsupported Kueue releases (see the release policy
+      in RELEASE.md); only the latest supported minor versions receive fixes
+    - Insecure configuration in a consuming cluster, such as disabling webhooks,
+      relaxing the provided RBAC, or running components with custom privileges
+    - Reports requiring pre-existing cluster-admin or equivalent privileged
+      access, since such access already permits the reported impact
 dependencies:
   third-party-packages: true
   dependencies-lists:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig release

#### What this PR does / why we need it:

The `vulnerability-reporting` section of `SECURITY-INSIGHTS.yaml` has been missing
its `in-scope` and `out-of-scope` subsections since the file was first added in
#1469, where they were intentionally deferred because it was not yet clear which
classes of issues were in or out of scope. This PR fills them in so the Security
Insights document is complete and Kueue's CLOMonitor score improves.

The scope is described in terms of Kueue's actual attack surface:

- **In-scope:** the Kueue controller-manager and its admission/validating
  webhooks, tenant isolation across ClusterQueues/LocalQueues/Cohorts (quota
  borrowing or preemption affecting another tenant's workloads), RBAC defaults in
  the shipped manifests and Helm chart, and the optional KueueViz dashboard
  (backend and frontend).
- **Out-of-scope:** vulnerabilities in Kubernetes core (delegated to the upstream
  Kubernetes security process at https://kubernetes.io/security/), issues that
  only affect unsupported Kueue releases, insecure configuration in a consuming
  cluster, and reports that require pre-existing privileged (cluster-admin)
  access.

While here, this also refreshes `header.expiration-date`, which had expired on
2024-09-28. An expired Security Insights document is flagged by CLOMonitor, so
leaving it stale would partially defeat the purpose of this change. Maintainers
should feel free to adjust the date or the scope wording to match their intent.

#### Which issue(s) this PR fixes:

Fixes #1473

#### Special notes for your reviewer:

The scope items reflect my reading of the project's architecture and the
Kubernetes subproject security conventions; please correct anything that does not
match the maintainers' intended reporting scope. This is the kind of section that
benefits from a maintainer's explicit sign-off, per the original issue.

> AI usage disclosure (per the project's AI contribution policy): I used an AI
> assistant to help draft the scope wording and the prose in this PR. The
> technical content reflects my own review of Kueue's architecture, and I take
> responsibility for the change.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the security policy expiration date to a newer review cycle.
  * Expanded reporting guidance by clearly defining what security issues are considered in-scope versus out-of-scope, including examples of allowed and excluded categories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->