### PR TITLE
Automated cherry pick of #12715: Reject negative and huge number of replicas in LeaderWorkerSet, add ...

### DIFF
--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_controller.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_controller.go
@@ -18,6 +18,8 @@ package leaderworkerset
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -36,7 +38,15 @@ var (
 
 const (
 	FrameworkName = "leaderworkerset.x-k8s.io/leaderworkerset"
+	// defaultLeaderWorkerSetReplicas mirrors the LeaderWorkerSet API default for
+	// spec.replicas (+kubebuilder:default=1), and is used when the field is unset.
+	defaultLeaderWorkerSetReplicas = 1
+	// maxLeaderWorkerSetReplicas is a sanity upper bound on spec.replicas that guards
+	// against unbounded per-replica Workload creation from an unreasonably large value.
+	maxLeaderWorkerSetReplicas = 1_000_000
 )
+
+var errInvalidLeaderWorkerSetReplicas = errors.New("invalid LeaderWorkerSet replicas")
 
 func init() {
 	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
@@ -66,6 +76,16 @@ func (lws *LeaderWorkerSet) GVK() schema.GroupVersionKind {
 }
 
 func SetupIndexes(context.Context, client.FieldIndexer) error {
+	return nil
+}
+
+func validateLeaderWorkerSetReplicaCount(replicas int32) error {
+	if replicas < 0 {
+		return fmt.Errorf("%w: must be >= 0, got %d", errInvalidLeaderWorkerSetReplicas, replicas)
+	}
+	if replicas > maxLeaderWorkerSetReplicas {
+		return fmt.Errorf("%w: must be <= %d, got %d", errInvalidLeaderWorkerSetReplicas, maxLeaderWorkerSetReplicas, replicas)
+	}
 	return nil
 }
 

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_multikueue_adapter.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_multikueue_adapter.go
@@ -111,7 +111,10 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 		return nil, fmt.Errorf("no origin UID annotation found for leaderworkerset: %s", klog.KObj(lws))
 	}
 
-	replicas := ptr.Deref(lws.Spec.Replicas, 1)
+	replicas := ptr.Deref(lws.Spec.Replicas, defaultLeaderWorkerSetReplicas)
+	if err := validateLeaderWorkerSetReplicaCount(replicas); err != nil {
+		return nil, err
+	}
 	keys := make([]types.NamespacedName, replicas)
 	for i := range replicas {
 		keys[i] = types.NamespacedName{
@@ -127,7 +130,11 @@ func (*multiKueueAdapter) GetExpectedWorkloadCount(ctx context.Context, c client
 	if err := c.Get(ctx, key, lws); err != nil {
 		return 0, err
 	}
-	return int(ptr.Deref(lws.Spec.Replicas, 1)), nil
+	replicas := ptr.Deref(lws.Spec.Replicas, defaultLeaderWorkerSetReplicas)
+	if err := validateLeaderWorkerSetReplicaCount(replicas); err != nil {
+		return 0, err
+	}
+	return int(replicas), nil
 }
 
 func (*multiKueueAdapter) GetWorkloadIndex(wl *kueue.Workload) int {

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_multikueue_adapter_test.go
@@ -172,6 +172,52 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).Obj(),
 			},
 		},
+		"GetExpectedWorkloadCount rejects negative replicas": {
+			managersLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
+				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).Replicas(-1).Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.GetExpectedWorkloadCount(ctx, managerClient, types.NamespacedName{Name: "lws1", Namespace: TestNamespace})
+				return err
+			},
+			wantError: errInvalidLeaderWorkerSetReplicas,
+			wantManagersLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
+				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).Replicas(-1).Obj(),
+			},
+		},
+		"GetExpectedWorkloadCount rejects replicas above maximum": {
+			managersLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
+				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).Replicas(maxLeaderWorkerSetReplicas + 1).Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.GetExpectedWorkloadCount(ctx, managerClient, types.NamespacedName{Name: "lws1", Namespace: TestNamespace})
+				return err
+			},
+			wantError: errInvalidLeaderWorkerSetReplicas,
+			wantManagersLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
+				*utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).Replicas(maxLeaderWorkerSetReplicas + 1).Obj(),
+			},
+		},
+		"WorkloadKeysFor rejects negative replicas": {
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.WorkloadKeysFor(utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).
+					Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-uid-123").
+					Replicas(-1).
+					Obj())
+				return err
+			},
+			wantError: errInvalidLeaderWorkerSetReplicas,
+		},
+		"WorkloadKeysFor rejects replicas above maximum": {
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.WorkloadKeysFor(utiltestingleaderworkerset.MakeLeaderWorkerSet("lws1", TestNamespace).
+					Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-uid-123").
+					Replicas(maxLeaderWorkerSetReplicas + 1).
+					Obj())
+				return err
+			},
+			wantError: errInvalidLeaderWorkerSetReplicas,
+		},
 		"sync creates missing remote leaderworkerset, WorkloadIdentifierAnnotations enabled": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
 			managersLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -255,7 +255,7 @@ func (r *Reconciler) filterWorkloads(lws *leaderworkersetv1.LeaderWorkerSet, exi
 		toDelete = utilslices.ToRefMap(existingWorkloads, func(e *kueue.Workload) string {
 			return e.Name
 		})
-		replicas = ptr.Deref(lws.Spec.Replicas, 1)
+		replicas = ptr.Deref(lws.Spec.Replicas, defaultLeaderWorkerSetReplicas)
 	)
 
 	// During normal scale-down, status.Replicas lags behind spec.Replicas,
@@ -285,7 +285,7 @@ func isRollingUpdateWithSurge(lws *leaderworkersetv1.LeaderWorkerSet) bool {
 		return false
 	}
 	maxSurge := int32(lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge.IntValue())
-	return maxSurge > 0 && lws.Status.UpdatedReplicas < ptr.Deref(lws.Spec.Replicas, 1)
+	return maxSurge > 0 && lws.Status.UpdatedReplicas < ptr.Deref(lws.Spec.Replicas, defaultLeaderWorkerSetReplicas)
 }
 
 func (r *Reconciler) createWorkload(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, workloadName string, index int) error {

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -124,6 +125,7 @@ var (
 	labelsPath                    = field.NewPath("metadata", "labels")
 	queueNameLabelPath            = labelsPath.Key(constants.QueueLabel)
 	specPath                      = field.NewPath("spec")
+	replicasPath                  = specPath.Child("replicas")
 	leaderWorkerTemplatePath      = specPath.Child("leaderWorkerTemplate")
 	leaderTemplatePath            = leaderWorkerTemplatePath.Child("leaderTemplate")
 	leaderTemplateMetaPath        = leaderTemplatePath.Child("metadata")
@@ -212,6 +214,7 @@ func GetWorkloadName(uid types.UID, name string, groupIndex string) string {
 func validateCreate(lws *LeaderWorkerSet) (field.ErrorList, error) {
 	var allErrs field.ErrorList
 	allErrs = append(allErrs, jobframework.ValidateQueueName(lws.Object())...)
+	allErrs = append(allErrs, validateReplicasField(lws)...)
 
 	if features.Enabled(features.AdmissionGatedBy) {
 		allErrs = append(allErrs, webhook.ValidateAdmissionGatedByAnnotationOnCreate(lws.Object())...)
@@ -225,6 +228,14 @@ func validateCreate(lws *LeaderWorkerSet) (field.ErrorList, error) {
 		allErrs = append(allErrs, validationErrs...)
 	}
 	return allErrs, nil
+}
+
+func validateReplicasField(lws *LeaderWorkerSet) field.ErrorList {
+	replicas := ptr.Deref(lws.Spec.Replicas, defaultLeaderWorkerSetReplicas)
+	if err := validateLeaderWorkerSetReplicaCount(replicas); err != nil {
+		return field.ErrorList{field.Invalid(replicasPath, replicas, err.Error())}
+	}
+	return nil
 }
 
 func validateTopologyRequest(lws *LeaderWorkerSet) (field.ErrorList, error) {

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
@@ -196,6 +196,32 @@ func TestValidateCreate(t *testing.T) {
 				Queue("test-queue").
 				Obj(),
 		},
+		"negative replicas": {
+			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				Replicas(-1).
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: replicasPath.String(),
+				},
+			}.ToAggregate(),
+		},
+		"replicas above maximum": {
+			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				Replicas(maxLeaderWorkerSetReplicas + 1).
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: replicasPath.String(),
+				},
+			}.ToAggregate(),
+		},
 		"invalid queue name": {
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				LeaderTemplate(corev1.PodTemplateSpec{}).
@@ -846,6 +872,40 @@ func TestValidateUpdate(t *testing.T) {
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
 					Field: queueNameLabelPath.String(),
+				},
+			}.ToAggregate(),
+		},
+		"set invalid replicas": {
+			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				Obj(),
+			newObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				Replicas(-1).
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: replicasPath.String(),
+				},
+			}.ToAggregate(),
+		},
+		"set replicas above maximum": {
+			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				Obj(),
+			newObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				Replicas(maxLeaderWorkerSetReplicas + 1).
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: replicasPath.String(),
 				},
 			}.ToAggregate(),
 		},


### PR DESCRIPTION
Cherry pick of #12715 on release-0.17.

#12715: Reject negative and huge number of replicas in LeaderWorkerSet, add ...

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug
/kind cleanup


```release-note
LeaderWorkerSet: Fixed a bug where a LeaderWorkerSet with a negative or excessively large `spec.replicas` could crash the Kueue controller during reconciliation and MultiKueue workload processing. Kueue now rejects `spec.replicas` values that are negative or greater than 1000000
```