### PR TITLE
Fix AFS ConsumedResources CPU truncating to zero on self-requeue

### DIFF
--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -44,6 +44,7 @@ import (
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	queueafs "sigs.k8s.io/kueue/pkg/cache/queue/afs"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
@@ -211,15 +212,14 @@ func (r *LocalQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	if afs.Enabled(r.admissionFSConfig) {
-		initNeeded := r.initializeAfsIfNeeded(&queueObj)
 		lqKey := utilqueue.Key(&queueObj)
-		entry, found := r.queues.AfsConsumedResources.Get(lqKey)
-		if !found {
-			log.V(3).Info("AFS cache entry deleted concurrently, skipping reconciliation")
-			return ctrl.Result{}, nil
-		}
+		hadCache, entry := r.initializeAfsIfNeeded(&queueObj)
 		sinceLastUpdate := r.clock.Now().Sub(entry.LastUpdate)
-		if interval := r.admissionFSConfig.UsageSamplingInterval.Duration; !initNeeded && sinceLastUpdate < interval && !r.queues.AfsEntryPenalties.HasPendingFor(lqKey) {
+		// Enforce the sampling interval when the cache already existed
+		// before this reconcile. Without this, self-triggered status
+		// updates cause sub-millisecond reconciles where the decay math
+		// truncates CPU consumed resources to zero.
+		if interval := r.admissionFSConfig.UsageSamplingInterval.Duration; hadCache && sinceLastUpdate < interval && !r.queues.AfsEntryPenalties.HasPendingFor(lqKey) {
 			return ctrl.Result{RequeueAfter: interval - sinceLastUpdate}, nil
 		}
 		if err := r.reconcileConsumedUsage(ctx, &queueObj); err != nil {
@@ -335,17 +335,14 @@ func (r *LocalQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.LocalQueue
 	return true
 }
 
-func (r *LocalQueueReconciler) initializeAfsIfNeeded(lq *kueue.LocalQueue) bool {
+func (r *LocalQueueReconciler) initializeAfsIfNeeded(lq *kueue.LocalQueue) (hadCache bool, entry queueafs.ConsumedResourcesEntry) {
 	if lq.Status.FairSharing == nil {
 		lq.Status.FairSharing = &kueue.LocalQueueFairSharingStatus{}
 	}
 
 	lqKey := utilqueue.Key(lq)
 	hasStatus := lq.Status.FairSharing.AdmissionFairSharingStatus != nil
-	_, hasCache := r.queues.AfsConsumedResources.Get(lqKey)
-	if hasStatus && hasCache {
-		return false
-	}
+	entry, hadCache = r.queues.AfsConsumedResources.Get(lqKey)
 
 	now := r.clock.Now()
 
@@ -355,12 +352,13 @@ func (r *LocalQueueReconciler) initializeAfsIfNeeded(lq *kueue.LocalQueue) bool 
 		}
 	}
 
-	if !hasCache {
+	if !hadCache {
 		currentUsage := r.getCurrentUsageForLocalQueue(lq.Spec.ClusterQueue, lqKey)
 		r.queues.AfsConsumedResources.Set(lqKey, currentUsage, now)
+		entry = queueafs.ConsumedResourcesEntry{Resources: currentUsage, LastUpdate: now}
 	}
 
-	return true
+	return hadCache, entry
 }
 
 func (r *LocalQueueReconciler) getCurrentUsageForLocalQueue(cqName kueue.ClusterQueueReference, lqKey utilqueue.LocalQueueReference) corev1.ResourceList {

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -571,6 +571,38 @@ func TestLocalQueueReconcile(t *testing.T) {
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
 			},
 		},
+		"AFS reconcile skips when cache is recent but status lacks AdmissionFairSharingStatus": {
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq-afs-skip").
+				Active(metav1.ConditionTrue).
+				Obj(),
+			localQueue: utiltestingapi.MakeLocalQueue("lq-afs-skip", "default").
+				ClusterQueue("cq-afs-skip").
+				Active(metav1.ConditionTrue).
+				FairSharing(&kueue.FairSharing{
+					Weight: new(resource.MustParse("1")),
+				}).
+				Obj(),
+			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("500m"),
+				},
+				// 1s ago: within the 5s sampling interval, so reconcile should skip.
+				LastUpdate: clock.Now().Add(-1 * time.Second),
+			},
+			wantLocalQueue: utiltestingapi.MakeLocalQueue("lq-afs-skip", "default").
+				ClusterQueue("cq-afs-skip").
+				Active(metav1.ConditionTrue).
+				FairSharing(&kueue.FairSharing{
+					Weight: new(resource.MustParse("1")),
+				}).
+				Obj(),
+			// 5s interval - 1s elapsed = 4s remaining
+			wantRequeueAfter: ptr.To(4 * time.Second),
+			afsConfig: &config.AdmissionFairSharing{
+				UsageHalfLifeTime:     metav1.Duration{Duration: 60 * time.Second},
+				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Second},
+			},
+		},
 	}
 
 	for name, tc := range cases {

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -1425,6 +1425,52 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing", "featur
 			util.ExpectWorkloadsToBePreempted(ctx, k8sClient, wlHighA)
 		})
 	})
+
+	ginkgo.When("Self-triggered reconciles do not truncate CPU", func() {
+		ginkgo.It("should maintain non-zero CPU ConsumedResources across sampling intervals", func() {
+			ginkgo.By("Creating a ClusterQueue and LocalQueue with AFS enabled")
+			cq := utiltestingapi.MakeClusterQueue("cq-afs-cpu").
+				Cohort("cohort").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "4").Obj(),
+				).Obj()
+			util.MustCreate(ctx, k8sClient, cq)
+			util.ExpectClusterQueuesToBeActive(ctx, k8sClient, cq)
+			cqs = append(cqs, cq)
+
+			lq := utiltestingapi.MakeLocalQueue("lq-afs-cpu", ns.Name).ClusterQueue(cq.Name).Obj()
+			util.MustCreate(ctx, k8sClient, lq)
+			util.ExpectLocalQueuesToBeActive(ctx, k8sClient, lq)
+			lqs = append(lqs, lq)
+
+			ginkgo.By("Admitting a workload with 500m CPU")
+			wl := createWorkload("lq-afs-cpu", "500m")
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+
+			ginkgo.By("Waiting for ConsumedResources CPU to become non-zero")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var lqObj kueue.LocalQueue
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lq), &lqObj)).To(gomega.Succeed())
+				g.Expect(lqObj.Status.FairSharing).NotTo(gomega.BeNil())
+				g.Expect(lqObj.Status.FairSharing.AdmissionFairSharingStatus).NotTo(gomega.BeNil())
+				consumed := lqObj.Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources
+				g.Expect(consumed).To(gomega.HaveKey(corev1.ResourceCPU))
+				cpu := consumed[corev1.ResourceCPU]
+				g.Expect(cpu.Cmp(resource.MustParse("0"))).To(gomega.BeNumerically(">", 0),
+					"ConsumedResources CPU should be > 0, got %v", cpu.String())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Verifying CPU stays non-zero across multiple sampling intervals")
+			gomega.Consistently(func(g gomega.Gomega) {
+				var lqObj kueue.LocalQueue
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lq), &lqObj)).To(gomega.Succeed())
+				cpu := lqObj.Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources[corev1.ResourceCPU]
+				g.Expect(cpu.Cmp(resource.MustParse("0"))).To(gomega.BeNumerically(">", 0),
+					"ConsumedResources CPU should remain > 0, got %v", cpu.String())
+			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+		})
+	})
 })
 
 var _ = ginkgo.Describe("Scheduler with AdmissionFairSharing = nil", ginkgo.Label("feature:fairsharing"), func() {


### PR DESCRIPTION


#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The LocalQueue `Update` predicate always returns `true`, including for status-only updates. When AFS writes `ConsumedResources` to status, the Update event re-enters `Reconcile` within ~40ms instead of the configured `usageSamplingInterval` (5s). The tiny `elapsed` makes the decay alpha near zero, truncating CPU to 0m while memory (much larger in milli-units) keeps rising.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Special notes for your reviewer:
Failing upgrade CI job in downstream (46/49 passed, AFS test failed 3x): https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_kueue-operator/2134/pull-ci-openshift-kueue-operator-release-1.4-upgrade-from-4.22-e2e-operator-upgrade-4-22-kueue-1-3-to-1-4/2072073388884496384

#### Does this PR introduce a user-facing change?

```release-note
AFS: Fixed ConsumedResources CPU truncating to zero when the sampling interval guard was bypassed by informer cache lag during initialization.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved Admission Fair Sharing to avoid unnecessary reconciles when sampling cache data is recent but fair-sharing status isn’t available yet.
  * Corrected CPU consumed accounting so it remains numerically positive and doesn’t truncate to zero after self-triggered or repeated updates.

* **Tests**
  * Added an integration test ensuring CPU consumed stays positive across sampling intervals.
  * Added a unit test for the “recent cache with missing fair-sharing status” scenario, including expected requeue timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->