### PR TITLE
TAS Scheduler PodSetSliceSize division-by-zero hardening

### DIFF
--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -148,6 +148,7 @@ type PodSetTopologyRequest struct {
 	// in `kueue.x-k8s.io/podset-slice-required-topology` annotation.
 	//
 	// +optional
+	// +kubebuilder:validation:Minimum=1
 	PodSetSliceSize *int32 `json:"podSetSliceSize,omitempty"`
 }
 

--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -231,6 +231,7 @@ type PodSetTopologyRequest struct {
 	// in `kueue.x-k8s.io/podset-slice-required-topology` annotation.
 	//
 	// +optional
+	// +kubebuilder:validation:Minimum=1
 	PodSetSliceSize *int32 `json:"podSetSliceSize,omitempty"`
 
 	// podsetSliceRequiredTopologyConstraints defines all layers of slice

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -8758,6 +8758,7 @@ spec:
                             Kueue finds a requested topology domain on a level defined
                             in `kueue.x-k8s.io/podset-slice-required-topology` annotation.
                           format: int32
+                          minimum: 1
                           type: integer
                         preferred:
                           description: |-
@@ -18198,6 +18199,7 @@ spec:
                             Kueue finds a requested topology domain on a level defined
                             in `kueue.x-k8s.io/podset-slice-required-topology` annotation.
                           format: int32
+                          minimum: 1
                           type: integer
                         podsetSliceRequiredTopologyConstraints:
                           description: |-

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -44,6 +44,8 @@ import (
 
 var (
 	errCodeAssumptionsViolated = errors.New("code assumptions violated")
+	errSliceSizeInvalid        = errors.New("slice size must be greater than 0")
+	errSliceSizeNotProvided    = errors.New("slice topology requested, but slice size not provided")
 )
 
 // domain holds the static information about placement of a topology
@@ -882,9 +884,9 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	}
 
 	// If slice topology is not requested then we can assume that slice is a single pod
-	sliceSize, reason := getSliceSizeWithSinglePodAsDefault(workersTasPodSetRequests.PodSet.TopologyRequest)
-	if len(reason) > 0 {
-		return nil, reason
+	sliceSize, err := getSliceSizeWithSinglePodAsDefault(workersTasPodSetRequests.PodSet.TopologyRequest)
+	if err != nil {
+		return nil, fmt.Sprintf("failed to determine slice size: %w", err)
 	}
 	state.sliceSize = sliceSize
 
@@ -1215,24 +1217,32 @@ func slicesRequested(tr *kueue.PodSetTopologyRequest) bool {
 	return (tr.PodSetSliceRequiredTopology != nil && tr.PodSetSliceSize != nil) || len(tr.PodsetSliceRequiredTopologyConstraints) > 0
 }
 
-func getSliceSizeWithSinglePodAsDefault(podSetTopologyRequest *kueue.PodSetTopologyRequest) (int32, string) {
+func getSliceSizeWithSinglePodAsDefault(podSetTopologyRequest *kueue.PodSetTopologyRequest) (int32, error) {
 	if podSetTopologyRequest == nil {
-		return 1, ""
+		return 1, nil
 	}
 
 	if len(podSetTopologyRequest.PodsetSliceRequiredTopologyConstraints) > 0 {
-		return podSetTopologyRequest.PodsetSliceRequiredTopologyConstraints[0].Size, ""
+		size := podSetTopologyRequest.PodsetSliceRequiredTopologyConstraints[0].Size
+		if size <= 0 {
+			return 0, errSliceSizeInvalid
+		}
+		return size, nil
 	}
 
 	if podSetTopologyRequest.PodSetSliceRequiredTopology == nil {
-		return 1, ""
+		return 1, nil
 	}
 
 	if podSetTopologyRequest.PodSetSliceSize == nil {
-		return 0, "slice topology requested, but slice size not provided"
+		return 0, errSliceSizeNotProvided
 	}
 
-	return *podSetTopologyRequest.PodSetSliceSize, ""
+	sliceSize := *podSetTopologyRequest.PodSetSliceSize
+	if sliceSize <= 0 {
+		return 0, errSliceSizeInvalid
+	}
+	return sliceSize, nil
 }
 
 // findBestFitDomain finds an index of the first domain with the lowest

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -17,12 +17,14 @@ limitations under the License.
 package scheduler
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 
+	"k8s.io/utils/ptr"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
@@ -936,6 +938,94 @@ func TestTruncateAssignment(t *testing.T) {
 			got := tas.TruncateAssignment(tc.assignment, tc.newCount)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("TruncateAssignment() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetSliceSizeWithSinglePodAsDefault(t *testing.T) {
+	tests := map[string]struct {
+		name     string
+		tr       *kueue.PodSetTopologyRequest
+		wantSize int32
+		wantErr  error
+	}{
+		"nil topology request returns 1": {
+			tr:       nil,
+			wantSize: 1,
+			wantErr:  nil,
+		},
+		"no slice requirement returns 1": {
+			tr:       &kueue.PodSetTopologyRequest{},
+			wantSize: 1,
+			wantErr:  nil,
+		},
+		"valid slice size from constraints": {
+			tr: &kueue.PodSetTopologyRequest{
+				PodsetSliceRequiredTopologyConstraints: []kueue.PodsetSliceRequiredTopologyConstraint{
+					{
+						Topology: "kubernetes.io/hostname",
+						Size:     5,
+					},
+				},
+			},
+			wantSize: 5,
+			wantErr:  nil,
+		},
+		"zero slice size from constraints is rejected": {
+			tr: &kueue.PodSetTopologyRequest{
+				PodsetSliceRequiredTopologyConstraints: []kueue.PodsetSliceRequiredTopologyConstraint{
+					{
+						Topology: "kubernetes.io/hostname",
+						Size:     0,
+					},
+				},
+			},
+			wantSize: 0,
+			wantErr:  errSliceSizeInvalid,
+		},
+		"valid explicit slice size": {
+			tr: &kueue.PodSetTopologyRequest{
+				PodSetSliceRequiredTopology: ptr.To("kubernetes.io/hostname"),
+				PodSetSliceSize:             ptr.To(int32(3)),
+			},
+			wantSize: 3,
+			wantErr:  nil,
+		},
+		"zero explicit slice size is rejected": {
+			tr: &kueue.PodSetTopologyRequest{
+				PodSetSliceRequiredTopology: ptr.To("kubernetes.io/hostname"),
+				PodSetSliceSize:             ptr.To(int32(0)),
+			},
+			wantSize: 0,
+			wantErr:  errSliceSizeInvalid,
+		},
+		"negative explicit slice size is rejected": {
+			tr: &kueue.PodSetTopologyRequest{
+				PodSetSliceRequiredTopology: ptr.To("kubernetes.io/hostname"),
+				PodSetSliceSize:             ptr.To(int32(-5)),
+			},
+			wantSize: 0,
+			wantErr:  errSliceSizeInvalid,
+		},
+		"slice topology requested but size not provided": {
+			tr: &kueue.PodSetTopologyRequest{
+				PodSetSliceRequiredTopology: ptr.To("kubernetes.io/hostname"),
+				PodSetSliceSize:             nil,
+			},
+			wantSize: 0,
+			wantErr:  errSliceSizeNotProvided,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			size, err := getSliceSizeWithSinglePodAsDefault(tc.tr)
+			if size != tc.wantSize {
+				t.Errorf("getSliceSizeWithSinglePodAsDefault() size got %d, want %d", size, tc.wantSize)
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("getSliceSizeWithSinglePodAsDefault() error got %v, want %v", err, tc.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/area tas
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Fix for the division-by-zero vulnerability in TAS scheduler consists of CRD schema Validation and and runtime Validation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Fix for the division-by-zero vulnerability in TAS scheduler by CRD schema and runtime validations.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter validation so workload slice sizes must be at least `1`.
  * Improved handling of topology slice sizing to reject missing or invalid values and provide clearer failures.
  * Updated the CRD schema to enforce these limits consistently for submitted resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->