### PR TITLE
Fix flaky StatefulSet e2e tests

### DIFF
--- a/test/e2e/singlecluster/baseline/statefulset_test.go
+++ b/test/e2e/singlecluster/baseline/statefulset_test.go
@@ -758,12 +758,13 @@ var _ = ginkgo.Describe("StatefulSet integration", ginkgo.Label("area:singleclus
 
 	ginkgo.When("StatefulSet scaling to zero with quota release", func() {
 		// Regression test for https://github.com/kubernetes-sigs/kueue/issues/12232
+		const numReplicas = int32(2)
 		ginkgo.It("should set the workload OnHold on scale-to-zero and clear it on scale-up", func() {
 			statefulSet := statefulsettesting.MakeStatefulSet("sts", ns.Name).
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				RequestAndLimit(corev1.ResourceCPU, "200m").
 				TerminationGracePeriod(1).
-				Replicas(3).
+				Replicas(numReplicas).
 				Queue(lq.Name).
 				Obj()
 			ginkgo.By("Create StatefulSet", func() {
@@ -776,7 +777,7 @@ var _ = ginkgo.Describe("StatefulSet integration", ginkgo.Label("area:singleclus
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdStatefulSet := &appsv1.StatefulSet{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(statefulSet), createdStatefulSet)).To(gomega.Succeed())
-					g.Expect(createdStatefulSet.Status.ReadyReplicas).To(gomega.Equal(int32(3)))
+					g.Expect(createdStatefulSet.Status.ReadyReplicas).To(gomega.Equal(numReplicas))
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -804,11 +805,21 @@ var _ = ginkgo.Describe("StatefulSet integration", ginkgo.Label("area:singleclus
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
+			ginkgo.By("Wait for StatefulSet scale-down to complete", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					createdStatefulSet := &appsv1.StatefulSet{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(statefulSet), createdStatefulSet)).
+						To(gomega.Succeed())
+
+					g.Expect(createdStatefulSet.Status.Replicas).To(gomega.Equal(int32(0)))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
 			ginkgo.By("Scale up replicas", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdStatefulSet := &appsv1.StatefulSet{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(statefulSet), createdStatefulSet)).To(gomega.Succeed())
-					createdStatefulSet.Spec.Replicas = ptr.To[int32](3)
+					createdStatefulSet.Spec.Replicas = new(numReplicas)
 					g.Expect(k8sClient.Update(ctx, createdStatefulSet)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -829,7 +840,7 @@ var _ = ginkgo.Describe("StatefulSet integration", ginkgo.Label("area:singleclus
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdStatefulSet := &appsv1.StatefulSet{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(statefulSet), createdStatefulSet)).To(gomega.Succeed())
-					g.Expect(createdStatefulSet.Status.ReadyReplicas).To(gomega.Equal(int32(3)))
+					g.Expect(createdStatefulSet.Status.ReadyReplicas).To(gomega.Equal(numReplicas))
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 		})


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

1. wait for LongTimeout until the status.replicas goes down to 0 before attempting to scale up again
2. reduce the number of replicas to 2 because the coverage is the same, but we are less likely to take long to stop the pods

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12666

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of an end-to-end scaling test for workloads that scale down to zero and back up.
  * Updated the test to use a configurable replica count and to confirm scale-down completion before validating readiness after scaling up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->