### PR TITLE
[release-0.17] KueueViz: Fix missing USER Directive to run kueueviz frontend as Non Root User

### DIFF
--- a/cmd/kueueviz/frontend/Dockerfile
+++ b/cmd/kueueviz/frontend/Dockerfile
@@ -28,6 +28,8 @@ COPY --from=builder /app/build ./build
 
 EXPOSE 8080
 
+USER node
+
 # Serve the built files directly.
 # env.js is expected to be mounted via ConfigMap at /app/build/env.js
 # when running in Kubernetes.


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubernetes-sigs/kueue/pull/12586 for 0.17

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
KueueViz: frontend container image now runs as a non-root user (node) to adhere to the principle of least privilege.
```
