### PR TITLE
fix: permanent TAS resource leak during workload deletion with missing topology

### DIFF
--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -605,7 +605,7 @@ func (c *clusterQueue) updateWorkloadTASUsage(log logr.Logger, wi *workload.Info
 		case op == add:
 			tasFlvCache.addUsage(log, key, tasUsage)
 		case op == subtract:
-			tasFlvCache.removeUsage(key)
+			tasFlvCache.removeUsage(log, key)
 		}
 	}
 }

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -603,7 +603,7 @@ func (c *clusterQueue) updateWorkloadTASUsage(log logr.Logger, wi *workload.Info
 		case tasFlvCache == nil:
 			log.V(2).Info("TAS flavor used by workload not found in cache", "tasFlavor", tasFlavor)
 		case op == add:
-			tasFlvCache.addUsage(key, tasUsage)
+			tasFlvCache.addUsage(log, key, tasUsage)
 		case op == subtract:
 			tasFlvCache.removeUsage(key)
 		}

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -597,11 +597,6 @@ func (c *clusterQueue) updateWorkloadTASUsage(log logr.Logger, wi *workload.Info
 	}
 	key := workload.Key(wi.Obj)
 	log = log.WithValues("workload", key)
-	if !c.isTASInitialized() {
-		log.V(2).Info("Delaying accounting of the TAS usage, because TAS cache is not initialized yet")
-		// TAS cache is not synced yet so we defer accounting for TAS usage.
-		return
-	}
 	for tasFlavor, tasUsage := range wi.TASUsage() {
 		tasFlvCache := c.tasCache.Get(tasFlavor)
 		switch {

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -21,6 +21,7 @@ import (
 	"maps"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -7423,11 +7424,12 @@ func TestFindTopologyAssignments(t *testing.T) {
 			}
 			tasFlavorCache := tasCache.NewTASFlavorCache(topologyInformation, flavorInformation)
 			if len(tc.priorOwnUsage) > 0 {
-				tasFlavorCache.addUsage("prior-wl", tc.priorOwnUsage)
+				tasFlavorCache.addUsage(log, "prior-wl", tc.priorOwnUsage)
 			}
 
 			if features.Enabled(features.TASHandleOverlappingFlavors) {
 				tc.aggregatedDomainUsages = aggregatedDomainUsagesForPriorFlavorUsage(
+					log,
 					topologyInformation,
 					flavorInformation,
 					tc.priorFlavorUsage,
@@ -7894,6 +7896,7 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 
 			if features.Enabled(features.TASHandleOverlappingFlavors) {
 				tc.aggregatedDomainUsages = aggregatedDomainUsagesForPriorFlavorUsage(
+					log,
 					topologyInfo,
 					flvInfo,
 					tc.priorFlavorUsage,
@@ -7936,6 +7939,7 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 // TODO: Once we commonize "TestFindTopologyAssignments" and "TestFindTopologyAssignmentsMultiLayerReplacement" into one,
 // we should remove this helper function.
 func aggregatedDomainUsagesForPriorFlavorUsage(
+	log logr.Logger,
 	topologyInfo topologyInformation,
 	flvInfo flavorInformation,
 	priorFlavorUsage []workload.TopologyDomainRequests,
@@ -7944,7 +7948,7 @@ func aggregatedDomainUsagesForPriorFlavorUsage(
 ) map[tas.TopologyDomainID]resources.Requests {
 	siblingCache := cache.NewTASFlavorCache(topologyInfo, flvInfo)
 	if len(priorFlavorUsage) > 0 {
-		siblingCache.addUsage("prior-wl", priorFlavorUsage)
+		siblingCache.addUsage(log, "prior-wl", priorFlavorUsage)
 	}
 
 	aggregatedDomainUsages := maps.Clone(initialAggregatedDomainUsages)

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -157,15 +157,16 @@ func (c *TASFlavorCache) snapshot(
 func (c *TASFlavorCache) addUsage(log logr.Logger, key workload.Reference, topologyRequests []workload.TopologyDomainRequests) {
 	if _, found := c.wlUsage[key]; found {
 		log.V(2).Info("Workload usage already exists in TAS flavor cache, self-healing by replacing it", "workload", key)
-		c.removeUsage(key)
+		c.removeUsage(log, key)
 	}
 	c.wlUsage[key] = slices.Clone(topologyRequests)
 	c.updateUsage(topologyRequests, add)
 }
 
-func (c *TASFlavorCache) removeUsage(key workload.Reference) {
+func (c *TASFlavorCache) removeUsage(log logr.Logger, key workload.Reference) {
 	value, found := c.wlUsage[key]
 	if !found {
+		log.V(2).Info("Workload usage not found during removal from TAS flavor cache", "workload", key)
 		return
 	}
 	c.updateUsage(value, subtract)

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -154,7 +154,11 @@ func (c *TASFlavorCache) snapshot(
 	return snapshot
 }
 
-func (c *TASFlavorCache) addUsage(key workload.Reference, topologyRequests []workload.TopologyDomainRequests) {
+func (c *TASFlavorCache) addUsage(log logr.Logger, key workload.Reference, topologyRequests []workload.TopologyDomainRequests) {
+	if _, found := c.wlUsage[key]; found {
+		log.V(2).Info("Workload usage already exists in TAS flavor cache, self-healing by replacing it", "workload", key)
+		c.removeUsage(key)
+	}
 	c.wlUsage[key] = slices.Clone(topologyRequests)
 	c.updateUsage(topologyRequests, add)
 }

--- a/pkg/cache/scheduler/tas_flavor_test.go
+++ b/pkg/cache/scheduler/tas_flavor_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/kueue/pkg/resources"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
+	logr := log.Log.WithName("tas-flavor-test")
+	wlKey := workload.Reference("default/wl1")
+
+	testCases := []struct {
+		name       string
+		operations func(cache *TASFlavorCache)
+		wantUsage  map[utiltas.TopologyDomainID]resources.Requests
+	}{
+		{
+			name: "add usage",
+			operations: func(cache *TASFlavorCache) {
+				cache.addUsage(logr, wlKey, []workload.TopologyDomainRequests{
+					{
+						Values: []string{"domain1"},
+						Count:  2,
+						SinglePodRequests: resources.Requests{
+							corev1.ResourceCPU: 2,
+						},
+					},
+				})
+			},
+			wantUsage: map[utiltas.TopologyDomainID]resources.Requests{
+				"domain1": {
+					corev1.ResourceCPU:  4,
+					corev1.ResourcePods: 2,
+				},
+			},
+		},
+		{
+			name: "add usage self-healing (replace existing)",
+			operations: func(cache *TASFlavorCache) {
+				// Initial add
+				cache.addUsage(logr, wlKey, []workload.TopologyDomainRequests{
+					{
+						Values: []string{"domain1"},
+						Count:  1,
+						SinglePodRequests: resources.Requests{
+							corev1.ResourceCPU: 1,
+						},
+					},
+				})
+				// Self-healing add (replaces existing usage)
+				cache.addUsage(logr, wlKey, []workload.TopologyDomainRequests{
+					{
+						Values: []string{"domain2"},
+						Count:  2,
+						SinglePodRequests: resources.Requests{
+							corev1.ResourceCPU: 3,
+						},
+					},
+				})
+			},
+			wantUsage: map[utiltas.TopologyDomainID]resources.Requests{
+				"domain1": {
+					corev1.ResourceCPU:  0,
+					corev1.ResourcePods: 0,
+				},
+				"domain2": {
+					corev1.ResourceCPU:  6,
+					corev1.ResourcePods: 2,
+				},
+			},
+		},
+		{
+			name: "remove usage",
+			operations: func(cache *TASFlavorCache) {
+				cache.addUsage(logr, wlKey, []workload.TopologyDomainRequests{
+					{
+						Values: []string{"domain1"},
+						Count:  1,
+						SinglePodRequests: resources.Requests{
+							corev1.ResourceCPU: 1,
+						},
+					},
+				})
+				cache.removeUsage(logr, wlKey)
+			},
+			wantUsage: map[utiltas.TopologyDomainID]resources.Requests{
+				"domain1": {
+					corev1.ResourceCPU:  0,
+					corev1.ResourcePods: 0,
+				},
+			},
+		},
+		{
+			name: "remove usage (key not found) handles gracefully",
+			operations: func(cache *TASFlavorCache) {
+				cache.removeUsage(logr, wlKey)
+			},
+			wantUsage: map[utiltas.TopologyDomainID]resources.Requests{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cache := &TASFlavorCache{
+				wlUsage: make(map[workload.Reference][]workload.TopologyDomainRequests),
+				usage:   make(map[utiltas.TopologyDomainID]resources.Requests),
+			}
+
+			tc.operations(cache)
+
+			if diff := cmp.Diff(tc.wantUsage, cache.usage, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Unexpected usage (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -1080,12 +1080,11 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				var wl1, wl2 *kueue.Workload
 				ginkgo.By("creating a workload which requires block and can fit", func() {
 					wl1 = utiltestingapi.MakeWorkload("wl1", ns.Name).
-						Queue(kueue.LocalQueueName(localQueue.Name)).
-						PodSets(*utiltestingapi.MakePodSet("main", 1).
-							Request(corev1.ResourceCPU, "4").
-							RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
-							Obj()).
-						Obj()
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "4").Obj()
+					wl1.Spec.PodSets[0].Count = 1
+					wl1.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
+						Required: ptr.To(utiltesting.DefaultBlockTopologyLevel),
+					}
 					util.MustCreate(ctx, k8sClient, wl1)
 				})
 
@@ -1135,12 +1134,11 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 					// Request the capacity that was freed by wl1.
 					wl2 = utiltestingapi.MakeWorkload("wl2", ns.Name).
-						Queue(kueue.LocalQueueName(localQueue.Name)).
-						PodSets(*utiltestingapi.MakePodSet("main", 1).
-							Request(corev1.ResourceCPU, "4").
-							RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
-							Obj()).
-						Obj()
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "4").Obj()
+					wl2.Spec.PodSets[0].Count = 1
+					wl2.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
+						Required: ptr.To(utiltesting.DefaultBlockTopologyLevel),
+					}
 					util.MustCreate(ctx, k8sClient, wl2)
 				})
 

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -1132,11 +1132,9 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 					// Request the capacity that was freed by wl1.
 					wl2 = utiltestingapi.MakeWorkload("wl2", ns.Name).
-						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "4").Obj()
-					wl2.Spec.PodSets[0].Count = 1
-					wl2.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
-						Required: ptr.To(utiltesting.DefaultBlockTopologyLevel),
-					}
+						Queue(kueue.LocalQueueName(localQueue.Name)).PodSets(*utiltestingapi.MakePodSet("worker", 2).
+						RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+						Obj()).Request(corev1.ResourceCPU, "1").Obj()
 					util.MustCreate(ctx, k8sClient, wl2)
 				})
 

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -1101,21 +1101,21 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 
-				ginkgo.By("delete the topology so that it becomes uninitialized", func() {
-					gomega.Expect(k8sClient.Delete(ctx, topology)).Should(gomega.Succeed())
+				ginkgo.By("trigger topology deletion", func() {
+					gomega.Expect(util.DeleteObject(ctx, k8sClient, topology)).To(gomega.Succeed())
 				})
 
-				ginkgo.By("remove topology finalizer to force deletion", func() {
+				ginkgo.By("remove topology finalizers to allow deletion", func() {
 					var updatedTopology kueue.Topology
 					gomega.Eventually(func(g gomega.Gomega) {
-						g.Expect(client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(topology), &updatedTopology))).To(gomega.Succeed())
-						if len(updatedTopology.Finalizers) == 0 {
-							return
-						}
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(topology), &updatedTopology)).To(gomega.Succeed())
 						updatedTopology.Finalizers = nil
-						g.Expect(client.IgnoreNotFound(k8sClient.Update(ctx, &updatedTopology))).Should(gomega.Succeed())
+						g.Expect(k8sClient.Update(ctx, &updatedTopology)).To(gomega.Succeed())
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
-					util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+				})
+
+				ginkgo.By("wait for the topology to be fully deleted", func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, false)
 				})
 
 				ginkgo.By("delete the workload while the topology is deleted", func() {

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -1075,6 +1075,68 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					))
 				})
 			})
+
+			ginkgo.It("should not leak TAS domains if a workload is deleted while the topology is uninitialized (#12545)", func() {
+				var wl1, wl2 *kueue.Workload
+				ginkgo.By("creating a workload which requires block and can fit", func() {
+					wl1 = utiltestingapi.MakeWorkload("wl1", ns.Name).
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "4").Obj()
+					wl1.Spec.PodSets[0].Count = 1
+					wl1.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
+						Required: ptr.To(utiltesting.DefaultBlockTopologyLevel),
+					}
+					util.MustCreate(ctx, k8sClient, wl1)
+				})
+
+				ginkgo.By("verify the workload is admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
+				})
+
+				ginkgo.By("delete the topology so that it becomes uninitialized", func() {
+					gomega.Expect(k8sClient.Delete(ctx, topology)).Should(gomega.Succeed())
+					// Remove the finalizer to force deletion
+					gomega.Eventually(func(g gomega.Gomega) {
+						err := k8sClient.Get(ctx, client.ObjectKeyFromObject(topology), topology)
+						if err != nil {
+							g.Expect(client.IgnoreNotFound(err)).Should(gomega.Succeed())
+							return
+						}
+						topology.Finalizers = nil
+						g.Expect(client.IgnoreNotFound(k8sClient.Update(ctx, topology))).Should(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+				})
+
+				ginkgo.By("delete the workload while the topology is deleted", func() {
+					gomega.Expect(k8sClient.Delete(ctx, wl1)).Should(gomega.Succeed())
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, wl1, true)
+				})
+
+				ginkgo.By("re-create the topology so that the queue becomes active again", func() {
+					topology = utiltestingapi.MakeDefaultTwoLevelTopology("default")
+					util.MustCreate(ctx, k8sClient, topology)
+				})
+
+				ginkgo.By("creating the second workload to verify the domain usage was not leaked", func() {
+					// Wait for the ClusterQueue to become active again
+					util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
+
+					// Request the capacity that was freed by wl1.
+					wl2 = utiltestingapi.MakeWorkload("wl2", ns.Name).
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "4").Obj()
+					wl2.Spec.PodSets[0].Count = 1
+					wl2.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
+						Required: ptr.To(utiltesting.DefaultBlockTopologyLevel),
+					}
+					util.MustCreate(ctx, k8sClient, wl2)
+				})
+
+				ginkgo.By("verify the second workload is admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 2)
+				})
+			})
 		})
 
 		ginkgo.When("Nodes are created before test with the hostname being the lowest level", func() {

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -1080,11 +1080,12 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				var wl1, wl2 *kueue.Workload
 				ginkgo.By("creating a workload which requires block and can fit", func() {
 					wl1 = utiltestingapi.MakeWorkload("wl1", ns.Name).
-						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "4").Obj()
-					wl1.Spec.PodSets[0].Count = 1
-					wl1.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
-						Required: ptr.To(utiltesting.DefaultBlockTopologyLevel),
-					}
+						Queue(kueue.LocalQueueName(localQueue.Name)).
+						PodSets(*utiltestingapi.MakePodSet("main", 1).
+							Request(corev1.ResourceCPU, "4").
+							RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+							Obj()).
+						Obj()
 					util.MustCreate(ctx, k8sClient, wl1)
 				})
 
@@ -1093,17 +1094,27 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
 				})
 
+				ginkgo.By("wait for the finalizer to be added to the topology", func() {
+					var updatedTopology kueue.Topology
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(topology), &updatedTopology)).To(gomega.Succeed())
+						g.Expect(updatedTopology.Finalizers).Should(gomega.Equal([]string{kueue.ResourceInUseFinalizerName}))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
 				ginkgo.By("delete the topology so that it becomes uninitialized", func() {
 					gomega.Expect(k8sClient.Delete(ctx, topology)).Should(gomega.Succeed())
-					// Remove the finalizer to force deletion
+				})
+
+				ginkgo.By("remove topology finalizer to force deletion", func() {
+					var updatedTopology kueue.Topology
 					gomega.Eventually(func(g gomega.Gomega) {
-						err := k8sClient.Get(ctx, client.ObjectKeyFromObject(topology), topology)
-						if err != nil {
-							g.Expect(client.IgnoreNotFound(err)).Should(gomega.Succeed())
+						g.Expect(client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(topology), &updatedTopology))).To(gomega.Succeed())
+						if len(updatedTopology.Finalizers) == 0 {
 							return
 						}
-						topology.Finalizers = nil
-						g.Expect(client.IgnoreNotFound(k8sClient.Update(ctx, topology))).Should(gomega.Succeed())
+						updatedTopology.Finalizers = nil
+						g.Expect(client.IgnoreNotFound(k8sClient.Update(ctx, &updatedTopology))).Should(gomega.Succeed())
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 					util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
 				})
@@ -1124,11 +1135,12 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 					// Request the capacity that was freed by wl1.
 					wl2 = utiltestingapi.MakeWorkload("wl2", ns.Name).
-						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "4").Obj()
-					wl2.Spec.PodSets[0].Count = 1
-					wl2.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
-						Required: ptr.To(utiltesting.DefaultBlockTopologyLevel),
-					}
+						Queue(kueue.LocalQueueName(localQueue.Name)).
+						PodSets(*utiltestingapi.MakePodSet("main", 1).
+							Request(corev1.ResourceCPU, "4").
+							RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+							Obj()).
+						Obj()
 					util.MustCreate(ctx, k8sClient, wl2)
 				})
 

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -1080,11 +1080,9 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				var wl1, wl2 *kueue.Workload
 				ginkgo.By("creating a workload which requires block and can fit", func() {
 					wl1 = utiltestingapi.MakeWorkload("wl1", ns.Name).
-						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "4").Obj()
-					wl1.Spec.PodSets[0].Count = 1
-					wl1.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
-						Required: ptr.To(utiltesting.DefaultBlockTopologyLevel),
-					}
+						Queue(kueue.LocalQueueName(localQueue.Name)).PodSets(*utiltestingapi.MakePodSet("worker", 2).
+						RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+						Obj()).Request(corev1.ResourceCPU, "1").Obj()
 					util.MustCreate(ctx, k8sClient, wl1)
 				})
 


### PR DESCRIPTION
# Description
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

Fixes a permanent resource leak in the scheduler's TAS cache. When a ClusterQueue relies on multiple TAS flavors, a temporary failure or misconfiguration (e.g., a deleted Topology) causes `isTASInitialized()` to evaluate to false. Previously, this caused an early return in `updateWorkloadTASUsage`, meaning completing or deleted workloads leaked their TAS resource usage globally. 

This PR removes the `!c.isTASInitialized()` early return in `updateWorkloadTASUsage`. Now, it unconditionally iterates over the workload's TAS usage and applies `addUsage` / `removeUsage` for any flavor that currently exists in the cache, safely ignoring missing flavors and allowing proper cleanup of resources during workload deletion.

#### Which issue(s) this PR fixes:

Fixes #12545

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
TAS: Fixed a bug that permanently leaked Topology-Aware Scheduling (TAS) resources if a workload was deleted while its ClusterQueue was temporarily missing a required Topology.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TAS usage accounting to update immediately, rather than waiting for TAS initialization.
  * TAS flavor usage updates now correctly self-heal when the same workload is re-added, and safely handle missing entries during add/remove to keep accounting accurate.

* **Tests**
  * Added an integration test to ensure TAS domains are not leaked when a workload is deleted while a topology is uninitialized, and that admission recovers correctly afterward.
  * Added a unit test covering TAS flavor usage aggregation and add/remove behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->