### PR TITLE
Automated cherry pick of #12334: bug: support for pod level resources

### DIFF
--- a/pkg/controller/core/indexer/indexer.go
+++ b/pkg/controller/core/indexer/indexer.go
@@ -37,7 +37,7 @@ const (
 	WorkloadQueueKey                     = "spec.queueName"
 	WorkloadClusterQueueKey              = "status.admission.clusterQueue"
 	QueueClusterQueueKey                 = "spec.clusterQueue"
-	LimitRangeHasContainerType           = "spec.hasContainerType"
+	LimitRangeHasContainerOrPodType      = "spec.hasContainerOrPodType"
 	WorkloadQuotaReservedKey             = "status.quotaReserved"
 	WorkloadRuntimeClassKey              = "spec.runtimeClass"
 	OwnerReferenceUID                    = "metadata.ownerReferences.uid"
@@ -124,14 +124,14 @@ func IndexWorkloadClusterQueue(obj client.Object) []string {
 	return []string{string(wl.Status.Admission.ClusterQueue)}
 }
 
-func IndexLimitRangeHasContainerType(obj client.Object) []string {
+func IndexLimitRangeHasContainerOrPodType(obj client.Object) []string {
 	lr, ok := obj.(*corev1.LimitRange)
 	if !ok {
 		return nil
 	}
-
 	for i := range lr.Spec.Limits {
-		if lr.Spec.Limits[i].Type == corev1.LimitTypeContainer {
+		t := lr.Spec.Limits[i].Type
+		if t == corev1.LimitTypeContainer || t == corev1.LimitTypePod {
 			return []string{"true"}
 		}
 	}
@@ -249,8 +249,8 @@ func Setup(ctx context.Context, indexer client.FieldIndexer) error {
 	if err := indexer.IndexField(ctx, &kueue.LocalQueue{}, QueueClusterQueueKey, IndexQueueClusterQueue); err != nil {
 		return fmt.Errorf("setting index on clusterQueue for localQueue: %w", err)
 	}
-	if err := indexer.IndexField(ctx, &corev1.LimitRange{}, LimitRangeHasContainerType, IndexLimitRangeHasContainerType); err != nil {
-		return fmt.Errorf("setting index on hasContainerType for limitRange: %w", err)
+	if err := indexer.IndexField(ctx, &corev1.LimitRange{}, LimitRangeHasContainerOrPodType, IndexLimitRangeHasContainerOrPodType); err != nil {
+		return fmt.Errorf("setting index on hasContainerOrPodType for limitRange: %w", err)
 	}
 	if err := indexer.IndexField(ctx, &kueue.Workload{}, OwnerReferenceUID, IndexOwnerUID); err != nil {
 		return fmt.Errorf("setting index on ownerReferences.uid for Workload: %w", err)

--- a/pkg/controller/core/indexer/indexer_test.go
+++ b/pkg/controller/core/indexer/indexer_test.go
@@ -20,13 +20,73 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
 )
+
+// helpers to build test objects without importing any package that transitively
+// imports this (indexer) package, which would create an import cycle.
+
+func makeWorkload(name, ns string) *kueue.Workload {
+	return &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
+}
+
+func makeLimitRange(name, ns string, types ...corev1.LimitType) *corev1.LimitRange {
+	items := make([]corev1.LimitRangeItem, len(types))
+	for i, t := range types {
+		items[i] = corev1.LimitRangeItem{Type: t}
+	}
+	return &corev1.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec:       corev1.LimitRangeSpec{Limits: items},
+	}
+}
+
+func TestIndexLimitRangeHasContainerOrPodType(t *testing.T) {
+	cases := map[string]struct {
+		obj  client.Object
+		want []string
+	}{
+		"non-LimitRange returns nil": {
+			obj:  makeWorkload("wl", "ns"),
+			want: nil,
+		},
+		"LimitRange with no limits returns nil": {
+			obj:  makeLimitRange("lr", "ns"),
+			want: nil,
+		},
+		"LimitRange with only Pod type returns nil": {
+			obj:  makeLimitRange("lr", "ns", corev1.LimitTypePod),
+			want: []string{"true"},
+		},
+		"LimitRange with Container type returns true": {
+			obj:  makeLimitRange("lr", "ns", corev1.LimitTypeContainer),
+			want: []string{"true"},
+		},
+		"LimitRange with both Pod and Container types returns true": {
+			obj:  makeLimitRange("lr", "ns", corev1.LimitTypePod, corev1.LimitTypeContainer),
+			want: []string{"true"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := IndexLimitRangeHasContainerOrPodType(tc.obj)
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
 
 // fakeFieldIndexer implements client.FieldIndexer for testing Setup().
 // It returns noMatchErr for DeviceClass objects when set, simulating a cluster

--- a/pkg/util/pod/pod.go
+++ b/pkg/util/pod/pod.go
@@ -137,7 +137,7 @@ func GenerateRoleHash(podSpec *corev1.PodSpec) (string, error) {
 }
 
 func SpecShape(podSpec *corev1.PodSpec) (result map[string]any) {
-	return map[string]any{
+	shape := map[string]any{
 		"initContainers":            ContainersShape(podSpec.InitContainers),
 		"containers":                ContainersShape(podSpec.Containers),
 		"nodeSelector":              podSpec.NodeSelector,
@@ -149,6 +149,12 @@ func SpecShape(podSpec *corev1.PodSpec) (result map[string]any) {
 		"overhead":                  podSpec.Overhead,
 		"resourceClaims":            podSpec.ResourceClaims,
 	}
+	// Pod-level resources (KEP-2837) only contribute to the shape when set, so that
+	// role hashes computed for pods without them stay stable across upgrades.
+	if podSpec.Resources != nil {
+		shape["resources"] = podSpec.Resources.Requests
+	}
+	return shape
 }
 
 func ContainersShape(containers []corev1.Container) (result []map[string]any) {

--- a/pkg/util/pod/pod_test.go
+++ b/pkg/util/pod/pod_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -248,6 +249,79 @@ func TestIsTerminated(t *testing.T) {
 			got := IsTerminated(tc.pod)
 			if tc.wantTerminated != got {
 				t.Errorf("Unexpected Pod terminal\nwant: %v\ngot: %v\n", tc.wantTerminated, got)
+			}
+		})
+	}
+}
+
+func TestSpecShape(t *testing.T) {
+	podResources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+		Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+	}
+	cases := map[string]struct {
+		podSpec       *corev1.PodSpec
+		wantResources any
+		wantPresent   bool
+	}{
+		"pod-level resources omitted when unset": {
+			podSpec:     &corev1.PodSpec{Containers: []corev1.Container{{Name: "c"}}},
+			wantPresent: false,
+		},
+		"pod-level resources included when set": {
+			podSpec:       &corev1.PodSpec{Containers: []corev1.Container{{Name: "c"}}, Resources: podResources},
+			wantResources: podResources.Requests,
+			wantPresent:   true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, present := SpecShape(tc.podSpec)["resources"]
+			if present != tc.wantPresent {
+				t.Fatalf("Unexpected presence of \"resources\" key: want %v, got %v", tc.wantPresent, present)
+			}
+			if diff := cmp.Diff(tc.wantResources, got); diff != "" {
+				t.Errorf("Unexpected resources shape (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGenerateRoleHash(t *testing.T) {
+	withoutPodResources := &corev1.PodSpec{Containers: []corev1.Container{{Name: "c"}}}
+	withPodResources := &corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "c"}},
+		Resources: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+		},
+	}
+
+	baseHash, err := GenerateRoleHash(withoutPodResources)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	cases := map[string]struct {
+		podSpec      *corev1.PodSpec
+		wantBaseHash bool
+	}{
+		"pod-level resources change the role hash": {
+			podSpec: withPodResources,
+		},
+		"spec without pod-level resources has a stable role hash": {
+			podSpec:      withoutPodResources.DeepCopy(),
+			wantBaseHash: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			gotHash, err := GenerateRoleHash(tc.podSpec)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if gotBaseHash := gotHash == baseHash; gotBaseHash != tc.wantBaseHash {
+				t.Errorf("Unexpected role hash comparison with base hash: want equality %t, base hash %q, got hash %q", tc.wantBaseHash, baseHash, gotHash)
 			}
 		})
 	}

--- a/pkg/util/testing/v1beta2/wrappers.go
+++ b/pkg/util/testing/v1beta2/wrappers.go
@@ -571,6 +571,28 @@ func (p *PodSetWrapper) Limit(r corev1.ResourceName, q string) *PodSetWrapper {
 	return p
 }
 
+func (p *PodSetWrapper) PodLevelRequest(r corev1.ResourceName, q string) *PodSetWrapper {
+	if p.Template.Spec.Resources == nil {
+		p.Template.Spec.Resources = &corev1.ResourceRequirements{}
+	}
+	if p.Template.Spec.Resources.Requests == nil {
+		p.Template.Spec.Resources.Requests = corev1.ResourceList{}
+	}
+	p.Template.Spec.Resources.Requests[r] = resource.MustParse(q)
+	return p
+}
+
+func (p *PodSetWrapper) PodLevelLimit(r corev1.ResourceName, q string) *PodSetWrapper {
+	if p.Template.Spec.Resources == nil {
+		p.Template.Spec.Resources = &corev1.ResourceRequirements{}
+	}
+	if p.Template.Spec.Resources.Limits == nil {
+		p.Template.Spec.Resources.Limits = corev1.ResourceList{}
+	}
+	p.Template.Spec.Resources.Limits[r] = resource.MustParse(q)
+	return p
+}
+
 func (p *PodSetWrapper) Image(image string) *PodSetWrapper {
 	p.Template.Spec.Containers[0].Image = image
 	return p

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -67,7 +67,7 @@ func handlePodOverhead(ctx context.Context, cl client.Client, wl *kueue.Workload
 func handlePodLimitRange(ctx context.Context, cl client.Client, wl *kueue.Workload) error {
 	// get the list of limit ranges
 	var limitRanges corev1.LimitRangeList
-	if err := cl.List(ctx, &limitRanges, &client.ListOptions{Namespace: wl.Namespace}, client.MatchingFields{indexer.LimitRangeHasContainerType: "true"}); err != nil {
+	if err := cl.List(ctx, &limitRanges, &client.ListOptions{Namespace: wl.Namespace}, client.MatchingFields{indexer.LimitRangeHasContainerOrPodType: "true"}); err != nil {
 		return err
 	}
 
@@ -75,22 +75,31 @@ func handlePodLimitRange(ctx context.Context, cl client.Client, wl *kueue.Worklo
 		return nil
 	}
 	summary := limitrange.Summarize(limitRanges.Items...)
-	containerLimits, found := summary[corev1.LimitTypeContainer]
-	if !found {
+	podLimits, foundPodLimits := summary[corev1.LimitTypePod]
+	containerLimits, foundContainerLimits := summary[corev1.LimitTypeContainer]
+	if !foundPodLimits && !foundContainerLimits {
 		return nil
 	}
 
 	for pi := range wl.Spec.PodSets {
 		pod := &wl.Spec.PodSets[pi].Template.Spec
-		for ci := range pod.InitContainers {
-			res := &pod.InitContainers[ci].Resources
-			res.Limits = resource.MergeResourceListKeepFirst(res.Limits, containerLimits.Default)
-			res.Requests = resource.MergeResourceListKeepFirst(res.Requests, containerLimits.DefaultRequest)
+		if foundContainerLimits {
+			for ci := range pod.InitContainers {
+				res := &pod.InitContainers[ci].Resources
+				res.Limits = resource.MergeResourceListKeepFirst(res.Limits, containerLimits.Default)
+				res.Requests = resource.MergeResourceListKeepFirst(res.Requests, containerLimits.DefaultRequest)
+			}
+			for ci := range pod.Containers {
+				res := &pod.Containers[ci].Resources
+				res.Limits = resource.MergeResourceListKeepFirst(res.Limits, containerLimits.Default)
+				res.Requests = resource.MergeResourceListKeepFirst(res.Requests, containerLimits.DefaultRequest)
+			}
 		}
-		for ci := range pod.Containers {
-			res := &pod.Containers[ci].Resources
-			res.Limits = resource.MergeResourceListKeepFirst(res.Limits, containerLimits.Default)
-			res.Requests = resource.MergeResourceListKeepFirst(res.Requests, containerLimits.DefaultRequest)
+		// Pod-level resources (KEP-2837) are an optional pointer, only set when the
+		// PodLevelResources feature is enabled and used.
+		if pod.Resources != nil && foundPodLimits {
+			pod.Resources.Limits = resource.MergeResourceListKeepFirst(pod.Resources.Limits, podLimits.Default)
+			pod.Resources.Requests = resource.MergeResourceListKeepFirst(pod.Resources.Requests, podLimits.DefaultRequest)
 		}
 	}
 	return nil
@@ -112,6 +121,11 @@ func UseLimitsAsMissingRequestsInPod(pod *corev1.PodSpec) {
 	for ci := range pod.Containers {
 		res := &pod.Containers[ci].Resources
 		res.Requests = resource.MergeResourceListKeepFirst(res.Requests, res.Limits)
+	}
+	// Pod-level resources (KEP-2837) are an optional pointer, only set when the
+	// PodLevelResources feature is enabled and used.
+	if pod.Resources != nil {
+		pod.Resources.Requests = resource.MergeResourceListKeepFirst(pod.Resources.Requests, pod.Resources.Limits)
 	}
 }
 
@@ -154,6 +168,17 @@ func ValidateResources(wi *Info) field.ErrorList {
 				allErrors = append(
 					allErrors,
 					field.Invalid(podSpecPath.Child("containers").Index(i), resNames, RequestsMustNotExceedLimitMessage),
+				)
+			}
+		}
+
+		// Pod-level resources (KEP-2837) are an optional pointer, only set when the
+		// PodLevelResources feature is enabled and used.
+		if podResources := ps.Template.Spec.Resources; podResources != nil {
+			if resNames := resources.NewRequests(podResources.Requests).GreaterKeys(resources.NewRequests(podResources.Limits)); len(resNames) > 0 {
+				allErrors = append(
+					allErrors,
+					field.Invalid(podSpecPath.Child("resources"), resNames, RequestsMustNotExceedLimitMessage),
 				)
 			}
 		}

--- a/pkg/workload/resources_test.go
+++ b/pkg/workload/resources_test.go
@@ -293,6 +293,52 @@ func TestAdjustResources(t *testing.T) {
 				).
 				Obj(),
 		},
+		"Handle pod-level resources with pod limit range": {
+			limitranges: []corev1.LimitRange{
+				utiltesting.MakeLimitRange("foo", "").
+					WithType(corev1.LimitTypePod).
+					WithValue(
+						"Default", corev1.ResourceCPU, "4",
+					).
+					WithValue(
+						"Default", corev1.ResourceMemory, "1Gi",
+					).
+					WithValue(
+						"DefaultRequest", corev1.ResourceCPU, "3",
+					).
+					WithValue(
+						"DefaultRequest", corev1.ResourceMemory, "512Mi",
+					).
+					LimitRange,
+			},
+			wl: utiltestingapi.MakeWorkload("foo", "").
+				PodSets(
+					*utiltestingapi.MakePodSet("a", 1).
+						PodLevelLimit(corev1.ResourceMemory, "2Gi").
+						Obj(),
+					*utiltestingapi.MakePodSet("b", 1).
+						PodLevelLimit(corev1.ResourceCPU, "6").
+						PodLevelRequest(corev1.ResourceCPU, "1").
+						Obj(),
+				).
+				Obj(),
+			wantWl: utiltestingapi.MakeWorkload("foo", "").
+				PodSets(
+					*utiltestingapi.MakePodSet("a", 1).
+						PodLevelLimit(corev1.ResourceCPU, "4").
+						PodLevelLimit(corev1.ResourceMemory, "2Gi").
+						PodLevelRequest(corev1.ResourceCPU, "3").
+						PodLevelRequest(corev1.ResourceMemory, "512Mi").
+						Obj(),
+					*utiltestingapi.MakePodSet("b", 1).
+						PodLevelLimit(corev1.ResourceCPU, "6").
+						PodLevelLimit(corev1.ResourceMemory, "1Gi").
+						PodLevelRequest(corev1.ResourceCPU, "1").
+						PodLevelRequest(corev1.ResourceMemory, "512Mi").
+						Obj(),
+				).
+				Obj(),
+		},
 		"Handle empty container limit range": {
 			limitranges: []corev1.LimitRange{
 				utiltesting.MakeLimitRange("foo", "").
@@ -316,6 +362,37 @@ func TestAdjustResources(t *testing.T) {
 					*utiltestingapi.MakePodSet("b", 1).
 						Limit(corev1.ResourceCPU, "6").
 						Request(corev1.ResourceCPU, "1").
+						Obj(),
+				).
+				Obj(),
+		},
+		"Apply pod-level limits to requests": {
+			wl: utiltestingapi.MakeWorkload("foo", "").
+				PodSets(
+					*utiltestingapi.MakePodSet("a", 1).
+						PodLevelLimit(corev1.ResourceCPU, "1").
+						PodLevelLimit(corev1.ResourceMemory, "1Gi").
+						Obj(),
+					*utiltestingapi.MakePodSet("b", 1).
+						PodLevelRequest(corev1.ResourceCPU, "2").
+						PodLevelLimit(corev1.ResourceCPU, "3").
+						PodLevelLimit(corev1.ResourceMemory, "1Gi").
+						Obj(),
+				).
+				Obj(),
+			wantWl: utiltestingapi.MakeWorkload("foo", "").
+				PodSets(
+					*utiltestingapi.MakePodSet("a", 1).
+						PodLevelLimit(corev1.ResourceCPU, "1").
+						PodLevelLimit(corev1.ResourceMemory, "1Gi").
+						PodLevelRequest(corev1.ResourceCPU, "1").
+						PodLevelRequest(corev1.ResourceMemory, "1Gi").
+						Obj(),
+					*utiltestingapi.MakePodSet("b", 1).
+						PodLevelRequest(corev1.ResourceCPU, "2").
+						PodLevelLimit(corev1.ResourceCPU, "3").
+						PodLevelLimit(corev1.ResourceMemory, "1Gi").
+						PodLevelRequest(corev1.ResourceMemory, "1Gi").
 						Obj(),
 				).
 				Obj(),
@@ -478,7 +555,7 @@ func TestAdjustResources(t *testing.T) {
 			cl := utiltesting.NewClientBuilder().WithLists(
 				&nodev1.RuntimeClassList{Items: tc.runtimeClasses},
 				&corev1.LimitRangeList{Items: tc.limitranges},
-			).WithIndex(&corev1.LimitRange{}, indexer.LimitRangeHasContainerType, indexer.IndexLimitRangeHasContainerType).
+			).WithIndex(&corev1.LimitRange{}, indexer.LimitRangeHasContainerOrPodType, indexer.IndexLimitRangeHasContainerOrPodType).
 				Build()
 			ctx, _ := utiltesting.ContextWithLog(t)
 			AdjustResources(ctx, cl, tc.wl)
@@ -515,6 +592,32 @@ func TestValidateResources(t *testing.T) {
 									Obj()).
 							Obj(),
 					).Obj(),
+			},
+		},
+		"valid workload with pod-level resources": {
+			workloadInfo: &Info{
+				Obj: utiltestingapi.MakeWorkload("alpha", metav1.NamespaceDefault).
+					PodSets(
+						*utiltestingapi.MakePodSet("a", 1).
+							PodLevelRequest(corev1.ResourceCPU, "100m").
+							PodLevelLimit(corev1.ResourceCPU, "200m").
+							Obj(),
+					).Obj(),
+			},
+		},
+		"invalid workload; pod-level requests exceed limits": {
+			workloadInfo: &Info{
+				Obj: utiltestingapi.MakeWorkload("alpha", metav1.NamespaceDefault).
+					PodSets(
+						*utiltestingapi.MakePodSet("a", 1).
+							PodLevelRequest(corev1.ResourceCPU, "300m").
+							PodLevelLimit(corev1.ResourceCPU, "200m").
+							Obj(),
+					).Obj(),
+			},
+			wantError: field.ErrorList{
+				field.Invalid(PodSetsPath.Index(0).Child("template").Child("spec").Child("resources"),
+					[]corev1.ResourceName{corev1.ResourceCPU}, RequestsMustNotExceedLimitMessage),
 			},
 		},
 		"invalid workload; multiple PodSet has invalid initContainers and containers": {

--- a/site/content/en/docs/concepts/workload.md
+++ b/site/content/en/docs/concepts/workload.md
@@ -75,13 +75,17 @@ Kueue uses the `podSets` resources requests to calculate the quota used by a Wor
 
 Kueue calculates the total resources usage for a Workload as the sum of the resource requests for each `podSet`. The resource usage of a `podSet` is equal to the resource requests of the pod spec multiplied by the `count`.
 
+#### Pod-level resources
+
+When the [`PodLevelResources`](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pod-level-resources/) feature is enabled in the cluster (Kubernetes 1.32+), a pod may declare CPU and memory requests and limits at the pod level via `pod.spec.resources` instead of, or in addition to, the per-container requests. Kueue accounts for these pod-level requests when computing a Workload's quota usage, and the requests-value adjustment and validation described below apply to `pod.spec.resources` as well as to container resources.
+
 #### Requests values adjustment
 
 Depending on the cluster setup, Kueue will adjust the resource usage of a Workload based on:
 
 - The cluster defines default values in [Limit Ranges](https://kubernetes.io/docs/concepts/policy/limit-range/), the default values will be used if not provided in the `spec`.
 - The created pods are subject of a [Runtime Class Overhead](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-overhead/).
-- The spec defines only resource limits, case in which the limit values will be treated as requests.
+- The spec defines only resource limits, case in which the limit values will be treated as requests. This also applies to limits set at the pod level via `pod.spec.resources`.
 
 #### Requests values validation
 
@@ -154,7 +158,7 @@ the requeueState (`.status.requeueState`) will be reset to null.
 
 ## Replicate labels from Jobs into Workloads
 You can configure Kueue to copy labels, at Workload creation, into the new Workload from the underlying Job or Pod objects. This can be useful for Workload identification and debugging.
-You can specify which labels should be copied by setting the `labelKeysToCopy` field in the configuration API (under `integrations`). By default, Kueue does not copy any Job or Pod label into the Workload. 
+You can specify which labels should be copied by setting the `labelKeysToCopy` field in the configuration API (under `integrations`). By default, Kueue does not copy any Job or Pod label into the Workload.
 
 ## Maximum execution time
 
@@ -170,7 +174,7 @@ Once deactivated, the accumulated time spent as active in previous "Admit/Evict"
 
 If `maximumExecutionTimeSeconds` is not specified, the workload has no execution time limit.
 
-You can configure the `maximumExecutionTimeSeconds` of the Workload associated with any supported Kueue Job by specifying the desired value as `kueue.x-k8s.io/max-exec-time-seconds` label of the job. 
+You can configure the `maximumExecutionTimeSeconds` of the Workload associated with any supported Kueue Job by specifying the desired value as `kueue.x-k8s.io/max-exec-time-seconds` label of the job.
 
 ## Workload updates by Kueue
 
@@ -185,13 +189,13 @@ for instructions on configuring feature gates.
 {{% /alert %}}
 
 
-By default Workload status updates are performed by Kueue using the [Server-Side Apply (SSA)](https://kubernetes.io/docs/reference/using-api/server-side-apply/). 
+By default Workload status updates are performed by Kueue using the [Server-Side Apply (SSA)](https://kubernetes.io/docs/reference/using-api/server-side-apply/).
 
 However due to the limitations of SSA ([missing support for duplicated key/value pairs](https://github.com/kubernetes/kubernetes/issues/113482)) we also offer to enable updating the Workload status
-with Merge Patches, by enabling the `WorkloadRequestUseMergePatch` feature gate. 
+with Merge Patches, by enabling the `WorkloadRequestUseMergePatch` feature gate.
 
 In particular, this allows users of Kueue to handle the following two issues:
-- [Add option to disable strict pod spec validation](https://github.com/kubernetes-sigs/kueue/issues/3540) 
+- [Add option to disable strict pod spec validation](https://github.com/kubernetes-sigs/kueue/issues/3540)
 Switching from ServerSideApply to Merge Patch allows partial updates without requiring the entire resource specification.
 This can bypass the strict validation rules causing issues with duplicated environment variables, aligning Kueue's behavior more closely with plain Kubernetes
 - [MultiKueue: remove the limitation that the external dispatches need to use kueue-admission field manager ](https://github.com/kubernetes-sigs/kueue/issues/6185)

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -2261,6 +2261,185 @@ var _ = ginkgo.Describe("Scheduler", func() {
 		)
 	})
 
+	ginkgo.When("The workload's podSet pod-level resource requests are not valid", func() {
+		var (
+			cq    *kueue.ClusterQueue
+			queue *kueue.LocalQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			cq = utiltestingapi.MakeClusterQueue("cluster-queue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, cq)
+			queue = utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue(cq.Name).Obj()
+			util.MustCreate(ctx, k8sClient, queue)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		})
+
+		expectQuotaReservedConditionMessage := func(wl *kueue.Workload, wantedStatus string) {
+			ginkgo.GinkgoHelper()
+			gomega.Eventually(func(g gomega.Gomega) {
+				rwl := kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &rwl)).Should(gomega.Succeed())
+				cond := meta.FindStatusCondition(rwl.Status.Conditions, kueue.WorkloadQuotaReserved)
+				g.Expect(cond).ShouldNot(gomega.BeNil())
+				g.Expect(cond.Message).Should(gomega.ContainSubstring(wantedStatus))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		}
+
+		ginkgo.It("blocks workloads when pod-level requests exceed pod-level limits", func() {
+			wl := utiltestingapi.MakeWorkload("pod-request-over-limit", ns.Name).
+				Queue(kueue.LocalQueueName(queue.Name)).
+				PodSets(
+					*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+						Request(corev1.ResourceCPU, "1").
+						Limit(corev1.ResourceCPU, "2").
+						PodLevelRequest(corev1.ResourceCPU, "3").
+						PodLevelLimit(corev1.ResourceCPU, "2").
+						Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+			expectQuotaReservedConditionMessage(wl, "resources validation failed:")
+		})
+
+		ginkgo.It("blocks workloads when pod-level requests exceed the pod LimitRange max", func() {
+			lr := utiltesting.MakeLimitRange("pod-max-limit", ns.Name).
+				WithType(corev1.LimitTypePod).
+				WithValue("Max", corev1.ResourceCPU, "1").
+				Obj()
+			util.MustCreate(ctx, k8sClient, lr)
+
+			wl := utiltestingapi.MakeWorkload("pod-request-over-max", ns.Name).
+				Queue(kueue.LocalQueueName(queue.Name)).
+				PodSets(
+					*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+						Request(corev1.ResourceCPU, "500m").
+						Limit(corev1.ResourceCPU, "500m").
+						PodLevelRequest(corev1.ResourceCPU, "2").
+						PodLevelLimit(corev1.ResourceCPU, "3").
+						Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+			expectQuotaReservedConditionMessage(wl, "resources didn't satisfy LimitRange constraints:")
+		})
+
+		ginkgo.It("blocks workloads when pod-level requests are below the pod LimitRange min", func() {
+			lr := utiltesting.MakeLimitRange("pod-min-limit", ns.Name).
+				WithType(corev1.LimitTypePod).
+				WithValue("Min", corev1.ResourceCPU, "3").
+				Obj()
+			util.MustCreate(ctx, k8sClient, lr)
+
+			wl := utiltestingapi.MakeWorkload("pod-request-under-min", ns.Name).
+				Queue(kueue.LocalQueueName(queue.Name)).
+				PodSets(
+					*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+						Request(corev1.ResourceCPU, "500m").
+						Limit(corev1.ResourceCPU, "500m").
+						PodLevelRequest(corev1.ResourceCPU, "2").
+						PodLevelLimit(corev1.ResourceCPU, "3").
+						Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+			expectQuotaReservedConditionMessage(wl, "resources didn't satisfy LimitRange constraints:")
+		})
+
+		ginkgo.It("admits workloads when pod-level resources satisfy the pod LimitRange", func() {
+			lr := utiltesting.MakeLimitRange("pod-resource-range", ns.Name).
+				WithType(corev1.LimitTypePod).
+				WithValue("Min", corev1.ResourceCPU, "1").
+				WithValue("Max", corev1.ResourceCPU, "4").
+				Obj()
+			util.MustCreate(ctx, k8sClient, lr)
+			wl := utiltestingapi.MakeWorkload("valid-pod-resources", ns.Name).
+				Queue(kueue.LocalQueueName(queue.Name)).
+				PodSets(
+					*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+						Request(corev1.ResourceCPU, "500m").
+						Limit(corev1.ResourceCPU, "500m").
+						PodLevelRequest(corev1.ResourceCPU, "2").
+						PodLevelLimit(corev1.ResourceCPU, "3").
+						Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, wl)
+		})
+	})
+
+	ginkgo.When("Pod-level resources are counted against ClusterQueue quota", func() {
+		var (
+			cq    *kueue.ClusterQueue
+			queue *kueue.LocalQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			cq = utiltestingapi.MakeClusterQueue("cluster-queue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "3").Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, cq)
+			queue = utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue(cq.Name).Obj()
+			util.MustCreate(ctx, k8sClient, queue)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		})
+		// Each workload has container-level req=500m (both would fit in 3 CPU if the
+		// scheduler used container values) and pod-level req=2 CPU (only one fits in 3
+		// CPU). The test verifies the scheduler accounts for the pod-level value.
+		ginkgo.It("Should block a second workload when pod-level requests exhaust quota", func() {
+			ginkgo.By("creating the first workload with pod-level CPU request of 2")
+			wl1 := utiltestingapi.MakeWorkload("wl1", ns.Name).
+				Queue(kueue.LocalQueueName(queue.Name)).
+				PodSets(
+					*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+						Request(corev1.ResourceCPU, "500m").
+						Limit(corev1.ResourceCPU, "500m").
+						PodLevelRequest(corev1.ResourceCPU, "2").
+						PodLevelLimit(corev1.ResourceCPU, "2").
+						Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl1)
+
+			ginkgo.By("verifying the first workload is admitted")
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, wl1)
+
+			ginkgo.By("creating the second workload with the same pod-level CPU request")
+			wl2 := utiltestingapi.MakeWorkload("wl2", ns.Name).
+				Queue(kueue.LocalQueueName(queue.Name)).
+				PodSets(
+					*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+						Request(corev1.ResourceCPU, "500m").
+						Limit(corev1.ResourceCPU, "500m").
+						PodLevelRequest(corev1.ResourceCPU, "2").
+						PodLevelLimit(corev1.ResourceCPU, "2").
+						Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl2)
+
+			ginkgo.By("verifying the second workload is pending due to insufficient quota")
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
+			util.ExpectPendingWorkloadsMetric(cq, 0, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq, "", 1)
+		})
+	})
+
 	ginkgo.When("Using clusterQueue stop policy", func() {
 		var (
 			cq    *kueue.ClusterQueue

--- a/test/integration/singlecluster/scheduler/workload_controller_test.go
+++ b/test/integration/singlecluster/scheduler/workload_controller_test.go
@@ -453,6 +453,50 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 				gomega.Expect(wl.Spec.PodSets).Should(gomega.BeComparableTo(wlRead.Spec.PodSets))
 			})
 		})
+
+		ginkgo.It("The pod-level limits should be used as pod-level request values", func() {
+			ginkgo.By("Create workload with only a pod-level limit (no pod-level request) and then create the LocalQueue", func() {
+				wl = utiltestingapi.MakeWorkload("pod-level-limit", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							PodLevelLimit(corev1.ResourceCPU, "2").
+							Obj(),
+					).
+					Obj()
+				util.MustCreate(ctx, k8sClient, wl)
+				util.MustCreate(ctx, k8sClient, localQueue)
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					read := kueue.Workload{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).Should(gomega.Succeed())
+					g.Expect(workload.HasQuotaReservation(&read)).Should(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Check queue resource consumption reflects the pod-level limit used as request", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
+					g.Expect(updatedCQ.Status).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
+						PendingWorkloads:   0,
+						ReservingWorkloads: 1,
+						FlavorsReservation: []kueue.FlavorUsage{{
+							Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+							Resources: []kueue.ResourceUsage{{
+								Name:  corev1.ResourceCPU,
+								Total: resource.MustParse("2"),
+							}},
+						}},
+					}, ignoreCqCondition, ignoreInClusterQueueStatus))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Check podSets spec is not mutated by synthesized pod-level requests", func() {
+				wlRead := kueue.Workload{}
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &wlRead)).To(gomega.Succeed())
+				gomega.Expect(wlRead.Spec.PodSets).Should(gomega.BeComparableTo(wl.Spec.PodSets))
+			})
+		})
 	})
 
 	ginkgo.When("Resource transformations are applied", func() {
@@ -740,6 +784,64 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 							Resources: []kueue.ResourceUsage{{
 								Name:  corev1.ResourceCPU,
 								Total: resource.MustParse("5"),
+							}},
+						}},
+					}, ignoreCqCondition, ignoreInClusterQueueStatus))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("Should sync the pod-level resource requests with the pod-level limit", framework.SlowSpec, func() {
+			// Workloads carry only a pod-level limit (no explicit pod-level request).
+			// The pod-level limit differs from the container LimitRange default request,
+			// so the ClusterQueue reservation verifies which value was used.
+			ginkgo.By("Create and wait for the first workload admission", func() {
+				wl = utiltestingapi.MakeWorkload("pod-level-one", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							PodLevelLimit(corev1.ResourceCPU, "4").
+							Obj(),
+					).
+					Obj()
+				util.MustCreate(ctx, k8sClient, wl)
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					read := kueue.Workload{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).Should(gomega.Succeed())
+					g.Expect(workload.HasQuotaReservation(&read)).Should(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			var wl2 *kueue.Workload
+			ginkgo.By("Create a second workload with the same pod-level limit; it should stay pending", func() {
+				wl2 = utiltestingapi.MakeWorkload("pod-level-two", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							PodLevelLimit(corev1.ResourceCPU, "4").
+							Obj(),
+					).
+					Obj()
+				util.MustCreate(ctx, k8sClient, wl2)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
+				util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
+				util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
+			})
+
+			ginkgo.By("Check queue resource consumption reflects the pod-level limit used as request", func() {
+				// 4 CPU from the first workload's pod-level limit (synced to request);
+				// 1 CPU remaining, not enough for the second workload.
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
+					g.Expect(updatedCQ.Status).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
+						PendingWorkloads:   1,
+						ReservingWorkloads: 1,
+						FlavorsReservation: []kueue.FlavorUsage{{
+							Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+							Resources: []kueue.ResourceUsage{{
+								Name:  corev1.ResourceCPU,
+								Total: resource.MustParse("4"),
 							}},
 						}},
 					}, ignoreCqCondition, ignoreInClusterQueueStatus))


### PR DESCRIPTION
Cherry pick of #12334 on release-0.17.

#12334: bug: support for pod level resources

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
Scheduling: Fixed resource accounting and validation for Pods using Kubernetes pod-level
resources (`pod.spec.resources`), including LimitRange defaulting and request/limit
validation.
```