### PR TITLE
Increase Workload PodSet limit to 18

### DIFF
--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -33,12 +33,12 @@ const (
 type WorkloadSpec struct {
 	// podSets is a list of sets of homogeneous pods, each described by a Pod spec
 	// and a count.
-	// There must be at least one element and at most 10.
+	// There must be at least one element and at most 40.
 	// podSets cannot be changed.
 	//
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=10
+	// +kubebuilder:validation:MaxItems=40
 	// +kubebuilder:validation:MinItems=1
 	PodSets []PodSet `json:"podSets"`
 
@@ -158,7 +158,7 @@ type Admission struct {
 	// podSetAssignments hold the admission results for each of the .spec.podSets entries.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=10
+	// +kubebuilder:validation:MaxItems=40
 	PodSetAssignments []PodSetAssignment `json:"podSetAssignments"`
 }
 
@@ -387,7 +387,7 @@ type WorkloadStatus struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=10
+	// +kubebuilder:validation:MaxItems=40
 	ReclaimablePods []ReclaimablePod `json:"reclaimablePods,omitempty"`
 
 	// admissionChecks list all the admission checks required by the workload and the current status
@@ -407,7 +407,7 @@ type WorkloadStatus struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=10
+	// +kubebuilder:validation:MaxItems=40
 	ResourceRequests []PodSetRequest `json:"resourceRequests,omitempty"`
 
 	// accumulatedPastExexcutionTimeSeconds holds the total time, in seconds, the workload spent
@@ -563,7 +563,7 @@ type AdmissionCheckState struct {
 	// podSetUpdates contains a list of pod set modifications suggested by AdmissionChecks.
 	// +optional
 	// +listType=atomic
-	// +kubebuilder:validation:MaxItems=10
+	// +kubebuilder:validation:MaxItems=40
 	PodSetUpdates []PodSetUpdate `json:"podSetUpdates,omitempty"`
 }
 

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -33,12 +33,12 @@ const (
 type WorkloadSpec struct {
 	// podSets is a list of sets of homogeneous pods, each described by a Pod spec
 	// and a count.
-	// There must be at least one element and at most 40.
+	// There must be at least one element and at most 18.
 	// podSets cannot be changed.
 	//
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=40
+	// +kubebuilder:validation:MaxItems=18
 	// +kubebuilder:validation:MinItems=1
 	PodSets []PodSet `json:"podSets"`
 
@@ -158,7 +158,7 @@ type Admission struct {
 	// podSetAssignments hold the admission results for each of the .spec.podSets entries.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=40
+	// +kubebuilder:validation:MaxItems=18
 	PodSetAssignments []PodSetAssignment `json:"podSetAssignments"`
 }
 
@@ -387,7 +387,7 @@ type WorkloadStatus struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=40
+	// +kubebuilder:validation:MaxItems=18
 	ReclaimablePods []ReclaimablePod `json:"reclaimablePods,omitempty"`
 
 	// admissionChecks list all the admission checks required by the workload and the current status
@@ -407,7 +407,7 @@ type WorkloadStatus struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=40
+	// +kubebuilder:validation:MaxItems=18
 	ResourceRequests []PodSetRequest `json:"resourceRequests,omitempty"`
 
 	// accumulatedPastExexcutionTimeSeconds holds the total time, in seconds, the workload spent
@@ -563,7 +563,7 @@ type AdmissionCheckState struct {
 	// podSetUpdates contains a list of pod set modifications suggested by AdmissionChecks.
 	// +optional
 	// +listType=atomic
-	// +kubebuilder:validation:MaxItems=40
+	// +kubebuilder:validation:MaxItems=18
 	PodSetUpdates []PodSetUpdate `json:"podSetUpdates,omitempty"`
 }
 

--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -28,12 +28,12 @@ import (
 type WorkloadSpec struct {
 	// podSets is a list of sets of homogeneous pods, each described by a Pod spec
 	// and a count.
-	// There must be at least one element and at most 10.
+	// There must be at least one element and at most 40.
 	// podSets cannot be changed.
 	//
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=10
+	// +kubebuilder:validation:MaxItems=40
 	// +kubebuilder:validation:MinItems=1
 	// +optional
 	PodSets []PodSet `json:"podSets"`
@@ -272,7 +272,7 @@ type Admission struct {
 	// podSetAssignments hold the admission results for each of the .spec.podSets entries.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=10
+	// +kubebuilder:validation:MaxItems=40
 	// +optional
 	PodSetAssignments []PodSetAssignment `json:"podSetAssignments"`
 }
@@ -649,7 +649,7 @@ type WorkloadStatus struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=10
+	// +kubebuilder:validation:MaxItems=40
 	ReclaimablePods []ReclaimablePod `json:"reclaimablePods,omitempty"`
 
 	// admissionChecks list all the admission checks required by the workload and the current status
@@ -669,7 +669,7 @@ type WorkloadStatus struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=10
+	// +kubebuilder:validation:MaxItems=40
 	ResourceRequests []PodSetRequest `json:"resourceRequests,omitempty"`
 
 	// accumulatedPastExecutionTimeSeconds holds the total time, in seconds, the workload spent
@@ -834,7 +834,7 @@ type AdmissionCheckState struct {
 	// podSetUpdates contains a list of pod set modifications suggested by AdmissionChecks.
 	// +optional
 	// +listType=atomic
-	// +kubebuilder:validation:MaxItems=10
+	// +kubebuilder:validation:MaxItems=40
 	PodSetUpdates []PodSetUpdate `json:"podSetUpdates,omitempty"`
 }
 

--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -28,12 +28,12 @@ import (
 type WorkloadSpec struct {
 	// podSets is a list of sets of homogeneous pods, each described by a Pod spec
 	// and a count.
-	// There must be at least one element and at most 40.
+	// There must be at least one element and at most 18.
 	// podSets cannot be changed.
 	//
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=40
+	// +kubebuilder:validation:MaxItems=18
 	// +kubebuilder:validation:MinItems=1
 	// +optional
 	PodSets []PodSet `json:"podSets"`
@@ -272,7 +272,7 @@ type Admission struct {
 	// podSetAssignments hold the admission results for each of the .spec.podSets entries.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=40
+	// +kubebuilder:validation:MaxItems=18
 	// +optional
 	PodSetAssignments []PodSetAssignment `json:"podSetAssignments"`
 }
@@ -649,7 +649,7 @@ type WorkloadStatus struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=40
+	// +kubebuilder:validation:MaxItems=18
 	ReclaimablePods []ReclaimablePod `json:"reclaimablePods,omitempty"`
 
 	// admissionChecks list all the admission checks required by the workload and the current status
@@ -669,7 +669,7 @@ type WorkloadStatus struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=40
+	// +kubebuilder:validation:MaxItems=18
 	ResourceRequests []PodSetRequest `json:"resourceRequests,omitempty"`
 
 	// accumulatedPastExecutionTimeSeconds holds the total time, in seconds, the workload spent
@@ -834,7 +834,7 @@ type AdmissionCheckState struct {
 	// podSetUpdates contains a list of pod set modifications suggested by AdmissionChecks.
 	// +optional
 	// +listType=atomic
-	// +kubebuilder:validation:MaxItems=40
+	// +kubebuilder:validation:MaxItems=18
 	PodSetUpdates []PodSetUpdate `json:"podSetUpdates,omitempty"`
 }
 

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -123,7 +123,7 @@ spec:
                   description: |-
                     podSets is a list of sets of homogeneous pods, each described by a Pod spec
                     and a count.
-                    There must be at least one element and at most 10.
+                    There must be at least one element and at most 40.
                     podSets cannot be changed.
                   items:
                     properties:
@@ -8345,7 +8345,7 @@ spec:
                     x-kubernetes-validations:
                       - message: minCount should be positive and less or equal to count
                         rule: 'has(self.minCount) ? self.minCount <= self.count : true'
-                  maxItems: 10
+                  maxItems: 40
                   minItems: 1
                   type: array
                   x-kubernetes-list-map-keys:
@@ -8560,7 +8560,7 @@ spec:
                         required:
                           - name
                         type: object
-                      maxItems: 10
+                      maxItems: 40
                       type: array
                       x-kubernetes-list-map-keys:
                         - name
@@ -8673,7 +8673,7 @@ spec:
                           required:
                             - name
                           type: object
-                        maxItems: 10
+                        maxItems: 40
                         type: array
                         x-kubernetes-list-type: atomic
                       requeueAfterSeconds:
@@ -8825,7 +8825,7 @@ spec:
                       - count
                       - name
                     type: object
-                  maxItems: 10
+                  maxItems: 40
                   type: array
                   x-kubernetes-list-map-keys:
                     - name
@@ -8881,7 +8881,7 @@ spec:
                     required:
                       - name
                     type: object
-                  maxItems: 10
+                  maxItems: 40
                   type: array
                   x-kubernetes-list-map-keys:
                     - name
@@ -9027,7 +9027,7 @@ spec:
                   description: |-
                     podSets is a list of sets of homogeneous pods, each described by a Pod spec
                     and a count.
-                    There must be at least one element and at most 10.
+                    There must be at least one element and at most 40.
                     podSets cannot be changed.
                   items:
                     properties:
@@ -17281,7 +17281,7 @@ spec:
                     x-kubernetes-validations:
                       - message: minCount should be positive and less or equal to count
                         rule: 'has(self.minCount) ? self.minCount <= self.count : true'
-                  maxItems: 10
+                  maxItems: 40
                   minItems: 1
                   type: array
                   x-kubernetes-list-map-keys:
@@ -17569,7 +17569,7 @@ spec:
                               - message: valuesPerLevel must have the same length as the number of levels in this TopologyAssignment
                                 rule: self.slices.all(x, size(x.valuesPerLevel) == size(self.levels))
                         type: object
-                      maxItems: 10
+                      maxItems: 40
                       type: array
                       x-kubernetes-list-map-keys:
                         - name
@@ -17681,7 +17681,7 @@ spec:
                           required:
                             - name
                           type: object
-                        maxItems: 10
+                        maxItems: 40
                         type: array
                         x-kubernetes-list-type: atomic
                       requeueAfterSeconds:
@@ -17868,7 +17868,7 @@ spec:
                       - count
                       - name
                     type: object
-                  maxItems: 10
+                  maxItems: 40
                   type: array
                   x-kubernetes-list-map-keys:
                     - name
@@ -17924,7 +17924,7 @@ spec:
                     required:
                       - name
                     type: object
-                  maxItems: 10
+                  maxItems: 40
                   type: array
                   x-kubernetes-list-map-keys:
                     - name

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -123,7 +123,7 @@ spec:
                   description: |-
                     podSets is a list of sets of homogeneous pods, each described by a Pod spec
                     and a count.
-                    There must be at least one element and at most 40.
+                    There must be at least one element and at most 18.
                     podSets cannot be changed.
                   items:
                     properties:
@@ -8345,7 +8345,7 @@ spec:
                     x-kubernetes-validations:
                       - message: minCount should be positive and less or equal to count
                         rule: 'has(self.minCount) ? self.minCount <= self.count : true'
-                  maxItems: 40
+                  maxItems: 18
                   minItems: 1
                   type: array
                   x-kubernetes-list-map-keys:
@@ -8560,7 +8560,7 @@ spec:
                         required:
                           - name
                         type: object
-                      maxItems: 40
+                      maxItems: 18
                       type: array
                       x-kubernetes-list-map-keys:
                         - name
@@ -8673,7 +8673,7 @@ spec:
                           required:
                             - name
                           type: object
-                        maxItems: 40
+                        maxItems: 18
                         type: array
                         x-kubernetes-list-type: atomic
                       requeueAfterSeconds:
@@ -8825,7 +8825,7 @@ spec:
                       - count
                       - name
                     type: object
-                  maxItems: 40
+                  maxItems: 18
                   type: array
                   x-kubernetes-list-map-keys:
                     - name
@@ -8881,7 +8881,7 @@ spec:
                     required:
                       - name
                     type: object
-                  maxItems: 40
+                  maxItems: 18
                   type: array
                   x-kubernetes-list-map-keys:
                     - name
@@ -9027,7 +9027,7 @@ spec:
                   description: |-
                     podSets is a list of sets of homogeneous pods, each described by a Pod spec
                     and a count.
-                    There must be at least one element and at most 40.
+                    There must be at least one element and at most 18.
                     podSets cannot be changed.
                   items:
                     properties:
@@ -17281,7 +17281,7 @@ spec:
                     x-kubernetes-validations:
                       - message: minCount should be positive and less or equal to count
                         rule: 'has(self.minCount) ? self.minCount <= self.count : true'
-                  maxItems: 40
+                  maxItems: 18
                   minItems: 1
                   type: array
                   x-kubernetes-list-map-keys:
@@ -17569,7 +17569,7 @@ spec:
                               - message: valuesPerLevel must have the same length as the number of levels in this TopologyAssignment
                                 rule: self.slices.all(x, size(x.valuesPerLevel) == size(self.levels))
                         type: object
-                      maxItems: 40
+                      maxItems: 18
                       type: array
                       x-kubernetes-list-map-keys:
                         - name
@@ -17681,7 +17681,7 @@ spec:
                           required:
                             - name
                           type: object
-                        maxItems: 40
+                        maxItems: 18
                         type: array
                         x-kubernetes-list-type: atomic
                       requeueAfterSeconds:
@@ -17868,7 +17868,7 @@ spec:
                       - count
                       - name
                     type: object
-                  maxItems: 40
+                  maxItems: 18
                   type: array
                   x-kubernetes-list-map-keys:
                     - name
@@ -17924,7 +17924,7 @@ spec:
                     required:
                       - name
                     type: object
-                  maxItems: 40
+                  maxItems: 18
                   type: array
                   x-kubernetes-list-map-keys:
                     - name

--- a/client-go/applyconfiguration/kueue/v1beta1/workloadspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/workloadspec.go
@@ -29,7 +29,7 @@ import (
 type WorkloadSpecApplyConfiguration struct {
 	// podSets is a list of sets of homogeneous pods, each described by a Pod spec
 	// and a count.
-	// There must be at least one element and at most 10.
+	// There must be at least one element and at most 40.
 	// podSets cannot be changed.
 	PodSets []PodSetApplyConfiguration `json:"podSets,omitempty"`
 	// queueName is the name of the LocalQueue the Workload is associated with.

--- a/client-go/applyconfiguration/kueue/v1beta1/workloadspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/workloadspec.go
@@ -29,7 +29,7 @@ import (
 type WorkloadSpecApplyConfiguration struct {
 	// podSets is a list of sets of homogeneous pods, each described by a Pod spec
 	// and a count.
-	// There must be at least one element and at most 40.
+	// There must be at least one element and at most 18.
 	// podSets cannot be changed.
 	PodSets []PodSetApplyConfiguration `json:"podSets,omitempty"`
 	// queueName is the name of the LocalQueue the Workload is associated with.

--- a/client-go/applyconfiguration/kueue/v1beta2/workloadspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/workloadspec.go
@@ -29,7 +29,7 @@ import (
 type WorkloadSpecApplyConfiguration struct {
 	// podSets is a list of sets of homogeneous pods, each described by a Pod spec
 	// and a count.
-	// There must be at least one element and at most 10.
+	// There must be at least one element and at most 40.
 	// podSets cannot be changed.
 	PodSets []PodSetApplyConfiguration `json:"podSets,omitempty"`
 	// queueName is the name of the LocalQueue the Workload is associated with.

--- a/client-go/applyconfiguration/kueue/v1beta2/workloadspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/workloadspec.go
@@ -29,7 +29,7 @@ import (
 type WorkloadSpecApplyConfiguration struct {
 	// podSets is a list of sets of homogeneous pods, each described by a Pod spec
 	// and a count.
-	// There must be at least one element and at most 40.
+	// There must be at least one element and at most 18.
 	// podSets cannot be changed.
 	PodSets []PodSetApplyConfiguration `json:"podSets,omitempty"`
 	// queueName is the name of the LocalQueue the Workload is associated with.

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -91,7 +91,7 @@ spec:
                 description: |-
                   podSets is a list of sets of homogeneous pods, each described by a Pod spec
                   and a count.
-                  There must be at least one element and at most 10.
+                  There must be at least one element and at most 40.
                   podSets cannot be changed.
                 items:
                   properties:
@@ -8796,7 +8796,7 @@ spec:
                   x-kubernetes-validations:
                   - message: minCount should be positive and less or equal to count
                     rule: 'has(self.minCount) ? self.minCount <= self.count : true'
-                maxItems: 10
+                maxItems: 40
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
@@ -9016,7 +9016,7 @@ spec:
                       required:
                       - name
                       type: object
-                    maxItems: 10
+                    maxItems: 40
                     type: array
                     x-kubernetes-list-map-keys:
                     - name
@@ -9141,7 +9141,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 10
+                      maxItems: 40
                       type: array
                       x-kubernetes-list-type: atomic
                     requeueAfterSeconds:
@@ -9296,7 +9296,7 @@ spec:
                   - count
                   - name
                   type: object
-                maxItems: 10
+                maxItems: 40
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -9353,7 +9353,7 @@ spec:
                   required:
                   - name
                   type: object
-                maxItems: 10
+                maxItems: 40
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -9526,7 +9526,7 @@ spec:
                 description: |-
                   podSets is a list of sets of homogeneous pods, each described by a Pod spec
                   and a count.
-                  There must be at least one element and at most 10.
+                  There must be at least one element and at most 40.
                   podSets cannot be changed.
                 items:
                   properties:
@@ -18275,7 +18275,7 @@ spec:
                   x-kubernetes-validations:
                   - message: minCount should be positive and less or equal to count
                     rule: 'has(self.minCount) ? self.minCount <= self.count : true'
-                maxItems: 10
+                maxItems: 40
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
@@ -18650,7 +18650,7 @@ spec:
                               number of levels in this TopologyAssignment
                             rule: self.slices.all(x, size(x.valuesPerLevel) == size(self.levels))
                       type: object
-                    maxItems: 10
+                    maxItems: 40
                     type: array
                     x-kubernetes-list-map-keys:
                     - name
@@ -18774,7 +18774,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 10
+                      maxItems: 40
                       type: array
                       x-kubernetes-list-type: atomic
                     requeueAfterSeconds:
@@ -18965,7 +18965,7 @@ spec:
                   - count
                   - name
                   type: object
-                maxItems: 10
+                maxItems: 40
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -19022,7 +19022,7 @@ spec:
                   required:
                   - name
                   type: object
-                maxItems: 10
+                maxItems: 40
                 type: array
                 x-kubernetes-list-map-keys:
                 - name

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -91,7 +91,7 @@ spec:
                 description: |-
                   podSets is a list of sets of homogeneous pods, each described by a Pod spec
                   and a count.
-                  There must be at least one element and at most 40.
+                  There must be at least one element and at most 18.
                   podSets cannot be changed.
                 items:
                   properties:
@@ -8796,7 +8796,7 @@ spec:
                   x-kubernetes-validations:
                   - message: minCount should be positive and less or equal to count
                     rule: 'has(self.minCount) ? self.minCount <= self.count : true'
-                maxItems: 40
+                maxItems: 18
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
@@ -9016,7 +9016,7 @@ spec:
                       required:
                       - name
                       type: object
-                    maxItems: 40
+                    maxItems: 18
                     type: array
                     x-kubernetes-list-map-keys:
                     - name
@@ -9141,7 +9141,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 40
+                      maxItems: 18
                       type: array
                       x-kubernetes-list-type: atomic
                     requeueAfterSeconds:
@@ -9296,7 +9296,7 @@ spec:
                   - count
                   - name
                   type: object
-                maxItems: 40
+                maxItems: 18
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -9353,7 +9353,7 @@ spec:
                   required:
                   - name
                   type: object
-                maxItems: 40
+                maxItems: 18
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -9526,7 +9526,7 @@ spec:
                 description: |-
                   podSets is a list of sets of homogeneous pods, each described by a Pod spec
                   and a count.
-                  There must be at least one element and at most 40.
+                  There must be at least one element and at most 18.
                   podSets cannot be changed.
                 items:
                   properties:
@@ -18275,7 +18275,7 @@ spec:
                   x-kubernetes-validations:
                   - message: minCount should be positive and less or equal to count
                     rule: 'has(self.minCount) ? self.minCount <= self.count : true'
-                maxItems: 40
+                maxItems: 18
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
@@ -18650,7 +18650,7 @@ spec:
                               number of levels in this TopologyAssignment
                             rule: self.slices.all(x, size(x.valuesPerLevel) == size(self.levels))
                       type: object
-                    maxItems: 40
+                    maxItems: 18
                     type: array
                     x-kubernetes-list-map-keys:
                     - name
@@ -18774,7 +18774,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 40
+                      maxItems: 18
                       type: array
                       x-kubernetes-list-type: atomic
                     requeueAfterSeconds:
@@ -18965,7 +18965,7 @@ spec:
                   - count
                   - name
                   type: object
-                maxItems: 40
+                maxItems: 18
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -19022,7 +19022,7 @@ spec:
                   required:
                   - name
                   type: object
-                maxItems: 40
+                maxItems: 18
                 type: array
                 x-kubernetes-list-map-keys:
                 - name

--- a/pkg/controller/jobframework/constants.go
+++ b/pkg/controller/jobframework/constants.go
@@ -18,5 +18,5 @@ package jobframework
 
 const (
 	// MaxPodSets is the maximum number of PodSets allowed in a Workload.
-	MaxPodSets = 10
+	MaxPodSets = 40
 )

--- a/pkg/controller/jobframework/constants.go
+++ b/pkg/controller/jobframework/constants.go
@@ -18,5 +18,5 @@ package jobframework
 
 const (
 	// MaxPodSets is the maximum number of PodSets allowed in a Workload.
-	MaxPodSets = 40
+	MaxPodSets = 18
 )

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -65,8 +65,11 @@ import (
 const (
 	FrameworkName                  = "pod"
 	ConditionTypeTerminationTarget = "TerminationTarget"
-	errMsgIncorrectGroupRoleCount  = "pod group can't include more than 10 roles"
 )
+
+// errMsgIncorrectGroupRoleCount is derived from jobframework.MaxPodSets so the
+// message stays in sync with the limit.
+var errMsgIncorrectGroupRoleCount = fmt.Sprintf("pod group can't include more than %d roles", jobframework.MaxPodSets)
 
 // Event reasons used by the pod controller
 const (

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -195,11 +195,11 @@ func TestConstructComposableWorkloadPodGroupRoleLimit(t *testing.T) {
 		wantErr   string
 	}{
 		"allows maximum pod group roles": {
-			roleCount: 10,
+			roleCount: jobframework.MaxPodSets,
 		},
 		"rejects more than maximum pod group roles": {
-			roleCount: 11,
-			wantErr:   "pod group can't include more than 10 roles",
+			roleCount: jobframework.MaxPodSets + 1,
+			wantErr:   errMsgIncorrectGroupRoleCount,
 		},
 	}
 

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -950,6 +950,17 @@ func TestRestorePodSetsInfo(t *testing.T) {
 }
 
 func TestValidateCreateRayClusterSpec(t *testing.T) {
+	// A RayCluster contributes one podSet for the head plus one per worker
+	// group, so jobframework.MaxPodSets worker groups (head + MaxPodSets)
+	// exceeds the per-Workload podSet limit.
+	tooManyWorkerGroups := make([]rayv1.WorkerGroupSpec, jobframework.MaxPodSets)
+	for i := range tooManyWorkerGroups {
+		tooManyWorkerGroups[i] = rayv1.WorkerGroupSpec{GroupName: fmt.Sprintf("workers%d", i+1)}
+	}
+	tooManyWorkerGroupsWithHead := make([]rayv1.WorkerGroupSpec, jobframework.MaxPodSets)
+	copy(tooManyWorkerGroupsWithHead, tooManyWorkerGroups)
+	tooManyWorkerGroupsWithHead[0] = rayv1.WorkerGroupSpec{GroupName: "head"}
+
 	testCases := map[string]struct {
 		object         client.Object
 		rayClusterSpec *rayv1.RayClusterSpec
@@ -1006,21 +1017,10 @@ func TestValidateCreateRayClusterSpec(t *testing.T) {
 				HeadGroupSpec: rayv1.HeadGroupSpec{
 					Template: corev1.PodTemplateSpec{},
 				},
-				WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
-					{GroupName: "workers1"},
-					{GroupName: "workers2"},
-					{GroupName: "workers3"},
-					{GroupName: "workers4"},
-					{GroupName: "workers5"},
-					{GroupName: "workers6"},
-					{GroupName: "workers7"},
-					{GroupName: "workers8"},
-					{GroupName: "workers9"},
-					{GroupName: "workers10"}, // 10 worker groups is too many
-				},
+				WorkerGroupSpecs: tooManyWorkerGroups,
 			},
 			wantErrors: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "workerGroupSpecs"), 11, jobframework.MaxPodSets),
+				field.TooMany(field.NewPath("spec", "workerGroupSpecs"), jobframework.MaxPodSets+1, jobframework.MaxPodSets),
 			},
 		},
 		"worker group named 'head'": {
@@ -1046,22 +1046,11 @@ func TestValidateCreateRayClusterSpec(t *testing.T) {
 				HeadGroupSpec: rayv1.HeadGroupSpec{
 					Template: corev1.PodTemplateSpec{},
 				},
-				WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
-					{GroupName: "head"},
-					{GroupName: "workers2"},
-					{GroupName: "workers3"},
-					{GroupName: "workers4"},
-					{GroupName: "workers5"},
-					{GroupName: "workers6"},
-					{GroupName: "workers7"},
-					{GroupName: "workers8"},
-					{GroupName: "workers9"},
-					{GroupName: "workers10"},
-				},
+				WorkerGroupSpecs: tooManyWorkerGroupsWithHead,
 			},
 			wantErrors: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "enableInTreeAutoscaling"), new(true), "a kueue managed job should only use autoscaling when workload slicing is enabled"),
-				field.TooMany(field.NewPath("spec", "workerGroupSpecs"), 11, jobframework.MaxPodSets),
+				field.TooMany(field.NewPath("spec", "workerGroupSpecs"), jobframework.MaxPodSets+1, jobframework.MaxPodSets),
 				field.Forbidden(field.NewPath("spec", "workerGroupSpecs").Index(0).Child("groupName"), fmt.Sprintf("%q is reserved for the head group", headGroupPodSetName)),
 			},
 		},

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -950,15 +950,8 @@ func TestRestorePodSetsInfo(t *testing.T) {
 }
 
 func TestValidateCreateRayClusterSpec(t *testing.T) {
-	// A RayCluster contributes one podSet for the head plus one per worker
-	// group, so jobframework.MaxPodSets worker groups (head + MaxPodSets)
-	// exceeds the per-Workload podSet limit.
-	tooManyWorkerGroups := make([]rayv1.WorkerGroupSpec, jobframework.MaxPodSets)
-	for i := range tooManyWorkerGroups {
-		tooManyWorkerGroups[i] = rayv1.WorkerGroupSpec{GroupName: fmt.Sprintf("workers%d", i+1)}
-	}
-	tooManyWorkerGroupsWithHead := make([]rayv1.WorkerGroupSpec, jobframework.MaxPodSets)
-	copy(tooManyWorkerGroupsWithHead, tooManyWorkerGroups)
+	tooManyWorkerGroups := testingrayutil.MakeWorkerGroups(jobframework.MaxPodSets)
+	tooManyWorkerGroupsWithHead := testingrayutil.MakeWorkerGroups(jobframework.MaxPodSets)
 	tooManyWorkerGroupsWithHead[0] = rayv1.WorkerGroupSpec{GroupName: "head"}
 
 	testCases := map[string]struct {

--- a/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
@@ -127,7 +127,11 @@ func TestValidateDefault(t *testing.T) {
 
 func TestValidateCreate(t *testing.T) {
 	worker := rayv1.WorkerGroupSpec{}
-	bigWorkerGroup := []rayv1.WorkerGroupSpec{worker, worker, worker, worker, worker, worker, worker, worker, worker, worker}
+	// head + jobframework.MaxPodSets worker groups exceeds the per-Workload podSet limit.
+	bigWorkerGroup := make([]rayv1.WorkerGroupSpec, jobframework.MaxPodSets)
+	for i := range bigWorkerGroup {
+		bigWorkerGroup[i] = worker
+	}
 
 	testcases := map[string]struct {
 		job          *rayv1.RayCluster
@@ -160,7 +164,7 @@ func TestValidateCreate(t *testing.T) {
 				WithWorkerGroups(bigWorkerGroup...).
 				Obj(),
 			wantErr: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "workerGroupSpecs"), 11, jobframework.MaxPodSets),
+				field.TooMany(field.NewPath("spec", "workerGroupSpecs"), jobframework.MaxPodSets+1, jobframework.MaxPodSets),
 			}.ToAggregate(),
 		},
 		"worker group uses head name": {

--- a/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
@@ -126,12 +126,7 @@ func TestValidateDefault(t *testing.T) {
 }
 
 func TestValidateCreate(t *testing.T) {
-	worker := rayv1.WorkerGroupSpec{}
-	// head + jobframework.MaxPodSets worker groups exceeds the per-Workload podSet limit.
-	bigWorkerGroup := make([]rayv1.WorkerGroupSpec, jobframework.MaxPodSets)
-	for i := range bigWorkerGroup {
-		bigWorkerGroup[i] = worker
-	}
+	bigWorkerGroup := testingrayutil.MakeWorkerGroups(jobframework.MaxPodSets)
 
 	testcases := map[string]struct {
 		job          *rayv1.RayCluster

--- a/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
@@ -127,7 +127,11 @@ func TestDefault(t *testing.T) {
 
 func TestValidateCreate(t *testing.T) {
 	worker := rayv1.WorkerGroupSpec{}
-	bigWorkerGroup := []rayv1.WorkerGroupSpec{worker, worker, worker, worker, worker, worker, worker, worker, worker, worker}
+	// head + jobframework.MaxPodSets worker groups exceeds the per-Workload podSet limit.
+	bigWorkerGroup := make([]rayv1.WorkerGroupSpec, jobframework.MaxPodSets)
+	for i := range bigWorkerGroup {
+		bigWorkerGroup[i] = worker
+	}
 
 	testcases := map[string]struct {
 		job          *rayv1.RayJob
@@ -203,7 +207,7 @@ func TestValidateCreate(t *testing.T) {
 				WithWorkerGroups(bigWorkerGroup...).
 				Obj(),
 			wantErr: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "rayClusterSpec", "workerGroupSpecs"), 11, jobframework.MaxPodSets),
+				field.TooMany(field.NewPath("spec", "rayClusterSpec", "workerGroupSpecs"), jobframework.MaxPodSets+1, jobframework.MaxPodSets),
 			}.ToAggregate(),
 		},
 		"valid managed - max worker groups with gcs fault tolerance": {

--- a/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
 	testingrayutil "sigs.k8s.io/kueue/pkg/util/testingjobs/rayjob"
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
@@ -126,12 +127,7 @@ func TestDefault(t *testing.T) {
 }
 
 func TestValidateCreate(t *testing.T) {
-	worker := rayv1.WorkerGroupSpec{}
-	// head + jobframework.MaxPodSets worker groups exceeds the per-Workload podSet limit.
-	bigWorkerGroup := make([]rayv1.WorkerGroupSpec, jobframework.MaxPodSets)
-	for i := range bigWorkerGroup {
-		bigWorkerGroup[i] = worker
-	}
+	bigWorkerGroup := testingraycluster.MakeWorkerGroups(jobframework.MaxPodSets)
 
 	testcases := map[string]struct {
 		job          *rayv1.RayJob

--- a/pkg/controller/jobs/rayservice/rayservice_webhook_test.go
+++ b/pkg/controller/jobs/rayservice/rayservice_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rayservice
 
 import (
+	"fmt"
 	"testing"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
@@ -24,9 +25,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 )
 
 func TestValidateCreate(t *testing.T) {
+	// head + jobframework.MaxPodSets worker groups exceeds the per-Workload podSet limit.
+	tooManyWorkerGroups := make([]rayv1.WorkerGroupSpec, jobframework.MaxPodSets)
+	for i := range tooManyWorkerGroups {
+		tooManyWorkerGroups[i] = rayv1.WorkerGroupSpec{GroupName: fmt.Sprintf("w%d", i+1)}
+	}
+
 	testCases := map[string]struct {
 		service   *rayv1.RayService
 		manageAll bool
@@ -84,18 +92,7 @@ func TestValidateCreate(t *testing.T) {
 								},
 							},
 						},
-						WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
-							{GroupName: "w1"},
-							{GroupName: "w2"},
-							{GroupName: "w3"},
-							{GroupName: "w4"},
-							{GroupName: "w5"},
-							{GroupName: "w6"},
-							{GroupName: "w7"},
-							{GroupName: "w8"},
-							{GroupName: "w9"},
-							{GroupName: "w10"}, // 10th worker group - too many
-						},
+						WorkerGroupSpecs: tooManyWorkerGroups,
 					},
 				},
 			},

--- a/pkg/controller/jobs/rayservice/rayservice_webhook_test.go
+++ b/pkg/controller/jobs/rayservice/rayservice_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package rayservice
 
 import (
-	"fmt"
 	"testing"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
@@ -26,14 +25,11 @@ import (
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	testingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
 )
 
 func TestValidateCreate(t *testing.T) {
-	// head + jobframework.MaxPodSets worker groups exceeds the per-Workload podSet limit.
-	tooManyWorkerGroups := make([]rayv1.WorkerGroupSpec, jobframework.MaxPodSets)
-	for i := range tooManyWorkerGroups {
-		tooManyWorkerGroups[i] = rayv1.WorkerGroupSpec{GroupName: fmt.Sprintf("w%d", i+1)}
-	}
+	tooManyWorkerGroups := testingraycluster.MakeWorkerGroups(jobframework.MaxPodSets)
 
 	testCases := map[string]struct {
 		service   *rayv1.RayService

--- a/pkg/util/testingjobs/raycluster/wrappers.go
+++ b/pkg/util/testingjobs/raycluster/wrappers.go
@@ -29,6 +29,16 @@ import (
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
 
+// MakeWorkerGroups returns count worker groups with distinct group names.
+// It is a helper for tests that need to exceed the per-Workload podSet limit.
+func MakeWorkerGroups(count int) []rayv1.WorkerGroupSpec {
+	groups := make([]rayv1.WorkerGroupSpec, count)
+	for i := range groups {
+		groups[i] = rayv1.WorkerGroupSpec{GroupName: fmt.Sprintf("workers-%d", i)}
+	}
+	return groups
+}
+
 // ClusterWrapper wraps a RayCluster.
 type ClusterWrapper struct{ rayv1.RayCluster }
 

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -3259,7 +3259,7 @@ This may be an empty string.</p>
 <td>
    <p>podSets is a list of sets of homogeneous pods, each described by a Pod spec
 and a count.
-There must be at least one element and at most 10.
+There must be at least one element and at most 40.
 podSets cannot be changed.</p>
 </td>
 </tr>

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -3259,7 +3259,7 @@ This may be an empty string.</p>
 <td>
    <p>podSets is a list of sets of homogeneous pods, each described by a Pod spec
 and a count.
-There must be at least one element and at most 40.
+There must be at least one element and at most 18.
 podSets cannot be changed.</p>
 </td>
 </tr>

--- a/site/content/en/docs/reference/kueue.v1beta2.md
+++ b/site/content/en/docs/reference/kueue.v1beta2.md
@@ -3682,7 +3682,7 @@ This may be an empty string.</p>
 <td>
    <p>podSets is a list of sets of homogeneous pods, each described by a Pod spec
 and a count.
-There must be at least one element and at most 10.
+There must be at least one element and at most 40.
 podSets cannot be changed.</p>
 </td>
 </tr>

--- a/site/content/en/docs/reference/kueue.v1beta2.md
+++ b/site/content/en/docs/reference/kueue.v1beta2.md
@@ -3682,7 +3682,7 @@ This may be an empty string.</p>
 <td>
    <p>podSets is a list of sets of homogeneous pods, each described by a Pod spec
 and a count.
-There must be at least one element and at most 40.
+There must be at least one element and at most 18.
 podSets cannot be changed.</p>
 </td>
 </tr>

--- a/site/content/en/docs/tasks/run/rayclusters.md
+++ b/site/content/en/docs/tasks/run/rayclusters.md
@@ -68,7 +68,7 @@ Note that a RayCluster will hold resource quotas while it exists. For optimal re
 Kueue controls the `spec.suspend` field of the RayCluster. When a RayCluster is admitted by Kueue, Kueue will unsuspend it by setting `spec.suspend` to `false`, regardless of its previous value.
 
 ### d. Limitations
-- Limited Worker Groups: Because a Kueue workload can have a maximum of 10 PodSets, the maximum number of `spec.workerGroupSpecs` is 9
+- Limited Worker Groups: Because a Kueue workload can have a maximum of 40 PodSets, the maximum number of `spec.workerGroupSpecs` is 39
 - In-Tree Autoscaling Constraints: Autoscaling is only supported for [elastic](/docs/concepts/elastic_workload) RayCluster objects. To enable in-tree autoscaling:
 
   1. Activate the `ElasticJobsViaWorkloadSlices` feature gate.

--- a/site/content/en/docs/tasks/run/rayclusters.md
+++ b/site/content/en/docs/tasks/run/rayclusters.md
@@ -68,7 +68,7 @@ Note that a RayCluster will hold resource quotas while it exists. For optimal re
 Kueue controls the `spec.suspend` field of the RayCluster. When a RayCluster is admitted by Kueue, Kueue will unsuspend it by setting `spec.suspend` to `false`, regardless of its previous value.
 
 ### d. Limitations
-- Limited Worker Groups: Because a Kueue workload can have a maximum of 40 PodSets, the maximum number of `spec.workerGroupSpecs` is 39
+- Limited Worker Groups: Because a Kueue workload can have a maximum of 18 PodSets, the maximum number of `spec.workerGroupSpecs` is 17
 - In-Tree Autoscaling Constraints: Autoscaling is only supported for [elastic](/docs/concepts/elastic_workload) RayCluster objects. To enable in-tree autoscaling:
 
   1. Activate the `ElasticJobsViaWorkloadSlices` feature gate.

--- a/site/content/en/docs/tasks/run/rayjobs.md
+++ b/site/content/en/docs/tasks/run/rayjobs.md
@@ -71,7 +71,7 @@ Kueue controls the `spec.suspend` field of the RayJob. When a RayJob is admitted
 
 - A Kueue managed RayJob cannot use an existing RayCluster.
 - The RayCluster should be deleted at the end of the job execution, `spec.ShutdownAfterJobFinishes` should be `true`.
-- Because a Kueue workload can have a maximum of 10 PodSets, the maximum number of `spec.rayClusterSpec.workerGroupSpecs` is 9.
+- Because a Kueue workload can have a maximum of 40 PodSets, the maximum number of `spec.rayClusterSpec.workerGroupSpecs` is 39.
 
 ## Example RayJob
 

--- a/site/content/en/docs/tasks/run/rayjobs.md
+++ b/site/content/en/docs/tasks/run/rayjobs.md
@@ -71,7 +71,7 @@ Kueue controls the `spec.suspend` field of the RayJob. When a RayJob is admitted
 
 - A Kueue managed RayJob cannot use an existing RayCluster.
 - The RayCluster should be deleted at the end of the job execution, `spec.ShutdownAfterJobFinishes` should be `true`.
-- Because a Kueue workload can have a maximum of 40 PodSets, the maximum number of `spec.rayClusterSpec.workerGroupSpecs` is 39.
+- Because a Kueue workload can have a maximum of 18 PodSets, the maximum number of `spec.rayClusterSpec.workerGroupSpecs` is 17.
 
 ## Example RayJob
 

--- a/site/content/en/docs/tasks/run/rayservices.md
+++ b/site/content/en/docs/tasks/run/rayservices.md
@@ -68,7 +68,7 @@ spec:
 Kueue controls the `spec.suspend` field of the RayService. When a RayService is admitted by Kueue, Kueue will unsuspend it by setting `spec.suspend` to `false`, regardless of its previous value.
 
 ### d. Limitations
-- Limited Worker Groups: Because a Kueue workload can have a maximum of 10 PodSets, the maximum number of `spec.rayClusterConfig.workerGroupSpecs` is 9
+- Limited Worker Groups: Because a Kueue workload can have a maximum of 40 PodSets, the maximum number of `spec.rayClusterConfig.workerGroupSpecs` is 39
 
 ## Example RayService
 

--- a/site/content/en/docs/tasks/run/rayservices.md
+++ b/site/content/en/docs/tasks/run/rayservices.md
@@ -68,7 +68,7 @@ spec:
 Kueue controls the `spec.suspend` field of the RayService. When a RayService is admitted by Kueue, Kueue will unsuspend it by setting `spec.suspend` to `false`, regardless of its previous value.
 
 ### d. Limitations
-- Limited Worker Groups: Because a Kueue workload can have a maximum of 40 PodSets, the maximum number of `spec.rayClusterConfig.workerGroupSpecs` is 39
+- Limited Worker Groups: Because a Kueue workload can have a maximum of 18 PodSets, the maximum number of `spec.rayClusterConfig.workerGroupSpecs` is 17
 
 ## Example RayService
 

--- a/test/integration/singlecluster/webhook/core/workload_test.go
+++ b/test/integration/singlecluster/webhook/core/workload_test.go
@@ -32,6 +32,7 @@ import (
 
 	kueuev1beta1 "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -45,7 +46,7 @@ var ns *corev1.Namespace
 
 const (
 	workloadName    = "workload-test"
-	podSetsMaxItems = 10
+	podSetsMaxItems = jobframework.MaxPodSets
 )
 
 var _ = ginkgo.Describe("Workload defaulting webhook", func() {
@@ -133,7 +134,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 		},
 			ginkgo.Entry("podSets count less than 1", 0, 1, true),
 			ginkgo.Entry("podSets count at the maximum", podSetsMaxItems, 1, false),
-			ginkgo.Entry("podSets count more than 10", podSetsMaxItems+1, 1, true),
+			ginkgo.Entry("podSets count more than the maximum", podSetsMaxItems+1, 1, true),
 			ginkgo.Entry("valid podSet, count can be 0", 3, 0, false),
 			ginkgo.Entry("valid podSet", 3, 3, false),
 		)


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it

Raises the per-Workload `MaxPodSets` limit from 10 to 18.

This bumps the `jobframework.MaxPodSets` constant and the `MaxItems` validation on the five podSet-indexed arrays in both the `v1beta1` and `v1beta2` Workload APIs, and regenerates the CRDs, Helm chart, apply configurations, and reference docs.

Integrations reserve technical podSets (for example, Ray uses a head, a submitter job, and a Redis cleanup job), which leaves too few podSets for actual worker groups. We run RayClusters whose shape is not known ahead of time and draw from a large catalog of worker/pod types, so a higher limit removes the need to fork Kueue as a workaround. This continues the direction of #11379 / #11388 (which moved the limit from 8 to 10).

Per discussion in #12818, 18 is the value maintainers aligned on for now: it gives users meaningfully more room while leaving headroom to revisit higher values in a future release, once there is feedback on how the increased count interacts with features like MultiKueue and ConcurrentAdmission.

## Which issue(s) this PR fixes

Fixes #12818

## Special notes for your reviewer

* All limit-dependent tests and the pod-group role-count error message derive from `jobframework.MaxPodSets`, so they won't drift on future bumps.
* The oversized Ray worker-group fixtures now come from a shared `testingjobs/raycluster.MakeWorkerGroups` helper (addressing @dkaluza's review nit).
* Validation-cost note: the `Workload` CRD carries CEL rules on the podSet-indexed subtrees whose estimated cost scales with `maxItems`; 18 stays well within the apiserver's CEL cost budget.

## Does this PR introduce a user-facing change?

```release-note
Workloads: Increase the maximum number of PodSets per Workload from 10 to 18.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the maximum allowed sizes for several workload-related list fields (including `podSets`) from **10 to 18**.
* **Bug Fixes**
  * Updated RayJob/RayCluster/RayService documentation and validation logic to match the new PodSet capacity (worker group specs capped at **17**).
  * Refreshed validation messaging, test cases, and API reference docs to use the new maximum consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->