### PR TITLE
docs: link kueue-populator from docs landing page

### DIFF
--- a/site/content/en/docs/_index.md
+++ b/site/content/en/docs/_index.md
@@ -6,3 +6,7 @@ menu:
   main:
     weight: 20
 ---
+
+## Experimental integrations
+
+- [Kueue Populator](https://github.com/kubernetes-sigs/kueue/tree/main/cmd/experimental/kueue-populator) automatically creates LocalQueues in namespaces selected by a ClusterQueue.

--- a/site/content/en/docs/_index.md
+++ b/site/content/en/docs/_index.md
@@ -7,6 +7,4 @@ menu:
     weight: 20
 ---
 
-## Experimental integrations
-
-- [Kueue Populator](https://github.com/kubernetes-sigs/kueue/tree/main/cmd/experimental/kueue-populator) automatically creates LocalQueues in namespaces selected by a ClusterQueue.
+For community-driven extensions and experimental controllers, see [Satellite Projects]({{< ref "/docs/satellite-projects" >}}).

--- a/site/content/en/docs/satellite-projects.md
+++ b/site/content/en/docs/satellite-projects.md
@@ -1,0 +1,27 @@
+---
+title: "Satellite Projects"
+linkTitle: "Satellite Projects"
+weight: 85
+description: >
+  Community-driven extensions and experimental controllers built on top of Kueue.
+---
+
+Satellite projects complement Kueue's core functionality with specialized controllers and integrations maintained outside the main binary.
+
+## Experimental
+
+The following experimental controllers are developed alongside Kueue but are not part of the main release. They demonstrate patterns for extending Kueue and provide opt-in capabilities for advanced use cases.
+
+### Kueue Populator
+
+[Kueue Populator](https://github.com/kubernetes-sigs/kueue/tree/main/cmd/experimental/kueue-populator) automatically creates `LocalQueue` resources in namespaces that match a `ClusterQueue`'s `namespaceSelector`. This simplifies provisioning for multi-tenant clusters where `LocalQueue`s should follow namespace lifecycle.
+
+**Status:** Experimental  
+**Build & Deploy:** Independent binary and Helm chart
+
+### Kueue Priority Booster
+
+[Kueue Priority Booster](https://github.com/kubernetes-sigs/kueue/tree/main/cmd/experimental/kueue-priority-booster) implements time-sharing fairness by gradually reducing the effective priority of long-running workloads via the `kueue.x-k8s.io/priority-boost` annotation. This enables same-priority workloads to preempt each other after a configurable window under the `LowerPriority` preemption policy.
+
+**Status:** Experimental  
+**Build & Deploy:** Independent binary and Helm chart


### PR DESCRIPTION
What this PR does / why we need it:
Adds a small reference to Kueue Populator from the documentation landing page. This satisfies the request in #8094 without adding a new docs page or duplicating the existing component README.

Which issue(s) this PR fixes:
Fixes #8094

Special notes for your reviewer:
This intentionally links to the existing experimental component README rather than introducing new generated docs content.

AI assistance disclosure:
I used AI assistance to locate the existing Kueue Populator README and prepare this small documentation link update.

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation landing page to point users to a new “Satellite Projects” page for community-driven extensions and experimental controllers.
  * Added the “Satellite Projects” documentation, including an “Experimental” section with opt-in projects such as Kueue Populator and Kueue Priority Booster, plus status and build/deploy details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
