### PR TITLE
Add e2e cluster-creation skills for single-cluster and MultiKueue

### DIFF
--- a/cmd/experimental/skills/README.md
+++ b/cmd/experimental/skills/README.md
@@ -7,6 +7,8 @@
 | [kueue-flake-debugger](kueue-flake-debugger/SKILL.md) | "debug a flake", "investigate test failure", "test timed out", "CI flake" |
 | [kueue-release-notes](kueue-release-notes/SKILL.md) | Review or propose a concise PR release note focused on the user-observable change. |
 | [was-cluster](was-cluster/SKILL.md) | "set up WAS cluster", "build WAS kind cluster", "run WAS e2e tests", "tear down WAS cluster", Workload-Aware Scheduling cluster management |
+| [kueue-e2e-cluster-singlecluster](kueue-e2e-cluster-singlecluster/SKILL.md) | "spin up an e2e cluster", "get a kind cluster ready for e2e", single-cluster e2e suite setup (baseline, extended, sequential, TAS, cert-manager, DRA) |
+| [kueue-e2e-cluster-multikueue](kueue-e2e-cluster-multikueue/SKILL.md) | "spin up MultiKueue e2e clusters", "set up manager/worker kind clusters", MultiKueue e2e suite setup (baseline, extended, sequential, DRA) |
 | [reviewer/](reviewer/README.md) | "review this PR", "review this code", "evaluate this diff", "score these commits", "review the changes between", "code quality evaluation", any code review of kueue changes |
 
 ---
@@ -26,5 +28,9 @@
 @kueue-release-notes/SKILL.md
 
 @was-cluster/SKILL.md
+
+@kueue-e2e-cluster-singlecluster/SKILL.md
+
+@kueue-e2e-cluster-multikueue/SKILL.md
 
 @reviewer/README.md

--- a/cmd/experimental/skills/kueue-e2e-cluster-multikueue/SKILL.md
+++ b/cmd/experimental/skills/kueue-e2e-cluster-multikueue/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: kueue-e2e-cluster-multikueue
+description: Create (or reuse) the manager + worker kind clusters for Kueue MultiKueue e2e development. Use when a user asks to spin up MultiKueue e2e clusters, get a local multi-cluster environment ready, or debug/iterate against a MultiKueue e2e suite (baseline, extended, sequential, DRA).
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+You are an expert in Kueue's MultiKueue e2e testing infrastructure (`hack/testing/e2e-multikueue-test.sh`, `hack/testing/e2e-common.sh`, `hack/testing/multikueue/*.kind.yaml`, `Makefile-test.mk`).
+
+## Goal
+
+Stand up three kind clusters — one manager, two workers — with Kueue deployed on all three and MultiKueue wired up, ready for e2e tests or manual poking, and leave them running for fast iteration.
+
+This skill is for **MultiKueue** suites (manager + worker clusters): `test-multikueue-e2e-baseline`, `test-multikueue-e2e-extended` (+ shards), `test-multikueue-e2e-sequential`, `test-e2e-multikueue-dra`. If the user just wants a single cluster (no MultiKueue), use the `kueue-e2e-cluster-singlecluster` skill instead.
+
+## Step 1 - Confirm platform and build the Kueue image
+
+```sh
+# amd64
+make kind-image-build
+
+# arm64 (Apple Silicon)
+PLATFORM=linux/arm64 make kind-image-build
+```
+
+Skip this only if using a released/staging image via `IMAGE_TAG` (see Step 4).
+
+## Step 2 - Pick the target suite
+
+| Suite | Target |
+|---|---|
+| Baseline (default) | `test-multikueue-e2e-baseline` |
+| Extended | `test-multikueue-e2e-extended` |
+| Extended shard 0 / 1 | `test-multikueue-e2e-extended-shard-0` / `-shard-1` |
+| Sequential | `test-multikueue-e2e-sequential` |
+| Dynamic Resource Allocation | `test-e2e-multikueue-dra` |
+
+Default to `test-multikueue-e2e-baseline` if the user has no preference.
+
+## Step 3 - Bring up the clusters in dev mode
+
+Set `E2E_MODE=dev` so all three clusters are created (or reused), Kueue is deployed on each, and everything is **kept alive** after the run:
+
+```sh
+E2E_MODE=dev make kind-image-build <target>
+# e.g.
+E2E_MODE=dev make kind-image-build test-multikueue-e2e-baseline
+```
+
+Cluster creation for manager/worker1/worker2 runs in parallel; image loading is also parallelized across the three clusters. Kueue deployment (`kueue_deploy`) runs sequentially — manager first, then worker1, then worker2.
+
+If the user only wants the environment ready without running tests, stay on `E2E_MODE=dev` and pass a non-matching `GINKGO_ARGS` label filter so ginkgo runs zero specs (and thus exits immediately without prompting) while the clusters are still brought up and Kueue deployed on all three:
+
+```sh
+E2E_MODE=dev GINKGO_ARGS="--label-filter=env-only-no-match" make kind-image-build test-multikueue-e2e-baseline
+```
+
+Since `E2E_MODE=dev` keeps clusters alive regardless of whether any specs ran, this avoids the interactive `E2E_RUN_ONLY_ENV=true` prompt entirely (that flag is considered legacy/likely to be removed — prefer this pattern). Tests can then be run manually, e.g.:
+
+```sh
+# With default KIND_CLUSTER_NAME=kind (clusters: kind-manager, kind-worker1, kind-worker2):
+./bin/ginkgo --json-report ./ginkgo.report -focus "MultiKueue when Creating a multikueue admission check Should run a jobSet on worker if admitted" -r
+
+# With custom KIND_CLUSTER_NAME=<name>:
+MANAGER_KIND_CLUSTER_NAME=<name>-manager \
+WORKER1_KIND_CLUSTER_NAME=<name>-worker1 \
+WORKER2_KIND_CLUSTER_NAME=<name>-worker2 \
+./bin/ginkgo --json-report ./ginkgo.report -focus "MultiKueue when Creating a multikueue admission check Should run a jobSet on worker if admitted" -r
+```
+
+Useful modifiers (combine with `E2E_MODE=dev`):
+
+- `GINKGO_ARGS="--label-filter=feature:jobset"` — filter specs.
+- `E2E_SKIP_REINSTALL=true` — skip reinstalling Kueue on clusters where the deployment already exists (dev mode only).
+- `E2E_SKIP_IMAGE_RELOAD=true` — skip re-pulling/reloading dependency images already cached (dev mode only).
+- `E2E_ENFORCE_OPERATOR_UPDATE=true` — force reinstalling external operators even when reusing clusters.
+- `KIND_CLUSTER_NAME=<name>` — base name; actual clusters become `<name>-manager`, `<name>-worker1`, `<name>-worker2` (default base is `kind`).
+
+## Step 4 - Optional: use a released or staging image instead of building
+
+```sh
+E2E_MODE=dev IMAGE_TAG=registry.k8s.io/kueue/kueue:v0.16.0 make test-multikueue-e2e-baseline
+E2E_MODE=dev IMAGE_TAG=us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue:main make test-multikueue-e2e-baseline
+```
+
+## Step 5 - Verify the clusters and contexts
+
+The script exports each cluster's kubeconfig into the default kubeconfig with contexts `kind-<name>-manager`, `kind-<name>-worker1`, `kind-<name>-worker2`:
+
+```sh
+kubectl config get-contexts
+kubectl --context kind-kind-manager -n kueue-system get pods
+kubectl --context kind-kind-worker1 -n kueue-system get pods
+kubectl --context kind-kind-worker2 -n kueue-system get pods
+```
+
+Each cluster's Kueue deployment must be available with ready webhook endpoints before the script proceeds — if the make target completed, all three should be healthy.
+
+## Step 6 - Iterate
+
+Rerun the same command to reuse the clusters, reload only what changed, and rerun tests:
+
+```sh
+E2E_MODE=dev make kind-image-build test-multikueue-e2e-baseline
+```
+
+## Step 7 - Clean up when done
+
+```sh
+kind delete clusters kind-manager kind-worker1 kind-worker2
+# or, with a custom KIND_CLUSTER_NAME=<name>:
+kind delete clusters <name>-manager <name>-worker1 <name>-worker2
+```
+
+## Troubleshooting pointers
+
+- Manager kind config: `hack/testing/multikueue/manager-cluster.kind.yaml`; worker config (shared by both workers): `hack/testing/multikueue/worker-cluster.kind.yaml`.
+- All lifecycle logic lives in `hack/testing/e2e-common.sh`; the MultiKueue-specific driver (parallel cluster creation, per-cluster kubeconfigs, `kueue_deploy` fan-out) is `hack/testing/e2e-multikueue-test.sh`.
+- For k8s 1.31 node images, the manager's kind config is patched to enable the `JobManagedBy` feature gate — see `startup()` in `e2e-multikueue-test.sh`.
+- Kubeconfigs are written to `$ARTIFACTS/kubeconfig-<cluster-name>`; per-cluster creation logs to `$ARTIFACTS/<cluster>-create.log`.
+- Full reference docs, including the dev-environment walkthrough: `site/content/en/docs/tasks/dev/setup_multikueue_development_environment.md` and `site/content/en/community/contribution_guidelines/testing.md`.

--- a/cmd/experimental/skills/kueue-e2e-cluster-singlecluster/SKILL.md
+++ b/cmd/experimental/skills/kueue-e2e-cluster-singlecluster/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: kueue-e2e-cluster-singlecluster
+description: Create (or reuse) a single kind cluster for Kueue e2e development. Use when a user asks to spin up an e2e cluster, get a local kind environment ready for e2e tests, or debug/iterate against a single-cluster e2e suite (baseline, extended, sequential, TAS, cert-manager, DRA).
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+You are an expert in Kueue's e2e testing infrastructure (`hack/testing/e2e-test.sh`, `hack/testing/e2e-common.sh`, `Makefile-test.mk`).
+
+## Goal
+
+Stand up a single kind cluster with Kueue (and any required job-framework operators) deployed, ready for e2e tests or manual poking, and leave it running for fast iteration.
+
+This skill is for **single-cluster** suites: `test-e2e-baseline`, `test-e2e-extended`, `test-e2e-sequential-baseline`, `test-e2e-sequential-extended`, `test-tas-e2e-baseline`, `test-tas-e2e-extended`, `test-e2e-certmanager`, `test-e2e-dra`, `test-e2e-dra-counter`. If the user wants MultiKueue (manager + worker clusters), use the `kueue-e2e-cluster-multikueue` skill instead.
+
+## Step 1 - Confirm platform and build the Kueue image
+
+Ask/confirm architecture. On Apple Silicon (arm64) `PLATFORM` must be set explicitly; on amd64 it can be omitted.
+
+```sh
+# amd64
+make kind-image-build
+
+# arm64
+PLATFORM=linux/arm64 make kind-image-build
+```
+
+Skip this step only if the user explicitly wants to use a released/staging image via `IMAGE_TAG` (see Step 4).
+
+## Step 2 - Pick the target suite
+
+Map the user's request to a Makefile target:
+
+| Suite | Target |
+|---|---|
+| Baseline (default) | `test-e2e-baseline` |
+| Extended (job-framework integrations) | `test-e2e-extended` |
+| Sequential baseline | `test-e2e-sequential-baseline` |
+| Sequential extended | `test-e2e-sequential-extended` |
+| Topology-Aware Scheduling baseline | `test-tas-e2e-baseline` |
+| Topology-Aware Scheduling extended | `test-tas-e2e-extended` |
+| cert-manager | `test-e2e-certmanager` |
+| Dynamic Resource Allocation | `test-e2e-dra` / `test-e2e-dra-counter` |
+
+Default to `test-e2e-baseline` if the user has no preference — it is the fastest to bring up and covers the core scheduling flows.
+
+## Step 3 - Bring up the cluster in dev mode
+
+Set `E2E_MODE=dev` so the cluster is created (or reused if it already exists), Kueue is deployed, and the cluster is **kept alive** after the run instead of being torn down:
+
+```sh
+E2E_MODE=dev make kind-image-build <target>
+# e.g.
+E2E_MODE=dev make kind-image-build test-e2e-baseline
+```
+
+If the user only wants the environment ready (no test run), stay on `E2E_MODE=dev` and pass a non-matching `GINKGO_ARGS` label filter so ginkgo runs zero specs and exits immediately, while the cluster is still brought up and Kueue deployed:
+
+```sh
+E2E_MODE=dev GINKGO_ARGS="--label-filter=env-only-no-match" make kind-image-build test-e2e-baseline
+```
+
+Since `E2E_MODE=dev` keeps the cluster alive regardless of whether any specs ran, this avoids the legacy interactive `E2E_RUN_ONLY_ENV=true` mode (prompts `Do you want to cleanup? [Y/n]`) entirely — that flag is considered legacy/likely to be removed, so prefer this pattern.
+
+Useful modifiers (combine with `E2E_MODE=dev`):
+
+- `GINKGO_ARGS="--label-filter=feature:jobset"` — filter which specs run.
+- `GINKGO_ARGS="--focus='some spec name'"` — focus on a specific spec.
+- `E2E_SKIP_REINSTALL=true` — skip reinstalling Kueue if the deployment already exists and the image is unchanged (dev mode only, for fast reruns).
+- `E2E_SKIP_IMAGE_RELOAD=true` — skip re-pulling/reloading dependency images already cached locally / present on kind nodes (dev mode only, speeds up repeat runs).
+- `E2E_ENFORCE_OPERATOR_UPDATE=true` — force reinstalling external operators (JobSet, AppWrapper, KubeRay, etc.) even when reusing a cluster.
+- `E2E_K8S_FULL_VERSION=1.35.5` — pick a specific Kubernetes version (see `E2E_K8S_VERSIONS` in `Makefile-test.mk` for the current supported list, e.g. `1.34.8 1.35.5 1.36.1`).
+- `KIND_CLUSTER_NAME=<name>` — use a non-default kind cluster name (default is `kind`), useful for running multiple clusters side by side.
+
+## Step 4 - Optional: use a released or staging image instead of building
+
+Skip `make kind-image-build` and pass `IMAGE_TAG`:
+
+```sh
+# Released version
+E2E_MODE=dev IMAGE_TAG=registry.k8s.io/kueue/kueue:v0.16.0 make test-e2e-baseline
+
+# Staging image (e.g. built from a PR or nightly)
+E2E_MODE=dev IMAGE_TAG=us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue:main make test-e2e-baseline
+```
+
+To reproduce a specific released version end-to-end (matching CRDs/manifests), `git checkout <tag>` first, since config is committed per release.
+
+## Step 5 - Verify the cluster is ready
+
+```sh
+kubectl get nodes
+kubectl -n kueue-system get pods
+kubectl -n kueue-system get deployment kueue-controller-manager
+```
+
+The e2e script itself waits for the Kueue deployment to become available and for its webhook endpoints to be ready before running tests, so if the make target completed, the cluster should already be healthy.
+
+## Step 6 - Iterate
+
+With `E2E_MODE=dev`, rerunning the same command reuses the existing cluster, rebuilds/reloads only what changed, and reruns tests — this is the normal iteration loop while developing:
+
+```sh
+E2E_MODE=dev make kind-image-build test-e2e-baseline
+```
+
+To loop a suite until it fails (flake hunting):
+
+```sh
+E2E_MODE=dev GINKGO_ARGS="--until-it-fails" make kind-image-build test-e2e-baseline
+```
+
+## Step 7 - Clean up when done
+
+```sh
+kind delete clusters kind
+# or, if a custom KIND_CLUSTER_NAME was used:
+kind delete clusters <name>
+```
+
+## Troubleshooting pointers
+
+- Cluster config lives in `hack/testing/kind-cluster.yaml` (or `hack/testing/kind-cluster-tas.yaml` for TAS suites).
+- All lifecycle logic (create/reuse/teardown, image loading, operator install/skip logic) lives in `hack/testing/e2e-common.sh`; the suite driver is `hack/testing/e2e-test.sh`.
+- If cluster creation fails, check `$ARTIFACTS/<cluster>-create.log` (kind create output) and `$ARTIFACTS/<cluster>-nodes.log` / `$ARTIFACTS/<cluster>-system-pods.log`.
+- Full reference docs: `site/content/en/community/contribution_guidelines/testing.md`.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation
/area testing

#### What this PR does / why we need it:

Adds two agent skills under `cmd/experimental/skills/` (see #12773 for prior art) that document how to create, or reuse, kind clusters for local Kueue e2e development and iteration:

- `kueue-e2e-cluster-singlecluster`: brings up a single kind cluster for the single-cluster e2e suites (baseline, extended, sequential, TAS, cert-manager, DRA).
- `kueue-e2e-cluster-multikueue`: brings up the manager + worker1 + worker2 kind clusters for the MultiKueue e2e suites (baseline, extended, sequential, DRA).

Both skills are derived directly from the existing `hack/testing/e2e-test.sh`, `hack/testing/e2e-multikueue-test.sh`, `hack/testing/e2e-common.sh`, and `Makefile-test.mk` tooling (no new scripts or Make targets are introduced), and reference the existing `E2E_MODE=dev` / `E2E_RUN_ONLY_ENV=true` developer workflows already documented in `site/content/en/community/contribution_guidelines/testing.md`.

Both skills were registered in `cmd/experimental/skills/README.md`'s trigger table and `@`-reference list.

**Manual validation:** I exercised the single-cluster skill end-to-end against a local Docker/kind environment: built the Kueue image, created a kind cluster via both the interactive (`E2E_RUN_ONLY_ENV=true`) and dev (`E2E_MODE=dev`) flows, confirmed the Kueue deployment and webhook endpoints became ready, confirmed dev-mode correctly reuses an existing cluster on rerun (ran real specs via `GINKGO_ARGS="--focus=..."` against the reused cluster), and confirmed cleanup via `kind delete clusters kind`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This uses the experimental AI-agent skills mechanism under `cmd/experimental/skills/` (see `AGENTS.md`), which is explicitly called out as experimental with no backwards/future compatibility guarantees. These are plain markdown runbooks, not executable code — no test/build changes are included.

AI assistance disclosure: this PR's skill content was drafted with AI assistance (per the [Kubernetes AI Tool Usage Policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance)) and manually reviewed and validated by me.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new experimental end-to-end test setup guides for local kind clusters, including both single-cluster and MultiKueue multi-cluster environments.
  * Expanded the skills index with new entries and added agent-readable reference links for the newly documented skills.
  * Included detailed instructions for building/using images, starting clusters in dev mode, verifying readiness, iterating/rerunning tests, and cleaning up, with troubleshooting pointers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->