### PR TITLE
Fix data race on stickyWorkload between Snapshot and RequeueIfNotPresent

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -22,6 +22,7 @@ import (
 	"maps"
 	"slices"
 	"sync"
+	"sync/atomic"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -80,29 +81,24 @@ var (
 // The workloadName field is accessed concurrently: Snapshot sorts a copy of
 // the pending workloads (via baseCompareFunc -> matches) without holding the
 // ClusterQueue's rwm lock, while RequeueIfNotPresent sets it during preemption.
-// It carries its own mutex so every read and write of the field is
-// synchronized regardless of the caller's locking.
+// It is a single field with only whole-value read/store/clear, so an
+// atomic.Pointer synchronizes every access regardless of the caller's locking
+// (nil means no sticky workload).
 type stickyWorkload struct {
-	mu           sync.RWMutex
-	workloadName workload.Reference
+	workloadName atomic.Pointer[workload.Reference]
 }
 
 func (s *stickyWorkload) matches(workload workload.Reference) bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.workloadName == workload
+	name := s.workloadName.Load()
+	return name != nil && *name == workload
 }
 
 func (s *stickyWorkload) clear() {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.workloadName = ""
+	s.workloadName.Store(nil)
 }
 
 func (s *stickyWorkload) set(workload workload.Reference) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.workloadName = workload
+	s.workloadName.Store(&workload)
 }
 
 func logStickyWorkloadSelectionIfVerbose(log logr.Logger, wl *kueue.Workload) {

--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -76,19 +76,32 @@ var (
 // workloads from going back to the head of the queue.  A workload is
 // considered sticky until it is admitted, unschedulable, or deleted.
 // See Kueue#6929 and Kueue#7101 for motivation.
+//
+// The workloadName field is accessed concurrently: Snapshot sorts a copy of
+// the pending workloads (via baseCompareFunc -> matches) without holding the
+// ClusterQueue's rwm lock, while RequeueIfNotPresent sets it during preemption.
+// It carries its own mutex so every read and write of the field is
+// synchronized regardless of the caller's locking.
 type stickyWorkload struct {
+	mu           sync.RWMutex
 	workloadName workload.Reference
 }
 
 func (s *stickyWorkload) matches(workload workload.Reference) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.workloadName == workload
 }
 
 func (s *stickyWorkload) clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.workloadName = ""
 }
 
 func (s *stickyWorkload) set(workload workload.Reference) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.workloadName = workload
 }
 

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -478,6 +478,58 @@ func TestSnapshotStableWithConcurrentFSUpdates(t *testing.T) {
 	}
 }
 
+// TestSnapshotConcurrentWithRequeueNoDataRace guards against a data race on the
+// sticky workload: Snapshot sorts a copy of the pending workloads through the
+// comparator (which reads stickyWorkload.workloadName) without holding the
+// ClusterQueue lock, while RequeueIfNotPresent writes that field during a
+// BestEffortFIFO preemption requeue. Run with -race to detect regressions.
+func TestSnapshotConcurrentWithRequeueNoDataRace(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	cq, err := newClusterQueue(ctx, nil,
+		&kueue.ClusterQueue{
+			Spec: kueue.ClusterQueueSpec{
+				QueueingStrategy: kueue.BestEffortFIFO,
+			},
+		},
+		defaultOrdering,
+		nil, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create ClusterQueue: %v", err)
+	}
+
+	// At least two workloads so Snapshot's sort actually invokes the
+	// comparator that reads the sticky workload.
+	wls := []*kueue.Workload{
+		utiltestingapi.MakeWorkload("wl1", defaultNamespace).Obj(),
+		utiltestingapi.MakeWorkload("wl2", defaultNamespace).Obj(),
+		utiltestingapi.MakeWorkload("wl3", defaultNamespace).Obj(),
+	}
+	for _, wl := range wls {
+		cq.PushOrUpdate(workload.NewInfo(wl))
+	}
+
+	// Writer: continuously set the sticky workload via a preemption requeue.
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				for _, wl := range wls {
+					cq.RequeueIfNotPresent(ctx, workload.NewInfo(wl), RequeueReasonPendingPreemption)
+				}
+			}
+		}
+	}()
+	defer close(stop)
+
+	// Reader: Snapshot reads the sticky workload through the comparator.
+	for range 1000 {
+		cq.Snapshot()
+	}
+}
+
 func TestPendingResources(t *testing.T) {
 	ctx, log := utiltesting.ContextWithLog(t)
 	now := time.Now()


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`stickyWorkload.workloadName` is read by `ClusterQueue.Snapshot()` through the sort comparator (`baseCompareFunc` -> `matches`) without holding the ClusterQueue's `rwm` lock, while `RequeueIfNotPresent()` writes it via `set()` during a BestEffortFIFO preemption requeue. The read path (Visibility API `PendingWorkloadsInfo` -> `Snapshot`) and the write path run in different lock domains, so access to the field is unsynchronized. That is a data race on a multi-word string, confirmed by `go test -race`.

This makes `stickyWorkload` self-synchronizing: the struct holds `workloadName` as an `atomic.Pointer[workload.Reference]`, and `matches` / `set` / `clear` do a single atomic load/store for every read and write (`nil` means no sticky workload). All access already funnels through those three methods, so the invariant is enforced by the type rather than by caller locking. Each access is a lock-free atomic op, so there is no added lock and lock ordering is unchanged.

I kept the fix on the field's own type instead of holding `rwm.RLock()` across `Snapshot`'s sort. That sort's fair-sharing path calls `client.Get` per LocalQueue, and `totalElements()` already takes and releases `rwm.RLock` internally, so widening the lock would hold it across I/O and nest read locks.

#### Which issue(s) this PR fixes:
Fixes #12532

#### Special notes for your reviewer:
Added `TestSnapshotConcurrentWithRequeueNoDataRace`, which runs `Snapshot()` concurrently with preemption requeues. It fails under `-race` without the fix (race at `set` / `matches`) and passes with it. `go test -race ./pkg/cache/queue/...` is green.

#### Does this PR introduce a user-facing change?
```release-note
VisibilityOnDemand: Fixed a data race between the Visibility API pending-workloads endpoint and preemption requeuing that could crash the queue manager for BestEffortFIFO ClusterQueues.
```

---

🤖 AI assistance disclosure (per the [Kubernetes AI Tool Usage Policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance)): this change was developed with AI assistance (Claude Code, Opus 4.8). The race was reproduced with `go test -race`, and I reviewed and validated the fix and the test locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrency behavior when taking queue snapshots while workloads are being requeued, reducing the likelihood of race-related issues.
  * Made sticky workload tracking safer under concurrent access.

* **Tests**
  * Added a concurrency test that repeatedly snapshots the queue while simultaneously requeueing workloads, aimed at catching potential data races (including under race detection).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
