### PR TITLE
Fix multikueue remote workload cleanup when worker is unavailable [0.18]

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -100,13 +100,14 @@ type wlReconciler struct {
 var _ reconcile.Reconciler = (*wlReconciler)(nil)
 
 type wlGroup struct {
-	local         *kueue.Workload
-	localClient   client.Client
-	remotes       map[string]*kueue.Workload
-	remoteClients map[string]*remoteClient
-	acName        kueue.AdmissionCheckReference
-	jobAdapter    jobframework.MultiKueueAdapter
-	controllerKey types.NamespacedName
+	local               *kueue.Workload
+	localClient         client.Client
+	remotes             map[string]*kueue.Workload
+	remoteClients       map[string]*remoteClient
+	acName              kueue.AdmissionCheckReference
+	jobAdapter          jobframework.MultiKueueAdapter
+	controllerKey       types.NamespacedName
+	unavailableClusters []string
 }
 
 type Option func(reconciler *wlReconciler)
@@ -255,6 +256,8 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 				return reconcile.Result{}, err
 			}
 		}
+		// Remote workloads on unavailable clusters will be cleaned up by
+		// the per-cluster GC once the cluster reconnects.
 		w.deletedWlCache.Delete(req.String())
 		return reconcile.Result{}, nil
 	}
@@ -271,26 +274,20 @@ func (w *wlReconciler) updateACS(ctx context.Context, wl *kueue.Workload, acs *k
 	})
 }
 
-func (w *wlReconciler) remoteClientsForAC(ctx context.Context, acName kueue.AdmissionCheckReference) (map[string]*remoteClient, error) {
+func (w *wlReconciler) remoteClientsForAC(ctx context.Context, acName kueue.AdmissionCheckReference) (availableClients map[string]*remoteClient, unavailableClusters []string, err error) {
 	cfg, err := w.helper.ConfigForAdmissionCheck(ctx, acName)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	clients := make(map[string]*remoteClient, len(cfg.Spec.Clusters))
+	availableClients = make(map[string]*remoteClient, len(cfg.Spec.Clusters))
 	for _, clusterName := range cfg.Spec.Clusters {
-		if client, found := w.clusters.controllerFor(clusterName); found {
-			// Skip the client if its reconnect is ongoing or it is disconnected.
-			if !client.connecting.Load() && !client.disconnected.Load() {
-				clients[clusterName] = client
-			}
+		if client, found := w.clusters.controllerFor(clusterName); found && !client.connecting.Load() && !client.disconnected.Load() {
+			availableClients[clusterName] = client
+		} else {
+			unavailableClusters = append(unavailableClusters, clusterName)
 		}
 	}
-	// Return an empty map (rather than an error) when all configured clusters
-	// are disconnected or reconnecting. This allows readGroup to construct an
-	// empty group, so reconcileGroup can apply the workerLostTimeout delay via
-	// the existing "reserving remote lost" branch instead of failing with
-	// ErrNoActiveClusters and retrying via controller-runtime backoff.
-	return clients, nil
+	return availableClients, unavailableClusters, nil
 }
 
 func (w *wlReconciler) adapter(local *kueue.Workload) (jobframework.MultiKueueAdapter, *metav1.OwnerReference) {
@@ -319,19 +316,20 @@ func (w *wlReconciler) adapter(local *kueue.Workload) (jobframework.MultiKueueAd
 }
 
 func (w *wlReconciler) readGroup(ctx context.Context, local *kueue.Workload, acName kueue.AdmissionCheckReference, adapter jobframework.MultiKueueAdapter, controllerName string) (*wlGroup, error) {
-	rClients, err := w.remoteClientsForAC(ctx, acName)
+	rClients, unavailable, err := w.remoteClientsForAC(ctx, acName)
 	if err != nil {
 		return nil, fmt.Errorf("admission check %q: %w", acName, err)
 	}
 
 	grp := wlGroup{
-		local:         local,
-		localClient:   w.client,
-		remotes:       make(map[string]*kueue.Workload, len(rClients)),
-		remoteClients: rClients,
-		acName:        acName,
-		jobAdapter:    adapter,
-		controllerKey: types.NamespacedName{Name: controllerName, Namespace: local.Namespace},
+		local:               local,
+		localClient:         w.client,
+		remotes:             make(map[string]*kueue.Workload, len(rClients)),
+		remoteClients:       rClients,
+		acName:              acName,
+		jobAdapter:          adapter,
+		controllerKey:       types.NamespacedName{Name: controllerName, Namespace: local.Namespace},
+		unavailableClusters: unavailable,
 	}
 
 	for remote, rClient := range rClients {
@@ -371,6 +369,10 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 				errs = append(errs, err)
 				log.V(2).Error(err, "Deleting remote workload", "workerCluster", rem)
 			}
+		}
+		if len(group.unavailableClusters) > 0 {
+			log.V(3).Info("Retrying remote workload cleanup, some clusters are unavailable", "unavailableClusters", group.unavailableClusters, "retryAfter", w.workerLostTimeout)
+			return reconcile.Result{RequeueAfter: w.workerLostTimeout}, errors.Join(errs...)
 		}
 		return reconcile.Result{}, errors.Join(errs...)
 	}

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -98,6 +98,7 @@ func TestWlReconcile(t *testing.T) {
 		worker2Jobs          []batchv1.Job
 
 		wantError             error
+		wantResult            *reconcile.Result
 		wantEvents            []utiltesting.EventRecord
 		wantManagersWorkloads []kueue.Workload
 		wantManagersJobs      []batchv1.Job
@@ -171,6 +172,32 @@ func TestWlReconcile(t *testing.T) {
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Obj(),
 			},
+		},
+		"missing workload (in deleted workload cache), reconnecting worker, GC handles cleanup": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			reconcileFor: "wl1",
+			managersDeletedWorkloads: []*kueue.Workload{
+				baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			worker1Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			worker1Jobs: []batchv1.Job{
+				*baseJobBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+			useSecondWorker:     true,
+			worker2Reconnecting: true,
+			worker2OnGetError:   errFake,
 		},
 		"missing workload (in deleted workload cache), no remote objects": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
@@ -288,7 +315,42 @@ func TestWlReconcile(t *testing.T) {
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					Obj(),
 			},
-			wantError: nil,
+			wantResult: &reconcile.Result{RequeueAfter: defaultWorkerLostTimeout},
+			wantError:  nil,
+		},
+		"wl without reservation, reconnecting worker with remote workload, requeues for cleanup": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			reconcileFor: "wl1",
+			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					Obj(),
+			},
+			useSecondWorker:     true,
+			worker2Reconnecting: true,
+			worker2OnGetError:   errFake,
+			worker2Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					Obj(),
+			},
+			wantWorker2Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+			wantResult: &reconcile.Result{RequeueAfter: defaultWorkerLostTimeout},
+			wantError:  nil,
 		},
 		"wl without reservation, clears the workload objects": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
@@ -1687,9 +1749,14 @@ func TestWlReconcile(t *testing.T) {
 					})
 				}
 
-				_, gotErr := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.reconcileFor, Namespace: TestNamespace}})
+				gotResult, gotErr := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.reconcileFor, Namespace: TestNamespace}})
 				if diff := cmp.Diff(tc.wantError, gotErr, cmpopts.EquateErrors()); diff != "" {
 					t.Errorf("unexpected error (-want/+got):\n%s", diff)
+				}
+				if tc.wantResult != nil {
+					if diff := cmp.Diff(*tc.wantResult, gotResult); diff != "" {
+						t.Errorf("unexpected result (-want/+got):\n%s", diff)
+					}
 				}
 
 				if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents); diff != "" {
@@ -1771,6 +1838,110 @@ func TestWlReconcile(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestOrphanedRemoteWorkloadCleanedAfterReconnect(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	fakeClock := testingclock.NewFakeClock(now)
+
+	features.SetFeatureGateDuringTest(t, features.WorkloadIdentifierAnnotations, false)
+
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	baseWorkloadBuilder := utiltestingapi.MakeWorkload("wl1", TestNamespace)
+	baseJobBuilder := testingjob.MakeJob("job1", TestNamespace).Suspend(false).ManagedBy(kueue.MultiKueueControllerName)
+
+	managerWl := *baseWorkloadBuilder.Clone().
+		AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+		ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+		Obj()
+	remoteWl := *baseWorkloadBuilder.Clone().
+		Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+		Obj()
+
+	managerBuilder := getClientBuilder(ctx).
+		WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).
+		WithLists(&kueue.WorkloadList{Items: []kueue.Workload{managerWl}}, &batchv1.JobList{Items: []batchv1.Job{*baseJobBuilder.DeepCopy()}}).
+		WithStatusSubresource(&managerWl).
+		WithObjects(
+			utiltestingapi.MakeMultiKueueConfig("config1").Clusters("worker1", "worker2").Obj(),
+			utiltestingapi.MakeAdmissionCheck("ac1").ControllerName(kueue.MultiKueueControllerName).
+				Parameters(kueue.SchemeGroupVersion.Group, "MultiKueueConfig", "config1").
+				Obj(),
+		)
+	managerClient := managerBuilder.Build()
+
+	adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
+	cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil)
+
+	w1remoteClient := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
+	w1remoteClient.client = NewNeverCachingClient(getClientBuilder(ctx).
+		WithStatusSubresource(&kueue.Workload{}).
+		WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).
+		Build())
+	w1remoteClient.connecting.Store(false)
+	cRec.remoteClients["worker1"] = w1remoteClient
+
+	worker2Client := NewNeverCachingClient(getClientBuilder(ctx).
+		WithLists(&kueue.WorkloadList{Items: []kueue.Workload{remoteWl}}).
+		WithStatusSubresource(&kueue.Workload{}).
+		WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).
+		Build())
+	w2remoteClient := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
+	w2remoteClient.client = worker2Client
+	w2remoteClient.connecting.Store(true)
+	cRec.remoteClients["worker2"] = w2remoteClient
+
+	helper, _ := admissioncheck.NewMultiKueueStoreHelper(managerClient)
+	recorder := &utiltesting.EventRecorder{}
+	reconciler := newWlReconciler(
+		managerClient,
+		helper,
+		cRec,
+		defaultOrigin,
+		recorder,
+		defaultWorkerLostTimeout,
+		time.Second,
+		adapters,
+		config.MultiKueueDispatcherModeAllAtOnce,
+		nil,
+		WithClock(t, fakeClock),
+	)
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "wl1", Namespace: TestNamespace}}
+
+	// Step 1: worker2 is reconnecting — reconcile should requeue and NOT delete worker2's workload.
+	result, err := reconciler.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error on first reconcile: %v", err)
+	}
+	if result.RequeueAfter != defaultWorkerLostTimeout {
+		t.Fatalf("expected RequeueAfter=%v, got %v", defaultWorkerLostTimeout, result.RequeueAfter)
+	}
+
+	wl2 := &kueue.Workload{}
+	if err := worker2Client.Get(ctx, req.NamespacedName, wl2); err != nil {
+		t.Fatalf("worker2 workload should still exist after first reconcile, got error: %v", err)
+	}
+
+	// Step 2: worker2 finishes reconnecting — reconcile should clean up the orphaned workload.
+	w2remoteClient.connecting.Store(false)
+
+	result, err = reconciler.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error on second reconcile: %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Fatalf("expected no RequeueAfter on second reconcile, got %v", result.RequeueAfter)
+	}
+
+	err = worker2Client.Get(ctx, req.NamespacedName, wl2)
+	if client.IgnoreNotFound(err) != nil {
+		t.Fatalf("unexpected error checking worker2 workload: %v", err)
+	}
+	if err == nil {
+		t.Fatal("worker2 workload should have been deleted after second reconcile")
 	}
 }
 

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -1484,6 +1484,94 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		})
 	})
 
+	ginkgo.It("should clean up the remote workload on a reconnected worker after the job finishes", framework.SlowSpec, func() {
+		job := testingjob.MakeJob("job", managerNs.Name).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
+			Obj()
+		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, job)
+		jobLookupKey := client.ObjectKeyFromObject(job)
+
+		createdWorkload := &kueue.Workload{}
+		wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
+
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+			PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).
+			Obj()
+
+		ginkgo.By("setting workload reservation in the management cluster", func() {
+			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, wlLookupKey, admission)
+		})
+
+		ginkgo.By("checking the workload creation in the worker clusters", func() {
+			managerWl := &kueue.Workload{}
+			gomega.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				g.Expect(createdWorkload.Spec).To(gomega.BeComparableTo(managerWl.Spec))
+				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				g.Expect(createdWorkload.Spec).To(gomega.BeComparableTo(managerWl.Spec))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		restoreConnectionToWorker1 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster1)
+
+		ginkgo.By("setting workload reservation in worker2, the workload is admitted and job is created in worker2", func() {
+			util.SetQuotaReservation(worker2TestCluster.ctx, worker2TestCluster.client, wlLookupKey, admission)
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				g.Expect(apimeta.IsStatusConditionTrue(createdWorkload.Status.Conditions, kueue.WorkloadAdmitted)).To(gomega.BeTrue())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("finishing the worker2 job", func() {
+			now := metav1.Now()
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdJob := batchv1.Job{}
+				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, jobLookupKey, &createdJob)).To(gomega.Succeed())
+				createdJob.Status.Conditions = append(createdJob.Status.Conditions,
+					batchv1.JobCondition{
+						Type:               batchv1.JobSuccessCriteriaMet,
+						Status:             corev1.ConditionTrue,
+						LastProbeTime:      now,
+						LastTransitionTime: now,
+						Message:            "Reached expected number of succeeded pods",
+					},
+					batchv1.JobCondition{
+						Type:               batchv1.JobComplete,
+						Status:             corev1.ConditionTrue,
+						LastProbeTime:      now,
+						LastTransitionTime: now,
+						Message:            "Job finished successfully",
+					})
+				createdJob.Status.Succeeded = 1
+				createdJob.Status.StartTime = &now
+				createdJob.Status.CompletionTime = &now
+				g.Expect(worker2TestCluster.client.Status().Update(worker2TestCluster.ctx, &createdJob)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("waiting for the manager workload to be finished", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				g.Expect(apimeta.IsStatusConditionTrue(createdWorkload.Status.Conditions, kueue.WorkloadFinished)).To(gomega.BeTrue())
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("the worker2 remote workload is cleaned up", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, wlLookupKey, createdWorkload)).To(utiltesting.BeNotFoundError())
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		restoreConnectionToWorker1()
+
+		ginkgo.By("the worker1 remote workload is cleaned up after reconnect", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, wlLookupKey, createdWorkload)).To(utiltesting.BeNotFoundError())
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
 	ginkgo.It("Should requeue the workload with a delay when the connection to the admitting worker is lost", framework.SlowSpec, func() {
 		jobSet := testingjobset.MakeJobSet("job-set", managerNs.Name).
 			Queue(managerLq.Name).


### PR DESCRIPTION
This is a manual cherry-pick of  https://github.com/kubernetes-sigs/kueue/pull/11515

```release-note
 MultiKueue: Fixed a bug where obsolete remote Workloads could remain on temporarily unavailable worker clusters when the manager Workload lost its reservation or was deleted. Kueue now retries cleanup after worker clusters reconnect.

```