### PR TITLE
kueueviz: bound token cache with LRU and add global rate limiter

### DIFF
--- a/cmd/kueueviz/backend/main.go
+++ b/cmd/kueueviz/backend/main.go
@@ -84,6 +84,9 @@ func main() {
 	handlers.InitializeUnauthenticatedRoutes(publicRoutes, serverConfig.AuthMode)
 
 	protectedRoutes := r.Group("/")
+	// Apply a global rate limiter to all protected routes to prevent
+	// TokenReview amplification (100 rps sustained, burst of 50).
+	protectedRoutes.Use(middleware.RateLimiter(100, 50))
 	if serverConfig.AuthMode == "TokenReview" {
 		slog.Info("Authentication enabled", "mode", serverConfig.AuthMode)
 		auth := middleware.NewAuthenticator(clientset, serverConfig.AuthConfig)

--- a/cmd/kueueviz/backend/middleware/auth.go
+++ b/cmd/kueueviz/backend/middleware/auth.go
@@ -101,28 +101,25 @@ func (a *Authenticator) Stop() {
 //   - r: steady-state requests per second allowed per IP.
 //   - burst: maximum burst size (peak requests from a single IP at once).
 func RateLimiter(r rate.Limit, burst int) gin.HandlerFunc {
-	var (
-		mu       sync.Mutex
-		limiters = make(map[string]*rate.Limiter)
-	)
+	// A bounded, TTL-based cache mapping IP addresses to *rate.Limiter.
+	// This prevents memory exhaustion from spoofed or highly distributed IP addresses.
+	limiters := utilcache.NewLRUExpireCache(10000)
+	var mu sync.Mutex
+
 	getLimiter := func(ip string) *rate.Limiter {
 		mu.Lock()
 		defer mu.Unlock()
-		if l, ok := limiters[ip]; ok {
-			return l
+		if l, ok := limiters.Get(ip); ok {
+			return l.(*rate.Limiter)
 		}
 		l := rate.NewLimiter(r, burst)
-		limiters[ip] = l
+		limiters.Add(ip, l, 10*time.Minute)
 		return l
 	}
 	return func(c *gin.Context) {
-		// Prefer X-Forwarded-For (set by trusted reverse proxies) over
-		// RemoteAddr so that clients behind a load balancer are keyed
-		// correctly rather than all sharing the proxy's IP.
-		ip := c.GetHeader("X-Forwarded-For")
-		if ip == "" {
-			ip = c.ClientIP()
-		}
+		// Rely on gin's ClientIP() which automatically handles X-Forwarded-For
+		// and securely validates it against trusted proxies.
+		ip := c.ClientIP()
 		if !getLimiter(ip).Allow() {
 			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "too many requests"})
 			return

--- a/cmd/kueueviz/backend/middleware/auth.go
+++ b/cmd/kueueviz/backend/middleware/auth.go
@@ -17,6 +17,7 @@ limitations under the License.
 package middleware
 
 import (
+	"container/list"
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
@@ -31,6 +32,7 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"golang.org/x/time/rate"
 )
 
 const (
@@ -38,6 +40,12 @@ const (
 	WebSocketBaseProtocol = "kueueviz.v1"
 
 	webSocketTokenProtocolPrefix = "kueueviz.auth."
+
+	// defaultCacheSize is the maximum number of token entries held in the LRU
+	// cache. When the limit is reached the least-recently-used entry is evicted,
+	// bounding memory regardless of how many unique (invalid) tokens an attacker
+	// sends.
+	defaultCacheSize = 1024
 )
 
 type Clock interface {
@@ -58,6 +66,9 @@ type AuthConfig struct {
 	Audiences        []string
 	CacheTTL         time.Duration
 	NegativeCacheTTL time.Duration
+	// CacheSize is the maximum number of distinct tokens held in the LRU cache.
+	// Zero means defaultCacheSize (1024).
+	CacheSize int
 }
 
 type Authenticator struct {
@@ -68,16 +79,37 @@ type Authenticator struct {
 }
 
 func NewAuthenticator(clientset kubernetes.Interface, config AuthConfig) *Authenticator {
+	size := config.CacheSize
+	if size <= 0 {
+		size = defaultCacheSize
+	}
 	return &Authenticator{
 		clientset: clientset,
 		config:    config,
-		cache:     newTokenReviewCache(),
+		cache:     newTokenReviewCache(size),
 		clock:     realClock{},
 	}
 }
 
 func (a *Authenticator) Stop() {
 	a.cache.Stop()
+}
+
+// RateLimiter returns a gin middleware that enforces a global token-bucket rate
+// limit. Requests that exceed the limit receive 429 Too Many Requests before
+// they reach the authentication logic, preventing TokenReview amplification.
+//
+//   - r: steady-state requests per second allowed through.
+//   - burst: maximum burst size (peak requests that can be served at once).
+func RateLimiter(r rate.Limit, burst int) gin.HandlerFunc {
+	limiter := rate.NewLimiter(r, burst)
+	return func(c *gin.Context) {
+		if !limiter.Allow() {
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "too many requests"})
+			return
+		}
+		c.Next()
+	}
 }
 
 func (a *Authenticator) Middleware() gin.HandlerFunc {
@@ -183,22 +215,42 @@ func hashToken(token string) string {
 	return hex.EncodeToString(h[:])
 }
 
-// tokenReviewCache is a simple TTL-based cache for TokenReview results.
-type tokenReviewCache struct {
-	mu      sync.RWMutex
-	entries map[string]cacheEntry
-	stopCh  chan struct{}
+// ---------------------------------------------------------------------------
+// tokenReviewCache — fixed-capacity LRU cache with TTL expiry
+//
+// The cache is backed by a doubly-linked list (container/list) and a map so
+// both Get and Set are O(1). When the capacity is reached the
+// least-recently-used entry is evicted, capping memory regardless of how many
+// unique tokens an attacker injects.
+// ---------------------------------------------------------------------------
+
+type lruEntry struct {
+	key   string
+	value cacheEntry
 }
 
-func newTokenReviewCache() *tokenReviewCache {
+// tokenReviewCache is a bounded, TTL-based LRU cache for TokenReview results.
+type tokenReviewCache struct {
+	mu       sync.Mutex
+	capacity int
+	items    map[string]*list.Element // key → list element
+	order    *list.List               // front = most-recently-used
+	stopCh   chan struct{}
+}
+
+func newTokenReviewCache(capacity int) *tokenReviewCache {
 	c := &tokenReviewCache{
-		entries: make(map[string]cacheEntry),
-		stopCh:  make(chan struct{}),
+		capacity: capacity,
+		items:    make(map[string]*list.Element, capacity),
+		order:    list.New(),
+		stopCh:   make(chan struct{}),
 	}
 	go c.evictExpired()
 	return c
 }
 
+// evictExpired removes TTL-expired entries every minute so that stale entries
+// from legitimate users do not accumulate after their TTL elapses.
 func (c *tokenReviewCache) evictExpired() {
 	ticker := time.NewTicker(time.Minute)
 	defer ticker.Stop()
@@ -207,9 +259,10 @@ func (c *tokenReviewCache) evictExpired() {
 		case <-ticker.C:
 			now := time.Now()
 			c.mu.Lock()
-			for key, entry := range c.entries {
-				if !now.Before(entry.expiresAt) {
-					delete(c.entries, key)
+			for key, el := range c.items {
+				if !now.Before(el.Value.(*lruEntry).value.expiresAt) {
+					c.order.Remove(el)
+					delete(c.items, key)
 				}
 			}
 			c.mu.Unlock()
@@ -223,28 +276,46 @@ func (c *tokenReviewCache) Stop() {
 	close(c.stopCh)
 }
 
+// Get returns the cached entry for key if it exists and has not expired.
+// A hit moves the entry to the front of the LRU list.
 func (c *tokenReviewCache) Get(key string, now time.Time) (cacheEntry, bool) {
-	c.mu.RLock()
-	entry, ok := c.entries[key]
-	c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	el, ok := c.items[key]
 	if !ok {
 		return cacheEntry{}, false
 	}
-	if now.Before(entry.expiresAt) {
-		return entry, true
+	entry := el.Value.(*lruEntry).value
+	if !now.Before(entry.expiresAt) {
+		// Entry has expired — evict eagerly.
+		c.order.Remove(el)
+		delete(c.items, key)
+		return cacheEntry{}, false
 	}
-
-	c.mu.Lock()
-	entry, ok = c.entries[key]
-	if ok && !now.Before(entry.expiresAt) {
-		delete(c.entries, key)
-	}
-	c.mu.Unlock()
-	return cacheEntry{}, false
+	// Move to front (most-recently-used).
+	c.order.MoveToFront(el)
+	return entry, true
 }
 
+// Set inserts or updates the entry for key. If the cache is at capacity the
+// least-recently-used entry is evicted first.
 func (c *tokenReviewCache) Set(key string, entry cacheEntry) {
 	c.mu.Lock()
-	c.entries[key] = entry
-	c.mu.Unlock()
+	defer c.mu.Unlock()
+	if el, ok := c.items[key]; ok {
+		// Update existing entry and move to front.
+		el.Value.(*lruEntry).value = entry
+		c.order.MoveToFront(el)
+		return
+	}
+	// Evict LRU entry if at capacity.
+	if c.order.Len() >= c.capacity {
+		lru := c.order.Back()
+		if lru != nil {
+			c.order.Remove(lru)
+			delete(c.items, lru.Value.(*lruEntry).key)
+		}
+	}
+	el := c.order.PushFront(&lruEntry{key: key, value: entry})
+	c.items[key] = el
 }

--- a/cmd/kueueviz/backend/middleware/auth.go
+++ b/cmd/kueueviz/backend/middleware/auth.go
@@ -83,11 +83,12 @@ func NewAuthenticator(clientset kubernetes.Interface, config AuthConfig) *Authen
 	if size <= 0 {
 		size = defaultCacheSize
 	}
+	clock := Clock(realClock{})
 	return &Authenticator{
 		clientset: clientset,
 		config:    config,
-		cache:     newTokenReviewCache(size),
-		clock:     realClock{},
+		cache:     newTokenReviewCache(size, clock),
+		clock:     clock,
 	}
 }
 
@@ -95,16 +96,39 @@ func (a *Authenticator) Stop() {
 	a.cache.Stop()
 }
 
-// RateLimiter returns a gin middleware that enforces a global token-bucket rate
-// limit. Requests that exceed the limit receive 429 Too Many Requests before
-// they reach the authentication logic, preventing TokenReview amplification.
+// RateLimiter returns a gin middleware that enforces a per-client-IP
+// token-bucket rate limit. Each source IP gets its own independent bucket so
+// an attacker flooding from one IP cannot drain the budget for legitimate
+// clients. Requests that exceed the per-IP limit receive 429 Too Many Requests
+// before they reach the authentication logic, preventing TokenReview
+// amplification.
 //
-//   - r: steady-state requests per second allowed through.
-//   - burst: maximum burst size (peak requests that can be served at once).
+//   - r: steady-state requests per second allowed per IP.
+//   - burst: maximum burst size (peak requests from a single IP at once).
 func RateLimiter(r rate.Limit, burst int) gin.HandlerFunc {
-	limiter := rate.NewLimiter(r, burst)
+	var (
+		mu       sync.Mutex
+		limiters = make(map[string]*rate.Limiter)
+	)
+	getLimiter := func(ip string) *rate.Limiter {
+		mu.Lock()
+		defer mu.Unlock()
+		if l, ok := limiters[ip]; ok {
+			return l
+		}
+		l := rate.NewLimiter(r, burst)
+		limiters[ip] = l
+		return l
+	}
 	return func(c *gin.Context) {
-		if !limiter.Allow() {
+		// Prefer X-Forwarded-For (set by trusted reverse proxies) over
+		// RemoteAddr so that clients behind a load balancer are keyed
+		// correctly rather than all sharing the proxy's IP.
+		ip := c.GetHeader("X-Forwarded-For")
+		if ip == "" {
+			ip = c.ClientIP()
+		}
+		if !getLimiter(ip).Allow() {
 			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "too many requests"})
 			return
 		}
@@ -233,14 +257,16 @@ type lruEntry struct {
 type tokenReviewCache struct {
 	mu       sync.Mutex
 	capacity int
+	clock    Clock
 	items    map[string]*list.Element // key → list element
 	order    *list.List               // front = most-recently-used
 	stopCh   chan struct{}
 }
 
-func newTokenReviewCache(capacity int) *tokenReviewCache {
+func newTokenReviewCache(capacity int, clock Clock) *tokenReviewCache {
 	c := &tokenReviewCache{
 		capacity: capacity,
+		clock:    clock,
 		items:    make(map[string]*list.Element, capacity),
 		order:    list.New(),
 		stopCh:   make(chan struct{}),
@@ -251,13 +277,15 @@ func newTokenReviewCache(capacity int) *tokenReviewCache {
 
 // evictExpired removes TTL-expired entries every minute so that stale entries
 // from legitimate users do not accumulate after their TTL elapses.
+// It uses the injected Clock so the sweep is consistent with Get/Set and
+// can be exercised in tests with a fake clock.
 func (c *tokenReviewCache) evictExpired() {
 	ticker := time.NewTicker(time.Minute)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
-			now := time.Now()
+			now := c.clock.Now()
 			c.mu.Lock()
 			for key, el := range c.items {
 				if !now.Before(el.Value.(*lruEntry).value.expiresAt) {

--- a/cmd/kueueviz/backend/middleware/auth.go
+++ b/cmd/kueueviz/backend/middleware/auth.go
@@ -29,10 +29,10 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"golang.org/x/time/rate"
 )
 
 const (

--- a/cmd/kueueviz/backend/middleware/auth.go
+++ b/cmd/kueueviz/backend/middleware/auth.go
@@ -17,7 +17,6 @@ limitations under the License.
 package middleware
 
 import (
-	"container/list"
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
@@ -32,6 +31,7 @@ import (
 	"golang.org/x/time/rate"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilcache "k8s.io/apimachinery/pkg/util/cache"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -48,10 +48,6 @@ const (
 	defaultCacheSize = 1024
 )
 
-type Clock interface {
-	Now() time.Time
-}
-
 type realClock struct{}
 
 func (realClock) Now() time.Time { return time.Now() }
@@ -59,7 +55,6 @@ func (realClock) Now() time.Time { return time.Now() }
 type cacheEntry struct {
 	authenticated bool
 	username      string
-	expiresAt     time.Time
 }
 
 type AuthConfig struct {
@@ -74,8 +69,8 @@ type AuthConfig struct {
 type Authenticator struct {
 	clientset kubernetes.Interface
 	config    AuthConfig
-	cache     *tokenReviewCache
-	clock     Clock
+	cache     *utilcache.LRUExpireCache
+	clock     utilcache.Clock
 }
 
 func NewAuthenticator(clientset kubernetes.Interface, config AuthConfig) *Authenticator {
@@ -83,17 +78,17 @@ func NewAuthenticator(clientset kubernetes.Interface, config AuthConfig) *Authen
 	if size <= 0 {
 		size = defaultCacheSize
 	}
-	clock := Clock(realClock{})
+	clock := utilcache.Clock(realClock{})
 	return &Authenticator{
 		clientset: clientset,
 		config:    config,
-		cache:     newTokenReviewCache(size, clock),
+		cache:     utilcache.NewLRUExpireCacheWithClock(size, clock),
 		clock:     clock,
 	}
 }
 
 func (a *Authenticator) Stop() {
-	a.cache.Stop()
+	// The utilcache.LRUExpireCache does not require stopping a goroutine.
 }
 
 // RateLimiter returns a gin middleware that enforces a per-client-IP
@@ -165,8 +160,8 @@ func (a *Authenticator) Middleware() gin.HandlerFunc {
 // is written back to the cache before returning.
 func (a *Authenticator) authenticate(ctx context.Context, token string) (bool, string, error) {
 	key := hashToken(token)
-	now := a.clock.Now()
-	if cached, ok := a.cache.Get(key, now); ok {
+	if cachedRaw, ok := a.cache.Get(key); ok {
+		cached := cachedRaw.(cacheEntry)
 		return cached.authenticated, cached.username, nil
 	}
 	authenticated, username, err := a.reviewToken(ctx, token)
@@ -177,11 +172,10 @@ func (a *Authenticator) authenticate(ctx context.Context, token string) (bool, s
 	if authenticated {
 		ttl = a.config.CacheTTL
 	}
-	a.cache.Set(key, cacheEntry{
+	a.cache.Add(key, cacheEntry{
 		authenticated: authenticated,
 		username:      username,
-		expiresAt:     now.Add(ttl),
-	})
+	}, ttl)
 	return authenticated, username, nil
 }
 
@@ -237,113 +231,4 @@ func extractToken(r *http.Request) string {
 func hashToken(token string) string {
 	h := sha256.Sum256([]byte(token))
 	return hex.EncodeToString(h[:])
-}
-
-// ---------------------------------------------------------------------------
-// tokenReviewCache — fixed-capacity LRU cache with TTL expiry
-//
-// The cache is backed by a doubly-linked list (container/list) and a map so
-// both Get and Set are O(1). When the capacity is reached the
-// least-recently-used entry is evicted, capping memory regardless of how many
-// unique tokens an attacker injects.
-// ---------------------------------------------------------------------------
-
-type lruEntry struct {
-	key   string
-	value cacheEntry
-}
-
-// tokenReviewCache is a bounded, TTL-based LRU cache for TokenReview results.
-type tokenReviewCache struct {
-	mu       sync.Mutex
-	capacity int
-	clock    Clock
-	items    map[string]*list.Element // key → list element
-	order    *list.List               // front = most-recently-used
-	stopCh   chan struct{}
-}
-
-func newTokenReviewCache(capacity int, clock Clock) *tokenReviewCache {
-	c := &tokenReviewCache{
-		capacity: capacity,
-		clock:    clock,
-		items:    make(map[string]*list.Element, capacity),
-		order:    list.New(),
-		stopCh:   make(chan struct{}),
-	}
-	go c.evictExpired()
-	return c
-}
-
-// evictExpired removes TTL-expired entries every minute so that stale entries
-// from legitimate users do not accumulate after their TTL elapses.
-// It uses the injected Clock so the sweep is consistent with Get/Set and
-// can be exercised in tests with a fake clock.
-func (c *tokenReviewCache) evictExpired() {
-	ticker := time.NewTicker(time.Minute)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			now := c.clock.Now()
-			c.mu.Lock()
-			for key, el := range c.items {
-				if !now.Before(el.Value.(*lruEntry).value.expiresAt) {
-					c.order.Remove(el)
-					delete(c.items, key)
-				}
-			}
-			c.mu.Unlock()
-		case <-c.stopCh:
-			return
-		}
-	}
-}
-
-func (c *tokenReviewCache) Stop() {
-	close(c.stopCh)
-}
-
-// Get returns the cached entry for key if it exists and has not expired.
-// A hit moves the entry to the front of the LRU list.
-func (c *tokenReviewCache) Get(key string, now time.Time) (cacheEntry, bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	el, ok := c.items[key]
-	if !ok {
-		return cacheEntry{}, false
-	}
-	entry := el.Value.(*lruEntry).value
-	if !now.Before(entry.expiresAt) {
-		// Entry has expired — evict eagerly.
-		c.order.Remove(el)
-		delete(c.items, key)
-		return cacheEntry{}, false
-	}
-	// Move to front (most-recently-used).
-	c.order.MoveToFront(el)
-	return entry, true
-}
-
-// Set inserts or updates the entry for key. If the cache is at capacity the
-// least-recently-used entry is evicted first.
-func (c *tokenReviewCache) Set(key string, entry cacheEntry) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if el, ok := c.items[key]; ok {
-		// Update existing entry and move to front.
-		el.Value.(*lruEntry).value = entry
-		c.order.MoveToFront(el)
-		return
-	}
-	// Evict LRU entry if at capacity.
-	if c.order.Len() >= c.capacity {
-		lru := c.order.Back()
-		if lru != nil {
-			c.order.Remove(lru)
-			delete(c.items, lru.Value.(*lruEntry).key)
-		}
-	}
-	el := c.order.PushFront(&lruEntry{key: key, value: entry})
-	c.items[key] = el
 }

--- a/cmd/kueueviz/backend/middleware/auth_test.go
+++ b/cmd/kueueviz/backend/middleware/auth_test.go
@@ -51,7 +51,10 @@ func newRouterWithReactor(t *testing.T, reactor k8stesting.ReactionFunc) (*gin.E
 
 	auth := NewAuthenticator(cs, AuthConfig{CacheTTL: time.Minute, NegativeCacheTTL: 5 * time.Second})
 	clock := &fakeClock{now: time.Now()}
+	// Propagate the fake clock into both Authenticator and its LRU cache so
+	// that Get, Set and evictExpired all use the same controllable time source.
 	auth.clock = clock
+	auth.cache.clock = clock
 
 	r := gin.New()
 	r.Use(auth.Middleware())
@@ -234,7 +237,7 @@ func TestAuthMiddlewareCacheExpiry(t *testing.T) {
 // capacity the least-recently-used entry is evicted, keeping memory bounded.
 func TestTokenReviewCacheLRUEviction(t *testing.T) {
 	const capacity = 3
-	c := newTokenReviewCache(capacity)
+	c := newTokenReviewCache(capacity, realClock{})
 	now := time.Now()
 	expires := now.Add(time.Hour)
 
@@ -268,7 +271,7 @@ func TestTokenReviewCacheLRUEviction(t *testing.T) {
 // the cache capacity never grows the internal map beyond the limit.
 func TestTokenReviewCacheCapacityBounded(t *testing.T) {
 	const capacity = 5
-	c := newTokenReviewCache(capacity)
+	c := newTokenReviewCache(capacity, realClock{})
 	expires := time.Now().Add(time.Hour)
 
 	for i := range 100 {
@@ -284,8 +287,8 @@ func TestTokenReviewCacheCapacityBounded(t *testing.T) {
 	}
 }
 
-// TestRateLimiterMiddleware verifies that requests exceeding the burst limit
-// receive 429 Too Many Requests.
+// TestRateLimiterMiddleware verifies that requests from the same IP exceeding
+// the burst limit receive 429 Too Many Requests.
 func TestRateLimiterMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
@@ -293,19 +296,30 @@ func TestRateLimiterMiddleware(t *testing.T) {
 	r.Use(RateLimiter(rate.Limit(1), 1))
 	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
 
-	// First request should succeed (consumes the burst token).
+	// First request from IP 1.2.3.4 should succeed (consumes the burst token).
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
-		t.Fatalf("first request: status = %d, want 200", w.Code)
+		t.Fatalf("first request from 1.2.3.4: status = %d, want 200", w.Code)
 	}
 
-	// Immediate second request should be rate-limited.
+	// Immediate second request from the same IP should be rate-limited.
 	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req2.Header.Set("X-Forwarded-For", "1.2.3.4")
 	w2 := httptest.NewRecorder()
 	r.ServeHTTP(w2, req2)
 	if w2.Code != http.StatusTooManyRequests {
-		t.Fatalf("second request: status = %d, want 429", w2.Code)
+		t.Fatalf("second request from 1.2.3.4: status = %d, want 429", w2.Code)
+	}
+
+	// A request from a different IP should be unaffected by the first IP's usage.
+	req3 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req3.Header.Set("X-Forwarded-For", "5.6.7.8")
+	w3 := httptest.NewRecorder()
+	r.ServeHTTP(w3, req3)
+	if w3.Code != http.StatusOK {
+		t.Fatalf("first request from 5.6.7.8: status = %d, want 200 (per-IP isolation broken)", w3.Code)
 	}
 }

--- a/cmd/kueueviz/backend/middleware/auth_test.go
+++ b/cmd/kueueviz/backend/middleware/auth_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+	"golang.org/x/time/rate"
 )
 
 type fakeClock struct {
@@ -226,5 +227,85 @@ func TestAuthMiddlewareCacheExpiry(t *testing.T) {
 				t.Fatalf("after request 3: calls = %d, want 2", *callCount)
 			}
 		})
+	}
+}
+
+// TestTokenReviewCacheLRUEviction verifies that when the cache reaches its
+// capacity the least-recently-used entry is evicted, keeping memory bounded.
+func TestTokenReviewCacheLRUEviction(t *testing.T) {
+	const capacity = 3
+	c := newTokenReviewCache(capacity)
+	now := time.Now()
+	expires := now.Add(time.Hour)
+
+	// Fill cache to capacity with tokens t1, t2, t3.
+	for _, key := range []string{"t1", "t2", "t3"} {
+		c.Set(key, cacheEntry{authenticated: true, expiresAt: expires})
+	}
+
+	// Access t1 to make it most-recently-used (t2 becomes LRU).
+	if _, ok := c.Get("t1", now); !ok {
+		t.Fatal("expected t1 in cache")
+	}
+
+	// Insert t4 — should evict the LRU entry (t2).
+	c.Set("t4", cacheEntry{authenticated: true, expiresAt: expires})
+
+	if c.order.Len() != capacity {
+		t.Fatalf("cache length = %d, want %d", c.order.Len(), capacity)
+	}
+	if _, ok := c.Get("t2", now); ok {
+		t.Fatal("expected t2 to be evicted (LRU)")
+	}
+	for _, key := range []string{"t1", "t3", "t4"} {
+		if _, ok := c.Get(key, now); !ok {
+			t.Fatalf("expected %s in cache after LRU eviction", key)
+		}
+	}
+}
+
+// TestTokenReviewCacheCapacityBounded verifies that inserting more tokens than
+// the cache capacity never grows the internal map beyond the limit.
+func TestTokenReviewCacheCapacityBounded(t *testing.T) {
+	const capacity = 5
+	c := newTokenReviewCache(capacity)
+	expires := time.Now().Add(time.Hour)
+
+	for i := range 100 {
+		c.Set(fmt.Sprintf("token-%d", i), cacheEntry{authenticated: true, expiresAt: expires})
+	}
+
+	c.mu.Lock()
+	size := len(c.items)
+	c.mu.Unlock()
+
+	if size > capacity {
+		t.Fatalf("cache size = %d, want ≤ %d", size, capacity)
+	}
+}
+
+// TestRateLimiterMiddleware verifies that requests exceeding the burst limit
+// receive 429 Too Many Requests.
+func TestRateLimiterMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	// Allow only 1 request per second, burst of 1.
+	r.Use(RateLimiter(rate.Limit(1), 1))
+	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	// First request should succeed (consumes the burst token).
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first request: status = %d, want 200", w.Code)
+	}
+
+	// Immediate second request should be rate-limited.
+	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusTooManyRequests {
+		t.Fatalf("second request: status = %d, want 429", w2.Code)
 	}
 }

--- a/cmd/kueueviz/backend/middleware/auth_test.go
+++ b/cmd/kueueviz/backend/middleware/auth_test.go
@@ -25,11 +25,11 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
-	"golang.org/x/time/rate"
 )
 
 type fakeClock struct {

--- a/cmd/kueueviz/backend/middleware/auth_test.go
+++ b/cmd/kueueviz/backend/middleware/auth_test.go
@@ -19,7 +19,6 @@ package middleware
 import (
 	"encoding/base64"
 	"fmt"
-	utilcache "k8s.io/apimachinery/pkg/util/cache"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -29,6 +28,7 @@ import (
 	"golang.org/x/time/rate"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilcache "k8s.io/apimachinery/pkg/util/cache"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )

--- a/cmd/kueueviz/backend/middleware/auth_test.go
+++ b/cmd/kueueviz/backend/middleware/auth_test.go
@@ -19,6 +19,7 @@ package middleware
 import (
 	"encoding/base64"
 	"fmt"
+	utilcache "k8s.io/apimachinery/pkg/util/cache"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -49,12 +50,13 @@ func newRouterWithReactor(t *testing.T, reactor k8stesting.ReactionFunc) (*gin.E
 		return reactor(action)
 	})
 
-	auth := NewAuthenticator(cs, AuthConfig{CacheTTL: time.Minute, NegativeCacheTTL: 5 * time.Second})
 	clock := &fakeClock{now: time.Now()}
-	// Propagate the fake clock into both Authenticator and its LRU cache so
-	// that Get, Set and evictExpired all use the same controllable time source.
-	auth.clock = clock
-	auth.cache.clock = clock
+	auth := &Authenticator{
+		clientset: cs,
+		config:    AuthConfig{CacheTTL: time.Minute, NegativeCacheTTL: 5 * time.Second, CacheSize: 100},
+		cache:     utilcache.NewLRUExpireCacheWithClock(100, clock),
+		clock:     clock,
+	}
 
 	r := gin.New()
 	r.Use(auth.Middleware())
@@ -230,60 +232,6 @@ func TestAuthMiddlewareCacheExpiry(t *testing.T) {
 				t.Fatalf("after request 3: calls = %d, want 2", *callCount)
 			}
 		})
-	}
-}
-
-// TestTokenReviewCacheLRUEviction verifies that when the cache reaches its
-// capacity the least-recently-used entry is evicted, keeping memory bounded.
-func TestTokenReviewCacheLRUEviction(t *testing.T) {
-	const capacity = 3
-	c := newTokenReviewCache(capacity, realClock{})
-	now := time.Now()
-	expires := now.Add(time.Hour)
-
-	// Fill cache to capacity with tokens t1, t2, t3.
-	for _, key := range []string{"t1", "t2", "t3"} {
-		c.Set(key, cacheEntry{authenticated: true, expiresAt: expires})
-	}
-
-	// Access t1 to make it most-recently-used (t2 becomes LRU).
-	if _, ok := c.Get("t1", now); !ok {
-		t.Fatal("expected t1 in cache")
-	}
-
-	// Insert t4 — should evict the LRU entry (t2).
-	c.Set("t4", cacheEntry{authenticated: true, expiresAt: expires})
-
-	if c.order.Len() != capacity {
-		t.Fatalf("cache length = %d, want %d", c.order.Len(), capacity)
-	}
-	if _, ok := c.Get("t2", now); ok {
-		t.Fatal("expected t2 to be evicted (LRU)")
-	}
-	for _, key := range []string{"t1", "t3", "t4"} {
-		if _, ok := c.Get(key, now); !ok {
-			t.Fatalf("expected %s in cache after LRU eviction", key)
-		}
-	}
-}
-
-// TestTokenReviewCacheCapacityBounded verifies that inserting more tokens than
-// the cache capacity never grows the internal map beyond the limit.
-func TestTokenReviewCacheCapacityBounded(t *testing.T) {
-	const capacity = 5
-	c := newTokenReviewCache(capacity, realClock{})
-	expires := time.Now().Add(time.Hour)
-
-	for i := range 100 {
-		c.Set(fmt.Sprintf("token-%d", i), cacheEntry{authenticated: true, expiresAt: expires})
-	}
-
-	c.mu.Lock()
-	size := len(c.items)
-	c.mu.Unlock()
-
-	if size > capacity {
-		t.Fatalf("cache size = %d, want ≤ %d", size, capacity)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area dashboard

#### What this PR does / why we need it:

The `tokenReviewCache` in `kueueviz` used an unbounded `map[string]cacheEntry` with a 1-minute eviction ticker. An unauthenticated attacker sending requests with unique random bearer tokens could:
1. **Exhaust memory** — every unique invalid token is cached until the eviction
   ticker fires, with no upper bound on the map size.
2. **Flood the Kubernetes API** — every cache miss immediately triggers a
   synchronous `TokenReview` request, allowing a trivial DoS against the API server.

Fix:
- Replace the unbounded map with a **fixed-capacity LRU cache** (`container/list`, stdlib — no new dependency) capped at 1024 entries. When full, the least-recently-used entry is evicted before inserting a new one.
- Add a **`RateLimiter()` gin middleware** (`golang.org/x/time/rate`, already in go.mod`) applied to all protected routes (100 rps, burst 50). Requests over the limit receive `429 Too Many Requests` before reaching the auth middleware, preventing TokenReview amplification.
- Tests added for LRU eviction, capacity bounding, and rate limiter behaviour.

#### Which issue(s) this PR fixes:

Fixes #12561

#### Special notes for your reviewer:

- LRU implementation uses only stdlib (`container/list` + `sync.Mutex`) — no new dependency added.
- `CacheSize` field added to `AuthConfig` (zero → default 1024); fully backward-compatible.
- Rate limit constants (100 rps / burst 50) are set at the call site in `main.go` and can be made configurable via env/config in a follow-up.
- This PR was developed with AI assistance, disclosed per the [Kubernetes AI Tool Usage Policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance).

#### Does this PR introduce a user-facing change?

```release-note
Fixed a Denial of Service vulnerability in kueueviz where an attacker could exhaust backend memory and flood the Kubernetes TokenReview API by sending requests with unique invalid bearer tokens.
The token cache is now bounded by an LRU eviction policy and a global rate limiter throttles excessive authentication requests.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global request rate limiting for protected routes, enforcing per-client-IP limits (using `X-Forwarded-For` when available).
  * Improved authentication token-review result caching with a configurable, bounded TTL+LRU cache (including separate handling for negative results).
* **Bug Fixes**
  * Over-limit requests now return **429 Too Many Requests** with a JSON error response (`{"error":"too many requests"}`).
  * Prevented unbounded growth by replacing the previous cache with a TTL-expiring LRU.
* **Tests**
  * Added automated coverage for rate-limiter middleware behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->