### PR TITLE
[Cleanup] Use structured errors in TAS Flavorassigner

### DIFF
--- a/pkg/scheduler/flavorassigner/errors.go
+++ b/pkg/scheduler/flavorassigner/errors.go
@@ -1,0 +1,57 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flavorassigner
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+)
+
+// Sentinel errors for TAS request building, so callers/tests can identify the
+// failure with errors.Is instead of matching on the message text.
+var (
+	ErrElasticRequiredTopologyNotSupported  = errors.New("required topology is not supported with ElasticJobsViaWorkloadSlices")
+	ErrElasticPreferredTopologyNotSupported = errors.New("preferred topology is not supported with ElasticJobsViaWorkloadSlices")
+	ErrNoTASCacheInformation                = errors.New("workload requires Topology, but there is no TAS cache information")
+	ErrNoTASFlavorAssigned                  = errors.New("no TAS flavor assigned")
+)
+
+// MultipleTASFlavorsAssignedError indicates that a PodSet ended up with more
+// than one TAS flavor assigned across its resources, which TAS cannot handle.
+// The offending flavors are kept as a field rather than only in the message so
+// callers can inspect them without parsing the error text.
+type MultipleTASFlavorsAssignedError struct {
+	Flavors []kueue.ResourceFlavorReference
+}
+
+func (e *MultipleTASFlavorsAssignedError) Error() string {
+	names := make([]string, len(e.Flavors))
+	for i, f := range e.Flavors {
+		names[i] = string(f)
+	}
+	return fmt.Sprintf("more than one TAS flavor assigned: %s", strings.Join(names, ", "))
+}
+
+// Is reports whether target is any MultipleTASFlavorsAssignedError (regardless of Flavors).
+// Callers must compare Flavors separately if exact error matching is required.
+func (e *MultipleTASFlavorsAssignedError) Is(target error) bool {
+	_, ok := target.(*MultipleTASFlavorsAssignedError)
+	return ok
+}

--- a/pkg/scheduler/flavorassigner/errors.go
+++ b/pkg/scheduler/flavorassigner/errors.go
@@ -19,6 +19,7 @@ package flavorassigner
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -36,7 +37,7 @@ var (
 // MultipleTASFlavorsAssignedError indicates that a PodSet ended up with more
 // than one TAS flavor assigned across its resources, which TAS cannot handle.
 // The offending flavors are kept as a field rather than only in the message so
-// callers can inspect them without parsing the error text.
+// callers can inspect them with errors.As instead of parsing the error text.
 type MultipleTASFlavorsAssignedError struct {
 	Flavors []kueue.ResourceFlavorReference
 }
@@ -49,9 +50,21 @@ func (e *MultipleTASFlavorsAssignedError) Error() string {
 	return fmt.Sprintf("more than one TAS flavor assigned: %s", strings.Join(names, ", "))
 }
 
-// Is reports whether target is any MultipleTASFlavorsAssignedError (regardless of Flavors).
-// Callers must compare Flavors separately if exact error matching is required.
+// Is reports equality for MultipleTASFlavorsAssignedError based on the
+// offending flavor set, so callers can use errors.Is for semantic matching.
 func (e *MultipleTASFlavorsAssignedError) Is(target error) bool {
-	_, ok := target.(*MultipleTASFlavorsAssignedError)
-	return ok
+	other, ok := target.(*MultipleTASFlavorsAssignedError)
+	if !ok {
+		return false
+	}
+	if e == nil || other == nil {
+		return e == other
+	}
+
+	eFlavors := append([]kueue.ResourceFlavorReference(nil), e.Flavors...)
+	otherFlavors := append([]kueue.ResourceFlavorReference(nil), other.Flavors...)
+	slices.Sort(eFlavors)
+	slices.Sort(otherFlavors)
+
+	return slices.Equal(eFlavors, otherFlavors)
 }

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -46,11 +46,8 @@ import (
 
 var (
 	statusComparer = cmp.Comparer(func(a, b Status) bool {
-		if a.err != nil && b.err != nil {
-			return errors.Is(a.err, b.err) || errors.Is(b.err, a.err)
-		}
 		if a.err != nil || b.err != nil {
-			return false
+			return errors.Is(a.err, b.err) || errors.Is(b.err, a.err)
 		}
 		return cmp.Equal(a.reasons, b.reasons, cmpopts.SortSlices(func(x, y string) bool {
 			return x < y
@@ -4352,16 +4349,8 @@ func TestWorkloadsTopologyRequests_ErrorBranches(t *testing.T) {
 			if len(tasReqs) != 0 {
 				t.Errorf("expected no TAS requests, got: %+v", tasReqs)
 			}
-			if tc.wantErr != nil && !errors.Is(tc.assignment.PodSets[0].Status.err, tc.wantErr) {
+			if tc.wantErr != nil && !errors.Is(tc.assignment.PodSets[0].Status.err, tc.wantErr) && !errors.Is(tc.wantErr, tc.assignment.PodSets[0].Status.err) {
 				t.Errorf("got error %v, want error %v", tc.assignment.PodSets[0].Status.err, tc.wantErr)
-			}
-			// For MultipleTASFlavorsAssignedError, also verify Flavors match
-			if wantMFE, ok := tc.wantErr.(*MultipleTASFlavorsAssignedError); ok {
-				if actualMFE, ok := tc.assignment.PodSets[0].Status.err.(*MultipleTASFlavorsAssignedError); ok {
-					if diff := cmp.Diff(wantMFE.Flavors, actualMFE.Flavors); diff != "" {
-						t.Errorf("Flavors mismatch (-want +got):\n%s", diff)
-					}
-				}
 			}
 			// When TAS request build fails, the assignment should be unfit so the workload is not admitted.
 			if got := tc.assignment.RepresentativeMode(); got != NoFit {
@@ -4598,16 +4587,8 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 				if len(tasReqs) != 0 {
 					t.Errorf("expected no TAS requests, got: %+v", tasReqs)
 				}
-				if !errors.Is(tc.assignment.PodSets[0].Status.err, tc.wantErr) {
+				if !errors.Is(tc.assignment.PodSets[0].Status.err, tc.wantErr) && !errors.Is(tc.wantErr, tc.assignment.PodSets[0].Status.err) {
 					t.Errorf("got error %v, want error %v", tc.assignment.PodSets[0].Status.err, tc.wantErr)
-				}
-				// For MultipleTASFlavorsAssignedError, also verify Flavors match
-				if wantMFE, ok := tc.wantErr.(*MultipleTASFlavorsAssignedError); ok {
-					if actualMFE, ok := tc.assignment.PodSets[0].Status.err.(*MultipleTASFlavorsAssignedError); ok {
-						if diff := cmp.Diff(wantMFE.Flavors, actualMFE.Flavors); diff != "" {
-							t.Errorf("Flavors mismatch (-want +got):\n%s", diff)
-						}
-					}
 				}
 				if got := tc.assignment.RepresentativeMode(); got != NoFit {
 					t.Errorf("RepresentativeMode() = %v, want NoFit (workload must not be admitted when elastic job validation fails)", got)

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -47,7 +47,7 @@ import (
 var (
 	statusComparer = cmp.Comparer(func(a, b Status) bool {
 		if a.err != nil && b.err != nil {
-			return errors.Is(a.err, b.err) || strings.HasPrefix(a.err.Error(), b.err.Error()) || strings.HasPrefix(b.err.Error(), a.err.Error())
+			return errors.Is(a.err, b.err) || errors.Is(b.err, a.err)
 		}
 		if a.err != nil || b.err != nil {
 			return false
@@ -3481,7 +3481,7 @@ func TestAssignFlavors(t *testing.T) {
 						},
 						Count: 1,
 						Status: Status{
-							err: errors.New("more than one TAS flavor assigned"),
+							err: &MultipleTASFlavorsAssignedError{Flavors: []kueue.ResourceFlavorReference{"tas-a", "tas-b"}},
 						},
 					},
 				},
@@ -4259,7 +4259,7 @@ func TestWorkloadsTopologyRequests_ErrorBranches(t *testing.T) {
 		cq         schdcache.ClusterQueueSnapshot
 		assignment Assignment
 		workload   workload.Info
-		wantErr    string
+		wantErr    error
 	}{
 		"workload requires Topology, but there is no TAS cache information": {
 			cq: schdcache.ClusterQueueSnapshot{
@@ -4285,7 +4285,7 @@ func TestWorkloadsTopologyRequests_ErrorBranches(t *testing.T) {
 					},
 				},
 			}),
-			wantErr: "workload requires Topology, but there is no TAS cache information",
+			wantErr: ErrNoTASCacheInformation,
 		},
 		"workload requires Topology, but there is no TAS flavor assigned": {
 			cq: schdcache.ClusterQueueSnapshot{
@@ -4311,7 +4311,7 @@ func TestWorkloadsTopologyRequests_ErrorBranches(t *testing.T) {
 					},
 				},
 			}),
-			wantErr: "no TAS flavor assigned",
+			wantErr: ErrNoTASFlavorAssigned,
 		},
 		"more than one TAS flavor assigned (onlyTASFlavor fails); RepresentativeMode must be NoFit": {
 			cq: schdcache.ClusterQueueSnapshot{
@@ -4342,7 +4342,7 @@ func TestWorkloadsTopologyRequests_ErrorBranches(t *testing.T) {
 					},
 				},
 			}),
-			wantErr: "more than one TAS flavor assigned: flavor-a, flavor-b",
+			wantErr: &MultipleTASFlavorsAssignedError{Flavors: []kueue.ResourceFlavorReference{"flavor-a", "flavor-b"}},
 		},
 	}
 
@@ -4352,12 +4352,16 @@ func TestWorkloadsTopologyRequests_ErrorBranches(t *testing.T) {
 			if len(tasReqs) != 0 {
 				t.Errorf("expected no TAS requests, got: %+v", tasReqs)
 			}
-			errMsg := ""
-			if tc.assignment.PodSets[0].Status.err != nil {
-				errMsg = tc.assignment.PodSets[0].Status.err.Error()
+			if tc.wantErr != nil && !errors.Is(tc.assignment.PodSets[0].Status.err, tc.wantErr) {
+				t.Errorf("got error %v, want error %v", tc.assignment.PodSets[0].Status.err, tc.wantErr)
 			}
-			if tc.wantErr != "" && errMsg != tc.wantErr {
-				t.Errorf("Error mismatch (-want +got):\n%s", cmp.Diff(tc.wantErr, errMsg))
+			// For MultipleTASFlavorsAssignedError, also verify Flavors match
+			if wantMFE, ok := tc.wantErr.(*MultipleTASFlavorsAssignedError); ok {
+				if actualMFE, ok := tc.assignment.PodSets[0].Status.err.(*MultipleTASFlavorsAssignedError); ok {
+					if diff := cmp.Diff(wantMFE.Flavors, actualMFE.Flavors); diff != "" {
+						t.Errorf("Flavors mismatch (-want +got):\n%s", diff)
+					}
+				}
 			}
 			// When TAS request build fails, the assignment should be unfit so the workload is not admitted.
 			if got := tc.assignment.RepresentativeMode(); got != NoFit {
@@ -4378,7 +4382,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 		cq         schdcache.ClusterQueueSnapshot
 		assignment Assignment
 		workload   workload.Info
-		wantErr    string
+		wantErr    error
 	}{
 		"required topology is rejected with ElasticJobsViaWorkloadSlices": {
 			cq: schdcache.ClusterQueueSnapshot{
@@ -4420,7 +4424,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					},
 				},
 			}),
-			wantErr: "required topology is not supported with ElasticJobsViaWorkloadSlices",
+			wantErr: ErrElasticRequiredTopologyNotSupported,
 		},
 		"preferred topology is rejected with ElasticJobsViaWorkloadSlices": {
 			cq: schdcache.ClusterQueueSnapshot{
@@ -4462,7 +4466,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					},
 				},
 			}),
-			wantErr: "preferred topology is not supported with ElasticJobsViaWorkloadSlices",
+			wantErr: ErrElasticPreferredTopologyNotSupported,
 		},
 		"preferred topology is rejected for new elastic workload": {
 			cq: schdcache.ClusterQueueSnapshot{
@@ -4493,7 +4497,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					},
 				},
 			}),
-			wantErr: "preferred topology is not supported with ElasticJobsViaWorkloadSlices",
+			wantErr: ErrElasticPreferredTopologyNotSupported,
 		},
 		"unconstrained topology is accepted with ElasticJobsViaWorkloadSlices": {
 			cq: schdcache.ClusterQueueSnapshot{
@@ -4590,14 +4594,20 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			tasReqs := tc.assignment.WorkloadsTopologyRequests(testr.New(t), &tc.workload, &tc.cq)
-			if tc.wantErr != "" {
+			if tc.wantErr != nil {
 				if len(tasReqs) != 0 {
 					t.Errorf("expected no TAS requests, got: %+v", tasReqs)
 				}
-				if tc.assignment.PodSets[0].Status.err == nil {
-					t.Errorf("expected error %q, got nil", tc.wantErr)
-				} else if diff := cmp.Diff(tc.wantErr, tc.assignment.PodSets[0].Status.err.Error()); diff != "" {
-					t.Errorf("Error mismatch (-want +got):\n%s", diff)
+				if !errors.Is(tc.assignment.PodSets[0].Status.err, tc.wantErr) {
+					t.Errorf("got error %v, want error %v", tc.assignment.PodSets[0].Status.err, tc.wantErr)
+				}
+				// For MultipleTASFlavorsAssignedError, also verify Flavors match
+				if wantMFE, ok := tc.wantErr.(*MultipleTASFlavorsAssignedError); ok {
+					if actualMFE, ok := tc.assignment.PodSets[0].Status.err.(*MultipleTASFlavorsAssignedError); ok {
+						if diff := cmp.Diff(wantMFE.Flavors, actualMFE.Flavors); diff != "" {
+							t.Errorf("Flavors mismatch (-want +got):\n%s", diff)
+						}
+					}
 				}
 				if got := tc.assignment.RepresentativeMode(); got != NoFit {
 					t.Errorf("RepresentativeMode() = %v, want NoFit (workload must not be admitted when elastic job validation fails)", got)

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -17,11 +17,9 @@ limitations under the License.
 package flavorassigner
 
 import (
-	"errors"
 	"fmt"
 	"maps"
 	"slices"
-	"strings"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -63,11 +61,11 @@ func (a *Assignment) WorkloadsTopologyRequests(log logr.Logger, wl *workload.Inf
 			// Only unconstrained topology is supported with elastic workload slices.
 			if workload.IsElasticWorkload(wl.Obj) && features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
 				if podSet.TopologyRequest != nil && podSet.TopologyRequest.Required != nil {
-					a.psError(psAssignment, errors.New("required topology is not supported with ElasticJobsViaWorkloadSlices"))
+					a.psError(psAssignment, ErrElasticRequiredTopologyNotSupported)
 					continue
 				}
 				if podSet.TopologyRequest != nil && podSet.TopologyRequest.Preferred != nil {
-					a.psError(psAssignment, errors.New("preferred topology is not supported with ElasticJobsViaWorkloadSlices"))
+					a.psError(psAssignment, ErrElasticPreferredTopologyNotSupported)
 					continue
 				}
 				previousAssignment = getPreviousTopologyAssignment(a.replaceWorkloadSlice, podSet.Name)
@@ -98,7 +96,7 @@ func podSetTopologyRequest(psAssignment *PodSetAssignment,
 	podSetIndex int,
 	previousAssignment *kueue.TopologyAssignment) (*schdcache.TASPodSetRequests, error) {
 	if len(cq.TASFlavors) == 0 {
-		return nil, errors.New("workload requires Topology, but there is no TAS cache information")
+		return nil, ErrNoTASCacheInformation
 	}
 	podCount := psAssignment.Count
 	tasFlvr, err := onlyTASFlavor(psAssignment.Flavors, cq.TASFlavors)
@@ -154,19 +152,14 @@ func onlyTASFlavor(
 	}
 
 	if flavors.Len() == 0 {
-		return nil, errors.New("no TAS flavor assigned")
+		return nil, ErrNoTASFlavorAssigned
 	}
 
 	if flavors.Len() == 1 {
 		return new(sets.List(flavors)[0]), nil
 	}
 
-	list := sets.List(flavors)
-	names := make([]string, len(list))
-	for i, n := range list {
-		names[i] = string(n)
-	}
-	return nil, fmt.Errorf("more than one TAS flavor assigned: %s", strings.Join(names, ", "))
+	return nil, &MultipleTASFlavorsAssignedError{Flavors: sets.List(flavors)}
 }
 
 func checkPodSetAndFlavorMatchForTAS(cq *schdcache.ClusterQueueSnapshot, ps *kueue.PodSet, flavor *kueue.ResourceFlavor, rg *schdcache.ResourceGroup) *string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Refactoring that improves error handling patterns as suggested in [the comment](https://github.com/kubernetes-sigs/kueue/pull/12562/changes#r3498546475)
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized TAS/flavor assignment failures to use consistent typed error values instead of ad-hoc string messages, improving identification and matching.
  * Added semantic error matching for cases like multiple TAS flavors being assigned, with order-insensitive flavor set comparison.
  * Improved clarity for missing TAS cache data, missing TAS flavor assignments, and unsupported elastic required/preferred topology.

* **Tests**
  * Updated assertions to compare errors using typed/sentinel errors rather than string comparisons, including the duplicated-flavor scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->