### PR TITLE
Use VeryLongTimeout in Prometheus e2e tests

### DIFF
--- a/test/e2e/singlecluster/baseline/prometheus_test.go
+++ b/test/e2e/singlecluster/baseline/prometheus_test.go
@@ -52,7 +52,7 @@ var _ = ginkgo.Describe("Prometheus", ginkgo.Label("area:prometheus", "feature:p
 				}
 			}
 			g.Expect(hasKueueTarget).To(gomega.BeTrue(), "Kueue target not found. Active targets: %v", result.Active)
-		}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+		}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
 	})
 
 	ginkgo.It("should scrape kueue_build_info metric via PromQL", func() {
@@ -64,7 +64,7 @@ var _ = ginkgo.Describe("Prometheus", ginkgo.Label("area:prometheus", "feature:p
 			g.Expect(ok).To(gomega.BeTrue())
 			g.Expect(vector).NotTo(gomega.BeEmpty())
 			g.Expect(string(vector[0].Metric[model.MetricNameLabel])).To(gomega.Equal(kueueBuildInfoMetric))
-		}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+		}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
 	})
 
 	ginkgo.It("should report workload admission metrics via PromQL", func() {
@@ -123,6 +123,6 @@ var _ = ginkgo.Describe("Prometheus", ginkgo.Label("area:prometheus", "feature:p
 			vector, ok := result.(model.Vector)
 			g.Expect(ok).To(gomega.BeTrue())
 			g.Expect(vector).NotTo(gomega.BeEmpty())
-		}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+		}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
 	})
 })


### PR DESCRIPTION


#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:
Use `VeryLongTimeout` to reduce flakes when target discovery is slow.
#### Which issue(s) this PR fixes:
Fixes #12711

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
