### PR TITLE
Fix race on AFS penalties update

### DIFF
--- a/pkg/cache/queue/afs/entry_penalties.go
+++ b/pkg/cache/queue/afs/entry_penalties.go
@@ -33,18 +33,22 @@ func NewPenaltyMap() *AfsEntryPenalties {
 }
 
 func (m *AfsEntryPenalties) Push(lqKey utilqueue.LocalQueueReference, penalty corev1.ResourceList) {
-	m.penalties.Add(lqKey, resource.MergeResourceListKeepSum(m.Peek(lqKey), penalty))
+	m.penalties.Update(lqKey, func(existing corev1.ResourceList, _ bool) corev1.ResourceList {
+		return resource.MergeResourceListKeepSum(existing, penalty)
+	})
 }
 
 func (m *AfsEntryPenalties) Sub(lqKey utilqueue.LocalQueueReference, penalty corev1.ResourceList) {
+	negated := make(corev1.ResourceList, len(penalty))
 	for k, v := range penalty {
-		v.Neg()
-		penalty[k] = v
+		q := v.DeepCopy()
+		q.Neg()
+		negated[k] = q
 	}
-	m.penalties.Add(lqKey, resource.MergeResourceListKeepSum(m.Peek(lqKey), penalty))
-	if canClearPenalty(m.Peek(lqKey)) {
-		m.penalties.Delete(lqKey)
-	}
+	m.penalties.UpdateOrDelete(lqKey, func(existing corev1.ResourceList) (corev1.ResourceList, bool) {
+		merged := resource.MergeResourceListKeepSum(existing, negated)
+		return merged, canClearPenalty(merged)
+	})
 }
 
 func canClearPenalty(penalty corev1.ResourceList) bool {

--- a/pkg/util/maps/maps.go
+++ b/pkg/util/maps/maps.go
@@ -100,6 +100,17 @@ func (dwc *SyncMap[K, V]) Add(k K, v V) {
 	dwc.m[k] = v
 }
 
+func (dwc *SyncMap[K, V]) UpdateOrDelete(k K, f func(existing V) (V, bool)) {
+	dwc.lock.Lock()
+	defer dwc.lock.Unlock()
+	newVal, canClear := f(dwc.m[k])
+	if canClear {
+		delete(dwc.m, k)
+	} else {
+		dwc.m[k] = newVal
+	}
+}
+
 func (dwc *SyncMap[K, V]) Get(k K) (V, bool) {
 	dwc.lock.RLock()
 	defer dwc.lock.RUnlock()

--- a/pkg/util/maps/maps_test.go
+++ b/pkg/util/maps/maps_test.go
@@ -18,6 +18,7 @@ package maps
 
 import (
 	"maps"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -290,5 +291,136 @@ func TestFilterKeys(t *testing.T) {
 				t.Errorf("Unexpected result, expecting %v", tc.want)
 			}
 		})
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	penalty := 5
+	cases := map[string]struct {
+		initial       map[string]int
+		localQueue    string
+		f             func(int, bool) int
+		want          int
+		wantUnchanged map[string]int
+	}{
+		"missing key is treated as zero value": {
+			initial:    map[string]int{},
+			localQueue: "default/lq1",
+			f:          func(existing int, _ bool) int { return existing + penalty },
+			want:       5,
+		},
+		"existing key is accumulated": {
+			initial:    map[string]int{"default/lq1": 3},
+			localQueue: "default/lq1",
+			f:          func(existing int, _ bool) int { return existing + penalty },
+			want:       8,
+		},
+		"different key is not affected": {
+			initial:       map[string]int{"default/lq2": 3},
+			localQueue:    "default/lq1",
+			f:             func(existing int, _ bool) int { return existing + penalty },
+			want:          penalty,
+			wantUnchanged: map[string]int{"default/lq2": 3},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			syncMap := NewSyncMap[string, int](0)
+			for k, v := range tc.initial {
+				syncMap.Add(k, v)
+			}
+			got := syncMap.Update(tc.localQueue, tc.f)
+			if got != tc.want {
+				t.Errorf("returned value: got %v, want %v", got, tc.want)
+			}
+			stored, found := syncMap.Get(tc.localQueue)
+			if !found {
+				t.Errorf("key %q not present after Update", tc.localQueue)
+			} else if stored != tc.want {
+				t.Errorf("persisted value: got %v, want %v", stored, tc.want)
+			}
+			for unchangedKey, wantVal := range tc.wantUnchanged {
+				gotVal, found := syncMap.Get(unchangedKey)
+				if !found {
+					t.Errorf("key %q was unexpectedly deleted", unchangedKey)
+					continue
+				}
+				if gotVal != wantVal {
+					t.Errorf("key %q: got %v, want %v", unchangedKey, gotVal, wantVal)
+				}
+			}
+		})
+	}
+}
+
+// TestUpdateConcurrent verifies that concurrent Update calls on the
+// same key never lose an update. Each goroutine increments by 1; the final
+// value must equal exactly n. A lost update produces a lower value because one
+// goroutine's write silently overwrites another's.
+func TestUpdateConcurrent(t *testing.T) {
+	const n = 500
+	const key = "default/lq1"
+
+	syncMap := NewSyncMap[string, int](0)
+
+	var wg sync.WaitGroup
+	barrier := make(chan struct{})
+
+	for range n {
+		wg.Go(func() {
+			<-barrier
+			syncMap.Update(key, func(existing int, _ bool) int { return existing + 1 })
+		})
+	}
+
+	close(barrier)
+	wg.Wait()
+
+	got, _ := syncMap.Get(key)
+	if got != n {
+		t.Errorf("lost updates detected: got %d, want %d", got, n)
+	}
+}
+
+// TestUpdateOrDeleteConcurrentWithPush verifies that UpdateOrDelete eliminates
+// the TOCTOU between checking canClearPenalty and calling Delete in the
+// original AfsEntryPenalties.Sub implementation
+// (https://github.com/kubernetes-sigs/kueue/issues/12546).
+func TestUpdateOrDeleteConcurrentWithPush(t *testing.T) {
+	const key = "default/lq1"
+
+	// n Sub goroutines each decrement by 1; n Push goroutines each increment by 1.
+	// The key starts at n so the decrements collectively cancel the initial value.
+	const n = 500
+
+	syncMap := NewSyncMap[string, int](0)
+	syncMap.Add(key, n)
+
+	var wg sync.WaitGroup
+	barrier := make(chan struct{})
+
+	for range n {
+		wg.Go(func() {
+			<-barrier
+			syncMap.UpdateOrDelete(key, func(existing int) (int, bool) {
+				v := existing - 1
+				return v, v == 0
+			})
+		})
+	}
+
+	for range n {
+		wg.Go(func() {
+			<-barrier
+			syncMap.Update(key, func(existing int, _ bool) int { return existing + 1 })
+		})
+	}
+
+	close(barrier)
+	wg.Wait()
+
+	got, _ := syncMap.Get(key)
+	if got != n {
+		t.Errorf("lost updates: got %d, want %d", got, n)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #12546

#### Special notes for your reviewer:
AI Assistance Disclosure: This pull request was developed with the assistance of AI (Claude Code).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
AFS: Fixed a race in Admission Fair Sharing penalty updates where concurrent workload operations could lose penalty changes, causing LocalQueues to receive incorrect priority.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Made AFS penalty adjustments fully atomic by merging deltas into stored totals and using conditional merge/delete behavior.
  * Improved penalty subtraction to avoid in-place mutation and reliably clear entries when totals drop to zero.

* **New Features**
  * Added a `UpdateOrDelete` operation to the synchronized map utility to support atomic conditional overwrite/removal.

* **Tests**
  * Added concurrency-focused tests covering `Update` and `UpdateOrDelete` correctness, including no lost updates under contention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->