### PR TITLE
Add securityContext and probes to KueueViz deployments

### DIFF
--- a/charts/kueue/templates/kueueviz/backend-deployment.yaml
+++ b/charts/kueue/templates/kueueviz/backend-deployment.yaml
@@ -77,4 +77,16 @@ spec:
           {{- end }}
           ports:
             - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
 {{- end }}

--- a/charts/kueue/templates/kueueviz/frontend-deployment.yaml
+++ b/charts/kueue/templates/kueueviz/frontend-deployment.yaml
@@ -73,6 +73,18 @@ spec:
           {{- end }}
           ports:
             - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
           volumeMounts:
             - name: env-config
               mountPath: /app/build/env.js

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -310,9 +310,17 @@ kueueViz:
         cpu: 500m
         memory: 512Mi
     # -- KueueViz frontend pod securityContext
-    podSecurityContext: {}
+    podSecurityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
     # -- KueueViz frontend container securityContext
-    containerSecurityContext: {}
+    containerSecurityContext:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
     # -- Environment variables for KueueViz frontend deployment
     env: []
     ingress:

--- a/config/components/kueueviz/backend-deployment.yaml
+++ b/config/components/kueueviz/backend-deployment.yaml
@@ -14,12 +14,34 @@ spec:
       labels:
         app: kueueviz-backend
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: backend
           image: backend:lastest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
           resources:
             limits:
               cpu: 500m

--- a/config/components/kueueviz/frontend-deployment.yaml
+++ b/config/components/kueueviz/frontend-deployment.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         app: kueueviz-frontend
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
         - name: env-config
           configMap:
@@ -24,6 +28,24 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
           resources:
             limits:
               cpu: 500m


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area dashboard

#### What this PR does / why we need it:

Fills in the KueueViz frontend Helm securityContext defaults to match the already hardened backend (runAsNonRoot, RuntimeDefault seccomp, readOnlyRootFilesystem, allowPrivilegeEscalation false, drop ALL), mirrors the same settings into the kustomize bases for both frontend and backend, and adds httpGet liveness/readiness probes on port 8080 for both workloads (chart templates and kustomize).

`helm lint` and `helm template` pass with the changes.

#### Which issue(s) this PR fixes:

Fixes #12481

#### Special notes for your reviewer:

Two things worth a check: the probes use `/` as the path since I did not find a dedicated health endpoint for either workload, and readOnlyRootFilesystem on the node based frontend should be confirmed against e2e in case the server writes temp files at startup.

This PR was written in part with the assistance of generative AI; I reviewed and verified the changes.

#### Does this PR introduce a user-facing change?

```release-note
KueueViz deployments now set securityContext (runAsNonRoot, readOnlyRootFilesystem, dropped capabilities) and liveness/readiness probes by default.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health checks for the KueueViz frontend and backend to improve service reliability and quicker detection of unhealthy pods.
* **Security**
  * Hardened KueueViz container settings by running as non-root, using default seccomp protections, restricting filesystem write access, disabling privilege escalation, and dropping unnecessary Linux capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->