### PR TITLE
Keep the sticky workload consistent during ClusterQueue heap and snapshot sorts

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -98,8 +98,8 @@ var (
 //   - Writes (set/clear) happen under the ClusterQueue's rwm lock, so heap
 //     operations, which also hold the lock, never observe it changing mid-sort.
 //   - Snapshot sorts a copy of the pending workloads without holding the lock,
-//     so it captures the sticky workload once per sort via matcher() instead of
-//     re-reading it on every comparison.
+//     so it captures the sticky workload once per sort via capturedMatcher()
+//     instead of re-reading it on every comparison.
 //
 // The field holds a single whole value (nil means no sticky workload), so an
 // atomic.Pointer keeps individual reads and writes memory-safe on top of the
@@ -113,11 +113,11 @@ func (s *stickyWorkload) matches(workload workload.Reference) bool {
 	return name != nil && *name == workload
 }
 
-// matcher captures the current sticky workload once and returns a predicate
-// bound to that fixed value. A sort that compares through the returned predicate
-// stays transitive even if set/clear runs concurrently, because every
+// capturedMatcher captures the current sticky workload once and returns a
+// predicate bound to that fixed value. A sort that compares through the returned
+// predicate stays transitive even if set/clear runs concurrently, because every
 // comparison in that sort observes the same sticky workload. See Kueue#12740.
-func (s *stickyWorkload) matcher() func(workload.Reference) bool {
+func (s *stickyWorkload) capturedMatcher() func(workload.Reference) bool {
 	name := s.workloadName.Load()
 	if name == nil {
 		return func(workload.Reference) bool { return false }
@@ -575,17 +575,17 @@ func resolveQuotaReservedReason(reason QuotaReservedReason) QuotaReservedReason 
 func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info, immediate bool, reason RequeueReason, quotaReservedReason QuotaReservedReason) bool {
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
+	key := workload.Key(wInfo.Obj)
 	// When preemptions are in-progress, keep re-attempting the same workload at
 	// the head for BestEffortFIFO queues (see documentation of stickyWorkload).
 	// The sticky workload is set under the lock so heap operations, which also
 	// hold the lock, never observe it changing mid-sort. See Kueue#12740.
 	if (reason == RequeueReasonPendingPreemption || reason == RequeueReasonPendingMigration) && c.queueingStrategy == kueue.BestEffortFIFO {
 		if logV := log.V(5); logV.Enabled() {
-			logV.Info("Setting sticky workload", "clusterQueue", wInfo.ClusterQueue, "workload", workload.Key(wInfo.Obj))
+			logV.Info("Setting sticky workload", "clusterQueue", wInfo.ClusterQueue, "workload", key)
 		}
-		c.sw.set(workload.Key(wInfo.Obj))
+		c.sw.set(key)
 	}
-	key := workload.Key(wInfo.Obj)
 	// wasTracked records whether the workload is already counted in pendingResourcesTotal before inflight state is cleared.
 	// Guards addPendingResources below to prevent double-counting if the workload was concurrently re-added to the heap or inadmissible.
 	wasTracked := c.inadmissibleWorkloads.hasKey(key) || c.heap.GetByKey(key) != nil
@@ -826,7 +826,7 @@ func (c *ClusterQueue) Snapshot() []*workload.Info {
 
 // buildSnapshotSort returns a function that sorts workload elements for Snapshot().
 // The sort runs without holding the ClusterQueue lock, so it captures the sticky
-// workload once per sort (via stickyWorkload.matcher) to keep the comparison
+// workload once per sort (via stickyWorkload.capturedMatcher) to keep the comparison
 // transitive even if the sticky workload changes concurrently. See Kueue#12740.
 // When fair-sharing is enabled, it also pre-computes FS usage per LocalQueue from
 // deep-copied AFS state to avoid inconsistent comparisons from concurrent updates.
@@ -843,7 +843,7 @@ func buildSnapshotSort(
 	log := ctrl.LoggerFrom(ctx)
 	if !enableAdmissionFs {
 		return func(elements []*workload.Info) {
-			slices.SortFunc(elements, baseCompareFunc(log, wo, sw.matcher()))
+			slices.SortFunc(elements, baseCompareFunc(log, wo, sw.capturedMatcher()))
 		}
 	}
 
@@ -863,7 +863,7 @@ func buildSnapshotSort(
 	return func(elements []*workload.Info) {
 		// Capture the sticky workload once so the sort stays transitive without
 		// holding the lock. See Kueue#12740.
-		baseCmp := baseCompareFunc(log, wo, sw.matcher())
+		baseCmp := baseCompareFunc(log, wo, sw.capturedMatcher())
 		usageCache := make(map[utilqueue.LocalQueueReference]float64)
 		for _, wInfo := range elements {
 			lqKey := utilqueue.KeyFromWorkload(wInfo.Obj)
@@ -958,7 +958,7 @@ func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.
 // baseCompareFunc orders workloads by sticky status, priority, timestamp, and UID.
 // stickyMatches reports whether a workload is the sticky one; callers pass a
 // live matcher (stickyWorkload.matches) for the heap or a captured one
-// (stickyWorkload.matcher) for the lock-free Snapshot sort. See Kueue#12740.
+// (stickyWorkload.capturedMatcher) for the lock-free Snapshot sort. See Kueue#12740.
 func baseCompareFunc(log logr.Logger, wo workload.Ordering, stickyMatches func(workload.Reference) bool) func(a, b *workload.Info) int {
 	return func(a, b *workload.Info) int {
 		aSticky := stickyMatches(workload.Key(a.Obj))

--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -92,12 +92,18 @@ var (
 // considered sticky until it is admitted, unschedulable, or deleted.
 // See Kueue#6929 and Kueue#7101 for motivation.
 //
-// The workloadName field is accessed concurrently: Snapshot sorts a copy of
-// the pending workloads (via baseCompareFunc -> matches) without holding the
-// ClusterQueue's rwm lock, while RequeueIfNotPresent sets it during preemption.
-// It is a single field with only whole-value read/store/clear, so an
-// atomic.Pointer synchronizes every access regardless of the caller's locking
-// (nil means no sticky workload).
+// The workloadName field is accessed concurrently and drives both the CQ heap
+// ordering and the Snapshot ordering used by the visibility server. Two
+// mechanisms keep every sort transitive (see Kueue#12740):
+//   - Writes (set/clear) happen under the ClusterQueue's rwm lock, so heap
+//     operations, which also hold the lock, never observe it changing mid-sort.
+//   - Snapshot sorts a copy of the pending workloads without holding the lock,
+//     so it captures the sticky workload once per sort via matcher() instead of
+//     re-reading it on every comparison.
+//
+// The field holds a single whole value (nil means no sticky workload), so an
+// atomic.Pointer keeps individual reads and writes memory-safe on top of the
+// ordering guarantees above.
 type stickyWorkload struct {
 	workloadName atomic.Pointer[workload.Reference]
 }
@@ -105,6 +111,17 @@ type stickyWorkload struct {
 func (s *stickyWorkload) matches(workload workload.Reference) bool {
 	name := s.workloadName.Load()
 	return name != nil && *name == workload
+}
+
+// matcher captures the current sticky workload once and returns a predicate
+// bound to that fixed value. A sort that compares through the returned predicate
+// stays transitive even if set/clear runs concurrently, because every
+// comparison in that sort observes the same sticky workload. See Kueue#12740.
+func (s *stickyWorkload) matcher() func(workload.Reference) bool {
+	name := s.workloadName.Load()
+	return func(key workload.Reference) bool {
+		return name != nil && *name == key
+	}
 }
 
 func (s *stickyWorkload) clear() {
@@ -250,13 +267,15 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.
 		opt(options)
 	}
 	sw := stickyWorkload{}
-	log := ctrl.LoggerFrom(ctx)
-	baseCmp := baseCompareFunc(log, wo, &sw)
-	compareFunc := queueOrderingFunc(ctx, client, wo, options.fsResWeights, options.enableAdmissionFs, options.afsEntryPenalties, options.afsConsumedResources, &sw)
+	// The heap comparator reads the sticky workload live on every comparison;
+	// this is safe because sticky writes and heap operations both hold rwm.
+	compareFunc := queueOrderingFunc(ctx, client, wo, options.fsResWeights, options.enableAdmissionFs, options.afsEntryPenalties, options.afsConsumedResources, sw.matches)
 	// Derive lessFunc from compareFunc for the heap.
 	lessFunc := func(a, b *workload.Info) bool { return compareFunc(a, b) < 0 }
+	// Snapshot sorts without the lock, so it captures the sticky workload once
+	// per sort rather than reading it live. See Kueue#12740.
 	snapshotSort := buildSnapshotSort(
-		ctx, compareFunc, baseCmp, client,
+		ctx, wo, &sw, client,
 		options.enableAdmissionFs, options.fsResWeights,
 		options.afsEntryPenalties, options.afsConsumedResources,
 	)
@@ -552,6 +571,16 @@ func resolveQuotaReservedReason(reason QuotaReservedReason) QuotaReservedReason 
 func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info, immediate bool, reason RequeueReason, quotaReservedReason QuotaReservedReason) bool {
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
+	// When preemptions are in-progress, keep re-attempting the same workload at
+	// the head for BestEffortFIFO queues (see documentation of stickyWorkload).
+	// The sticky workload is set under the lock so heap operations, which also
+	// hold the lock, never observe it changing mid-sort. See Kueue#12740.
+	if (reason == RequeueReasonPendingPreemption || reason == RequeueReasonPendingMigration) && c.queueingStrategy == kueue.BestEffortFIFO {
+		if logV := log.V(5); logV.Enabled() {
+			logV.Info("Setting sticky workload", "clusterQueue", wInfo.ClusterQueue, "workload", workload.Key(wInfo.Obj))
+		}
+		c.sw.set(workload.Key(wInfo.Obj))
+	}
 	key := workload.Key(wInfo.Obj)
 	// wasTracked records whether the workload is already counted in pendingResourcesTotal before inflight state is cleared.
 	// Guards addPendingResources below to prevent double-counting if the workload was concurrently re-added to the heap or inadmissible.
@@ -792,25 +821,28 @@ func (c *ClusterQueue) Snapshot() []*workload.Info {
 }
 
 // buildSnapshotSort returns a function that sorts workload elements for Snapshot().
-// When fair-sharing is enabled, it pre-computes FS usage per LocalQueue from
+// The sort runs without holding the ClusterQueue lock, so it captures the sticky
+// workload once per sort (via stickyWorkload.matcher) to keep the comparison
+// transitive even if the sticky workload changes concurrently. See Kueue#12740.
+// When fair-sharing is enabled, it also pre-computes FS usage per LocalQueue from
 // deep-copied AFS state to avoid inconsistent comparisons from concurrent updates.
 func buildSnapshotSort(
 	ctx context.Context,
-	compareFunc func(a, b *workload.Info) int,
-	baseCmp func(a, b *workload.Info) int,
+	wo workload.Ordering,
+	sw *stickyWorkload,
 	cl client.Client,
 	enableAdmissionFs bool,
 	fsResWeights map[corev1.ResourceName]float64,
 	afsEntryPenalties *queueafs.AfsEntryPenalties,
 	afsConsumedResources *queueafs.AfsConsumedResources,
 ) func(elements []*workload.Info) {
+	log := ctrl.LoggerFrom(ctx)
 	if !enableAdmissionFs {
 		return func(elements []*workload.Info) {
-			slices.SortFunc(elements, compareFunc)
+			slices.SortFunc(elements, baseCompareFunc(log, wo, sw.matcher()))
 		}
 	}
 
-	log := ctrl.LoggerFrom(ctx)
 	getLQWeight := func(lqKey utilqueue.LocalQueueReference) (float64, bool) {
 		if cl == nil {
 			return 1, true
@@ -825,6 +857,9 @@ func buildSnapshotSort(
 	}
 
 	return func(elements []*workload.Info) {
+		// Capture the sticky workload once so the sort stays transitive without
+		// holding the lock. See Kueue#12740.
+		baseCmp := baseCompareFunc(log, wo, sw.matcher())
 		usageCache := make(map[utilqueue.LocalQueueReference]float64)
 		for _, wInfo := range elements {
 			lqKey := utilqueue.KeyFromWorkload(wInfo.Obj)
@@ -903,17 +938,7 @@ func (c *ClusterQueue) Active() bool {
 // quotaReservedReason represents the WorkloadQuotaReserved condition reason computed by the scheduler.
 // Returns true if the workload was inserted.
 func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.Info, reason RequeueReason, quotaReservedReason QuotaReservedReason) bool {
-	// when preemptions are in-progress, we keep attempting to
-	// schedule the same workload for BestEffortFIFO queues. See
-	// documentation of stickyWorkload for more details
 	log := ctrl.LoggerFrom(ctx)
-	if (reason == RequeueReasonPendingPreemption || reason == RequeueReasonPendingMigration) && c.queueingStrategy == kueue.BestEffortFIFO {
-		if logV := log.V(5); logV.Enabled() {
-			logV.Info("Setting sticky workload", "clusterQueue", wInfo.ClusterQueue, "workload", workload.Key(wInfo.Obj))
-		}
-		c.sw.set(workload.Key(wInfo.Obj))
-	}
-
 	var immediate bool
 	if c.queueingStrategy == kueue.StrictFIFO {
 		immediate = reason != RequeueReasonNamespaceMismatch
@@ -927,10 +952,13 @@ func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.
 }
 
 // baseCompareFunc orders workloads by sticky status, priority, timestamp, and UID.
-func baseCompareFunc(log logr.Logger, wo workload.Ordering, sw *stickyWorkload) func(a, b *workload.Info) int {
+// stickyMatches reports whether a workload is the sticky one; callers pass a
+// live matcher (stickyWorkload.matches) for the heap or a captured one
+// (stickyWorkload.matcher) for the lock-free Snapshot sort. See Kueue#12740.
+func baseCompareFunc(log logr.Logger, wo workload.Ordering, stickyMatches func(workload.Reference) bool) func(a, b *workload.Info) int {
 	return func(a, b *workload.Info) int {
-		aSticky := sw.matches(workload.Key(a.Obj))
-		bSticky := sw.matches(workload.Key(b.Obj))
+		aSticky := stickyMatches(workload.Key(a.Obj))
+		bSticky := stickyMatches(workload.Key(b.Obj))
 		if aSticky != bSticky {
 			if aSticky {
 				logStickyWorkloadSelectionIfVerbose(log, a.Obj)
@@ -968,10 +996,10 @@ func queueOrderingFunc(
 	enableAdmissionFs bool,
 	afsEntryPenalties *queueafs.AfsEntryPenalties,
 	afsConsumedResources *queueafs.AfsConsumedResources,
-	sw *stickyWorkload,
+	stickyMatches func(workload.Reference) bool,
 ) func(a, b *workload.Info) int {
 	log := ctrl.LoggerFrom(ctx)
-	baseCmp := baseCompareFunc(log, wo, sw)
+	baseCmp := baseCompareFunc(log, wo, stickyMatches)
 	if !enableAdmissionFs {
 		return baseCmp
 	}

--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -119,8 +119,12 @@ func (s *stickyWorkload) matches(workload workload.Reference) bool {
 // comparison in that sort observes the same sticky workload. See Kueue#12740.
 func (s *stickyWorkload) matcher() func(workload.Reference) bool {
 	name := s.workloadName.Load()
+	if name == nil {
+		return func(workload.Reference) bool { return false }
+	}
+	captured := *name
 	return func(key workload.Reference) bool {
-		return name != nil && *name == key
+		return captured == key
 	}
 }
 

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -594,7 +594,9 @@ func TestSnapshotConsistentUnderConcurrentStickyChange(t *testing.T) {
 	// lock) to force a change mid-sort, which the lock-free Snapshot must
 	// tolerate; the fix makes it capture the value once per sort.
 	stop := make(chan struct{})
+	started := make(chan struct{})
 	go func() {
+		close(started)
 		for {
 			select {
 			case <-stop:
@@ -607,6 +609,9 @@ func TestSnapshotConsistentUnderConcurrentStickyChange(t *testing.T) {
 			}
 		}
 	}()
+	// Block until the writer is scheduled, so the loop below cannot finish before
+	// any churn has happened and pass vacuously.
+	<-started
 	defer close(stop)
 
 	for i := range 2000 {

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package queue
 
 import (
+	"fmt"
 	"slices"
 	"testing"
 	"time"
@@ -527,6 +528,96 @@ func TestSnapshotConcurrentWithRequeueNoDataRace(t *testing.T) {
 	// Reader: Snapshot reads the sticky workload through the comparator.
 	for range 1000 {
 		cq.Snapshot()
+	}
+}
+
+// TestSnapshotConsistentUnderConcurrentStickyChange guards against Kueue#12740:
+// Snapshot sorts a copy of the pending workloads without holding the
+// ClusterQueue lock, so the comparator must observe a single, consistent sticky
+// workload for the whole sort. If it re-read the sticky workload on every
+// comparison, a concurrent change could make the ordering non-transitive and
+// corrupt the Snapshot order. This is a logic bug, not a data race: the atomic
+// pointer already makes each access memory-safe, so -race does not catch it.
+//
+// With equal priority and creation timestamp, every valid Snapshot is either the
+// pure UID order or exactly one workload (the sticky one) pulled to the front
+// followed by the rest in UID order. Any other permutation means the sort
+// observed the sticky workload changing mid-sort.
+func TestSnapshotConsistentUnderConcurrentStickyChange(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	cq, err := newClusterQueue(ctx, nil,
+		&kueue.ClusterQueue{
+			Spec: kueue.ClusterQueueSpec{
+				QueueingStrategy: kueue.BestEffortFIFO,
+			},
+		},
+		defaultOrdering,
+		nil, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create ClusterQueue: %v", err)
+	}
+
+	now := time.Now().Truncate(time.Second)
+	// Names are listed in UID order; equal priority and creation timestamp make
+	// UID the only tiebreak once stickiness is accounted for.
+	names := []string{"wl1", "wl2", "wl3", "wl4", "wl5", "wl6"}
+	keys := make([]workload.Reference, len(names))
+	for i, name := range names {
+		wl := utiltestingapi.MakeWorkload(name, defaultNamespace).
+			Creation(now).UID(types.UID(fmt.Sprintf("uid-%d", i))).Obj()
+		cq.PushOrUpdate(workload.NewInfo(wl))
+		keys[i] = workload.Key(wl)
+	}
+
+	// Valid orderings: pure UID order, or any single workload pulled to the front.
+	valid := [][]string{slices.Clone(names)}
+	for i := range names {
+		order := []string{names[i]}
+		for j := range names {
+			if j != i {
+				order = append(order, names[j])
+			}
+		}
+		valid = append(valid, order)
+	}
+	isValid := func(got []string) bool {
+		for _, v := range valid {
+			if slices.Equal(got, v) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Writer: continuously churn the sticky workload so it can change while a
+	// Snapshot sort is in flight. It sets the field directly (bypassing the
+	// lock) to force a change mid-sort, which the lock-free Snapshot must
+	// tolerate; the fix makes it capture the value once per sort.
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				for _, k := range keys {
+					cq.sw.set(k)
+				}
+				cq.sw.clear()
+			}
+		}
+	}()
+	defer close(stop)
+
+	for i := range 2000 {
+		snap := cq.Snapshot()
+		got := make([]string, len(snap))
+		for j, wInfo := range snap {
+			got[j] = wInfo.Obj.Name
+		}
+		if !isValid(got) {
+			t.Fatalf("call %d: non-transitive Snapshot ordering %v; sticky workload changed mid-sort", i+1, got)
+		}
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
#12736 made `stickyWorkload` an atomic pointer, which fixed the data race but
not the underlying ordering problem it was a symptom of (#12740): the sticky
workload drives both the CQ heap ordering and the visibility-server Snapshot
ordering, and it can change mid-sort, making the comparison non-transitive and
corrupting the resulting order.

This fixes both sort paths:

- Heap: the sticky-workload write is moved from `RequeueIfNotPresent` (which
  held no lock) into `requeueIfNotPresent` under `rwm.Lock()`, so heap
  operations, which also hold the lock, never observe it changing mid-sort.
- Snapshot: this sort runs without the lock by design (FS usage is
  pre-computed), so instead of locking it, the comparator now captures the
  sticky workload once per sort via a new `stickyWorkload.matcher()`, keeping a
  single sort transitive while preserving the lock-free snapshot.

#### Which issue(s) this PR fixes:
Fixes #12740

#### Special notes for your reviewer:
The reporter suggested acquiring the broader lock before writing the sticky
workload. That covers the heap, but the Snapshot sort is intentionally
lock-free, so locking the write alone would not make it transitive; hence the
per-sort capture for Snapshot. If you would rather hold the read lock around the
Snapshot sort instead, I am happy to switch to that.

Validation (local):
- `go test -race ./pkg/cache/queue/...` passes
- the new test `TestSnapshotConsistentUnderConcurrentStickyChange` fails
  deterministically on main (non-transitive order) and passes with this fix
- `gofmt` clean, `golangci-lint` reports 0 issues on the package

This PR was written with AI assistance (Claude Code), per the Kubernetes AI
contribution guidance; I have reviewed and validated every change.

#### Does this PR introduce a user-facing change?
```release-note
Scheduling: Fixed a concurrency bug in BestEffortFIFO ClusterQueues where the
sticky Workload could change while pending Workloads were being sorted, making
the comparison non-transitive and potentially corrupting the scheduler queue or
visibility snapshot ordering.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ClusterQueue sticky-workload selection so heap admission remains transitive and consistent even as sticky signals change concurrently.
  * Stabilized Snapshot ordering by capturing sticky state once per snapshot sort to prevent mid-sort inconsistencies.
  * Updated requeue handling for BestEffortFIFO so sticky state is applied under the proper lock for specific pending conditions.
* **Tests**
  * Added a concurrency-focused test to verify Snapshot order remains consistent while sticky scheduling changes during snapshot creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->