### PR TITLE
kueueviz: re-validate bearer token on long-lived WebSocket connections

### DIFF
--- a/cmd/kueueviz/backend/handlers/handlers.go
+++ b/cmd/kueueviz/backend/handlers/handlers.go
@@ -19,6 +19,7 @@ package handlers
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"k8s.io/client-go/dynamic"
@@ -33,12 +34,16 @@ type TokenValidator interface {
 type Handlers struct {
 	client    Client
 	validator TokenValidator // nil when auth is disabled
+	// tokenRevalidationInterval controls how often a live WebSocket connection
+	// re-verifies the bearer token. Defaults to 30 s; overridable in tests.
+	tokenRevalidationInterval time.Duration
 }
 
 func New(client Client, validator TokenValidator) *Handlers {
 	return &Handlers{
-		client:    client,
-		validator: validator,
+		client:                    client,
+		validator:                 validator,
+		tokenRevalidationInterval: 30 * time.Second,
 	}
 }
 

--- a/cmd/kueueviz/backend/handlers/handlers.go
+++ b/cmd/kueueviz/backend/handlers/handlers.go
@@ -17,19 +17,28 @@ limitations under the License.
 package handlers
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"k8s.io/client-go/dynamic"
 )
 
-type Handlers struct {
-	client Client
+// TokenValidator is implemented by middleware.Authenticator and allows
+// WebSocket handlers to periodically re-verify a bearer token.
+type TokenValidator interface {
+	ValidateToken(ctx context.Context, token string) (bool, error)
 }
 
-func New(client Client) *Handlers {
+type Handlers struct {
+	client    Client
+	validator TokenValidator // nil when auth is disabled
+}
+
+func New(client Client, validator TokenValidator) *Handlers {
 	return &Handlers{
-		client: client,
+		client:    client,
+		validator: validator,
 	}
 }
 

--- a/cmd/kueueviz/backend/handlers/websocket_handler.go
+++ b/cmd/kueueviz/backend/handlers/websocket_handler.go
@@ -51,6 +51,10 @@ var upgrader = websocket.Upgrader{
 	},
 }
 
+const (
+	tokenValidationTimeout = 5 * time.Second
+)
+
 // GenericWebSocketHandler creates a WebSocket endpoint with informer-based real-time updates
 // Accepts one or more GroupVersionKinds to watch for changes
 func (h *Handlers) GenericWebSocketHandler(dataFetcher func(ctx context.Context) (any, error), gvks ...schema.GroupVersionKind) gin.HandlerFunc {
@@ -214,7 +218,7 @@ func (h *Handlers) handleInformerUpdates(ctx context.Context, conn *websocket.Co
 		case <-authTickerC:
 			// Use a short timeout so a slow or unavailable API server cannot
 			// block this goroutine indefinitely.
-			validateCtx, validateCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			validateCtx, validateCancel := context.WithTimeout(ctx, tokenValidationTimeout)
 			ok, err := h.validator.ValidateToken(validateCtx, token)
 			validateCancel()
 			if err != nil {
@@ -224,7 +228,7 @@ func (h *Handlers) handleInformerUpdates(ctx context.Context, conn *websocket.Co
 			}
 			if err != nil || !ok {
 				// Set a write deadline so the close-frame write cannot block indefinitely.
-				_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				_ = conn.SetWriteDeadline(time.Now().Add(writeDeadlineExtension))
 				_ = conn.WriteMessage(
 					websocket.CloseMessage,
 					websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "token expired or revoked"),

--- a/cmd/kueueviz/backend/handlers/websocket_handler.go
+++ b/cmd/kueueviz/backend/handlers/websocket_handler.go
@@ -131,7 +131,6 @@ func (h *Handlers) sendData(ctx context.Context, conn *websocket.Conn, dataFetch
 	return nil
 }
 
-
 // handleInformerUpdates uses Kubernetes informers to stream real-time changes
 // Supports watching multiple resource types by registering handlers for all provided GVKs
 func (h *Handlers) handleInformerUpdates(ctx context.Context, conn *websocket.Conn, token string, dataFetcher func(ctx context.Context) (any, error), gvks ...schema.GroupVersionKind) {

--- a/cmd/kueueviz/backend/handlers/websocket_handler.go
+++ b/cmd/kueueviz/backend/handlers/websocket_handler.go
@@ -135,7 +135,7 @@ func (h *Handlers) sendData(ctx context.Context, conn *websocket.Conn, dataFetch
 // re-verifies the bearer token against the Kubernetes TokenReview API.
 // This bounds the window in which a revoked or expired token can still
 // receive cluster data.
-const tokenRevalidationInterval = 30 * time.Second
+var tokenRevalidationInterval = 30 * time.Second
 
 // handleInformerUpdates uses Kubernetes informers to stream real-time changes
 // Supports watching multiple resource types by registering handlers for all provided GVKs

--- a/cmd/kueueviz/backend/handlers/websocket_handler.go
+++ b/cmd/kueueviz/backend/handlers/websocket_handler.go
@@ -58,6 +58,10 @@ func (h *Handlers) GenericWebSocketHandler(dataFetcher func(ctx context.Context)
 		startTime := time.Now()
 		slog.Debug("WebSocket handler started")
 
+		// Extract the bearer token stored by auth.Middleware (empty when auth is disabled).
+		token, _ := c.Get("token")
+		tokenStr, _ := token.(string)
+
 		// Upgrade the HTTP connection to a WebSocket connection
 		connStart := time.Now()
 		conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
@@ -91,7 +95,7 @@ func (h *Handlers) GenericWebSocketHandler(dataFetcher func(ctx context.Context)
 		}
 
 		// Use informer-based updates for real-time streaming
-		h.handleInformerUpdates(ctx, conn, dataFetcher, gvks...)
+		h.handleInformerUpdates(ctx, conn, tokenStr, dataFetcher, gvks...)
 
 		slog.Debug("WebSocket handler completed", "duration", time.Since(startTime))
 	}
@@ -127,9 +131,15 @@ func (h *Handlers) sendData(ctx context.Context, conn *websocket.Conn, dataFetch
 	return nil
 }
 
+// tokenRevalidationInterval controls how often an open WebSocket connection
+// re-verifies the bearer token against the Kubernetes TokenReview API.
+// This bounds the window in which a revoked or expired token can still
+// receive cluster data.
+const tokenRevalidationInterval = 30 * time.Second
+
 // handleInformerUpdates uses Kubernetes informers to stream real-time changes
 // Supports watching multiple resource types by registering handlers for all provided GVKs
-func (h *Handlers) handleInformerUpdates(ctx context.Context, conn *websocket.Conn, dataFetcher func(ctx context.Context) (any, error), gvks ...schema.GroupVersionKind) {
+func (h *Handlers) handleInformerUpdates(ctx context.Context, conn *websocket.Conn, token string, dataFetcher func(ctx context.Context) (any, error), gvks ...schema.GroupVersionKind) {
 	// Channel to signal when debounced update should be sent
 	updateChan := make(chan struct{}, 1)
 
@@ -192,11 +202,35 @@ func (h *Handlers) handleInformerUpdates(ctx context.Context, conn *websocket.Co
 		registrations = append(registrations, registrationInfo{gvk: gvk, reg: registration})
 	}
 
+	// Periodic token re-validation: close the connection if the bearer token
+	// is revoked or has expired. Only active when a TokenValidator is wired in.
+	var authTicker *time.Ticker
+	var authTickerC <-chan time.Time
+	if h.validator != nil && token != "" {
+		authTicker = time.NewTicker(tokenRevalidationInterval)
+		defer authTicker.Stop()
+		authTickerC = authTicker.C
+	}
+
 	// Handle updates from the informers
 	for {
 		select {
 		case <-ctx.Done():
 			return
+		case <-authTickerC:
+			ok, err := h.validator.ValidateToken(ctx, token)
+			if err != nil {
+				slog.Warn("Token re-validation failed; closing WebSocket", "error", err)
+			} else if !ok {
+				slog.Info("Bearer token is no longer valid; closing WebSocket")
+			}
+			if err != nil || !ok {
+				_ = conn.WriteMessage(
+					websocket.CloseMessage,
+					websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "token expired or revoked"),
+				)
+				return
+			}
 		case <-updateChan:
 			if err := h.sendData(ctx, conn, dataFetcher); err != nil {
 				slog.Error("Error sending update", "error", err)

--- a/cmd/kueueviz/backend/handlers/websocket_handler.go
+++ b/cmd/kueueviz/backend/handlers/websocket_handler.go
@@ -131,11 +131,6 @@ func (h *Handlers) sendData(ctx context.Context, conn *websocket.Conn, dataFetch
 	return nil
 }
 
-// tokenRevalidationInterval controls how often an open WebSocket connection
-// re-verifies the bearer token against the Kubernetes TokenReview API.
-// This bounds the window in which a revoked or expired token can still
-// receive cluster data.
-var tokenRevalidationInterval = 30 * time.Second
 
 // handleInformerUpdates uses Kubernetes informers to stream real-time changes
 // Supports watching multiple resource types by registering handlers for all provided GVKs
@@ -207,7 +202,7 @@ func (h *Handlers) handleInformerUpdates(ctx context.Context, conn *websocket.Co
 	var authTicker *time.Ticker
 	var authTickerC <-chan time.Time
 	if h.validator != nil && token != "" {
-		authTicker = time.NewTicker(tokenRevalidationInterval)
+		authTicker = time.NewTicker(h.tokenRevalidationInterval)
 		defer authTicker.Stop()
 		authTickerC = authTicker.C
 	}

--- a/cmd/kueueviz/backend/handlers/websocket_handler.go
+++ b/cmd/kueueviz/backend/handlers/websocket_handler.go
@@ -218,13 +218,19 @@ func (h *Handlers) handleInformerUpdates(ctx context.Context, conn *websocket.Co
 		case <-ctx.Done():
 			return
 		case <-authTickerC:
-			ok, err := h.validator.ValidateToken(ctx, token)
+			// Use a short timeout so a slow or unavailable API server cannot
+			// block this goroutine indefinitely.
+			validateCtx, validateCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ok, err := h.validator.ValidateToken(validateCtx, token)
+			validateCancel()
 			if err != nil {
 				slog.Warn("Token re-validation failed; closing WebSocket", "error", err)
 			} else if !ok {
 				slog.Info("Bearer token is no longer valid; closing WebSocket")
 			}
 			if err != nil || !ok {
+				// Set a write deadline so the close-frame write cannot block indefinitely.
+				_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 				_ = conn.WriteMessage(
 					websocket.CloseMessage,
 					websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "token expired or revoked"),

--- a/cmd/kueueviz/backend/handlers/websocket_handler_test.go
+++ b/cmd/kueueviz/backend/handlers/websocket_handler_test.go
@@ -42,6 +42,18 @@ var closedChan = func() <-chan struct{} {
 	return ch
 }()
 
+const (
+	// testTokenRevalidationInterval is a short interval used in tests to quickly
+	// trigger the token re-validation ticker without waiting 30 seconds.
+	testTokenRevalidationInterval = 100 * time.Millisecond
+
+	// testPollInterval is the polling frequency used in waitUntil calls.
+	testPollInterval = 10 * time.Millisecond
+
+	// testTimeout is the maximum duration tests will wait for an async condition.
+	testTimeout = 2 * time.Second
+)
+
 type mockTokenValidator struct {
 	mu    sync.Mutex
 	valid bool
@@ -267,7 +279,7 @@ func TestWebSocketHandleInformerUpdates(t *testing.T) {
 				h := &Handlers{
 					client:                    client,
 					validator:                 validator,
-					tokenRevalidationInterval: 100 * time.Millisecond,
+					tokenRevalidationInterval: testTokenRevalidationInterval,
 				}
 				conn, closeServer := newTestWebSocketConnectionWithToken(t, h, "test-token", dataFetcher, gvk)
 				defer closeServer()
@@ -276,7 +288,7 @@ func TestWebSocketHandleInformerUpdates(t *testing.T) {
 				readMessage(t, conn)
 
 				// Token should be validated successfully initially (by the ticker)
-				waitUntil(t, 2*time.Second, 10*time.Millisecond, func() bool {
+				waitUntil(t, testTimeout, testPollInterval, func() bool {
 					return validator.getCalls() >= 1
 				}, "expected token validator to be called")
 
@@ -303,7 +315,7 @@ func TestWebSocketHandleInformerUpdates(t *testing.T) {
 					} else {
 						t.Fatalf("expected CloseError, got %v", err)
 					}
-				case <-time.After(2 * time.Second):
+				case <-time.After(testTimeout):
 					t.Fatalf("timeout waiting for connection to close after token expiration")
 				}
 			},
@@ -398,7 +410,7 @@ func TestWebSocketHandleInformerUpdates(t *testing.T) {
 				}
 				select {
 				case <-drainDone:
-				case <-time.After(2 * time.Second):
+				case <-time.After(testTimeout):
 					t.Fatalf("reader goroutine did not exit after connection close")
 				}
 			},
@@ -427,7 +439,7 @@ func TestWebSocketHandleInformerUpdates(t *testing.T) {
 					t.Fatalf("failed to write 9KB message to server: %v", err)
 				}
 
-				if err := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+				if err := conn.SetReadDeadline(time.Now().Add(testTimeout)); err != nil {
 					t.Fatalf("set read deadline: %v", err)
 				}
 
@@ -499,7 +511,7 @@ func newTestWebSocketConnection(
 func readMessage(t *testing.T, conn *websocket.Conn) {
 	t.Helper()
 
-	if err := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+	if err := conn.SetReadDeadline(time.Now().Add(testTimeout)); err != nil {
 		t.Fatalf("set read deadline: %v", err)
 	}
 	if _, _, err := conn.ReadMessage(); err != nil {

--- a/cmd/kueueviz/backend/handlers/websocket_handler_test.go
+++ b/cmd/kueueviz/backend/handlers/websocket_handler_test.go
@@ -45,7 +45,6 @@ var closedChan = func() <-chan struct{} {
 type mockTokenValidator struct {
 	mu    sync.Mutex
 	valid bool
-	err   error
 	calls int
 }
 
@@ -53,7 +52,7 @@ func (m *mockTokenValidator) ValidateToken(ctx context.Context, token string) (b
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.calls++
-	return m.valid, m.err
+	return m.valid, nil
 }
 
 func (m *mockTokenValidator) getCalls() int {
@@ -62,11 +61,10 @@ func (m *mockTokenValidator) getCalls() int {
 	return m.calls
 }
 
-func (m *mockTokenValidator) setValid(valid bool, err error) {
+func (m *mockTokenValidator) setValid(valid bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.valid = valid
-	m.err = err
 }
 
 type alwaysDone struct{}
@@ -255,10 +253,6 @@ func TestWebSocketHandleInformerUpdates(t *testing.T) {
 		},
 		"closes connection when token becomes invalid": {
 			run: func(t *testing.T) {
-				origInterval := tokenRevalidationInterval
-				tokenRevalidationInterval = 100 * time.Millisecond
-				defer func() { tokenRevalidationInterval = origInterval }()
-
 				gvk := schema.GroupVersionKind{Group: "group", Version: "v1", Kind: "Kind"}
 				informer := newMockInformer()
 				client := newMockClient(map[schema.GroupVersionKind]*mockInformer{gvk: informer})
@@ -270,7 +264,12 @@ func TestWebSocketHandleInformerUpdates(t *testing.T) {
 					return map[string]int64{"call": fetchCalls.Add(1)}, nil
 				}
 
-				conn, closeServer := newTestWebSocketConnectionWithToken(t, &Handlers{client: client, validator: validator}, "test-token", dataFetcher, gvk)
+				h := &Handlers{
+					client:                    client,
+					validator:                 validator,
+					tokenRevalidationInterval: 100 * time.Millisecond,
+				}
+				conn, closeServer := newTestWebSocketConnectionWithToken(t, h, "test-token", dataFetcher, gvk)
 				defer closeServer()
 
 				// Read initial message
@@ -282,7 +281,7 @@ func TestWebSocketHandleInformerUpdates(t *testing.T) {
 				}, "expected token validator to be called")
 
 				// Now simulate token expiration/revocation
-				validator.setValid(false, nil)
+				validator.setValid(false)
 
 				// The connection should be closed by the server
 				errChan := make(chan error, 1)

--- a/cmd/kueueviz/backend/handlers/websocket_handler_test.go
+++ b/cmd/kueueviz/backend/handlers/websocket_handler_test.go
@@ -42,6 +42,33 @@ var closedChan = func() <-chan struct{} {
 	return ch
 }()
 
+type mockTokenValidator struct {
+	mu    sync.Mutex
+	valid bool
+	err   error
+	calls int
+}
+
+func (m *mockTokenValidator) ValidateToken(ctx context.Context, token string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls++
+	return m.valid, m.err
+}
+
+func (m *mockTokenValidator) getCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
+func (m *mockTokenValidator) setValid(valid bool, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.valid = valid
+	m.err = err
+}
+
 type alwaysDone struct{}
 
 func (alwaysDone) Name() string {
@@ -226,6 +253,62 @@ func TestWebSocketHandleInformerUpdates(t *testing.T) {
 				}
 			},
 		},
+		"closes connection when token becomes invalid": {
+			run: func(t *testing.T) {
+				origInterval := tokenRevalidationInterval
+				tokenRevalidationInterval = 100 * time.Millisecond
+				defer func() { tokenRevalidationInterval = origInterval }()
+
+				gvk := schema.GroupVersionKind{Group: "group", Version: "v1", Kind: "Kind"}
+				informer := newMockInformer()
+				client := newMockClient(map[schema.GroupVersionKind]*mockInformer{gvk: informer})
+
+				validator := &mockTokenValidator{valid: true}
+
+				var fetchCalls atomic.Int64
+				dataFetcher := func(_ context.Context) (any, error) {
+					return map[string]int64{"call": fetchCalls.Add(1)}, nil
+				}
+
+				conn, closeServer := newTestWebSocketConnectionWithToken(t, &Handlers{client: client, validator: validator}, "test-token", dataFetcher, gvk)
+				defer closeServer()
+
+				// Read initial message
+				readMessage(t, conn)
+
+				// Token should be validated successfully initially (by the ticker)
+				waitUntil(t, 2*time.Second, 10*time.Millisecond, func() bool {
+					return validator.getCalls() >= 1
+				}, "expected token validator to be called")
+
+				// Now simulate token expiration/revocation
+				validator.setValid(false, nil)
+
+				// The connection should be closed by the server
+				errChan := make(chan error, 1)
+				go func() {
+					_, _, err := conn.ReadMessage()
+					errChan <- err
+				}()
+
+				select {
+				case err := <-errChan:
+					if err == nil {
+						t.Fatalf("expected read error due to connection closure, but got none")
+					}
+					var closeErr *websocket.CloseError
+					if errors.As(err, &closeErr) {
+						if closeErr.Code != websocket.ClosePolicyViolation {
+							t.Fatalf("expected close code %d, got %d", websocket.ClosePolicyViolation, closeErr.Code)
+						}
+					} else {
+						t.Fatalf("expected CloseError, got %v", err)
+					}
+				case <-time.After(2 * time.Second):
+					t.Fatalf("timeout waiting for connection to close after token expiration")
+				}
+			},
+		},
 		"removes event handlers on context cancellation": {
 			run: func(t *testing.T) {
 				gvkA := schema.GroupVersionKind{Group: "group-a", Version: "v1", Kind: "KindA"}
@@ -370,15 +453,22 @@ func TestWebSocketHandleInformerUpdates(t *testing.T) {
 	}
 }
 
-func newTestWebSocketConnection(
+func newTestWebSocketConnectionWithToken(
 	t *testing.T,
 	handlers *Handlers,
+	token string,
 	dataFetcher func(ctx context.Context) (any, error),
 	gvks ...schema.GroupVersionKind,
 ) (*websocket.Conn, func()) {
 	t.Helper()
 
 	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		if token != "" {
+			c.Set("token", token)
+		}
+		c.Next()
+	})
 	router.GET("/ws/test", handlers.GenericWebSocketHandler(dataFetcher, gvks...))
 
 	server := httptest.NewServer(router)
@@ -396,6 +486,15 @@ func newTestWebSocketConnection(
 	}
 
 	return conn, closeServer
+}
+
+func newTestWebSocketConnection(
+	t *testing.T,
+	handlers *Handlers,
+	dataFetcher func(ctx context.Context) (any, error),
+	gvks ...schema.GroupVersionKind,
+) (*websocket.Conn, func()) {
+	return newTestWebSocketConnectionWithToken(t, handlers, "", dataFetcher, gvks...)
 }
 
 func readMessage(t *testing.T, conn *websocket.Conn) {

--- a/cmd/kueueviz/backend/main.go
+++ b/cmd/kueueviz/backend/main.go
@@ -78,7 +78,7 @@ func main() {
 		IdleTimeout: 90 * time.Second,
 	}
 
-	h := handlers.New(handlers.NewClientFromManager(manager))
+	h := handlers.New(handlers.NewClientFromManager(manager), nil)
 
 	publicRoutes := r.Group("/")
 	handlers.InitializeUnauthenticatedRoutes(publicRoutes, serverConfig.AuthMode)
@@ -88,6 +88,7 @@ func main() {
 		slog.Info("Authentication enabled", "mode", serverConfig.AuthMode)
 		auth := middleware.NewAuthenticator(clientset, serverConfig.AuthConfig)
 		protectedRoutes.Use(auth.Middleware())
+		h = handlers.New(handlers.NewClientFromManager(manager), auth)
 	}
 
 	h.InitializeWebSocketRoutes(protectedRoutes)

--- a/cmd/kueueviz/backend/middleware/auth.go
+++ b/cmd/kueueviz/backend/middleware/auth.go
@@ -88,36 +88,11 @@ func (a *Authenticator) Middleware() gin.HandlerFunc {
 			return
 		}
 
-		key := hashToken(token)
-
-		now := a.clock.Now()
-		if cached, ok := a.cache.Get(key, now); ok {
-			if cached.authenticated {
-				c.Set("username", cached.username)
-				c.Set("token", token)
-				c.Next()
-				return
-			}
-			abortUnauthorized(c, "invalid token")
-			return
-		}
-
-		authenticated, username, err := a.reviewToken(c.Request.Context(), token)
+		authenticated, username, err := a.authenticate(c.Request.Context(), token)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{"error": "authentication service unavailable"})
 			return
 		}
-
-		ttl := a.config.NegativeCacheTTL
-		if authenticated {
-			ttl = a.config.CacheTTL
-		}
-		a.cache.Set(key, cacheEntry{
-			authenticated: authenticated,
-			username:      username,
-			expiresAt:     now.Add(ttl),
-		})
-
 		if !authenticated {
 			abortUnauthorized(c, "invalid token")
 			return
@@ -129,18 +104,18 @@ func (a *Authenticator) Middleware() gin.HandlerFunc {
 	}
 }
 
-// ValidateToken checks whether token is still valid using the cache and, if
-// the cache entry has expired, by issuing a fresh TokenReview against the
-// Kubernetes API. It returns true only when the token is authenticated.
-func (a *Authenticator) ValidateToken(ctx context.Context, token string) (bool, error) {
+// authenticate hashes the token, checks the shared TTL cache, and falls back
+// to a live TokenReview when the cache entry is absent or expired. The result
+// is written back to the cache before returning.
+func (a *Authenticator) authenticate(ctx context.Context, token string) (bool, string, error) {
 	key := hashToken(token)
 	now := a.clock.Now()
 	if cached, ok := a.cache.Get(key, now); ok {
-		return cached.authenticated, nil
+		return cached.authenticated, cached.username, nil
 	}
 	authenticated, username, err := a.reviewToken(ctx, token)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 	ttl := a.config.NegativeCacheTTL
 	if authenticated {
@@ -151,7 +126,16 @@ func (a *Authenticator) ValidateToken(ctx context.Context, token string) (bool, 
 		username:      username,
 		expiresAt:     now.Add(ttl),
 	})
-	return authenticated, nil
+	return authenticated, username, nil
+}
+
+// ValidateToken performs a live TokenReview against the Kubernetes API,
+// intentionally bypassing the shared cache so that WebSocket re-checks always
+// reflect the current revocation state of the token. The result is NOT written
+// back to the shared cache to avoid extending a revoked session.
+func (a *Authenticator) ValidateToken(ctx context.Context, token string) (bool, error) {
+	authenticated, _, err := a.reviewToken(ctx, token)
+	return authenticated, err
 }
 
 func (a *Authenticator) reviewToken(ctx context.Context, token string) (bool, string, error) {

--- a/cmd/kueueviz/backend/middleware/auth.go
+++ b/cmd/kueueviz/backend/middleware/auth.go
@@ -94,6 +94,7 @@ func (a *Authenticator) Middleware() gin.HandlerFunc {
 		if cached, ok := a.cache.Get(key, now); ok {
 			if cached.authenticated {
 				c.Set("username", cached.username)
+				c.Set("token", token)
 				c.Next()
 				return
 			}
@@ -123,8 +124,34 @@ func (a *Authenticator) Middleware() gin.HandlerFunc {
 		}
 
 		c.Set("username", username)
+		c.Set("token", token)
 		c.Next()
 	}
+}
+
+// ValidateToken checks whether token is still valid using the cache and, if
+// the cache entry has expired, by issuing a fresh TokenReview against the
+// Kubernetes API. It returns true only when the token is authenticated.
+func (a *Authenticator) ValidateToken(ctx context.Context, token string) (bool, error) {
+	key := hashToken(token)
+	now := a.clock.Now()
+	if cached, ok := a.cache.Get(key, now); ok {
+		return cached.authenticated, nil
+	}
+	authenticated, username, err := a.reviewToken(ctx, token)
+	if err != nil {
+		return false, err
+	}
+	ttl := a.config.NegativeCacheTTL
+	if authenticated {
+		ttl = a.config.CacheTTL
+	}
+	a.cache.Set(key, cacheEntry{
+		authenticated: authenticated,
+		username:      username,
+		expiresAt:     now.Add(ttl),
+	})
+	return authenticated, nil
 }
 
 func (a *Authenticator) reviewToken(ctx context.Context, token string) (bool, string, error) {

--- a/cmd/kueueviz/frontend/src/useWebSocket.js
+++ b/cmd/kueueviz/frontend/src/useWebSocket.js
@@ -78,7 +78,14 @@ const useWebSocket = (url) => {
     };
 
     ws.onclose = (event) => {
-      console.log('WebSocket connection closed', 'code:', event.code);
+      console.log('WebSocket connection closed', 'code:', event.code, 'reason:', event.reason);
+      if (event.code !== 1000 && event.code !== 1001) {
+        if (event.code === 1008) {
+          setError('WebSocket connection closed: Token expired or revoked. Please log in again.');
+        } else {
+          setError(`WebSocket connection closed unexpectedly (code: ${event.code}). Please refresh the page.`);
+        }
+      }
     };
 
     return () => {

--- a/cmd/kueueviz/frontend/src/useWebSocket.js
+++ b/cmd/kueueviz/frontend/src/useWebSocket.js
@@ -56,8 +56,11 @@ const useWebSocket = (url) => {
       protocols.push(`${WS_TOKEN_PROTOCOL_PREFIX}${encodeTokenForProtocol(token)}`);
     }
     const ws = new WebSocket(fullUrl, protocols);
+    let handledErrorEvent = false;
 
     ws.onopen = () => {
+      handledErrorEvent = false;
+      setError(null);
       console.log(`Connected to WebSocket: ${fullUrl}`);
     };
 
@@ -73,6 +76,7 @@ const useWebSocket = (url) => {
 
     ws.onerror = (err) => {
       console.error('WebSocket error:', err);
+      handledErrorEvent = true;
       if (ws.readyState === WebSocket.CONNECTING) {
         setError('Failed to connect to WebSocket.');
       } else {
@@ -83,6 +87,9 @@ const useWebSocket = (url) => {
 
     ws.onclose = (event) => {
       console.log('WebSocket connection closed', 'code:', event.code, 'reason:', event.reason);
+      if (handledErrorEvent) {
+        return;
+      }
       switch (event.code) {
         case WS_CLOSE_NORMAL:
         case WS_CLOSE_GOING_AWAY:

--- a/cmd/kueueviz/frontend/src/useWebSocket.js
+++ b/cmd/kueueviz/frontend/src/useWebSocket.js
@@ -18,6 +18,10 @@ import { useEffect, useState } from 'react';
 import { buildWebSocketUrl } from './utils/urlHelper';
 import { useAuth } from './AuthContext';
 
+const WS_CLOSE_NORMAL = 1000;
+const WS_CLOSE_GOING_AWAY = 1001;
+const WS_CLOSE_POLICY_VIOLATION = 1008;
+
 const WS_BASE_PROTOCOL = 'kueueviz.v1';
 const WS_TOKEN_PROTOCOL_PREFIX = 'kueueviz.auth.';
 
@@ -79,12 +83,17 @@ const useWebSocket = (url) => {
 
     ws.onclose = (event) => {
       console.log('WebSocket connection closed', 'code:', event.code, 'reason:', event.reason);
-      if (event.code !== 1000 && event.code !== 1001) {
-        if (event.code === 1008) {
+      switch (event.code) {
+        case WS_CLOSE_NORMAL:
+        case WS_CLOSE_GOING_AWAY:
+          // Normal closures, no error needed.
+          break;
+        case WS_CLOSE_POLICY_VIOLATION:
           setError('WebSocket connection closed: Token expired or revoked. Please log in again.');
-        } else {
+          break;
+        default:
           setError(`WebSocket connection closed unexpectedly (code: ${event.code}). Please refresh the page.`);
-        }
+          break;
       }
     };
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->
/kind bug
/area dashboard

#### What this PR does / why we need it:
The kueueviz WebSocket handler authenticated the bearer token only once on the initial HTTP upgrade. After that, `handleInformerUpdates` streamed cluster data in an infinite loop with no further token checks, a user whose token expired or ServiceAccount was revoked continued receiving real-time sensitive cluster data indefinitely.

Fix:
- Store the raw bearer token in gin context (`"token"` key) inside `auth.Middleware`.
- Add `Authenticator.ValidateToken`, reuses the existing TokenReview + TTL-cache.
- Add a `TokenValidator` interface in the handlers package (nil-safe when auth is disabled).
- Add a 30-second re-auth ticker in `handleInformerUpdates`; closes the connection
  with `ClosePolicyViolation` if the token is invalid.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12563 

#### Special notes for your reviewer:
- No behaviour change when `AuthMode != "TokenReview"`, the ticker is never started.
- `ValidateToken` reuses the TTL cache, so no extra API calls between cache expiry.
- This PR was developed with AI assistance, disclosed per the [Kubernetes AI Tool Usage Policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
KueueViz: Fixed a security issue in kueueviz where WebSocket connections continued streaming cluster data after a bearer token expired or was revoked.
Connections are now closed within 30 seconds of token invalidation.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebSocket streams now periodically re-check bearer token validity (default every 30s) and close active sessions when the token is revoked/expired.
* **Bug Fixes**
  * WebSocket connections now terminate with a clear “token expired or revoked” policy-violation close reason when revalidation fails.
  * Frontend now displays more specific WebSocket error messages based on the close code.
* **Improvements**
  * Token authentication now returns more accurate HTTP status codes (401 for invalid tokens, 503 when token review fails) and preserves auth details in request context.
* **Tests**
  * Added coverage for token revalidation and close behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->