### PR TITLE
Reject negative and huge number of replicas in LeaderWorkerSet, add ...

### DIFF
--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_controller.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_controller.go
@@ -18,6 +18,8 @@ package leaderworkerset
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -36,7 +38,15 @@ var (
 
 const (
 	FrameworkName = "leaderworkerset.x-k8s.io/leaderworkerset"
+	// defaultLeaderWorkerSetReplicas mirrors the LeaderWorkerSet API default for
+	// spec.replicas (+kubebuilder:default=1), and is used when the field is unset.
+	defaultLeaderWorkerSetReplicas = 1
+	// maxLeaderWorkerSetReplicas is a sanity upper bound on spec.replicas that guards
+	// against unbounded per-replica Workload creation from an unreasonably large value.
+	maxLeaderWorkerSetReplicas = 1_000_000
 )
+
+var errInvalidLeaderWorkerSetReplicas = errors.New("invalid LeaderWorkerSet replicas")
 
 func init() {
 	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
@@ -66,6 +76,16 @@ func (lws *LeaderWorkerSet) GVK() schema.GroupVersionKind {
 }
 
 func SetupIndexes(context.Context, client.FieldIndexer) error {
+	return nil
+}
+
+func validateLeaderWorkerSetReplicaCount(replicas int32) error {
+	if replicas < 0 {
+		return fmt.Errorf("%w: must be >= 0, got %d", errInvalidLeaderWorkerSetReplicas, replicas)
+	}
+	if replicas > maxLeaderWorkerSetReplicas {
+		return fmt.Errorf("%w: must be <= %d, got %d", errInvalidLeaderWorkerSetReplicas, maxLeaderWorkerSetReplicas, replicas)
+	}
 	return nil
 }
 

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_multikueue_adapter.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_multikueue_adapter.go
@@ -111,7 +111,10 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 		return nil, fmt.Errorf("no origin UID annotation found for leaderworkerset: %s", klog.KObj(lws))
 	}
 
-	replicas := ptr.Deref(lws.Spec.Replicas, 1)
+	replicas := ptr.Deref(lws.Spec.Replicas, defaultLeaderWorkerSetReplicas)
+	if err := validateLeaderWorkerSetReplicaCount(replicas); err != nil {
+		return nil, err
+	}
 	keys := make([]types.NamespacedName, replicas)
 	for i := range replicas {
 		keys[i] = types.NamespacedName{
@@ -127,7 +130,11 @@ func (*multiKueueAdapter) GetExpectedWorkloadCount(ctx context.Context, c client
 	if err := c.Get(ctx, key, lws); err != nil {
 		return 0, err
 	}
-	return int(ptr.Deref(lws.Spec.Replicas, 1)), nil
+	replicas := ptr.Deref(lws.Spec.Replicas, defaultLeaderWorkerSetReplicas)
+	if err := validateLeaderWorkerSetReplicaCount(replicas); err != nil {
+		return 0, err
+	}
+	return int(replicas), nil
 }
 
 func (*multiKueueAdapter) GetWorkloadIndex(wl *kueue.Workload) int {

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_multikueue_adapter_test.go
@@ -174,6 +174,52 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).Obj(),
 			},
 		},
+		"GetExpectedWorkloadCount rejects negative replicas": {
+			managersLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
+				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).Replicas(-1).Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.GetExpectedWorkloadCount(ctx, managerClient, types.NamespacedName{Name: "lws1", Namespace: TestNamespace})
+				return err
+			},
+			wantError: errInvalidLeaderWorkerSetReplicas,
+			wantManagersLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
+				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).Replicas(-1).Obj(),
+			},
+		},
+		"GetExpectedWorkloadCount rejects replicas above maximum": {
+			managersLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
+				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).Replicas(maxLeaderWorkerSetReplicas + 1).Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.GetExpectedWorkloadCount(ctx, managerClient, types.NamespacedName{Name: "lws1", Namespace: TestNamespace})
+				return err
+			},
+			wantError: errInvalidLeaderWorkerSetReplicas,
+			wantManagersLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
+				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).Replicas(maxLeaderWorkerSetReplicas + 1).Obj(),
+			},
+		},
+		"WorkloadKeysFor rejects negative replicas": {
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.WorkloadKeysFor(utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).
+					Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-uid-123").
+					Replicas(-1).
+					Obj())
+				return err
+			},
+			wantError: errInvalidLeaderWorkerSetReplicas,
+		},
+		"WorkloadKeysFor rejects replicas above maximum": {
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.WorkloadKeysFor(utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).
+					Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-uid-123").
+					Replicas(maxLeaderWorkerSetReplicas + 1).
+					Obj())
+				return err
+			},
+			wantError: errInvalidLeaderWorkerSetReplicas,
+		},
 		"sync creates missing remote leaderworkerset, WorkloadIdentifierAnnotations enabled": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
 			managersLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -259,7 +259,7 @@ func (r *Reconciler) filterWorkloads(lws *leaderworkersetv1.LeaderWorkerSet, exi
 		toDelete = utilslices.ToRefMap(existingWorkloads, func(e *kueue.Workload) string {
 			return e.Name
 		})
-		replicas = ptr.Deref(lws.Spec.Replicas, 1)
+		replicas = ptr.Deref(lws.Spec.Replicas, defaultLeaderWorkerSetReplicas)
 	)
 
 	// During normal scale-down, status.Replicas lags behind spec.Replicas,
@@ -289,7 +289,7 @@ func isRollingUpdateWithSurge(lws *leaderworkersetv1.LeaderWorkerSet) bool {
 		return false
 	}
 	maxSurge := int32(lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge.IntValue())
-	return maxSurge > 0 && lws.Status.UpdatedReplicas < ptr.Deref(lws.Spec.Replicas, 1)
+	return maxSurge > 0 && lws.Status.UpdatedReplicas < ptr.Deref(lws.Spec.Replicas, defaultLeaderWorkerSetReplicas)
 }
 
 func (r *Reconciler) createWorkload(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, workloadName string, index int) error {

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -128,6 +129,7 @@ var (
 	labelsPath                    = field.NewPath("metadata", "labels")
 	queueNameLabelPath            = labelsPath.Key(constants.QueueLabel)
 	specPath                      = field.NewPath("spec")
+	replicasPath                  = specPath.Child("replicas")
 	leaderWorkerTemplatePath      = specPath.Child("leaderWorkerTemplate")
 	leaderTemplatePath            = leaderWorkerTemplatePath.Child("leaderTemplate")
 	leaderTemplateMetaPath        = leaderTemplatePath.Child("metadata")
@@ -221,6 +223,7 @@ func validateCreate(lws *LeaderWorkerSet) (field.ErrorList, error) {
 	var allErrs field.ErrorList
 	allErrs = append(allErrs, jobframework.ValidateQueueName(lws.Object())...)
 	allErrs = append(allErrs, jobframework.ValidateElasticJobAnnotation(lws.Object(), lws.GVK())...)
+	allErrs = append(allErrs, validateReplicasField(lws)...)
 
 	if features.Enabled(features.AdmissionGatedBy) {
 		allErrs = append(allErrs, webhook.ValidateAdmissionGatedByAnnotationOnCreate(lws.Object())...)
@@ -234,6 +237,14 @@ func validateCreate(lws *LeaderWorkerSet) (field.ErrorList, error) {
 		allErrs = append(allErrs, validationErrs...)
 	}
 	return allErrs, nil
+}
+
+func validateReplicasField(lws *LeaderWorkerSet) field.ErrorList {
+	replicas := ptr.Deref(lws.Spec.Replicas, defaultLeaderWorkerSetReplicas)
+	if err := validateLeaderWorkerSetReplicaCount(replicas); err != nil {
+		return field.ErrorList{field.Invalid(replicasPath, replicas, err.Error())}
+	}
+	return nil
 }
 
 func validateTopologyRequest(lws *LeaderWorkerSet) (field.ErrorList, error) {

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
@@ -239,6 +239,32 @@ func TestValidateCreate(t *testing.T) {
 				Queue("test-queue").
 				Obj(),
 		},
+		"negative replicas": {
+			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				Replicas(-1).
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: replicasPath.String(),
+				},
+			}.ToAggregate(),
+		},
+		"replicas above maximum": {
+			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				Replicas(maxLeaderWorkerSetReplicas + 1).
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: replicasPath.String(),
+				},
+			}.ToAggregate(),
+		},
 		"invalid queue name": {
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -899,6 +925,40 @@ func TestValidateUpdate(t *testing.T) {
 				LeaderTemplate(corev1.PodTemplateSpec{}).
 				Queue("new-test-queue").
 				Obj(),
+		},
+		"set invalid replicas": {
+			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				Obj(),
+			newObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				Replicas(-1).
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: replicasPath.String(),
+				},
+			}.ToAggregate(),
+		},
+		"set replicas above maximum": {
+			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				Obj(),
+			newObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				Replicas(maxLeaderWorkerSetReplicas + 1).
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: replicasPath.String(),
+				},
+			}.ToAggregate(),
 		},
 		"change queue name when replicas ready": {
 			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").


### PR DESCRIPTION
…checks in multikueue adapter, webhook admission

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
LeaderWorkerSet: Fixed a bug where a LeaderWorkerSet with a negative or excessively large `spec.replicas` could crash the Kueue controller during reconciliation and MultiKueue workload processing. Kueue now rejects `spec.replicas` values that are negative or greater than 1000000
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added admission validation to reject out-of-range `spec.replicas` for LeaderWorkerSet on create/update.
  * Standardized default replica behavior using a single configured default (no more hardcoded fallback).
  * Ensured workload key generation and expected workload counts enforce the same replica validation and handle invalid values safely.
* **Tests**
  * Added cases covering negative and above-maximum replica values for both workload counting and workload key generation.
  * Added webhook test coverage for invalid replica update/create scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->