### PR TITLE
[Skills] Add code style skill for structured errors

### DIFF
--- a/cmd/experimental/skills/reviewer/README.md
+++ b/cmd/experimental/skills/reviewer/README.md
@@ -26,7 +26,7 @@ Each skill is independent and can be applied in parallel with the others. When r
 | [code-eval](code-eval/SKILL.md) | runs code evaluation and produces a scored report |
 | [architectural-decisions](architectural-decisions/SKILL.md) | domain — unjustified complexity, duplicated logic across types/adapters, scope creep, or misplaced code (see ToC inside) |
 | [buggy-behavior](buggy-behavior/SKILL.md) | domain — logic errors, broken edge cases, feature-gate bugs, deletions that break backwards compatibility during rolling upgrades (see ToC inside) |
-| [code-style](code-style/SKILL.md) | domain — imprecise names, convention drift, reinvented helpers, wrong log verbosity, misaligned test names, typos (see ToC inside) |
+| [code-style](code-style/SKILL.md) | domain — imprecise names, convention drift, reinvented helpers, wrong log verbosity, misaligned test names, typos, structured errors (see ToC inside) |
 | [comments](comments/SKILL.md) | domain — over-commenting, what-not-why narration, inaccurate comments, missing TODOs on compatibility shims (see ToC inside) |
 | [security](security/SKILL.md) | domain — input-validation gaps, injection, DoS, nil-safety crashes, authz relaxation, info disclosure, supply-chain weakening, webhook safety regressions (see ToC inside) |
 | [imprecise-names](code-style/imprecise-names/SKILL.md) | identifier whose name does not describe exactly what it contains (code-style) |
@@ -35,6 +35,7 @@ Each skill is independent and can be applied in parallel with the others. When r
 | [wrong-log-verbosity](code-style/wrong-log-verbosity/SKILL.md) | per-reconcile-cycle log lines emitted at `V(2)` (code-style) |
 | [misaligned-test-names](code-style/misaligned-test-names/SKILL.md) | test function names that do not reflect the function or behavior under test (code-style) |
 | [code-style-typos](code-style/code-style-typos/SKILL.md) | typos in identifiers, strings, or any text introduced by the diff (code-style) |
+| [structured-errors](code-style/structured-errors/SKILL.md) | error checking done via string comparison on `err.Error()` instead of structured/typed errors (code-style) |
 | [illogical-structure](architectural-decisions/illogical-structure/SKILL.md) | code a future maintainer will struggle to follow, modify, or extend (architectural-decisions) |
 | [nonsensical-decisions](architectural-decisions/nonsensical-decisions/SKILL.md) | unnecessary indirection, mismatched abstractions, confusing data flow (architectural-decisions) |
 | [avoidable-complexity](architectural-decisions/avoidable-complexity/SKILL.md) | solutions more elaborate than the problem requires (architectural-decisions) |
@@ -91,6 +92,7 @@ Each skill is independent and can be applied in parallel with the others. When r
 @code-style/wrong-log-verbosity/SKILL.md
 @code-style/misaligned-test-names/SKILL.md
 @code-style/code-style-typos/SKILL.md
+@code-style/structured-errors/SKILL.md
 @architectural-decisions/illogical-structure/SKILL.md
 @architectural-decisions/nonsensical-decisions/SKILL.md
 @architectural-decisions/avoidable-complexity/SKILL.md

--- a/cmd/experimental/skills/reviewer/code-style/SKILL.md
+++ b/cmd/experimental/skills/reviewer/code-style/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-style
-description: Review a diff for naming precision, convention drift, reinvented helpers, log-verbosity mistakes, misaligned test names, and typos.
+description: Review a diff for naming precision, convention drift, reinvented helpers, log-verbosity mistakes, misaligned test names, typos, and error checking that relies on string comparison instead of structured errors.
 license: Apache-2.0
 metadata:
   copyright: The Kubernetes Authors
@@ -25,6 +25,7 @@ rule below.
 | [wrong-log-verbosity](./wrong-log-verbosity/SKILL.md) | per-reconcile-cycle log lines emitted at `V(2)` |
 | [misaligned-test-names](./misaligned-test-names/SKILL.md) | test function names that do not reflect the function or behavior under test |
 | [code-style-typos](./code-style-typos/SKILL.md) | typos in identifiers, strings, or any text introduced by the diff |
+| [structured-errors](./structured-errors/SKILL.md) | error checking done via string comparison on `err.Error()` instead of structured/typed errors |
 
 @./imprecise-names/SKILL.md
 @./convention-drift/SKILL.md
@@ -32,6 +33,7 @@ rule below.
 @./wrong-log-verbosity/SKILL.md
 @./misaligned-test-names/SKILL.md
 @./code-style-typos/SKILL.md
+@./structured-errors/SKILL.md
 
 ## What not to include
 

--- a/cmd/experimental/skills/reviewer/code-style/structured-errors/SKILL.md
+++ b/cmd/experimental/skills/reviewer/code-style/structured-errors/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: structured-errors
+description: Flag error checking done via string comparison on err.Error() instead of structured/typed errors checked with errors.Is/errors.As.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Structured Errors
+
+**Structured errors over string comparison** — error checking (especially in tests)
+done via substring/equality checks on `err.Error()` instead of a sentinel or typed
+error checked with `errors.Is` / `errors.As`. String-matching turns tests into
+"change detector" tests, where a purely cosmetic wording tweak forces updates across
+every test that asserted on it.
+
+- A test asserting `err.Error() == "..."` or `strings.Contains(err.Error(), "...")`
+  against a bare `errors.New(...)` / `fmt.Errorf(...)`. Prefer a sentinel
+  (`var ErrFoo = errors.New(...)`) or a typed error with an `Is` method, checked with
+  `errors.Is`.
+- An error whose data (offending names, counts, a resource reference) only exists in
+  the formatted message (`fmt.Errorf("...: %s", x)`) when a caller already needs that
+  data. Prefer a typed error struct with the data as a field.
+- A `cmp.Comparer` or similar helper that falls back to `strings.HasPrefix` to work
+  around errors not being directly comparable — make the errors comparable instead
+  (sentinel values or an `Is` method), and prefer `cmpopts.EquateErrors()` in tests.
+
+Don't require a sentinel for a one-off error that's never compared (e.g. wrapped with
+`%w` and only logged).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Adds a `structured-errors` code-review skill under `cmd/experimental/skills/reviewer/code-style/`
that flags error checks (especially in tests) done via string comparison on `err.Error()`,
and recommends sentinel or typed errors checked with `errors.Is`/`errors.As` instead —
so future reviews suggest this pattern instead of relying on ad hoc feedback.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded review guidance for identifying improper error handling patterns.
  * Added a new rule covering structured errors, encouraging typed or sentinel error checks instead of comparing error message text.
  * Updated the skill reference list so the new guidance is easier to find.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->