### PR TITLE
Fix AFS entry penalty leak for workloads admitted via AdmissionChecks

### DIFF
--- a/pkg/cache/queue/afs/entry_penalties.go
+++ b/pkg/cache/queue/afs/entry_penalties.go
@@ -47,6 +47,16 @@ func (m *AfsEntryPenalties) Sub(lqKey utilqueue.LocalQueueReference, penalty cor
 	}
 	m.penalties.UpdateOrDelete(lqKey, func(existing corev1.ResourceList) (corev1.ResourceList, bool) {
 		merged := resource.MergeResourceListKeepSum(existing, negated)
+		// Sub recomputes the amount at settlement time rather than recording it at
+		// push time, so it can exceed what was pushed (e.g. after a restart loses the
+		// in-memory penalties). Clamp at zero: a mismatch must not become a permanent
+		// usage discount for the LocalQueue.
+		for k, v := range merged {
+			if v.Sign() < 0 {
+				v.Set(0)
+				merged[k] = v
+			}
+		}
 		return merged, canClearPenalty(merged)
 	})
 }

--- a/pkg/cache/queue/afs/entry_penalties_test.go
+++ b/pkg/cache/queue/afs/entry_penalties_test.go
@@ -1,0 +1,93 @@
+// Copyright The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package afs
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
+)
+
+func TestSub(t *testing.T) {
+	lqKey := utilqueue.NewLocalQueueReference("ns", "lq")
+
+	cases := map[string]struct {
+		push        corev1.ResourceList
+		sub         corev1.ResourceList
+		wantPending bool
+		wantPenalty corev1.ResourceList
+	}{
+		"subtracting the pushed amount clears the entry": {
+			push:        corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+			sub:         corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+			wantPending: false,
+			wantPenalty: corev1.ResourceList{},
+		},
+		"partial subtraction keeps the remainder": {
+			push:        corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+			sub:         corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			wantPending: true,
+			wantPenalty: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("3")},
+		},
+		"subtracting more than pushed clamps at zero and clears the entry": {
+			push:        corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+			sub:         corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+			wantPending: false,
+			wantPenalty: corev1.ResourceList{},
+		},
+		"subtracting without a prior push does not leave a negative entry": {
+			sub:         corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+			wantPending: false,
+			wantPenalty: corev1.ResourceList{},
+		},
+		"clamping applies per resource": {
+			push: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+			sub: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			wantPending: true,
+			wantPenalty: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("3"),
+				corev1.ResourceMemory: resource.MustParse("0"),
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			m := NewPenaltyMap()
+			if tc.push != nil {
+				m.Push(lqKey, tc.push.DeepCopy())
+			}
+			m.Sub(lqKey, tc.sub.DeepCopy())
+
+			if got := m.HasPendingFor(lqKey); got != tc.wantPending {
+				t.Errorf("HasPendingFor() = %v, want %v", got, tc.wantPending)
+			}
+			got := m.Peek(lqKey)
+			if len(got) != len(tc.wantPenalty) {
+				t.Fatalf("Peek() = %v, want %v", got, tc.wantPenalty)
+			}
+			for name, want := range tc.wantPenalty {
+				if v, ok := got[name]; !ok || v.Cmp(want) != 0 {
+					t.Errorf("Peek()[%s] = %s, want %s", name, v.String(), want.String())
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -1432,9 +1432,6 @@ func (r *WorkloadReconciler) Update(e event.TypedUpdateEvent[*kueue.Workload]) b
 		if !r.cache.AddOrUpdateWorkload(log, wlCopy) {
 			log.V(2).Info("ClusterQueue for workload didn't exist; ignored for now")
 		}
-		if afs.Enabled(r.admissionFSConfig) && status == workload.StatusAdmitted && r.cache.ClusterQueueUsesAdmissionFairSharing(wlCopy.Status.Admission.ClusterQueue) {
-			r.updateAfsConsumedUsage(log, wlCopy)
-		}
 	case workload.FromQuotaReservedOrAdmittedToPending(prevStatus, status):
 		if cq, reason, latency, ok := workload.EvictionPendingLatency(e.ObjectOld, e.ObjectNew, r.clock.Now()); ok {
 			metrics.ReportWorkloadEvictionLatency(cq, reason, latency, r.customLabels.CQGet(cq), r.roleTracker)
@@ -1492,6 +1489,17 @@ func (r *WorkloadReconciler) Update(e event.TypedUpdateEvent[*kueue.Workload]) b
 		// Workload update in the cache is handled here; however, some fields are immutable
 		// and are not supposed to actually change anything.
 		r.cache.AddOrUpdateWorkload(log, wlCopy)
+	}
+	// The AFS entry penalty must be settled on every transition into Admitted
+	// (#12539). It is settled outside the switch so that no transition into
+	// Admitted is missed, and after it so that the cache already accounts for
+	// the workload usage read by updateAfsConsumedUsage. Deactivation wins
+	// over admission: a workload deactivated in the same event was removed
+	// from the cache by the first case and must not be charged.
+	if active && status == workload.StatusAdmitted && prevStatus != workload.StatusAdmitted &&
+		afs.Enabled(r.admissionFSConfig) &&
+		r.cache.ClusterQueueUsesAdmissionFairSharing(wlCopy.Status.Admission.ClusterQueue) {
+		r.updateAfsConsumedUsage(log, wlCopy)
 	}
 	r.queues.QueueSecondPassIfNeeded(ctx, wlCopy, 0)
 	return true

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -54,6 +54,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/dra"
 	"sigs.k8s.io/kueue/pkg/features"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
+	afs "sigs.k8s.io/kueue/pkg/util/admissionfairsharing"
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -541,6 +542,101 @@ func TestUpdateRemovesStaleQueueEntryForOnHoldWorkload(t *testing.T) {
 
 	if pending := qManager.PendingWorkloadsInfo("cq"); len(pending) != 0 {
 		t.Fatalf("expected no workloads in pending queue, got %d", len(pending))
+	}
+}
+
+func TestUpdateSettlesAfsEntryPenalty(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	lqKey := utilqueue.NewLocalQueueReference("ns", "lq")
+
+	makeWl := func() *utiltestingapi.WorkloadWrapper {
+		return utiltestingapi.MakeWorkload("wl", "ns").
+			Queue("lq").
+			Active(true).
+			Request(corev1.ResourceCPU, "4")
+	}
+	pending := makeWl().Obj()
+	quotaReserved := makeWl().
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), now).
+		Obj()
+	admitted := makeWl().
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), now).
+		AdmittedAt(true, now).
+		Obj()
+	deactivatedAdmitted := makeWl().
+		Active(false).
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), now).
+		AdmittedAt(true, now).
+		Obj()
+
+	cases := map[string]struct {
+		oldWl       *kueue.Workload
+		newWl       *kueue.Workload
+		wantSettled bool
+	}{
+		"Pending to Admitted settles the entry penalty": {
+			oldWl:       pending,
+			newWl:       admitted,
+			wantSettled: true,
+		},
+		"QuotaReserved to Admitted settles the entry penalty": {
+			oldWl:       quotaReserved,
+			newWl:       admitted,
+			wantSettled: true,
+		},
+		"Pending to QuotaReserved does not settle the entry penalty": {
+			oldWl:       pending,
+			newWl:       quotaReserved,
+			wantSettled: false,
+		},
+		"Admitted to Admitted does not settle the entry penalty again": {
+			oldWl:       admitted,
+			newWl:       admitted,
+			wantSettled: false,
+		},
+		"deactivation in the same event does not settle the entry penalty": {
+			oldWl:       quotaReserved,
+			newWl:       deactivatedAdmitted,
+			wantSettled: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			afsConfig := &configapi.AdmissionFairSharing{
+				UsageHalfLifeTime:     metav1.Duration{Duration: time.Minute},
+				UsageSamplingInterval: metav1.Duration{Duration: time.Second},
+			}
+			cl := utiltesting.NewClientBuilder().Build()
+			recorder := &utiltesting.EventRecorder{}
+			cqCache := schdcache.New(cl, schdcache.WithAdmissionFairSharing(afsConfig))
+			qManager := qcache.NewManagerForUnitTests(cl, cqCache, qcache.WithAdmissionFairSharing(afsConfig))
+			reconciler := NewWorkloadReconciler(cl, qManager, cqCache, recorder, WithAdmissionFairSharing(afsConfig))
+
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cq := utiltestingapi.MakeClusterQueue("cq").
+				AdmissionMode(kueue.UsageBasedAdmissionFairSharing).
+				Active(metav1.ConditionTrue).
+				Obj()
+			setupClusterQueue(ctx, t, cl, qManager, cqCache, cq, false)
+			lq := utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj()
+			setupLocalQueue(ctx, t, cl, qManager, lq, false)
+			if err := cqCache.AddLocalQueue(lq); err != nil {
+				t.Fatalf("couldn't add the local queue to the scheduler cache: %v", err)
+			}
+
+			// Seed the penalty with the same amount the settlement recomputes,
+			// mirroring the push done by the scheduler at assume time.
+			qManager.AfsEntryPenalties.Push(lqKey, afs.CalculateEntryPenalty(workload.NewInfo(tc.newWl).SumTotalRequests(reconciler.resourceFormatter), afsConfig))
+
+			reconciler.Update(event.TypedUpdateEvent[*kueue.Workload]{
+				ObjectOld: tc.oldWl.DeepCopy(),
+				ObjectNew: tc.newWl.DeepCopy(),
+			})
+
+			if hasPending := qManager.AfsEntryPenalties.HasPendingFor(lqKey); hasPending == tc.wantSettled {
+				t.Errorf("HasPendingFor() = %v, want settled = %v", hasPending, tc.wantSettled)
+			}
+		})
 	}
 }
 

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -1161,6 +1161,65 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 		})
 	})
 
+	ginkgo.When("Using AdmissionFairSharing with AdmissionChecks", ginkgo.Label("feature:admissionfairsharing"), func() {
+		var (
+			check *kueue.AdmissionCheck
+			cq    *kueue.ClusterQueue
+			lq    *kueue.LocalQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			check = utiltestingapi.MakeAdmissionCheck("check1").ControllerName("ctrl").Obj()
+			util.MustCreate(ctx, k8sClient, check)
+			util.SetAdmissionCheckActive(ctx, k8sClient, check, metav1.ConditionTrue)
+
+			cq = utiltestingapi.MakeClusterQueue("cq-with-check").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas(defaultFlavor.Name).Resource(corev1.ResourceCPU, "8").Obj()).
+				AdmissionMode(kueue.UsageBasedAdmissionFairSharing).
+				AdmissionChecks(kueue.AdmissionCheckReference(check.Name)).
+				Obj()
+			util.MustCreate(ctx, k8sClient, cq)
+
+			lq = utiltestingapi.MakeLocalQueue("lq-a", ns.Name).
+				FairSharing(&kueue.FairSharing{Weight: new(resource.MustParse("1"))}).
+				ClusterQueue(cq.Name).Obj()
+			lqs = append(lqs, lq)
+			util.MustCreate(ctx, k8sClient, lq)
+		})
+
+		ginkgo.AfterEach(func() {
+			// Delete in dependency order so the in-use finalizers can be
+			// removed: workloads -> ClusterQueue -> AdmissionCheck.
+			for _, wl := range wls {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, wl, true)
+			}
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, check, true)
+		})
+
+		ginkgo.It("should subtract the entry penalty when the workload is admitted via an AdmissionCheck", func() {
+			lqKey := utilqueue.NewLocalQueueReference(ns.Name, kueue.LocalQueueName(lq.Name))
+
+			ginkgo.By("Creating a workload which reserves quota and waits for the admission check")
+			wl := createWorkload("lq-a", "4")
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, wl)
+
+			ginkgo.By("Verifying the entry penalty is pending while the workload is in QuotaReserved")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(qManager.AfsEntryPenalties.HasPendingFor(lqKey)).To(gomega.BeTrue(), "entry penalty should be pending for lq-a")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Marking the admission check Ready so the workload transitions from QuotaReserved to Admitted")
+			util.SetWorkloadsAdmissionCheck(ctx, k8sClient, wl, kueue.AdmissionCheckReference(check.Name), kueue.CheckStateReady, true)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+
+			ginkgo.By("Verifying the entry penalty is subtracted after admission")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(qManager.AfsEntryPenalties.HasPendingFor(lqKey)).To(gomega.BeFalse(), "entry penalty should be subtracted for lq-a after admission via admission check")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
 	ginkgo.When("Preemption is enabled in fairsharing and there are large values of quota and weights", func() {
 		var (
 			cqA *kueue.ClusterQueue


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

With AdmissionFairSharing enabled, workloads receive an entry penalty when they are assumed. That penalty was only settled on the `Pending → Admitted` path.

Workloads gated by AdmissionChecks, such as ProvisioningRequest, MultiKueue, or TAS, are admitted through `Pending → QuotaReserved → Admitted`. The final transition did not settle the entry penalty, so the LocalQueue's fair-sharing usage stayed artificially inflated and its later workloads were deprioritized.

This seems to be a regression introduced by the AFS consumed-resources cache refactor (#7780). Before that refactor, settlement happened during the LocalQueue reconciler's recomputation and was transition-independent. The refactor moved settlement into the workload status-transition switch, where it was only wired to the `Pending → Admitted` case.

This PR fixes the leak by settling the entry penalty whenever a workload transitions into `Admitted`. The settle call is centralized after the status-transition switch so it also covers transitions handled by earlier cases, instead of duplicating the call in a dedicated `QuotaReserved → Admitted` case.

It also clamps `AfsEntryPenalties.Sub` at zero, so settling without a matching in-memory penalty, for example after restart, cannot create a permanent usage discount.

Also added regression coverage for the AdmissionCheck admission path. AI assistance was used for parts of this change.

Rollback paths such as `QuotaReserved → Pending` eviction or deletion while QuotaReserved are left for follow-up  #12787, since they have different lifecycle semantics.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12539

#### Special notes for your reviewer:
- On the clamp: the settle amount is recomputed at settlement time rather than recorded at push time, so it can exceed what was pushed. For example, a manager restart can clear the in-memory penalties while the workload keeps its persisted QuotaReserved state. Clamping at zero prevents that mismatch from becoming a permanent usage discount.

- Test isolation: without the settlement fix, the new `QuotaReserved → Admitted` unit case fails and the new integration test times out. Without the clamp, the new over-subtraction `Sub` unit cases fail.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
AdmissionFairSharing: Fixed a bug where workloads admitted via AdmissionChecks could keep their entry penalty permanently, inflating LocalQueue fair-sharing usage and deprioritizing later workloads.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Admission fair-sharing penalties no longer become negative and are cleared correctly when fully offset.
  * Penalties are settled when workloads become admitted, including after quota reservation, while avoiding inactive or unchanged workloads.

* **Tests**
  * Added coverage for subtraction edge cases and admission-state transitions.
  * Added integration coverage confirming penalties clear after admission checks become ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->