### PR TITLE
kueueviz: fix CSWSH by removing permissive CheckOrigin

### DIFF
--- a/cmd/kueueviz/backend/handlers/websocket_handler.go
+++ b/cmd/kueueviz/backend/handlers/websocket_handler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"net/http"
 	"time"
 
 	"github.com/bep/debounce"
@@ -33,6 +34,9 @@ import (
 // WebSocket upgrader
 var upgrader = websocket.Upgrader{
 	Subprotocols: []string{middleware.WebSocketBaseProtocol},
+	CheckOrigin: func(r *http.Request) bool {
+		return middleware.ValidateWebSocketOrigin(r.Header.Get("Origin"), r.Host)
+	},
 }
 
 // GenericWebSocketHandler creates a WebSocket endpoint with informer-based real-time updates

--- a/cmd/kueueviz/backend/handlers/websocket_handler.go
+++ b/cmd/kueueviz/backend/handlers/websocket_handler.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
-	"net/http"
 	"time"
 
 	"github.com/bep/debounce"
@@ -33,9 +32,6 @@ import (
 
 // WebSocket upgrader
 var upgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool {
-		return true
-	},
 	Subprotocols: []string{middleware.WebSocketBaseProtocol},
 }
 

--- a/cmd/kueueviz/backend/middleware/cors.go
+++ b/cmd/kueueviz/backend/middleware/cors.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/viper"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // validateOrigin validates and sanitizes a CORS origin URL
@@ -117,35 +118,46 @@ func SetupCORS() (gin.HandlerFunc, error) {
 
 // ValidateWebSocketOrigin validates if the given WebSocket origin is allowed
 func ValidateWebSocketOrigin(origin, host string) bool {
+	log := ctrllog.Log.WithName("cors")
+
 	if origin == "" {
+		log.V(4).Info("WebSocket origin allowed", "reason", "no origin header provided")
 		return true // No origin header, typically allowed
 	}
 
 	// Fast path for same-host (default gorilla/websocket behavior)
 	u, err := url.Parse(origin)
-	if err == nil {
-		if strings.EqualFold(u.Host, host) {
-			return true
-		}
+	if err != nil {
+		log.V(2).Info("WebSocket origin rejected", "origin", origin, "reason", "unparseable origin URL", "error", err)
+		return false
+	}
 
-		// In development mode, allow cross-port localhost connections (e.g. for E2E testing)
-		if gin.Mode() != gin.ReleaseMode && (u.Hostname() == "localhost" || u.Hostname() == "127.0.0.1") {
-			return true
-		}
+	if strings.EqualFold(u.Host, host) {
+		log.V(4).Info("WebSocket origin allowed", "origin", origin, "host", host, "reason", "same host")
+		return true
+	}
+
+	// In development mode, allow cross-port localhost connections (e.g. for E2E testing)
+	if gin.Mode() != gin.ReleaseMode && (u.Hostname() == "localhost" || u.Hostname() == "127.0.0.1") {
+		log.V(4).Info("WebSocket origin allowed", "origin", origin, "reason", "localhost in development mode")
+		return true
 	}
 
 	config, err := ConfigureCORS()
 	if err != nil {
+		log.V(2).Error(err, "WebSocket origin validation failed", "reason", "could not load CORS config")
 		return false
 	}
 
 	canonicalOrigin := canonicalizeOrigin(origin)
 	for _, allowed := range config.AllowOrigins {
 		if canonicalizeOrigin(allowed) == canonicalOrigin {
+			log.V(4).Info("WebSocket origin allowed", "origin", origin, "reason", "matches allowed CORS origins", "allowed", allowed)
 			return true
 		}
 	}
 
+	log.V(2).Info("WebSocket origin rejected", "origin", origin, "host", host, "reason", "does not match allowed CORS origins")
 	return false
 }
 

--- a/cmd/kueueviz/backend/middleware/cors.go
+++ b/cmd/kueueviz/backend/middleware/cors.go
@@ -127,7 +127,7 @@ func ValidateWebSocketOrigin(origin, host string) bool {
 		if strings.EqualFold(u.Host, host) {
 			return true
 		}
-		
+
 		// In development mode, allow cross-port localhost connections (e.g. for E2E testing)
 		if gin.Mode() != gin.ReleaseMode && (u.Hostname() == "localhost" || u.Hostname() == "127.0.0.1") {
 			return true
@@ -139,11 +139,33 @@ func ValidateWebSocketOrigin(origin, host string) bool {
 		return false
 	}
 
+	canonicalOrigin := canonicalizeOrigin(origin)
 	for _, allowed := range config.AllowOrigins {
-		if allowed == origin {
+		if canonicalizeOrigin(allowed) == canonicalOrigin {
 			return true
 		}
 	}
 
 	return false
+}
+
+func canonicalizeOrigin(o string) string {
+	u, err := url.Parse(o)
+	if err != nil {
+		return o
+	}
+
+	scheme := strings.ToLower(u.Scheme)
+	host := strings.ToLower(u.Hostname())
+	port := u.Port()
+
+	if (scheme == "http" && port == "80") || (scheme == "https" && port == "443") {
+		port = ""
+	}
+
+	if port != "" {
+		host = host + ":" + port
+	}
+
+	return fmt.Sprintf("%s://%s", scheme, host)
 }

--- a/cmd/kueueviz/backend/middleware/cors.go
+++ b/cmd/kueueviz/backend/middleware/cors.go
@@ -114,3 +114,29 @@ func SetupCORS() (gin.HandlerFunc, error) {
 	}
 	return cors.New(config), nil
 }
+
+// ValidateWebSocketOrigin validates if the given WebSocket origin is allowed
+func ValidateWebSocketOrigin(origin, host string) bool {
+	if origin == "" {
+		return true // No origin header, typically allowed
+	}
+
+	// Fast path for same-host (default gorilla/websocket behavior)
+	u, err := url.Parse(origin)
+	if err == nil && strings.EqualFold(u.Host, host) {
+		return true
+	}
+
+	config, err := ConfigureCORS()
+	if err != nil {
+		return false
+	}
+
+	for _, allowed := range config.AllowOrigins {
+		if allowed == "*" || allowed == origin {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cmd/kueueviz/backend/middleware/cors.go
+++ b/cmd/kueueviz/backend/middleware/cors.go
@@ -123,8 +123,15 @@ func ValidateWebSocketOrigin(origin, host string) bool {
 
 	// Fast path for same-host (default gorilla/websocket behavior)
 	u, err := url.Parse(origin)
-	if err == nil && strings.EqualFold(u.Host, host) {
-		return true
+	if err == nil {
+		if strings.EqualFold(u.Host, host) {
+			return true
+		}
+		
+		// In development mode, allow cross-port localhost connections (e.g. for E2E testing)
+		if gin.Mode() != gin.ReleaseMode && (u.Hostname() == "localhost" || u.Hostname() == "127.0.0.1") {
+			return true
+		}
 	}
 
 	config, err := ConfigureCORS()
@@ -133,7 +140,7 @@ func ValidateWebSocketOrigin(origin, host string) bool {
 	}
 
 	for _, allowed := range config.AllowOrigins {
-		if allowed == "*" || allowed == origin {
+		if allowed == origin {
 			return true
 		}
 	}

--- a/cmd/kueueviz/backend/middleware/cors_test.go
+++ b/cmd/kueueviz/backend/middleware/cors_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package middleware
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spf13/viper"
+)
+
+func TestValidateWebSocketOrigin(t *testing.T) {
+	// Save and restore gin mode
+	originalMode := gin.Mode()
+	t.Cleanup(func() {
+		gin.SetMode(originalMode)
+	})
+
+	tests := []struct {
+		name           string
+		origin         string
+		host           string
+		allowedOrigins string
+		ginMode        string
+		expected       bool
+	}{
+		{
+			name:     "empty origin is allowed",
+			origin:   "",
+			host:     "example.com",
+			expected: true,
+		},
+		{
+			name:     "same host is allowed",
+			origin:   "http://example.com:8080",
+			host:     "example.com:8080",
+			expected: true,
+		},
+		{
+			name:     "different host is denied",
+			origin:   "http://malicious.com",
+			host:     "example.com",
+			expected: false,
+		},
+		{
+			name:     "localhost cross-port in dev mode is allowed",
+			origin:   "http://localhost:3000",
+			host:     "localhost:8080",
+			ginMode:  gin.DebugMode,
+			expected: true,
+		},
+		{
+			name:     "localhost cross-port in release mode is denied without config",
+			origin:   "http://localhost:3000",
+			host:     "localhost:8080",
+			ginMode:  gin.ReleaseMode,
+			expected: false,
+		},
+		{
+			name:           "localhost cross-port in release mode is allowed with config",
+			origin:         "http://localhost:3000",
+			host:           "localhost:8080",
+			allowedOrigins: "http://localhost:3000",
+			ginMode:        gin.ReleaseMode,
+			expected:       true,
+		},
+		{
+			name:           "allowed origin from config is allowed",
+			origin:         "https://allowed.com",
+			host:           "example.com",
+			allowedOrigins: "https://allowed.com",
+			expected:       true,
+		},
+		{
+			name:           "unlisted origin with config is denied",
+			origin:         "https://not-allowed.com",
+			host:           "example.com",
+			allowedOrigins: "https://allowed.com",
+			expected:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.ginMode != "" {
+				gin.SetMode(tt.ginMode)
+			} else {
+				gin.SetMode(gin.DebugMode)
+			}
+
+			if tt.allowedOrigins != "" {
+				viper.Set("KUEUEVIZ_ALLOWED_ORIGINS", tt.allowedOrigins)
+			} else {
+				viper.Set("KUEUEVIZ_ALLOWED_ORIGINS", "")
+			}
+
+			result := ValidateWebSocketOrigin(tt.origin, tt.host)
+			if result != tt.expected {
+				t.Errorf("ValidateWebSocketOrigin() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCanonicalizeOrigin(t *testing.T) {
+	tests := []struct {
+		name     string
+		origin   string
+		expected string
+	}{
+		{
+			name:     "http with port 80",
+			origin:   "http://example.com:80",
+			expected: "http://example.com",
+		},
+		{
+			name:     "https with port 443",
+			origin:   "https://example.com:443",
+			expected: "https://example.com",
+		},
+		{
+			name:     "custom port",
+			origin:   "http://example.com:8080",
+			expected: "http://example.com:8080",
+		},
+		{
+			name:     "mixed case",
+			origin:   "HTTP://ExAmPle.COM:80",
+			expected: "http://example.com",
+		},
+		{
+			name:     "invalid url fallback",
+			origin:   "://invalid",
+			expected: "://invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := canonicalizeOrigin(tt.origin)
+			if result != tt.expected {
+				t.Errorf("canonicalizeOrigin() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description
#### What type of PR is this?

/kind bug
/area dashboard

#### What this PR does / why we need it:

Fixes a Cross-Site WebSocket Hijacking (CSWSH) vulnerability in the KueueViz Backend where the WebSocket handler allowed connections from any origin. Previously, the `CheckOrigin` function unconditionally returned `true`, which completely bypassed CORS validation for WebSockets and could allow an attacker to silently extract sensitive real-time Kubernetes cluster metadata if a victim visited a malicious external website while running KueueViz.

This PR removes the permissive `CheckOrigin` override in `GenericWebSocketHandler`. By removing this custom function, `gorilla/websocket` automatically falls back to its default secure validation behavior, which strictly compares the `Origin` header against the `Host` header to ensure they match, securing the real-time WebSocket endpoints against CSWSH attacks. 

#### Which issue(s) this PR fixes:

Fixes #12531

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
KueueViz: Fixed a Cross-Site WebSocket Hijacking (CSWSH) vulnerability in the KueueViz Backend by strictly validating WebSocket Origin headers to prevent unauthorized cross-origin data extraction.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket connections now validate the request origin before allowing a connection, improving protection against unauthorized cross-site access.
  * Local development access remains supported for localhost and 127.0.0.1, while matching allowed origins continues to work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->