### PR TITLE
Automated cherry pick of #12764: cleanup: pin serve version in KueueViz frontend Dockerfile

### DIFF
--- a/cmd/kueueviz/frontend/Dockerfile
+++ b/cmd/kueueviz/frontend/Dockerfile
@@ -21,7 +21,7 @@ FROM node:25-slim AS runtime
 
 WORKDIR /app
 
-RUN npm install -g serve
+RUN npm install -g "serve@$(node -p "require('./package-lock.json').packages['node_modules/serve'].version")"
 
 # Copy only the built files from builder
 COPY --from=builder /app/build ./build


### PR DESCRIPTION
Cherry pick of #12764 on release-0.17.
#12764: cleanup: pin serve version in KueueViz frontend Dockerfile
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
NONE
```