### PR TITLE
Add Kubeflow Trainer TrainJob example to Run Jobs Using Python docs

### DIFF
--- a/site/content/en/docs/tasks/run/python_jobs.md
+++ b/site/content/en/docs/tasks/run/python_jobs.md
@@ -275,3 +275,73 @@ hello world
 You can further customize the job, and can ask questions on the [Flux Operator issues board](https://github.com/flux-framework/flux-operator/issues).
 Finally, for instructions for how to do this with YAML outside of Python, see [Run A Flux MiniCluster](/docs/tasks/run/external_workloads/flux_miniclusters/).
 
+### Kubeflow Trainer Job
+
+For this example, we will use [Kubeflow Trainer](https://trainer.kubeflow.org/en/latest/)
+to submit a `TrainJob` (the Kubeflow Trainer v2 API), and specifically the
+[Kubeflow SDK](https://github.com/kubeflow/sdk) to do this easily. Unlike the previous
+examples, the SDK builds and submits the resource for us, so we don't construct the CRD by
+hand. The `kubeflow` dependency is declared in the script's inline metadata and will be
+automatically installed by `uv run`.
+
+This example assumes Kubeflow Trainer v2 is installed, the built-in `torch-distributed`
+`ClusterTrainingRuntime` is available, and Kueue is configured to manage TrainJobs. For these
+prerequisites (installing Kubeflow Trainer, the runtime, and enabling the TrainJob
+integration in Kueue), follow the [Run A TrainJob](/docs/tasks/run/trainjobs/) guide. You'll
+also need the queues created:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/kueue/main/site/static/examples/admin/single-clusterqueue-setup.yaml
+```
+
+Write the following script to `sample-trainjob.py`:
+
+{{< include file="examples/python/sample-trainjob.py" lang="python" >}}
+
+The Kueue integration is the `Labels` option, which sets the `kueue.x-k8s.io/queue-name`
+label on the TrainJob so Kueue can admit it to the right local queue (the same label the
+other examples set on their job metadata).
+
+Now try running the example:
+
+```bash
+uv run sample-trainjob.py
+```
+```console
+⭐️ Submitting TrainJob to runtime torch-distributed...
+⭐️ Created TrainJob md3b82e943a5
+Use:
+"kubectl get queue" to see queue assignment
+"kubectl get trainjobs" to see TrainJobs
+```
+
+Using the TrainJob name printed above, you can watch the TrainJob and stream its logs with
+the Kubeflow SDK:
+
+```python
+from kubeflow.trainer import TrainerClient
+
+client = TrainerClient()
+job_name = "md3b82e943a5"
+
+# Wait until Kueue admits the TrainJob and it starts running, then stream its logs.
+client.wait_for_job_status(name=job_name, status={"Running"})
+for logline in client.get_job_logs(job_name, follow=True):
+    print(logline)
+```
+```console
+[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
+Distributed Training with WORLD_SIZE: 1, RANK: 0, LOCAL_RANK: 0.
+Train Epoch: 0 [0/60000]	Loss: 2.310645
+Train Epoch: 0 [1000/60000]	Loss: 1.935180
+Train Epoch: 0 [2000/60000]	Loss: 2.096165
+...
+Train Epoch: 2 [58000/60000]	Loss: 0.372064
+Train Epoch: 2 [59000/60000]	Loss: 0.226857
+Training is finished
+```
+
+You can further customize the job, and ask questions on the
+[Kubeflow Trainer issues board](https://github.com/kubeflow/trainer/issues).
+Finally, for instructions for how to do this with YAML outside of Python, see
+[Run A TrainJob](/docs/tasks/run/trainjobs/).

--- a/site/static/examples/python/sample-trainjob.py
+++ b/site/static/examples/python/sample-trainjob.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "kubeflow",
+# ]
+# ///
+
+import argparse
+from kubeflow.trainer import TrainerClient, CustomTrainer
+from kubeflow.trainer.options import Labels
+
+# sample-trainjob.py
+# This example demonstrates submitting a Kubeflow Trainer TrainJob, managed by
+# Kueue, using the Kubeflow SDK. It runs a small distributed PyTorch training
+# job (Fashion-MNIST) against the built-in "torch-distributed" runtime.
+
+
+def train_pytorch():
+    import os
+
+    import torch
+    from torch import nn
+    import torch.nn.functional as F
+    from torchvision import datasets, transforms
+    import torch.distributed as dist
+    from torch.utils.data import DataLoader, DistributedSampler
+
+    # Kubeflow Trainer configures the distributed environment automatically.
+    device, backend = ("cuda", "nccl") if torch.cuda.is_available() else ("cpu", "gloo")
+    dist.init_process_group(backend=backend)
+
+    local_rank = int(os.getenv("LOCAL_RANK", 0))
+    print(
+        "Distributed Training with WORLD_SIZE: {}, RANK: {}, LOCAL_RANK: {}.".format(
+            dist.get_world_size(), dist.get_rank(), local_rank
+        )
+    )
+
+    class Net(nn.Module):
+        def __init__(self):
+            super(Net, self).__init__()
+            self.conv1 = nn.Conv2d(1, 20, 5, 1)
+            self.conv2 = nn.Conv2d(20, 50, 5, 1)
+            self.fc1 = nn.Linear(4 * 4 * 50, 500)
+            self.fc2 = nn.Linear(500, 10)
+
+        def forward(self, x):
+            x = F.relu(self.conv1(x))
+            x = F.max_pool2d(x, 2, 2)
+            x = F.relu(self.conv2(x))
+            x = F.max_pool2d(x, 2, 2)
+            x = x.view(-1, 4 * 4 * 50)
+            x = F.relu(self.fc1(x))
+            x = self.fc2(x)
+            return F.log_softmax(x, dim=1)
+
+    device = torch.device(f"{device}:{local_rank}")
+    model = nn.parallel.DistributedDataParallel(Net().to(device))
+    model.train()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
+
+    # Download the dataset on the rank-0 process first, then load it on every rank.
+    if local_rank == 0:
+        datasets.FashionMNIST(
+            "./data", train=True, download=True, transform=transforms.ToTensor()
+        )
+    dist.barrier()
+    dataset = datasets.FashionMNIST(
+        "./data", train=True, download=False, transform=transforms.ToTensor()
+    )
+    train_loader = DataLoader(
+        dataset, batch_size=100, sampler=DistributedSampler(dataset)
+    )
+
+    for epoch in range(3):
+        for batch_idx, (inputs, labels) in enumerate(train_loader):
+            inputs, labels = inputs.to(device), labels.to(device)
+            loss = F.nll_loss(model(inputs), labels)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            if batch_idx % 10 == 0 and dist.get_rank() == 0:
+                print(
+                    "Train Epoch: {} [{}/{}]\tLoss: {:.6f}".format(
+                        epoch,
+                        batch_idx * len(inputs),
+                        len(train_loader.dataset),
+                        loss.item(),
+                    )
+                )
+
+    dist.barrier()
+    if dist.get_rank() == 0:
+        print("Training is finished")
+    dist.destroy_process_group()
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        description="Submit Kueue Kubeflow Trainer TrainJob Example",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument(
+        "--runtime",
+        help="Kubeflow Trainer runtime to use",
+        default="torch-distributed",
+    )
+    parser.add_argument(
+        "--queue-name",
+        help="Kueue local queue name",
+        default="user-queue",
+    )
+    parser.add_argument(
+        "--num-nodes",
+        help="Number of PyTorch training nodes",
+        type=int,
+        default=1,
+    )
+    return parser
+
+
+def main():
+    """
+    Submit a TrainJob via the Kubeflow SDK. This requires Kubeflow Trainer to be
+    installed, the selected runtime to exist, and Kueue with TrainJob integration.
+    """
+    parser = get_parser()
+    args, _ = parser.parse_known_args()
+
+    client = TrainerClient()
+    print(f"⭐️ Submitting TrainJob to runtime {args.runtime}...")
+    job_name = client.train(
+        runtime=args.runtime,
+        trainer=CustomTrainer(
+            func=train_pytorch,
+            num_nodes=args.num_nodes,
+            resources_per_node={"cpu": 1, "memory": "2Gi"},
+        ),
+        options=[Labels({"kueue.x-k8s.io/queue-name": args.queue_name})],
+    )
+    print(f"⭐️ Created TrainJob {job_name}")
+    print(
+        'Use:\n"kubectl get queue" to see queue assignment\n'
+        '"kubectl get trainjobs" to see TrainJobs'
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
/area website

#### What this PR does / why we need it:
Adds a "Kubeflow Trainer Job" example to the "Run Jobs Using Python" documentation page, showing how to submit a Kubeflow Trainer v2 `TrainJob` managed by Kueue using the Kubeflow SDK.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12634 

#### Special notes for your reviewer:
**Depends on** #12615 
The example was validated end-to-end on a local kind cluster (Kubeflow Trainer v2 + Kueue with the TrainJob integration enabled). The console output, `kubectl get trainjobs` state, and training logs shown in the doc are from that run.

**AI disclosure:** I used an AI coding assistant (Claude Code) to help draft the example script and documentation. I reviewed all content and validated it on a live cluster before submitting.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a runnable Python example that submits a Kubeflow Trainer v2 `TrainJob` using the Kubeflow SDK and queue-based scheduling.
  * The example trains a small distributed PyTorch model, streams progress, and prints helpful `kubectl` viewing commands.

* **Documentation**
  * Expanded the “Run Jobs Using Python” guide with a Kubeflow Trainer Job walkthrough, including prerequisites, single-clusterqueue setup, and queue admission via label configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->