### PR TITLE
Drop legacy E2E_RUN_ONLY_ENV

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -56,7 +56,6 @@ E2E_K8S_FULL_VERSION ?= $(filter $(E2E_K8S_VERSION).%,$(E2E_K8S_VERSIONS))
 # Default to E2E_K8S_VERSION.0 if no match is found
 E2E_K8S_FULL_VERSION := $(or $(E2E_K8S_FULL_VERSION),$(E2E_K8S_VERSION).0)
 E2E_KIND_VERSION ?= kindest/node:v$(E2E_K8S_FULL_VERSION)
-E2E_RUN_ONLY_ENV ?= false
 E2E_USE_HELM ?= false
 E2E_MODE ?= ci
 E2E_SKIP_REINSTALL ?= false
@@ -373,7 +372,6 @@ run-test-e2e-baseline-%:
 		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="singlecluster/baseline" \
 		E2E_CONFIG_FOLDER="baseline" \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
-		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		E2E_USE_HELM=$(E2E_USE_HELM) \
 		./hack/testing/e2e-test.sh
 
@@ -389,7 +387,6 @@ run-test-e2e-extended-%:
 		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="singlecluster/extended" \
 		E2E_CONFIG_FOLDER="extended" \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
-		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		E2E_USE_HELM=$(E2E_USE_HELM) \
 		./hack/testing/e2e-test.sh
 
@@ -403,7 +400,6 @@ run-test-multikueue-e2e-baseline-%:
 		E2E_TARGET_FOLDER="multikueue/baseline" \
 		E2E_CONFIG_FOLDER="multikueue/baseline" \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
-		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		E2E_USE_HELM=$(E2E_USE_HELM) \
 		./hack/testing/e2e-multikueue-test.sh
 
@@ -419,7 +415,6 @@ run-test-multikueue-e2e-extended-%:
 		E2E_TARGET_FOLDER="multikueue/extended" \
 		E2E_CONFIG_FOLDER=$(E2E_CONFIG_FOLDER) \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
-		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		E2E_USE_HELM=$(E2E_USE_HELM) \
 		./hack/testing/e2e-multikueue-test.sh
 
@@ -434,7 +429,6 @@ run-test-tas-e2e-baseline-%:
 		KIND_CLUSTER_FILE="kind-cluster-tas.yaml" E2E_TARGET_FOLDER="tas/baseline" \
 		E2E_CONFIG_FOLDER="baseline" \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
-		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		E2E_USE_HELM=$(E2E_USE_HELM) \
 		./hack/testing/e2e-test.sh
 
@@ -450,7 +444,6 @@ run-test-tas-e2e-extended-%:
 		KIND_CLUSTER_FILE="kind-cluster-tas.yaml" E2E_TARGET_FOLDER="tas/extended" \
 		E2E_CONFIG_FOLDER="extended" \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
-		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		E2E_USE_HELM=$(E2E_USE_HELM) \
 		./hack/testing/e2e-test.sh
 
@@ -465,7 +458,6 @@ run-test-e2e-sequential-baseline-%:
 	KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="sequential/baseline" \
 	E2E_CONFIG_FOLDER="baseline" \
 	TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
-	E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 	E2E_USE_HELM=$(E2E_USE_HELM) \
 	./hack/testing/e2e-test.sh
 
@@ -480,7 +472,6 @@ run-test-e2e-sequential-extended-%:
 	KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="sequential/extended" \
 	E2E_CONFIG_FOLDER="extended" \
 	TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
-	E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 	E2E_USE_HELM=$(E2E_USE_HELM) \
 	./hack/testing/e2e-test.sh
 
@@ -496,7 +487,6 @@ run-test-e2e-certmanager-%:
 		CERTMANAGER_VERSION=$(CERTMANAGER_VERSION) \
 		PROMETHEUS_OPERATOR_VERSION=$(PROMETHEUS_OPERATOR_VERSION) \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
-		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		E2E_USE_HELM=$(E2E_USE_HELM) \
 		./hack/testing/e2e-test.sh
 
@@ -511,7 +501,6 @@ run-test-e2e-upgrade-%:
 		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="upgrade" \
 		KUEUE_UPGRADE_FROM_VERSION=$(KUEUE_UPGRADE_FROM_VERSION) \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
-		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		./hack/testing/e2e-test.sh
 
 run-test-e2e-certmanager-upgrade-%: K8S_VERSION = $(@:run-test-e2e-certmanager-upgrade-%=%)
@@ -526,7 +515,6 @@ run-test-e2e-certmanager-upgrade-%:
 		KUEUE_UPGRADE_FROM_VERSION=$(KUEUE_UPGRADE_FROM_VERSION) \
 		CERTMANAGER_VERSION=$(CERTMANAGER_VERSION) \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
-		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		./hack/testing/e2e-test.sh
 
 run-test-e2e-dra-%: K8S_VERSION = $(@:run-test-e2e-dra-%=%)
@@ -540,7 +528,6 @@ run-test-e2e-dra-%:
 		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="dra/whole-device" \
 		DRA_EXAMPLE_DRIVER_VERSION=$(DRA_EXAMPLE_DRIVER_VERSION) \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
-		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		./hack/testing/e2e-test.sh
 
 run-test-e2e-multikueue-dra-%: K8S_VERSION = $(@:run-test-e2e-multikueue-dra-%=%)
@@ -554,7 +541,6 @@ run-test-e2e-multikueue-dra-%:
 		DRA_EXAMPLE_DRIVER_VERSION=$(DRA_EXAMPLE_DRIVER_VERSION) \
 		E2E_TARGET_FOLDER="multikueue/dra" \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
-		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		./hack/testing/e2e-multikueue-test.sh
 
 .PHONY: test-e2e-dra-counter
@@ -572,7 +558,6 @@ run-test-e2e-dra-counter-%:
 		DRA_EXAMPLE_DRIVER_VERSION=$(DRA_EXAMPLE_DRIVER_VERSION) \
 		DRA_GPU_PARTITIONS=4 \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
-		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		./hack/testing/e2e-test.sh
 
 run-test-e2e-multikueue-sequential-%: K8S_VERSION = $(@:run-test-e2e-multikueue-sequential-%=%)
@@ -588,7 +573,6 @@ run-test-e2e-multikueue-sequential-%:
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
 		CLUSTERPROFILE_VERSION=$(CLUSTERPROFILE_VERSION) \
 		CLUSTERPROFILE_PLUGIN_IMAGE_VERSION=$(CLUSTERPROFILE_PLUGIN_IMAGE_VERSION) \
-		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		E2E_USE_HELM=$(E2E_USE_HELM) \
 		./hack/testing/e2e-multikueue-test.sh
 
@@ -621,7 +605,6 @@ run-test-e2e-k8s-main-was:
 		PROMETHEUS_OPERATOR_VERSION=$(PROMETHEUS_OPERATOR_VERSION) \
 		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="singlecluster" \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
-		E2E_RUN_ONLY_ENV=$(E2E_RUN_ONLY_ENV) \
 		E2E_USE_HELM=$(E2E_USE_HELM) \
 		WAS_ENABLED=true \
 		./hack/testing/e2e-test.sh

--- a/hack/testing/e2e-kueueviz-local.sh
+++ b/hack/testing/e2e-kueueviz-local.sh
@@ -59,18 +59,6 @@ cd -
 cd "${ROOT_DIR}/test/e2e/kueueviz/"
 npm install
 
-if [ "$E2E_RUN_ONLY_ENV" = "true" ]; then
-  read -rp "Do you want to cleanup? [Y/n] " reply
-  if [[ "$reply" =~ ^[nN]$ ]]; then
-    trap - EXIT
-    echo "Skipping cleanup for backend, frontend, and kind cluster."
-    echo -e "\nBackend cleanup:\n  kill $BACKEND_PID"
-    echo -e "\nFrontend cleanup:\n  kill $FRONTEND_PID"
-    echo -e "\nKind cluster cleanup:\n  kind delete clusters $KIND_CLUSTER_NAME"
-  fi
-  exit 0
-fi
-
 # Run Cypress tests for kueueviz frontend
 npm run cypress:run
 cd -

--- a/hack/testing/e2e-multikueue-test.sh
+++ b/hack/testing/e2e-multikueue-test.sh
@@ -109,15 +109,5 @@ $KIND export kubeconfig --name "$WORKER1_KIND_CLUSTER_NAME"
 $KIND export kubeconfig --name "$WORKER2_KIND_CLUSTER_NAME"
 kueue_deploy
 
-if [ "$E2E_RUN_ONLY_ENV" = "true" ]; then
-  read -rp "Do you want to cleanup? [Y/n] " reply
-  if [[ "$reply" =~ ^[nN]$ ]]; then
-    trap - EXIT
-    echo "Skipping cleanup for kind clusters."
-    echo -e "\nKind cluster cleanup:\n  kind delete clusters $MANAGER_KIND_CLUSTER_NAME $WORKER1_KIND_CLUSTER_NAME $WORKER2_KIND_CLUSTER_NAME"
-  fi
-  exit 0
-fi
-
 run_e2e_ginkgo --json-report=e2e.json --output-dir="$ARTIFACTS" -v ./test/e2e/"${E2E_TARGET_FOLDER}"/...
 "$ROOT_DIR/bin/ginkgo-top" -i "$ARTIFACTS/e2e.json" > "$ARTIFACTS/e2e-top.yaml"

--- a/hack/testing/e2e-test.sh
+++ b/hack/testing/e2e-test.sh
@@ -59,15 +59,5 @@ if [[ -n ${PROMETHEUS_OPERATOR_VERSION:-} && ("$GINKGO_ARGS" =~ feature:promethe
     deploy_kueue_prometheus_config ""
 fi
 
-if [ "$E2E_RUN_ONLY_ENV" = "true" ]; then
-  read -rp "Do you want to cleanup? [Y/n] " reply
-  if [[ "$reply" =~ ^[nN]$ ]]; then
-    trap - EXIT
-    echo "Skipping cleanup for kind cluster."
-    echo -e "\nKind cluster cleanup:\n  kind delete clusters $KIND_CLUSTER_NAME"
-  fi
-  exit 0
-fi
-
 run_e2e_ginkgo --json-report=e2e.json --output-dir="$ARTIFACTS" -v ./test/e2e/"${E2E_TARGET_FOLDER}"/...
 "$ROOT_DIR/bin/ginkgo-top" -i "$ARTIFACTS/e2e.json" > "$ARTIFACTS/e2e-top.yaml"

--- a/site/content/en/community/contribution_guidelines/testing.md
+++ b/site/content/en/community/contribution_guidelines/testing.md
@@ -192,16 +192,6 @@ E2E_MODE=dev IMAGE_TAG=us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue
 
 This is useful to reproduce issues on a specific released version (e.g. for on-call debugging). For installing a released version into a real cluster (not e2e), see [Install a released version](/docs/getting-started/installation/#install-a-released-version).
 
-### Legacy: interactive attach mode
-
-Run `E2E_RUN_ONLY_ENV=true make kind-image-build test-multikueue-e2e-baseline` and wait for the `Do you want to cleanup? [Y/n] ` to appear (CI-style behavior).
-
-The cluster is ready, and now you can run tests from another terminal:
-```shell
-<your_kueue_path>/bin/ginkgo --json-report ./ginkgo.report -focus "MultiKueue when Creating a multikueue admission check Should run a jobSet on worker if admitted" -r
-```
-or from VSCode.
-
 ## Running subset of integration or e2e tests
 
 ### Use label filters for integration tests

--- a/site/content/zh-CN/community/contribution_guidelines/testing.md
+++ b/site/content/zh-CN/community/contribution_guidelines/testing.md
@@ -190,16 +190,6 @@ E2E_MODE=dev IMAGE_TAG=us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue
 
 适用于在特定已发布版本上复现问题（例如值班排查）。若要在真实集群（非 e2e）中安装已发布版本，请参阅[安装已发布版本](/zh-cn/docs/installation/#install-a-released-version)。
 
-### 旧方式：交互式附加模式 {#legacy-interactive-attach-mode}
-
-运行 `E2E_RUN_ONLY_ENV=true make kind-image-build test-multikueue-e2e-baseline` 并等待 `Do you want to cleanup? [Y/n] ` 出现（CI 风格行为）。
-
-集群已准备就绪，现在你可以从另一个终端运行测试：
-```shell
-<your_kueue_path>/bin/ginkgo --json-report ./ginkgo.report -focus "MultiKueue when Creating a multikueue admission check Should run a jobSet on worker if admitted" -r
-```
-或从 VSCode 运行。
-
 ## 运行集成或 e2e 测试子集 {#running-subset-of-integration-or-e2e-tests}
 
 ### 使用标签过滤集成测试 {#use-label-filters-for-integration-tests}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Drop legacy E2E_RUN_ONLY_ENV
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12802 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * e2e test flows now run through to completion without stopping for an interactive cleanup prompt.
  * Cypress and Ginkgo-based e2e runs proceed automatically after setup, improving consistency across test commands.

* **Documentation**
  * Removed outdated guidance for the legacy interactive test mode.
  * Updated testing docs to reflect the streamlined e2e workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->