### PR TITLE
Fix populator error swallowing

### DIFF
--- a/cmd/experimental/kueue-populator/pkg/controller/controller.go
+++ b/cmd/experimental/kueue-populator/pkg/controller/controller.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-
 	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/cmd/experimental/kueue-populator/pkg/controller/controller.go
+++ b/cmd/experimental/kueue-populator/pkg/controller/controller.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -147,6 +148,7 @@ func (r *KueuePopulatorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
+	var errs []error
 	for i := range cqs.Items {
 		cq := &cqs.Items[i]
 		if !cq.DeletionTimestamp.IsZero() {
@@ -154,10 +156,11 @@ func (r *KueuePopulatorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 		if err := r.ensureLocalQueueExists(ctx, cq, &ns); err != nil {
 			log.Error(err, "Failed to ensure LocalQueue exists in namespace", "clusterQueue", klog.KObj(cq), "namespace", klog.KObj(&ns))
+			errs = append(errs, err)
 		}
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, utilerrors.NewAggregate(errs)
 }
 
 func (r *KueuePopulatorReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/cmd/experimental/kueue-populator/pkg/controller/controller.go
+++ b/cmd/experimental/kueue-populator/pkg/controller/controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -25,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
 	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -148,7 +149,7 @@ func (r *KueuePopulatorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
-	var errs []error
+	var errs error
 	for i := range cqs.Items {
 		cq := &cqs.Items[i]
 		if !cq.DeletionTimestamp.IsZero() {
@@ -156,11 +157,11 @@ func (r *KueuePopulatorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 		if err := r.ensureLocalQueueExists(ctx, cq, &ns); err != nil {
 			log.Error(err, "Failed to ensure LocalQueue exists in namespace", "clusterQueue", klog.KObj(cq), "namespace", klog.KObj(&ns))
-			errs = append(errs, err)
+			errs = errors.Join(errs, err)
 		}
 	}
 
-	return ctrl.Result{}, utilerrors.NewAggregate(errs)
+	return ctrl.Result{}, errs
 }
 
 func (r *KueuePopulatorReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/cmd/experimental/kueue-populator/pkg/controller/controller_test.go
+++ b/cmd/experimental/kueue-populator/pkg/controller/controller_test.go
@@ -48,12 +48,12 @@ type Event struct {
 	Message   string
 }
 
-// errCreateFailedForTest simulates a transient API error (or a TOCTOU race
-// where a conflicting object is created between Get and Create) when
-// injected via the fake client's interceptor.
-var errCreateFailedForTest = errors.New("create failed")
-
 func TestKueuePopulatorReconciler(t *testing.T) {
+	// errCreateFailedForTest simulates a transient API error (or a TOCTOU race
+	// where a conflicting object is created between Get and Create) when
+	// injected via the fake client's interceptor.
+	errCreateFailedForTest := errors.New("create failed")
+
 	cases := map[string]struct {
 		clusterQueues       []*kueue.ClusterQueue
 		namespaces          []*corev1.Namespace

--- a/cmd/experimental/kueue-populator/pkg/controller/controller_test.go
+++ b/cmd/experimental/kueue-populator/pkg/controller/controller_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"context"
+	"errors"
 	"slices"
 	"strings"
 	"testing"
@@ -29,7 +31,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -44,6 +48,11 @@ type Event struct {
 	Message   string
 }
 
+// errCreateFailedForTest simulates a transient API error (or a TOCTOU race
+// where a conflicting object is created between Get and Create) when
+// injected via the fake client's interceptor.
+var errCreateFailedForTest = errors.New("create failed")
+
 func TestKueuePopulatorReconciler(t *testing.T) {
 	cases := map[string]struct {
 		clusterQueues       []*kueue.ClusterQueue
@@ -53,6 +62,7 @@ func TestKueuePopulatorReconciler(t *testing.T) {
 		localQueueName      string
 		localQueueNameMode  kueuepopulatorconfig.LocalQueueNameMode
 		req                 reconcile.Request
+		createErr           error
 		wantError           error
 		wantLQs             []kueue.LocalQueue
 		wantEvents          []Event
@@ -517,6 +527,37 @@ func TestKueuePopulatorReconciler(t *testing.T) {
 				},
 			},
 		},
+
+		"should return an error and requeue when LocalQueue creation fails": {
+			clusterQueues: []*kueue.ClusterQueue{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "cq"},
+					Spec: kueue.ClusterQueueSpec{
+						NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"dep": "eng"}},
+					},
+				},
+			},
+			namespaces: []*corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "ns",
+						Labels: map[string]string{"dep": "eng"},
+					},
+				},
+			},
+			localQueueName: "default-lq",
+			req:            reconcile.Request{NamespacedName: types.NamespacedName{Name: "ns"}},
+			createErr:      errCreateFailedForTest,
+			wantError:      errCreateFailedForTest,
+			wantLQs:        []kueue.LocalQueue{},
+			wantEvents: []Event{
+				{
+					EventType: corev1.EventTypeWarning,
+					Reason:    "LocalQueueCreationFailed",
+					Message:   "Failed to create LocalQueue default-lq in namespace ns: create failed",
+				},
+			},
+		},
 	}
 
 	for name, tc := range cases {
@@ -526,6 +567,13 @@ func TestKueuePopulatorReconciler(t *testing.T) {
 			_ = kueue.AddToScheme(scheme)
 
 			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if tc.createErr != nil {
+				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+					Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+						return tc.createErr
+					},
+				})
+			}
 
 			for _, cq := range tc.clusterQueues {
 				builder.WithObjects(cq)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area kueue-populator

#### What this PR does / why we need it:
In `KueuePopulatorReconciler.Reconcile`, errors returned from
`ensureLocalQueueExists` were logged but not propagated. Since
`Reconcile` unconditionally returned `ctrl.Result{}, nil`, controller-runtime
never requeued the request on failure — so a transient API error, rate
limit, or a TOCTOU race (a conflicting `LocalQueue` created between the
`Get` check and the `Create` call) would silently and permanently prevent
a `LocalQueue` from being provisioned for that namespace, with no retry.

This PR accumulates errors encountered while ensuring `LocalQueue`s exist
across all matching `ClusterQueue`s in a reconcile pass, and returns them
as an aggregated error via `utilerrors.NewAggregate`, so controller-runtime
requeues the request when something goes wrong. Behavior is unchanged
when there are no errors (`NewAggregate(nil)` returns `nil`).

Added a unit test that injects a `Create` failure via the fake client's
interceptor and asserts that `Reconcile` now returns a non-nil error
(previously it did not).

#### Which issue(s) this PR fixes:
Fixes #12569

#### Special notes for your reviewer:
Verified via unit tests (`go test ./cmd/experimental/kueue-populator/pkg/controller/...`),
which pass, including the new regression test. I wasn't able to run the
local integration/e2e suites for `kueue-populator` due to local envtest/CRD
generation setup, but they don't exercise this reconcile path directly and
should be covered by CI.

#### Does this PR introduce a user-facing change?
```release-note
kueue-populator: Fixed a bug where an error creating a LocalQueue was logged but not returned from Reconcile, 
preventing controller-runtime from retrying. LocalQueue creation failures are now aggregated and returned so the request is requeued.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reconciliation now returns an error when LocalQueue creation fails (instead of silently succeeding).
  * When multiple matching ClusterQueues fail, reconciliation returns a combined error so all failures are surfaced.
* **Tests**
  * Added deterministic test coverage for transient LocalQueue creation failures.
  * Verifies reconciliation returns the injected error, does not create LocalQueue objects, and emits the expected `LocalQueueCreationFailed` warning event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->