### PR TITLE
Don't admit workload when WaitingForReplacementPods=True.

### DIFF
--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -1016,6 +1016,10 @@ const (
 	// WorkloadDeactivationTarget means that the Workload should be deactivated.
 	// This condition is temporary, so it should be removed after deactivation.
 	WorkloadDeactivationTarget = "DeactivationTarget"
+
+	// WorkloadWaitingForReplacementPods means that Kueue doesn't observe all
+	// the Pods declared for the group.
+	WorkloadWaitingForReplacementPods = "WaitingForReplacementPods"
 )
 
 // Reasons for the WorkloadPreemptionBlocked condition.

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -539,6 +539,11 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 					return ctrl.Result{}, client.IgnoreNotFound(err)
 				}
 
+				if !workload.IsAdmissible(&wl) {
+					log.V(3).Info("Workload is inadmissible after backoff, waiting for condition change", "workload", klog.KObj(&wl))
+					return ctrl.Result{}, nil
+				}
+
 				if err := r.queues.AddOrUpdateWorkload(log, wl.DeepCopy()); err != nil {
 					log.V(2).Info("failed to put the workload back into queue", "error", err)
 					return ctrl.Result{}, err

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -75,10 +75,6 @@ const (
 )
 
 const (
-	// WorkloadWaitingForReplacementPods is True when Kueue doesn't observe all
-	// the Pods declared for the group.
-	WorkloadWaitingForReplacementPods = "WaitingForReplacementPods"
-
 	// WorkloadPodsFailed means that at least one Pod are not runnable or not succeeded.
 	WorkloadPodsFailed = "PodsFailed"
 )
@@ -712,8 +708,13 @@ func (p *Pod) Load(ctx context.Context, c client.Client, key *types.NamespacedNa
 	return !p.isFound, nil
 }
 
+// fastAdmission determines if the pod is configured for fast admission based on specific annotations.
+func (p *Pod) fastAdmission() bool {
+	return p.pod.GetAnnotations()[podconstants.GroupFastAdmissionAnnotationKey] == podconstants.GroupFastAdmissionAnnotationValue
+}
+
 func (p *Pod) constructGroupPodSets() ([]kueue.PodSet, error) {
-	if _, useFastAdmission := p.pod.GetAnnotations()[podconstants.GroupFastAdmissionAnnotationKey]; useFastAdmission {
+	if p.fastAdmission() {
 		tc, err := p.groupTotalCount()
 		if err != nil {
 			return nil, err
@@ -827,9 +828,8 @@ func (p *Pod) validatePodGroupMetadata(r events.EventRecorder, activePods []core
 	}
 
 	originalQueue := jobframework.QueueName(p)
-	_, useFastAdmission := p.pod.GetAnnotations()[podconstants.GroupFastAdmissionAnnotationKey]
 
-	if !useFastAdmission && len(activePods) < groupTotalCount {
+	if !p.fastAdmission() && len(activePods) < groupTotalCount {
 		errMsg := fmt.Sprintf("'%s' group has fewer runnable pods than expected", utilpod.GetPodGroupName(&p.pod))
 		r.Eventf(p.Object(), nil, corev1.EventTypeWarning, jobframework.ReasonErrWorkloadCompose, "ErrWorkloadCompose", errMsg)
 		return jobframework.UnretryableError(errMsg)
@@ -1242,9 +1242,7 @@ func (p *Pod) FindMatchingWorkloads(ctx context.Context, c client.Client, r even
 			return nil, nil, fmt.Errorf("failed to calculate pod role hash: %w", errors.Join(roleHashErrors...))
 		}
 
-		if absentCount := int(ps.Count) - len(roleActivePods); absentCount > 0 {
-			absentPods += absentCount
-		}
+		absentPods += p.countAbsentPods(ps, len(roleActivePods))
 
 		if excessCount := len(roleActivePods) - int(ps.Count); excessCount > 0 {
 			sortActivePods(roleActivePods)
@@ -1291,6 +1289,16 @@ func (p *Pod) FindMatchingWorkloads(ctx context.Context, c client.Client, r even
 		return nil, nil, err
 	}
 	return workload, []*kueue.Workload{}, nil
+}
+
+func (p *Pod) countAbsentPods(ps kueue.PodSet, activePods int) int {
+	if p.fastAdmission() {
+		if ps.Count > 0 && activePods == 0 {
+			return 1
+		}
+		return 0
+	}
+	return max(0, int(ps.Count)-activePods)
 }
 
 func (p *Pod) equivalentToWorkload(wl *kueue.Workload, jobPodSets []kueue.PodSet) bool {
@@ -1384,7 +1392,7 @@ func (p *Pod) waitingForReplacementPodsCondition(wl *kueue.Workload) (*metav1.Co
 		return nil, false
 	}
 
-	replCond := apimeta.FindStatusCondition(wl.Status.Conditions, WorkloadWaitingForReplacementPods)
+	replCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadWaitingForReplacementPods)
 	replCondStatus := p.absentPods > 0
 
 	// Nothing to change.
@@ -1396,7 +1404,7 @@ func (p *Pod) waitingForReplacementPodsCondition(wl *kueue.Workload) (*metav1.Co
 
 	if replCond == nil {
 		replCond = &metav1.Condition{
-			Type: WorkloadWaitingForReplacementPods,
+			Type: kueue.WorkloadWaitingForReplacementPods,
 		}
 		updated = true
 	} else {

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -1722,7 +1722,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -1741,7 +1741,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -1866,7 +1866,7 @@ func TestReconciler(t *testing.T) {
 						Message: "Pods succeeded: 1/2. Pods failed: 1/2",
 					}).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -1891,7 +1891,7 @@ func TestReconciler(t *testing.T) {
 						Message: "Pods succeeded: 1/2. Pods failed: 1/2",
 					}).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -2071,7 +2071,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -2091,7 +2091,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -2389,7 +2389,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Preempted to accommodate a higher priority Workload",
 					}).
 					Condition(metav1.Condition{
-						Type:               WorkloadWaitingForReplacementPods,
+						Type:               kueue.WorkloadWaitingForReplacementPods,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.NewTime(now),
 						Reason:             kueue.WorkloadEvictedByPreemption,
@@ -2416,7 +2416,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Preempted to accommodate a higher priority Workload",
 					}).
 					Condition(metav1.Condition{
-						Type:               WorkloadWaitingForReplacementPods,
+						Type:               kueue.WorkloadWaitingForReplacementPods,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.NewTime(now),
 						Reason:             kueue.WorkloadEvictedByPreemption,
@@ -2469,7 +2469,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Preempted to accommodate a higher priority Workload",
 					}).
 					Condition(metav1.Condition{
-						Type:               WorkloadWaitingForReplacementPods,
+						Type:               kueue.WorkloadWaitingForReplacementPods,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.NewTime(now),
 						Reason:             kueue.WorkloadEvictedByPreemption,
@@ -2517,7 +2517,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Preempted to accommodate a higher priority Workload",
 					}).
 					Condition(metav1.Condition{
-						Type:               WorkloadWaitingForReplacementPods,
+						Type:               kueue.WorkloadWaitingForReplacementPods,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.NewTime(now),
 						Reason:             kueue.WorkloadEvictedByPreemption,
@@ -2670,7 +2670,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -2690,7 +2690,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -2736,7 +2736,7 @@ func TestReconciler(t *testing.T) {
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -2758,7 +2758,7 @@ func TestReconciler(t *testing.T) {
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -3004,7 +3004,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -3029,7 +3029,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -3130,7 +3130,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -3156,7 +3156,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
 					ReclaimablePods(kueue.ReclaimablePod{Name: "4ebdd4a6", Count: 1}).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -3249,7 +3249,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -3274,7 +3274,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -3488,7 +3488,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -3510,7 +3510,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -3936,7 +3936,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -3957,7 +3957,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -4061,7 +4061,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Preempted to accommodate a higher priority Workload",
 					}).
 					Condition(metav1.Condition{
-						Type:               WorkloadWaitingForReplacementPods,
+						Type:               kueue.WorkloadWaitingForReplacementPods,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.NewTime(now),
 						Reason:             kueue.WorkloadEvictedByPreemption,
@@ -4088,7 +4088,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Preempted to accommodate a higher priority Workload",
 					}).
 					Condition(metav1.Condition{
-						Type:               WorkloadWaitingForReplacementPods,
+						Type:               kueue.WorkloadWaitingForReplacementPods,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.NewTime(now),
 						Reason:             kueue.WorkloadEvictedByPreemption,
@@ -4157,7 +4157,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Workload evicted due to a PodsReady timeout",
 					}).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  "PodsReadyTimeout",
 						Message: "Workload evicted due to a PodsReady timeout",
@@ -4181,7 +4181,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Workload evicted due to a PodsReady timeout",
 					}).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  "PodsReadyTimeout",
 						Message: "Workload evicted due to a PodsReady timeout",
@@ -4342,7 +4342,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -4366,7 +4366,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -4578,7 +4578,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -4599,7 +4599,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -5221,7 +5221,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -5305,7 +5305,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -5402,7 +5402,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Preempted to accommodate a higher priority Workload",
 					}).
 					Condition(metav1.Condition{
-						Type:               WorkloadWaitingForReplacementPods,
+						Type:               kueue.WorkloadWaitingForReplacementPods,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.NewTime(now),
 						Reason:             kueue.WorkloadEvictedByPreemption,
@@ -5456,7 +5456,7 @@ func TestReconciler(t *testing.T) {
 						Message: "Exceeded the PodsReady timeout",
 					}).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  kueue.WorkloadEvictedByPreemption,
 						Message: "Preempted to accommodate a higher priority Workload",
@@ -5504,7 +5504,7 @@ func TestReconciler(t *testing.T) {
 						Message: "Exceeded the PodsReady timeout",
 					}).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  kueue.WorkloadEvictedByPodsReadyTimeout,
 						Message: "Exceeded the PodsReady timeout",
@@ -5557,7 +5557,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Preempted to accommodate a higher priority Workload",
 					}).
 					Condition(metav1.Condition{
-						Type:               WorkloadWaitingForReplacementPods,
+						Type:               kueue.WorkloadWaitingForReplacementPods,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.NewTime(now),
 						Reason:             kueue.WorkloadEvictedByPreemption,
@@ -5607,7 +5607,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Preempted to accommodate a higher priority Workload",
 					}).
 					Condition(metav1.Condition{
-						Type:               WorkloadWaitingForReplacementPods,
+						Type:               kueue.WorkloadWaitingForReplacementPods,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.NewTime(now),
 						Reason:             kueue.WorkloadEvictedByPreemption,
@@ -5654,7 +5654,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -5696,7 +5696,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionFalse,
 						Reason:  kueue.WorkloadPodsReady,
 						Message: "No pods need replacement",
@@ -6224,7 +6224,6 @@ func TestRecordPodSchedulingGateRemovalSeconds(t *testing.T) {
 					KueueFinalizer().
 					GroupNameLabel("group").
 					GroupTotalCount("2").
-					Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
 					Label(constants.PodSetLabel, pogGroupPodSetName).
 					Label(constants.LocalQueueLabel, lqName).
 					Label(constants.ClusterQueueLabel, cqName).
@@ -6240,7 +6239,6 @@ func TestRecordPodSchedulingGateRemovalSeconds(t *testing.T) {
 					KueueSchedulingGate().
 					GroupNameLabel("group").
 					GroupTotalCount("2").
-					Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
 					Obj(),
 			},
 			workloads: []kueue.Workload{
@@ -6259,7 +6257,7 @@ func TestRecordPodSchedulingGateRemovalSeconds(t *testing.T) {
 					).
 					AdmittedAt(true, now.Add(-2*time.Second)).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  kueue.WorkloadPodsReady,
 						Message: "No pods need replacement",
@@ -6277,7 +6275,6 @@ func TestRecordPodSchedulingGateRemovalSeconds(t *testing.T) {
 					KueueFinalizer().
 					GroupNameLabel("group").
 					GroupTotalCount("2").
-					Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
 					Label(constants.PodSetLabel, pogGroupPodSetName).
 					Label(constants.LocalQueueLabel, lqName).
 					Label(constants.ClusterQueueLabel, cqName).
@@ -6293,7 +6290,6 @@ func TestRecordPodSchedulingGateRemovalSeconds(t *testing.T) {
 					KueueFinalizer().
 					GroupNameLabel("group").
 					GroupTotalCount("2").
-					Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
 					Label(constants.PodSetLabel, pogGroupPodSetName).
 					Label(constants.LocalQueueLabel, lqName).
 					Label(constants.ClusterQueueLabel, cqName).

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -1150,7 +1150,8 @@ func IsActive(w *kueue.Workload) bool {
 
 // IsAdmissible returns true if the workload can be added to the queue.
 func IsAdmissible(w *kueue.Workload) bool {
-	return !HasAdmissionGate(w) && !workloadfinish.IsFinished(w) && IsActive(w) && !HasQuotaReservation(w) && !IsOnHold(w)
+	return !HasAdmissionGate(w) && !workloadfinish.IsFinished(w) && IsActive(w) && !HasQuotaReservation(w) && !IsOnHold(w) &&
+		!apimeta.IsStatusConditionTrue(w.Status.Conditions, kueue.WorkloadWaitingForReplacementPods)
 }
 
 // HasAdmissionGate returns true if the workload has an admission gate annotation and the AdmissionGatedBy feature is on

--- a/test/e2e/singlecluster/baseline/pod_test.go
+++ b/test/e2e/singlecluster/baseline/pod_test.go
@@ -228,7 +228,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 					g.Expect(createdWorkload.Status.Conditions).To(gomega.ContainElements(
 						gomega.BeComparableTo(metav1.Condition{
-							Type:    pod.WorkloadWaitingForReplacementPods,
+							Type:    kueue.WorkloadWaitingForReplacementPods,
 							Status:  metav1.ConditionTrue,
 							Reason:  pod.WorkloadPodsFailed,
 							Message: "Some Failed pods need replacement",
@@ -272,7 +272,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 					g.Expect(createdWorkload.Status.Conditions).To(gomega.ContainElements(
 						gomega.BeComparableTo(metav1.Condition{
-							Type:    pod.WorkloadWaitingForReplacementPods,
+							Type:    kueue.WorkloadWaitingForReplacementPods,
 							Status:  metav1.ConditionFalse,
 							Reason:  kueue.WorkloadPodsReady,
 							Message: "No pods need replacement",

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -899,7 +899,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 						g.Expect(createdWorkload.Status.Conditions).To(gomega.ContainElements(
 							gomega.BeComparableTo(metav1.Condition{
-								Type:    podcontroller.WorkloadWaitingForReplacementPods,
+								Type:    kueue.WorkloadWaitingForReplacementPods,
 								Status:  metav1.ConditionTrue,
 								Reason:  "ByTest",
 								Message: "by test",
@@ -954,7 +954,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 						g.Expect(createdWorkload.Status.Conditions).To(gomega.ContainElements(
 							gomega.BeComparableTo(metav1.Condition{
-								Type:    podcontroller.WorkloadWaitingForReplacementPods,
+								Type:    kueue.WorkloadWaitingForReplacementPods,
 								Status:  metav1.ConditionFalse,
 								Reason:  kueue.WorkloadPodsReady,
 								Message: "No pods need replacement",
@@ -1025,7 +1025,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 						g.Expect(createdWorkload.Status.Conditions).To(gomega.ContainElements(
 							gomega.BeComparableTo(metav1.Condition{
-								Type:    podcontroller.WorkloadWaitingForReplacementPods,
+								Type:    kueue.WorkloadWaitingForReplacementPods,
 								Status:  metav1.ConditionTrue,
 								Reason:  podcontroller.WorkloadPodsFailed,
 								Message: "Some Failed pods need replacement",
@@ -1050,7 +1050,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 						g.Expect(createdWorkload.Status.Conditions).To(gomega.ContainElements(
 							gomega.BeComparableTo(metav1.Condition{
-								Type:    podcontroller.WorkloadWaitingForReplacementPods,
+								Type:    kueue.WorkloadWaitingForReplacementPods,
 								Status:  metav1.ConditionFalse,
 								Reason:  kueue.WorkloadPodsReady,
 								Message: "No pods need replacement",
@@ -1070,7 +1070,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 						g.Expect(createdWorkload.Status.Conditions).To(gomega.ContainElements(
 							gomega.BeComparableTo(metav1.Condition{
-								Type:    podcontroller.WorkloadWaitingForReplacementPods,
+								Type:    kueue.WorkloadWaitingForReplacementPods,
 								Status:  metav1.ConditionTrue,
 								Reason:  podcontroller.WorkloadPodsFailed,
 								Message: "Some Failed pods need replacement",
@@ -1093,7 +1093,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 						g.Expect(createdWorkload.Status.Conditions).To(gomega.ContainElements(
 							gomega.BeComparableTo(metav1.Condition{
-								Type:    podcontroller.WorkloadWaitingForReplacementPods,
+								Type:    kueue.WorkloadWaitingForReplacementPods,
 								Status:  metav1.ConditionFalse,
 								Reason:  kueue.WorkloadPodsReady,
 								Message: "No pods need replacement",
@@ -1512,7 +1512,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 								Message: "The workload is admitted",
 							}, util.IgnoreConditionTimestampsAndObservedGeneration),
 							gomega.BeComparableTo(metav1.Condition{
-								Type:    podcontroller.WorkloadWaitingForReplacementPods,
+								Type:    kueue.WorkloadWaitingForReplacementPods,
 								Status:  metav1.ConditionTrue,
 								Reason:  kueue.WorkloadPreempted,
 								Message: "By test",
@@ -1537,7 +1537,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 						g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 						g.Expect(wl.Status.Conditions).To(gomega.ContainElements(
 							gomega.BeComparableTo(metav1.Condition{
-								Type:    podcontroller.WorkloadWaitingForReplacementPods,
+								Type:    kueue.WorkloadWaitingForReplacementPods,
 								Status:  metav1.ConditionFalse,
 								Reason:  kueue.WorkloadPodsReady,
 								Message: "No pods need replacement",
@@ -2400,7 +2400,7 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 					Message: "The workload backoff was finished",
 				},
 				metav1.Condition{
-					Type:    podcontroller.WorkloadWaitingForReplacementPods,
+					Type:    kueue.WorkloadWaitingForReplacementPods,
 					Status:  metav1.ConditionTrue,
 					Reason:  "PodsReadyTimeout",
 					Message: fmt.Sprintf("Exceeded the PodsReady timeout %s", wlKey.String()),
@@ -2445,12 +2445,207 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 					Message: "The workload has no reservation",
 				},
 				metav1.Condition{
-					Type:    podcontroller.WorkloadWaitingForReplacementPods,
+					Type:    kueue.WorkloadWaitingForReplacementPods,
 					Status:  metav1.ConditionTrue,
 					Reason:  "DeactivatedDueToRequeuingLimitExceeded",
 					Message: "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
 				},
 			)
+		})
+	})
+})
+
+var _ = ginkgo.Describe("Pod controller interacting with scheduler when waitForPodsReady enabled", ginkgo.Label("job:pod", "area:jobs"), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+	const (
+		backoffBaseSeconds = 1
+	)
+
+	var (
+		ns *corev1.Namespace
+		fl *kueue.ResourceFlavor
+		cq *kueue.ClusterQueue
+		lq *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeAll(func() {
+		waitForPodsReady := &configapi.WaitForPodsReady{
+			Timeout: metav1.Duration{Duration: util.ShortTimeout},
+			RequeuingStrategy: &configapi.RequeuingStrategy{
+				Timestamp:          new(configapi.EvictionTimestamp),
+				BackoffLimitCount:  new(int32(2)),
+				BackoffBaseSeconds: new(int32(backoffBaseSeconds)),
+			},
+		}
+		nsSelector := &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      corev1.LabelMetadataName,
+					Operator: metav1.LabelSelectorOpNotIn,
+					Values:   []string{"kube-system", "kueue-system"},
+				},
+			},
+		}
+		mjnsSelector, err := metav1.LabelSelectorAsSelector(nsSelector)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		fwk.StartManager(ctx, cfg, managerSetup(
+			false,
+			true,
+			&configapi.Configuration{WaitForPodsReady: waitForPodsReady},
+			jobframework.WithManagedJobsNamespaceSelector(mjnsSelector),
+			jobframework.WithEnabledFrameworks([]string{"pod"}),
+		))
+	})
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "core-")
+
+		fl = utiltestingapi.MakeResourceFlavor("fl").Obj()
+		util.MustCreate(ctx, k8sClient, fl)
+
+		cq = utiltestingapi.MakeClusterQueue("cq").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(fl.Name).
+				Resource(corev1.ResourceCPU, "9").
+				Resource(corev1.ResourceMemory, "36").
+				Obj()).
+			Obj()
+		util.MustCreate(ctx, k8sClient, cq)
+
+		lq = utiltestingapi.MakeLocalQueue("lq", ns.Name).ClusterQueue(cq.Name).Obj()
+		util.MustCreate(ctx, k8sClient, lq)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, fl, true)
+	})
+
+	ginkgo.When("pod group not ready", func() {
+		ginkgo.It("shouldn't re-admit workload with WaitingForReplacementPods=True", func() {
+			podGroupName := "pod-group"
+			pod := testingpod.MakePod("pod", ns.Name).
+				GroupNameLabel(podGroupName).
+				GroupTotalCount("1").
+				Queue(lq.Name).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			ginkgo.By("Creating pod", func() {
+				util.MustCreate(ctx, k8sClient, pod)
+			})
+
+			wlKey := types.NamespacedName{Name: podGroupName, Namespace: pod.Namespace}
+
+			ginkgo.By("Checking that workload was created and admitted", func() {
+				util.ExpectWorkloadsToBeAdmittedByKeys(ctx, k8sClient, wlKey)
+			})
+
+			ginkgo.By("Terminating a pod", func() {
+				util.SetPodsPhaseByKeys(ctx, k8sClient, corev1.PodFailed, client.ObjectKeyFromObject(pod))
+			})
+
+			ginkgo.By("Checking that workload was evicted due to pods ready timeout", func() {
+				util.ExpectWorkloadsToBeEvictedByKeys(ctx, k8sClient, wlKey)
+			})
+
+			ginkgo.By("Waiting for BackoffFinished", func() {
+				wl := &kueue.Workload{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
+					g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusTrueAndReason(kueue.WorkloadRequeued, kueue.WorkloadBackoffFinished))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking the workload isn't admitted due to don't have pod replacements", func() {
+				wl := &kueue.Workload{}
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
+					g.Expect(workload.IsActive(wl)).Should(gomega.BeTrue())
+					g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusFalse(kueue.WorkloadQuotaReserved))
+					g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusFalse(kueue.WorkloadAdmitted))
+					g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadEvicted))
+					g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadWaitingForReplacementPods))
+				}, util.ShortConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+			})
+
+			replacementPod := testingpod.MakePod("replacement-pod", ns.Name).
+				GroupNameLabel(podGroupName).
+				GroupTotalCount("1").
+				Queue(lq.Name).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			ginkgo.By("Creating replacement pod", func() {
+				util.MustCreate(ctx, k8sClient, replacementPod)
+			})
+
+			ginkgo.By("Checking that workload was admitted", func() {
+				util.ExpectWorkloadsToBeAdmittedByKeys(ctx, k8sClient, wlKey)
+			})
+		})
+
+		ginkgo.It("shouldn't re-admit workload with WaitingForReplacementPods=True and fast admission", func() {
+			podGroupName := "pod-group"
+			pod := testingpod.MakePod("pod", ns.Name).
+				Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
+				GroupNameLabel(podGroupName).
+				GroupTotalCount("2").
+				Queue(lq.Name).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			ginkgo.By("Creating pod", func() {
+				util.MustCreate(ctx, k8sClient, pod)
+			})
+
+			wlKey := types.NamespacedName{Name: podGroupName, Namespace: pod.Namespace}
+
+			ginkgo.By("Checking that workload was created and admitted", func() {
+				util.ExpectWorkloadsToBeAdmittedByKeys(ctx, k8sClient, wlKey)
+			})
+
+			ginkgo.By("Terminating a pod", func() {
+				util.SetPodsPhaseByKeys(ctx, k8sClient, corev1.PodFailed, client.ObjectKeyFromObject(pod))
+			})
+
+			ginkgo.By("Checking that workload was evicted due to pods ready timeout", func() {
+				util.ExpectWorkloadsToBeEvictedByKeys(ctx, k8sClient, wlKey)
+			})
+
+			ginkgo.By("Waiting for BackoffFinished", func() {
+				wl := &kueue.Workload{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
+					g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusTrueAndReason(kueue.WorkloadRequeued, kueue.WorkloadBackoffFinished))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking the workload isn't admitted due to don't have pod replacements", func() {
+				wl := &kueue.Workload{}
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
+					g.Expect(workload.IsActive(wl)).Should(gomega.BeTrue())
+					g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusFalse(kueue.WorkloadQuotaReserved))
+					g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusFalse(kueue.WorkloadAdmitted))
+					g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadEvicted))
+					g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadWaitingForReplacementPods))
+				}, util.ShortConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+			})
+
+			replacementPod := testingpod.MakePod("replacement-pod", ns.Name).
+				Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
+				GroupNameLabel(podGroupName).
+				GroupTotalCount("2").
+				Queue(lq.Name).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			ginkgo.By("Creating replacement pod", func() {
+				util.MustCreate(ctx, k8sClient, replacementPod)
+			})
+
+			ginkgo.By("Checking that workload was admitted", func() {
+				util.ExpectWorkloadsToBeAdmittedByKeys(ctx, k8sClient, wlKey)
+			})
 		})
 	})
 })

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -933,16 +933,21 @@ func AwaitAndVerifyCreatedWorkload(ctx context.Context, client client.Client, wl
 	return createdWorkload
 }
 
-func SetPodsPhase(ctx context.Context, k8sClient client.Client, phase corev1.PodPhase, pods ...*corev1.Pod) {
+func SetPodsPhaseByKeys(ctx context.Context, k8sClient client.Client, phase corev1.PodPhase, keys ...client.ObjectKey) {
 	ginkgo.GinkgoHelper()
-	for _, p := range pods {
+	for _, key := range keys {
 		updatedPod := corev1.Pod{}
 		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(p), &updatedPod)).To(gomega.Succeed())
+			g.Expect(k8sClient.Get(ctx, key, &updatedPod)).To(gomega.Succeed())
 			updatedPod.Status.Phase = phase
 			g.Expect(k8sClient.Status().Update(ctx, &updatedPod)).To(gomega.Succeed())
 		}, Timeout, Interval).Should(gomega.Succeed(), AssertMsg("Failed to set pod phase", &updatedPod))
 	}
+}
+
+func SetPodsPhase(ctx context.Context, k8sClient client.Client, phase corev1.PodPhase, pods ...*corev1.Pod) {
+	ginkgo.GinkgoHelper()
+	SetPodsPhaseByKeys(ctx, k8sClient, phase, podKeys(pods)...)
 }
 
 func BindPodWithNode(ctx context.Context, k8sClient client.Client, nodeName string, pods ...*corev1.Pod) {
@@ -1513,6 +1518,14 @@ func workloadKeys(wls []*kueue.Workload) []client.ObjectKey {
 		wlKeys = append(wlKeys, client.ObjectKeyFromObject(wl))
 	}
 	return wlKeys
+}
+
+func podKeys(pods []*corev1.Pod) []client.ObjectKey {
+	keys := make([]client.ObjectKey, 0, len(pods))
+	for _, p := range pods {
+		keys = append(keys, client.ObjectKeyFromObject(p))
+	}
+	return keys
 }
 
 func uniqueKeys(keys []client.ObjectKey) []client.ObjectKey {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12656

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
PodGroup integration: Fixed a bug that allowed Workloads corresponding to PodGroups with the `WaitingForReplacementPods=True` condition to be re-admitted immediately.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new workload condition type for “waiting for replacement pods”.
* **Bug Fixes**
  * Prevented workloads from re-entering queues after backoff when they’re no longer admissible.
  * Blocked admission while “waiting for replacement pods” is true.
  * Improved pod replacement handling for fast-admission scenarios, including more accurate absent-pod counting.
* **Tests**
  * Updated unit, e2e, and integration assertions to use the shared condition type constant.
  * Added a helper to set pod phases by object keys for broader test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->