### PR TITLE
cleanup: pin serve version in KueueViz frontend Dockerfile

### DIFF
--- a/cmd/kueueviz/frontend/Dockerfile
+++ b/cmd/kueueviz/frontend/Dockerfile
@@ -18,7 +18,8 @@ RUN npm run build
 # Install `serve` into a self-contained prefix on BUILDPLATFORM. `serve` is
 # pure JavaScript, so its node_modules tree can be copied verbatim into the
 # target-arch runtime image without re-running npm there.
-RUN npm install --prefix /opt/serve serve
+RUN npm install --prefix /opt/serve \
+  "serve@$(node -p "require('./package-lock.json').packages['node_modules/serve'].version")"
 
 # Runtime stage uses TARGETPLATFORM so the produced image carries correct
 # arch metadata for the multi-arch manifest. It contains no RUN steps, so


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area dashboard
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

The frontend Dockerfile installed `serve` unpinned, so every build grabbed whatever was latest. That means non-deterministic builds, and no review if that release is broken or compromised.

Pin it to the version already in `package-lock.json` by reading it from the lockfile at build time, instead of hardcoding it. This way `package.json` / `package-lock.json` stays the single source of truth Dependabot already bumps.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build consistency by using the same pinned version of a runtime dependency during image creation, reducing the risk of version mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->