### PR TITLE
KEP: Add OnHold reason to precedence rules for inadmissible workloads observability

### DIFF
--- a/keps/10852-inadmissible-workloads-observability/README.md
+++ b/keps/10852-inadmissible-workloads-observability/README.md
@@ -285,6 +285,9 @@ const (
 	// WorkloadPendingEvaluation indicates that the workload is pending evaluation in the scheduling queue.
 	WorkloadPendingEvaluation = "PendingEvaluation"
 
+	// WorkloadOnHold indicates that the workload's quota reservation is intentionally released.
+	WorkloadOnHold = "OnHold"
+
 	// WorkloadAdmittedReasonNoReservation indicates that the workload has no reservation.
 	WorkloadAdmittedReasonNoReservation = "NoReservation"
 
@@ -314,11 +317,12 @@ is not evaluated or reported.
 | Precedence | Reason Token | Description / Scenario | Location in Memory |
 | :--- | :--- | :--- | :--- |
 | **1** | `Deactivated` | Workload is explicitly deactivated (`spec.active: false`). | None |
-| **2** | `Misconfigured` | Workload points to a non-existent queue or has invalid DRA configs. | None |
-| **3** | `NoMatchingFlavor` | Workload requests a flavor that does not exist or whose taints it does not tolerate. | `ClusterQueue.inadmissibleWorkloads` |
-| **4** | `Suspended` | Administrative hold (the queue's StopPolicy is active). | None |
-| **5** | `AdmissionGated` | Gated state (AdmissionGatedBy annotation). | None |
-| **6** | `WaitingForPodsReady` | Scheduling hold (waiting for previously admitted workloads to reach PodsReady under `waitForPodsReady` configuration). | blocks and waits |
+| **2** | `OnHold` | Workload's quota reservation is intentionally released (e.g. StatefulSet scale-to-zero). | None |
+| **3** | `Misconfigured` | Workload points to a non-existent queue or has invalid DRA configs. | None |
+| **4** | `NoMatchingFlavor` | Workload requests a flavor that does not exist or whose taints it does not tolerate. | `ClusterQueue.inadmissibleWorkloads` |
+| **5** | `Suspended` | Administrative hold (the queue's StopPolicy is active). | None |
+| **6** | `AdmissionGated` | Gated state (AdmissionGatedBy annotation). | None |
+| **7** | `WaitingForPodsReady` | Scheduling hold (waiting for previously admitted workloads to reach PodsReady under `waitForPodsReady` configuration). | blocks and waits |
 
 #### 2. Nominated Flavor Reasons
 These blockers apply to the nominated flavor assignment selected by the


### PR DESCRIPTION
#### What type of PR is this?
/kind kep

#### What this PR does / why we need it:

In the meantime a new reason for `QuotaReserved` condition was added and it should be included in precedence rules.

#### Which issue(s) this PR fixes:
Part of #10852

#### Special notes for your reviewer:

## Rationale for prioritizing `OnHold` over `Misconfigured`

If we were to prioritize `Misconfigured` over `OnHold`, we would introduce a race condition that leads to temporary quota waste and scheduling churn.

### Scenario A: Prioritizing `Misconfigured` > `OnHold` (Incorrect)

1. **StatefulSet scaled to 0**: The workload is intentionally parked by setting it to `OnHold` (status `QuotaReserved=False` with reason `OnHold`).
2. **LocalQueue is deleted**: The workload is now also misconfigured.
3. **Reconciliation**: Because `Misconfigured` has higher precedence, the status reason is overwritten to `Misconfigured`. We have now **lost** the `OnHold` state in the workload status.
4. **LocalQueue is recreated**: The administrator fixes the queue.
5. **Reconciliation**: The workload controller sees the queue exists and the workload is active. Since it is no longer marked as `OnHold` (the reason was overwritten), it transitions to `PendingEvaluation`.
6. **Scheduler Admits the Workload**: The scheduler reserves quota for it. This is **wasted quota** because the StatefulSet is still scaled to 0.
7. **StatefulSet Reconciler runs**: It sees the workload has quota but `replicas == 0`, so it evicts it and sets it back to `OnHold` to release the quota.

**Churn**: In steps 6-7, the workload temporarily acquired quota it didn't need, potentially blocking other workloads in the same ClusterQueue.

### Scenario B: Prioritizing `OnHold` > `Misconfigured`

1. **StatefulSet scaled to 0**: Workload is set to `OnHold`.
2. **LocalQueue is deleted**: Workload is also misconfigured.
3. **Reconciliation**: Because `OnHold` has higher precedence, the status remains `OnHold`. The queue manager knows it is not admissible (due to `OnHold`) and does not attempt to queue it.
4. **LocalQueue is recreated**: Status remains `OnHold`. No scheduling attempt is made (no quota wasted).
5. **User scales up (replicas > 0)**: The StatefulSet controller clears the `OnHold` status.
   - If the queue was not fixed, it immediately blocks on `Misconfigured`.
   - If the queue was fixed, it schedules normally.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new workload condition reason, `OnHold`, to indicate workloads whose quota reservation has been intentionally released.
  * Updated the documented precedence order for `QuotaReserved=False` reasons to include `OnHold`, adjusting the relative priority of subsequent flavor-independent blockers accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->