### PR TITLE
KEP: Set empty underlying_cause for non QuotaReserved admission issues for inadmissible workloads

### DIFF
--- a/keps/10852-inadmissible-workloads-observability/README.md
+++ b/keps/10852-inadmissible-workloads-observability/README.md
@@ -476,9 +476,7 @@ A set of metrics is introduced to track unadmitted workloads when the
     `AdmissionGated`).
 
 If a workload has successfully obtained a quota reservation (`QuotaReserved` is `True`),
-the `underlying_cause` label is populated as follows:
-- For `UnsatisfiedAdmissionChecks`: Set to `ChecksNotReady`.
-- For `PendingDelayedTopologyRequests`: Set to `PendingTopology`.
+the `underlying_cause` label is left empty (`""`), which indicates that the value in the `reason` label is the root cause for the workload not being admitted.
 
 **Handling of Missing or Unset Status Conditions**
 
@@ -502,8 +500,8 @@ of these mapping combinations are detailed below:
 | :--- | :--- | :--- | :--- | :--- |
 | `NoReservation` | `False (WaitingForQuota)` | `NoReservation` | `WaitingForQuota` | Workload is waiting for queue capacity. |
 | `NoReservation` | `False (Misconfigured)` | `NoReservation` | `Misconfigured` | Workload has structural/configuration errors. |
-| `UnsatisfiedAdmissionChecks` | `True (N/A)` | `UnsatisfiedAdmissionChecks` | `ChecksNotReady` | Quota is reserved, but blocked by pending admission checks. |
-| `PendingDelayedTopologyRequests` | `True (N/A)` | `PendingDelayedTopologyRequests` | `PendingTopology` | Quota is reserved, but blocked by delayed topology paths. |
+| `UnsatisfiedAdmissionChecks` | `True (N/A)` | `UnsatisfiedAdmissionChecks` | `""` | Quota is reserved, but blocked by pending admission checks. |
+| `PendingDelayedTopologyRequests` | `True (N/A)` | `PendingDelayedTopologyRequests` | `""` | Quota is reserved, but blocked by delayed topology paths. |
 
 
 ### Troubleshooting & End-User Inspection


### PR DESCRIPTION
#### What type of PR is this?
/kind kep

#### What this PR does / why we need it:

As discussed here https://github.com/kubernetes-sigs/kueue/pull/12759#discussion_r3520095719

We don't need to set `underlying_reason` label explicitly if it doesn't bring any value, we can assume that empty value means that the reason is the root cause of the problem as we do for other metrics:
- https://github.com/kubernetes-sigs/kueue/blob/8771f2d5e3e39014e4f822d9534b824f9ecb7bf4/pkg/metrics/metrics.go#L607
- https://github.com/kubernetes-sigs/kueue/blob/8771f2d5e3e39014e4f822d9534b824f9ecb7bf4/pkg/metrics/metrics.go#L636

#### Which issue(s) this PR fixes:
Part of #10852

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the Prometheus metrics schema for unadmitted workloads.
  * Updated guidance so `underlying_cause` is left empty when a workload is not blocked by `QuotaReserved`-related reasons.
  * Adjusted the listed `Admitted` reason values to use an empty `underlying_cause` in the affected cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->