### PR TITLE
Automated cherry pick of #12045: fix: cap elastic job ungating to granted quota

### DIFF
--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -20,8 +20,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -75,12 +79,24 @@ func SetupWithManager(mgr ctrl.Manager, cfg *configapi.Configuration, roleTracke
 	podHandler := elasticPodHandler{
 		expectationsStore: r.expectationsStore,
 	}
+	// Reconcile by the stable slice-chain key rather than by an individual
+	// workload, so every slice in a chain (and every pod that names any slice in
+	// it) maps to a single reconcile request. Reconcile then resolves the active
+	// slice from that key.
+	sliceKeyHandler := handler.TypedEnqueueRequestsFromMapFunc(
+		func(_ context.Context, wl *kueue.Workload) []reconcile.Request {
+			return []reconcile.Request{{NamespacedName: types.NamespacedName{
+				Namespace: wl.Namespace,
+				Name:      workloadslicing.SliceName(wl),
+			}}}
+		},
+	)
 	return ControllerName, builder.TypedControllerManagedBy[reconcile.Request](mgr).
 		Named("elastic_job_ungater").
 		WatchesRawSource(source.TypedKind(
 			mgr.GetCache(),
 			&kueue.Workload{},
-			&handler.TypedEnqueueRequestForObject[*kueue.Workload]{},
+			sliceKeyHandler,
 			r,
 		)).
 		Watches(&corev1.Pod{}, &podHandler).
@@ -96,27 +112,34 @@ func (r *elasticJobUngater) Reconcile(ctx context.Context, req reconcile.Request
 	log := ctrl.LoggerFrom(ctx)
 	log.V(2).Info("Reconcile ElasticJobUngater")
 
-	wl := &kueue.Workload{}
-	if err := r.client.Get(ctx, req.NamespacedName, wl); err != nil {
-		if client.IgnoreNotFound(err) != nil {
-			return reconcile.Result{}, err
-		}
-		return reconcile.Result{}, nil
-	}
 	if !r.expectationsStore.Satisfied(log, req.NamespacedName) {
 		return reconcile.Result{}, errPendingUngateOps
 	}
-	// Ungate pods for workloads that were admitted (including finished ones
-	// whose pods may still be gated after scale-up). Pending workloads that
-	// were never admitted keep their pods gated.
-	if !workloadslicing.IsElasticWorkload(wl) {
-		return reconcile.Result{}, nil
+
+	// req.Name is the stable slice-chain key shared by every slice and pod in the
+	// chain (see workloadslicing.SliceName); it is the name of the chain's root
+	// slice. Load it to find the owning job, then resolve the active (latest
+	// admitted, non-finished) slice from the job's slice chain: it is the only
+	// one whose granted PodSet counts define how many pods may be ungated, so the
+	// cap is always taken from the live slice regardless of which slice (or which
+	// pod's stamped WorkloadAnnotation) triggered the event.
+	root := &kueue.Workload{}
+	if err := r.client.Get(ctx, req.NamespacedName, root); err != nil {
+		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
-	if !workload.IsAdmitted(wl) && !workload.HasQuotaReservation(wl) {
+	active, err := r.activeSlice(ctx, root)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if active == nil {
+		// Anomaly: the event was queued for an admitted, non-finished elastic slice
+		// (see shouldUngate), yet the chain has no active slice now — e.g. it just
+		// finished, or the root lost its controller owner between events.
+		log.V(2).Info("no active elastic slice resolved for the chain; skipping ungating", "workload", klog.KObj(root))
 		return reconcile.Result{}, nil
 	}
 
-	pods, err := r.listGatedPods(ctx, wl)
+	pods, err := r.podsToUngate(ctx, active)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -150,7 +173,13 @@ func (r *elasticJobUngater) Reconcile(ctx context.Context, req reconcile.Request
 	return reconcile.Result{}, err
 }
 
-func (r *elasticJobUngater) listGatedPods(ctx context.Context, wl *kueue.Workload) ([]*corev1.Pod, error) {
+func (r *elasticJobUngater) podsToUngate(ctx context.Context, wl *kueue.Workload) ([]*corev1.Pod, error) {
+	// All pods in the slice chain share the same WorkloadSliceNameAnnotation,
+	// so the index lookup returns every pod created on behalf of this job.
+	// Although those pods may still carry an older slice's name in their
+	// WorkloadAnnotation (the template is stamped at the slice's admission),
+	// wl is the chain's active slice (resolved in Reconcile), so its granted
+	// PodSet counts are the right cap for ungating any of them.
 	sliceName := workloadslicing.SliceName(wl)
 	var podList corev1.PodList
 	if err := r.client.List(ctx, &podList,
@@ -160,14 +189,58 @@ func (r *elasticJobUngater) listGatedPods(ctx context.Context, wl *kueue.Workloa
 		return nil, fmt.Errorf("listing pods for workload slice: %w", err)
 	}
 
-	var gated []*corev1.Pod
+	granted := workload.ExtractPodSetCountsFromWorkload(wl)
+	gatedPerPodSet := make(map[kueue.PodSetReference][]*corev1.Pod)
+	ungatedPerPodSet := make(map[kueue.PodSetReference]int32)
 	for i := range podList.Items {
-		if utilpod.HasGate(&podList.Items[i], kueue.ElasticJobSchedulingGate) &&
-			podList.Items[i].Annotations[kueue.WorkloadAnnotation] == wl.Name {
-			gated = append(gated, &podList.Items[i])
+		p := &podList.Items[i]
+		ps := kueue.PodSetReference(p.Labels[constants.PodSetLabel])
+		if utilpod.HasGate(p, kueue.ElasticJobSchedulingGate) {
+			gatedPerPodSet[ps] = append(gatedPerPodSet[ps], p)
+		} else {
+			// Already-ungated pods consume quota too.
+			ungatedPerPodSet[ps]++
 		}
 	}
+
+	log := ctrl.LoggerFrom(ctx)
+	var gated []*corev1.Pod
+	for ps, candidates := range gatedPerPodSet {
+		room := granted[ps] - ungatedPerPodSet[ps]
+		var toUngate []*corev1.Pod
+		if room > 0 {
+			// Ungate the lowest-named pods first for deterministic behavior.
+			slices.SortFunc(candidates, func(a, b *corev1.Pod) int { return strings.Compare(a.Name, b.Name) })
+			toUngate = candidates
+			if int32(len(candidates)) > room {
+				toUngate = candidates[:room]
+			}
+		}
+		log.V(4).Info("elastic ungating quota accounting for PodSet",
+			"podSet", ps,
+			"grantedCount", granted[ps],
+			"alreadyUngatedCount", ungatedPerPodSet[ps],
+			"gatedCount", len(candidates),
+			"ungatingCount", len(toUngate),
+		)
+		gated = append(gated, toUngate...)
+	}
 	return gated, nil
+}
+
+// activeSlice resolves the active (latest admitted, non-finished) workload slice
+// of the chain that anyWl belongs to, or nil if none qualifies. It looks up the
+// chain through the owning job's workload index, reusing the same slice ordering
+// as the rest of the slicing code (workloadslicing.FindLatestActiveWorkload).
+func (r *elasticJobUngater) activeSlice(ctx context.Context, anyWl *kueue.Workload) (*kueue.Workload, error) {
+	owner := metav1.GetControllerOf(anyWl)
+	if owner == nil {
+		return nil, nil
+	}
+	jobObject := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{Namespace: anyWl.Namespace, Name: owner.Name},
+	}
+	return workloadslicing.FindLatestActiveWorkload(ctx, r.client, jobObject, schema.FromAPIVersionAndKind(owner.APIVersion, owner.Kind))
 }
 
 // Workload predicates
@@ -182,6 +255,7 @@ func (r *elasticJobUngater) Update(e event.TypedUpdateEvent[*kueue.Workload]) bo
 
 func shouldUngate(wl *kueue.Workload) bool {
 	return workloadslicing.IsElasticWorkload(wl) &&
+		!workload.IsFinished(wl) &&
 		(workload.IsAdmitted(wl) || workload.HasQuotaReservation(wl))
 }
 
@@ -221,18 +295,32 @@ func (h *elasticPodHandler) queueReconcileForPod(ctx context.Context, object cli
 	if !isPod {
 		return
 	}
-	wlName, found := pod.Annotations[kueue.WorkloadAnnotation]
-	if !found {
+	// Enqueue by the stable slice-chain key, not the pod's stamped
+	// WorkloadAnnotation. A pod minted after a scale-up still carries the previous
+	// (now Finished) slice's name, but the chain key is shared by every slice, so
+	// Reconcile can always resolve the active slice from it.
+	sliceName := podSliceName(pod)
+	if sliceName == "" {
 		return
 	}
 	key := types.NamespacedName{
-		Name:      wlName,
+		Name:      sliceName,
 		Namespace: pod.Namespace,
 	}
 	// Mark expectation as observed when the gate has been removed or the pod is deleted.
 	if !utilpod.HasGate(pod, kueue.ElasticJobSchedulingGate) || deleted {
-		log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(pod), "workload", key.String())
+		log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(pod), "workloadSlice", key.String())
 		h.expectationsStore.ObservedUID(log, key, pod.UID)
 	}
 	q.AddAfter(reconcile.Request{NamespacedName: key}, constants.UpdatesBatchPeriod)
+}
+
+// podSliceName returns the slice-chain key for a pod: the WorkloadSliceName
+// annotation if present, otherwise the stamped Workload annotation. Mirrors
+// indexer.IndexPodWorkloadSliceName so the key matches the pod index.
+func podSliceName(pod *corev1.Pod) string {
+	if v, found := pod.Annotations[kueue.WorkloadSliceNameAnnotation]; found {
+		return v
+	}
+	return pod.Annotations[kueue.WorkloadAnnotation]
 }

--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -25,12 +25,14 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/constants"
 	coreindexer "sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/expectations"
@@ -45,6 +47,8 @@ var podCmpOpts = []gocmp.Option{
 	cmpopts.IgnoreFields(corev1.Pod{}, "TypeMeta", "ObjectMeta.ResourceVersion",
 		"ObjectMeta.DeletionTimestamp"),
 }
+
+var rayClusterGVK = schema.GroupVersionKind{Group: "ray.io", Version: "v1", Kind: "RayCluster"}
 
 func TestReconcile(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
@@ -62,6 +66,7 @@ func TestReconcile(t *testing.T) {
 				*utiltestingapi.MakeWorkload("wl", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					ControllerReference(rayClusterGVK, "ray", "ray-uid").
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuotaAt(
 						utiltestingapi.MakeAdmission("cq").
@@ -92,6 +97,7 @@ func TestReconcile(t *testing.T) {
 				*utiltestingapi.MakeWorkload("wl", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					ControllerReference(rayClusterGVK, "ray", "ray-uid").
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuotaAt(
 						utiltestingapi.MakeAdmission("cq").
@@ -140,6 +146,7 @@ func TestReconcile(t *testing.T) {
 				*utiltestingapi.MakeWorkload("wl", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					ControllerReference(rayClusterGVK, "ray", "ray-uid").
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuotaAt(
 						utiltestingapi.MakeAdmission("cq").
@@ -234,6 +241,7 @@ func TestReconcile(t *testing.T) {
 				*utiltestingapi.MakeWorkload("wl", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					ControllerReference(rayClusterGVK, "ray", "ray-uid").
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuotaAt(
 						utiltestingapi.MakeAdmission("cq").
@@ -261,12 +269,19 @@ func TestReconcile(t *testing.T) {
 			},
 			wantErr: errPendingUngateOps,
 		},
-		"only ungate own pods after scale-up": {
+		"reconciling latest admitted slice ungates pods minted by the previous slice": {
+			// Surplus scale-up pods stay annotated with the chain-root workload
+			// name (the template was stamped at the root slice's admission), but
+			// they all share the same WorkloadSliceNameAnnotation. The reconcile
+			// of the latest admitted slice ("wl-slice-1") therefore sees both pods
+			// via the WorkloadSliceNameKey index and ungates them up to its own
+			// granted count, regardless of which past slice they were minted by.
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("wl-slice-1", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					ControllerReference(rayClusterGVK, "ray", "ray-uid").
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuotaAt(
 						utiltestingapi.MakeAdmission("cq").
@@ -277,36 +292,13 @@ func TestReconcile(t *testing.T) {
 					).
 					AdmittedAt(true, now).
 					Obj(),
-			},
-			pods: []corev1.Pod{
-				*testingpod.MakePod("pod-from-parent", "ns").
-					Annotation(kueue.WorkloadAnnotation, "wl").
-					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
-					Gate(kueue.ElasticJobSchedulingGate).
-					Obj(),
-				*testingpod.MakePod("pod-from-scale-up", "ns").
-					Annotation(kueue.WorkloadAnnotation, "wl-slice-1").
-					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
-					Gate(kueue.ElasticJobSchedulingGate).
-					Obj(),
-			},
-			wantPods: []corev1.Pod{
-				*testingpod.MakePod("pod-from-parent", "ns").
-					Annotation(kueue.WorkloadAnnotation, "wl").
-					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
-					Gate(kueue.ElasticJobSchedulingGate).
-					Obj(),
-				*testingpod.MakePod("pod-from-scale-up", "ns").
-					Annotation(kueue.WorkloadAnnotation, "wl-slice-1").
-					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
-					Obj(),
-			},
-		},
-		"skip pods belonging to non-admitted workload after scale-up": {
-			workloads: []kueue.Workload{
+				// Root slice, now Finished by the replacement. It is the chain key
+				// (reconcile target) and persists for the life of the job, so the
+				// ungater can load it to find the owning job and resolve the chain.
 				*utiltestingapi.MakeWorkload("wl", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					ControllerReference(rayClusterGVK, "ray", "ray-uid").
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuotaAt(
 						utiltestingapi.MakeAdmission("cq").
@@ -316,35 +308,29 @@ func TestReconcile(t *testing.T) {
 							Obj(), now,
 					).
 					AdmittedAt(true, now).
-					Obj(),
-				*utiltestingapi.MakeWorkload("wl-slice-1", "ns").
-					Finalizers(kueue.ResourceInUseFinalizerName).
-					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
-					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
+					FinishedAt(now).
 					Obj(),
 			},
 			pods: []corev1.Pod{
-				*testingpod.MakePod("pod-from-admitted-slice", "ns").
+				*testingpod.MakePod("pod-from-parent", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl").
 					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
 					Gate(kueue.ElasticJobSchedulingGate).
 					Obj(),
-				*testingpod.MakePod("pod-from-pending-slice", "ns").
+				*testingpod.MakePod("pod-from-scale-up", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl-slice-1").
 					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
 					Gate(kueue.ElasticJobSchedulingGate).
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
-				*testingpod.MakePod("pod-from-admitted-slice", "ns").
+				*testingpod.MakePod("pod-from-parent", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl").
 					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
 					Obj(),
-				*testingpod.MakePod("pod-from-pending-slice", "ns").
+				*testingpod.MakePod("pod-from-scale-up", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl-slice-1").
 					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
-					Gate(kueue.ElasticJobSchedulingGate).
 					Obj(),
 			},
 		},
@@ -353,6 +339,7 @@ func TestReconcile(t *testing.T) {
 				*utiltestingapi.MakeWorkload("wl", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					ControllerReference(rayClusterGVK, "ray", "ray-uid").
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuotaAt(
 						utiltestingapi.MakeAdmission("cq").
@@ -380,13 +367,199 @@ func TestReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
+		"skip surplus pods over quota during scale-up": {
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					ControllerReference(rayClusterGVK, "ray", "ray-uid").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "flavor", "1").
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+				// Replacement slice for the scale-up to 3 replicas; still Pending
+				// because it does not fit the ClusterQueue quota.
+				*utiltestingapi.MakeWorkload("wl-slice-1", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					ControllerReference(rayClusterGVK, "ray", "ray-uid").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()).
+					Obj(),
+			},
+			// All pods carry the chain-root workload name, as they are minted from
+			// the RayCluster template stamped at the root slice's admission.
+			pods: []corev1.Pod{
+				*testingpod.MakePod("pod-0", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+				*testingpod.MakePod("pod-1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+				*testingpod.MakePod("pod-2", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+			// Only the single granted replica is ungated; the surplus stays gated.
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("pod-0", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Obj(),
+				*testingpod.MakePod("pod-1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+				*testingpod.MakePod("pod-2", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+		},
+		"no-op for finished slice": {
+			// Slice replacement marks the previous slice Finished while keeping
+			// its Admitted and QuotaReserved conditions True. Reconciling the chain
+			// must not ungate any pods using this slice's stale count: activeSlice
+			// skips finished slices and, with no other live slice in the chain,
+			// returns nil so nothing is ungated.
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					ControllerReference(rayClusterGVK, "ray", "ray-uid").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "flavor", "3").
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					FinishedAt(now).
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("pod", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("pod", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+		},
+		"ungate surplus once replacement admitted": {
+			// The replacement slice ("wl-slice-1") becomes the latest admitted
+			// slice on scale-up to 3 replicas. Reconciling by the chain key
+			// resolves it as the active slice and ungates the surplus pods that
+			// were stuck during scale-up — including the ones still carrying the
+			// chain-root name in their WorkloadAnnotation. All slices share the
+			// chain key, so the workload order in the fixture does not matter.
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-slice-1", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					ControllerReference(rayClusterGVK, "ray", "ray-uid").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "flavor", "3").
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+				// Root slice, now Finished by the replacement. Kept so the test
+				// fixture matches a real chain, even though the reconcile target
+				// is the replacement above.
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					ControllerReference(rayClusterGVK, "ray", "ray-uid").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "flavor", "1").
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					FinishedAt(now).
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("pod-0", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+				*testingpod.MakePod("pod-1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+				*testingpod.MakePod("pod-2", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("pod-0", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Obj(),
+				*testingpod.MakePod("pod-1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Obj(),
+				*testingpod.MakePod("pod-2", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Obj(),
+			},
+		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctx, log := utiltesting.ContextWithLog(t)
+
+			// Real elastic pods always carry the PodSet label; default it here so the
+			// per-PodSet ungating cap has a key to match against.
+			for i := range tc.pods {
+				ensureDefaultPodSetLabel(&tc.pods[i])
+			}
+			for i := range tc.wantPods {
+				ensureDefaultPodSetLabel(&tc.wantPods[i])
+			}
+
 			clientBuilder := utiltesting.NewClientBuilder().
 				WithIndex(&corev1.Pod{}, coreindexer.WorkloadSliceNameKey, coreindexer.IndexPodWorkloadSliceName).
+				WithIndex(&kueue.Workload{}, coreindexer.OwnerReferenceIndexKey(rayClusterGVK), coreindexer.WorkloadOwnerIndexFunc(rayClusterGVK)).
 				WithInterceptorFuncs(interceptor.Funcs{
 					Patch: func(ctx context.Context, clnt client.WithWatch, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
 						// The fake client doesn't handle MergePatch for slice fields correctly.
@@ -424,7 +597,12 @@ func TestReconcile(t *testing.T) {
 				return
 			}
 
-			key := client.ObjectKeyFromObject(&tc.workloads[0])
+			// The ungater reconciles by the stable slice-chain key, not by an
+			// individual workload name, so derive the request key from the chain.
+			key := types.NamespacedName{
+				Namespace: tc.workloads[0].Namespace,
+				Name:      workloadslicing.SliceName(&tc.workloads[0]),
+			}
 			if len(tc.expectUIDs) > 0 {
 				ungater.expectationsStore.ExpectUIDs(log, key, tc.expectUIDs)
 			}
@@ -444,5 +622,18 @@ func TestReconcile(t *testing.T) {
 				t.Errorf("Pods after reconcile (-want,+got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// ensureDefaultPodSetLabel sets the default PodSet label on the pod unless it
+// already carries one. Elastic pods always have this label in practice (set
+// when the job is started), and the ungater relies on it to cap ungating per
+// PodSet to the granted quota.
+func ensureDefaultPodSetLabel(p *corev1.Pod) {
+	if p.Labels == nil {
+		p.Labels = map[string]string{}
+	}
+	if _, ok := p.Labels[constants.PodSetLabel]; !ok {
+		p.Labels[constants.PodSetLabel] = string(kueue.DefaultPodSetName)
 	}
 }

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -137,6 +137,25 @@ func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject
 	}), nil
 }
 
+// FindLatestActiveWorkload returns the newest non-finished workload slice owned
+// by the provided job object/gvk that holds a quota reservation, or nil if none
+// qualifies. This is the chain's "active" slice: its granted PodSet counts
+// define the admitted capacity. It builds on FindNotFinishedWorkloads, so the
+// returned slice respects the same ordering (newest last, with
+// WorkloadSliceReplacementFor as a tiebreaker on equal creation timestamps).
+func FindLatestActiveWorkload(ctx context.Context, clnt client.Client, jobObject client.Object, jobObjectGVK schema.GroupVersionKind) (*kueue.Workload, error) {
+	workloads, err := FindNotFinishedWorkloads(ctx, clnt, jobObject, jobObjectGVK)
+	if err != nil {
+		return nil, err
+	}
+	for i := range slices.Backward(workloads) {
+		if workload.HasQuotaReservation(&workloads[i]) {
+			return &workloads[i], nil
+		}
+	}
+	return nil, nil
+}
+
 // ScaledDown returns true if the new pod sets represent a scale-down operation.
 // This is determined by checking whether at least one new pod set has fewer replicas
 // than its corresponding old pod set, and none of the old pod sets have fewer replicas

--- a/test/e2e/singlecluster/extended/kuberay_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_test.go
@@ -138,7 +138,12 @@ var _ = ginkgo.Describe("Kuberay", ginkgo.Label("area:singlecluster", "feature:k
 		cq = utiltestingapi.MakeClusterQueue(clusterQueueName).
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas(rf.Name).
-					Resource(corev1.ResourceCPU, "3").
+					// Head + workers, plus 500m for the autoscaler sidecar that
+					// BuildPodSets accounts for on in-tree-autoscaling clusters,
+					// with enough headroom for the multi-step scale-up test to
+					// reach 5 running workers (head 1 + sidecar 500m + submitter
+					// 400m + 5x400m workers = 3.9 CPU).
+					Resource(corev1.ResourceCPU, "4").
 					Resource(corev1.ResourceMemory, "2Gi").Obj()).
 			Obj()
 		util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -42,15 +43,18 @@ import (
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	pkgconstants "sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/features"
+	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	"sigs.k8s.io/kueue/pkg/util/tas"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
+	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 	"sigs.k8s.io/kueue/test/integration/framework"
@@ -4209,6 +4213,20 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 	})
 })
 
+// ungatedPodNames is a helper that returns the names of the pods in nsName
+// that no longer carry the elastic-job scheduling gate.
+func ungatedPodNames(g gomega.Gomega, nsName string) sets.Set[string] {
+	pods := &corev1.PodList{}
+	g.Expect(k8sClient.List(ctx, pods, client.InNamespace(nsName))).Should(gomega.Succeed())
+	ungated := sets.New[string]()
+	for i := range pods.Items {
+		if !utilpod.HasGate(&pods.Items[i], kueue.ElasticJobSchedulingGate) {
+			ungated.Insert(pods.Items[i].Name)
+		}
+	}
+	return ungated
+}
+
 var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		ns             *corev1.Namespace
@@ -4343,6 +4361,167 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 				g.Expect(workload.IsAdmitted(&workloads.Items[i])).Should(gomega.BeTrue())
 			}
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("Should cap elastic pod ungating to the granted quota", framework.SlowSpec, func() {
+		// Regression for kueue#11977: the ungater ungated every gated pod found
+		// via the workload-slice index, so surplus pods minted for an over-quota
+		// scale-up bypassed the ClusterQueue quota. Not Ray-specific; reproduced
+		// here with a batch Job.
+		const (
+			grantedPodCount = 2
+			totalPods       = 3
+		)
+
+		testJob := testingjob.MakeJob("ungate-cap", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "1").
+			Parallelism(grantedPodCount).
+			Completions(grantedPodCount).
+			Obj()
+
+		ginkgo.By("creating the job")
+		util.MustCreate(ctx, k8sClient, testJob)
+
+		var (
+			jobWorkload *kueue.Workload
+			podSet      kueue.PodSetReference
+		)
+		ginkgo.By("admitting the job's workload at the granted pod count")
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			jobWorkload = &workloads.Items[0]
+			g.Expect(workload.IsAdmitted(jobWorkload)).Should(gomega.BeTrue())
+			g.Expect(jobWorkload.Spec.PodSets).Should(gomega.HaveLen(1))
+			g.Expect(jobWorkload.Spec.PodSets[0].Count).Should(gomega.BeEquivalentTo(int32(grantedPodCount)))
+			podSet = jobWorkload.Spec.PodSets[0].Name
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By(fmt.Sprintf("minting %d gated pods (more than the granted %d)", totalPods, grantedPodCount))
+		for i := range totalPods {
+			pod := testingpod.MakePod(fmt.Sprintf("pod-%d", i), ns.Name).
+				Annotation(kueue.WorkloadAnnotation, jobWorkload.Name).
+				Annotation(kueue.WorkloadSliceNameAnnotation, jobWorkload.Name).
+				Label(pkgconstants.PodSetLabel, string(podSet)).
+				Gate(kueue.ElasticJobSchedulingGate).
+				Obj()
+			util.MustCreate(ctx, k8sClient, pod)
+		}
+
+		ginkgo.By("the ungater ungates exactly the granted count and leaves the surplus gated")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(sets.List(ungatedPodNames(g, ns.Name))).Should(gomega.HaveLen(grantedPodCount))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("the cap is stable: the ungater never exceeds the granted quota")
+		gomega.Consistently(func(g gomega.Gomega) {
+			g.Expect(sets.List(ungatedPodNames(g, ns.Name))).Should(gomega.HaveLen(grantedPodCount))
+		}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("Should ungate a scale-up pod minted after the replacement slice was admitted", framework.SlowSpec, func() {
+		// Reproduces the trigger gap behind kueue#12045: after a scale-up the
+		// replacement slice is the active workload while the previous slice is
+		// Finished. A pod carrying the Finished slice's name enqueues that slice,
+		// which the reconcile guard skips, so nothing re-reconciles the active one.
+		// Completions must cover the scaled-up size: podsCount is min(parallelism, completions).
+		testJob := testingjob.MakeJob("late-ungate", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "1").
+			Parallelism(1).
+			Completions(2).
+			Obj()
+
+		ginkgo.By("creating the job with a single pod")
+		util.MustCreate(ctx, k8sClient, testJob)
+
+		var (
+			rootWorkloadName string
+			podSet           kueue.PodSetReference
+		)
+		ginkgo.By("admitting the root slice at 1 pod")
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			g.Expect(workload.IsAdmitted(&workloads.Items[0])).Should(gomega.BeTrue())
+			g.Expect(workloads.Items[0].Spec.PodSets[0].Count).Should(gomega.BeEquivalentTo(int32(1)))
+			rootWorkloadName = workloads.Items[0].Name
+			podSet = workloads.Items[0].Spec.PodSets[0].Name
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		// Ungate the root's pod first so the late pod is the second of the active
+		// slice's two: capping at the Finished root's stale count (1) would starve
+		// it, so only enqueuing the active slice (granted 2) ungates it.
+		initialPod := testingpod.MakePod("initial-pod", ns.Name).
+			Annotation(kueue.WorkloadAnnotation, rootWorkloadName).
+			Annotation(kueue.WorkloadSliceNameAnnotation, rootWorkloadName).
+			Label(pkgconstants.PodSetLabel, string(podSet)).
+			Gate(kueue.ElasticJobSchedulingGate).
+			Obj()
+		ginkgo.By("minting the root slice's pod and waiting for it to be ungated")
+		util.MustCreate(ctx, k8sClient, initialPod)
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(initialPod), initialPod)).Should(gomega.Succeed())
+			g.Expect(utilpod.HasGate(initialPod, kueue.ElasticJobSchedulingGate)).Should(gomega.BeFalse())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("increasing the job's parallelism to 2 to emulate scale-up")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
+			testJob.Spec.Parallelism = ptr.To[int32](2)
+			g.Expect(k8sClient.Update(ctx, testJob)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		var activeWorkload *kueue.Workload
+		ginkgo.By("the replacement slice is admitted at 2 pods and the root slice is finished")
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(2))
+			var foundFinishedRoot bool
+			for i := range workloads.Items {
+				wl := &workloads.Items[i]
+				if workload.IsFinished(wl) {
+					g.Expect(wl.Name).Should(gomega.Equal(rootWorkloadName))
+					foundFinishedRoot = true
+					continue
+				}
+				g.Expect(workload.IsAdmitted(wl)).Should(gomega.BeTrue())
+				g.Expect(wl.Spec.PodSets[0].Count).Should(gomega.BeEquivalentTo(int32(2)))
+				activeWorkload = wl
+				podSet = wl.Spec.PodSets[0].Name
+			}
+			g.Expect(foundFinishedRoot).Should(gomega.BeTrue())
+			g.Expect(activeWorkload).ShouldNot(gomega.BeNil())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		// Mint the late pod only now, after the replacement was reconciled,
+		// carrying the Finished root slice's name.
+		latePod := testingpod.MakePod("late-pod", ns.Name).
+			Annotation(kueue.WorkloadAnnotation, rootWorkloadName).
+			Annotation(kueue.WorkloadSliceNameAnnotation, rootWorkloadName).
+			Label(pkgconstants.PodSetLabel, string(podSet)).
+			Gate(kueue.ElasticJobSchedulingGate).
+			Obj()
+		ginkgo.By("minting a late gated pod annotated with the finished root slice")
+		util.MustCreate(ctx, k8sClient, latePod)
+
+		ginkgo.By("the ungater ungates the late pod within the granted quota")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(latePod), latePod)).Should(gomega.Succeed())
+			g.Expect(utilpod.HasGate(latePod, kueue.ElasticJobSchedulingGate)).Should(gomega.BeFalse(),
+				"late scale-up pod must be ungated, but it stayed scheduling-gated")
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("the cap holds: both granted pods are ungated and no surplus is")
+		gomega.Consistently(func(g gomega.Gomega) {
+			g.Expect(sets.List(ungatedPodNames(g, ns.Name))).Should(gomega.HaveLen(2))
+		}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 	})
 
 	ginkgo.It("Should support scheduling pending workload after freeing capacity on scale-down", func() {


### PR DESCRIPTION
Cherry pick of #12045 on release-0.17.

#12045: fix: cap elastic job ungating to granted quota

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug

#### Special notes for your reviewer:
The automated cherry-pick robot could not apply #12045 cleanly, so this was prepared manually (conflicts in `elastic_job_ungater.go`, `elastic_job_ungater_test.go`, and `kuberay_test.go`).

The only deviations from #12045 are release-0.17-specific:
- The `PodSchedulingGateRemovalSeconds` metric plumbing (the `clock` field and the `RecordPodSchedulingGateRemovalSeconds` call) is not present on release-0.17 and is not part of #12045, so it was omitted, along with the `TestRecordPodSchedulingGateRemovalSeconds` unit test that exercises it.

Everything else matches #12045, including capping ungating to the per-PodSet granted quota and raising the Kuberay e2e ClusterQueue CPU quota from 3 to 4. `go build`, `go vet`, and the `elasticjobs` + `workloadslicing` unit tests pass locally.

```release-note
ElasticJobsViaWorkloadSlices: Fixed a bug where worker pods of an elastic job could be ungated after scale up, 
past the ClusterQueue quota; ungating is now capped to the replicas granted quota across the workload-slice chain.
```