### PR TITLE
[release-0.17] Fix data race on stickyWorkload between Snapshot and RequeueIfNotPresent

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"slices"
 	"sync"
+	"sync/atomic"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -71,20 +72,28 @@ var (
 // workloads from going back to the head of the queue.  A workload is
 // considered sticky until it is admitted, unschedulable, or deleted.
 // See Kueue#6929 and Kueue#7101 for motivation.
+//
+// The workloadName field is accessed concurrently: Snapshot sorts a copy of
+// the pending workloads (via baseCompareFunc -> matches) without holding the
+// ClusterQueue's rwm lock, while RequeueIfNotPresent sets it during preemption.
+// It is a single field with only whole-value read/store/clear, so an
+// atomic.Pointer synchronizes every access regardless of the caller's locking
+// (nil means no sticky workload).
 type stickyWorkload struct {
-	workloadName workload.Reference
+	workloadName atomic.Pointer[workload.Reference]
 }
 
 func (s *stickyWorkload) matches(workload workload.Reference) bool {
-	return s.workloadName == workload
+	name := s.workloadName.Load()
+	return name != nil && *name == workload
 }
 
 func (s *stickyWorkload) clear() {
-	s.workloadName = ""
+	s.workloadName.Store(nil)
 }
 
 func (s *stickyWorkload) set(workload workload.Reference) {
-	s.workloadName = workload
+	s.workloadName.Store(&workload)
 }
 
 func logStickyWorkloadSelectionIfVerbose(log logr.Logger, wl *kueue.Workload) {

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -477,6 +477,58 @@ func TestSnapshotStableWithConcurrentFSUpdates(t *testing.T) {
 	}
 }
 
+// TestSnapshotConcurrentWithRequeueNoDataRace guards against a data race on the
+// sticky workload: Snapshot sorts a copy of the pending workloads through the
+// comparator (which reads stickyWorkload.workloadName) without holding the
+// ClusterQueue lock, while RequeueIfNotPresent writes that field during a
+// BestEffortFIFO preemption requeue. Run with -race to detect regressions.
+func TestSnapshotConcurrentWithRequeueNoDataRace(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	cq, err := newClusterQueue(ctx, nil,
+		&kueue.ClusterQueue{
+			Spec: kueue.ClusterQueueSpec{
+				QueueingStrategy: kueue.BestEffortFIFO,
+			},
+		},
+		defaultOrdering,
+		nil, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create ClusterQueue: %v", err)
+	}
+
+	// At least two workloads so Snapshot's sort actually invokes the
+	// comparator that reads the sticky workload.
+	wls := []*kueue.Workload{
+		utiltestingapi.MakeWorkload("wl1", defaultNamespace).Obj(),
+		utiltestingapi.MakeWorkload("wl2", defaultNamespace).Obj(),
+		utiltestingapi.MakeWorkload("wl3", defaultNamespace).Obj(),
+	}
+	for _, wl := range wls {
+		cq.PushOrUpdate(workload.NewInfo(wl))
+	}
+
+	// Writer: continuously set the sticky workload via a preemption requeue.
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				for _, wl := range wls {
+					cq.RequeueIfNotPresent(ctx, workload.NewInfo(wl), RequeueReasonPendingPreemption)
+				}
+			}
+		}
+	}()
+	defer close(stop)
+
+	// Reader: Snapshot reads the sticky workload through the comparator.
+	for range 1000 {
+		cq.Snapshot()
+	}
+}
+
 func Test_DeleteFromLocalQueue(t *testing.T) {
 	ctx, log := utiltesting.ContextWithLog(t)
 	cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(time.Now()))


### PR DESCRIPTION
This is a manual cherry-pick of #12736 (the automated release-0.17 cherry-pick failed to apply due to a conflict in `cluster_queue_test.go`; resolved by keeping only the new `TestSnapshotConcurrentWithRequeueNoDataRace` test, since `TestPendingResources` / `TestPendingInLocalQueueCountsInflight` do not exist on release-0.17).

/assign mimowo

```release-note
VisibilityOnDemand: Fixed a data race between the Visibility API pending-workloads endpoint and preemption requeuing that could crash the queue manager for BestEffortFIFO ClusterQueues.
```