### PR TITLE
feat(docs): Add migration guide for Kubeflow Trainer v1 -> v2

### DIFF
--- a/site/content/en/docs/tasks/run/kubeflow/_index.md
+++ b/site/content/en/docs/tasks/run/kubeflow/_index.md
@@ -13,7 +13,7 @@ The tasks below show you how to run Kueue managed Kubeflow Trainer v1 Jobs.
 {{% alert title="Warning" color="warning" %}}
 **Deprecation Notice:** The integration with [Kubeflow Trainer v1](https://www.kubeflow.org/docs/components/trainer/legacy-v1/) (PyTorchJob, TFJob, XGBoostJob, PaddleJob, JAXJob) is **deprecated** in Kueue and will be removed in a future release, tentatively **v0.20**.
 
-Kubeflow Trainer v1 is now legacy. We strongly recommend migrating to [Kubeflow Trainer v2](https://github.com/kubeflow/trainer) (which is supported in Kueue via [TrainJob](/docs/tasks/run/trainjobs/)), or using an alternative framework such as [JobSet](/docs/tasks/run/jobsets/) to run your jobs.
+Kubeflow Trainer v1 is now legacy. We strongly recommend migrating to [Kubeflow Trainer v2](https://github.com/kubeflow/trainer) (which is supported in Kueue via [TrainJob](/docs/tasks/run/trainjobs/)), or using an alternative framework such as [JobSet](/docs/tasks/run/jobsets/) to run your jobs. See the [Kubeflow Trainer v1 to v2 migration guide](https://trainer.kubeflow.org/en/latest/operator-guides/migration.html) for details on how to migrate.
 {{% /alert %}}
 
 ### [Trainer v1](https://github.com/kubeflow/trainer) Integration

--- a/site/content/en/docs/tasks/run/kubeflow/jaxjobs.md
+++ b/site/content/en/docs/tasks/run/kubeflow/jaxjobs.md
@@ -13,7 +13,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 {{% alert title="Warning" color="warning" %}}
 **Deprecation Notice:** The integration with [Kubeflow Trainer v1](https://www.kubeflow.org/docs/components/trainer/legacy-v1/) (including JAXJob) is **deprecated** in Kueue and will be removed in a future release, tentatively **v0.20**.
 
-Kubeflow Trainer v1 is now legacy. We strongly recommend migrating to [Kubeflow Trainer v2](https://github.com/kubeflow/trainer) (which is supported in Kueue via [TrainJob](/docs/tasks/run/trainjobs/)), or using an alternative framework such as [JobSet](/docs/tasks/run/jobsets/) to run your jobs.
+Kubeflow Trainer v1 is now legacy. We strongly recommend migrating to [Kubeflow Trainer v2](https://github.com/kubeflow/trainer) (which is supported in Kueue via [TrainJob](/docs/tasks/run/trainjobs/)), or using an alternative framework such as [JobSet](/docs/tasks/run/jobsets/) to run your jobs. See the [Kubeflow Trainer v1 to v2 migration guide](https://trainer.kubeflow.org/en/latest/operator-guides/migration.html) for details on how to migrate.
 {{% /alert %}}
 
 ## Before you begin

--- a/site/content/en/docs/tasks/run/kubeflow/paddlejobs.md
+++ b/site/content/en/docs/tasks/run/kubeflow/paddlejobs.md
@@ -13,7 +13,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 {{% alert title="Warning" color="warning" %}}
 **Deprecation Notice:** The integration with [Kubeflow Trainer v1](https://www.kubeflow.org/docs/components/trainer/legacy-v1/) (including PaddleJob) is **deprecated** in Kueue and will be removed in a future release, tentatively **v0.20**.
 
-Kubeflow Trainer v1 is now legacy. We strongly recommend migrating to [Kubeflow Trainer v2](https://github.com/kubeflow/trainer) (which is supported in Kueue via [TrainJob](/docs/tasks/run/trainjobs/)), or using an alternative framework such as [JobSet](/docs/tasks/run/jobsets/) to run your jobs.
+Kubeflow Trainer v1 is now legacy. We strongly recommend migrating to [Kubeflow Trainer v2](https://github.com/kubeflow/trainer) (which is supported in Kueue via [TrainJob](/docs/tasks/run/trainjobs/)), or using an alternative framework such as [JobSet](/docs/tasks/run/jobsets/) to run your jobs. See the [Kubeflow Trainer v1 to v2 migration guide](https://trainer.kubeflow.org/en/latest/operator-guides/migration.html) for details on how to migrate.
 {{% /alert %}}
 
 ## Before you begin

--- a/site/content/en/docs/tasks/run/kubeflow/pytorchjobs.md
+++ b/site/content/en/docs/tasks/run/kubeflow/pytorchjobs.md
@@ -13,7 +13,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 {{% alert title="Warning" color="warning" %}}
 **Deprecation Notice:** The integration with [Kubeflow Trainer v1](https://www.kubeflow.org/docs/components/trainer/legacy-v1/) (including PyTorchJob) is **deprecated** in Kueue and will be removed in a future release, tentatively **v0.20**.
 
-Kubeflow Trainer v1 is now legacy. We strongly recommend migrating to [Kubeflow Trainer v2](https://github.com/kubeflow/trainer) (which is supported in Kueue via [TrainJob](/docs/tasks/run/trainjobs/)), or using an alternative framework such as [JobSet](/docs/tasks/run/jobsets/) to run your jobs.
+Kubeflow Trainer v1 is now legacy. We strongly recommend migrating to [Kubeflow Trainer v2](https://github.com/kubeflow/trainer) (which is supported in Kueue via [TrainJob](/docs/tasks/run/trainjobs/)), or using an alternative framework such as [JobSet](/docs/tasks/run/jobsets/) to run your jobs. See the [Kubeflow Trainer v1 to v2 migration guide](https://trainer.kubeflow.org/en/latest/operator-guides/migration.html) for details on how to migrate.
 {{% /alert %}}
 
 ## Before you begin

--- a/site/content/en/docs/tasks/run/kubeflow/tfjobs.md
+++ b/site/content/en/docs/tasks/run/kubeflow/tfjobs.md
@@ -13,7 +13,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 {{% alert title="Warning" color="warning" %}}
 **Deprecation Notice:** The integration with [Kubeflow Trainer v1](https://www.kubeflow.org/docs/components/trainer/legacy-v1/) (including TFJob) is **deprecated** in Kueue and will be removed in a future release, tentatively **v0.20**.
 
-Kubeflow Trainer v1 is now legacy. We strongly recommend migrating to [Kubeflow Trainer v2](https://github.com/kubeflow/trainer) (which is supported in Kueue via [TrainJob](/docs/tasks/run/trainjobs/)), or using an alternative framework such as [JobSet](/docs/tasks/run/jobsets/) to run your jobs.
+Kubeflow Trainer v1 is now legacy. We strongly recommend migrating to [Kubeflow Trainer v2](https://github.com/kubeflow/trainer) (which is supported in Kueue via [TrainJob](/docs/tasks/run/trainjobs/)), or using an alternative framework such as [JobSet](/docs/tasks/run/jobsets/) to run your jobs. See the [Kubeflow Trainer v1 to v2 migration guide](https://trainer.kubeflow.org/en/latest/operator-guides/migration.html) for details on how to migrate.
 {{% /alert %}}
 
 ## Before you begin

--- a/site/content/en/docs/tasks/run/kubeflow/xgboostjobs.md
+++ b/site/content/en/docs/tasks/run/kubeflow/xgboostjobs.md
@@ -14,7 +14,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 {{% alert title="Warning" color="warning" %}}
 **Deprecation Notice:** The integration with [Kubeflow Trainer v1](https://www.kubeflow.org/docs/components/trainer/legacy-v1/) (including XGBoostJob) is **deprecated** in Kueue and will be removed in a future release, tentatively **v0.20**.
 
-Kubeflow Trainer v1 is now legacy. We strongly recommend migrating to [Kubeflow Trainer v2](https://github.com/kubeflow/trainer) (which is supported in Kueue via [TrainJob](/docs/tasks/run/trainjobs/)), or using an alternative framework such as [JobSet](/docs/tasks/run/jobsets/) to run your jobs.
+Kubeflow Trainer v1 is now legacy. We strongly recommend migrating to [Kubeflow Trainer v2](https://github.com/kubeflow/trainer) (which is supported in Kueue via [TrainJob](/docs/tasks/run/trainjobs/)), or using an alternative framework such as [JobSet](/docs/tasks/run/jobsets/) to run your jobs. See the [Kubeflow Trainer v1 to v2 migration guide](https://trainer.kubeflow.org/en/latest/operator-guides/migration.html) for details on how to migrate.
 {{% /alert %}}
 
 ## Before you begin

--- a/site/content/zh-CN/docs/tasks/run/kubeflow/_index.md
+++ b/site/content/zh-CN/docs/tasks/run/kubeflow/_index.md
@@ -18,7 +18,7 @@ no_list: true
 {{% alert title="警告" color="warning" %}}
 **弃用通知：** Kueue 中与 [Kubeflow Trainer v1](https://www.kubeflow.org/docs/components/trainer/legacy-v1/)（PyTorchJob、TFJob、XGBoostJob、PaddleJob、JAXJob）的集成已**弃用**，并将于未来的版本（暂定 **v0.20**）中移除。
 
-Kubeflow Trainer v1 现在已是传统遗留项目（legacy）。我们强烈建议迁移到 [Kubeflow Trainer v2](https://github.com/kubeflow/trainer)（在 Kueue 中已通过 [TrainJob](/docs/tasks/run/trainjobs/)（英文文档）提供支持），或者使用其他替代框架（例如 [JobSet](/zh-cn/docs/tasks/run/jobsets/)）来运行您的作业。
+Kubeflow Trainer v1 现在已是传统遗留项目（legacy）。我们强烈建议迁移到 [Kubeflow Trainer v2](https://github.com/kubeflow/trainer)（在 Kueue 中已通过 [TrainJob](/docs/tasks/run/trainjobs/)（英文文档）提供支持），或者使用其他替代框架（例如 [JobSet](/zh-cn/docs/tasks/run/jobsets/)）来运行您的作业。有关如何迁移的详细信息，请参阅 [Kubeflow Trainer v1 到 v2 迁移指南](https://trainer.kubeflow.org/en/latest/operator-guides/migration.html)（英文文档）。
 {{% /alert %}}
 
 - [运行 Kueue 管理的 Kubeflow PyTorchJob](/zh-cn/docs/tasks/run/kubeflow/pytorchjobs)。

--- a/site/content/zh-CN/docs/tasks/run/kubeflow/jaxjobs.md
+++ b/site/content/zh-CN/docs/tasks/run/kubeflow/jaxjobs.md
@@ -15,7 +15,7 @@ JAXJob 时，如何利用 Kueue 的调度和资源管理能力。
 {{% alert title="警告" color="warning" %}}
 **弃用通知：** Kueue 中与 [Kubeflow Trainer v1](https://www.kubeflow.org/docs/components/trainer/legacy-v1/)（包括 JAXJob）的集成已**弃用**，并将于未来的版本（暂定 **v0.20**）中移除。
 
-Kubeflow Trainer v1 现在已是传统遗留项目（legacy）。我们强烈建议迁移到 [Kubeflow Trainer v2](https://github.com/kubeflow/trainer)（在 Kueue 中已通过 [TrainJob](/docs/tasks/run/trainjobs/)（英文文档）提供支持），或者使用其他替代框架（例如 [JobSet](/zh-cn/docs/tasks/run/jobsets/)）来运行您的作业。
+Kubeflow Trainer v1 现在已是传统遗留项目（legacy）。我们强烈建议迁移到 [Kubeflow Trainer v2](https://github.com/kubeflow/trainer)（在 Kueue 中已通过 [TrainJob](/docs/tasks/run/trainjobs/)（英文文档）提供支持），或者使用其他替代框架（例如 [JobSet](/zh-cn/docs/tasks/run/jobsets/)）来运行您的作业。有关如何迁移的详细信息，请参阅 [Kubeflow Trainer v1 到 v2 迁移指南](https://trainer.kubeflow.org/en/latest/operator-guides/migration.html)（英文文档）。
 {{% /alert %}}
 
 ## 开始之前  {#before-you-begin}

--- a/site/content/zh-CN/docs/tasks/run/kubeflow/paddlejobs.md
+++ b/site/content/zh-CN/docs/tasks/run/kubeflow/paddlejobs.md
@@ -15,7 +15,7 @@ PaddleJob 时，如何利用 Kueue 的调度和资源管理能力。
 {{% alert title="警告" color="warning" %}}
 **弃用通知：** Kueue 中与 [Kubeflow Trainer v1](https://www.kubeflow.org/docs/components/trainer/legacy-v1/)（包括 PaddleJob）的集成已**弃用**，并将于未来的版本（暂定 **v0.20**）中移除。
 
-Kubeflow Trainer v1 现在已是传统遗留项目（legacy）。我们强烈建议迁移到 [Kubeflow Trainer v2](https://github.com/kubeflow/trainer)（在 Kueue 中已通过 [TrainJob](/docs/tasks/run/trainjobs/)（英文文档）提供支持），或者使用其他替代框架（例如 [JobSet](/zh-cn/docs/tasks/run/jobsets/)）来运行您的作业。
+Kubeflow Trainer v1 现在已是传统遗留项目（legacy）。我们强烈建议迁移到 [Kubeflow Trainer v2](https://github.com/kubeflow/trainer)（在 Kueue 中已通过 [TrainJob](/docs/tasks/run/trainjobs/)（英文文档）提供支持），或者使用其他替代框架（例如 [JobSet](/zh-cn/docs/tasks/run/jobsets/)）来运行您的作业。有关如何迁移的详细信息，请参阅 [Kubeflow Trainer v1 到 v2 迁移指南](https://trainer.kubeflow.org/en/latest/operator-guides/migration.html)（英文文档）。
 {{% /alert %}}
 
 ## 开始之前  {#before-you-begin}

--- a/site/content/zh-CN/docs/tasks/run/kubeflow/pytorchjobs.md
+++ b/site/content/zh-CN/docs/tasks/run/kubeflow/pytorchjobs.md
@@ -15,7 +15,7 @@ PyTorchJob 时，如何利用 Kueue 的调度和资源管理能力。
 {{% alert title="警告" color="warning" %}}
 **弃用通知：** Kueue 中与 [Kubeflow Trainer v1](https://www.kubeflow.org/docs/components/trainer/legacy-v1/)（包括 PyTorchJob）的集成已**弃用**，并将于未来的版本（暂定 **v0.20**）中移除。
 
-Kubeflow Trainer v1 现在已是传统遗留项目（legacy）。我们强烈建议迁移到 [Kubeflow Trainer v2](https://github.com/kubeflow/trainer)（在 Kueue 中已通过 [TrainJob](/docs/tasks/run/trainjobs/)（英文文档）提供支持），或者使用其他替代框架（例如 [JobSet](/zh-cn/docs/tasks/run/jobsets/)）来运行您的作业。
+Kubeflow Trainer v1 现在已是传统遗留项目（legacy）。我们强烈建议迁移到 [Kubeflow Trainer v2](https://github.com/kubeflow/trainer)（在 Kueue 中已通过 [TrainJob](/docs/tasks/run/trainjobs/)（英文文档）提供支持），或者使用其他替代框架（例如 [JobSet](/zh-cn/docs/tasks/run/jobsets/)）来运行您的作业。有关如何迁移的详细信息，请参阅 [Kubeflow Trainer v1 到 v2 迁移指南](https://trainer.kubeflow.org/en/latest/operator-guides/migration.html)（英文文档）。
 {{% /alert %}}
 
 ## 开始之前  {#before-you-begin}

--- a/site/content/zh-CN/docs/tasks/run/kubeflow/tfjobs.md
+++ b/site/content/zh-CN/docs/tasks/run/kubeflow/tfjobs.md
@@ -15,7 +15,7 @@ TFJob 时，如何利用 Kueue 的调度和资源管理能力。
 {{% alert title="警告" color="warning" %}}
 **弃用通知：** Kueue 中与 [Kubeflow Trainer v1](https://www.kubeflow.org/docs/components/trainer/legacy-v1/)（包括 TFJob）的集成已**弃用**，并将于未来的版本（暂定 **v0.20**）中移除。
 
-Kubeflow Trainer v1 现在已是传统遗留项目（legacy）。我们强烈建议迁移到 [Kubeflow Trainer v2](https://github.com/kubeflow/trainer)（在 Kueue 中已通过 [TrainJob](/docs/tasks/run/trainjobs/)（英文文档）提供支持），或者使用其他替代框架（例如 [JobSet](/zh-cn/docs/tasks/run/jobsets/)）来运行您的作业。
+Kubeflow Trainer v1 现在已是传统遗留项目（legacy）。我们强烈建议迁移到 [Kubeflow Trainer v2](https://github.com/kubeflow/trainer)（在 Kueue 中已通过 [TrainJob](/docs/tasks/run/trainjobs/)（英文文档）提供支持），或者使用其他替代框架（例如 [JobSet](/zh-cn/docs/tasks/run/jobsets/)）来运行您的作业。有关如何迁移的详细信息，请参阅 [Kubeflow Trainer v1 到 v2 迁移指南](https://trainer.kubeflow.org/en/latest/operator-guides/migration.html)（英文文档）。
 {{% /alert %}}
 
 ## 开始之前  {#before-you-begin}

--- a/site/content/zh-CN/docs/tasks/run/kubeflow/xgboostjobs.md
+++ b/site/content/zh-CN/docs/tasks/run/kubeflow/xgboostjobs.md
@@ -15,7 +15,7 @@ XGBoostJob 时，如何利用 Kueue 的调度和资源管理能力。
 {{% alert title="警告" color="warning" %}}
 **弃用通知：** Kueue 中与 [Kubeflow Trainer v1](https://www.kubeflow.org/docs/components/trainer/legacy-v1/)（包括 XGBoostJob）的集成已**弃用**，并将于未来的版本（暂定 **v0.20**）中移除。
 
-Kubeflow Trainer v1 现在已是传统遗留项目（legacy）。我们强烈建议迁移到 [Kubeflow Trainer v2](https://github.com/kubeflow/trainer)（在 Kueue 中已通过 [TrainJob](/docs/tasks/run/trainjobs/)（英文文档）提供支持），或者使用其他替代框架（例如 [JobSet](/zh-cn/docs/tasks/run/jobsets/)）来运行您的作业。
+Kubeflow Trainer v1 现在已是传统遗留项目（legacy）。我们强烈建议迁移到 [Kubeflow Trainer v2](https://github.com/kubeflow/trainer)（在 Kueue 中已通过 [TrainJob](/docs/tasks/run/trainjobs/)（英文文档）提供支持），或者使用其他替代框架（例如 [JobSet](/zh-cn/docs/tasks/run/jobsets/)）来运行您的作业。有关如何迁移的详细信息，请参阅 [Kubeflow Trainer v1 到 v2 迁移指南](https://trainer.kubeflow.org/en/latest/operator-guides/migration.html)（英文文档）。
 {{% /alert %}}
 
 ## 开始之前  {#before-you-begin}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->
/kind feature
/area website

#### What this PR does / why we need it:

Followup after this: https://github.com/kubernetes-sigs/kueue/pull/12601#discussion_r3514241511 to add migration guide for Kubeflow Trainer v1 -> v2.

/assign @mimowo @tenzen-y @kannon92 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Kubeflow Trainer v1 deprecation notices across multiple training job docs.
  * Added clearer migration guidance, including recommendations to move to Kubeflow Trainer v2 or use alternatives like JobSet.
  * Included links to the Trainer v1 to v2 migration guide in both English and Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->