### PR TITLE
Avoid cloning per-node usage maps when building TAS snapshots

### DIFF
--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -146,11 +146,11 @@ func (c *TASFlavorCache) snapshot(
 	for domainID, usage := range tasDomainUsages {
 		snapshot.addTASUsage(domainID, usage)
 	}
-	for nodeName, usage := range c.nonTasUsageCache.usagePerNode() {
+	c.nonTasUsageCache.forEachNodeUsage(func(nodeName string, usage resources.Requests) {
 		if domainID, ok := nodeToDomain[nodeName]; ok {
 			snapshot.addNonTASUsage(domainID, usage)
 		}
-	}
+	})
 	return snapshot
 }
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
+	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+)
+
+const (
+	benchBlockLabel = "cloud.provider.com/topology-block"
+	benchRackLabel  = "cloud.provider.com/topology-rack"
+	benchHostLabel  = corev1.LabelHostname
+)
+
+type benchTopology struct {
+	nodes          int
+	nodesPerRack   int
+	racksPerBlock  int
+	flavors        int
+	withNonTASPods bool
+}
+
+func buildBenchNodes(t benchTopology) []corev1.Node {
+	nodes := make([]corev1.Node, 0, t.nodes)
+	for i := 0; i < t.nodes; i++ {
+		rack := i / t.nodesPerRack
+		block := rack / t.racksPerBlock
+		host := fmt.Sprintf("node-%d", i)
+		node := testingnode.MakeNode(host).
+			Label(benchBlockLabel, fmt.Sprintf("block-%d", block)).
+			Label(benchRackLabel, fmt.Sprintf("rack-%d", rack)).
+			Label(benchHostLabel, host).
+			StatusAllocatable(corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("96"),
+				corev1.ResourceMemory: resource.MustParse("384Gi"),
+				corev1.ResourcePods:   resource.MustParse("110"),
+			}).
+			Ready().
+			Obj()
+		nodes = append(nodes, *node)
+	}
+	return nodes
+}
+
+func BenchmarkTASFlavorSnapshot(b *testing.B) {
+	topologies := []benchTopology{
+		{nodes: 100, nodesPerRack: 16, racksPerBlock: 16, withNonTASPods: true},
+		{nodes: 500, nodesPerRack: 16, racksPerBlock: 16, withNonTASPods: true},
+		{nodes: 2500, nodesPerRack: 16, racksPerBlock: 16, withNonTASPods: true},
+		{nodes: 2500, nodesPerRack: 16, racksPerBlock: 16, flavors: 15, withNonTASPods: true},
+		{nodes: 2500, nodesPerRack: 16, racksPerBlock: 16},
+	}
+
+	for _, topo := range topologies {
+		flavors := max(1, topo.flavors)
+		name := fmt.Sprintf("nodes=%d/flavors=%d", topo.nodes, flavors)
+		if topo.withNonTASPods {
+			name += "/withNonTASPods"
+		}
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			log := logr.Discard()
+
+			nodes := buildBenchNodes(topo)
+			levels := []string{benchBlockLabel, benchRackLabel, benchHostLabel}
+
+			tasCache := NewTASCache(nil)
+			for i := range nodes {
+				tasCache.SyncNode(&nodes[i])
+			}
+
+			if topo.withNonTASPods {
+				for i := range nodes {
+					pod := testingpod.MakePod(fmt.Sprintf("bg-%d", i), "default").
+						NodeName(nodes[i].Name).
+						Request(corev1.ResourceCPU, "1").
+						Request(corev1.ResourceMemory, "1Gi").
+						StatusPhase(corev1.PodRunning).
+						Obj()
+					tasCache.Update(pod, log)
+				}
+			}
+
+			flavorCaches := make([]*TASFlavorCache, flavors)
+			for i := range flavorCaches {
+				flavorCaches[i] = tasCache.NewTASFlavorCache(
+					topologyInformation{Levels: levels},
+					flavorInformation{TopologyName: "default"},
+				)
+			}
+
+			for b.Loop() {
+				for _, flavorCache := range flavorCaches {
+					_ = flavorCache.snapshot(
+						log,
+						tasCache.nodesCache.find(flavorCache.flavor.NodeLabels, flavorCache.topology.Levels),
+						nil,
+					)
+				}
+			}
+		})
+	}
+}

--- a/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
@@ -111,13 +111,14 @@ func BenchmarkTASFlavorSnapshot(b *testing.B) {
 				)
 			}
 
+			flavorNodes := make([][]*nodeInfo, len(flavorCaches))
+			for i, flavorCache := range flavorCaches {
+				flavorNodes[i] = tasCache.nodesCache.find(flavorCache.flavor.NodeLabels, flavorCache.topology.Levels)
+			}
+
 			for b.Loop() {
-				for _, flavorCache := range flavorCaches {
-					_ = flavorCache.snapshot(
-						log,
-						tasCache.nodesCache.find(flavorCache.flavor.NodeLabels, flavorCache.topology.Levels),
-						nil,
-					)
+				for i, flavorCache := range flavorCaches {
+					_ = flavorCache.snapshot(log, flavorNodes[i], nil)
 				}
 			}
 		})

--- a/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
@@ -44,7 +44,7 @@ type benchTopology struct {
 
 func buildBenchNodes(t benchTopology) []corev1.Node {
 	nodes := make([]corev1.Node, 0, t.nodes)
-	for i := 0; i < t.nodes; i++ {
+	for i := range t.nodes {
 		rack := i / t.nodesPerRack
 		block := rack / t.racksPerBlock
 		host := fmt.Sprintf("node-%d", i)

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache.go
@@ -82,14 +82,15 @@ func (n *nonTasUsageCache) delete(key client.ObjectKey, log logr.Logger) {
 	delete(n.podUsage, key)
 }
 
-func (n *nonTasUsageCache) usagePerNode() map[string]resources.Requests {
+// forEachNodeUsage invokes fn for each node's usage while holding the read lock.
+// usage is the live cache entry, not a copy: fn must only read it, and must not
+// mutate or retain it beyond the call. Clone it if a longer-lived copy is needed.
+func (n *nonTasUsageCache) forEachNodeUsage(fn func(node string, usage resources.Requests)) {
 	n.lock.RLock()
 	defer n.lock.RUnlock()
-	usage := make(map[string]resources.Requests, len(n.nodeUsage))
 	for node, reqs := range n.nodeUsage {
-		usage[node] = reqs.Clone()
+		fn(node, reqs)
 	}
-	return usage
 }
 
 // addNodeUsage increments the pre-aggregated per-node usage.

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
@@ -42,10 +42,18 @@ func verifyNodeUsageConsistency(t *testing.T, cache *nonTasUsageCache) {
 		expected[pv.node].Add(pv.usage)
 		expected[pv.node][corev1.ResourcePods]++
 	}
-	got := cache.usagePerNode()
+	got := collectNodeUsage(cache)
 	if diff := cmp.Diff(expected, got); diff != "" {
 		t.Errorf("nodeUsage inconsistent with podUsage (-recomputed +nodeUsage):\n%s", diff)
 	}
+}
+
+func collectNodeUsage(cache *nonTasUsageCache) map[string]resources.Requests {
+	usage := map[string]resources.Requests{}
+	cache.forEachNodeUsage(func(node string, reqs resources.Requests) {
+		usage[node] = reqs.Clone()
+	})
+	return usage
 }
 
 func makePod(name, namespace, node string, cpu string) *corev1.Pod {
@@ -178,8 +186,8 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 			if wantUsage == nil {
 				wantUsage = map[string]resources.Requests{}
 			}
-			if diff := cmp.Diff(wantUsage, cache.usagePerNode()); diff != "" {
-				t.Errorf("usagePerNode() mismatch (-want +got):\n%s", diff)
+			if diff := cmp.Diff(wantUsage, collectNodeUsage(cache)); diff != "" {
+				t.Errorf("collectNodeUsage() mismatch (-want +got):\n%s", diff)
 			}
 
 			// Explicitly verify the internal nodeUsage map has no leftover


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area tas
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Replaces `nonTasUsageCache.usagePerNode()`, which allocated a new map and deep-cloned every per-node `Requests` on each TAS snapshot, with `forEachNodeUsage(fn)`, which reads and subtracts per-node usage in place under the read lock, avoiding the copy. See #12580 for the background on the CPU and GC overhead this addresses at scale.

Benchmark results
Without change:
<img width="2070" height="184" alt="image" src="https://github.com/user-attachments/assets/08ee1d1c-e717-4957-ad6a-98a14a09a1a5" />

With change:
<img width="1035" height="92" alt="Screenshot 2026-07-01 at 10 39 46 AM" src="https://github.com/user-attachments/assets/025b31d0-2a9d-4867-a5bc-8410ba6d36fb" />

pprof flame graph results
Without change:
<img width="3010" height="878" alt="image" src="https://github.com/user-attachments/assets/6436cc73-2ae4-431c-aa15-6bd2e0569ef6" />

With changes:
<img width="3016" height="920" alt="image" src="https://github.com/user-attachments/assets/4e6b6eb8-41b2-4c63-8404-0dd694c1c082" />


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #12580

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Reduced the CPU and memory overhead of building the topology snapshot on large clusters by no longer cloning per-node usage maps on every scheduling cycle.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new benchmark to measure snapshot performance across different topology sizes and workload mixes.
  * Updated cache tests to validate node usage through a new iteration path, keeping coverage aligned with current behavior.

* **Performance**
  * Improved how cache data is traversed during snapshot generation, helping support more efficient processing without changing results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->